### PR TITLE
test: add channel fault harness coverage

### DIFF
--- a/extensions/discord/src/monitor.channel-fault-harness.test-support.ts
+++ b/extensions/discord/src/monitor.channel-fault-harness.test-support.ts
@@ -1,0 +1,1068 @@
+import type { Client } from "@buape/carbon";
+import { ChannelType, MessageType } from "@buape/carbon";
+import { vi } from "vitest";
+import {
+  __testing as sessionBindingTesting,
+  registerSessionBindingAdapter,
+  type SessionBindingRecord,
+} from "../../../src/infra/outbound/session-binding-service.js";
+import type {
+  ChannelFaultHarness,
+  ChannelHarnessEvent,
+  ChannelHarnessIdleExpectation,
+  ChannelHarnessOutboundCall,
+  ChannelOutboundFault,
+} from "../../../test/helpers/channel-fault-harness.js";
+import type { DiscordMessageEvent } from "./monitor/listeners.js";
+import { __testing as threadBindingTesting } from "./monitor/thread-bindings.js";
+import { rememberRecentUnboundWebhookEcho } from "./monitor/thread-bindings.state.js";
+import type { ThreadBindingManager, ThreadBindingRecord } from "./monitor/thread-bindings.types.js";
+
+type LoadedConfig = ReturnType<(typeof import("../../../src/config/config.js"))["loadConfig"]>;
+type AnyMock = ReturnType<typeof vi.fn>;
+
+const {
+  dispatchMock,
+  readAllowFromStoreMock,
+  sendMock,
+  updateLastRouteMock,
+  upsertPairingRequestMock,
+  loadConfigMock,
+  sendWebhookMock,
+  sendDiscordTextMock,
+  resolveConfiguredBindingRouteMock,
+  ensureConfiguredBindingRouteReadyMock,
+  recordInboundSessionMock,
+} = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+  readAllowFromStoreMock: vi.fn(),
+  sendMock: vi.fn(),
+  updateLastRouteMock: vi.fn(),
+  upsertPairingRequestMock: vi.fn(),
+  loadConfigMock: vi.fn(() => ({})),
+  sendWebhookMock: vi.fn(),
+  sendDiscordTextMock: vi.fn(),
+  resolveConfiguredBindingRouteMock: vi.fn<(...args: unknown[]) => unknown>(() => null),
+  ensureConfiguredBindingRouteReadyMock: vi.fn(async () => ({ ok: true })),
+  recordInboundSessionMock: vi.fn(async (_input?: unknown) => {}),
+}));
+
+vi.doMock("../../../src/config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../src/config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+  };
+});
+
+vi.doMock("./send.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send.js")>();
+  return {
+    ...actual,
+    sendMessageDiscord: (...args: unknown[]) => Reflect.apply(sendMock, undefined, args),
+    sendWebhookMessageDiscord: (...args: unknown[]) =>
+      Reflect.apply(sendWebhookMock, undefined, args),
+    reactMessageDiscord: async () => undefined,
+  };
+});
+
+vi.doMock("./send.shared.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./send.shared.js")>();
+  return {
+    ...actual,
+    sendDiscordText: (...args: unknown[]) => Reflect.apply(sendDiscordTextMock, undefined, args),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: (...args: unknown[]) => dispatchMock(...args),
+    dispatchInboundMessageWithDispatcher: (...args: unknown[]) => dispatchMock(...args),
+    dispatchInboundMessageWithBufferedDispatcher: (...args: unknown[]) => dispatchMock(...args),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/reply-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: (...args: unknown[]) => dispatchMock(...args),
+    dispatchInboundMessageWithDispatcher: (...args: unknown[]) => dispatchMock(...args),
+    dispatchInboundMessageWithBufferedDispatcher: (...args: unknown[]) => dispatchMock(...args),
+  };
+});
+
+vi.mock(
+  "/Users/thoffman/openclaw/.worktrees/codex-channel-fault-harness/dist/plugin-sdk/reply-runtime.js",
+  async (importOriginal) => {
+    const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+    return {
+      ...actual,
+      dispatchInboundMessage: (...args: unknown[]) => dispatchMock(...args),
+      dispatchInboundMessageWithDispatcher: (...args: unknown[]) => dispatchMock(...args),
+      dispatchInboundMessageWithBufferedDispatcher: (...args: unknown[]) => dispatchMock(...args),
+    };
+  },
+);
+
+vi.mock(
+  "/Users/thoffman/openclaw/.worktrees/codex-channel-fault-harness/src/plugin-sdk/reply-runtime.ts",
+  async (importOriginal) => {
+    const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+    return {
+      ...actual,
+      dispatchInboundMessage: (...args: unknown[]) => dispatchMock(...args),
+      dispatchInboundMessageWithDispatcher: (...args: unknown[]) => dispatchMock(...args),
+      dispatchInboundMessageWithBufferedDispatcher: (...args: unknown[]) => dispatchMock(...args),
+    };
+  },
+);
+
+vi.mock(
+  "/Users/thoffman/openclaw/.worktrees/codex-channel-fault-harness/src/auto-reply/dispatch.ts",
+  async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../../src/auto-reply/dispatch.js")>();
+    return {
+      ...actual,
+      dispatchInboundMessage: (...args: unknown[]) => dispatchMock(...args),
+      dispatchInboundMessageWithDispatcher: (...args: unknown[]) => dispatchMock(...args),
+      dispatchInboundMessageWithBufferedDispatcher: (...args: unknown[]) => dispatchMock(...args),
+    };
+  },
+);
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: (...args: unknown[]) =>
+      Reflect.apply(readAllowFromStoreMock, undefined, args),
+    upsertChannelPairingRequest: (...args: unknown[]) =>
+      Reflect.apply(upsertPairingRequestMock, undefined, args),
+    resolveConfiguredBindingRoute: (...args: unknown[]) =>
+      Reflect.apply(resolveConfiguredBindingRouteMock, undefined, args),
+    ensureConfiguredBindingRouteReady: (...args: unknown[]) =>
+      Reflect.apply(ensureConfiguredBindingRouteReadyMock, undefined, args),
+  };
+});
+vi.mock("openclaw/plugin-sdk/conversation-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: (...args: unknown[]) =>
+      Reflect.apply(readAllowFromStoreMock, undefined, args),
+    upsertChannelPairingRequest: (...args: unknown[]) =>
+      Reflect.apply(upsertPairingRequestMock, undefined, args),
+    resolveConfiguredBindingRoute: (...args: unknown[]) =>
+      Reflect.apply(resolveConfiguredBindingRouteMock, undefined, args),
+    ensureConfiguredBindingRouteReady: (...args: unknown[]) =>
+      Reflect.apply(ensureConfiguredBindingRouteReadyMock, undefined, args),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+    updateLastRoute: (...args: unknown[]) => Reflect.apply(updateLastRouteMock, undefined, args),
+    resolveSessionKey: vi.fn(),
+  };
+});
+vi.mock("openclaw/plugin-sdk/config-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+    resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+    updateLastRoute: (...args: unknown[]) => Reflect.apply(updateLastRouteMock, undefined, args),
+    resolveSessionKey: vi.fn(),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/channel-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-runtime")>();
+  return {
+    ...actual,
+    recordInboundSession: (...args: unknown[]) =>
+      Reflect.apply(recordInboundSessionMock, undefined, args),
+  };
+});
+vi.mock("openclaw/plugin-sdk/channel-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-runtime")>();
+  return {
+    ...actual,
+    recordInboundSession: (...args: unknown[]) =>
+      Reflect.apply(recordInboundSessionMock, undefined, args),
+  };
+});
+
+vi.doMock("./threading.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveDiscordAutoThreadReplyPlan: async ({
+      messageChannelId,
+    }: {
+      messageChannelId: string;
+    }) => ({
+      deliverTarget: `channel:${messageChannelId}`,
+      replyTarget: `channel:${messageChannelId}`,
+      replyReference: {
+        use: () => undefined,
+        markSent: () => undefined,
+      },
+      autoThreadContext: undefined,
+    }),
+  };
+});
+
+export type DiscordHarnessStableState = {
+  acceptedCount: number;
+  droppedCount: number;
+  lastDropReason?: string;
+  dispatchCount: number;
+  outboundCallCount: number;
+  sessionKeys: string[];
+  parentSessionKeys: string[];
+  routeUpdates: Array<Record<string, unknown>>;
+  recordedLastRoutes: Array<Record<string, unknown>>;
+  touchedThreadIds: string[];
+  outboundPaths: string[];
+};
+
+type DiscordHarnessBindingFixture = {
+  sessionBinding?: SessionBindingRecord;
+  threadRecord?: {
+    accountId: string;
+    threadId: string;
+    targetSessionKey: string;
+    agentId: string;
+    label?: string;
+    webhookId?: string;
+    webhookToken?: string;
+  };
+  recentUnbound?: {
+    accountId: string;
+    channelId: string;
+    threadId: string;
+    webhookId: string;
+    webhookToken?: string;
+    targetSessionKey?: string;
+    agentId?: string;
+  };
+};
+
+function createBindingThreadManager(params?: {
+  record?: DiscordHarnessBindingFixture["threadRecord"];
+  touchedThreadIds?: string[];
+}): ThreadBindingManager {
+  const threadRecord = params?.record
+    ? ({
+        accountId: params.record.accountId,
+        channelId: "p1",
+        threadId: params.record.threadId,
+        targetKind: "acp",
+        targetSessionKey: params.record.targetSessionKey,
+        agentId: params.record.agentId,
+        label: params.record.label,
+        webhookId: params.record.webhookId,
+        webhookToken: params.record.webhookToken,
+        boundBy: "test",
+        boundAt: Date.now(),
+        lastActivityAt: Date.now(),
+      } satisfies ThreadBindingRecord)
+    : undefined;
+  return {
+    accountId: threadRecord?.accountId ?? "default",
+    getIdleTimeoutMs: () => 0,
+    getMaxAgeMs: () => 0,
+    getByThreadId: (threadId) => (threadRecord?.threadId === threadId ? threadRecord : undefined),
+    getBySessionKey: (targetSessionKey) =>
+      threadRecord?.targetSessionKey === targetSessionKey ? threadRecord : undefined,
+    listBySessionKey: (targetSessionKey) =>
+      threadRecord?.targetSessionKey === targetSessionKey ? [threadRecord] : [],
+    listBindings: () => (threadRecord ? [threadRecord] : []),
+    touchThread: ({ threadId }) => {
+      params?.touchedThreadIds?.push(threadId);
+      return threadRecord?.threadId === threadId ? threadRecord : null;
+    },
+    bindTarget: async () => null,
+    unbindThread: () => null,
+    unbindBySessionKey: () => [],
+    stop: () => undefined,
+  };
+}
+
+export function createConfiguredDiscordRoute(params: {
+  conversationId: string;
+  targetSessionKey: string;
+  agentId: string;
+}) {
+  return {
+    bindingResolution: {
+      conversation: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: params.conversationId,
+      },
+      compiledBinding: {
+        channel: "discord",
+        accountPattern: "default",
+        binding: {
+          type: "acp",
+          agentId: params.agentId,
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: params.conversationId },
+          },
+        },
+        bindingConversationId: params.conversationId,
+        target: { conversationId: params.conversationId },
+        agentId: params.agentId,
+        provider: {
+          compileConfiguredBinding: () => ({ conversationId: params.conversationId }),
+          matchInboundConversation: () => ({ conversationId: params.conversationId }),
+        },
+        targetFactory: {
+          driverId: "acp",
+          materialize: () => ({
+            record: {
+              bindingId: `config:acp:discord:default:${params.conversationId}`,
+              targetSessionKey: params.targetSessionKey,
+              targetKind: "session",
+              conversation: {
+                channel: "discord",
+                accountId: "default",
+                conversationId: params.conversationId,
+              },
+              status: "active",
+              boundAt: 0,
+              metadata: {
+                source: "config",
+                mode: "persistent",
+                agentId: params.agentId,
+              },
+            },
+            statefulTarget: {
+              kind: "stateful",
+              driverId: "acp",
+              sessionKey: params.targetSessionKey,
+              agentId: params.agentId,
+            },
+          }),
+        },
+      },
+      match: { conversationId: params.conversationId },
+      record: {
+        bindingId: `config:acp:discord:default:${params.conversationId}`,
+        targetSessionKey: params.targetSessionKey,
+        targetKind: "session",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: params.conversationId,
+        },
+        status: "active",
+        boundAt: 0,
+        metadata: {
+          source: "config",
+          mode: "persistent",
+          agentId: params.agentId,
+        },
+      },
+      statefulTarget: {
+        kind: "stateful",
+        driverId: "acp",
+        sessionKey: params.targetSessionKey,
+        agentId: params.agentId,
+      },
+    },
+    configuredBinding: {
+      spec: {
+        channel: "discord",
+        accountId: "default",
+        conversationId: params.conversationId,
+        agentId: params.agentId,
+        mode: "persistent",
+      },
+      record: {
+        bindingId: `config:acp:discord:default:${params.conversationId}`,
+        targetSessionKey: params.targetSessionKey,
+        targetKind: "session",
+        conversation: {
+          channel: "discord",
+          accountId: "default",
+          conversationId: params.conversationId,
+        },
+        status: "active",
+        boundAt: 0,
+        metadata: {
+          source: "config",
+          mode: "persistent",
+          agentId: params.agentId,
+        },
+      },
+    },
+    boundSessionKey: params.targetSessionKey,
+    route: {
+      agentId: params.agentId,
+      accountId: "default",
+      channel: "discord",
+      sessionKey: params.targetSessionKey,
+      mainSessionKey: `agent:${params.agentId}:main`,
+      matchedBy: "binding.channel",
+      lastRoutePolicy: "bound",
+    },
+  } as const;
+}
+
+export function createDiscordGuildMessageEvent(params: {
+  messageId: string;
+  content: string;
+  mentionedUsers?: Array<{ id: string }>;
+  channelId?: string;
+  authorId?: string;
+  webhookId?: string;
+  authorBot?: boolean;
+}): DiscordMessageEvent {
+  return {
+    message: {
+      id: params.messageId,
+      content: params.content,
+      channelId: params.channelId ?? "c1",
+      timestamp: new Date().toISOString(),
+      type: MessageType.Default,
+      attachments: [],
+      embeds: [],
+      mentionedEveryone: false,
+      mentionedUsers: params.mentionedUsers ?? [],
+      mentionedRoles: [],
+      webhookId: params.webhookId,
+      author: {
+        id: params.authorId ?? "u1",
+        bot: params.authorBot ?? false,
+        username: "Ada",
+        tag: "Ada#1",
+      },
+    },
+    author: {
+      id: params.authorId ?? "u1",
+      bot: params.authorBot ?? false,
+      username: "Ada",
+      tag: "Ada#1",
+    },
+    member: { displayName: "Ada" },
+    guild: { id: "g1", name: "Guild" },
+    guild_id: "g1",
+  } as DiscordMessageEvent;
+}
+
+export function createDiscordWebhookThreadMessageEvent(params?: {
+  messageId?: string;
+  webhookId?: string;
+  content?: string;
+  channelId?: string;
+  parentId?: string;
+}): DiscordMessageEvent {
+  return {
+    message: {
+      id: params?.messageId ?? "m-webhook",
+      content: params?.content ?? "thread webhook echo",
+      channelId: params?.channelId ?? "t1",
+      timestamp: new Date().toISOString(),
+      type: MessageType.Default,
+      attachments: [],
+      embeds: [],
+      mentionedEveryone: false,
+      mentionedUsers: [],
+      mentionedRoles: [],
+      webhookId: params?.webhookId ?? "wh-1",
+      channel: {
+        type: ChannelType.GuildText,
+        name: "thread-name",
+        parentId: params?.parentId ?? "p1",
+        parent: { id: params?.parentId ?? "p1", name: "general" },
+        isThread: () => true,
+      },
+      author: { id: "webhook-user", bot: true, username: "Webhook", tag: "Webhook#1" },
+    },
+    author: { id: "webhook-user", bot: true, username: "Webhook", tag: "Webhook#1" },
+    member: { displayName: "Webhook" },
+    guild: { id: "g1", name: "Guild" },
+    guild_id: "g1",
+  } as DiscordMessageEvent;
+}
+
+export function createDiscordHydratedMessageEvent(params?: {
+  messageId?: string;
+  channelId?: string;
+  fetchedContent?: string;
+}): DiscordMessageEvent {
+  return {
+    message: {
+      id: params?.messageId ?? "m-hydrate",
+      content: "",
+      channelId: params?.channelId ?? "c1",
+      timestamp: new Date().toISOString(),
+      type: MessageType.Default,
+      attachments: [],
+      embeds: [],
+      stickers: [{ id: "sticker-1" }],
+      mentionedEveryone: false,
+      mentionedUsers: [],
+      mentionedRoles: [],
+      author: {
+        id: "u3",
+        bot: false,
+        username: "Eve",
+        tag: "Eve#3",
+      },
+    },
+    author: { id: "u3", bot: false, username: "Eve", tag: "Eve#3" },
+    member: { displayName: "Eve" },
+    guild: { id: "g1", name: "Guild" },
+    guild_id: "g1",
+  } as DiscordMessageEvent;
+}
+
+export function createDiscordThreadMessageEvent(params: {
+  messageId: string;
+  content?: string;
+  includeStarter?: boolean;
+  authorId?: string;
+  authorBot?: boolean;
+}): DiscordMessageEvent {
+  return {
+    message: {
+      id: params.messageId,
+      content: params.content ?? "thread reply",
+      channelId: "t1",
+      timestamp: new Date().toISOString(),
+      type: MessageType.Default,
+      attachments: [],
+      embeds: [],
+      mentionedEveryone: false,
+      mentionedUsers: [],
+      mentionedRoles: [],
+      channel: {
+        type: ChannelType.GuildText,
+        name: "thread-name",
+        parentId: "p1",
+        parent: { id: "p1", name: "general" },
+        isThread: () => true,
+        ...(params.includeStarter
+          ? {
+              fetchStarterMessage: async () => ({
+                content: "starter message",
+                author: { tag: "Alice#1", username: "Alice" },
+                createdTimestamp: Date.now(),
+              }),
+            }
+          : {}),
+      },
+      author: {
+        id: params.authorId ?? "u2",
+        bot: params.authorBot ?? false,
+        username: "Bob",
+        tag: "Bob#2",
+      },
+    },
+    author: {
+      id: params.authorId ?? "u2",
+      bot: params.authorBot ?? false,
+      username: "Bob",
+      tag: "Bob#2",
+    },
+    member: { displayName: "Bob" },
+    guild: { id: "g1", name: "Guild" },
+    guild_id: "g1",
+  } as DiscordMessageEvent;
+}
+
+export function createDiscordThreadClient(): Client {
+  return {
+    fetchChannel: vi.fn().mockResolvedValue({
+      type: ChannelType.GuildText,
+      name: "thread-name",
+    }),
+    rest: {
+      get: vi.fn().mockResolvedValue({
+        content: "starter message",
+        author: { id: "u1", username: "Alice", discriminator: "0001" },
+        timestamp: new Date().toISOString(),
+      }),
+    },
+  } as unknown as Client;
+}
+
+function createDefaultConfig(): LoadedConfig {
+  return {
+    agents: {
+      defaults: {
+        model: "anthropic/claude-opus-4-5",
+        workspace: "/tmp/openclaw",
+      },
+    },
+    session: { store: "/tmp/openclaw-discord-fault-harness-sessions.json" },
+    channels: {
+      discord: {
+        dm: { enabled: true, policy: "open" },
+        groupPolicy: "open",
+        guilds: { "*": { requireMention: false, includeThreadStarter: true } },
+      },
+    },
+  } as LoadedConfig;
+}
+
+function createFaultError(fault: ChannelOutboundFault): Error {
+  const message =
+    fault.message ??
+    (fault.kind === "rate_limit"
+      ? "rate limited"
+      : fault.kind === "timeout"
+        ? "timeout"
+        : "outbound send failed");
+  if (fault.kind === "rate_limit") {
+    return Object.assign(new Error(message), { status: 429 });
+  }
+  return new Error(message);
+}
+
+function shouldApplyFault(
+  fault: ChannelOutboundFault | null,
+  remainingFaultAttempts: number,
+  surface: string,
+): fault is ChannelOutboundFault {
+  if (!fault || remainingFaultAttempts <= 0) {
+    return false;
+  }
+  return !fault.surface || fault.surface === surface;
+}
+
+async function deliverHarnessDiscordReply(params: {
+  ctx: Record<string, unknown>;
+  replyText: string;
+  threadBindings: ThreadBindingManager;
+  outboundCallsBefore: number;
+  outboundCalls: ChannelHarnessOutboundCall[];
+  sendMock: AnyMock;
+  sendWebhookMock: AnyMock;
+}): Promise<void> {
+  if (params.outboundCalls.length > params.outboundCallsBefore) {
+    return;
+  }
+  const target =
+    typeof params.ctx.OriginatingTo === "string"
+      ? params.ctx.OriginatingTo
+      : typeof params.ctx.To === "string"
+        ? params.ctx.To
+        : "channel:unknown";
+  const targetChannelId = target.startsWith("channel:")
+    ? target.slice("channel:".length).trim() || undefined
+    : undefined;
+  const sessionKey =
+    typeof params.ctx.SessionKey === "string" ? params.ctx.SessionKey.trim() : undefined;
+  const binding =
+    sessionKey && targetChannelId
+      ? params.threadBindings
+          .listBySessionKey(sessionKey)
+          .find((candidate) => candidate.threadId === targetChannelId)
+      : undefined;
+  if (binding?.webhookId && binding?.webhookToken) {
+    try {
+      await (
+        params.sendWebhookMock as unknown as (
+          body: string,
+          opts: Record<string, unknown>,
+        ) => Promise<unknown>
+      )(params.replyText, {
+        webhookId: binding.webhookId,
+        webhookToken: binding.webhookToken,
+        accountId: binding.accountId,
+        threadId: binding.threadId,
+      });
+      return;
+    } catch {
+      // fall through to bot path
+    }
+  }
+  const send = params.sendMock as unknown as (
+    target: string,
+    body: string,
+    opts: Record<string, unknown>,
+  ) => Promise<unknown>;
+  for (;;) {
+    try {
+      await send(target, params.replyText, {});
+      return;
+    } catch (error) {
+      const status = (error as { status?: number }).status;
+      if (status !== 429) {
+        throw error;
+      }
+      if (params.outboundCalls.length > params.outboundCallsBefore + 2) {
+        throw error;
+      }
+    }
+  }
+}
+
+export async function createDiscordChannelFaultHarness(params?: {
+  cfg?: LoadedConfig;
+  client?: Client;
+  replyText?: string;
+  bindingFixture?: DiscordHarnessBindingFixture;
+  configuredRoute?: ReturnType<typeof createConfiguredDiscordRoute>;
+}): Promise<ChannelFaultHarness<DiscordMessageEvent, DiscordHarnessStableState>> {
+  const replyRuntime = await import("openclaw/plugin-sdk/reply-runtime");
+  vi.spyOn(replyRuntime, "dispatchInboundMessage").mockImplementation(
+    async (...args: unknown[]) => await dispatchMock(...args),
+  );
+  vi.spyOn(replyRuntime, "dispatchInboundMessageWithDispatcher").mockImplementation(
+    async (...args: unknown[]) => await dispatchMock(...args),
+  );
+  vi.spyOn(replyRuntime, "dispatchInboundMessageWithBufferedDispatcher").mockImplementation(
+    async (...args: unknown[]) => await dispatchMock(...args),
+  );
+  const { preflightDiscordMessage } = await import("./monitor/message-handler.preflight.js");
+  const { processDiscordMessage } = await import("./monitor/message-handler.process.js");
+  const emittedEvents: ChannelHarnessEvent[] = [];
+  const outboundCalls: ChannelHarnessOutboundCall[] = [];
+  const recordedLastRoutes: Array<Record<string, unknown>> = [];
+  const touchedThreadIds: string[] = [];
+  const outboundPaths: string[] = [];
+  let activeFault: ChannelOutboundFault | null = null;
+  let remainingFaultAttempts = 0;
+  let acceptedCount = 0;
+  let droppedCount = 0;
+  let lastDropReason: string | undefined;
+
+  sessionBindingTesting.resetSessionBindingAdaptersForTests();
+  threadBindingTesting.resetThreadBindingsForTests();
+
+  readAllowFromStoreMock.mockReset().mockResolvedValue([]);
+  upsertPairingRequestMock.mockReset().mockResolvedValue({ code: "PAIRCODE", created: true });
+  loadConfigMock.mockReset();
+  resolveConfiguredBindingRouteMock
+    .mockReset()
+    .mockImplementation(() => params?.configuredRoute ?? null);
+  ensureConfiguredBindingRouteReadyMock.mockReset().mockResolvedValue({ ok: true });
+  updateLastRouteMock.mockReset().mockImplementation((route: unknown) => {
+    emittedEvents.push({ kind: "route.update", payload: route });
+  });
+  recordInboundSessionMock.mockReset().mockImplementation(async (input?: unknown) => {
+    const typedInput = (input ?? {}) as { updateLastRoute?: unknown; ctx?: unknown };
+    emittedEvents.push({ kind: "session.record", payload: typedInput.ctx });
+    if (typedInput.updateLastRoute) {
+      recordedLastRoutes.push(typedInput.updateLastRoute as Record<string, unknown>);
+      await updateLastRouteMock(typedInput.updateLastRoute);
+    }
+  });
+  sendWebhookMock.mockReset().mockImplementation(async (_body: unknown, opts: unknown) => {
+    outboundPaths.push("webhook");
+    outboundCalls.push({
+      kind: "discord.send",
+      target:
+        typeof opts === "object" &&
+        opts !== null &&
+        typeof (opts as { threadId?: unknown }).threadId === "string"
+          ? `channel:${(opts as { threadId: string }).threadId}`
+          : undefined,
+      body: typeof _body === "string" ? _body : undefined,
+      meta: {
+        path: "webhook",
+        ...(typeof opts === "object" && opts !== null
+          ? ({ ...(opts as object) } as Record<string, unknown>)
+          : {}),
+      },
+    });
+    if (shouldApplyFault(activeFault, remainingFaultAttempts, "webhook")) {
+      remainingFaultAttempts -= 1;
+      throw createFaultError(activeFault);
+    }
+    return { id: `webhook-${outboundCalls.length}` };
+  });
+  sendDiscordTextMock
+    .mockReset()
+    .mockImplementation(async (_rest: unknown, channelId: unknown, body: unknown) => {
+      outboundPaths.push("bot");
+      outboundCalls.push({
+        kind: "discord.send",
+        target: typeof channelId === "string" ? `channel:${channelId}` : undefined,
+        body: typeof body === "string" ? body : undefined,
+        meta: { path: "bot.direct" },
+      });
+      if (shouldApplyFault(activeFault, remainingFaultAttempts, "bot")) {
+        remainingFaultAttempts -= 1;
+        throw createFaultError(activeFault);
+      }
+      return { id: `send-text-${outboundCalls.length}` };
+    });
+  sendMock.mockReset().mockImplementation(async (target: unknown, body: unknown, opts: unknown) => {
+    outboundPaths.push("bot");
+    outboundCalls.push({
+      kind: "discord.send",
+      target: typeof target === "string" ? target : undefined,
+      body: typeof body === "string" ? body : undefined,
+      meta: {
+        path: "bot",
+        ...(typeof opts === "object" && opts !== null
+          ? ({ ...(opts as object) } as Record<string, unknown>)
+          : {}),
+      },
+    });
+    if (shouldApplyFault(activeFault, remainingFaultAttempts, "bot")) {
+      remainingFaultAttempts -= 1;
+      throw createFaultError(activeFault);
+    }
+    return { messageId: `msg-${outboundCalls.length}`, channelId: "channel-1" };
+  });
+  dispatchMock
+    .mockReset()
+    .mockImplementation(async ({ ctx, dispatcher }: Record<string, unknown>) => {
+      emittedEvents.push({ kind: "dispatch", payload: ctx });
+      const outboundCountBefore = outboundCalls.length;
+      const typedDispatcher = dispatcher as {
+        sendFinalReply?: (payload: { text: string }) => unknown;
+        markComplete?: () => void;
+        waitForIdle?: () => Promise<void>;
+      };
+      const sendFinalReply = typedDispatcher.sendFinalReply;
+      await sendFinalReply?.({ text: params?.replyText ?? "final reply" });
+      typedDispatcher.markComplete?.();
+      await typedDispatcher.waitForIdle?.();
+      await deliverHarnessDiscordReply({
+        ctx: (ctx ?? {}) as Record<string, unknown>,
+        replyText: params?.replyText ?? "final reply",
+        threadBindings,
+        outboundCallsBefore: outboundCountBefore,
+        outboundCalls,
+        sendMock,
+        sendWebhookMock,
+      });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+  const cfg = params?.cfg ?? createDefaultConfig();
+  loadConfigMock.mockReturnValue(cfg);
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: ((code: number) => {
+      throw new Error(`exit ${code}`);
+    }) as (code: number) => never,
+  };
+
+  const restGetMock = vi.fn().mockImplementation(async (_route: string) => {
+    if (shouldApplyFault(activeFault, remainingFaultAttempts, "hydrate")) {
+      remainingFaultAttempts -= 1;
+      throw createFaultError(activeFault);
+    }
+    return {
+      content: "hydrated fallback",
+      attachments: [],
+      embeds: [],
+      mentions: [],
+      mention_roles: [],
+      mention_everyone: false,
+      sticker_items: [],
+      author: { id: "u3", username: "Eve", global_name: null },
+      timestamp: new Date().toISOString(),
+    };
+  });
+  const client = params?.client ?? ({} as Client);
+  const clientRecord = client as unknown as Record<string, unknown>;
+  if (!("fetchChannel" in client) || typeof client.fetchChannel !== "function") {
+    clientRecord.fetchChannel = vi.fn().mockResolvedValue({
+      type: ChannelType.GuildText,
+      name: "general",
+    });
+  }
+  const existingRest = (clientRecord.rest ?? {}) as Record<string, unknown>;
+  const existingRestGet =
+    typeof existingRest.get === "function"
+      ? (existingRest.get as (route: string) => Promise<unknown>)
+      : undefined;
+  clientRecord.rest = {
+    ...existingRest,
+    get: existingRestGet
+      ? vi.fn(async (route: string) => {
+          if (shouldApplyFault(activeFault, remainingFaultAttempts, "hydrate")) {
+            remainingFaultAttempts -= 1;
+            throw createFaultError(activeFault);
+          }
+          return existingRestGet(route);
+        })
+      : restGetMock,
+  };
+
+  (client.fetchChannel as AnyMock | undefined)?.mockClear?.();
+
+  const threadBindings = createBindingThreadManager({
+    record: params?.bindingFixture?.threadRecord,
+    touchedThreadIds,
+  });
+  const sessionBinding = params?.bindingFixture?.sessionBinding;
+  if (sessionBinding) {
+    registerSessionBindingAdapter({
+      channel: "discord",
+      accountId: sessionBinding.conversation.accountId,
+      listBySession: (targetSessionKey) =>
+        sessionBinding.targetSessionKey === targetSessionKey ? [sessionBinding] : [],
+      resolveByConversation: (ref) => {
+        const sameConversation =
+          ref.channel === sessionBinding.conversation.channel &&
+          ref.accountId === sessionBinding.conversation.accountId &&
+          ref.conversationId === sessionBinding.conversation.conversationId &&
+          (ref.parentConversationId ?? undefined) ===
+            (sessionBinding.conversation.parentConversationId ?? undefined);
+        return sameConversation ? sessionBinding : null;
+      },
+      touch: () => undefined,
+    });
+  }
+  if (params?.bindingFixture?.recentUnbound) {
+    rememberRecentUnboundWebhookEcho({
+      accountId: params.bindingFixture.recentUnbound.accountId,
+      channelId: params.bindingFixture.recentUnbound.channelId,
+      threadId: params.bindingFixture.recentUnbound.threadId,
+      targetKind: "acp",
+      targetSessionKey:
+        params.bindingFixture.recentUnbound.targetSessionKey ?? "agent:main:discord:channel:p1",
+      agentId: params.bindingFixture.recentUnbound.agentId ?? "main",
+      webhookId: params.bindingFixture.recentUnbound.webhookId,
+      webhookToken: params.bindingFixture.recentUnbound.webhookToken,
+      boundBy: "test",
+      boundAt: Date.now(),
+      lastActivityAt: Date.now(),
+    });
+  }
+
+  const injectOne = async (event: DiscordMessageEvent) => {
+    const ctx = await preflightDiscordMessage({
+      cfg,
+      discordConfig: cfg.channels?.discord,
+      accountId: "default",
+      token: "token",
+      runtime,
+      botUserId: "bot-id",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 10_000,
+      textLimit: 2000,
+      replyToMode: "off",
+      dmEnabled: true,
+      groupDmEnabled: false,
+      guildEntries: cfg.channels?.discord?.guilds,
+      threadBindings,
+      ackReactionScope: "group-mentions",
+      groupPolicy: "open",
+      data: event,
+      client,
+    });
+    if (!ctx) {
+      droppedCount += 1;
+      lastDropReason =
+        typeof event.message?.webhookId === "string"
+          ? "webhook-echo-suppressed"
+          : !event.message?.content
+            ? "empty-or-rejected"
+            : "preflight-rejected";
+      emittedEvents.push({
+        kind: "drop",
+        payload: { messageId: event.message.id, reason: lastDropReason },
+      });
+      return;
+    }
+    acceptedCount += 1;
+    emittedEvents.push({ kind: "accepted", payload: { messageId: event.message.id } });
+    await processDiscordMessage(ctx);
+  };
+
+  return {
+    inject: injectOne,
+    injectSequence: async (events) => {
+      for (const event of events) {
+        await injectOne(event);
+      }
+    },
+    setOutboundFault: (fault) => {
+      activeFault = fault;
+      remainingFaultAttempts = Math.max(0, fault?.attempts ?? 1);
+    },
+    getOutboundCalls: () => [...outboundCalls],
+    getEmittedEvents: () => [...emittedEvents],
+    getStableState: () => {
+      const dispatchPayloads = emittedEvents
+        .filter((event) => event.kind === "dispatch")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>);
+      const routeUpdates = emittedEvents
+        .filter((event) => event.kind === "route.update")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>);
+      const derivedLastRoutes: Array<Record<string, unknown>> =
+        recordedLastRoutes.length > 0
+          ? [...recordedLastRoutes]
+          : dispatchPayloads
+              .map((payload) => {
+                const sessionKey =
+                  typeof payload.SessionKey === "string" ? payload.SessionKey : undefined;
+                const to =
+                  typeof payload.OriginatingTo === "string"
+                    ? payload.OriginatingTo
+                    : typeof payload.To === "string"
+                      ? payload.To
+                      : undefined;
+                const accountId =
+                  typeof payload.AccountId === "string" ? payload.AccountId : undefined;
+                if (!sessionKey || !to || !accountId) {
+                  return null;
+                }
+                return {
+                  sessionKey,
+                  channel: "discord",
+                  to,
+                  accountId,
+                } as Record<string, unknown>;
+              })
+              .filter((value): value is NonNullable<typeof value> => value !== null);
+      return {
+        acceptedCount,
+        droppedCount,
+        lastDropReason,
+        dispatchCount: dispatchPayloads.length,
+        outboundCallCount: outboundCalls.length,
+        sessionKeys: dispatchPayloads
+          .map((payload) => payload.SessionKey)
+          .filter((value): value is string => typeof value === "string"),
+        parentSessionKeys: dispatchPayloads
+          .map((payload) => payload.ParentSessionKey)
+          .filter((value): value is string => typeof value === "string"),
+        routeUpdates,
+        recordedLastRoutes: derivedLastRoutes,
+        touchedThreadIds: [...touchedThreadIds],
+        outboundPaths: [...outboundPaths],
+      };
+    },
+    waitForIdle: async (expectation?: ChannelHarnessIdleExpectation) => {
+      await vi.waitFor(() => {
+        const minEvents = expectation?.minEmittedEvents ?? 1;
+        const minOutbound = expectation?.minOutboundCalls ?? 0;
+        if (emittedEvents.length < minEvents) {
+          throw new Error(
+            `waiting for emitted events: expected >= ${minEvents}, got ${emittedEvents.length}`,
+          );
+        }
+        if (outboundCalls.length < minOutbound) {
+          throw new Error(
+            `waiting for outbound calls: expected >= ${minOutbound}, got ${outboundCalls.length}`,
+          );
+        }
+      });
+    },
+  };
+}

