### PR TITLE
fix(agents): strip unsupported strict tool flags for OpenAI proxies

### DIFF
--- a/extensions/memory-lancedb/lancedb-runtime.ts
+++ b/extensions/memory-lancedb/lancedb-runtime.ts
@@ -35,10 +35,90 @@ type LanceDbRuntimeLoaderDeps = {
   }) => Promise<string>;
 };
 
-const MEMORY_LANCEDB_RUNTIME_MANIFEST: RuntimeManifest = (() => {
-  const packageJson = JSON.parse(
-    fs.readFileSync(new URL("./package.json", import.meta.url), "utf8"),
-  ) as {
+/**
+ * Resolve the package.json path for the memory-lancedb plugin.
+ * Uses createRequire to handle both development and bundled environments correctly.
+ * In bundled mode, import.meta.url may point to a different location than expected.
+ */
+function resolvePackageJsonPath(): string {
+  const pluginRequire = createRequire(import.meta.url);
+
+  // Strategy 1: Try to resolve relative to this module's URL
+  // Works in development mode where files are not bundled
+  try {
+    const relativePath = pluginRequire.resolve("./package.json");
+    if (fs.existsSync(relativePath)) {
+      return relativePath;
+    }
+  } catch {
+    // Continue to fallback strategies
+  }
+
+  // Strategy 2: In bundled mode, look for extensions/memory-lancedb/package.json
+  // relative to the dist directory
+  try {
+    // Get the dist directory by resolving the main openclaw package
+    const openclawMain = pluginRequire.resolve("openclaw");
+    const distDir = path.dirname(openclawMain);
+    const bundledPackageJson = path.join(distDir, "extensions", "memory-lancedb", "package.json");
+    if (fs.existsSync(bundledPackageJson)) {
+      return bundledPackageJson;
+    }
+  } catch {
+    // Continue to fallback strategies
+  }
+
+  // Strategy 3: Try to find it relative to the @lancedb/lancedb package location
+  try {
+    const lancedbEntry = pluginRequire.resolve("@lancedb/lancedb");
+    // Walk up to find the memory-lancedb plugin directory
+    let currentDir = path.dirname(lancedbEntry);
+    for (let i = 0; i < 15 && currentDir !== "/"; i++) {
+      const candidatePath = path.join(currentDir, "package.json");
+      if (fs.existsSync(candidatePath)) {
+        const content = JSON.parse(fs.readFileSync(candidatePath, "utf8")) as {
+          name?: string;
+        };
+        if (content.name === "@openclaw/memory-lancedb" || content.name === "memory-lancedb") {
+          return candidatePath;
+        }
+      }
+      currentDir = path.dirname(currentDir);
+    }
+  } catch {
+    // Ignore resolution errors
+  }
+
+  // Strategy 4: Walk up from current module location looking for extensions/memory-lancedb
+  try {
+    let currentDir = path.dirname(new URL(import.meta.url).pathname);
+    for (let i = 0; i < 10 && currentDir !== "/"; i++) {
+      const candidatePath = path.join(currentDir, "extensions", "memory-lancedb", "package.json");
+      if (fs.existsSync(candidatePath)) {
+        return candidatePath;
+      }
+      // Also check for direct package.json with the right name
+      const directPath = path.join(currentDir, "package.json");
+      if (fs.existsSync(directPath)) {
+        const content = JSON.parse(fs.readFileSync(directPath, "utf8")) as {
+          name?: string;
+        };
+        if (content.name === "@openclaw/memory-lancedb" || content.name === "memory-lancedb") {
+          return directPath;
+        }
+      }
+      currentDir = path.dirname(currentDir);
+    }
+  } catch {
+    // Ignore resolution errors
+  }
+
+  throw new Error("memory-lancedb: could not resolve package.json path");
+}
+
+function buildRuntimeManifest(): RuntimeManifest {
+  const packageJsonPath = resolvePackageJsonPath();
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
     dependencies?: Record<string, string>;
   };
   const lanceDbSpec = packageJson.dependencies?.["@lancedb/lancedb"];
@@ -53,7 +133,17 @@ const MEMORY_LANCEDB_RUNTIME_MANIFEST: RuntimeManifest = (() => {
       "@lancedb/lancedb": lanceDbSpec,
     },
   };
-})();
+}
+
+// Lazily compute the manifest to avoid issues during module initialization
+let _runtimeManifest: RuntimeManifest | null = null;
+
+function getRuntimeManifest(): RuntimeManifest {
+  if (!_runtimeManifest) {
+    _runtimeManifest = buildRuntimeManifest();
+  }
+  return _runtimeManifest;
+}
 
 function resolveRuntimeDir(stateDir: string): string {
   return path.join(stateDir, "plugin-runtimes", "memory-lancedb", "lancedb");
@@ -187,7 +277,7 @@ export function createLanceDbRuntimeLoader(overrides: Partial<LanceDbRuntimeLoad
   const deps: LanceDbRuntimeLoaderDeps = {
     env: overrides.env ?? process.env,
     resolveStateDir: overrides.resolveStateDir ?? resolveStateDir,
-    runtimeManifest: overrides.runtimeManifest ?? MEMORY_LANCEDB_RUNTIME_MANIFEST,
+    runtimeManifest: overrides.runtimeManifest ?? getRuntimeManifest(),
     importBundled: overrides.importBundled ?? (() => import("@lancedb/lancedb")),
     importResolved: overrides.importResolved ?? defaultImportResolved,
     resolveRuntimeEntry: overrides.resolveRuntimeEntry ?? defaultResolveRuntimeEntry,

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -295,6 +295,20 @@ describe("normalizeModelCompat", () => {
     expect(supportsStrictMode(normalized)).toBeUndefined();
   });
 
+  it("leaves strict mode available for direct Azure OpenAI routes", () => {
+    const model = {
+      ...baseModel(),
+      provider: "azure-openai",
+      id: "gpt-4o",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsStrictMode(normalized)).toBeUndefined();
+  });
+
   it("preserves explicit strict-mode opt-out for OpenRouter OpenAI-backed routes", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -281,6 +281,70 @@ describe("normalizeModelCompat", () => {
     expect(supportsStrictMode(normalized)).toBe(true);
   });
 
+  it("leaves strict mode available for OpenRouter OpenAI-backed routes", () => {
+    const model = {
+      ...baseModel(),
+      provider: "openrouter",
+      id: "openai/gpt-4o",
+      baseUrl: "https://openrouter.ai/api/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsStrictMode(normalized)).toBeUndefined();
+  });
+
+  it("preserves explicit strict-mode opt-out for OpenRouter OpenAI-backed routes", () => {
+    const model = {
+      ...baseModel(),
+      provider: "openrouter",
+      id: "openai/gpt-4o",
+      baseUrl: "https://openrouter.ai/api/v1",
+      compat: { supportsStrictMode: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
+    expect(supportsStrictMode(normalized)).toBe(false);
+  });
+
+  it("forces strict mode off when provider is openrouter but baseUrl is not an OpenRouter route", () => {
+    const model = {
+      ...baseModel(),
+      provider: "openrouter",
+      id: "openai/gpt-4o",
+      baseUrl: "https://proxy.example.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsStrictMode(normalized)).toBe(false);
+  });
+
+  it("leaves strict mode available for custom providers routed to OpenRouter", () => {
+    const model = {
+      ...baseModel(),
+      provider: "custom-router",
+      id: "openai/gpt-4o",
+      baseUrl: "https://openrouter.ai/api/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsStrictMode(normalized)).toBeUndefined();
+  });
+
+  it("defers strict-mode forcing for openrouter auto routes until runtime routing is known", () => {
+    const model = {
+      ...baseModel(),
+      provider: "openrouter",
+      id: "auto",
+      baseUrl: "https://openrouter.ai/api/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model);
+    expect(supportsStrictMode(normalized)).toBeUndefined();
+  });
+
   it("does not mutate caller model when forcing supportsDeveloperRole off", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -86,6 +86,22 @@ function isOpenAINativeEndpoint(baseUrl: string): boolean {
   }
 }
 
+function isDirectOpenAIStrictBaseUrl(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return (
+      host === "api.openai.com" || host === "chatgpt.com" || host.endsWith(".openai.azure.com")
+    );
+  } catch {
+    const normalized = baseUrl.toLowerCase();
+    return (
+      normalized.includes("api.openai.com") ||
+      normalized.includes("chatgpt.com") ||
+      normalized.includes(".openai.azure.com")
+    );
+  }
+}
+
 function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
 }
@@ -135,7 +151,9 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const hasStreamingUsageOverride = compat?.supportsUsageInStreaming !== undefined;
   const targetStrictMode =
     compat?.supportsStrictMode ??
-    (hasOpenRouterStrictToolSupportRoute(model) || isOpenRouterBaseUrl(baseUrl)
+    (hasOpenRouterStrictToolSupportRoute(model) ||
+    isOpenRouterBaseUrl(baseUrl) ||
+    isDirectOpenAIStrictBaseUrl(baseUrl)
       ? undefined
       : false);
   if (

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -1,5 +1,9 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ModelCompatConfig } from "../config/types.models.js";
+import {
+  hasOpenRouterStrictToolSupportRoute,
+  isOpenRouterBaseUrl,
+} from "./openai-strict-tool-support.js";
 
 export const XAI_TOOL_SCHEMA_PROFILE = "xai";
 export const HTML_ENTITY_TOOL_CALL_ARGUMENTS_ENCODING = "html-entities";
@@ -129,7 +133,11 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   }
   const forcedDeveloperRole = compat?.supportsDeveloperRole === true;
   const hasStreamingUsageOverride = compat?.supportsUsageInStreaming !== undefined;
-  const targetStrictMode = compat?.supportsStrictMode ?? false;
+  const targetStrictMode =
+    compat?.supportsStrictMode ??
+    (hasOpenRouterStrictToolSupportRoute(model) || isOpenRouterBaseUrl(baseUrl)
+      ? undefined
+      : false);
   if (
     compat?.supportsDeveloperRole !== undefined &&
     hasStreamingUsageOverride &&
@@ -146,12 +154,12 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
           ...compat,
           supportsDeveloperRole: forcedDeveloperRole || false,
           ...(hasStreamingUsageOverride ? {} : { supportsUsageInStreaming: false }),
-          supportsStrictMode: targetStrictMode,
+          ...(targetStrictMode === undefined ? {} : { supportsStrictMode: targetStrictMode }),
         }
       : {
           supportsDeveloperRole: false,
           supportsUsageInStreaming: false,
-          supportsStrictMode: false,
+          ...(targetStrictMode === undefined ? {} : { supportsStrictMode: targetStrictMode }),
         },
   } as typeof model;
 }

--- a/src/agents/openai-strict-tool-support.test.ts
+++ b/src/agents/openai-strict-tool-support.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { hasOpenRouterStrictToolSupportRoute } from "./openai-strict-tool-support.js";
+
+describe("hasOpenRouterStrictToolSupportRoute", () => {
+  it("keeps strict mode for OpenRouter OpenAI routes pinned to Azure", () => {
+    expect(
+      hasOpenRouterStrictToolSupportRoute({
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: {
+          openRouterRouting: {
+            order: ["azure"],
+            allowFallbacks: false,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("strips strict mode for non-OpenAI OpenRouter routes pinned to Azure", () => {
+    expect(
+      hasOpenRouterStrictToolSupportRoute({
+        id: "mistralai/mistral-large",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: {
+          openRouterRouting: {
+            order: ["azure"],
+            allowFallbacks: false,
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps strict mode for OpenRouter endpoint slugs pinned to OpenAI", () => {
+    expect(
+      hasOpenRouterStrictToolSupportRoute({
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: {
+          openRouterRouting: {
+            order: ["openai/turbo"],
+            allowFallbacks: false,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/agents/openai-strict-tool-support.ts
+++ b/src/agents/openai-strict-tool-support.ts
@@ -44,10 +44,18 @@ function resolveExclusiveOpenRouterProvider(model: { compat?: unknown }): string
           providers?: unknown;
         })
       : undefined;
+  const normalizeProviderId = (value: string): string => {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return "";
+    }
+    const slashIndex = normalized.indexOf("/");
+    return slashIndex === -1 ? normalized : normalized.slice(0, slashIndex);
+  };
   const normalizeRoutingList = (value: unknown): string[] =>
     Array.isArray(value)
       ? value
-          .flatMap((entry) => (typeof entry === "string" ? [entry.trim().toLowerCase()] : []))
+          .flatMap((entry) => (typeof entry === "string" ? [normalizeProviderId(entry)] : []))
           .filter(Boolean)
       : [];
   const allowFallbacks = routing?.allowFallbacks ?? routing?.allow_fallbacks;

--- a/src/agents/openai-strict-tool-support.ts
+++ b/src/agents/openai-strict-tool-support.ts
@@ -43,6 +43,7 @@ function routesOpenRouterToProvider(
     !Array.isArray(compat.openRouterRouting)
       ? (compat.openRouterRouting as {
           allow_fallbacks?: unknown;
+          allowFallbacks?: unknown;
           only?: unknown;
           order?: unknown;
           providers?: unknown;
@@ -60,7 +61,7 @@ function routesOpenRouterToProvider(
     return true;
   }
 
-  const allowFallbacks = routing?.allow_fallbacks;
+  const allowFallbacks = routing?.allowFallbacks ?? routing?.allow_fallbacks;
   const order = normalizeRoutingList(routing?.order);
   if (allowFallbacks === false && order.length === 1 && order[0] === providerId) {
     return true;

--- a/src/agents/openai-strict-tool-support.ts
+++ b/src/agents/openai-strict-tool-support.ts
@@ -1,0 +1,102 @@
+function getHeaderValue(
+  headers: Record<string, string> | undefined,
+  headerName: string,
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const target = headerName.toLowerCase();
+  let matchedValue: string | undefined;
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === target) {
+      matchedValue = value;
+    }
+  }
+  return matchedValue;
+}
+
+export function isOpenRouterBaseUrl(baseUrl: unknown): boolean {
+  if (typeof baseUrl !== "string" || !baseUrl.trim()) {
+    return false;
+  }
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "openrouter.ai" || host === "api.openrouter.ai";
+  } catch {
+    return false;
+  }
+}
+
+function routesOpenRouterToProvider(
+  model: {
+    compat?: unknown;
+  },
+  providerId: string,
+): boolean {
+  const compat =
+    model.compat && typeof model.compat === "object" && !Array.isArray(model.compat)
+      ? (model.compat as { openRouterRouting?: unknown })
+      : undefined;
+  const routing =
+    compat?.openRouterRouting &&
+    typeof compat.openRouterRouting === "object" &&
+    !Array.isArray(compat.openRouterRouting)
+      ? (compat.openRouterRouting as {
+          allow_fallbacks?: unknown;
+          only?: unknown;
+          order?: unknown;
+          providers?: unknown;
+        })
+      : undefined;
+  const normalizeRoutingList = (value: unknown): string[] =>
+    Array.isArray(value)
+      ? value
+          .flatMap((entry) => (typeof entry === "string" ? [entry.trim().toLowerCase()] : []))
+          .filter(Boolean)
+      : [];
+
+  const only = normalizeRoutingList(routing?.only);
+  if (only.length === 1 && only[0] === providerId) {
+    return true;
+  }
+
+  const allowFallbacks = routing?.allow_fallbacks;
+  const order = normalizeRoutingList(routing?.order);
+  if (allowFallbacks === false && order.length === 1 && order[0] === providerId) {
+    return true;
+  }
+
+  const providers = normalizeRoutingList(routing?.providers);
+  return providers.length === 1 && providers[0] === providerId;
+}
+
+export function hasOpenRouterStrictToolSupportRoute(model: {
+  baseUrl?: unknown;
+  compat?: unknown;
+  id?: unknown;
+  headers?: unknown;
+}): boolean {
+  if (!isOpenRouterBaseUrl(model.baseUrl)) {
+    return false;
+  }
+
+  const modelId = typeof model.id === "string" ? model.id.trim().toLowerCase() : "";
+  if (modelId.startsWith("openai/") || routesOpenRouterToProvider(model, "openai")) {
+    return true;
+  }
+  if (!modelId.startsWith("anthropic/") && !routesOpenRouterToProvider(model, "anthropic")) {
+    return false;
+  }
+
+  const anthropicBetaHeader = getHeaderValue(
+    model.headers && typeof model.headers === "object" && !Array.isArray(model.headers)
+      ? (model.headers as Record<string, string>)
+      : undefined,
+    "x-anthropic-beta",
+  );
+  return (
+    anthropicBetaHeader
+      ?.split(",")
+      .some((value) => value.trim() === "structured-outputs-2025-11-13") === true
+  );
+}

--- a/src/agents/openai-strict-tool-support.ts
+++ b/src/agents/openai-strict-tool-support.ts
@@ -80,7 +80,10 @@ export function hasOpenRouterStrictToolSupportRoute(model: {
 
   const modelId = typeof model.id === "string" ? model.id.trim().toLowerCase() : "";
   const exclusiveProvider = resolveExclusiveOpenRouterProvider(model);
-  if (exclusiveProvider === "openai" || exclusiveProvider === "azure") {
+  if (exclusiveProvider === "openai") {
+    return true;
+  }
+  if (exclusiveProvider === "azure" && modelId.startsWith("openai/")) {
     return true;
   }
   if (modelId.startsWith("openai/")) {

--- a/src/agents/openai-strict-tool-support.ts
+++ b/src/agents/openai-strict-tool-support.ts
@@ -27,12 +27,7 @@ export function isOpenRouterBaseUrl(baseUrl: unknown): boolean {
   }
 }
 
-function routesOpenRouterToProvider(
-  model: {
-    compat?: unknown;
-  },
-  providerId: string,
-): boolean {
+function resolveExclusiveOpenRouterProvider(model: { compat?: unknown }): string | undefined {
   const compat =
     model.compat && typeof model.compat === "object" && !Array.isArray(model.compat)
       ? (model.compat as { openRouterRouting?: unknown })
@@ -55,20 +50,14 @@ function routesOpenRouterToProvider(
           .flatMap((entry) => (typeof entry === "string" ? [entry.trim().toLowerCase()] : []))
           .filter(Boolean)
       : [];
-
-  const only = normalizeRoutingList(routing?.only);
-  if (only.length === 1 && only[0] === providerId) {
-    return true;
-  }
-
   const allowFallbacks = routing?.allowFallbacks ?? routing?.allow_fallbacks;
   const order = normalizeRoutingList(routing?.order);
-  if (allowFallbacks === false && order.length === 1 && order[0] === providerId) {
-    return true;
+  if (allowFallbacks === false && order.length === 1) {
+    return order[0];
   }
 
   const providers = normalizeRoutingList(routing?.providers);
-  return providers.length === 1 && providers[0] === providerId;
+  return providers.length === 1 ? providers[0] : undefined;
 }
 
 export function hasOpenRouterStrictToolSupportRoute(model: {
@@ -82,10 +71,17 @@ export function hasOpenRouterStrictToolSupportRoute(model: {
   }
 
   const modelId = typeof model.id === "string" ? model.id.trim().toLowerCase() : "";
-  if (modelId.startsWith("openai/") || routesOpenRouterToProvider(model, "openai")) {
+  const exclusiveProvider = resolveExclusiveOpenRouterProvider(model);
+  if (exclusiveProvider === "openai") {
     return true;
   }
-  if (!modelId.startsWith("anthropic/") && !routesOpenRouterToProvider(model, "anthropic")) {
+  if (modelId.startsWith("openai/")) {
+    return exclusiveProvider === undefined;
+  }
+  if (exclusiveProvider && exclusiveProvider !== "anthropic") {
+    return false;
+  }
+  if (!modelId.startsWith("anthropic/") && exclusiveProvider !== "anthropic") {
     return false;
   }
 

--- a/src/agents/openai-strict-tool-support.ts
+++ b/src/agents/openai-strict-tool-support.ts
@@ -72,16 +72,16 @@ export function hasOpenRouterStrictToolSupportRoute(model: {
 
   const modelId = typeof model.id === "string" ? model.id.trim().toLowerCase() : "";
   const exclusiveProvider = resolveExclusiveOpenRouterProvider(model);
-  if (exclusiveProvider === "openai") {
+  if (exclusiveProvider === "openai" || exclusiveProvider === "azure") {
     return true;
   }
   if (modelId.startsWith("openai/")) {
     return exclusiveProvider === undefined;
   }
-  if (exclusiveProvider && exclusiveProvider !== "anthropic") {
+  if (exclusiveProvider !== "anthropic") {
     return false;
   }
-  if (!modelId.startsWith("anthropic/") && exclusiveProvider !== "anthropic") {
+  if (!modelId.startsWith("anthropic/")) {
     return false;
   }
 

--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -736,6 +736,80 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
     expect(payload.tools?.[0]?.function?.strict).toBe(true);
   });
 
+  it("preserves function.strict for OpenRouter OpenAI endpoint slugs pinned to OpenAI", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "openai/gpt-4o",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/openai/gpt-4o": {
+                params: {
+                  provider: {
+                    order: ["openai/turbo"],
+                    allowFallbacks: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("keeps function.strict for direct Azure OpenAI routes", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "azure-openai",
+      applyModelId: "gpt-4o",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "azure-openai",
+        id: "gpt-4o",
+        baseUrl: "https://example.openai.azure.com/openai/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
   it("still strips function.strict for other OpenRouter proxy routes", () => {
     const payload = runExtraParamsCase({
       applyProvider: "openrouter",

--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -1,7 +1,15 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Model } from "@mariozechner/pi-ai";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../../test-utils/env.js";
+import { __testing as providerCapabilitiesTesting } from "../provider-capabilities.js";
+import { __testing as extraParamsTesting } from "./extra-params.js";
 import { runExtraParamsCase } from "./extra-params.test-support.js";
+import {
+  createOpenRouterSystemCacheWrapper,
+  createOpenRouterWrapper,
+  isProxyReasoningUnsupported,
+} from "./proxy-stream-wrappers.js";
 
 function makeModel<
   TApi extends "openai-completions" | "openai-responses" | "openai-codex-responses",
@@ -40,7 +48,45 @@ function applyAndCapture(params: {
 describe("extra-params: OpenAI attribution", () => {
   const envSnapshot = captureEnv(["OPENCLAW_VERSION"]);
 
+  beforeEach(() => {
+    extraParamsTesting.setProviderRuntimeDepsForTest({
+      prepareProviderExtraParams: () => undefined,
+      wrapProviderStreamFn: (params) => {
+        if (params.provider !== "openrouter") {
+          return params.context.streamFn;
+        }
+
+        const providerRouting =
+          params.context.extraParams?.provider != null &&
+          typeof params.context.extraParams.provider === "object"
+            ? (params.context.extraParams.provider as Record<string, unknown>)
+            : undefined;
+        let streamFn = params.context.streamFn;
+        if (providerRouting) {
+          const underlying = streamFn;
+          streamFn = (model, context, options) =>
+            (underlying as StreamFn)(
+              {
+                ...model,
+                compat: { ...model.compat, openRouterRouting: providerRouting },
+              },
+              context,
+              options,
+            );
+        }
+
+        const skipReasoningInjection =
+          params.context.modelId === "auto" || isProxyReasoningUnsupported(params.context.modelId);
+        const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
+        return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
+      },
+    });
+    providerCapabilitiesTesting.setResolveProviderCapabilitiesWithPluginForTest(() => undefined);
+  });
+
   afterEach(() => {
+    extraParamsTesting.resetProviderRuntimeDepsForTest();
+    providerCapabilitiesTesting.resetDepsForTests();
     envSnapshot.restore();
   });
 
@@ -109,6 +155,47 @@ describe("extra-params: OpenAI attribution", () => {
 });
 
 describe("extra-params: OpenAI-compatible tool payloads", () => {
+  beforeEach(() => {
+    extraParamsTesting.setProviderRuntimeDepsForTest({
+      prepareProviderExtraParams: () => undefined,
+      wrapProviderStreamFn: (params) => {
+        if (params.provider !== "openrouter") {
+          return params.context.streamFn;
+        }
+
+        const providerRouting =
+          params.context.extraParams?.provider != null &&
+          typeof params.context.extraParams.provider === "object"
+            ? (params.context.extraParams.provider as Record<string, unknown>)
+            : undefined;
+        let streamFn = params.context.streamFn;
+        if (providerRouting) {
+          const underlying = streamFn;
+          streamFn = (model, context, options) =>
+            (underlying as StreamFn)(
+              {
+                ...model,
+                compat: { ...model.compat, openRouterRouting: providerRouting },
+              },
+              context,
+              options,
+            );
+        }
+
+        const skipReasoningInjection =
+          params.context.modelId === "auto" || isProxyReasoningUnsupported(params.context.modelId);
+        const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
+        return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
+      },
+    });
+    providerCapabilitiesTesting.setResolveProviderCapabilitiesWithPluginForTest(() => undefined);
+  });
+
+  afterEach(() => {
+    extraParamsTesting.resetProviderRuntimeDepsForTest();
+    providerCapabilitiesTesting.resetDepsForTests();
+  });
+
   it("strips function.strict for non-native openai-completions endpoints", () => {
     const payload = runExtraParamsCase({
       applyProvider: "lmstudio",
@@ -228,37 +315,7 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
     expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
   });
 
-  it("keeps function.strict for OpenRouter Anthropic routes with structured outputs enabled", () => {
-    const payload = runExtraParamsCase({
-      applyProvider: "openrouter",
-      applyModelId: "anthropic/claude-sonnet-4",
-      model: makeModel({
-        api: "openai-completions",
-        provider: "openrouter",
-        id: "anthropic/claude-sonnet-4",
-        baseUrl: "https://openrouter.ai/api/v1",
-        headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
-      }),
-      payload: {
-        tools: [
-          {
-            type: "function",
-            function: {
-              name: "web_search",
-              parameters: { type: "object", properties: {} },
-              strict: true,
-            },
-          },
-        ],
-      },
-    }).payload as {
-      tools?: Array<{ function?: Record<string, unknown> }>;
-    };
-
-    expect(payload.tools?.[0]?.function?.strict).toBe(true);
-  });
-
-  it("keeps function.strict when a later-cased OpenRouter Anthropic beta header opts in", () => {
+  it("strips function.strict when a later-cased OpenRouter Anthropic beta header opts in on a default route", () => {
     const payload = runExtraParamsCase({
       applyProvider: "openrouter",
       applyModelId: "anthropic/claude-sonnet-4",
@@ -288,7 +345,7 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
       tools?: Array<{ function?: Record<string, unknown> }>;
     };
 
-    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
   });
 
   it("keeps function.strict for OpenRouter OpenAI-backed routes", () => {

--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -3,6 +3,20 @@ import { afterEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../../test-utils/env.js";
 import { runExtraParamsCase } from "./extra-params.test-support.js";
 
+function makeModel<
+  TApi extends "openai-completions" | "openai-responses" | "openai-codex-responses",
+>(model: Pick<Model<TApi>, "api" | "provider" | "id"> & Partial<Model<TApi>>): Model<TApi> {
+  return {
+    name: model.id,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 1,
+    maxTokens: 1,
+    ...model,
+  } as Model<TApi>;
+}
+
 function applyAndCapture(params: {
   provider: string;
   modelId: string;
@@ -91,5 +105,453 @@ describe("extra-params: OpenAI attribution", () => {
       originator: "openclaw",
       "User-Agent": "openclaw/2026.3.22",
     });
+  });
+});
+
+describe("extra-params: OpenAI-compatible tool payloads", () => {
+  it("strips function.strict for non-native openai-completions endpoints", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "lmstudio",
+      applyModelId: "nemotron-nano-3",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "lmstudio",
+        id: "nemotron-nano-3",
+        baseUrl: "http://lmstudio.local:1234/v1",
+        compat: { supportsStrictMode: false },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              description: "search the web",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("keeps function.strict when compat explicitly enables it on non-native endpoints", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "custom-openai",
+      applyModelId: "tool-friendly-model",
+      model: makeModel({
+        api: "openai-responses",
+        provider: "custom-openai",
+        id: "tool-friendly-model",
+        baseUrl: "https://proxy.example.com/v1",
+        compat: { supportsStrictMode: true },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              description: "search the web",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("keeps function.strict for native openai-responses with no explicit baseUrl", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-4o",
+      model: makeModel({
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-4o",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("strips function.strict for non-native openai-codex-responses endpoints", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.4",
+      model: makeModel({
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        id: "gpt-5.4",
+        baseUrl: "https://proxy.example.com/backend-api",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("keeps function.strict for OpenRouter Anthropic routes with structured outputs enabled", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "anthropic/claude-sonnet-4",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("keeps function.strict when a later-cased OpenRouter Anthropic beta header opts in", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "anthropic/claude-sonnet-4",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: {
+          "x-anthropic-beta": "other-beta",
+          "X-Anthropic-Beta": "structured-outputs-2025-11-13",
+        },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("keeps function.strict for OpenRouter OpenAI-backed routes", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "openai/gpt-4o",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("strips function.strict when provider is openrouter but the route is a non-OpenRouter proxy", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "openai/gpt-4o",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openai/gpt-4o",
+        baseUrl: "https://proxy.example.com/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("keeps function.strict for custom providers routed to OpenRouter", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "custom-router",
+      applyModelId: "openai/gpt-4o",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "custom-router",
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("keeps function.strict for openrouter auto requests dynamically routed to OpenAI", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "auto",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/auto": {
+                params: {
+                  provider: {
+                    only: ["openai"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "auto",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
+  it("strips function.strict when an OpenRouter route only prefers OpenAI but still allows fallbacks", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "auto",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/auto": {
+                params: {
+                  provider: {
+                    order: ["openai"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "auto",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("strips function.strict when an OpenRouter OpenAI-backed route explicitly disables strict mode", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "openai/gpt-4o",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: { supportsStrictMode: false },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("strips function.strict for non-Anthropic OpenRouter routes even with structured outputs headers", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "deepseek/deepseek-chat-v3-0324",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "deepseek/deepseek-chat-v3-0324",
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("still strips function.strict for other OpenRouter proxy routes", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "anthropic/claude-sonnet-4",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -378,7 +378,7 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
     expect(payload.tools?.[0]?.function?.strict).toBe(true);
   });
 
-  it("keeps function.strict for openrouter auto requests dynamically routed to OpenAI", () => {
+  it("strips function.strict when provider.only does not guarantee an exclusive OpenAI route", () => {
     const payload = runExtraParamsCase({
       applyProvider: "openrouter",
       applyModelId: "auto",
@@ -419,7 +419,7 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
       tools?: Array<{ function?: Record<string, unknown> }>;
     };
 
-    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
   });
 
   it("strips function.strict when an OpenRouter route only prefers OpenAI but still allows fallbacks", () => {
@@ -549,6 +549,51 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
         api: "openai-completions",
         provider: "openrouter",
         id: "deepseek/deepseek-chat-v3-0324",
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("strips function.strict for Anthropic model slugs when routing is pinned to a non-Anthropic provider", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "anthropic/claude-sonnet-4",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/anthropic/claude-sonnet-4": {
+                params: {
+                  provider: {
+                    providers: ["amazon-bedrock"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
         baseUrl: "https://openrouter.ai/api/v1",
         headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
       }),

--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -571,6 +571,81 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
     expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
   });
 
+  it("strips function.strict for default-routed Anthropic OpenRouter routes", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "anthropic/claude-sonnet-4",
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("preserves function.strict for Anthropic OpenRouter routes pinned to Anthropic", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "anthropic/claude-sonnet-4",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/anthropic/claude-sonnet-4": {
+                params: {
+                  provider: {
+                    providers: ["anthropic"],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "anthropic/claude-sonnet-4",
+        baseUrl: "https://openrouter.ai/api/v1",
+        headers: { "x-anthropic-beta": "structured-outputs-2025-11-13" },
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
   it("strips function.strict for Anthropic model slugs when routing is pinned to a non-Anthropic provider", () => {
     const payload = runExtraParamsCase({
       applyProvider: "openrouter",
@@ -614,6 +689,51 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
     };
 
     expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
+  });
+
+  it("preserves function.strict for OpenRouter OpenAI routes pinned to Azure", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "openai/gpt-4o",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/openai/gpt-4o": {
+                params: {
+                  provider: {
+                    order: ["azure"],
+                    allowFallbacks: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "openai/gpt-4o",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
   });
 
   it("still strips function.strict for other OpenRouter proxy routes", () => {

--- a/src/agents/pi-embedded-runner/extra-params.openai.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai.test.ts
@@ -466,6 +466,51 @@ describe("extra-params: OpenAI-compatible tool payloads", () => {
     expect(payload.tools?.[0]?.function).not.toHaveProperty("strict");
   });
 
+  it("keeps function.strict when an OpenRouter route disables fallbacks with allowFallbacks", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openrouter",
+      applyModelId: "auto",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/auto": {
+                params: {
+                  provider: {
+                    order: ["openai"],
+                    allowFallbacks: false,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: makeModel({
+        api: "openai-completions",
+        provider: "openrouter",
+        id: "auto",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      payload: {
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "web_search",
+              parameters: { type: "object", properties: {} },
+              strict: true,
+            },
+          },
+        ],
+      },
+    }).payload as {
+      tools?: Array<{ function?: Record<string, unknown> }>;
+    };
+
+    expect(payload.tools?.[0]?.function?.strict).toBe(true);
+  });
+
   it("strips function.strict when an OpenRouter OpenAI-backed route explicitly disables strict mode", () => {
     const payload = runExtraParamsCase({
       applyProvider: "openrouter",

--- a/src/agents/pi-embedded-runner/extra-params.test-support.ts
+++ b/src/agents/pi-embedded-runner/extra-params.test-support.ts
@@ -9,7 +9,7 @@ export type ExtraParamsCapture<TPayload extends Record<string, unknown>> = {
 };
 
 type RunExtraParamsCaseParams<
-  TApi extends "openai-completions" | "openai-responses",
+  TApi extends "openai-completions" | "openai-responses" | "openai-codex-responses",
   TPayload extends Record<string, unknown>,
 > = {
   applyModelId?: string;
@@ -23,7 +23,7 @@ type RunExtraParamsCaseParams<
 };
 
 export function runExtraParamsCase<
-  TApi extends "openai-completions" | "openai-responses",
+  TApi extends "openai-completions" | "openai-responses" | "openai-codex-responses",
   TPayload extends Record<string, unknown>,
 >(params: RunExtraParamsCaseParams<TApi, TPayload>): ExtraParamsCapture<TPayload> {
   const captured: ExtraParamsCapture<TPayload> = {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -33,6 +33,7 @@ import {
   createOpenAIFastModeWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIServiceTierWrapper,
+  createOpenAIStrictToolWrapper,
   resolveOpenAIFastMode,
   resolveOpenAIServiceTier,
 } from "./openai-stream-wrappers.js";
@@ -352,6 +353,7 @@ export function applyExtraParamsToAgent(
     agent.streamFn,
     effectiveExtraParams,
   );
+  agent.streamFn = createOpenAIStrictToolWrapper(agent.streamFn, effectiveExtraParams);
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [resolvedExtraParams, override],

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
+import { hasOpenRouterStrictToolSupportRoute } from "../openai-strict-tool-support.js";
 import { resolveProviderAttributionHeaders } from "../provider-attribution.js";
 import { log } from "./logger.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
@@ -166,6 +167,75 @@ function shouldStripResponsesPromptCache(model: { api?: unknown; baseUrl?: unkno
   return !isDirectOpenAIBaseUrl(model.baseUrl);
 }
 
+function stripUnsupportedStrictFlag(tool: unknown): unknown {
+  if (!tool || typeof tool !== "object") {
+    return tool;
+  }
+  const toolObj = tool as Record<string, unknown>;
+  const fn = toolObj.function;
+  if (!fn || typeof fn !== "object") {
+    return tool;
+  }
+  const fnObj = fn as Record<string, unknown>;
+  if (typeof fnObj.strict !== "boolean") {
+    return tool;
+  }
+  const nextFunction = { ...fnObj };
+  delete nextFunction.strict;
+  return { ...toolObj, function: nextFunction };
+}
+
+function shouldStripOpenAIStrictFlag(model: {
+  api?: unknown;
+  baseUrl?: unknown;
+  headers?: unknown;
+  id?: unknown;
+  provider?: unknown;
+  compat?: { supportsStrictMode?: boolean };
+}): boolean {
+  if (model.compat?.supportsStrictMode === true) {
+    return false;
+  }
+  if (
+    model.api !== "openai-completions" &&
+    model.api !== "openai-responses" &&
+    model.api !== "openai-codex-responses"
+  ) {
+    return false;
+  }
+  if (model.compat?.supportsStrictMode === false) {
+    return true;
+  }
+  if (hasOpenRouterStrictToolSupportRoute(model)) {
+    return false;
+  }
+  // Missing baseUrl means pi-ai will use the default OpenAI endpoint, so keep
+  // strict mode for that direct path.
+  if (typeof model.baseUrl !== "string" || !model.baseUrl.trim()) {
+    return false;
+  }
+  return !isDirectOpenAIBaseUrl(model.baseUrl);
+}
+
+function applyOpenAIStrictFlagPayloadOverrides(params: {
+  payloadObj: Record<string, unknown>;
+  model: {
+    api?: unknown;
+    baseUrl?: unknown;
+    headers?: unknown;
+    id?: unknown;
+    provider?: unknown;
+    compat?: { supportsStrictMode?: boolean };
+  };
+}): void {
+  if (!shouldStripOpenAIStrictFlag(params.model)) {
+    return;
+  }
+  if (!Array.isArray(params.payloadObj.tools)) {
+    return;
+  }
+  params.payloadObj.tools = params.payloadObj.tools.map(stripUnsupportedStrictFlag);
+}
 function applyOpenAIResponsesPayloadOverrides(params: {
   payloadObj: Record<string, unknown>;
   forceStore: boolean;
@@ -338,6 +408,31 @@ export function createOpenAIResponsesContextManagementWrapper(
         }
         return originalOnPayload?.(payload, model);
       },
+    });
+  };
+}
+
+export function createOpenAIStrictToolWrapper(
+  baseStreamFn: StreamFn | undefined,
+  extraParams?: Record<string, unknown>,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const providerRouting =
+      extraParams?.provider != null && typeof extraParams.provider === "object"
+        ? (extraParams.provider as Record<string, unknown>)
+        : undefined;
+    const effectiveModel = providerRouting
+      ? ({
+          ...model,
+          compat: { ...model.compat, openRouterRouting: providerRouting },
+        } as typeof model)
+      : model;
+    if (!shouldStripOpenAIStrictFlag(effectiveModel)) {
+      return underlying(model, context, options);
+    }
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      applyOpenAIStrictFlagPayloadOverrides({ payloadObj, model: effectiveModel });
     });
   };
 }


### PR DESCRIPTION
## Summary
- strip `function.strict` from tool payloads for non-native OpenAI-compatible endpoints unless compat explicitly opts in
- keep native OpenAI requests unchanged
- add regression coverage for LM Studio-style endpoints and explicit strict-mode support

## Testing
- pre-commit `pnpm check` during commit
- targeted: `src/agents/pi-embedded-runner/extra-params.openai.test.ts`

Fixes #51742