### PR TITLE
ACP: recover hung bound turns

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1,3 +1,4 @@
+import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -69,6 +70,10 @@ import {
   validateRuntimeOptionPatch,
 } from "./runtime-options.js";
 import { SessionActorQueue } from "./session-actor-queue.js";
+
+const ACP_TURN_TIMEOUT_GRACE_MS = 1_000;
+const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
+const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
 
 export class AcpSessionManager {
   private readonly actorQueue = new SessionActorQueue();
@@ -621,6 +626,7 @@ export class AcpSessionManager {
         let activeTurnStarted = false;
         let sawTurnOutput = false;
         let retryFreshHandle = false;
+        let skipPostTurnCleanup = false;
         try {
           const ensured = await this.ensureRuntimeHandle({
             cfg: input.cfg,
@@ -667,26 +673,56 @@ export class AcpSessionManager {
             input.signal && typeof AbortSignal.any === "function"
               ? AbortSignal.any([input.signal, internalAbortController.signal])
               : internalAbortController.signal;
-          for await (const event of runtime.runTurn({
-            handle,
-            text: input.text,
-            attachments: input.attachments,
-            mode: input.mode,
-            requestId: input.requestId,
-            signal: combinedSignal,
-          })) {
-            if (event.type === "error") {
-              streamError = new AcpRuntimeError(
-                normalizeAcpErrorCode(event.code),
-                event.message?.trim() || "ACP turn failed before completion.",
-              );
-            } else if (event.type === "text_delta" || event.type === "tool_call") {
-              sawTurnOutput = true;
+          const eventGate = { open: true };
+          const turnPromise = (async () => {
+            for await (const event of runtime.runTurn({
+              handle,
+              text: input.text,
+              attachments: input.attachments,
+              mode: input.mode,
+              requestId: input.requestId,
+              signal: combinedSignal,
+            })) {
+              if (!eventGate.open) {
+                continue;
+              }
+              if (event.type === "error") {
+                streamError = new AcpRuntimeError(
+                  normalizeAcpErrorCode(event.code),
+                  event.message?.trim() || "ACP turn failed before completion.",
+                );
+              } else if (event.type === "text_delta" || event.type === "tool_call") {
+                sawTurnOutput = true;
+              }
+              if (input.onEvent) {
+                await input.onEvent(event);
+              }
             }
-            if (input.onEvent) {
-              await input.onEvent(event);
+            if (eventGate.open && streamError) {
+              throw streamError;
             }
-          }
+          })();
+          const turnTimeoutMs = this.resolveTurnTimeoutMs({
+            cfg: input.cfg,
+            meta,
+          });
+          await this.awaitTurnWithTimeout({
+            sessionKey,
+            turnPromise,
+            timeoutMs: turnTimeoutMs + ACP_TURN_TIMEOUT_GRACE_MS,
+            timeoutLabelMs: turnTimeoutMs,
+            onTimeout: async () => {
+              eventGate.open = false;
+              skipPostTurnCleanup = true;
+              if (!activeTurn) {
+                return;
+              }
+              await this.cleanupTimedOutTurn({
+                sessionKey,
+                activeTurn,
+              });
+            },
+          });
           if (streamError) {
             throw streamError;
           }
@@ -735,7 +771,14 @@ export class AcpSessionManager {
           if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
             this.activeTurnBySession.delete(actorKey);
           }
-          if (!retryFreshHandle && runtime && handle && meta && meta.mode !== "oneshot") {
+          if (
+            !retryFreshHandle &&
+            !skipPostTurnCleanup &&
+            runtime &&
+            handle &&
+            meta &&
+            meta.mode !== "oneshot"
+          ) {
             ({ handle } = await this.reconcileRuntimeSessionIdentifiers({
               cfg: input.cfg,
               sessionKey,
@@ -745,7 +788,14 @@ export class AcpSessionManager {
               failOnStatusError: false,
             }));
           }
-          if (!retryFreshHandle && runtime && handle && meta && meta.mode === "oneshot") {
+          if (
+            !retryFreshHandle &&
+            !skipPostTurnCleanup &&
+            runtime &&
+            handle &&
+            meta &&
+            meta.mode === "oneshot"
+          ) {
             try {
               await runtime.close({
                 handle,
@@ -765,6 +815,173 @@ export class AcpSessionManager {
         }
       }
     });
+  }
+
+  private resolveTurnTimeoutMs(params: { cfg: OpenClawConfig; meta: SessionAcpMeta }): number {
+    const runtimeTimeoutSeconds = resolveRuntimeOptionsFromMeta(params.meta).timeoutSeconds;
+    if (
+      typeof runtimeTimeoutSeconds === "number" &&
+      Number.isFinite(runtimeTimeoutSeconds) &&
+      runtimeTimeoutSeconds > 0
+    ) {
+      return Math.max(1_000, Math.round(runtimeTimeoutSeconds * 1_000));
+    }
+    return resolveAgentTimeoutMs({
+      cfg: params.cfg,
+      minMs: 1_000,
+    });
+  }
+
+  private async awaitTurnWithTimeout<T>(params: {
+    sessionKey: string;
+    turnPromise: Promise<T>;
+    timeoutMs: number;
+    timeoutLabelMs: number;
+    onTimeout: () => Promise<void>;
+  }): Promise<T> {
+    const observedTurnPromise: Promise<
+      | {
+          kind: "value";
+          value: T;
+        }
+      | {
+          kind: "error";
+          error: unknown;
+        }
+    > = params.turnPromise.then(
+      (value) => ({
+        kind: "value" as const,
+        value,
+      }),
+      (error) => ({
+        kind: "error" as const,
+        error,
+      }),
+    );
+
+    if (params.timeoutMs <= 0) {
+      const outcome = await observedTurnPromise;
+      if (outcome.kind === "error") {
+        throw outcome.error;
+      }
+      return outcome.value;
+    }
+
+    const timeoutToken = Symbol("acp-turn-timeout");
+    let timer: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<typeof timeoutToken>((resolve) => {
+      timer = setTimeout(() => resolve(timeoutToken), params.timeoutMs);
+      timer.unref?.();
+    });
+
+    try {
+      const outcome = await Promise.race([observedTurnPromise, timeoutPromise]);
+      if (outcome === timeoutToken) {
+        void observedTurnPromise.then((lateOutcome) => {
+          if (lateOutcome.kind === "error") {
+            logVerbose(
+              `acp-manager: detached late turn error after timeout for ${params.sessionKey}: ${String(lateOutcome.error)}`,
+            );
+          }
+        });
+        await params.onTimeout();
+        throw new AcpRuntimeError(
+          "ACP_TURN_FAILED",
+          `ACP turn timed out after ${Math.max(1, Math.round(params.timeoutLabelMs / 1_000))}s.`,
+        );
+      }
+      if (outcome.kind === "error") {
+        throw outcome.error;
+      }
+      return outcome.value;
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  private async cleanupTimedOutTurn(params: {
+    sessionKey: string;
+    activeTurn: ActiveTurnState;
+  }): Promise<void> {
+    params.activeTurn.abortController.abort();
+    if (!params.activeTurn.cancelPromise) {
+      params.activeTurn.cancelPromise = params.activeTurn.runtime.cancel({
+        handle: params.activeTurn.handle,
+        reason: ACP_TURN_TIMEOUT_REASON,
+      });
+    }
+    await this.awaitCleanupWithGrace({
+      sessionKey: params.sessionKey,
+      label: "cancel",
+      promise: params.activeTurn.cancelPromise,
+    });
+    await this.awaitCleanupWithGrace({
+      sessionKey: params.sessionKey,
+      label: "close",
+      promise: params.activeTurn.runtime.close({
+        handle: params.activeTurn.handle,
+        reason: ACP_TURN_TIMEOUT_REASON,
+      }),
+    });
+    this.clearCachedRuntimeState(params.sessionKey);
+  }
+
+  private async awaitCleanupWithGrace(params: {
+    sessionKey: string;
+    label: "cancel" | "close";
+    promise: Promise<unknown>;
+  }): Promise<void> {
+    const observedCleanupPromise: Promise<
+      | {
+          kind: "done";
+        }
+      | {
+          kind: "error";
+          error: unknown;
+        }
+    > = params.promise.then(
+      () => ({
+        kind: "done" as const,
+      }),
+      (error) => ({
+        kind: "error" as const,
+        error,
+      }),
+    );
+    const timeoutToken = Symbol(`acp-timeout-${params.label}`);
+    let timer: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<typeof timeoutToken>((resolve) => {
+      timer = setTimeout(() => resolve(timeoutToken), ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS);
+      timer.unref?.();
+    });
+
+    try {
+      const outcome = await Promise.race([observedCleanupPromise, timeoutPromise]);
+      if (outcome === timeoutToken) {
+        void observedCleanupPromise.then((lateOutcome) => {
+          if (lateOutcome.kind === "error") {
+            logVerbose(
+              `acp-manager: detached timed-out turn ${params.label} cleanup failed for ${params.sessionKey}: ${String(lateOutcome.error)}`,
+            );
+          }
+        });
+        logVerbose(
+          `acp-manager: timed-out turn ${params.label} cleanup exceeded ${ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS}ms for ${params.sessionKey}`,
+        );
+        return;
+      }
+      if (outcome.kind === "error") {
+        logVerbose(
+          `acp-manager: timed-out turn ${params.label} cleanup failed for ${params.sessionKey}: ${String(outcome.error)}`,
+        );
+      }
+    } finally {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    }
   }
 
   async cancelSession(params: {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -21,6 +21,7 @@ import type {
   AcpRuntime,
   AcpRuntimeCapabilities,
   AcpRuntimeHandle,
+  AcpRuntimeSessionMode,
   AcpRuntimeStatus,
 } from "../runtime/types.js";
 import { reconcileManagerRuntimeSessionIdentifiers } from "./manager.identity-reconcile.js";
@@ -706,6 +707,7 @@ export class AcpSessionManager {
             cfg: input.cfg,
             meta,
           });
+          const sessionMode = meta.mode;
           await this.awaitTurnWithTimeout({
             sessionKey,
             turnPromise,
@@ -720,6 +722,7 @@ export class AcpSessionManager {
               await this.cleanupTimedOutTurn({
                 sessionKey,
                 activeTurn,
+                mode: sessionMode,
               });
             },
           });
@@ -904,6 +907,7 @@ export class AcpSessionManager {
   private async cleanupTimedOutTurn(params: {
     sessionKey: string;
     activeTurn: ActiveTurnState;
+    mode: AcpRuntimeSessionMode;
   }): Promise<void> {
     params.activeTurn.abortController.abort();
     if (!params.activeTurn.cancelPromise) {
@@ -912,27 +916,43 @@ export class AcpSessionManager {
         reason: ACP_TURN_TIMEOUT_REASON,
       });
     }
-    await this.awaitCleanupWithGrace({
+    const cancelFinished = await this.awaitCleanupWithGrace({
       sessionKey: params.sessionKey,
       label: "cancel",
       promise: params.activeTurn.cancelPromise,
     });
-    await this.awaitCleanupWithGrace({
+    if (params.mode !== "oneshot") {
+      return;
+    }
+    const closePromise = params.activeTurn.runtime.close({
+      handle: params.activeTurn.handle,
+      reason: ACP_TURN_TIMEOUT_REASON,
+    });
+    const closeFinished = await this.awaitCleanupWithGrace({
       sessionKey: params.sessionKey,
       label: "close",
-      promise: params.activeTurn.runtime.close({
-        handle: params.activeTurn.handle,
-        reason: ACP_TURN_TIMEOUT_REASON,
-      }),
+      promise: closePromise,
     });
-    this.clearCachedRuntimeState(params.sessionKey);
+    if (cancelFinished && closeFinished) {
+      this.clearCachedRuntimeStateIfHandleMatches({
+        sessionKey: params.sessionKey,
+        handle: params.activeTurn.handle,
+      });
+      return;
+    }
+    void Promise.allSettled([params.activeTurn.cancelPromise, closePromise]).then(() => {
+      this.clearCachedRuntimeStateIfHandleMatches({
+        sessionKey: params.sessionKey,
+        handle: params.activeTurn.handle,
+      });
+    });
   }
 
   private async awaitCleanupWithGrace(params: {
     sessionKey: string;
     label: "cancel" | "close";
     promise: Promise<unknown>;
-  }): Promise<void> {
+  }): Promise<boolean> {
     const observedCleanupPromise: Promise<
       | {
           kind: "done";
@@ -970,13 +990,14 @@ export class AcpSessionManager {
         logVerbose(
           `acp-manager: timed-out turn ${params.label} cleanup exceeded ${ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS}ms for ${params.sessionKey}`,
         );
-        return;
+        return false;
       }
       if (outcome.kind === "error") {
         logVerbose(
           `acp-manager: timed-out turn ${params.label} cleanup failed for ${params.sessionKey}: ${String(outcome.error)}`,
         );
       }
+      return true;
     } finally {
       if (timer) {
         clearTimeout(timer);
@@ -1634,5 +1655,28 @@ export class AcpSessionManager {
 
   private clearCachedRuntimeState(sessionKey: string): void {
     this.runtimeCache.clear(normalizeActorKey(sessionKey));
+  }
+
+  private clearCachedRuntimeStateIfHandleMatches(params: {
+    sessionKey: string;
+    handle: AcpRuntimeHandle;
+  }): void {
+    const cached = this.getCachedRuntimeState(params.sessionKey);
+    if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {
+      return;
+    }
+    this.clearCachedRuntimeState(params.sessionKey);
+  }
+
+  private runtimeHandlesMatch(a: AcpRuntimeHandle, b: AcpRuntimeHandle): boolean {
+    return (
+      a.sessionKey === b.sessionKey &&
+      a.backend === b.backend &&
+      a.runtimeSessionName === b.runtimeSessionName &&
+      (a.cwd ?? "") === (b.cwd ?? "") &&
+      (a.acpxRecordId ?? "") === (b.acpxRecordId ?? "") &&
+      (a.backendSessionId ?? "") === (b.backendSessionId ?? "") &&
+      (a.agentSessionId ?? "") === (b.agentSessionId ?? "")
+    );
   }
 }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -270,6 +270,72 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
 
+  it("reproduces queue starvation when a runtime turn never completes", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+
+    let releaseFirstTurn!: () => void;
+    const firstTurnGate = new Promise<void>((resolve) => {
+      releaseFirstTurn = resolve;
+    });
+    let firstTurnStarted = false;
+
+    runtimeState.runTurn.mockImplementation(async function* (input: { requestId: string }) {
+      if (input.requestId === "r1") {
+        firstTurnStarted = true;
+        await firstTurnGate;
+      }
+      yield { type: "done" as const };
+    });
+
+    const manager = new AcpSessionManager();
+    const first = manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    while (!firstTurnStarted) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+
+    const second = manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "second",
+      mode: "prompt",
+      requestId: "r2",
+    });
+    let secondSettled = false;
+    void second.finally(() => {
+      secondSettled = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(manager.getObservabilitySnapshot(baseCfg).turns).toMatchObject({
+      active: 1,
+      queueDepth: 2,
+    });
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    expect(secondSettled).toBe(false);
+
+    releaseFirstTurn();
+    await Promise.all([first, second]);
+
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+  });
+
   it("runs turns for different ACP sessions in parallel", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -271,7 +271,7 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
 
-  it("times out a hung runtime turn and lets queued work continue", async () => {
+  it("times out a hung persistent turn without closing the session and lets queued work continue", async () => {
     vi.useFakeTimers();
     try {
       const runtimeState = createRuntime();
@@ -332,27 +332,111 @@ describe("AcpSessionManager", () => {
       });
       await expect(second).resolves.toBeUndefined();
 
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
       expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
       expect(runtimeState.cancel).toHaveBeenCalledWith(
         expect.objectContaining({
           reason: "turn-timeout",
         }),
       );
-      expect(runtimeState.close).toHaveBeenCalledWith(
-        expect.objectContaining({
-          reason: "turn-timeout",
-        }),
-      );
-      expect(manager.getObservabilitySnapshot(cfg).turns).toMatchObject({
-        active: 0,
-        queueDepth: 0,
-        completed: 1,
-        failed: 1,
+      expect(runtimeState.close).not.toHaveBeenCalled();
+      expect(manager.getObservabilitySnapshot(cfg)).toMatchObject({
+        runtimeCache: {
+          activeSessions: 1,
+        },
+        turns: {
+          active: 0,
+          queueDepth: 0,
+          completed: 1,
+          failed: 1,
+        },
       });
 
       const states = extractStatesFromUpserts();
       expect(states).toContain("error");
       expect(states.at(-1)).toBe("idle");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps timed-out runtime handles counted until timeout cleanup finishes", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      runtimeState.cancel.mockImplementation(() => new Promise(() => {}));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+
+      let firstTurnStarted = false;
+      runtimeState.runTurn.mockImplementation(async function* (input: { requestId: string }) {
+        if (input.requestId === "r1") {
+          firstTurnStarted = true;
+          await new Promise(() => {});
+        }
+        yield { type: "done" as const };
+      });
+
+      const manager = new AcpSessionManager();
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+        },
+        agents: {
+          defaults: {
+            timeoutSeconds: 1,
+          },
+        },
+      } as OpenClawConfig;
+
+      const first = manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(firstTurnStarted).toBe(true);
+      });
+
+      await vi.advanceTimersByTimeAsync(4_500);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP turn timed out after 1s.",
+      });
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+
+      await expect(
+        manager.runTurn({
+          cfg,
+          sessionKey: "agent:codex:acp:session-b",
+          text: "second",
+          mode: "prompt",
+          requestId: "r2",
+        }),
+      ).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: expect.stringContaining("max concurrent sessions"),
+      });
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -98,7 +98,7 @@ function createRuntime(): {
   };
 }
 
-function readySessionMeta() {
+function readySessionMeta(overrides: Partial<SessionAcpMeta> = {}): SessionAcpMeta {
   return {
     backend: "acpx",
     agent: "codex",
@@ -106,6 +106,7 @@ function readySessionMeta() {
     mode: "persistent" as const,
     state: "idle" as const,
     lastActivityAt: Date.now(),
+    ...overrides,
   };
 }
 
@@ -270,70 +271,91 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
 
-  it("reproduces queue starvation when a runtime turn never completes", async () => {
-    const runtimeState = createRuntime();
-    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-      id: "acpx",
-      runtime: runtimeState.runtime,
-    });
-    hoisted.readAcpSessionEntryMock.mockReturnValue({
-      sessionKey: "agent:codex:acp:session-1",
-      storeSessionKey: "agent:codex:acp:session-1",
-      acp: readySessionMeta(),
-    });
+  it("times out a hung runtime turn and lets queued work continue", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockReturnValue({
+        sessionKey: "agent:codex:acp:session-1",
+        storeSessionKey: "agent:codex:acp:session-1",
+        acp: readySessionMeta(),
+      });
 
-    let releaseFirstTurn!: () => void;
-    const firstTurnGate = new Promise<void>((resolve) => {
-      releaseFirstTurn = resolve;
-    });
-    let firstTurnStarted = false;
+      let firstTurnStarted = false;
+      runtimeState.runTurn.mockImplementation(async function* (input: { requestId: string }) {
+        if (input.requestId === "r1") {
+          firstTurnStarted = true;
+          await new Promise(() => {});
+        }
+        yield { type: "done" as const };
+      });
 
-    runtimeState.runTurn.mockImplementation(async function* (input: { requestId: string }) {
-      if (input.requestId === "r1") {
-        firstTurnStarted = true;
-        await firstTurnGate;
-      }
-      yield { type: "done" as const };
-    });
+      const manager = new AcpSessionManager();
+      const cfg = {
+        ...baseCfg,
+        agents: {
+          defaults: {
+            timeoutSeconds: 1,
+          },
+        },
+      } as OpenClawConfig;
 
-    const manager = new AcpSessionManager();
-    const first = manager.runTurn({
-      cfg: baseCfg,
-      sessionKey: "agent:codex:acp:session-1",
-      text: "first",
-      mode: "prompt",
-      requestId: "r1",
-    });
+      const first = manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(firstTurnStarted).toBe(true);
+      });
 
-    while (!firstTurnStarted) {
-      await new Promise((resolve) => setTimeout(resolve, 1));
+      const second = manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      });
+
+      await vi.advanceTimersByTimeAsync(3_500);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP turn timed out after 1s.",
+      });
+      await expect(second).resolves.toBeUndefined();
+
+      expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+      expect(runtimeState.cancel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "turn-timeout",
+        }),
+      );
+      expect(runtimeState.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "turn-timeout",
+        }),
+      );
+      expect(manager.getObservabilitySnapshot(cfg).turns).toMatchObject({
+        active: 0,
+        queueDepth: 0,
+        completed: 1,
+        failed: 1,
+      });
+
+      const states = extractStatesFromUpserts();
+      expect(states).toContain("error");
+      expect(states.at(-1)).toBe("idle");
+    } finally {
+      vi.useRealTimers();
     }
-
-    const second = manager.runTurn({
-      cfg: baseCfg,
-      sessionKey: "agent:codex:acp:session-1",
-      text: "second",
-      mode: "prompt",
-      requestId: "r2",
-    });
-    let secondSettled = false;
-    void second.finally(() => {
-      secondSettled = true;
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(manager.getObservabilitySnapshot(baseCfg).turns).toMatchObject({
-      active: 1,
-      queueDepth: 2,
-    });
-    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
-    expect(secondSettled).toBe(false);
-
-    releaseFirstTurn();
-    await Promise.all([first, second]);
-
-    expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
   });
 
   it("runs turns for different ACP sessions in parallel", async () => {


### PR DESCRIPTION
## Summary

- Problem: a bound ACP session could stop replying indefinitely if one `runtime.runTurn()` never completed, because later turns on that session stayed queued behind the stuck turn.
- Why it matters: Discord ACP bindings like `#codex-1` could look dead until the gateway or session was manually reset.
- What changed: `AcpSessionManager.runTurn()` now applies a manager-side watchdog, aborts/cancels/closes timed-out turns, drops the stale cached runtime handle, and lets queued turns proceed.
- What did NOT change (scope boundary): this PR does not change ACP projection or Discord readback behavior beyond unsticking the bound session turn queue.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #51816

## User-visible / Behavior Changes

- Bound ACP sessions no longer stay wedged behind a single hung turn forever.
- When a turn exceeds its watchdog timeout, the session now returns an ACP turn failure instead of starving all later turns on that binding.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22, `pnpm test` wrapper
- Model/provider: `openai-codex/gpt-5.4` via acpx/Codex ACP session
- Integration/channel (if any): persistent Discord ACP binding (`#codex-1`)
- Relevant config (redacted): Discord ACP thread binding on `agent:codex:acp:binding:discord:default:f56b4624dd829241`

### Steps

1. Start one ACP turn whose runtime never completes.
2. Enqueue a second turn on the same ACP session.
3. Observe that the manager watchdog times out the hung turn, cancels/closes the stale runtime, and allows the queued turn to proceed.

### Expected

- A single hung turn should not be able to starve all later turns on the same ACP binding indefinitely.

### Actual

- Before this change, `AcpSessionManager.runTurn()` waited forever on the hung turn and kept the session actor occupied.
- After this change, the manager times out the stuck turn and frees the session actor queue.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence used:

- unit regression in `src/acp/control-plane/manager.test.ts`
- live gateway logs showing prior Discord inbound worker timeouts on `#codex-1`
- live verification after the fix: sending new messages via `LOOPER_BOT_TOKEN` to `#codex-1` now causes the bound ACP session state to return to `idle` promptly and Bob emits a fresh reply message instead of leaving the worker hung

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/acp/control-plane/manager.test.ts`
  - `pnpm build`
  - direct `acpx` prompt against the bound session returned visible text after the session was reset
  - live Discord probes sent to `#codex-1` via `LOOPER_BOT_TOKEN` produced fresh Bob replies and advanced the bound ACP session back to `idle`
- Edge cases checked:
  - queued second turn runs after the first timed-out turn is cleaned up
  - timeout path calls ACP cancel/close and drops the stale cached runtime handle
  - service-managed gateway (`systemd --user`) also round-trips after restarting on the built fix
- What you did **not** verify:
  - full `pnpm check` on this workstation is currently blocked by unrelated untracked plugin-sdk docs formatting work outside this PR diff

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `5cb9f5eb49`
- Files/config to restore: `src/acp/control-plane/manager.core.ts`, `src/acp/control-plane/manager.test.ts`
- Known bad symptoms reviewers should watch for: unexpected ACP turn timeout errors on legitimately long-running sessions if operators want a larger timeout than the current manager fallback

## Risks and Mitigations

- Risk: the new watchdog could end legitimately long turns earlier than some operators expect.
  - Mitigation: session-level ACP runtime timeouts already exist; the manager uses the session timeout when configured and otherwise falls back to the existing agent timeout baseline instead of a new tiny default.
- Risk: cleanup of a timed-out runtime turn could itself hang.
  - Mitigation: cancel/close cleanup is bounded and late cleanup failures are logged without re-blocking the session actor queue.