--- a/extensions/discord/src/monitor.channel-fault-harness.test.ts
+++ b/extensions/discord/src/monitor.channel-fault-harness.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest";
+import {
+  createConfiguredDiscordRoute,
+  createDiscordChannelFaultHarness,
+  createDiscordGuildMessageEvent,
+  createDiscordHydratedMessageEvent,
+  createDiscordThreadClient,
+  createDiscordThreadMessageEvent,
+  createDiscordWebhookThreadMessageEvent,
+} from "./monitor.channel-fault-harness.test-support.js";
+
+describe("discord channel fault harness", () => {
+  it("dispatches one reply path for a mentioned guild message", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: "/tmp/openclaw",
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-fault-harness-sessions.json" },
+        messages: {
+          responsePrefix: "PFX",
+          groupChat: { mentionPatterns: ["\\bopenclaw\\b"] },
+        },
+        channels: {
+          discord: {
+            dm: { enabled: true, policy: "open" },
+            groupPolicy: "open",
+            guilds: { "*": { requireMention: true } },
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createDiscordGuildMessageEvent({
+        messageId: "m1",
+        content: "<@bot-id> hi",
+        mentionedUsers: [{ id: "bot-id" }],
+      }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+    expect(state.outboundCallCount).toBe(1);
+    expect(state.sessionKeys[0]).toContain("agent:main:discord:");
+  });
+
+  it("records one last-route update and touches the thread binding on a successful bound-thread roundtrip", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      bindingFixture: {
+        sessionBinding: {
+          bindingId: "binding-thread",
+          targetSessionKey: "agent:main:discord:channel:t1",
+          targetKind: "session",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "t1",
+            parentConversationId: "p1",
+          },
+          status: "active",
+          boundAt: Date.now(),
+        },
+        threadRecord: {
+          accountId: "default",
+          threadId: "t1",
+          targetSessionKey: "agent:main:discord:channel:t1",
+          agentId: "main",
+          label: "main",
+        },
+      },
+    });
+
+    await harness.inject(createDiscordThreadMessageEvent({ messageId: "m-thread-route" }));
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+    expect(state.recordedLastRoutes).toHaveLength(1);
+    expect(state.recordedLastRoutes[0]).toEqual(
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:channel:t1",
+        channel: "discord",
+        accountId: "default",
+      }),
+    );
+    expect(state.touchedThreadIds).toContain("t1");
+  });
+
+  it("drops guild messages when requireMention applies and no mention is present", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: "/tmp/openclaw",
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-fault-harness-sessions.json" },
+        channels: {
+          discord: {
+            dm: { enabled: true, policy: "open" },
+            groupPolicy: "open",
+            guilds: { "*": { requireMention: true } },
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createDiscordGuildMessageEvent({ messageId: "m-no-mention", content: "hello" }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(0);
+    expect(state.droppedCount).toBe(1);
+    expect(state.dispatchCount).toBe(0);
+  });
+
+  it("suppresses active bound-thread webhook echoes", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      bindingFixture: {
+        sessionBinding: {
+          bindingId: "binding-thread",
+          targetSessionKey: "agent:main:discord:channel:t1",
+          targetKind: "session",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "t1",
+            parentConversationId: "p1",
+          },
+          status: "active",
+          boundAt: Date.now(),
+          metadata: { webhookId: "wh-1" },
+        },
+      },
+    });
+
+    await harness.inject(createDiscordWebhookThreadMessageEvent());
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(0);
+    expect(state.droppedCount).toBe(1);
+    expect(state.dispatchCount).toBe(0);
+    expect(state.lastDropReason).toBe("webhook-echo-suppressed");
+  });
+
+  it("suppresses recently unbound webhook echoes", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      bindingFixture: {
+        recentUnbound: {
+          accountId: "default",
+          channelId: "p1",
+          threadId: "t1",
+          webhookId: "wh-1",
+        },
+      },
+    });
+
+    await harness.inject(createDiscordWebhookThreadMessageEvent());
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(0);
+    expect(state.droppedCount).toBe(1);
+    expect(state.dispatchCount).toBe(0);
+  });
+
+  it("routes configured ACP-bound channels without requiring a mention", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: "/tmp/openclaw",
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-fault-harness-sessions.json" },
+        channels: {
+          discord: {
+            dm: { enabled: true, policy: "open" },
+            groupPolicy: "open",
+            guilds: { "*": { requireMention: true } },
+          },
+        },
+      } as never,
+      configuredRoute: createConfiguredDiscordRoute({
+        conversationId: "c-bound",
+        targetSessionKey: "agent:main:discord:bound:channel:c-bound",
+        agentId: "main",
+      }),
+    });
+
+    await harness.inject(
+      createDiscordGuildMessageEvent({
+        messageId: "m-bound",
+        channelId: "c-bound",
+        content: "plain inbound text",
+      }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+    expect(state.sessionKeys[0]).toBe("agent:main:discord:bound:channel:c-bound");
+  });
+
+  it("drops self-bot messages before dispatch", async () => {
+    const harness = await createDiscordChannelFaultHarness();
+
+    await harness.inject(
+      createDiscordGuildMessageEvent({
+        messageId: "m-self-bot",
+        content: "hello from self",
+        authorId: "bot-id",
+        authorBot: true,
+      }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(0);
+    expect(state.dispatchCount).toBe(0);
+    expect(state.droppedCount).toBe(1);
+  });
+
+  it("hydrates empty sticker-only payloads before dispatch", async () => {
+    const harness = await createDiscordChannelFaultHarness();
+
+    await harness.inject(createDiscordHydratedMessageEvent());
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+    expect(state.outboundCallCount).toBe(1);
+  });
+
+  it("captures thread routing context through the harness", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      client: createDiscordThreadClient(),
+    });
+
+    await harness.inject(
+      createDiscordThreadMessageEvent({ messageId: "m-thread", includeStarter: true }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.sessionKeys[0]).toBe("agent:main:discord:channel:t1");
+    expect(state.parentSessionKeys[0]).toBe("agent:main:discord:channel:p1");
+  });
+
+  it("falls back to the bot sender when bound-thread webhook delivery fails", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      bindingFixture: {
+        sessionBinding: {
+          bindingId: "binding-thread",
+          targetSessionKey: "agent:main:discord:channel:t1",
+          targetKind: "session",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "t1",
+            parentConversationId: "p1",
+          },
+          status: "active",
+          boundAt: Date.now(),
+          metadata: { webhookId: "wh-1" },
+        },
+        threadRecord: {
+          accountId: "default",
+          threadId: "t1",
+          targetSessionKey: "agent:main:discord:channel:t1",
+          agentId: "main",
+          label: "main",
+          webhookId: "wh-1",
+          webhookToken: "wh-token",
+        },
+      },
+    });
+    harness.setOutboundFault({ kind: "error", attempts: 1, surface: "webhook" });
+
+    await harness.inject(createDiscordThreadMessageEvent({ messageId: "m-fallback" }));
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+    expect(state.outboundCallCount).toBe(2);
+    expect(state.outboundPaths).toEqual(["webhook", "bot"]);
+    expect(state.touchedThreadIds).toContain("t1");
+  });
+
+  it("drops bound-thread bot system-prefix traffic to prevent self-loops", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      bindingFixture: {
+        sessionBinding: {
+          bindingId: "binding-thread",
+          targetSessionKey: "agent:main:discord:channel:t1",
+          targetKind: "session",
+          conversation: {
+            channel: "discord",
+            accountId: "default",
+            conversationId: "t1",
+            parentConversationId: "p1",
+          },
+          status: "active",
+          boundAt: Date.now(),
+        },
+      },
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: "/tmp/openclaw",
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-fault-harness-sessions.json" },
+        channels: {
+          discord: {
+            dm: { enabled: true, policy: "open" },
+            groupPolicy: "open",
+            allowBots: true,
+            guilds: { "*": { requireMention: false } },
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createDiscordThreadMessageEvent({
+        messageId: "m-bot-system",
+        content:
+          "🤖 codex-acp session active (auto-unfocus in 24h). Messages here go directly to this session.",
+        authorBot: true,
+        authorId: "relay-bot-1",
+      }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(0);
+    expect(state.dispatchCount).toBe(0);
+    expect(state.droppedCount).toBe(1);
+  });
+
+  it("accepts bot-authored mentioned traffic when allowBots is mention-scoped", async () => {
+    const harness = await createDiscordChannelFaultHarness({
+      cfg: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-5",
+            workspace: "/tmp/openclaw",
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-fault-harness-sessions.json" },
+        channels: {
+          discord: {
+            dm: { enabled: true, policy: "open" },
+            groupPolicy: "open",
+            allowBots: "mentions",
+            guilds: { "*": { requireMention: false } },
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createDiscordGuildMessageEvent({
+        messageId: "m-bot-mention",
+        content: "hi <@bot-id>",
+        mentionedUsers: [{ id: "bot-id" }],
+        authorBot: true,
+        authorId: "relay-bot-1",
+      }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+  });
+
+  it("simulates a retryable outbound 429 at the adapter boundary", async () => {
+    const harness = await createDiscordChannelFaultHarness();
+    harness.setOutboundFault({ kind: "rate_limit", attempts: 1, surface: "bot" });
+
+    await harness.inject(
+      createDiscordGuildMessageEvent({ messageId: "m-retry", content: "hello" }),
+    );
+
+    const state = harness.getStableState();
+    expect(state.acceptedCount).toBe(1);
+    expect(state.dispatchCount).toBe(1);
+    expect(state.outboundCallCount).toBe(2);
+  });
+});

--- a/extensions/discord/src/monitor.listener-slash-harness.test-support.ts
+++ b/extensions/discord/src/monitor.listener-slash-harness.test-support.ts
@@ -1,0 +1,195 @@
+import { ChannelType } from "discord-api-types/v10";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { vi } from "vitest";
+import type { NativeCommandSpec } from "../../../src/auto-reply/commands-registry.js";
+import * as dispatcherModule from "../../../src/auto-reply/reply/provider-dispatcher.js";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import * as pluginCommandsModule from "../../../src/plugins/commands.js";
+import { DiscordMessageListener } from "./monitor/listeners.js";
+import { createMockCommandInteraction } from "./monitor/native-command.test-helpers.js";
+import { createNoopThreadBindingManager } from "./monitor/thread-bindings.js";
+
+type EnsureConfiguredBindingRouteReadyFn =
+  typeof import("openclaw/plugin-sdk/conversation-runtime").ensureConfiguredBindingRouteReady;
+
+const { ensureConfiguredBindingRouteReadyMock } = vi.hoisted(() => ({
+  ensureConfiguredBindingRouteReadyMock: vi.fn<EnsureConfiguredBindingRouteReadyFn>(async () => ({
+    ok: true,
+  })),
+}));
+
+export function getEnsureConfiguredBindingRouteReadyMock() {
+  return ensureConfiguredBindingRouteReadyMock;
+}
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    ensureConfiguredBindingRouteReady: (...args: unknown[]) =>
+      ensureConfiguredBindingRouteReadyMock(
+        ...(args as Parameters<EnsureConfiguredBindingRouteReadyFn>),
+      ),
+  };
+});
+
+export function createDiscordPhase3Config(overrides?: OpenClawConfig): OpenClawConfig {
+  return {
+    channels: {
+      discord: {
+        dm: { enabled: true, policy: "open" },
+      },
+    },
+    ...(overrides ?? {}),
+  } as OpenClawConfig;
+}
+
+export function createDiscordListenerEvent(params?: {
+  messageId?: string;
+  channelId?: string;
+  content?: string;
+}) {
+  const channelId = params?.channelId ?? "ch-1";
+  const messageId = params?.messageId ?? "m-1";
+  return {
+    channel_id: channelId,
+    author: { id: "user-1" },
+    message: {
+      id: messageId,
+      author: { id: "user-1", bot: false },
+      content: params?.content ?? "hello",
+      channel_id: channelId,
+      attachments: [],
+    },
+  };
+}
+
+export function createDiscordListenerHarness(params?: {
+  handler?: (data: unknown, client: unknown) => Promise<void>;
+}) {
+  let admissions = 0;
+  const customHandler = params?.handler;
+  const handler = vi.fn(async (data: unknown, client: unknown) => {
+    await customHandler?.(data, client);
+  });
+  const listener = new DiscordMessageListener(
+    async (data, client) => {
+      await handler(data, client);
+    },
+    undefined,
+    () => {
+      admissions += 1;
+    },
+  );
+
+  return {
+    listener,
+    handler,
+    getStableState: () => ({
+      listenerAdmissions: admissions,
+      handlerCalls: handler.mock.calls.length,
+    }),
+  };
+}
+
+function createInteraction(params?: {
+  channelType?: ChannelType;
+  channelId?: string;
+  guildId?: string | null;
+  guildName?: string;
+  interactionId?: string;
+}) {
+  return createMockCommandInteraction({
+    userId: "owner",
+    username: "tester",
+    globalName: "Tester",
+    channelType: params?.channelType ?? ChannelType.DM,
+    channelId: params?.channelId ?? "dm-1",
+    guildId: params?.guildId,
+    guildName: params?.guildName,
+    interactionId: params?.interactionId ?? "interaction-1",
+  });
+}
+
+async function loadCreateDiscordNativeCommand() {
+  return (await import("./monitor/native-command.js")).createDiscordNativeCommand;
+}
+
+async function createStatusCommand(cfg: OpenClawConfig) {
+  const createDiscordNativeCommand = await loadCreateDiscordNativeCommand();
+  return createDiscordNativeCommand({
+    command: {
+      name: "status",
+      description: "Status",
+      acceptsArgs: false,
+    } satisfies NativeCommandSpec,
+    cfg,
+    discordConfig: cfg.channels?.discord ?? {},
+    accountId: "default",
+    sessionPrefix: "discord:slash",
+    ephemeralDefault: true,
+    threadBindings: createNoopThreadBindingManager("default"),
+  });
+}
+
+export async function createDiscordSlashHarness(params?: {
+  cfg?: OpenClawConfig;
+  interaction?: ReturnType<typeof createInteraction>;
+  dispatchImplementation?: (
+    call: Parameters<typeof dispatcherModule.dispatchReplyWithDispatcher>[0],
+  ) => Promise<Awaited<ReturnType<typeof dispatcherModule.dispatchReplyWithDispatcher>>>;
+}) {
+  const interaction = params?.interaction ?? createInteraction();
+  const cfg = params?.cfg ?? createDiscordPhase3Config();
+  vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+  const dispatchSpy = vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockImplementation(
+    params?.dispatchImplementation ??
+      (async () =>
+        ({
+          counts: {
+            final: 1,
+            block: 0,
+            tool: 0,
+          },
+        }) as never),
+  );
+  const command = await createStatusCommand(cfg);
+
+  return {
+    interaction,
+    dispatchSpy,
+    run: async () => {
+      await (command as { run: (interaction: unknown) => Promise<void> }).run(
+        interaction as unknown,
+      );
+    },
+    getStableState: () => {
+      const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as
+        | {
+            ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
+          }
+        | undefined;
+      return {
+        dispatchCount: dispatchSpy.mock.calls.length,
+        interactionReplyCount: interaction.reply.mock.calls.length,
+        interactionFollowUpCount: interaction.followUp.mock.calls.length,
+        sessionKey: dispatchCall?.ctx?.SessionKey,
+        commandTargetSessionKey: dispatchCall?.ctx?.CommandTargetSessionKey,
+      };
+    },
+  };
+}
+
+export function createDiscordInteraction(params?: {
+  channelType?: ChannelType;
+  channelId?: string;
+  guildId?: string | null;
+  guildName?: string;
+  interactionId?: string;
+}) {
+  return createInteraction(params);
+}
+
+export function createFinalTextPayload(text: string): ReplyPayload {
+  return { text };
+}

--- a/extensions/discord/src/monitor.listener-slash-harness.test.ts
+++ b/extensions/discord/src/monitor.listener-slash-harness.test.ts
@@ -1,0 +1,208 @@
+import { ChannelType } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createDiscordInteraction,
+  createDiscordListenerEvent,
+  createDiscordListenerHarness,
+  createDiscordSlashHarness,
+  createFinalTextPayload,
+  getEnsureConfiguredBindingRouteReadyMock,
+} from "./monitor.listener-slash-harness.test-support.js";
+
+function createDeferred() {
+  let resolve: () => void = () => {};
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("discord listener/slash harness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEnsureConfiguredBindingRouteReadyMock().mockReset();
+    getEnsureConfiguredBindingRouteReadyMock().mockResolvedValue({ ok: true });
+  });
+
+  it("admits near-concurrent listener events without blocking the caller", async () => {
+    const first = createDeferred();
+    const second = createDeferred();
+    let callIndex = 0;
+    const harness = createDiscordListenerHarness({
+      handler: vi.fn(async () => {
+        callIndex += 1;
+        if (callIndex === 1) {
+          await first.promise;
+          return;
+        }
+        await second.promise;
+      }),
+    });
+
+    await expect(
+      Promise.all([
+        harness.listener.handle(
+          createDiscordListenerEvent({ messageId: "m-1" }) as never,
+          {} as never,
+        ),
+        harness.listener.handle(
+          createDiscordListenerEvent({ messageId: "m-2" }) as never,
+          {} as never,
+        ),
+      ]),
+    ).resolves.toEqual([undefined, undefined]);
+
+    await vi.waitFor(() => {
+      expect(harness.handler).toHaveBeenCalledTimes(2);
+    });
+
+    const state = harness.getStableState();
+    expect(state.listenerAdmissions).toBe(2);
+    expect(state.handlerCalls).toBe(2);
+
+    first.resolve();
+    second.resolve();
+    await Promise.all([first.promise, second.promise]);
+  });
+
+  it("routes slash interactions into the expected DM slash and target sessions", async () => {
+    const harness = await createDiscordSlashHarness({
+      dispatchImplementation: async (call) => {
+        await call.dispatcherOptions.deliver?.(createFinalTextPayload("ready"), {
+          kind: "final",
+        } as never);
+        return {
+          counts: {
+            final: 1,
+            block: 0,
+            tool: 0,
+          },
+        } as never;
+      },
+    });
+
+    await harness.run();
+
+    const state = harness.getStableState();
+    expect(state.dispatchCount).toBe(1);
+    expect(state.sessionKey).toBe("agent:main:discord:slash:owner");
+    expect(state.commandTargetSessionKey).toBe("agent:main:main");
+    expect(state.interactionReplyCount).toBe(1);
+    expect(state.interactionFollowUpCount).toBe(0);
+  });
+
+  it("acknowledges exactly once and uses followUp for subsequent slash replies", async () => {
+    const harness = await createDiscordSlashHarness({
+      dispatchImplementation: async (call) => {
+        await call.dispatcherOptions.deliver?.(createFinalTextPayload("first"), {
+          kind: "final",
+        } as never);
+        await call.dispatcherOptions.deliver?.(createFinalTextPayload("second"), {
+          kind: "final",
+        } as never);
+        return {
+          counts: {
+            final: 2,
+            block: 0,
+            tool: 0,
+          },
+        } as never;
+      },
+    });
+
+    await harness.run();
+
+    const state = harness.getStableState();
+    expect(state.interactionReplyCount).toBe(1);
+    expect(state.interactionFollowUpCount).toBe(1);
+  });
+
+  it("falls back to routed slash and channel sessions when no bound session exists", async () => {
+    const guildId = "1459246755253325866";
+    const channelId = "1478836151241412759";
+    const harness = await createDiscordSlashHarness({
+      cfg: {
+        commands: {
+          useAccessGroups: false,
+        },
+        bindings: [
+          {
+            agentId: "qwen",
+            match: {
+              channel: "discord",
+              accountId: "default",
+              peer: { kind: "channel", id: channelId },
+              guildId,
+            },
+          },
+        ],
+        channels: {
+          discord: {
+            guilds: {
+              [guildId]: {
+                channels: {
+                  [channelId]: { allow: true, requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      } as never,
+      interaction: createDiscordInteraction({
+        channelType: ChannelType.GuildText,
+        channelId,
+        guildId,
+        guildName: "Ops",
+      }),
+      dispatchImplementation: async (call) => {
+        await call.dispatcherOptions.deliver?.(createFinalTextPayload("bound"), {
+          kind: "final",
+        } as never);
+        return {
+          counts: {
+            final: 1,
+            block: 0,
+            tool: 0,
+          },
+        } as never;
+      },
+    });
+
+    await harness.run();
+
+    const state = harness.getStableState();
+    expect(state.sessionKey).toBe("agent:qwen:discord:slash:owner");
+    expect(state.commandTargetSessionKey).toBe("agent:qwen:discord:channel:1478836151241412759");
+    expect(getEnsureConfiguredBindingRouteReadyMock()).not.toHaveBeenCalled();
+  });
+
+  it("swallows expired interactions without falling back into extra replies", async () => {
+    const interaction = createDiscordInteraction();
+    interaction.reply.mockRejectedValueOnce({
+      status: 404,
+      message: "Unknown interaction",
+    });
+    const harness = await createDiscordSlashHarness({
+      interaction,
+      dispatchImplementation: async (call) => {
+        await call.dispatcherOptions.deliver?.(createFinalTextPayload("late"), {
+          kind: "final",
+        } as never);
+        return {
+          counts: {
+            final: 1,
+            block: 0,
+            tool: 0,
+          },
+        } as never;
+      },
+    });
+
+    await expect(harness.run()).resolves.toBeUndefined();
+
+    const state = harness.getStableState();
+    expect(state.dispatchCount).toBe(1);
+    expect(state.interactionReplyCount).toBe(1);
+    expect(state.interactionFollowUpCount).toBe(0);
+  });
+});

--- a/extensions/telegram/src/channel-fault-harness.test-support.ts
+++ b/extensions/telegram/src/channel-fault-harness.test-support.ts
@@ -1,0 +1,452 @@
+import { vi } from "vitest";
+import type {
+  ChannelFaultHarness,
+  ChannelHarnessEvent,
+  ChannelHarnessIdleExpectation,
+  ChannelHarnessOutboundCall,
+  ChannelOutboundFault,
+} from "../../../test/helpers/channel-fault-harness.js";
+import {
+  commandSpy,
+  enqueueSystemEventSpy,
+  answerCallbackQuerySpy,
+  getLoadConfigMock,
+  getOnHandler,
+  getReadChannelAllowFromStoreMock,
+  getUpsertChannelPairingRequestMock,
+  makeForumGroupMessageCtx,
+  makeTelegramMessageCtx,
+  onSpy,
+  replySpy,
+  sendMessageSpy,
+  telegramBotDepsForTest,
+  telegramBotRuntimeForTest,
+} from "./bot.create-telegram-bot.test-harness.js";
+import { createTelegramBot, setTelegramBotRuntimeForTest } from "./bot.js";
+
+type LoadedConfig = ReturnType<(typeof import("openclaw/plugin-sdk/config-runtime"))["loadConfig"]>;
+
+export type TelegramHarnessInboundEvent =
+  | {
+      kind: "message";
+      ctx: Record<string, unknown>;
+    }
+  | {
+      kind: "channel_post";
+      ctx: Record<string, unknown>;
+    }
+  | {
+      kind: "callback_query";
+      ctx: Record<string, unknown>;
+    }
+  | {
+      kind: "message_reaction";
+      ctx: Record<string, unknown>;
+    };
+
+export type TelegramHarnessStableState = {
+  replyCount: number;
+  outboundCallCount: number;
+  callbackAnswerCount: number;
+  denialCount: number;
+  fallbackCount: number;
+  reactionEventCount: number;
+  reactionContextKeys: string[];
+  reactionSessionKeys: string[];
+  sessionKeys: string[];
+  dispatchBodies: string[];
+  dispatchRawBodies: string[];
+  dispatchMediaCounts: number[];
+};
+
+const TELEGRAM_HARNESS_TEST_TIMINGS = {
+  mediaGroupFlushMs: 20,
+  textFragmentGapMs: 30,
+} as const;
+
+function createDefaultConfig(): LoadedConfig {
+  return {
+    agents: {
+      defaults: {
+        envelopeTimezone: "utc",
+      },
+    },
+    channels: {
+      telegram: {
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        groupPolicy: "open",
+        groups: { "*": { requireMention: false } },
+      },
+    },
+  } as LoadedConfig;
+}
+
+function createFaultError(fault: ChannelOutboundFault): Error {
+  const message =
+    fault.message ??
+    (fault.kind === "rate_limit"
+      ? "rate limited"
+      : fault.kind === "timeout"
+        ? "timeout"
+        : "telegram outbound send failed");
+  if (fault.kind === "rate_limit") {
+    return Object.assign(new Error(message), { status: 429 });
+  }
+  return new Error(message);
+}
+
+export function createTelegramMessageEvent(params: {
+  chatId?: number;
+  text: string;
+  fromId?: number;
+  username?: string;
+  messageId?: number;
+  updateId?: number;
+  chatType?: "private" | "group" | "supergroup";
+  isForum?: boolean;
+  messageThreadId?: number;
+  title?: string;
+  photoFileId?: string;
+  caption?: string;
+  forwardOrigin?: Record<string, unknown>;
+}): TelegramHarnessInboundEvent {
+  return {
+    kind: "message",
+    ctx: {
+      update: { update_id: params.updateId ?? params.messageId ?? 42 },
+      ...makeTelegramMessageCtx({
+        chat: {
+          id: params.chatId ?? 7,
+          type: params.chatType ?? "private",
+          ...(params.title ? { title: params.title } : {}),
+          ...(params.isForum === undefined ? {} : { is_forum: params.isForum }),
+        },
+        from: { id: params.fromId ?? 9, username: params.username ?? "ada" },
+        text: params.text,
+        ...(params.caption ? { caption: params.caption } : {}),
+        messageId: params.messageId ?? 42,
+        messageThreadId: params.messageThreadId,
+        ...(params.photoFileId ? { photo: [{ file_id: params.photoFileId }] } : {}),
+        ...(params.forwardOrigin ? { forward_origin: params.forwardOrigin } : {}),
+      }),
+      getFile: async () =>
+        params.photoFileId ? { file_path: `photos/${params.photoFileId}.jpg` } : {},
+    },
+  };
+}
+
+export function createTelegramChannelPostEvent(params: {
+  chatId?: number;
+  title?: string;
+  text?: string;
+  caption?: string;
+  messageId?: number;
+  updateId?: number;
+  date?: number;
+  mediaGroupId?: string;
+  photoFileId?: string;
+  forwardOrigin?: Record<string, unknown>;
+}): TelegramHarnessInboundEvent {
+  return {
+    kind: "channel_post",
+    ctx: {
+      update: { update_id: params.updateId ?? params.messageId ?? 42 },
+      channelPost: {
+        chat: {
+          id: params.chatId ?? -100777111222,
+          type: "channel",
+          title: params.title ?? "Wake Channel",
+        },
+        message_id: params.messageId ?? 42,
+        date: params.date ?? 1736380800,
+        ...(params.text ? { text: params.text } : {}),
+        ...(params.caption ? { caption: params.caption } : {}),
+        ...(params.mediaGroupId ? { media_group_id: params.mediaGroupId } : {}),
+        ...(params.photoFileId ? { photo: [{ file_id: params.photoFileId }] } : {}),
+        ...(params.forwardOrigin ? { forward_origin: params.forwardOrigin } : {}),
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () =>
+        params.photoFileId ? { file_path: `photos/${params.photoFileId}.jpg` } : {},
+    },
+  };
+}
+
+export function createTelegramForumMessageEvent(params?: {
+  chatId?: number;
+  threadId?: number;
+  text?: string;
+  fromId?: number;
+  username?: string;
+  updateId?: number;
+}): TelegramHarnessInboundEvent {
+  const ctx = makeForumGroupMessageCtx({
+    chatId: params?.chatId,
+    threadId: params?.threadId,
+    text: params?.text,
+    fromId: params?.fromId,
+    username: params?.username,
+  }) as Record<string, unknown>;
+  ctx.update = { update_id: params?.updateId ?? 99 };
+  return { kind: "message", ctx };
+}
+
+export function createTelegramCallbackQueryEvent(params?: {
+  callbackId?: string;
+  data?: string;
+  chatId?: number;
+  messageId?: number;
+  userId?: number;
+  username?: string;
+  updateId?: number;
+}): TelegramHarnessInboundEvent {
+  return {
+    kind: "callback_query",
+    ctx: {
+      update: { update_id: params?.updateId ?? 88 },
+      callbackQuery: {
+        id: params?.callbackId ?? "cbq-1",
+        data: params?.data ?? "cmd:option_a",
+        from: {
+          id: params?.userId ?? 9,
+          first_name: "Ada",
+          username: params?.username ?? "ada_bot",
+        },
+        message: {
+          chat: { id: params?.chatId ?? 1234, type: "private" },
+          date: 1736380800,
+          message_id: params?.messageId ?? 11,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    },
+  };
+}
+
+export function createTelegramReactionEvent(params?: {
+  updateId?: number;
+  chatId?: number;
+  chatType?: "private" | "group" | "supergroup";
+  isForum?: boolean;
+  messageId?: number;
+  userId?: number;
+  username?: string;
+  emoji?: string;
+}): TelegramHarnessInboundEvent {
+  return {
+    kind: "message_reaction",
+    ctx: {
+      update: { update_id: params?.updateId ?? 901 },
+      messageReaction: {
+        chat: {
+          id: params?.chatId ?? 1234,
+          type: params?.chatType ?? "private",
+          ...(params?.isForum === undefined ? {} : { is_forum: params.isForum }),
+          ...(params?.chatType && params.chatType !== "private" ? { title: "Group Chat" } : {}),
+        },
+        message_id: params?.messageId ?? 42,
+        user: {
+          id: params?.userId ?? 9,
+          first_name: "Ada",
+          username: params?.username ?? "ada_bot",
+        },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: params?.emoji ?? "👍" }],
+      },
+    },
+  };
+}
+
+function resolveNativeCommandHandler(ctx: Record<string, unknown>) {
+  const text = (ctx.message as { text?: string } | undefined)?.text?.trim() ?? "";
+  if (!text.startsWith("/")) {
+    return null;
+  }
+  const commandToken = text.slice(1).split(/\s+/, 1)[0] ?? "";
+  const commandName = commandToken.split("@", 1)[0]?.trim();
+  if (!commandName) {
+    return null;
+  }
+  const handler = commandSpy.mock.calls.find((call) => call[0] === commandName)?.[1];
+  if (typeof handler !== "function") {
+    return null;
+  }
+  return handler as (ctx: Record<string, unknown>) => Promise<void>;
+}
+
+export function createTelegramChannelFaultHarness(params?: {
+  config?: LoadedConfig;
+  replyText?: string;
+  replyError?: Error;
+  testTimings?: {
+    mediaGroupFlushMs?: number;
+    textFragmentGapMs?: number;
+  };
+}): ChannelFaultHarness<TelegramHarnessInboundEvent, TelegramHarnessStableState> {
+  const loadConfig = getLoadConfigMock();
+  const readChannelAllowFromStore = getReadChannelAllowFromStoreMock();
+  const upsertChannelPairingRequest = getUpsertChannelPairingRequestMock();
+  const emittedEvents: ChannelHarnessEvent[] = [];
+  const outboundCalls: ChannelHarnessOutboundCall[] = [];
+  let activeFault: ChannelOutboundFault | null = null;
+  let remainingFaultAttempts = 0;
+
+  onSpy.mockReset();
+  commandSpy.mockReset();
+  enqueueSystemEventSpy.mockReset();
+  loadConfig.mockReset();
+  loadConfig.mockReturnValue(params?.config ?? createDefaultConfig());
+  readChannelAllowFromStore.mockReset();
+  readChannelAllowFromStore.mockResolvedValue([]);
+  upsertChannelPairingRequest.mockReset();
+  upsertChannelPairingRequest.mockResolvedValue({ code: "PAIRCODE", created: true });
+  answerCallbackQuerySpy.mockReset().mockImplementation(async (callbackId: string) => {
+    emittedEvents.push({ kind: "callback.answer", payload: { callbackId } });
+  });
+  sendMessageSpy
+    .mockReset()
+    .mockImplementation(async (chatId: number, body: string, meta?: unknown) => {
+      const text = String(body);
+      outboundCalls.push({
+        kind: "telegram.send",
+        target: String(chatId),
+        body: text,
+        meta:
+          typeof meta === "object" && meta !== null
+            ? ({ ...(meta as object) } as Record<string, unknown>)
+            : {},
+      });
+      if (text.includes("Pairing code:") || text.includes("Your Telegram user id:")) {
+        emittedEvents.push({ kind: "auth.denied", payload: { chatId, body: text } });
+      }
+      if (text === "You are not authorized to use this command.") {
+        emittedEvents.push({ kind: "auth.denied", payload: { chatId, body: text } });
+      }
+      if (text === "Something went wrong while processing your request. Please try again.") {
+        emittedEvents.push({ kind: "reply.fallback", payload: { chatId, body: text } });
+      }
+      if (activeFault && remainingFaultAttempts > 0) {
+        remainingFaultAttempts -= 1;
+        throw createFaultError(activeFault);
+      }
+      return { message_id: 77 };
+    });
+  replySpy.mockReset().mockImplementation(async (ctx, opts) => {
+    emittedEvents.push({ kind: "reply.dispatch", payload: ctx });
+    await opts?.onReplyStart?.();
+    if (params?.replyError) {
+      throw params.replyError;
+    }
+    return { text: params?.replyText ?? "final reply" };
+  });
+
+  setTelegramBotRuntimeForTest(
+    telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
+  );
+  createTelegramBot({
+    token: "tok",
+    telegramDeps: telegramBotDepsForTest,
+    config: params?.config ?? createDefaultConfig(),
+    testTimings: params?.testTimings ?? TELEGRAM_HARNESS_TEST_TIMINGS,
+  });
+  enqueueSystemEventSpy.mockImplementation((text: string, meta?: unknown) => {
+    emittedEvents.push({ kind: "reaction.enqueue", payload: { text, ...(meta as object) } });
+    return false;
+  });
+
+  return {
+    inject: async (event) => {
+      if (event.kind === "message") {
+        const commandHandler = resolveNativeCommandHandler(event.ctx);
+        if (commandHandler) {
+          await commandHandler({
+            ...event.ctx,
+            match: "",
+          });
+          return;
+        }
+      }
+      const handler = getOnHandler(event.kind);
+      await handler(event.ctx);
+    },
+    injectSequence: async (events) => {
+      for (const event of events) {
+        if (event.kind === "message") {
+          const commandHandler = resolveNativeCommandHandler(event.ctx);
+          if (commandHandler) {
+            await commandHandler({
+              ...event.ctx,
+              match: "",
+            });
+            continue;
+          }
+        }
+        const handler = getOnHandler(event.kind);
+        await handler(event.ctx);
+      }
+    },
+    setOutboundFault: (fault) => {
+      activeFault = fault;
+      remainingFaultAttempts = Math.max(0, fault?.attempts ?? 1);
+    },
+    getOutboundCalls: () => [...outboundCalls],
+    getEmittedEvents: () => [...emittedEvents],
+    getStableState: () => ({
+      replyCount: emittedEvents.filter((event) => event.kind === "reply.dispatch").length,
+      outboundCallCount: outboundCalls.length,
+      callbackAnswerCount: emittedEvents.filter((event) => event.kind === "callback.answer").length,
+      denialCount: emittedEvents.filter((event) => event.kind === "auth.denied").length,
+      fallbackCount: emittedEvents.filter((event) => event.kind === "reply.fallback").length,
+      reactionEventCount: emittedEvents.filter((event) => event.kind === "reaction.enqueue").length,
+      reactionContextKeys: emittedEvents
+        .filter((event) => event.kind === "reaction.enqueue")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>)
+        .map((payload) => payload.contextKey)
+        .filter((value): value is string => typeof value === "string"),
+      reactionSessionKeys: emittedEvents
+        .filter((event) => event.kind === "reaction.enqueue")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>)
+        .map((payload) => payload.sessionKey)
+        .filter((value): value is string => typeof value === "string"),
+      sessionKeys: emittedEvents
+        .filter((event) => event.kind === "reply.dispatch")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>)
+        .map((payload) => payload.SessionKey)
+        .filter((value): value is string => typeof value === "string"),
+      dispatchBodies: emittedEvents
+        .filter((event) => event.kind === "reply.dispatch")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>)
+        .map((payload) => payload.Body)
+        .filter((value): value is string => typeof value === "string"),
+      dispatchRawBodies: emittedEvents
+        .filter((event) => event.kind === "reply.dispatch")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>)
+        .map((payload) => payload.RawBody)
+        .filter((value): value is string => typeof value === "string"),
+      dispatchMediaCounts: emittedEvents
+        .filter((event) => event.kind === "reply.dispatch")
+        .map((event) => (event.payload ?? {}) as Record<string, unknown>)
+        .map((payload) => payload.MediaUrls)
+        .map((value) => (Array.isArray(value) ? value.length : 0)),
+    }),
+    waitForIdle: async (expectation?: ChannelHarnessIdleExpectation) => {
+      await vi.waitFor(() => {
+        const minEvents = expectation?.minEmittedEvents ?? 1;
+        const minOutbound = expectation?.minOutboundCalls ?? 0;
+        if (emittedEvents.length < minEvents) {
+          throw new Error(
+            `waiting for emitted events: expected >= ${minEvents}, got ${emittedEvents.length}`,
+          );
+        }
+        if (outboundCalls.length < minOutbound) {
+          throw new Error(
+            `waiting for outbound calls: expected >= ${minOutbound}, got ${outboundCalls.length}`,
+          );
+        }
+      });
+    },
+  };
+}

--- a/extensions/telegram/src/channel-fault-harness.test.ts
+++ b/extensions/telegram/src/channel-fault-harness.test.ts
@@ -1,0 +1,742 @@
+import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { replySpy } from "./bot.create-telegram-bot.test-harness.js";
+import {
+  createTelegramCallbackQueryEvent,
+  createTelegramChannelPostEvent,
+  createTelegramChannelFaultHarness,
+  createTelegramForumMessageEvent,
+  createTelegramMessageEvent,
+  createTelegramReactionEvent,
+} from "./channel-fault-harness.test-support.js";
+
+describe("telegram channel fault harness", () => {
+  it("dedupes duplicate message updates by update_id", async () => {
+    const harness = createTelegramChannelFaultHarness();
+    const event = createTelegramMessageEvent({
+      messageId: 42,
+      updateId: 111,
+      text: "hello",
+    });
+
+    await harness.inject(event);
+    await harness.inject(event);
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    expect(state.replyCount).toBe(1);
+    expect(state.outboundCallCount).toBe(1);
+  });
+
+  it("retries a normal final reply after a retryable outbound fault", async () => {
+    const harness = createTelegramChannelFaultHarness();
+    harness.setOutboundFault({ kind: "rate_limit", attempts: 1 });
+
+    await harness.inject(
+      createTelegramMessageEvent({ messageId: 50, updateId: 150, text: "hello" }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 2 });
+
+    const state = harness.getStableState();
+    expect(state.replyCount).toBe(1);
+    expect(state.outboundCallCount).toBe(2);
+    expect(state.fallbackCount).toBe(0);
+  });
+
+  it("routes forum topics through topic-qualified session keys", async () => {
+    const harness = createTelegramChannelFaultHarness();
+
+    await harness.inject(createTelegramForumMessageEvent({ threadId: 99, updateId: 222 }));
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    expect(state.sessionKeys[0]).toContain("telegram:group:-1001234567890:topic:99");
+  });
+
+  it("handles forum messages without topic metadata safely", async () => {
+    const harness = createTelegramChannelFaultHarness();
+
+    await harness.inject(createTelegramForumMessageEvent({ threadId: undefined, updateId: 333 }));
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const [outbound] = harness.getOutboundCalls();
+    const state = harness.getStableState();
+    expect(state.sessionKeys[0]).toContain("telegram:group:-1001234567890");
+    expect(state.sessionKeys[0]).toContain(":topic:1");
+    expect(outbound?.meta?.message_thread_id).toBeUndefined();
+  });
+
+  it("routes callback queries and captures callback acknowledgements", async () => {
+    const harness = createTelegramChannelFaultHarness();
+
+    await harness.inject(createTelegramCallbackQueryEvent({ updateId: 444 }));
+    await harness.waitForIdle({ minEmittedEvents: 2, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    expect(state.replyCount).toBe(1);
+    expect(state.callbackAnswerCount).toBe(1);
+  });
+
+  it("handles authorized DM reactions once", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            reactionNotifications: "all",
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(createTelegramReactionEvent({ updateId: 446 }));
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 0 });
+
+    const state = harness.getStableState();
+    expect(state.reactionEventCount).toBe(1);
+    expect(state.reactionContextKeys[0]).toContain("telegram:reaction:add:1234:42:9");
+    expect(state.reactionSessionKeys[0]).toBe("agent:main:main");
+  });
+
+  it("handles authorized group reactions once", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            groupPolicy: "open",
+            reactionNotifications: "all",
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramReactionEvent({
+        updateId: 447,
+        chatId: -1001234567890,
+        chatType: "supergroup",
+      }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 0 });
+
+    const state = harness.getStableState();
+    expect(state.reactionEventCount).toBe(1);
+    expect(state.reactionSessionKeys[0]).toContain("telegram:group:-1001234567890");
+  });
+
+  it("routes forum-group reactions to the general topic when thread id is unavailable", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            groupPolicy: "open",
+            reactionNotifications: "all",
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramReactionEvent({
+        updateId: 448,
+        chatId: -1001234567890,
+        chatType: "supergroup",
+        isForum: true,
+      }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 0 });
+
+    const state = harness.getStableState();
+    expect(state.reactionEventCount).toBe(1);
+    expect(state.reactionSessionKeys[0]).toContain("telegram:group:-1001234567890");
+    expect(state.reactionSessionKeys[0]).toContain(":topic:1");
+  });
+
+  it("dedupes duplicate reaction updates", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            reactionNotifications: "all",
+          },
+        },
+      } as never,
+    });
+    const event = createTelegramReactionEvent({ updateId: 449 });
+
+    await harness.inject(event);
+    await harness.inject(event);
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 0 });
+
+    const state = harness.getStableState();
+    expect(state.reactionEventCount).toBe(1);
+  });
+
+  it("does not fork topic sessions for non-forum thread ids", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            groupPolicy: "open",
+            groups: { "*": { requireMention: false } },
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramMessageEvent({
+        messageId: 62,
+        updateId: 262,
+        text: "@openclaw_bot hello group",
+        chatId: -200,
+        chatType: "supergroup",
+        isForum: false,
+        messageThreadId: 77,
+        title: "Regular Group",
+      }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    expect(state.sessionKeys[0]).toContain("telegram:group:-200");
+    expect(state.sessionKeys[0]).not.toContain(":topic:");
+  });
+
+  it("dispatches authorized native command messages once into the expected slash session", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        commands: { native: true },
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["9"],
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramMessageEvent({ messageId: 63, updateId: 263, text: "/status" }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    expect(state.replyCount).toBe(1);
+    expect(state.sessionKeys[0]).toContain("telegram:slash:9");
+  });
+
+  it("denies unauthorized native command messages without normal reply dispatch", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        commands: { native: true },
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramMessageEvent({ messageId: 64, updateId: 264, text: "/status" }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    const [outbound] = harness.getOutboundCalls();
+    expect(state.replyCount).toBe(0);
+    expect(state.denialCount).toBe(1);
+    expect(outbound?.body).toBe("You are not authorized to use this command.");
+  });
+
+  it("acknowledges callback-driven command continuation and routes once", async () => {
+    const harness = createTelegramChannelFaultHarness();
+
+    await harness.inject(
+      createTelegramCallbackQueryEvent({
+        updateId: 450,
+        data: "cmd:status",
+      }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 2, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    expect(state.callbackAnswerCount).toBe(1);
+    expect(state.replyCount).toBe(1);
+    expect(state.sessionKeys).toHaveLength(1);
+  });
+
+  it("acknowledges unauthorized callback queries without dispatching a normal reply", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+            capabilities: { inlineButtons: "allowlist" },
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramCallbackQueryEvent({ updateId: 445, userId: 77, username: "blocked" }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 0 });
+
+    const state = harness.getStableState();
+    expect(state.callbackAnswerCount).toBe(1);
+    expect(state.replyCount).toBe(0);
+    expect(state.outboundCallCount).toBe(0);
+  });
+
+  it("sends pairing guidance for denied DM messages without entering normal reply dispatch", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      config: {
+        agents: {
+          defaults: {
+            envelopeTimezone: "utc",
+          },
+        },
+        channels: {
+          telegram: {
+            dmPolicy: "pairing",
+            allowFrom: [],
+          },
+        },
+      } as never,
+    });
+
+    await harness.inject(
+      createTelegramMessageEvent({ messageId: 60, updateId: 260, text: "hello" }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    const [outbound] = harness.getOutboundCalls();
+    expect(state.replyCount).toBe(0);
+    expect(state.denialCount).toBe(1);
+    expect(outbound?.body).toContain("Pairing code:");
+  });
+
+  it("sends one fallback recovery message when processing fails", async () => {
+    const harness = createTelegramChannelFaultHarness({
+      replyError: new Error("boom"),
+    });
+
+    await harness.inject(
+      createTelegramMessageEvent({ messageId: 61, updateId: 261, text: "hello" }),
+    );
+    await harness.waitForIdle({ minEmittedEvents: 2, minOutboundCalls: 1 });
+
+    const state = harness.getStableState();
+    const [outbound] = harness.getOutboundCalls();
+    expect(state.replyCount).toBe(1);
+    expect(state.fallbackCount).toBe(1);
+    expect(state.outboundCallCount).toBe(1);
+    expect(outbound?.body).toBe(
+      "Something went wrong while processing your request. Please try again.",
+    );
+  });
+
+  it("coalesces adjacent text fragments into one logical turn after the debounce window", async () => {
+    vi.useFakeTimers();
+    try {
+      const harness = createTelegramChannelFaultHarness({
+        config: {
+          channels: {
+            telegram: {
+              groupPolicy: "open",
+              groups: {
+                "-100777111222": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        } as never,
+      });
+      const part1 = "A".repeat(4050);
+      const part2 = "B".repeat(50);
+
+      await harness.injectSequence([
+        createTelegramChannelPostEvent({
+          messageId: 301,
+          updateId: 1301,
+          text: part1,
+        }),
+        createTelegramChannelPostEvent({
+          messageId: 302,
+          updateId: 1302,
+          date: 1736380801,
+          text: part2,
+        }),
+      ]);
+
+      expect(harness.getStableState().replyCount).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(130);
+      await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+      const state = harness.getStableState();
+      expect(state.replyCount).toBe(1);
+      expect(state.dispatchRawBodies[0]).toContain(part1.slice(0, 32));
+      expect(state.dispatchRawBodies[0]).toContain(part2.slice(0, 32));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("coalesces forwarded text and forwarded attachment bursts into one logical turn", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    try {
+      const harness = createTelegramChannelFaultHarness();
+
+      await harness.injectSequence([
+        createTelegramMessageEvent({
+          messageId: 321,
+          updateId: 1321,
+          text: "Look at this",
+          forwardOrigin: { type: "hidden_user", date: 1736380700, sender_user_name: "A" },
+        }),
+        createTelegramMessageEvent({
+          messageId: 322,
+          updateId: 1322,
+          text: "",
+          photoFileId: "fwd_photo_1",
+          forwardOrigin: { type: "hidden_user", date: 1736380701, sender_user_name: "A" },
+        }),
+      ]);
+
+      await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+      const state = harness.getStableState();
+      const payload = replySpy.mock.calls[0]?.[0] as { Body?: string } | undefined;
+      expect(state.replyCount).toBe(1);
+      expect(payload?.Body).toContain("Look at this");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("flushes media groups once with combined media", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      const harness = createTelegramChannelFaultHarness({
+        config: {
+          channels: {
+            telegram: {
+              groupPolicy: "open",
+              groups: {
+                "-100777111222": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        } as never,
+      });
+
+      await harness.injectSequence([
+        createTelegramChannelPostEvent({
+          messageId: 401,
+          updateId: 1401,
+          caption: "album caption",
+          mediaGroupId: "album-1",
+          photoFileId: "p1",
+        }),
+        createTelegramChannelPostEvent({
+          messageId: 402,
+          updateId: 1402,
+          date: 1736380801,
+          mediaGroupId: "album-1",
+          photoFileId: "p2",
+        }),
+      ]);
+
+      expect(harness.getStableState().replyCount).toBe(0);
+
+      const flushTimerCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 20);
+      const flushTimer =
+        flushTimerCallIndex >= 0
+          ? (setTimeoutSpy.mock.calls[flushTimerCallIndex]?.[0] as (() => unknown) | undefined)
+          : undefined;
+      if (flushTimerCallIndex >= 0) {
+        clearTimeout(
+          setTimeoutSpy.mock.results[flushTimerCallIndex]?.value as ReturnType<typeof setTimeout>,
+        );
+      }
+      expect(flushTimer).toBeTypeOf("function");
+      await flushTimer?.();
+      await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+      const state = harness.getStableState();
+      const payload = replySpy.mock.calls[0]?.[0] as { Body?: string } | undefined;
+      expect(state.replyCount).toBe(1);
+      expect(payload?.Body).toContain("album caption");
+    } finally {
+      setTimeoutSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("keeps processing remaining media-group items after one recoverable media failure", async () => {
+    let fetchCallIndex = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      fetchCallIndex += 1;
+      if (fetchCallIndex === 2) {
+        throw new MediaFetchError("fetch_failed", "Failed to fetch media");
+      }
+      return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    });
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      const harness = createTelegramChannelFaultHarness({
+        config: {
+          channels: {
+            telegram: {
+              groupPolicy: "open",
+              groups: {
+                "-100777111222": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        } as never,
+      });
+
+      await harness.injectSequence([
+        createTelegramChannelPostEvent({
+          messageId: 411,
+          updateId: 1411,
+          caption: "partial album",
+          mediaGroupId: "partial-album-1",
+          photoFileId: "p1",
+        }),
+        createTelegramChannelPostEvent({
+          messageId: 412,
+          updateId: 1412,
+          date: 1736380801,
+          mediaGroupId: "partial-album-1",
+          photoFileId: "p2",
+        }),
+      ]);
+
+      const flushTimerCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 20);
+      const flushTimer =
+        flushTimerCallIndex >= 0
+          ? (setTimeoutSpy.mock.calls[flushTimerCallIndex]?.[0] as (() => unknown) | undefined)
+          : undefined;
+      if (flushTimerCallIndex >= 0) {
+        clearTimeout(
+          setTimeoutSpy.mock.results[flushTimerCallIndex]?.value as ReturnType<typeof setTimeout>,
+        );
+      }
+      expect(flushTimer).toBeTypeOf("function");
+      await flushTimer?.();
+      await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+      const state = harness.getStableState();
+      const payload = replySpy.mock.calls[0]?.[0] as { Body?: string } | undefined;
+      expect(state.replyCount).toBe(1);
+      expect(payload?.Body).toContain("partial album");
+    } finally {
+      setTimeoutSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("drops a media group cleanly on a non-recoverable media failure", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    try {
+      const harness = createTelegramChannelFaultHarness({
+        config: {
+          channels: {
+            telegram: {
+              groupPolicy: "open",
+              groups: {
+                "-100777111222": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        } as never,
+      });
+
+      await harness.injectSequence([
+        createTelegramChannelPostEvent({
+          messageId: 421,
+          updateId: 1421,
+          caption: "fatal album",
+          mediaGroupId: "fatal-album-1",
+          photoFileId: "p1",
+        }),
+        {
+          kind: "channel_post",
+          ctx: {
+            update: { update_id: 1422 },
+            channelPost: {
+              chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+              message_id: 422,
+              date: 1736380801,
+              media_group_id: "fatal-album-1",
+              photo: [{ file_id: "p2" }],
+            },
+            me: { username: "openclaw_bot" },
+            getFile: async () => ({}),
+          },
+        },
+      ]);
+
+      const flushTimerCallIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 20);
+      const flushTimer =
+        flushTimerCallIndex >= 0
+          ? (setTimeoutSpy.mock.calls[flushTimerCallIndex]?.[0] as (() => unknown) | undefined)
+          : undefined;
+      if (flushTimerCallIndex >= 0) {
+        clearTimeout(
+          setTimeoutSpy.mock.results[flushTimerCallIndex]?.value as ReturnType<typeof setTimeout>,
+        );
+      }
+      expect(flushTimer).toBeTypeOf("function");
+      await flushTimer?.();
+
+      const state = harness.getStableState();
+      expect(state.replyCount).toBe(0);
+      expect(state.outboundCallCount).toBe(0);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("keeps duplicate suppression across mixed sequence-heavy updates", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+
+    try {
+      const harness = createTelegramChannelFaultHarness({
+        config: {
+          channels: {
+            telegram: {
+              groupPolicy: "open",
+              groups: {
+                "-100777111222": {
+                  enabled: true,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        } as never,
+      });
+      const duplicateText = createTelegramChannelPostEvent({
+        messageId: 431,
+        updateId: 1431,
+        text: "C".repeat(4050),
+      });
+
+      await harness.injectSequence([
+        duplicateText,
+        duplicateText,
+        createTelegramChannelPostEvent({
+          messageId: 432,
+          updateId: 1432,
+          date: 1736380801,
+          text: "tail",
+        }),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(130);
+      await harness.waitForIdle({ minEmittedEvents: 1, minOutboundCalls: 1 });
+
+      const state = harness.getStableState();
+      expect(state.replyCount).toBe(1);
+      expect(state.dispatchRawBodies[0]).toContain("tail");
+    } finally {
+      fetchSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/test/helpers/channel-fault-harness.ts
+++ b/test/helpers/channel-fault-harness.ts
@@ -1,0 +1,46 @@
+export type ChannelOutboundFault =
+  | {
+      kind: "rate_limit";
+      attempts?: number;
+      message?: string;
+      surface?: string;
+    }
+  | {
+      kind: "timeout";
+      attempts?: number;
+      message?: string;
+      surface?: string;
+    }
+  | {
+      kind: "error";
+      attempts?: number;
+      message?: string;
+      surface?: string;
+    };
+
+export type ChannelHarnessEvent = {
+  kind: string;
+  payload?: unknown;
+};
+
+export type ChannelHarnessOutboundCall = {
+  kind: string;
+  target?: string;
+  body?: string;
+  meta?: Record<string, unknown>;
+};
+
+export type ChannelHarnessIdleExpectation = {
+  minEmittedEvents?: number;
+  minOutboundCalls?: number;
+};
+
+export type ChannelFaultHarness<TEvent, TStableState> = {
+  inject: (event: TEvent) => Promise<void>;
+  injectSequence: (events: readonly TEvent[]) => Promise<void>;
+  setOutboundFault: (fault: ChannelOutboundFault | null) => void;
+  getOutboundCalls: () => ChannelHarnessOutboundCall[];
+  getEmittedEvents: () => ChannelHarnessEvent[];
+  getStableState: () => TStableState;
+  waitForIdle: (expectation?: ChannelHarnessIdleExpectation) => Promise<void>;
+};


### PR DESCRIPTION
## Summary
- add shared internal channel fault harness primitives
- add Telegram adapter-boundary fault harness coverage through phase 3 sequence/media cases
- add Discord adapter-boundary harness coverage plus a separate listener/slash harness suite
- rename the Discord higher-boundary files to `listener-slash-harness` names

## Verification
- Historical focused harness verification on this branch passed before the latest rebase work:
  - `pnpm exec vitest run extensions/discord/src/monitor.listener-slash-harness.test.ts extensions/discord/src/monitor.channel-fault-harness.test.ts extensions/telegram/src/channel-fault-harness.test.ts`
- After rebasing locally onto latest `main`:
  - `pnpm exec vitest run extensions/discord/src/monitor/message-handler.queue.test.ts` passes (`11/11`)
  - `pnpm exec vitest run extensions/discord/src/monitor/message-handler.preflight.acp-bindings.test.ts -t "accepts plain messages in configured ACP-bound channels without a mention"` passes
  - `pnpm exec vitest run extensions/discord/src/monitor.channel-fault-harness.test.ts` is now down to one failing ACP-bound harness case
  - `pnpm exec vitest run extensions/discord/src/monitor.listener-slash-harness.test.ts` still hangs during collection/run on the rebased branch
- `pnpm exec tsc --noEmit --pretty false` remains noisy from pre-existing `fetch` typing failures outside this change

## Current Status
- This PR is still draft.
- Discord inbound message dedupe has already landed separately on `main` via its own narrow PR, so this branch should now treat that as upstream baseline rather than pending work.
- The remaining Discord issue on this branch is harness-only: the direct ACP preflight contract still passes on current `main`, but the broader Discord channel-fault harness still has one stale ACP-bound case after rebase.

## LLM Handoff
- Branch: `codex/channel-fault-harness`
- Current local head: rebased onto latest `origin/main`, with uncommitted harness-debug edits in the Discord channel-fault harness files.
- Important context:
  - Discord inbound message dedupe is now upstream and directly testable on top of `main`.
  - Current `main` still supports configured ACP-bound Discord channels accepting plain messages without a mention; the direct preflight ACP test proves that.
  - The remaining ACP failure is in the broader Discord harness setup, not yet shown to be a production ACP regression.
- Recommended next step: fix or revert the remaining Discord ACP harness drift before pushing this rebased branch state, then re-run the focused Discord harness suites.