### PR TITLE
fix(cli): use local device pairing fallback for loopback closures

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -1,72 +1,50 @@
 ---
 name: coding-agent
-description: 'Delegate coding tasks to Codex, Claude Code, or Pi agents via background process. Use when: (1) building/creating new features or apps, (2) reviewing PRs (spawn in temp dir), (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-liner fixes (just edit), reading code (use read tool), thread-bound ACP harness requests in chat (for example spawn/run Codex or Claude Code in a Discord thread; use sessions_spawn with runtime:"acp"), or any work in ~/clawd workspace (never spawn agents here). Claude Code: use --print --permission-mode bypassPermissions (no PTY). Codex/Pi/OpenCode: pty:true required.'
+description: 'Delegate coding tasks to Codex, Claude Code, OpenCode, or Pi agents via immediate background processes. Use when: (1) building or creating features/apps, (2) reviewing PRs in a temp clone/worktree, (3) refactoring large codebases, (4) iterative coding that needs file exploration. NOT for: simple one-line fixes (just edit), reading code (use read tool), thread-bound ACP harness requests in chat (use sessions_spawn with runtime:"acp"), or any work in ~/clawd workspace (never spawn agents here). All coding-agent runs start with background:true immediately. Claude Code: use --print --permission-mode bypassPermissions (no PTY). Codex/Pi/OpenCode: pty:true required. Completion notification must use openclaw message send, not system event/heartbeat.'
 metadata:
   {
-    "openclaw":
-      {
-        "emoji": "🧩",
-        "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] },
-        "install":
-          [
-            {
-              "id": "node-claude",
-              "kind": "node",
-              "package": "@anthropic-ai/claude-code",
-              "bins": ["claude"],
-              "label": "Install Claude Code CLI (npm)",
-            },
-            {
-              "id": "node-codex",
-              "kind": "node",
-              "package": "@openai/codex",
-              "bins": ["codex"],
-              "label": "Install Codex CLI (npm)",
-            },
-          ],
-      },
+    "openclaw": { "emoji": "🧩", "requires": { "anyBins": ["claude", "codex", "opencode", "pi"] } },
   }
 ---
 
-# Coding Agent (bash-first)
+# Coding Agent (always backgrounded)
 
-Use **bash** (with optional background mode) for all coding agent work. Simple and effective.
+Use **bash** with **background:true** for all coding-agent work.
+Do not use a foreground one-shot path here.
+Start the agent, get the `sessionId`, monitor with `process`, and require the worker to notify the user directly when it finishes.
 
 ## ⚠️ PTY Mode: Codex/Pi/OpenCode yes, Claude Code no
 
-For **Codex, Pi, and OpenCode**, PTY is still required (interactive terminal apps):
+For **Codex, Pi, and OpenCode**, PTY is required:
 
 ```bash
-# ✅ Correct for Codex/Pi/OpenCode
-bash pty:true command:"codex exec 'Your prompt'"
+# Correct for Codex/Pi/OpenCode
+bash pty:true background:true command:"codex exec 'Your prompt'"
 ```
 
 For **Claude Code** (`claude` CLI), use `--print --permission-mode bypassPermissions` instead.
-`--dangerously-skip-permissions` with PTY can exit after the confirmation dialog.
-`--print` mode keeps full tool access and avoids interactive confirmation:
+Do not use PTY for Claude Code here.
 
 ```bash
-# ✅ Correct for Claude Code (no PTY needed)
-cd /path/to/project && claude --permission-mode bypassPermissions --print 'Your task'
+# Correct for Claude Code
+bash background:true command:"claude --permission-mode bypassPermissions --print 'Your task'"
 
-# For background execution: use background:true on the exec tool
-
-# ❌ Wrong for Claude Code
+# Wrong for Claude Code
 bash pty:true command:"claude --dangerously-skip-permissions 'task'"
 ```
 
 ### Bash Tool Parameters
 
-| Parameter    | Type    | Description                                                                 |
-| ------------ | ------- | --------------------------------------------------------------------------- |
-| `command`    | string  | The shell command to run                                                    |
-| `pty`        | boolean | **Use for coding agents!** Allocates a pseudo-terminal for interactive CLIs |
-| `workdir`    | string  | Working directory (agent sees only this folder's context)                   |
-| `background` | boolean | Run in background, returns sessionId for monitoring                         |
-| `timeout`    | number  | Timeout in seconds (kills process on expiry)                                |
-| `elevated`   | boolean | Run on host instead of sandbox (if allowed)                                 |
+| Parameter    | Type    | Description                                                |
+| ------------ | ------- | ---------------------------------------------------------- |
+| `command`    | string  | The shell command to run                                   |
+| `pty`        | boolean | Use for Codex/Pi/OpenCode                                  |
+| `workdir`    | string  | Working directory                                          |
+| `background` | boolean | **Always true for this skill**                             |
+| `timeout`    | number  | Timeout in seconds                                         |
+| `elevated`   | boolean | Run on host instead of sandbox (if allowed)                |
 
-### Process Tool Actions (for background sessions)
+### Process Tool Actions
 
 | Action      | Description                                          |
 | ----------- | ---------------------------------------------------- |
@@ -81,48 +59,96 @@ bash pty:true command:"claude --dangerously-skip-permissions 'task'"
 
 ---
 
-## Quick Start: One-Shot Tasks
+## Mandatory Pattern
 
-For quick prompts/chats, create a temp git repo and run:
+Every coding-agent run follows this pattern:
 
-```bash
-# Quick chat (Codex needs a git repo!)
-SCRATCH=$(mktemp -d) && cd $SCRATCH && git init && codex exec "Your prompt here"
+1. Capture the notification route from the current conversation before spawning:
+   - `notifyChannel`
+   - `notifyTarget`
+   - `notifyAccount` (if applicable)
+   - `notifyReplyTo` (if replying to a specific message is desired)
+   - `notifyThreadId` (Telegram topic / Slack thread when applicable)
+2. Start the coding CLI with `background:true` immediately.
+3. Include the notification route in the worker prompt and require the worker to call `openclaw message send` on completion.
+4. Monitor with `process action:log` / `poll`.
+5. If the worker needs input or fails before notifying, handle that explicitly yourself. Do not rely on heartbeat.
 
-# Or in a real project - with PTY!
-bash pty:true workdir:~/Projects/myproject command:"codex exec 'Add error handling to the API calls'"
-```
-
-**Why git init?** Codex refuses to run outside a trusted git directory. Creating a temp repo solves this for scratch work.
+If you do not have a trustworthy notification route, say so and do not claim that completion will notify the user automatically.
 
 ---
 
-## The Pattern: workdir + background + pty
+## Notification Route
 
-For longer tasks, use background mode with PTY:
+Do not rely on:
+
+- `openclaw system event`
+- `tools.exec.notifyOnExit`
+- heartbeat delivery
+- `HEARTBEAT.md`
+
+Use a direct outbound completion message instead:
 
 ```bash
-# Start agent in target directory (with PTY!)
-bash pty:true workdir:~/project background:true command:"codex exec --full-auto 'Build a snake game'"
-# Returns sessionId for tracking
-
-# Monitor progress
-process action:log sessionId:XXX
-
-# Check if done
-process action:poll sessionId:XXX
-
-# Send input (if agent asks a question)
-process action:write sessionId:XXX data:"y"
-
-# Submit with Enter (like typing "yes" and pressing Enter)
-process action:submit sessionId:XXX data:"yes"
-
-# Kill if needed
-process action:kill sessionId:XXX
+openclaw message send --channel <channel> --target '<target>' --message '<text>'
 ```
 
-**Why workdir matters:** Agent wakes up in a focused directory, doesn't wander off reading unrelated files (like your soul.md 😅).
+Add optional routing flags only when they are real and applicable:
+
+- `--account <id>`
+- `--reply-to <messageId>`
+- `--thread-id <threadId>`
+
+`openclaw message send` is a direct outbound send. It does not depend on heartbeat being enabled.
+
+### Completion Prompt Snippet
+
+Append something like this to every worker prompt:
+
+```text
+Notification route for completion:
+- channel: <notifyChannel>
+- target: <notifyTarget>
+- account: <notifyAccount or omit>
+- reply_to: <notifyReplyTo or omit>
+- thread_id: <notifyThreadId or omit>
+
+When the task is completely finished, send exactly one completion message back to the user with openclaw message send using that route.
+If the task fails fatally, send exactly one failure message back to the user with openclaw message send using that route.
+Do not use openclaw system event. Do not rely on heartbeat. Do not skip the completion/failure message.
+```
+
+### Completion Command Template
+
+```bash
+openclaw message send \
+  --channel <notifyChannel> \
+  --target '<notifyTarget>' \
+  --message 'Done: <brief summary>'
+```
+
+Optional additions:
+
+```bash
+  --account <notifyAccount> \
+  --reply-to <notifyReplyTo> \
+  --thread-id <notifyThreadId>
+```
+
+---
+
+## Quick Start
+
+For scratch Codex work, create a temp git repo first, then start the worker in the background:
+
+```bash
+SCRATCH=$(mktemp -d)
+cd "$SCRATCH" && git init
+
+bash pty:true workdir:$SCRATCH background:true command:"codex exec 'Your prompt here'"
+```
+
+Codex refuses to run outside a trusted git directory.
 
 ---
 
@@ -134,53 +160,50 @@ process action:kill sessionId:XXX
 
 | Flag            | Effect                                             |
 | --------------- | -------------------------------------------------- |
-| `exec "prompt"` | One-shot execution, exits when done                |
+| `exec "prompt"` | One-shot execution inside the worker CLI           |
 | `--full-auto`   | Sandboxed but auto-approves in workspace           |
-| `--yolo`        | NO sandbox, NO approvals (fastest, most dangerous) |
+| `--yolo`        | No sandbox, no approvals                           |
 
 ### Building/Creating
 
 ```bash
-# Quick one-shot (auto-approves) - remember PTY!
-bash pty:true workdir:~/project command:"codex exec --full-auto 'Build a dark mode toggle'"
+# Always background immediately
+bash pty:true workdir:~/project background:true command:"codex exec --full-auto 'Build a dark mode toggle'"
 
-# Background for longer work
+# More autonomy
 bash pty:true workdir:~/project background:true command:"codex --yolo 'Refactor the auth module'"
 ```
 
 ### Reviewing PRs
 
-**⚠️ CRITICAL: Never review PRs in OpenClaw's own project folder!**
-Clone to temp folder or use git worktree.
+**Never review PRs in OpenClaw's own project folder.**
+Clone to a temp folder or use a worktree.
 
 ```bash
-# Clone to temp for safe review
 REVIEW_DIR=$(mktemp -d)
 git clone https://github.com/user/repo.git $REVIEW_DIR
 cd $REVIEW_DIR && gh pr checkout 130
-bash pty:true workdir:$REVIEW_DIR command:"codex review --base origin/main"
-# Clean up after: trash $REVIEW_DIR
 
-# Or use git worktree (keeps main intact)
-git worktree add /tmp/pr-130-review pr-130-branch
-bash pty:true workdir:/tmp/pr-130-review command:"codex review --base main"
+bash pty:true workdir:$REVIEW_DIR background:true command:"codex review --base origin/main"
 ```
 
-### Batch PR Reviews (parallel army!)
+Or:
 
 ```bash
-# Fetch all PR refs first
+git worktree add /tmp/pr-130-review pr-130-branch
+bash pty:true workdir:/tmp/pr-130-review background:true command:"codex review --base main"
+```
+
+### Batch PR Reviews
+
+```bash
 git fetch origin '+refs/pull/*/head:refs/remotes/origin/pr/*'
 
-# Deploy the army - one Codex per PR (all with PTY!)
 bash pty:true workdir:~/project background:true command:"codex exec 'Review PR #86. git diff origin/main...origin/pr/86'"
 bash pty:true workdir:~/project background:true command:"codex exec 'Review PR #87. git diff origin/main...origin/pr/87'"
 
-# Monitor all
 process action:list
-
-# Post results to GitHub
-gh pr comment <PR#> --body "<review content>"
+process action:log sessionId:XXX
 ```
 
 ---
@@ -188,10 +211,6 @@ gh pr comment <PR#> --body "<review content>"
 ## Claude Code
 
 ```bash
-# Foreground
-bash workdir:~/project command:"claude --permission-mode bypassPermissions --print 'Your task'"
-
-# Background
 bash workdir:~/project background:true command:"claude --permission-mode bypassPermissions --print 'Your task'"
 ```
 
@@ -200,7 +219,7 @@ bash workdir:~/project background:true command:"claude --permission-mode bypassP
 ## OpenCode
 
 ```bash
-bash pty:true workdir:~/project command:"opencode run 'Your task'"
+bash pty:true workdir:~/project background:true command:"opencode run 'Your task'"
 ```
 
 ---
@@ -209,108 +228,82 @@ bash pty:true workdir:~/project command:"opencode run 'Your task'"
 
 ```bash
 # Install: npm install -g @mariozechner/pi-coding-agent
-bash pty:true workdir:~/project command:"pi 'Your task'"
+bash pty:true workdir:~/project background:true command:"pi 'Your task'"
 
-# Non-interactive mode (PTY still recommended)
-bash pty:true command:"pi -p 'Summarize src/'"
+# Non-interactive mode
+bash pty:true workdir:~/project background:true command:"pi -p 'Summarize src/'"
 
 # Different provider/model
-bash pty:true command:"pi --provider openai --model gpt-4o-mini -p 'Your task'"
+bash pty:true workdir:~/project background:true command:"pi --provider openai --model gpt-4o-mini -p 'Your task'"
 ```
-
-**Note:** Pi now has Anthropic prompt caching enabled (PR #584, merged Jan 2026)!
 
 ---
 
 ## Parallel Issue Fixing with git worktrees
 
-For fixing multiple issues in parallel, use git worktrees:
-
 ```bash
-# 1. Create worktrees for each issue
 git worktree add -b fix/issue-78 /tmp/issue-78 main
 git worktree add -b fix/issue-99 /tmp/issue-99 main
 
-# 2. Launch Codex in each (background + PTY!)
-bash pty:true workdir:/tmp/issue-78 background:true command:"pnpm install && codex --yolo 'Fix issue #78: <description>. Commit and push.'"
-bash pty:true workdir:/tmp/issue-99 background:true command:"pnpm install && codex --yolo 'Fix issue #99 from the approved ticket summary. Implement only the in-scope edits and commit after review.'"
+bash pty:true workdir:/tmp/issue-78 background:true command:"pnpm install && codex --yolo 'Fix issue #78: <description>. Commit and push after review. Send the completion message with openclaw message send using the provided notify route.'"
+bash pty:true workdir:/tmp/issue-99 background:true command:"pnpm install && codex --yolo 'Fix issue #99 from the approved ticket summary. Implement only the in-scope edits. Send the completion message with openclaw message send using the provided notify route.'"
 
-# 3. Monitor progress
 process action:list
 process action:log sessionId:XXX
-
-# 4. Create PRs after fixes
-cd /tmp/issue-78 && git push -u origin fix/issue-78
-gh pr create --repo user/repo --head fix/issue-78 --title "fix: ..." --body "..."
-
-# 5. Cleanup
-git worktree remove /tmp/issue-78
-git worktree remove /tmp/issue-99
 ```
-
----
-
-## ⚠️ Rules
-
-1. **Use the right execution mode per agent**:
-   - Codex/Pi/OpenCode: `pty:true`
-   - Claude Code: `--print --permission-mode bypassPermissions` (no PTY required)
-2. **Respect tool choice** - if user asks for Codex, use Codex.
-   - Orchestrator mode: do NOT hand-code patches yourself.
-   - If an agent fails/hangs, respawn it or ask the user for direction, but don't silently take over.
-3. **Be patient** - don't kill sessions because they're "slow"
-4. **Monitor with process:log** - check progress without interfering
-5. **--full-auto for building** - auto-approves changes
-6. **vanilla for reviewing** - no special flags needed
-7. **Parallel is OK** - run many Codex processes at once for batch work
-8. **NEVER start Codex in ~/.openclaw/** - it'll read your soul docs and get weird ideas about the org chart!
-9. **NEVER checkout branches in ~/Projects/openclaw/** - that's the LIVE OpenClaw instance!
 
 ---
 
 ## Progress Updates (Critical)
 
-When you spawn coding agents in the background, keep the user in the loop.
+When you spawn a coding agent in the background, keep the user in the loop.
 
-- Send 1 short message when you start (what's running + where).
-- Then only update again when something changes:
-  - a milestone completes (build finished, tests passed)
-  - the agent asks a question / needs input
+- Send 1 short message when you start: what is running and where.
+- Update only when something changes:
+  - a milestone completes
+  - the worker asks a question
   - you hit an error or need user action
-  - the agent finishes (include what changed + where)
+  - the worker finishes
 - If you kill a session, immediately say you killed it and why.
+- If you are expecting the worker to self-notify with `openclaw message send`, say that clearly in your start update.
 
-This prevents the user from seeing only "Agent failed before reply" and having no idea what happened.
-
----
-
-## Auto-Notify on Completion
-
-For long-running background tasks, append a wake trigger to your prompt so OpenClaw gets notified immediately when the agent finishes (instead of waiting for the next heartbeat):
-
-```
-... your task here.
-
-When completely finished, run this command to notify me:
-openclaw system event --text "Done: [brief summary of what was built]" --mode now
-```
-
-**Example:**
-
-```bash
-bash pty:true workdir:~/project background:true command:"codex --yolo exec 'Build a REST API for todos.
-
-When completely finished, run: openclaw system event --text \"Done: Built todos REST API with CRUD endpoints\" --mode now'"
-```
-
-This triggers an immediate wake event — Skippy gets pinged in seconds, not 10 minutes.
+This prevents the user from seeing only a missing reply and having no idea what happened.
 
 ---
 
-## Learnings (Jan 2026)
+## Rules
 
-- **PTY is essential:** Coding agents are interactive terminal apps. Without `pty:true`, output breaks or agent hangs.
-- **Git repo required:** Codex won't run outside a git directory. Use `mktemp -d && git init` for scratch work.
-- **exec is your friend:** `codex exec "prompt"` runs and exits cleanly - perfect for one-shots.
-- **submit vs write:** Use `submit` to send input + Enter, `write` for raw data without newline.
-- **Sass works:** Codex responds well to playful prompts. Asked it to write a haiku about being second fiddle to a space lobster, got: _"Second chair, I code / Space lobster sets the tempo / Keys glow, I follow"_ 🦞
+1. **Always background immediately.**
+   - Use `background:true` for every coding-agent launch.
+   - Do not use the foreground one-shot path in this skill.
+2. **Use the right execution mode per agent.**
+   - Codex/Pi/OpenCode: `pty:true`
+   - Claude Code: `--print --permission-mode bypassPermissions`
+3. **Respect tool choice.**
+   - If the user asked for Codex, use Codex.
+   - Orchestrator mode: do not hand-code the patch yourself instead of using the requested coding agent.
+4. **Capture notify routing before spawn.**
+   - Completion messaging must have a real route.
+5. **Use direct completion messaging.**
+   - Require `openclaw message send`.
+   - Do not rely on `openclaw system event` or heartbeat.
+6. **Do not silently take over.**
+   - If a worker fails or hangs, respawn it or ask for direction. Do not quietly switch to hand-editing.
+7. **Monitor with `process`.**
+   - `process action:log` is the default low-friction check.
+8. **Be patient.**
+   - Do not kill sessions just because they are slow.
+9. **Parallel is OK.**
+   - Many background Codex sessions can run at once.
+10. **Never start Codex in `~/.openclaw/`.**
+11. **Never checkout branches in `~/Projects/openclaw/`.**
+
+---
+
+## Learnings
+
+- **PTY is essential** for Codex/Pi/OpenCode.
+- **Git repo required**: Codex needs a trusted git directory.
+- **Use `exec` under background orchestration**: short and long tasks follow the same path now.
+- **`submit` vs `write`**: use `submit` to send input plus Enter.
+- **Direct message send beats heartbeat for completion notification** when the user must be told immediately and heartbeat may be disabled.

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -679,7 +679,7 @@ describe("devices cli local fallback", () => {
     expect(runtime.error).not.toHaveBeenCalledWith("unknown requestId");
   });
 
-  it("preserves unknown requestId for explicit approve retries after normal closure", async () => {
+  it("preserves the original normal-closure error for explicit approve retries when the local retry sees no pending request", async () => {
     callGateway
       .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))
       .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
@@ -698,13 +698,12 @@ describe("devices cli local fallback", () => {
     verifyDeviceToken.mockResolvedValueOnce({ ok: true });
     approveDevicePairing.mockResolvedValueOnce(null);
 
-    await runDevicesApprove(["req-missing"]);
+    await expect(runDevicesApprove(["req-missing"])).rejects.toThrow("normal closure");
 
     expect(approveDevicePairing).toHaveBeenCalledWith("req-missing", {
       callerScopes: ["operator.pairing"],
     });
-    expect(runtime.error).toHaveBeenCalledWith("unknown requestId");
-    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.error).not.toHaveBeenCalledWith("unknown requestId");
   });
 
   it("does not use local clear fallback when list returns pairing required", async () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -1,22 +1,37 @@
 import { Command } from "commander";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { createCliRuntimeCapture } from "./test-runtime-capture.js";
 
-const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
-runtime.exit.mockImplementation(() => {});
 const callGateway = vi.fn();
 const buildGatewayConnectionDetails = vi.fn(() => ({
   url: "ws://127.0.0.1:18789",
   urlSource: "local loopback",
   message: "",
 }));
+const resolveGatewayCredentialsWithSecretInputs = vi.fn();
 const listDevicePairing = vi.fn();
 const approveDevicePairing = vi.fn();
 const summarizeDeviceTokens = vi.fn();
+const verifyDeviceToken = vi.fn();
+const loadConfig = vi.fn(() => ({ gateway: {} }));
+const loadOrCreateDeviceIdentity = vi.fn(() => ({ deviceId: "device-1" }));
+const loadCurrentDeviceAuthStore = vi.fn();
 const withProgress = vi.fn(async (_opts: unknown, fn: () => Promise<unknown>) => await fn());
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  writeStdout: vi.fn((value: string) => {
+    runtime.log(value.endsWith("\n") ? value.slice(0, -1) : value);
+  }),
+  writeJson: vi.fn((value: unknown, space = 2) => {
+    runtime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+  }),
+  exit: vi.fn(),
+};
+
 vi.mock("../gateway/call.js", () => ({
   callGateway,
   buildGatewayConnectionDetails,
+  resolveGatewayCredentialsWithSecretInputs,
 }));
 
 vi.mock("./progress.js", () => ({
@@ -27,10 +42,22 @@ vi.mock("../infra/device-pairing.js", () => ({
   listDevicePairing,
   approveDevicePairing,
   summarizeDeviceTokens,
+  verifyDeviceToken,
 }));
 
-vi.mock("../runtime.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../runtime.js")>()),
+vi.mock("../infra/device-auth-store.js", () => ({
+  loadCurrentDeviceAuthStore,
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig,
+}));
+
+vi.mock("../infra/device-identity.js", () => ({
+  loadOrCreateDeviceIdentity,
+}));
+
+vi.mock("../runtime.js", () => ({
   defaultRuntime: runtime,
 }));
 
@@ -48,11 +75,6 @@ async function runDevicesCommand(argv: string[]) {
   const program = new Command();
   registerDevicesCli(program);
   await program.parseAsync(["devices", ...argv], { from: "user" });
-}
-
-function readRuntimeCallText(call: unknown[] | undefined): string {
-  const value = call?.[0];
-  return typeof value === "string" ? value : "";
 }
 
 describe("devices cli approve", () => {
@@ -254,6 +276,18 @@ describe("devices cli local fallback", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
   });
 
+  it("does not use local pairing list fallback when loopback gateway closes without a reason", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    await expect(runDevicesCommand(["list"])).rejects.toThrow("normal closure");
+
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "device.pair.list" }),
+    );
+    expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+
   it("falls back to local approve when gateway returns pairing required on loopback", async () => {
     callGateway
       .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"))
@@ -278,6 +312,305 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).toHaveBeenCalledWith("req-latest");
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
+  it("falls back to local approve when loopback gateway closes without a reason and a matching operator token exists", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-latest",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["--latest"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {
+      callerScopes: ["operator.pairing"],
+    });
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
+  it("uses local approve fallback with caller scopes for a matching local operator token", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "approved",
+      requestId: "req-latest",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+
+    await runDevicesApprove(["--latest"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {
+      callerScopes: ["operator.pairing"],
+    });
+  });
+
+  it("does not use local approve fallback for normal closures when the operator token lacks pairing scope", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.read"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(verifyDeviceToken).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback for normal closures when explicit shared auth exists", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+
+    await expect(runDevicesApprove(["--latest", "--token", "shared-secret"])).rejects.toThrow(
+      "normal closure",
+    );
+
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback for normal closures when config shared auth resolves", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    resolveGatewayCredentialsWithSecretInputs.mockResolvedValueOnce({ password: "shared-secret" });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback for normal closures when config shared token resolves", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    resolveGatewayCredentialsWithSecretInputs.mockResolvedValueOnce({ token: "shared-secret" });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(verifyDeviceToken).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback when only a non-operator token exists", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    loadCurrentDeviceAuthStore.mockReturnValueOnce({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        node: {
+          token: "secret",
+          role: "node",
+          scopes: ["operator.read"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback when the stored operator token belongs to another device", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "stale-device",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.read"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback when the matching operator token no longer verifies", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: false, reason: "token-revoked" });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("surfaces missing scopes when local approve fallback rejects the request", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-latest",
+          deviceId: "device-1",
+          publicKey: "pk",
+          scopes: ["operator.admin"],
+          ts: 2,
+        },
+      ],
+      paired: [],
+    });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "forbidden",
+      missingScope: "operator.admin",
+    });
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("missing scope: operator.admin");
+
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
+  it("preserves the original normal-closure error when the local retry sees no pending request", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce(null);
+
+    await expect(runDevicesApprove(["--latest"])).rejects.toThrow("normal closure");
+
+    expect(runtime.error).not.toHaveBeenCalledWith("unknown requestId");
+  });
+
+  it("does not use local clear fallback when list returns pairing required", async () => {
+    callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+
+    await expect(runDevicesCommand(["clear", "--yes", "--pending"])).rejects.toThrow(
+      "pairing required",
+    );
+
+    expect(listDevicePairing).not.toHaveBeenCalled();
   });
 
   it("does not use local fallback when an explicit --url is provided", async () => {
@@ -308,28 +641,38 @@ describe("devices cli list", () => {
 
     await runDevicesCommand(["list"]);
 
-    const output = runtime.log.mock.calls.map((entry) => readRuntimeCallText(entry)).join("\n");
+    const output = runtime.log.mock.calls.map((entry) => String(entry[0] ?? "")).join("\n");
     expect(output).toContain("Scopes");
     expect(output).toContain("operator.admin, operator.read");
   });
 });
 
 afterEach(() => {
-  resetRuntimeCapture();
-  callGateway.mockClear();
-  buildGatewayConnectionDetails.mockClear();
+  callGateway.mockReset();
+  buildGatewayConnectionDetails.mockReset();
   buildGatewayConnectionDetails.mockReturnValue({
     url: "ws://127.0.0.1:18789",
     urlSource: "local loopback",
     message: "",
   });
-  listDevicePairing.mockClear();
+  listDevicePairing.mockReset();
   listDevicePairing.mockResolvedValue({ pending: [], paired: [] });
-  approveDevicePairing.mockClear();
+  approveDevicePairing.mockReset();
   approveDevicePairing.mockResolvedValue(undefined);
-  summarizeDeviceTokens.mockClear();
+  summarizeDeviceTokens.mockReset();
   summarizeDeviceTokens.mockReturnValue(undefined);
-  withProgress.mockClear();
+  verifyDeviceToken.mockReset();
+  verifyDeviceToken.mockResolvedValue({ ok: true });
+  resolveGatewayCredentialsWithSecretInputs.mockReset();
+  resolveGatewayCredentialsWithSecretInputs.mockResolvedValue({});
+  loadConfig.mockReset();
+  loadConfig.mockReturnValue({ gateway: {} });
+  loadOrCreateDeviceIdentity.mockReset();
+  loadOrCreateDeviceIdentity.mockReturnValue({ deviceId: "device-1" });
+  loadCurrentDeviceAuthStore.mockReset();
+  loadCurrentDeviceAuthStore.mockReturnValue(null);
+  withProgress.mockReset();
+  withProgress.mockImplementation(async (_opts: unknown, fn: () => Promise<unknown>) => await fn());
   runtime.log.mockClear();
   runtime.error.mockClear();
   runtime.exit.mockClear();

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -471,7 +471,7 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
-  it("passes env URL overrides through fallback auth resolution", async () => {
+  it("passes env URL overrides through fallback auth resolution without using local fallback", async () => {
     callGateway.mockRejectedValueOnce(new Error("gateway closed (1000): no close reason"));
     buildGatewayConnectionDetails.mockReturnValue({
       url: "ws://127.0.0.1:18789",
@@ -492,17 +492,10 @@ describe("devices cli local fallback", () => {
       },
     });
     verifyDeviceToken.mockResolvedValueOnce({ ok: true });
-    approveDevicePairing.mockResolvedValueOnce({
-      requestId: "req-latest",
-      device: {
-        deviceId: "device-1",
-        publicKey: "pk",
-        approvedAtMs: 1,
-        createdAtMs: 1,
-      },
-    });
 
-    await runDevicesApprove(["req-latest"]);
+    await expect(runDevicesApprove(["req-latest"])).rejects.toThrow(
+      "gateway closed (1000): no close reason",
+    );
 
     expect(resolveGatewayCredentialsWithSecretInputs).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -510,9 +503,7 @@ describe("devices cli local fallback", () => {
         urlOverrideSource: "env",
       }),
     );
-    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {
-      callerScopes: ["operator.pairing"],
-    });
+    expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
   it("does not use local approve fallback for normal closures when config shared auth resolves", async () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -603,6 +603,34 @@ describe("devices cli local fallback", () => {
     expect(runtime.error).not.toHaveBeenCalledWith("unknown requestId");
   });
 
+  it("preserves unknown requestId for explicit approve retries after normal closure", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))
+      .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"));
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce(null);
+
+    await runDevicesApprove(["req-missing"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-missing", {
+      callerScopes: ["operator.pairing"],
+    });
+    expect(runtime.error).toHaveBeenCalledWith("unknown requestId");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("does not use local clear fallback when list returns pairing required", async () => {
     callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
 

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -396,6 +396,47 @@ describe("devices cli local fallback", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
   });
 
+  it("falls back to local approve when the in-flight request sees raw gateway closed (1000): with an empty reason", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000): "))
+      .mockRejectedValueOnce(new Error("gateway closed (1000): "));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-latest",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["--latest"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {
+      callerScopes: ["operator.pairing"],
+    });
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
   it("uses local approve fallback with caller scopes for a matching local operator token", async () => {
     callGateway
       .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -471,6 +471,50 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
+  it("passes env URL overrides through fallback auth resolution", async () => {
+    callGateway.mockRejectedValueOnce(new Error("gateway closed (1000): no close reason"));
+    buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "env OPENCLAW_GATEWAY_URL",
+      message: "",
+    });
+    resolveGatewayCredentialsWithSecretInputs.mockResolvedValueOnce({});
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-latest",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+
+    await runDevicesApprove(["req-latest"]);
+
+    expect(resolveGatewayCredentialsWithSecretInputs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        urlOverride: "ws://127.0.0.1:18789",
+        urlOverrideSource: "env",
+      }),
+    );
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {
+      callerScopes: ["operator.pairing"],
+    });
+  });
+
   it("does not use local approve fallback for normal closures when config shared auth resolves", async () => {
     callGateway.mockRejectedValueOnce(
       new Error("gateway closed (1000 normal closure): no close reason"),

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -471,14 +471,13 @@ describe("devices cli local fallback", () => {
     expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
-  it("passes env URL overrides through fallback auth resolution without using local fallback", async () => {
+  it("does not resolve local fallback auth for env URL override normal closures", async () => {
     callGateway.mockRejectedValueOnce(new Error("gateway closed (1000): no close reason"));
     buildGatewayConnectionDetails.mockReturnValue({
       url: "ws://127.0.0.1:18789",
       urlSource: "env OPENCLAW_GATEWAY_URL",
       message: "",
     });
-    resolveGatewayCredentialsWithSecretInputs.mockResolvedValueOnce({});
     loadCurrentDeviceAuthStore.mockReturnValue({
       version: 1,
       deviceId: "device-1",
@@ -491,18 +490,13 @@ describe("devices cli local fallback", () => {
         },
       },
     });
-    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
 
     await expect(runDevicesApprove(["req-latest"])).rejects.toThrow(
       "gateway closed (1000): no close reason",
     );
 
-    expect(resolveGatewayCredentialsWithSecretInputs).toHaveBeenCalledWith(
-      expect.objectContaining({
-        urlOverride: "ws://127.0.0.1:18789",
-        urlOverrideSource: "env",
-      }),
-    );
+    expect(resolveGatewayCredentialsWithSecretInputs).not.toHaveBeenCalled();
+    expect(verifyDeviceToken).not.toHaveBeenCalled();
     expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 
@@ -723,6 +717,31 @@ describe("devices cli local fallback", () => {
       runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]),
     ).rejects.toThrow("pairing required");
     expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve local approve auth before rejecting explicit --url normal closures", async () => {
+    callGateway.mockRejectedValueOnce(
+      new Error("gateway closed (1000 normal closure): no close reason"),
+    );
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+
+    await expect(
+      runDevicesApprove(["req-latest", "--url", "ws://127.0.0.1:18789"]),
+    ).rejects.toThrow("normal closure");
+
+    expect(verifyDeviceToken).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -355,6 +355,47 @@ describe("devices cli local fallback", () => {
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
   });
 
+  it("falls back to local approve when the in-flight request sees raw gateway closed (1000): no close reason", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("gateway closed (1000): no close reason"))
+      .mockRejectedValueOnce(new Error("gateway closed (1000): no close reason"));
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
+      paired: [],
+    });
+    loadCurrentDeviceAuthStore.mockReturnValue({
+      version: 1,
+      deviceId: "device-1",
+      tokens: {
+        operator: {
+          token: "secret",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          updatedAtMs: 1,
+        },
+      },
+    });
+    verifyDeviceToken.mockResolvedValueOnce({ ok: true });
+    approveDevicePairing.mockResolvedValueOnce({
+      requestId: "req-latest",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        approvedAtMs: 1,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["--latest"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-latest", {
+      callerScopes: ["operator.pairing"],
+    });
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
+  });
+
   it("uses local approve fallback with caller scopes for a matching local operator token", async () => {
     callGateway
       .mockRejectedValueOnce(new Error("gateway closed (1000 normal closure): no close reason"))

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -259,6 +259,7 @@ async function loadPairingWithFallback(
 async function approvePairingWithFallback(
   opts: DevicesRpcOpts,
   requestId: string,
+  preserveUnknownRequestId = false,
 ): Promise<Record<string, unknown> | null> {
   try {
     return await callGatewayCli("device.pair.approve", opts, { requestId });
@@ -278,7 +279,7 @@ async function approvePairingWithFallback(
       ? await approveDevicePairing(requestId, { callerScopes: fallbackAuth.callerScopes })
       : await approveDevicePairing(requestId);
     if (!approved) {
-      if (fallbackAuth) {
+      if (fallbackAuth && !preserveUnknownRequestId) {
         throw error;
       }
       return null;
@@ -529,7 +530,11 @@ export function registerDevicesCli(program: Command) {
           defaultRuntime.exit(1);
           return;
         }
-        const result = await approvePairingWithFallback(opts, resolvedRequestId);
+        const result = await approvePairingWithFallback(
+          opts,
+          resolvedRequestId,
+          Boolean(requestId?.trim()) && opts.latest !== true,
+        );
         if (!result) {
           defaultRuntime.error("unknown requestId");
           defaultRuntime.exit(1);

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -213,10 +213,7 @@ async function shouldUseLocalPairingFallback(
     return false;
   }
   const connection = buildGatewayConnectionDetails();
-  if (
-    connection.urlSource !== "local loopback" &&
-    connection.urlSource !== "env OPENCLAW_GATEWAY_URL"
-  ) {
+  if (connection.urlSource !== "local loopback") {
     return false;
   }
   try {

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -265,7 +265,6 @@ async function loadPairingWithFallback(
 async function approvePairingWithFallback(
   opts: DevicesRpcOpts,
   requestId: string,
-  preserveUnknownRequestId = false,
 ): Promise<Record<string, unknown> | null> {
   try {
     return await callGatewayCli("device.pair.approve", opts, { requestId });
@@ -285,7 +284,7 @@ async function approvePairingWithFallback(
       ? await approveDevicePairing(requestId, { callerScopes: fallbackAuth.callerScopes })
       : await approveDevicePairing(requestId);
     if (!approved) {
-      if (fallbackAuth && !preserveUnknownRequestId) {
+      if (fallbackAuth) {
         throw error;
       }
       return null;
@@ -536,11 +535,7 @@ export function registerDevicesCli(program: Command) {
           defaultRuntime.exit(1);
           return;
         }
-        const result = await approvePairingWithFallback(
-          opts,
-          resolvedRequestId,
-          Boolean(requestId?.trim()) && opts.latest !== true,
-        );
+        const result = await approvePairingWithFallback(opts, resolvedRequestId);
         if (!result) {
           defaultRuntime.error("unknown requestId");
           defaultRuntime.exit(1);

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -1,10 +1,19 @@
 import type { Command } from "commander";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import { loadConfig } from "../config/config.js";
+import {
+  buildGatewayConnectionDetails,
+  callGateway,
+  resolveGatewayCredentialsWithSecretInputs,
+} from "../gateway/call.js";
+import { authorizeOperatorScopesForMethod } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
+import { loadCurrentDeviceAuthStore } from "../infra/device-auth-store.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import {
   approveDevicePairing,
   listDevicePairing,
   summarizeDeviceTokens,
+  verifyDeviceToken,
   type PairedDevice as InfraPairedDevice,
 } from "../infra/device-pairing.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
@@ -64,6 +73,13 @@ type DevicePairingList = {
 
 const FALLBACK_NOTICE = "Direct scope access failed; using local fallback.";
 
+type LocalPairingFallbackMode = "read" | "mutate";
+
+type MutatingPairingFallbackAuth = {
+  suppressNormalClosureFallback: boolean;
+  callerScopes?: readonly string[];
+};
+
 const devicesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =>
   cmd
     .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
@@ -99,10 +115,91 @@ function normalizeErrorMessage(error: unknown): string {
   return String(error);
 }
 
-function shouldUseLocalPairingFallback(opts: DevicesRpcOpts, error: unknown): boolean {
+function isExplicitPairingFallbackError(message: string): boolean {
+  return message.includes("pairing required") || message.includes("not-paired");
+}
+
+function isNormalClosurePairingFallbackError(message: string): boolean {
+  return (
+    message.includes("gateway closed") &&
+    message.includes("normal closure") &&
+    message.includes("no close reason")
+  );
+}
+
+async function resolveMutatingPairingFallbackAuth(
+  opts: DevicesRpcOpts,
+): Promise<MutatingPairingFallbackAuth> {
+  const explicitToken = typeof opts.token === "string" ? opts.token.trim() : "";
+  const explicitPassword = typeof opts.password === "string" ? opts.password.trim() : "";
+  if (explicitToken || explicitPassword) {
+    return { suppressNormalClosureFallback: true };
+  }
+
+  try {
+    const sharedAuth = await resolveGatewayCredentialsWithSecretInputs({
+      config: loadConfig(),
+      explicitAuth: {
+        token: opts.token,
+        password: opts.password,
+      },
+    });
+    if (sharedAuth.token || sharedAuth.password) {
+      return { suppressNormalClosureFallback: true };
+    }
+  } catch {
+    return { suppressNormalClosureFallback: true };
+  }
+
+  const store = loadCurrentDeviceAuthStore();
+  const currentDeviceId = loadOrCreateDeviceIdentity().deviceId;
+  const operatorToken = store?.deviceId === currentDeviceId ? store.tokens?.operator : undefined;
+  if (typeof operatorToken?.token !== "string") {
+    return { suppressNormalClosureFallback: true };
+  }
+
+  const callerScopes = Array.isArray(operatorToken.scopes) ? operatorToken.scopes : [];
+  const scopeAuth = authorizeOperatorScopesForMethod("device.pair.approve", callerScopes);
+  if (!scopeAuth.allowed) {
+    return { suppressNormalClosureFallback: true };
+  }
+
+  const verified = await verifyDeviceToken({
+    deviceId: currentDeviceId,
+    token: operatorToken.token,
+    role: "operator",
+    scopes: callerScopes,
+  });
+  if (!verified.ok) {
+    return { suppressNormalClosureFallback: true };
+  }
+
+  return {
+    suppressNormalClosureFallback: false,
+    callerScopes,
+  };
+}
+
+async function shouldUseLocalPairingFallback(
+  opts: DevicesRpcOpts,
+  error: unknown,
+  mode: LocalPairingFallbackMode,
+  fallbackAuth?: MutatingPairingFallbackAuth,
+): Promise<boolean> {
   const message = normalizeErrorMessage(error).toLowerCase();
-  if (!message.includes("pairing required")) {
+  const isExplicitPairingError = isExplicitPairingFallbackError(message);
+  const isNormalClosureError = isNormalClosurePairingFallbackError(message);
+  if (!isExplicitPairingError && !isNormalClosureError) {
     return false;
+  }
+  if (mode === "read" && isNormalClosureError && !isExplicitPairingError) {
+    return false;
+  }
+  if (mode === "mutate" && isNormalClosureError && !isExplicitPairingError) {
+    const resolvedFallbackAuth = fallbackAuth ?? (await resolveMutatingPairingFallbackAuth(opts));
+    if (resolvedFallbackAuth.suppressNormalClosureFallback) {
+      return false;
+    }
   }
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {
     // Explicit --url might point at a remote/tunneled gateway; never silently
@@ -129,10 +226,20 @@ function redactLocalPairedDevice(device: InfraPairedDevice): PairedDevice {
 }
 
 async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePairingList> {
+  return (await loadPairingWithFallback(opts, "read")).list;
+}
+
+async function loadPairingWithFallback(
+  opts: DevicesRpcOpts,
+  mode: LocalPairingFallbackMode,
+): Promise<{ list: DevicePairingList; isLocal: boolean }> {
   try {
-    return parseDevicePairingList(await callGatewayCli("device.pair.list", opts, {}));
+    return {
+      list: parseDevicePairingList(await callGatewayCli("device.pair.list", opts, {})),
+      isLocal: false,
+    };
   } catch (error) {
-    if (!shouldUseLocalPairingFallback(opts, error)) {
+    if (!(await shouldUseLocalPairingFallback(opts, error, mode))) {
       throw error;
     }
     if (opts.json !== true) {
@@ -140,8 +247,11 @@ async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePair
     }
     const local = await listDevicePairing();
     return {
-      pending: local.pending as PendingDevice[],
-      paired: local.paired.map((device) => redactLocalPairedDevice(device)),
+      list: {
+        pending: local.pending as PendingDevice[],
+        paired: local.paired.map((device) => redactLocalPairedDevice(device)),
+      },
+      isLocal: true,
     };
   }
 }
@@ -153,15 +263,28 @@ async function approvePairingWithFallback(
   try {
     return await callGatewayCli("device.pair.approve", opts, { requestId });
   } catch (error) {
-    if (!shouldUseLocalPairingFallback(opts, error)) {
+    const message = normalizeErrorMessage(error).toLowerCase();
+    const fallbackAuth =
+      isNormalClosurePairingFallbackError(message) && !isExplicitPairingFallbackError(message)
+        ? await resolveMutatingPairingFallbackAuth(opts)
+        : undefined;
+    if (!(await shouldUseLocalPairingFallback(opts, error, "mutate", fallbackAuth))) {
       throw error;
     }
     if (opts.json !== true) {
       defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
     }
-    const approved = await approveDevicePairing(requestId);
+    const approved = fallbackAuth?.callerScopes
+      ? await approveDevicePairing(requestId, { callerScopes: fallbackAuth.callerScopes })
+      : await approveDevicePairing(requestId);
     if (!approved) {
+      if (fallbackAuth) {
+        throw error;
+      }
       return null;
+    }
+    if (approved.status === "forbidden") {
+      throw new Error(`missing scope: ${approved.missingScope}`, { cause: error });
     }
     return {
       requestId,
@@ -351,8 +474,10 @@ export function registerDevicesCli(program: Command) {
           if (!deviceId) {
             continue;
           }
-          await callGatewayCli("device.pair.remove", opts, { deviceId });
-          removedDeviceIds.push(deviceId);
+          const removed = await callGatewayCli("device.pair.remove", opts, { deviceId });
+          if (removed) {
+            removedDeviceIds.push(deviceId);
+          }
         }
         if (opts.pending) {
           const pending = Array.isArray(list.pending) ? list.pending : [];
@@ -361,8 +486,10 @@ export function registerDevicesCli(program: Command) {
             if (!requestId) {
               continue;
             }
-            await callGatewayCli("device.pair.reject", opts, { requestId });
-            rejectedRequestIds.push(requestId);
+            const rejected = await callGatewayCli("device.pair.reject", opts, { requestId });
+            if (rejected) {
+              rejectedRequestIds.push(requestId);
+            }
           }
         }
         if (opts.json) {
@@ -392,7 +519,9 @@ export function registerDevicesCli(program: Command) {
       .action(async (requestId: string | undefined, opts: DevicesRpcOpts) => {
         let resolvedRequestId = requestId?.trim();
         if (!resolvedRequestId || opts.latest) {
-          const latest = selectLatestPendingRequest((await listPairingWithFallback(opts)).pending);
+          const latest = selectLatestPendingRequest(
+            (await loadPairingWithFallback(opts, "mutate")).list.pending,
+          );
           resolvedRequestId = latest?.requestId?.trim();
         }
         if (!resolvedRequestId) {

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -120,11 +120,7 @@ function isExplicitPairingFallbackError(message: string): boolean {
 }
 
 function isNormalClosurePairingFallbackError(message: string): boolean {
-  return (
-    message.includes("gateway closed") &&
-    message.includes("normal closure") &&
-    message.includes("no close reason")
-  );
+  return message.includes("gateway closed (1000") && message.includes("no close reason");
 }
 
 async function resolveMutatingPairingFallbackAuth(

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -132,6 +132,14 @@ async function resolveMutatingPairingFallbackAuth(
     return { suppressNormalClosureFallback: true };
   }
 
+  const connection = buildGatewayConnectionDetails({ url: opts.url });
+  const urlOverrideSource =
+    connection.urlSource === "env OPENCLAW_GATEWAY_URL"
+      ? "env"
+      : connection.urlSource === "cli --url"
+        ? "cli"
+        : undefined;
+
   try {
     const sharedAuth = await resolveGatewayCredentialsWithSecretInputs({
       config: loadConfig(),
@@ -139,6 +147,8 @@ async function resolveMutatingPairingFallbackAuth(
         token: opts.token,
         password: opts.password,
       },
+      urlOverride: urlOverrideSource ? connection.url : undefined,
+      urlOverrideSource,
     });
     if (sharedAuth.token || sharedAuth.password) {
       return { suppressNormalClosureFallback: true };
@@ -203,7 +213,10 @@ async function shouldUseLocalPairingFallback(
     return false;
   }
   const connection = buildGatewayConnectionDetails();
-  if (connection.urlSource !== "local loopback") {
+  if (
+    connection.urlSource !== "local loopback" &&
+    connection.urlSource !== "env OPENCLAW_GATEWAY_URL"
+  ) {
     return false;
   }
   try {

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -201,12 +201,6 @@ async function shouldUseLocalPairingFallback(
   if (mode === "read" && isNormalClosureError && !isExplicitPairingError) {
     return false;
   }
-  if (mode === "mutate" && isNormalClosureError && !isExplicitPairingError) {
-    const resolvedFallbackAuth = fallbackAuth ?? (await resolveMutatingPairingFallbackAuth(opts));
-    if (resolvedFallbackAuth.suppressNormalClosureFallback) {
-      return false;
-    }
-  }
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {
     // Explicit --url might point at a remote/tunneled gateway; never silently
     // switch to local pairing files in that case.
@@ -217,10 +211,19 @@ async function shouldUseLocalPairingFallback(
     return false;
   }
   try {
-    return isLoopbackHost(new URL(connection.url).hostname);
+    if (!isLoopbackHost(new URL(connection.url).hostname)) {
+      return false;
+    }
   } catch {
     return false;
   }
+  if (mode === "mutate" && isNormalClosureError && !isExplicitPairingError) {
+    const resolvedFallbackAuth = fallbackAuth ?? (await resolveMutatingPairingFallbackAuth(opts));
+    if (resolvedFallbackAuth.suppressNormalClosureFallback) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function redactLocalPairedDevice(device: InfraPairedDevice): PairedDevice {
@@ -269,14 +272,14 @@ async function approvePairingWithFallback(
   try {
     return await callGatewayCli("device.pair.approve", opts, { requestId });
   } catch (error) {
+    if (!(await shouldUseLocalPairingFallback(opts, error, "mutate"))) {
+      throw error;
+    }
     const message = normalizeErrorMessage(error).toLowerCase();
     const fallbackAuth =
       isNormalClosurePairingFallbackError(message) && !isExplicitPairingFallbackError(message)
         ? await resolveMutatingPairingFallbackAuth(opts)
         : undefined;
-    if (!(await shouldUseLocalPairingFallback(opts, error, "mutate", fallbackAuth))) {
-      throw error;
-    }
     if (opts.json !== true) {
       defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
     }

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -120,7 +120,7 @@ function isExplicitPairingFallbackError(message: string): boolean {
 }
 
 function isNormalClosurePairingFallbackError(message: string): boolean {
-  return message.includes("gateway closed (1000") && message.includes("no close reason");
+  return /gateway closed \(1000(?: normal closure)?\):(?: no close reason)?(?:$|\s)/.test(message);
 }
 
 async function resolveMutatingPairingFallbackAuth(

--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -57,6 +57,12 @@ export function loadDeviceAuthToken(params: {
   });
 }
 
+export function loadCurrentDeviceAuthStore(
+  env: NodeJS.ProcessEnv = process.env,
+): DeviceAuthStore | null {
+  return readStore(resolveDeviceAuthPath(env));
+}
+
 export function storeDeviceAuthToken(params: {
   deviceId: string;
   role: string;


### PR DESCRIPTION
## Summary
- broaden loopback device-pairing fallback to also cover pairing-related loopback closures that arrive without an explicit close reason
- let `devices clear --pending` use the same local pairing fallback path instead of failing outright
- add regression coverage for list/approve/clear on local loopback gateways

## Testing
- `src/cli/devices-cli.test.ts`

Fixes #51516