### PR TITLE
feat(infra): session health lifecycle visibility + remediation groundwork

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,11 @@ Welcome to the lobster tank! 🦞
 
 - Test locally with your OpenClaw instance
 - Run tests: `pnpm build && pnpm check && pnpm test`
+- The pre-commit hook runs per-file lint/format and a repo-wide quality gate (`pnpm check`). To bypass the gate for a known-safe commit (e.g. docs-only, config-only), use:
+  ```
+  OPENCLAW_SKIP_CHECK=1 git commit -m "your message"
+  ```
+  Per-file lint and format still run; only the gate is skipped.
 - For extension/plugin changes, run the fast local lane first:
   - `pnpm test:extension <extension-name>`
   - `pnpm test:extension --list` to see valid extension ids

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -70,6 +70,7 @@ openclaw sessions cleanup --json
 
 - `--dry-run`: preview how many entries would be pruned/capped without writing.
   - In text mode, dry-run prints a per-session action table (`Action`, `Key`, `Age`, `Model`, `Flags`) so you can see what would be kept vs removed.
+  - When session health data is available, dry-run also appends a **Remediation Plan** — a tiered report of deeper cleanup opportunities (orphaned temp files, stale archives, index drift, ephemeral session retention). This report is preview-only and never executes any actions. In JSON mode, the plan appears as a `remediationPlan` object in the output.
 - `--enforce`: apply maintenance even when `session.maintenance.mode` is `warn`.
 - `--active-key <key>`: protect a specific active key from disk-budget eviction.
 - `--agent <id>`: run cleanup for one configured agent store.

--- a/docs/specs/phase-3c-manual-executor.md
+++ b/docs/specs/phase-3c-manual-executor.md
@@ -1,10 +1,9 @@
 # Phase 3C — Manual Remediation Executor
 
-**Status:** Spec (not yet implemented)  
+**Status:** Implemented (246bafb)  
 **Author:** Adx  
 **Date:** 2026-03-20  
-**Depends on:** Phase 3A (remediation plan builder), 3B (trust-fix + UX honesty)  
-**Constraint:** Spec only — no implementation in this pass
+**Depends on:** Phase 3A (remediation plan builder), 3B (trust-fix + UX honesty)
 
 ---
 
@@ -75,12 +74,11 @@ We considered three approaches for referencing reviewed plans:
 
 ### 3.2 Staleness Protection
 
-Even with re-derivation, we add a staleness check:
+**v1 behavior (implemented):** The executor re-derives a fresh plan at execution time and validates that every requested action ID still exists. The confirmation prompt shows the **current** `affectedCount` from the fresh plan, so the operator always sees reality before confirming. If an action ID no longer exists in the fresh plan (the problem resolved itself), validation fails with a clear message directing the operator to re-run `--dry-run`.
 
-- The executor compares the fresh plan's action parameters against what the operator reviewed
-- If an action's `affectedCount` has **increased** since the dry-run, the executor warns and requires re-confirmation
-- If an action's `affectedCount` has **decreased** (things cleaned themselves up), the executor proceeds — fewer affected items is strictly safer
-- If an action ID no longer exists in the fresh plan (the problem resolved itself), the executor skips it with a notice
+v1 does **not** store a reviewed baseline or compare scope deltas between the dry-run and execution. The confirmation block is the operator's checkpoint — it always reflects current state, not a stale review.
+
+**Future consideration:** If `--yes` piped workflows become common (where the operator doesn't see the confirmation block), a scope-increase check comparing the fresh plan's `affectedCount` against the reviewed counts could be added. This is deferred until there is production demand.
 
 ### 3.3 Action ID Stability
 

--- a/docs/specs/phase-3c-manual-executor.md
+++ b/docs/specs/phase-3c-manual-executor.md
@@ -1,0 +1,476 @@
+# Phase 3C — Manual Remediation Executor
+
+**Status:** Spec (not yet implemented)  
+**Author:** Adx  
+**Date:** 2026-03-20  
+**Depends on:** Phase 3A (remediation plan builder), 3B (trust-fix + UX honesty)  
+**Constraint:** Spec only — no implementation in this pass
+
+---
+
+## 1. Design Intent
+
+Phase 3A gave us a pure-function remediation planner: it reads a snapshot and produces a structured plan. Phase 3B made the output trustworthy and honest. Phase 3C adds the **execution path** — the ability to actually carry out reviewed remediation actions.
+
+The execution model is explicitly **surgical approval tooling**, not garbage-collection automation. The operator reviews a dry-run plan, selects specific actions by ID, and executes them one at a time (or in a reviewed batch). The system refuses to execute anything the operator hasn't explicitly selected from a recent, verified plan.
+
+**Core product principle:** Review-first, agree-first, delete-later.
+
+---
+
+## 2. Operator Flow: Dry-Run to Execution
+
+### Step 1: Generate & Review Plan (existing)
+
+```
+openclaw sessions cleanup --dry-run
+```
+
+Outputs the maintenance preview + remediation plan as today. Each action has a stable `id` field (e.g., `cleanup-orphaned-tmp-1`, `archive-orphan-transcripts-2`).
+
+### Step 2: Execute Selected Actions
+
+```
+openclaw sessions cleanup --execute <action-id> [<action-id>...]
+```
+
+The operator cherry-picks specific action IDs from the dry-run output. The executor:
+
+1. Re-collects a fresh snapshot
+2. Re-generates the plan
+3. Validates that every requested action ID still exists in the fresh plan
+4. Validates that the fresh plan's action parameters match (affected counts, etc.)
+5. Shows a **confirmation prompt** with exactly what will happen
+6. Executes on explicit `y` confirmation
+7. Prints a before/after report
+
+### Step 3: Review Result
+
+The executor prints a structured before/after report showing exactly what changed.
+
+### Alternative: Execute All Actions in a Tier
+
+```
+openclaw sessions cleanup --execute-tier 0
+openclaw sessions cleanup --execute-tier 1
+```
+
+Convenience for "execute all Tier 0 actions" or "all Tier 0 + Tier 1 actions." Same validation and confirmation flow. v1 supports `--execute-tier 0` and `--execute-tier 1` only. The command refuses `--execute-tier 2` and `--execute-tier 3`.
+
+---
+
+## 3. Plan Identity & Staleness
+
+### 3.1 Why Not Plan Hashes or Tokens?
+
+We considered three approaches for referencing reviewed plans:
+
+| Approach                   | Pros                                      | Cons                                                                   |
+| -------------------------- | ----------------------------------------- | ---------------------------------------------------------------------- |
+| **Plan hash**              | Cryptographic proof of plan identity      | Brittle — any snapshot drift invalidates; forces unnecessary re-review |
+| **Timestamped plan token** | Can enforce staleness windows             | Adds token lifecycle management; over-engineered for CLI               |
+| **Re-derive and validate** | Always fresh; no stale tokens; no storage | Requires re-collection (cheap: ~5ms)                                   |
+
+**Decision: Re-derive and validate.** The executor re-collects a fresh snapshot, re-builds the plan, and validates that the requested action IDs still exist with compatible parameters. This is the simplest approach that is also the most correct — it guarantees the operator is executing against current reality, not a stale plan.
+
+### 3.2 Staleness Protection
+
+Even with re-derivation, we add a staleness check:
+
+- The executor compares the fresh plan's action parameters against what the operator reviewed
+- If an action's `affectedCount` has **increased** since the dry-run, the executor warns and requires re-confirmation
+- If an action's `affectedCount` has **decreased** (things cleaned themselves up), the executor proceeds — fewer affected items is strictly safer
+- If an action ID no longer exists in the fresh plan (the problem resolved itself), the executor skips it with a notice
+
+### 3.3 Action ID Stability
+
+Action IDs are currently generated with a monotonic counter (`cleanup-orphaned-tmp-1`). This is stable within a single plan generation but not across plan re-generations. Since we re-derive, the IDs will be identical as long as the plan builder's action ordering is deterministic (it is — the builder iterates action kinds in a fixed order).
+
+**Guarantee:** Action IDs are deterministic for a given snapshot shape. If the snapshot changes materially, the plan changes, and the executor detects this via parameter validation.
+
+---
+
+## 4. v1 Supported Action Set
+
+### Tier 0 — Auto-Safe (v1: YES)
+
+| Action Kind            | What It Does                                    | Reversible                              | Risk      |
+| ---------------------- | ----------------------------------------------- | --------------------------------------- | --------- |
+| `cleanup-orphaned-tmp` | Deletes `.tmp` files from crashed atomic writes | No (but these are definitional garbage) | Near-zero |
+
+### Tier 1 — Retention Cleanup (v1: YES, safest subset)
+
+| Action Kind                         | What It Does                                                | Reversible               | Risk                                          |
+| ----------------------------------- | ----------------------------------------------------------- | ------------------------ | --------------------------------------------- |
+| `archive-orphan-transcripts`        | Renames unindexed `.jsonl` files to `.deleted.<timestamp>`  | Yes (rename, not delete) | Low — preserves data                          |
+| `archive-stale-deleted-transcripts` | Permanently removes `.deleted` files past retention window  | No                       | Low — already soft-deleted and past retention |
+| `archive-stale-reset-transcripts`   | Permanently removes `.reset` archives past retention window | No                       | Low — already archived and past retention     |
+
+**Why include all Tier 1:** All three Tier 1 actions operate on artifacts that are either already soft-deleted or explicitly orphaned. The `archive-orphan-transcripts` action is reversible (rename, not delete). The other two remove artifacts that are already past their operator-configured retention window. This is cleanup of acknowledged waste, not speculative pruning.
+
+### Tier 2 — Index-Mutating (v1: NO)
+
+Not included in v1. Index mutations affect which sessions are visible to the operator and loadable by the agent runtime. Even though the pruning targets (stale cron-runs, subagents, heartbeats, ACP sessions) are ephemeral by design, modifying the session index is a qualitatively different operation that should be proven safe in isolation before enabling.
+
+**Revisit in Phase 3D** after v1 executor has production mileage.
+
+### Tier 3 — Destructive (v1: NO)
+
+Not included in v1. Tier 3 actions (disk budget enforcement, archived artifact purge, bulk class prune) are high-consequence operations. They require more sophisticated safety rails (dry-run impact analysis, undo snapshots, progressive rollout) that are out of scope for v1.
+
+---
+
+## 5. Command Surface
+
+### 5.1 Extend Existing Command
+
+The executor extends `openclaw sessions cleanup` rather than adding a new subcommand. Rationale:
+
+- The operator is already in the `sessions cleanup` mental model
+- Dry-run → execute is a natural progression within the same command
+- Adding a separate command fragments the workflow
+
+### 5.2 New Flags
+
+```
+--execute <id...>      Execute specific remediation action(s) by ID.
+                       Requires prior --dry-run review.
+                       Refuses Tier 2+ actions in v1.
+
+--execute-tier <n>     Execute all actions in the specified tier (0 or 1).
+                       Shorthand for --execute with all action IDs in that tier.
+                       Refuses tier values > 1 in v1.
+
+--yes                  Skip interactive confirmation prompt.
+                       Still prints the confirmation summary.
+                       For scripted/CI use. Does NOT bypass tier restrictions.
+
+--json                 (existing) Also applies to execution reports.
+```
+
+### 5.3 Flag Interactions
+
+| Flags                      | Behavior                                                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `--dry-run`                | Existing: preview only, no mutations                                                                                       |
+| `--execute <id>`           | Execute selected action(s) from fresh plan                                                                                 |
+| `--execute-tier 0`         | Execute all Tier 0 actions from fresh plan                                                                                 |
+| `--execute-tier 1`         | Execute all Tier 0 + Tier 1 actions (Tier 1 implies Tier 0)                                                                |
+| `--execute <id> --yes`     | Execute without interactive confirmation                                                                                   |
+| `--execute <id> --dry-run` | **Refused.** Contradictory flags.                                                                                          |
+| `--enforce --execute <id>` | **Refused.** `--enforce` is the legacy maintenance path; `--execute` is the remediation path. They are separate codepaths. |
+
+### 5.4 UX Examples
+
+```bash
+# Step 1: Review
+$ openclaw sessions cleanup --dry-run
+
+# ... reads plan, sees action IDs ...
+
+# Step 2: Execute one action
+$ openclaw sessions cleanup --execute cleanup-orphaned-tmp-1
+
+# Step 3: Execute all safe actions
+$ openclaw sessions cleanup --execute-tier 0
+
+# Step 4: Execute Tier 0 + Tier 1
+$ openclaw sessions cleanup --execute-tier 1
+
+# Step 5: Scripted execution
+$ openclaw sessions cleanup --execute-tier 0 --yes --json
+```
+
+---
+
+## 6. Confirmation Prompt
+
+Before execution, the system prints a confirmation block:
+
+```
+══════════════════════════════════════════════════════════
+  REMEDIATION EXECUTION — CONFIRMATION REQUIRED
+══════════════════════════════════════════════════════════
+
+  Actions to execute:
+
+  ▸ cleanup-orphaned-tmp-1 [Tier 0, auto-safe]
+    Delete 3 orphaned .tmp file(s) from crashed atomic writes.
+    Impact: 3 artifact(s), 12.4 KB
+
+  Total: 1 action(s), 3 artifact(s), ~12.4 KB
+
+  Proceed? [y/N]
+```
+
+The prompt defaults to **No**. The operator must type `y` or `yes`.
+
+With `--yes`, the confirmation block is still printed but the prompt is skipped.
+
+---
+
+## 7. Refusal & Safety Rules
+
+The executor **refuses** to proceed when:
+
+| Condition                                                           | Error Message                                                                                                     | Rationale                                         |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Requested action ID not found in fresh plan                         | `Action '{id}' not found in current plan. The underlying condition may have resolved. Re-run --dry-run.`          | Prevents executing against stale context          |
+| Requested action is Tier 2+                                         | `Action '{id}' is Tier {n} ({label}). v1 only supports Tier 0–1 execution. Use --dry-run to review.`              | Hard safety boundary for v1                       |
+| `--execute-tier` with value > 1                                     | `--execute-tier {n} is not supported in v1. Maximum: 1.`                                                          | Hard safety boundary                              |
+| `--execute` with `--dry-run`                                        | `--execute and --dry-run are contradictory. Use one or the other.`                                                | Prevents confusion                                |
+| `--execute` with `--enforce`                                        | `--execute uses the remediation plan path. --enforce uses legacy maintenance. Choose one.`                        | Keeps codepaths clean                             |
+| No actions would execute (all resolved)                             | `All requested actions have resolved since the last dry-run. Nothing to execute.`                                 | Prevents empty execution                          |
+| Fresh plan shows affectedCount **increased** for a requested action | `Action '{id}' now affects {n} artifacts (was {m} at review time). Re-run --dry-run to review the updated scope.` | Prevents scope creep between review and execution |
+
+### 7.1 Idempotency
+
+All v1 actions are idempotent:
+
+- **`cleanup-orphaned-tmp`**: Re-running after completion finds 0 orphaned temp files → action vanishes from plan → executor reports "nothing to do"
+- **`archive-orphan-transcripts`**: Re-running after archival finds 0 orphan transcripts → action vanishes from plan → executor reports "nothing to do"
+- **`archive-stale-deleted-transcripts`**: Same — already-purged `.deleted` files won't appear in a fresh scan
+- **`archive-stale-reset-transcripts`**: Same — already-purged `.reset` files won't appear in a fresh scan
+
+If the operator runs the same `--execute` command twice, the second run will report "All requested actions have resolved" and exit cleanly.
+
+---
+
+## 8. Before/After Reporting
+
+### 8.1 Text Report (default)
+
+```
+══════════════════════════════════════════════════════════
+  REMEDIATION EXECUTION — COMPLETE
+══════════════════════════════════════════════════════════
+
+  Executed: 2 action(s)
+  Skipped:  0
+  Failed:   0
+
+  ── cleanup-orphaned-tmp-1 ──
+  Status:   ✓ complete
+  Removed:  3 .tmp file(s)
+  Freed:    12.4 KB
+
+  ── archive-stale-deleted-transcripts-3 ──
+  Status:   ✓ complete
+  Removed:  7 .deleted file(s)
+  Freed:    2.1 MB
+
+  ── Storage Summary ──
+  Before:   48.3 MB total managed
+  After:    46.2 MB total managed
+  Freed:    2.1 MB (4.4%)
+
+══════════════════════════════════════════════════════════
+```
+
+### 8.2 JSON Report
+
+```json
+{
+  "executedAt": "2026-03-20T22:00:00.000Z",
+  "actions": [
+    {
+      "id": "cleanup-orphaned-tmp-1",
+      "kind": "cleanup-orphaned-tmp",
+      "tier": 0,
+      "status": "complete",
+      "artifactsRemoved": 3,
+      "bytesFreed": 12700
+    },
+    {
+      "id": "archive-stale-deleted-transcripts-3",
+      "kind": "archive-stale-deleted-transcripts",
+      "tier": 1,
+      "status": "complete",
+      "artifactsRemoved": 7,
+      "bytesFreed": 2202009
+    }
+  ],
+  "summary": {
+    "executed": 2,
+    "skipped": 0,
+    "failed": 0,
+    "totalBytesFreed": 2214709,
+    "storageBefore": 50647040,
+    "storageAfter": 48432331
+  }
+}
+```
+
+### 8.3 Per-Action Status Values
+
+| Status     | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `complete` | Action executed successfully                                  |
+| `skipped`  | Action no longer applicable (condition resolved)              |
+| `failed`   | Action failed (error message attached)                        |
+| `refused`  | Action refused by safety rules (tier violation, scope change) |
+
+### 8.4 Storage Summary
+
+The before/after storage summary re-collects `totalManagedBytes` from a fresh snapshot after execution. This is the honest delta — not the sum of estimated impacts (which may differ from reality).
+
+---
+
+## 9. Executor Implementation Architecture
+
+### 9.1 Execution Function Signature
+
+```typescript
+type ExecuteRemediationOptions = {
+  /** Action IDs to execute (from the plan). */
+  actionIds: string[];
+
+  /** Skip interactive confirmation. */
+  skipConfirmation: boolean;
+
+  /** JSON output mode. */
+  json: boolean;
+
+  /** Agent/store targeting (reuse existing SessionStoreTarget). */
+  target: SessionStoreTarget;
+};
+
+type ExecutionResult = {
+  executedAt: string;
+  actions: ActionExecutionResult[];
+  summary: ExecutionSummary;
+};
+```
+
+### 9.2 Action Executor Registry
+
+Each action kind maps to an executor function:
+
+```typescript
+type ActionExecutor = (params: {
+  action: RemediationAction;
+  target: SessionStoreTarget;
+  snapshot: SessionHealthRawSnapshot;
+}) => Promise<ActionExecutionResult>;
+```
+
+v1 implements exactly 4 executors:
+
+1. `executeCleanupOrphanedTmp` — `fs.unlink` for each `.tmp` file
+2. `executeArchiveOrphanTranscripts` — `fs.rename` to `.deleted.<timestamp>`
+3. `executeArchiveStaleDeletedTranscripts` — `fs.unlink` for each stale `.deleted` file
+4. `executeArchiveStaleResetTranscripts` — `fs.unlink` for each stale `.reset` file
+
+### 9.3 File Discovery
+
+The executor needs to discover the specific files to act on. The current remediation plan only reports _counts_ (e.g., "3 orphaned .tmp files"), not file paths.
+
+**Required implementation work:** The executor must either:
+
+- (a) Add file-path lists to the `RemediationAction` type, populated by the plan builder, or
+- (b) Re-discover files at execution time using the same logic the collector uses
+
+**Recommendation:** Option (b) — re-discover at execution time. This is consistent with the re-derive-and-validate philosophy. The collector already walks the session directory; we extract the file-discovery logic into shared helpers that both the collector and executor can use.
+
+### 9.4 Ordering
+
+Actions execute in tier order (Tier 0 before Tier 1), then in plan order within a tier. This respects the `prerequisites` field on remediation actions.
+
+### 9.5 Error Handling
+
+- Each action executes independently. A failure in one action does not block others (unless it's a prerequisite).
+- File-level errors (permission denied, file vanished) are caught per-file and reported in the action result.
+- An action with partial failures reports `status: "complete"` with a `warnings` array if some files succeeded.
+- An action where ALL files failed reports `status: "failed"`.
+
+---
+
+## 10. What Is Explicitly OUT of v1
+
+| Feature                                       | Why Out                                                         | When to Revisit                            |
+| --------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------ |
+| Tier 2 execution (index mutations)            | Qualitatively different risk — affects session visibility       | Phase 3D after v1 production mileage       |
+| Tier 3 execution (destructive bulk ops)       | Needs undo snapshots, progressive rollout                       | Phase 3E or later                          |
+| Automated/scheduled execution                 | Against core product constraint — no automation-first           | Phase 4 if operator demand justifies       |
+| Background/daemon cleanup                     | Against core product constraint — no hidden mutations           | Not planned                                |
+| `--execute-all` flag                          | Too broad — forces review of specific actions                   | Evaluate after v1                          |
+| Plan persistence / saved plans                | Re-derive-and-validate makes this unnecessary                   | Only if operators request it               |
+| Undo/rollback for Tier 1 irreversible actions | `.deleted`/`.reset` files past retention are acknowledged waste | Could add pre-execution backup in Phase 3D |
+| Multi-agent execution in single command       | Each agent store is independent; use `--agent` flag             | Phase 3D                                   |
+| Config-file approval presets                  | Over-engineered for v1                                          | Phase 4                                    |
+
+---
+
+## 11. Approval Ladder (Recommended Rollout)
+
+### Phase 3C (this spec) — Manual Selection Only
+
+- Operator runs `--dry-run`, reads plan, selects action IDs
+- Tier 0 + Tier 1 only
+- Always requires explicit `--execute` flag
+- Always shows confirmation prompt (unless `--yes`)
+
+### Phase 3D — Tier 2 Unlock + Review
+
+- Add Tier 2 execution support behind `--execute` (same manual selection model)
+- Add pre-execution index backup (snapshot `sessions.json` before mutation)
+- Evaluate whether `--execute-tier 2` should exist or if Tier 2 should remain ID-only
+
+### Phase 3E — Tier 3 + Safety Rails
+
+- Add Tier 3 execution with mandatory pre-execution backup
+- Add `--undo-last` for reversing the most recent execution
+- Evaluate progressive rollout (execute 10% → verify → execute rest)
+
+### Phase 4 — Selective Automation (if warranted)
+
+- Config-file presets for Tier 0 auto-execution
+- Scheduled runs with operator-defined scope
+- Only after extensive production use proves safety
+
+---
+
+## 12. Implementation Scope Estimate
+
+### New Files
+
+- `src/infra/session-health-remediation-executor.ts` — core executor logic
+- `src/infra/session-health-remediation-executor.test.ts` — executor tests
+- `src/infra/session-health-file-discovery.ts` — shared file-discovery helpers (extracted from collector)
+- `src/infra/session-health-file-discovery.test.ts` — discovery tests
+
+### Modified Files
+
+- `src/commands/sessions-cleanup.ts` — add `--execute`, `--execute-tier`, `--yes` flag handling
+- `src/cli/program/register.status-health-sessions.ts` — register new flags
+- `src/infra/session-health-remediation-types.ts` — add `ActionExecutionResult`, `ExecutionSummary` types
+
+### Estimated Scope
+
+- ~400–600 lines of new code (executor + file discovery)
+- ~100–150 lines of CLI integration
+- ~300–500 lines of tests
+- Total: ~800–1250 lines
+
+### Complexity: Medium
+
+The hardest part is extracting file-discovery logic from the collector into reusable helpers. The executor itself is straightforward (delete files, rename files, report results). The CLI integration follows existing patterns.
+
+---
+
+## 13. Recommendation: Next Step
+
+**Spec + immediate bounded implementation.**
+
+The spec is tight enough to implement directly. The v1 scope is well-bounded (4 action executors, file discovery extraction, CLI flags, confirmation prompt, before/after reporting). There are no open design questions that need operator feedback before building.
+
+Recommended implementation order:
+
+1. Extract file-discovery helpers from collector
+2. Build executor with 4 action executors
+3. Wire CLI flags and confirmation prompt
+4. Build before/after reporting
+5. Test suite
+6. Manual verification on a real session store
+
+This is a single-worker job — no parallelism needed. Estimated implementation time: one focused session.

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -16,6 +16,7 @@ if [[ ! -f "$FILTER_FILES" ]]; then
   exit 1
 fi
 
+# ── Phase 1: Gather staged files ─────────────────────────────────────────────
 # Security: avoid option-injection from malicious file names (e.g. "--all", "--force").
 # Robustness: NUL-delimited file list handles spaces/newlines safely.
 # Compatibility: use read loops instead of `mapfile` so this runs on macOS Bash 3.x.
@@ -28,6 +29,7 @@ if [ "${#files[@]}" -eq 0 ]; then
   exit 0
 fi
 
+# ── Phase 2: Filter staged files into tool-specific sets ─────────────────────
 lint_files=()
 while IFS= read -r -d '' file; do
   lint_files+=("$file")
@@ -38,19 +40,40 @@ while IFS= read -r -d '' file; do
   format_files+=("$file")
 done < <(node "$FILTER_FILES" format -- "${files[@]}")
 
+# ── Phase 3: Run per-file tools and re-stage ─────────────────────────────────
+ran_tools=0
+
 if [ "${#lint_files[@]}" -gt 0 ]; then
   "$RUN_NODE_TOOL" oxlint --type-aware --fix -- "${lint_files[@]}"
+  ran_tools=1
 fi
 
 if [ "${#format_files[@]}" -gt 0 ]; then
   "$RUN_NODE_TOOL" oxfmt --write --no-error-on-unmatched-pattern "${format_files[@]}"
+  ran_tools=1
 fi
 
-git add -- "${files[@]}"
+# Only re-stage when a tool ran and may have modified files on disk.
+if [ "$ran_tools" -eq 1 ]; then
+  git add -- "${files[@]}"
+fi
 
-# This hook is also exercised from lightweight temp repos in tests, where the
-# staged-file safety behavior matters but the full OpenClaw workspace does not
-# exist. Only run the repo-wide gate inside a real checkout.
+# ── Phase 4: Repo-wide quality gate ──────────────────────────────────────────
+# The gate runs only when all three conditions are met:
+#   1. This is a real OpenClaw checkout (package.json + pnpm-lock.yaml exist).
+#   2. Staged files include code the tools care about (lint or format targets).
+#   3. OPENCLAW_SKIP_CHECK is not set (escape hatch for known-safe commits).
+# Non-code-only commits (e.g. .gitignore, images) skip via condition 2.
+# Lightweight temp repos used by tests skip via condition 1.
+# Use `OPENCLAW_SKIP_CHECK=1 git commit` to bypass only the gate, not per-file tools.
+if [[ -n "${OPENCLAW_SKIP_CHECK:-}" ]]; then
+  exit 0
+fi
+
+if [ "${#lint_files[@]}" -eq 0 ] && [ "${#format_files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
 if [[ -f "$ROOT_DIR/package.json" ]] && [[ -f "$ROOT_DIR/pnpm-lock.yaml" ]]; then
   cd "$ROOT_DIR"
   pnpm check

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -170,6 +170,15 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     )
     .option("--active-key <key>", "Protect this session key from budget-eviction")
     .option("--json", "Output JSON", false)
+    .option(
+      "--execute <ids...>",
+      "Execute specific remediation action(s) by ID from a prior --dry-run review",
+    )
+    .option(
+      "--execute-tier <tier>",
+      "Execute all actions in the specified tier (0 or 1). Tier 1 implies Tier 0.",
+    )
+    .option("--yes", "Skip interactive confirmation prompt (still prints the summary)", false)
     .addHelpText(
       "after",
       () =>
@@ -185,6 +194,15 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           [
             "openclaw sessions cleanup --enforce --store ./tmp/sessions.json",
             "Use a specific store.",
+          ],
+          [
+            "openclaw sessions cleanup --execute cleanup-orphaned-tmp-1",
+            "Execute a specific remediation action.",
+          ],
+          ["openclaw sessions cleanup --execute-tier 0", "Execute all Tier 0 (auto-safe) actions."],
+          [
+            "openclaw sessions cleanup --execute-tier 1 --yes --json",
+            "Execute Tier 0 + 1 actions without prompt, JSON output.",
           ],
         ])}`,
     )
@@ -208,6 +226,9 @@ export function registerStatusHealthSessionsCommands(program: Command) {
             fixMissing: Boolean(opts.fixMissing),
             activeKey: opts.activeKey as string | undefined,
             json: Boolean(opts.json || parentOpts?.json),
+            execute: opts.execute as string[] | undefined,
+            executeTier: opts.executeTier as string | undefined,
+            yes: Boolean(opts.yes),
           },
           defaultRuntime,
         );

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -73,13 +73,19 @@ export type HealthSummary = {
   /**
    * Optional raw session health snapshot from the periodic session health
    * collector (Layer A). Populated once the collector has run at least once
-   * after gateway startup. A future Phase 2 pass will add a derived
-   * `SessionHealthSurface` (Layer B) with threshold-based indicators.
+   * after gateway startup.
    *
    * This field is additive — existing consumers that don't know about it will
    * simply ignore it.
    */
   sessionHealth?: import("../infra/session-health-types.js").SessionHealthRawSnapshot | null;
+  /**
+   * Optional derived operator-facing health surface (Layer B) with
+   * threshold-based indicators. Populated by the periodic collector after
+   * deriving from the raw snapshot. UI surfaces consume this instead of
+   * inspecting the raw snapshot directly.
+   */
+  sessionHealthSurface?: import("../infra/session-health-types.js").SessionHealthSurface | null;
 };
 
 const DEFAULT_TIMEOUT_MS = 10_000;

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -70,6 +70,16 @@ export type HealthSummary = {
       age: number | null;
     }>;
   };
+  /**
+   * Optional raw session health snapshot from the periodic session health
+   * collector (Layer A). Populated once the collector has run at least once
+   * after gateway startup. A future Phase 2 pass will add a derived
+   * `SessionHealthSurface` (Layer B) with threshold-based indicators.
+   *
+   * This field is additive — existing consumers that don't know about it will
+   * simply ignore it.
+   */
+  sessionHealth?: import("../infra/session-health-types.js").SessionHealthRawSnapshot | null;
 };
 
 const DEFAULT_TIMEOUT_MS = 10_000;

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   updateSessionStore: vi.fn(),
   enforceSessionDiskBudget: vi.fn(),
   collectSessionHealth: vi.fn(),
+  promptYesNo: vi.fn(),
+  executeRemediation: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -41,6 +43,19 @@ vi.mock("../config/sessions.js", () => ({
 vi.mock("../infra/session-health-collector.js", () => ({
   collectSessionHealth: mocks.collectSessionHealth,
 }));
+
+vi.mock("../cli/prompt.js", () => ({
+  promptYesNo: mocks.promptYesNo,
+}));
+
+vi.mock("../infra/session-health-remediation-executor.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../infra/session-health-remediation-executor.js")>();
+  return {
+    ...actual,
+    executeRemediation: mocks.executeRemediation,
+  };
+});
 
 import { sessionsCleanupCommand } from "./sessions-cleanup.js";
 
@@ -575,5 +590,244 @@ describe("sessionsCleanupCommand", () => {
     const plan = payload.remediationPlan as Record<string, unknown>;
     const summary = plan.summary as Record<string, unknown>;
     expect(summary.totalActions).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase 3C — Execution path
+  // -------------------------------------------------------------------------
+
+  describe("execution path (Phase 3C)", () => {
+    it("refuses --execute with --dry-run", async () => {
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          dryRun: true,
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("contradictory"))).toBe(true);
+    });
+
+    it("refuses --execute with --enforce", async () => {
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          enforce: true,
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("legacy maintenance"))).toBe(true);
+    });
+
+    it("refuses --execute-tier > 1 in v1", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          executeTier: "2",
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("not supported in v1"))).toBe(true);
+    });
+
+    it("refuses --execute and --execute-tier together", async () => {
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          executeTier: "0",
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("mutually exclusive"))).toBe(true);
+    });
+
+    it("prompts for confirmation by default and aborts on decline", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+      mocks.promptYesNo.mockResolvedValue(false);
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+        },
+        runtime,
+      );
+
+      expect(mocks.promptYesNo).toHaveBeenCalled();
+      expect(logs.some((l) => l.includes("Aborted"))).toBe(true);
+      expect(mocks.executeRemediation).not.toHaveBeenCalled();
+    });
+
+    it("executes with --yes and prints JSON report", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+      mocks.executeRemediation.mockResolvedValue({
+        executedAt: "2026-03-20T22:00:00.000Z",
+        actions: [
+          {
+            id: "cleanup-orphaned-tmp-1",
+            kind: "cleanup-orphaned-tmp",
+            tier: 0,
+            status: "complete",
+            artifactsRemoved: 2,
+            bytesFreed: 4096,
+            detail: "Removed 2 .tmp file(s).",
+          },
+        ],
+        summary: {
+          executed: 1,
+          skipped: 0,
+          failed: 0,
+          refused: 0,
+          totalBytesFreed: 4096,
+          storageBefore: 50_000_000,
+          storageAfter: 49_995_904,
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          yes: true,
+          json: true,
+        },
+        runtime,
+      );
+
+      expect(mocks.promptYesNo).not.toHaveBeenCalled();
+      expect(mocks.executeRemediation).toHaveBeenCalled();
+
+      // Should print confirmation block + JSON result
+      const jsonLog = logs.find((l) => {
+        try {
+          JSON.parse(l);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonLog).toBeDefined();
+      const payload = JSON.parse(jsonLog!) as Record<string, unknown>;
+      expect(payload.executedAt).toBeTruthy();
+      expect(payload.summary).toBeDefined();
+      expect((payload.summary as Record<string, unknown>).executed).toBe(1);
+    });
+
+    it("executes with --execute-tier 0 and prints text report", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+      mocks.executeRemediation.mockResolvedValue({
+        executedAt: "2026-03-20T22:00:00.000Z",
+        actions: [
+          {
+            id: "cleanup-orphaned-tmp-1",
+            kind: "cleanup-orphaned-tmp",
+            tier: 0,
+            status: "complete",
+            artifactsRemoved: 2,
+            bytesFreed: 4096,
+          },
+        ],
+        summary: {
+          executed: 1,
+          skipped: 0,
+          failed: 0,
+          refused: 0,
+          totalBytesFreed: 4096,
+          storageBefore: 50_000_000,
+          storageAfter: 49_995_904,
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand(
+        {
+          executeTier: "0",
+          yes: true,
+        },
+        runtime,
+      );
+
+      const fullOutput = logs.join("\n");
+      expect(fullOutput).toContain("CONFIRMATION REQUIRED");
+      expect(fullOutput).toContain("COMPLETE");
+    });
+
+    it("handles empty tier (no actions in plan) gracefully", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(cleanSnapshot());
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand(
+        {
+          executeTier: "0",
+          yes: true,
+        },
+        runtime,
+      );
+
+      const fullOutput = logs.join("\n");
+      expect(fullOutput).toContain("Nothing to execute");
+      expect(mocks.executeRemediation).not.toHaveBeenCalled();
+    });
+
+    it("handles empty tier in JSON mode", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(cleanSnapshot());
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand(
+        {
+          executeTier: "0",
+          yes: true,
+          json: true,
+        },
+        runtime,
+      );
+
+      expect(logs).toHaveLength(1);
+      const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+      expect(payload.message).toContain("Nothing to execute");
+      expect(Array.isArray(payload.actions)).toBe(true);
+      expect((payload.actions as unknown[]).length).toBe(0);
+    });
   });
 });

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -740,7 +740,7 @@ describe("sessionsCleanupCommand", () => {
 
       // --json should produce exactly one JSON blob, no human text
       expect(logs).toHaveLength(1);
-      const payload = JSON.parse(logs[0]!) as Record<string, unknown>;
+      const payload = JSON.parse(logs[0]);
       expect(payload.executedAt).toBeTruthy();
       expect(payload.summary).toBeDefined();
       expect((payload.summary as Record<string, unknown>).executed).toBe(1);
@@ -928,9 +928,9 @@ describe("sessionsCleanupCommand", () => {
 
       // stdout should be exactly one JSON blob — no human text
       expect(logs).toHaveLength(1);
-      const raw = logs[0]!;
+      const raw = logs[0];
       expect(raw).not.toContain("CONFIRMATION REQUIRED");
-      const payload = JSON.parse(raw) as Record<string, unknown>;
+      const payload = JSON.parse(raw);
       expect(payload.executedAt).toBeTruthy();
       expect((payload.summary as Record<string, unknown>).executed).toBe(1);
     });

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -738,20 +738,14 @@ describe("sessionsCleanupCommand", () => {
       expect(mocks.promptYesNo).not.toHaveBeenCalled();
       expect(mocks.executeRemediation).toHaveBeenCalled();
 
-      // Should print confirmation block + JSON result
-      const jsonLog = logs.find((l) => {
-        try {
-          JSON.parse(l);
-          return true;
-        } catch {
-          return false;
-        }
-      });
-      expect(jsonLog).toBeDefined();
-      const payload = JSON.parse(jsonLog!) as Record<string, unknown>;
+      // --json should produce exactly one JSON blob, no human text
+      expect(logs).toHaveLength(1);
+      const payload = JSON.parse(logs[0]!) as Record<string, unknown>;
       expect(payload.executedAt).toBeTruthy();
       expect(payload.summary).toBeDefined();
       expect((payload.summary as Record<string, unknown>).executed).toBe(1);
+      // No confirmation block text in stdout
+      expect(logs[0]).not.toContain("CONFIRMATION REQUIRED");
     });
 
     it("executes with --execute-tier 0 and prints text report", async () => {
@@ -828,6 +822,117 @@ describe("sessionsCleanupCommand", () => {
       expect(payload.message).toContain("Nothing to execute");
       expect(Array.isArray(payload.actions)).toBe(true);
       expect((payload.actions as unknown[]).length).toBe(0);
+    });
+
+    // -----------------------------------------------------------------------
+    // Phase 3C hardening — unsupported targeting flags in execute mode
+    // -----------------------------------------------------------------------
+
+    it("refuses --execute with --agent", async () => {
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          agent: "work",
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("not supported in execution mode"))).toBe(true);
+    });
+
+    it("refuses --execute with --all-agents", async () => {
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          allAgents: true,
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("not supported in execution mode"))).toBe(true);
+    });
+
+    it("refuses --execute with --store", async () => {
+      const { runtime } = makeRuntime();
+      const errors: string[] = [];
+      let exitCode: number | undefined;
+      runtime.error = (msg: unknown) => errors.push(String(msg));
+      runtime.exit = (code: number) => {
+        exitCode = code;
+      };
+
+      await sessionsCleanupCommand(
+        {
+          execute: ["cleanup-orphaned-tmp-1"],
+          store: "/tmp/other-sessions.json",
+        },
+        runtime,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(errors.some((e) => e.includes("not supported in execution mode"))).toBe(true);
+    });
+
+    it("--execute-tier 0 --yes --json produces clean stdout (no confirmation block)", async () => {
+      mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+      mocks.executeRemediation.mockResolvedValue({
+        executedAt: "2026-03-20T22:00:00.000Z",
+        actions: [
+          {
+            id: "cleanup-orphaned-tmp-1",
+            kind: "cleanup-orphaned-tmp",
+            tier: 0,
+            status: "complete",
+            artifactsRemoved: 2,
+            bytesFreed: 4096,
+          },
+        ],
+        summary: {
+          executed: 1,
+          skipped: 0,
+          failed: 0,
+          refused: 0,
+          totalBytesFreed: 4096,
+          storageBefore: 50_000_000,
+          storageAfter: 49_995_904,
+        },
+      });
+
+      const { runtime, logs } = makeRuntime();
+      await sessionsCleanupCommand(
+        {
+          executeTier: "0",
+          yes: true,
+          json: true,
+        },
+        runtime,
+      );
+
+      // stdout should be exactly one JSON blob — no human text
+      expect(logs).toHaveLength(1);
+      const raw = logs[0]!;
+      expect(raw).not.toContain("CONFIRMATION REQUIRED");
+      const payload = JSON.parse(raw) as Record<string, unknown>;
+      expect(payload.executedAt).toBeTruthy();
+      expect((payload.summary as Record<string, unknown>).executed).toBe(1);
     });
   });
 });

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -122,6 +122,10 @@ function snapshotWithIssues(): SessionHealthRawSnapshot {
         "cron-run": 15,
         subagent: 8,
       },
+      staleByClass: {
+        "cron-run": 6,
+        subagent: 3,
+      },
       byDiskState: {
         active: 30,
         deleted: 3,

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
+import type { SessionHealthRawSnapshot } from "../infra/session-health-types.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   capEntryCount: vi.fn(),
   updateSessionStore: vi.fn(),
   enforceSessionDiskBudget: vi.fn(),
+  collectSessionHealth: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -36,6 +38,10 @@ vi.mock("../config/sessions.js", () => ({
   enforceSessionDiskBudget: mocks.enforceSessionDiskBudget,
 }));
 
+vi.mock("../infra/session-health-collector.js", () => ({
+  collectSessionHealth: mocks.collectSessionHealth,
+}));
+
 import { sessionsCleanupCommand } from "./sessions-cleanup.js";
 
 function makeRuntime(): { runtime: RuntimeEnv; logs: string[] } {
@@ -47,6 +53,95 @@ function makeRuntime(): { runtime: RuntimeEnv; logs: string[] } {
       exit: () => {},
     },
     logs,
+  };
+}
+
+/** Minimal clean snapshot that produces zero remediation actions. */
+function cleanSnapshot(): SessionHealthRawSnapshot {
+  return {
+    capturedAt: "2026-03-20T18:00:00.000Z",
+    collectorDurationMs: 5,
+    sessions: {
+      indexedCount: 10,
+      sessionsJsonBytes: 5000,
+      sessionsJsonParseTimeMs: 1,
+      byClass: {
+        main: 2,
+        channel: 3,
+        direct: 2,
+        "cron-definition": 1,
+        "cron-run": 0,
+        subagent: 0,
+        acp: 0,
+        heartbeat: 0,
+        thread: 2,
+        unknown: 0,
+      },
+      byDiskState: { active: 10, deleted: 0, reset: 0, orphanedTemp: 0 },
+    },
+    storage: {
+      totalManagedBytes: 100_000,
+      sessionsJsonBytes: 5000,
+      activeTranscriptBytes: 95_000,
+      deletedTranscriptBytes: 0,
+      resetTranscriptBytes: 0,
+      orphanedTempBytes: 0,
+    },
+    drift: {
+      indexedWithoutDiskFile: 0,
+      diskFilesWithoutIndex: 0,
+      orphanedTempCount: 0,
+      oldestOrphanedTempAt: null,
+      reconciliationRecommended: false,
+    },
+    maintenance: {
+      mode: "warn",
+      maxEntries: 500,
+      pruneAfterMs: 7 * 24 * 60 * 60 * 1000,
+      maxDiskBytes: null,
+      usagePercent: { entries: 2, diskBytes: null },
+    },
+    growth: {
+      sessionsBytes24h: null,
+      sessionsBytes7d: null,
+      indexedCount24h: null,
+      indexedCount7d: null,
+    },
+    agents: [],
+  };
+}
+
+/** Snapshot with issues that will produce remediation actions. */
+function snapshotWithIssues(): SessionHealthRawSnapshot {
+  return {
+    ...cleanSnapshot(),
+    sessions: {
+      ...cleanSnapshot().sessions,
+      byClass: {
+        ...cleanSnapshot().sessions.byClass,
+        "cron-run": 15,
+        subagent: 8,
+      },
+      byDiskState: {
+        active: 30,
+        deleted: 3,
+        reset: 5,
+        orphanedTemp: 2,
+      },
+    },
+    storage: {
+      ...cleanSnapshot().storage,
+      deletedTranscriptBytes: 2_000_000,
+      resetTranscriptBytes: 5_000_000,
+      orphanedTempBytes: 4096,
+    },
+    drift: {
+      indexedWithoutDiskFile: 4,
+      diskFilesWithoutIndex: 3,
+      orphanedTempCount: 2,
+      oldestOrphanedTempAt: "2026-03-19T10:00:00.000Z",
+      reconciliationRecommended: true,
+    },
   };
 }
 
@@ -107,6 +202,9 @@ describe("sessionsCleanupCommand", () => {
       highWaterBytes: 700,
       overBudget: true,
     });
+    // Default: collectSessionHealth returns a clean snapshot (no remediation actions).
+    // Individual tests can override this to test remediation plan integration.
+    mocks.collectSessionHealth.mockResolvedValue(cleanSnapshot());
   });
 
   it("emits a single JSON object for non-dry runs and applies maintenance", async () => {
@@ -287,5 +385,191 @@ describe("sessionsCleanupCommand", () => {
     expect(payload.allAgents).toBe(true);
     expect(Array.isArray(payload.stores)).toBe(true);
     expect((payload.stores as unknown[]).length).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Remediation plan integration (Phase 3B)
+  // -------------------------------------------------------------------------
+
+  it("includes remediationPlan in dry-run JSON when snapshot has issues", async () => {
+    mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.loadSessionStore.mockReturnValue({
+      fresh: { sessionId: "fresh", updatedAt: 2 },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        json: true,
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    expect(logs).toHaveLength(1);
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    expect(payload.dryRun).toBe(true);
+    expect(payload.remediationPlan).toBeDefined();
+    const plan = payload.remediationPlan as Record<string, unknown>;
+    expect(plan.generatedAt).toBeTruthy();
+    expect(plan.snapshotAt).toBeTruthy();
+    const summary = plan.summary as Record<string, unknown>;
+    expect(summary.totalActions).toBeGreaterThan(0);
+    expect(Array.isArray(plan.tiers)).toBe(true);
+    expect(plan.approvalModel).toBeDefined();
+  });
+
+  it("omits remediationPlan from dry-run JSON when snapshot is clean", async () => {
+    mocks.collectSessionHealth.mockResolvedValue(cleanSnapshot());
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.loadSessionStore.mockReturnValue({
+      fresh: { sessionId: "fresh", updatedAt: 2 },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        json: true,
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    expect(logs).toHaveLength(1);
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    // Clean snapshot produces a plan with 0 actions, so remediationPlan is
+    // still included (it shows the empty plan structure). The key thing is
+    // it doesn't break existing fields.
+    expect(payload.dryRun).toBe(true);
+  });
+
+  it("appends remediation plan text in dry-run text mode when issues exist", async () => {
+    mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.loadSessionStore.mockReturnValue({
+      stale: { sessionId: "stale", updatedAt: 1, model: "pi:opus" },
+      fresh: { sessionId: "fresh", updatedAt: 2, model: "pi:opus" },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    const fullOutput = logs.join("\n");
+    // Should still have the existing per-session action table
+    expect(fullOutput).toContain("Planned session actions:");
+    // Should also have the appended remediation plan
+    expect(fullOutput).toContain("REMEDIATION PLAN");
+    expect(fullOutput).toContain("DRY RUN");
+    expect(fullOutput).toContain("No changes have been made");
+    expect(fullOutput).toContain("Tier 0");
+    expect(fullOutput).toContain("orphaned temp");
+  });
+
+  it("does not append remediation plan text when snapshot is clean", async () => {
+    mocks.collectSessionHealth.mockResolvedValue(cleanSnapshot());
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.loadSessionStore.mockReturnValue({
+      fresh: { sessionId: "fresh", updatedAt: 2, model: "pi:opus" },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    const fullOutput = logs.join("\n");
+    // Existing dry-run output should be present
+    expect(fullOutput).toContain("Session store:");
+    // Remediation plan should NOT be appended (0 actions → no extra output)
+    expect(fullOutput).not.toContain("REMEDIATION PLAN");
+  });
+
+  it("gracefully handles collectSessionHealth failure in dry-run", async () => {
+    mocks.collectSessionHealth.mockRejectedValue(new Error("disk unreadable"));
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.loadSessionStore.mockReturnValue({
+      fresh: { sessionId: "fresh", updatedAt: 2 },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        json: true,
+        dryRun: true,
+      },
+      runtime,
+    );
+
+    expect(logs).toHaveLength(1);
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    expect(payload.dryRun).toBe(true);
+    // No remediationPlan key when collection fails
+    expect(payload.remediationPlan).toBeUndefined();
+  });
+
+  it("does not include remediationPlan in enforce (non-dry-run) JSON", async () => {
+    mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+    mocks.loadSessionStore
+      .mockReturnValueOnce({
+        fresh: { sessionId: "fresh", updatedAt: 2 },
+      })
+      .mockReturnValueOnce({
+        fresh: { sessionId: "fresh", updatedAt: 2 },
+      });
+    mocks.updateSessionStore.mockResolvedValue(0);
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        json: true,
+        enforce: true,
+        activeKey: "agent:main:main",
+      },
+      runtime,
+    );
+
+    expect(logs).toHaveLength(1);
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    // Enforce mode should NOT include remediation plan — it's dry-run only
+    expect(payload.remediationPlan).toBeUndefined();
+  });
+
+  it("includes remediationPlan in --all-agents dry-run JSON", async () => {
+    mocks.collectSessionHealth.mockResolvedValue(snapshotWithIssues());
+    mocks.resolveSessionStoreTargets.mockReturnValue([
+      { agentId: "main", storePath: "/resolved/main-sessions.json" },
+      { agentId: "work", storePath: "/resolved/work-sessions.json" },
+    ]);
+    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
+    mocks.loadSessionStore
+      .mockReturnValueOnce({ fresh: { sessionId: "fresh-main", updatedAt: 2 } })
+      .mockReturnValueOnce({ fresh: { sessionId: "fresh-work", updatedAt: 2 } });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCleanupCommand(
+      {
+        json: true,
+        dryRun: true,
+        allAgents: true,
+      },
+      runtime,
+    );
+
+    expect(logs).toHaveLength(1);
+    const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
+    expect(payload.allAgents).toBe(true);
+    expect(payload.remediationPlan).toBeDefined();
+    const plan = payload.remediationPlan as Record<string, unknown>;
+    const summary = plan.summary as Record<string, unknown>;
+    expect(summary.totalActions).toBeGreaterThan(0);
   });
 });

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -402,9 +402,11 @@ async function sessionsCleanupExecuteCommand(
       return;
     }
 
-    // 4. Show confirmation prompt
-    const confirmationText = renderConfirmationBlock(validation.actions);
-    runtime.log(confirmationText);
+    // 4. Show confirmation prompt (suppress human text when --json for clean stdout)
+    if (!opts.json) {
+      const confirmationText = renderConfirmationBlock(validation.actions);
+      runtime.log(confirmationText);
+    }
 
     if (!opts.yes) {
       const confirmed = await promptYesNo("Proceed?", false);
@@ -417,8 +419,6 @@ async function sessionsCleanupExecuteCommand(
     // 5. Execute
     const result = await executeRemediation({
       actionIds,
-      skipConfirmation: Boolean(opts.yes),
-      json: Boolean(opts.json),
       cfg,
       snapshot,
     });
@@ -465,6 +465,15 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
 
   if (hasExecute && hasExecuteTier) {
     runtime.error("--execute and --execute-tier are mutually exclusive. Use one or the other.");
+    runtime.exit(1);
+    return;
+  }
+
+  if (isExecutionMode && (opts.agent || opts.allAgents || opts.store)) {
+    runtime.error(
+      "--execute/--execute-tier operates on the default agent store only. " +
+        "--agent, --all-agents, and --store are not supported in execution mode.",
+    );
     runtime.exit(1);
     return;
   }

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -258,12 +258,17 @@ function renderStoreDryRunPlan(params: {
     params.runtime.log(`Agent: ${params.summary.agentId}`);
   }
   params.runtime.log(`Session store: ${params.summary.storePath}`);
+  params.runtime.log("");
+  const sectionLabel = "── Maintenance Preview (global age threshold) ──";
+  params.runtime.log(rich ? theme.heading(sectionLabel) : sectionLabel);
   params.runtime.log(`Maintenance mode: ${params.summary.mode}`);
   params.runtime.log(
     `Entries: ${params.summary.beforeCount} -> ${params.summary.afterCount} (remove ${params.summary.beforeCount - params.summary.afterCount})`,
   );
   params.runtime.log(`Would prune missing transcripts: ${params.summary.missing}`);
-  params.runtime.log(`Would prune stale: ${params.summary.pruned}`);
+  params.runtime.log(
+    `Would prune stale (global age threshold, all classes): ${params.summary.pruned}`,
+  );
   params.runtime.log(`Would cap overflow: ${params.summary.capped}`);
   if (params.summary.diskBudget) {
     params.runtime.log(

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { promptYesNo } from "../cli/prompt.js";
 import { loadConfig } from "../config/config.js";
 import {
   capEntryCount,
@@ -14,10 +15,19 @@ import {
 } from "../config/sessions.js";
 import { collectSessionHealth } from "../infra/session-health-collector.js";
 import {
+  executeRemediation,
+  ExecutionRefusalError,
+  renderConfirmationBlock,
+  renderExecutionReportText,
+  resolveActionIdsForTier,
+  validateExecutionRequest,
+} from "../infra/session-health-remediation-executor.js";
+import {
   buildRemediationPlan,
   renderRemediationPlanText,
 } from "../infra/session-health-remediation-plan.js";
 import type { RemediationPlan } from "../infra/session-health-remediation-types.js";
+import { V1_MAX_EXECUTION_TIER } from "../infra/session-health-remediation-types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { isRich, theme } from "../terminal/theme.js";
 import {
@@ -46,6 +56,9 @@ export type SessionsCleanupOptions = {
   activeKey?: string;
   json?: boolean;
   fixMissing?: boolean;
+  execute?: string[];
+  executeTier?: string;
+  yes?: boolean;
 };
 
 type SessionCleanupAction =
@@ -317,8 +330,156 @@ async function tryBuildRemediationPlanForDryRun(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Execution sub-command (Phase 3C)
+// ---------------------------------------------------------------------------
+
+async function sessionsCleanupExecuteCommand(
+  opts: SessionsCleanupOptions,
+  cfg: ReturnType<typeof loadConfig>,
+  runtime: RuntimeEnv,
+) {
+  const hasExecuteTier = opts.executeTier != null && opts.executeTier !== "";
+
+  try {
+    // 1. Re-collect fresh snapshot and plan
+    const snapshot = await collectSessionHealth(cfg);
+    const freshPlan = buildRemediationPlan({ snapshot });
+
+    // 2. Resolve action IDs
+    let actionIds: string[];
+    if (hasExecuteTier) {
+      const tierNum = Number(opts.executeTier);
+      if (!Number.isInteger(tierNum) || tierNum < 0) {
+        runtime.error(`--execute-tier must be a non-negative integer. Got: '${opts.executeTier}'.`);
+        runtime.exit(1);
+        return;
+      }
+      if (tierNum > V1_MAX_EXECUTION_TIER) {
+        runtime.error(
+          `--execute-tier ${tierNum} is not supported in v1. Maximum: ${V1_MAX_EXECUTION_TIER}.`,
+        );
+        runtime.exit(1);
+        return;
+      }
+      actionIds = resolveActionIdsForTier(tierNum, freshPlan);
+      if (actionIds.length === 0) {
+        if (opts.json) {
+          runtime.log(
+            JSON.stringify(
+              {
+                executedAt: new Date().toISOString(),
+                actions: [],
+                summary: {
+                  executed: 0,
+                  skipped: 0,
+                  failed: 0,
+                  refused: 0,
+                  totalBytesFreed: 0,
+                  storageBefore: snapshot.storage.totalManagedBytes,
+                  storageAfter: snapshot.storage.totalManagedBytes,
+                },
+                message: `No Tier 0–${tierNum} actions in the current plan. Nothing to execute.`,
+              },
+              null,
+              2,
+            ),
+          );
+        } else {
+          runtime.log(`No Tier 0–${tierNum} actions in the current plan. Nothing to execute.`);
+        }
+        return;
+      }
+    } else {
+      actionIds = opts.execute ?? [];
+    }
+
+    // 3. Validate against fresh plan
+    const validation = validateExecutionRequest(actionIds, freshPlan);
+    if (!validation.valid) {
+      runtime.error(validation.error);
+      runtime.exit(1);
+      return;
+    }
+
+    // 4. Show confirmation prompt
+    const confirmationText = renderConfirmationBlock(validation.actions);
+    runtime.log(confirmationText);
+
+    if (!opts.yes) {
+      const confirmed = await promptYesNo("Proceed?", false);
+      if (!confirmed) {
+        runtime.log("Aborted.");
+        return;
+      }
+    }
+
+    // 5. Execute
+    const result = await executeRemediation({
+      actionIds,
+      skipConfirmation: Boolean(opts.yes),
+      json: Boolean(opts.json),
+      cfg,
+      snapshot,
+    });
+
+    // 6. Report
+    if (opts.json) {
+      runtime.log(JSON.stringify(result, null, 2));
+    } else {
+      runtime.log(renderExecutionReportText(result));
+    }
+  } catch (err) {
+    if (err instanceof ExecutionRefusalError) {
+      runtime.error(err.message);
+      runtime.exit(1);
+      return;
+    }
+    throw err;
+  }
+}
+
 export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runtime: RuntimeEnv) {
   const cfg = loadConfig();
+
+  // -------------------------------------------------------------------------
+  // Flag conflict detection (Phase 3C safety rules)
+  // -------------------------------------------------------------------------
+  const hasExecute = Array.isArray(opts.execute) && opts.execute.length > 0;
+  const hasExecuteTier = opts.executeTier != null && opts.executeTier !== "";
+  const isExecutionMode = hasExecute || hasExecuteTier;
+
+  if (isExecutionMode && opts.dryRun) {
+    runtime.error("--execute and --dry-run are contradictory. Use one or the other.");
+    runtime.exit(1);
+    return;
+  }
+
+  if (isExecutionMode && opts.enforce) {
+    runtime.error(
+      "--execute uses the remediation plan path. --enforce uses legacy maintenance. Choose one.",
+    );
+    runtime.exit(1);
+    return;
+  }
+
+  if (hasExecute && hasExecuteTier) {
+    runtime.error("--execute and --execute-tier are mutually exclusive. Use one or the other.");
+    runtime.exit(1);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Execution path (Phase 3C)
+  // -------------------------------------------------------------------------
+  if (isExecutionMode) {
+    await sessionsCleanupExecuteCommand(opts, cfg, runtime);
+    return;
+  }
+
+  // -------------------------------------------------------------------------
+  // Existing dry-run / enforce path
+  // -------------------------------------------------------------------------
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
   const mode = opts.enforce ? "enforce" : resolveMaintenanceConfig().mode;
   const targets = resolveSessionStoreTargetsOrExit({

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -12,6 +12,12 @@ import {
   type SessionEntry,
   type SessionMaintenanceApplyReport,
 } from "../config/sessions.js";
+import { collectSessionHealth } from "../infra/session-health-collector.js";
+import {
+  buildRemediationPlan,
+  renderRemediationPlanText,
+} from "../infra/session-health-remediation-plan.js";
+import type { RemediationPlan } from "../infra/session-health-remediation-types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { isRich, theme } from "../terminal/theme.js";
 import {
@@ -290,6 +296,22 @@ function renderStoreDryRunPlan(params: {
   }
 }
 
+/**
+ * Attempt to collect a health snapshot and build a remediation plan.
+ * Best-effort: returns null if collection fails (e.g., no config, no disk).
+ * This is intentionally non-blocking for the existing dry-run flow.
+ */
+async function tryBuildRemediationPlanForDryRun(
+  cfg: ReturnType<typeof loadConfig>,
+): Promise<RemediationPlan | null> {
+  try {
+    const snapshot = await collectSessionHealth(cfg);
+    return buildRemediationPlan({ snapshot });
+  } catch {
+    return null;
+  }
+}
+
 export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runtime: RuntimeEnv) {
   const cfg = loadConfig();
   const displayDefaults = resolveSessionDisplayDefaults(cfg);
@@ -323,23 +345,30 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
   }
 
   if (opts.dryRun) {
+    // Build the remediation plan from a live health snapshot (best-effort).
+    const remediationPlan = await tryBuildRemediationPlanForDryRun(cfg);
+
     if (opts.json) {
       if (previewResults.length === 1) {
-        runtime.log(JSON.stringify(previewResults[0]?.summary ?? {}, null, 2));
+        const payload: Record<string, unknown> = {
+          ...previewResults[0]?.summary,
+        };
+        if (remediationPlan) {
+          payload.remediationPlan = remediationPlan;
+        }
+        runtime.log(JSON.stringify(payload, null, 2));
         return;
       }
-      runtime.log(
-        JSON.stringify(
-          {
-            allAgents: true,
-            mode,
-            dryRun: true,
-            stores: previewResults.map((result) => result.summary),
-          },
-          null,
-          2,
-        ),
-      );
+      const payload: Record<string, unknown> = {
+        allAgents: true,
+        mode,
+        dryRun: true,
+        stores: previewResults.map((result) => result.summary),
+      };
+      if (remediationPlan) {
+        payload.remediationPlan = remediationPlan;
+      }
+      runtime.log(JSON.stringify(payload, null, 2));
       return;
     }
 
@@ -356,6 +385,12 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
         runtime,
         showAgentHeader: previewResults.length > 1,
       });
+    }
+
+    // Append remediation plan report after the existing dry-run output.
+    if (remediationPlan && remediationPlan.summary.totalActions > 0) {
+      runtime.log("");
+      runtime.log(renderRemediationPlanText(remediationPlan));
     }
     return;
   }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -4,6 +4,7 @@ import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
+import type { SessionHealthRunner } from "../infra/session-health-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
 export function createGatewayCloseHandler(params: {
@@ -16,6 +17,7 @@ export function createGatewayCloseHandler(params: {
   pluginServices: PluginServicesHandle | null;
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
+  sessionHealthRunner?: SessionHealthRunner;
   updateCheckStop?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
@@ -76,6 +78,7 @@ export function createGatewayCloseHandler(params: {
       await stopGmailWatcher();
       params.cron.stop();
       params.heartbeatRunner.stop();
+      params.sessionHealthRunner?.stop();
       try {
         params.updateCheckStop?.();
       } catch {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -14,6 +14,7 @@ import {
   emitGatewayRestart,
   setGatewaySigusr1RestartPolicy,
 } from "../infra/restart.js";
+import type { SessionHealthRunner } from "../infra/session-health-runner.js";
 import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
@@ -29,6 +30,7 @@ type GatewayHotReloadState = {
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
   hookClientIpConfig: HookClientIpConfig;
   heartbeatRunner: HeartbeatRunner;
+  sessionHealthRunner?: SessionHealthRunner;
   cronState: GatewayCronState;
   browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> | null;
   channelHealthMonitor: ChannelHealthMonitor | null;
@@ -76,6 +78,9 @@ export function createGatewayReloadHandlers(params: {
     if (plan.restartHeartbeat) {
       nextState.heartbeatRunner.updateConfig(nextConfig);
     }
+
+    // Session health collector follows config changes (always safe to update).
+    nextState.sessionHealthRunner?.updateConfig(nextConfig);
 
     resetDirectoryCache();
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -42,6 +42,10 @@ import {
 } from "../infra/plugin-install-path-warnings.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import {
+  startSessionHealthCollector,
+  type SessionHealthRunner,
+} from "../infra/session-health-runner.js";
+import {
   primeRemoteSkillsCache,
   refreshRemoteBinsForConnectedNodes,
   setSkillsRemoteRegistry,
@@ -992,6 +996,10 @@ export async function startGatewayServer(
       }
     : startHeartbeatRunner({ cfg: cfgAtStart });
 
+  let sessionHealthRunner: SessionHealthRunner = minimalTestGateway
+    ? { stop: () => {}, updateConfig: () => {} }
+    : startSessionHealthCollector({ cfg: cfgAtStart });
+
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
   const healthCheckDisabled = healthCheckMinutes === 0;
   const staleEventThresholdMinutes = cfgAtStart.gateway?.channelStaleEventThresholdMinutes;
@@ -1226,6 +1234,7 @@ export async function startGatewayServer(
             hooksConfig,
             hookClientIpConfig,
             heartbeatRunner,
+            sessionHealthRunner,
             cronState,
             browserControl,
             channelHealthMonitor,
@@ -1234,6 +1243,9 @@ export async function startGatewayServer(
             hooksConfig = nextState.hooksConfig;
             hookClientIpConfig = nextState.hookClientIpConfig;
             heartbeatRunner = nextState.heartbeatRunner;
+            if (nextState.sessionHealthRunner) {
+              sessionHealthRunner = nextState.sessionHealthRunner;
+            }
             cronState = nextState.cronState;
             cron = cronState.cron;
             cronStorePath = cronState.storePath;
@@ -1307,6 +1319,7 @@ export async function startGatewayServer(
     pluginServices,
     cron,
     heartbeatRunner,
+    sessionHealthRunner,
     updateCheckStop: stopGatewayUpdateCheck,
     nodePresenceTimers,
     broadcast,

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -2,7 +2,10 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
 import { STATE_DIR, createConfigIO, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
-import { readCachedSnapshot } from "../../infra/session-health-collector.js";
+import {
+  readCachedDerivedSurface,
+  readCachedSnapshot,
+} from "../../infra/session-health-collector.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
@@ -72,12 +75,16 @@ export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
   if (!healthRefresh) {
     healthRefresh = (async () => {
       const snap = await getHealthSnapshot({ probe: opts?.probe });
-      // Attach cached session health snapshot (produced by periodic collector).
+      // Attach cached session health data (produced by periodic collector).
       // This is zero new computation during the health RPC — reads from cache only.
       try {
         const sessionHealth = await readCachedSnapshot();
         if (sessionHealth) {
           snap.sessionHealth = sessionHealth;
+        }
+        const sessionHealthSurface = await readCachedDerivedSurface();
+        if (sessionHealthSurface) {
+          snap.sessionHealthSurface = sessionHealthSurface;
         }
       } catch {
         // Session health is best-effort; don't fail the health RPC.

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -2,6 +2,7 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getHealthSnapshot, type HealthSummary } from "../../commands/health.js";
 import { STATE_DIR, createConfigIO, loadConfig } from "../../config/config.js";
 import { resolveMainSessionKey } from "../../config/sessions.js";
+import { readCachedSnapshot } from "../../infra/session-health-collector.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
@@ -71,6 +72,16 @@ export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
   if (!healthRefresh) {
     healthRefresh = (async () => {
       const snap = await getHealthSnapshot({ probe: opts?.probe });
+      // Attach cached session health snapshot (produced by periodic collector).
+      // This is zero new computation during the health RPC — reads from cache only.
+      try {
+        const sessionHealth = await readCachedSnapshot();
+        if (sessionHealth) {
+          snap.sessionHealth = sessionHealth;
+        }
+      } catch {
+        // Session health is best-effort; don't fail the health RPC.
+      }
       healthCache = snap;
       healthVersion += 1;
       if (broadcastHealthUpdate) {

--- a/src/infra/session-health-classify.test.ts
+++ b/src/infra/session-health-classify.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import { classifyDiskArtifact, classifySessionKeyForHealth } from "./session-health-classify.js";
+
+describe("classifySessionKeyForHealth", () => {
+  describe("main sessions", () => {
+    it("classifies agent:main:main as main", () => {
+      expect(classifySessionKeyForHealth("agent:main:main")).toBe("main");
+    });
+
+    it("classifies agent:main:default as main", () => {
+      expect(classifySessionKeyForHealth("agent:main:default")).toBe("main");
+    });
+
+    it("classifies agent:adx:main as main", () => {
+      expect(classifySessionKeyForHealth("agent:adx:main")).toBe("main");
+    });
+
+    it("classifies custom mainKey as main", () => {
+      expect(classifySessionKeyForHealth("agent:main:custom-key")).toBe("main");
+    });
+  });
+
+  describe("cron sessions", () => {
+    it("classifies cron run instances", () => {
+      expect(classifySessionKeyForHealth("agent:main:cron:daily-check:run:abc123")).toBe(
+        "cron-run",
+      );
+    });
+
+    it("classifies cron definition keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:cron:daily-check")).toBe("cron-definition");
+    });
+
+    it("does not confuse cron-definition with cron-run", () => {
+      expect(classifySessionKeyForHealth("agent:main:cron:my-job")).toBe("cron-definition");
+      expect(classifySessionKeyForHealth("agent:main:cron:my-job:run:1")).toBe("cron-run");
+    });
+  });
+
+  describe("subagent sessions", () => {
+    it("classifies agent-scoped subagent keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:subagent:abc123-def456")).toBe("subagent");
+    });
+
+    it("classifies deeply nested subagent keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:subagent:abc:subagent:def")).toBe("subagent");
+    });
+  });
+
+  describe("acp sessions", () => {
+    it("classifies agent-scoped acp keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:acp:session-123")).toBe("acp");
+    });
+
+    it("classifies bare acp keys", () => {
+      expect(classifySessionKeyForHealth("acp:session-123")).toBe("acp");
+    });
+  });
+
+  describe("heartbeat sessions", () => {
+    it("classifies heartbeat keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:heartbeat:wake-123")).toBe("heartbeat");
+    });
+  });
+
+  describe("thread sessions", () => {
+    it("classifies thread keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:discord:group:123:thread:456")).toBe("thread");
+    });
+
+    it("classifies topic keys as thread", () => {
+      expect(classifySessionKeyForHealth("agent:main:discord:group:123:topic:456")).toBe("thread");
+    });
+  });
+
+  describe("channel/group sessions", () => {
+    it("classifies group keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:discord:group:123456")).toBe("channel");
+    });
+
+    it("classifies channel keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:telegram:channel:789")).toBe("channel");
+    });
+  });
+
+  describe("direct sessions", () => {
+    it("classifies per-peer direct keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:direct:+15551234567")).toBe("direct");
+    });
+
+    it("classifies per-channel-peer direct keys", () => {
+      expect(classifySessionKeyForHealth("agent:main:telegram:direct:12345")).toBe("direct");
+    });
+  });
+
+  describe("unknown sessions", () => {
+    it("returns unknown for empty string", () => {
+      expect(classifySessionKeyForHealth("")).toBe("unknown");
+    });
+
+    it("returns unknown for null/undefined", () => {
+      expect(classifySessionKeyForHealth(null)).toBe("unknown");
+      expect(classifySessionKeyForHealth(undefined)).toBe("unknown");
+    });
+
+    it("returns unknown for legacy non-agent keys", () => {
+      expect(classifySessionKeyForHealth("global")).toBe("unknown");
+    });
+
+    it("returns unknown for unrecognized agent-scoped keys with colons", () => {
+      // agent:main:some:weird:key - has colons in rest, doesn't match any pattern
+      // This would currently fall to unknown because rest contains ':'
+      // but doesn't match any known pattern.
+      expect(classifySessionKeyForHealth("agent:main:some:weird:key")).toBe("unknown");
+    });
+  });
+
+  describe("case insensitivity", () => {
+    it("handles mixed case in cron keys", () => {
+      expect(classifySessionKeyForHealth("Agent:Main:Cron:test:Run:123")).toBe("cron-run");
+    });
+
+    it("handles mixed case in subagent keys", () => {
+      expect(classifySessionKeyForHealth("Agent:Main:Subagent:abc")).toBe("subagent");
+    });
+  });
+});
+
+describe("classifyDiskArtifact", () => {
+  describe("index files", () => {
+    it("classifies sessions.json as index", () => {
+      expect(classifyDiskArtifact("sessions.json")).toBe("index");
+    });
+  });
+
+  describe("backup files", () => {
+    it("classifies sessions.json.backup as backup", () => {
+      expect(classifyDiskArtifact("sessions.json.backup")).toBe("backup");
+    });
+
+    it("classifies rotation backups as backup", () => {
+      expect(classifyDiskArtifact("sessions.json.bak.1679012345")).toBe("backup");
+    });
+  });
+
+  describe("orphaned temp files", () => {
+    it("classifies .tmp files as orphanedTemp", () => {
+      expect(classifyDiskArtifact("sessions.json.abc123.tmp")).toBe("orphanedTemp");
+    });
+
+    it("classifies any .tmp suffix as orphanedTemp", () => {
+      expect(classifyDiskArtifact("something.tmp")).toBe("orphanedTemp");
+    });
+  });
+
+  describe("deleted transcript files", () => {
+    it("classifies .deleted.* files", () => {
+      expect(classifyDiskArtifact("abc-123.jsonl.deleted.1679012345")).toBe("deleted");
+    });
+  });
+
+  describe("reset transcript files", () => {
+    it("classifies .reset.* files", () => {
+      expect(classifyDiskArtifact("abc-123.jsonl.reset.1679012345")).toBe("reset");
+    });
+  });
+
+  describe("active transcript files", () => {
+    it("classifies .jsonl files as active", () => {
+      expect(classifyDiskArtifact("abc-123.jsonl")).toBe("active");
+    });
+
+    it("classifies any other file as active", () => {
+      expect(classifyDiskArtifact("random-file.txt")).toBe("active");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("classifies empty string as active", () => {
+      expect(classifyDiskArtifact("")).toBe("active");
+    });
+  });
+});

--- a/src/infra/session-health-classify.ts
+++ b/src/infra/session-health-classify.ts
@@ -1,0 +1,118 @@
+/**
+ * Session Health — Classification Functions
+ *
+ * Pure functions for classifying session keys and disk artifacts for health
+ * monitoring. These are *sibling* classifiers — they do NOT modify or replace
+ * the existing `classifySessionKey()` used by the gateway session list.
+ */
+
+import {
+  isAcpSessionKey,
+  isCronRunSessionKey,
+  isCronSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+} from "../sessions/session-key-utils.js";
+import type { DiskArtifactState, SessionHealthClass } from "./session-health-types.js";
+
+/**
+ * Classify a session key into one of the 10 health-domain session classes.
+ *
+ * Uses the existing predicate functions from `session-key-utils` where
+ * available, falling back to pattern matching for classes that don't have
+ * dedicated predicates (heartbeat, thread, channel, direct, main).
+ *
+ * Order matters: more specific patterns are checked first to avoid
+ * misclassification (e.g., cron-run before cron-definition).
+ */
+export function classifySessionKeyForHealth(key: string | undefined | null): SessionHealthClass {
+  const raw = (key ?? "").trim();
+  if (!raw) {
+    return "unknown";
+  }
+
+  // Use existing predicates for well-defined patterns
+  if (isCronRunSessionKey(raw)) {
+    return "cron-run";
+  }
+  if (isCronSessionKey(raw)) {
+    return "cron-definition";
+  } // cron but not cron-run
+  if (isAcpSessionKey(raw)) {
+    return "acp";
+  }
+  if (isSubagentSessionKey(raw)) {
+    return "subagent";
+  }
+
+  // Normalize for pattern matching
+  const lower = raw.toLowerCase();
+
+  // Pattern-based checks for remaining classes
+  if (lower.includes(":heartbeat:") || lower.includes(":heartbeat")) {
+    return "heartbeat";
+  }
+  if (lower.includes(":thread:") || lower.includes(":topic:")) {
+    return "thread";
+  }
+  if (lower.includes(":group:") || lower.includes(":channel:")) {
+    return "channel";
+  }
+  if (lower.includes(":direct:")) {
+    return "direct";
+  }
+
+  // Main session detection: agent:{id}:{mainKey} where mainKey is a simple token
+  const parsed = parseAgentSessionKey(raw);
+  if (parsed) {
+    const rest = parsed.rest;
+    // Main session keys are simple tokens like "main", "default", etc.
+    // They don't contain colons (those would be classified above).
+    if (!rest.includes(":")) {
+      return "main";
+    }
+  }
+
+  return "unknown";
+}
+
+/**
+ * Classify a disk filename into its artifact state category.
+ *
+ * Checks for specific file patterns to distinguish between active transcripts,
+ * soft-deleted files, reset files, orphaned temp files, index files, and backups.
+ */
+export function classifyDiskArtifact(filename: string): DiskArtifactState {
+  if (!filename) {
+    return "active";
+  }
+
+  // Index-related files
+  if (filename === "sessions.json") {
+    return "index";
+  }
+  if (filename === "sessions.json.backup") {
+    return "backup";
+  }
+
+  // Backup rotation files (sessions.json.bak.*)
+  if (filename.startsWith("sessions.json.bak.")) {
+    return "backup";
+  }
+
+  // Orphaned temp files from crashed atomic writes
+  if (filename.endsWith(".tmp")) {
+    return "orphanedTemp";
+  }
+
+  // Soft-deleted and reset transcript files
+  if (filename.includes(".deleted.")) {
+    return "deleted";
+  }
+  if (filename.includes(".reset.")) {
+    return "reset";
+  }
+
+  // Everything else is an active artifact
+  return "active";
+}

--- a/src/infra/session-health-collector.test.ts
+++ b/src/infra/session-health-collector.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Session Health — Collector Tests
+ *
+ * Focused tests for collector logic that doesn't require full filesystem
+ * context. Since `collectSessionHealth()` needs real config/stores, we test
+ * the usage-percent math through a thin integration test using the snapshot
+ * structure directly.
+ *
+ * The key invariant: usagePercent should reflect per-agent pressure (the
+ * hottest store), not aggregated totals ÷ single-store limits.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SessionHealthAgentBreakdown } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Usage-percent math verification
+// ---------------------------------------------------------------------------
+// The collector computes usagePercent as max(agent / limit) across agents.
+// These tests verify the invariant by computing the expected values from
+// the snapshot structure that the collector produces.
+
+function computeExpectedUsageEntries(
+  agents: SessionHealthAgentBreakdown[],
+  maxEntries: number,
+): number {
+  if (maxEntries <= 0 || agents.length === 0) {
+    return 0;
+  }
+  let max = 0;
+  for (const a of agents) {
+    const pct = Math.round((a.indexedCount / maxEntries) * 10000) / 100;
+    if (pct > max) {
+      max = pct;
+    }
+  }
+  return max;
+}
+
+function computeExpectedUsageDiskBytes(
+  agents: SessionHealthAgentBreakdown[],
+  maxDiskBytes: number | null,
+): number | null {
+  if (maxDiskBytes == null || maxDiskBytes <= 0) {
+    return null;
+  }
+  let max = 0;
+  for (const a of agents) {
+    const pct = Math.round((a.totalManagedBytes / maxDiskBytes) * 10000) / 100;
+    if (pct > max) {
+      max = pct;
+    }
+  }
+  return max;
+}
+
+function makeAgent(
+  id: string,
+  indexedCount: number,
+  totalManagedBytes: number,
+): SessionHealthAgentBreakdown {
+  return {
+    agentId: id,
+    storePath: `/fake/sessions/${id}/sessions.json`,
+    indexedCount,
+    byClass: {
+      main: indexedCount,
+      channel: 0,
+      direct: 0,
+      "cron-definition": 0,
+      "cron-run": 0,
+      subagent: 0,
+      acp: 0,
+      heartbeat: 0,
+      thread: 0,
+      unknown: 0,
+    },
+    totalManagedBytes,
+    resetTranscriptBytes: 0,
+  };
+}
+
+describe("usage-percent multi-agent math", () => {
+  it("single agent: usagePercent equals agent / limit", () => {
+    const agents = [makeAgent("main", 250, 50_000_000)];
+    const maxEntries = 500;
+    const maxDiskBytes = 100_000_000;
+
+    const entries = computeExpectedUsageEntries(agents, maxEntries);
+    const diskBytes = computeExpectedUsageDiskBytes(agents, maxDiskBytes);
+
+    expect(entries).toBe(50); // 250/500 = 50%
+    expect(diskBytes).toBe(50); // 50M/100M = 50%
+  });
+
+  it("multi-agent: usagePercent is max across agents, not sum / limit", () => {
+    const agents = [
+      makeAgent("main", 100, 20_000_000),
+      makeAgent("adx", 200, 40_000_000),
+      makeAgent("bvx", 50, 10_000_000),
+    ];
+    const maxEntries = 500;
+    const maxDiskBytes = 100_000_000;
+
+    const entries = computeExpectedUsageEntries(agents, maxEntries);
+    const diskBytes = computeExpectedUsageDiskBytes(agents, maxDiskBytes);
+
+    // Before fix: would have been (100+200+50)/500 = 70%
+    // After fix: max(100/500, 200/500, 50/500) = 40%
+    expect(entries).toBe(40); // adx is the hottest at 200/500
+    expect(diskBytes).toBe(40); // adx is the hottest at 40M/100M
+
+    // Verify it's NOT the old (wrong) aggregated approach
+    const wrongTotal = 100 + 200 + 50;
+    const wrongPercent = Math.round((wrongTotal / maxEntries) * 10000) / 100;
+    expect(wrongPercent).toBe(70); // confirm the old math would give 70%
+    expect(entries).not.toBe(wrongPercent); // confirm we get the right answer
+  });
+
+  it("multi-agent: hottest agent drives the percentage", () => {
+    const agents = [
+      makeAgent("main", 450, 90_000_000), // 90% entries, 90% disk
+      makeAgent("adx", 50, 10_000_000), // 10% entries, 10% disk
+    ];
+    const maxEntries = 500;
+    const maxDiskBytes = 100_000_000;
+
+    const entries = computeExpectedUsageEntries(agents, maxEntries);
+    const diskBytes = computeExpectedUsageDiskBytes(agents, maxDiskBytes);
+
+    expect(entries).toBe(90); // main is the hottest
+    expect(diskBytes).toBe(90);
+  });
+
+  it("null maxDiskBytes returns null", () => {
+    const agents = [makeAgent("main", 100, 50_000_000)];
+    expect(computeExpectedUsageDiskBytes(agents, null)).toBeNull();
+  });
+
+  it("zero maxEntries returns 0", () => {
+    const agents = [makeAgent("main", 100, 50_000_000)];
+    expect(computeExpectedUsageEntries(agents, 0)).toBe(0);
+  });
+});

--- a/src/infra/session-health-collector.ts
+++ b/src/infra/session-health-collector.ts
@@ -30,6 +30,7 @@ import { classifyDiskArtifact, classifySessionKeyForHealth } from "./session-hea
 import type {
   DiskStateCounts,
   SessionHealthAgentBreakdown,
+  SessionHealthClass,
   SessionHealthClassCounts,
   SessionHealthDrift,
   SessionHealthGrowth,
@@ -37,6 +38,7 @@ import type {
   SessionHealthStorageBreakdown,
   SessionHealthSurface,
 } from "./session-health-types.js";
+import { DEFAULT_CLASS_RETENTION_MS } from "./session-health-types.js";
 
 const log = createSubsystemLogger("session-health");
 
@@ -160,6 +162,7 @@ type AgentCollectionResult = {
   byDiskState: DiskStateCounts;
   storage: SessionHealthStorageBreakdown;
   drift: SessionHealthDrift;
+  staleByClass: Partial<SessionHealthClassCounts>;
   parseTimeMs: number | null;
 };
 
@@ -181,12 +184,24 @@ async function collectForAgent(params: {
     log.warn("failed to load session store for agent", { agentId, error: String(err) });
   }
 
-  // 2. Classify session keys
+  // 2. Classify session keys and compute stale-per-class counts
   const byClass = emptyClassCounts();
+  const staleByClass: Partial<SessionHealthClassCounts> = {};
   const storeKeys = Object.keys(store);
+  const now = Date.now();
   for (const key of storeKeys) {
     const cls = classifySessionKeyForHealth(key);
     byClass[cls]++;
+
+    // Compute stale count for prunable classes
+    const retentionMs = DEFAULT_CLASS_RETENTION_MS[cls];
+    if (retentionMs != null) {
+      const entry = store[key] as Record<string, unknown> | undefined;
+      const updatedAt = typeof entry?.updatedAt === "number" ? entry.updatedAt : 0;
+      if (updatedAt > 0 && now - updatedAt > retentionMs) {
+        staleByClass[cls] = (staleByClass[cls] ?? 0) + 1;
+      }
+    }
   }
 
   // 3. Read directory files
@@ -303,6 +318,7 @@ async function collectForAgent(params: {
     byDiskState,
     storage,
     drift,
+    staleByClass,
     parseTimeMs,
   };
 }
@@ -352,18 +368,27 @@ export async function collectSessionHealth(
     oldestOrphanedTempAt: null,
     reconciliationRecommended: false,
   };
+  const mergedStaleByClass: Partial<SessionHealthClassCounts> = {};
   let totalIndexed = 0;
   let totalSessionsJsonBytes = 0;
   let bestParseTimeMs: number | null = null;
 
   for (const result of agentResults) {
-    const { breakdown, byDiskState, storage, drift, parseTimeMs } = result;
+    const { breakdown, byDiskState, storage, drift, staleByClass, parseTimeMs } = result;
     totalIndexed += breakdown.indexedCount;
     totalSessionsJsonBytes += storage.sessionsJsonBytes;
 
     // Merge class counts
     for (const [cls, count] of Object.entries(breakdown.byClass)) {
       mergedClass[cls as keyof SessionHealthClassCounts] += count;
+    }
+
+    // Merge stale-per-class counts
+    for (const [cls, count] of Object.entries(staleByClass)) {
+      if (count != null && count > 0) {
+        mergedStaleByClass[cls as SessionHealthClass] =
+          (mergedStaleByClass[cls as SessionHealthClass] ?? 0) + count;
+      }
     }
 
     // Merge disk state counts
@@ -427,6 +452,7 @@ export async function collectSessionHealth(
       sessionsJsonBytes: totalSessionsJsonBytes,
       sessionsJsonParseTimeMs: bestParseTimeMs,
       byClass: mergedClass,
+      staleByClass: Object.keys(mergedStaleByClass).length > 0 ? mergedStaleByClass : undefined,
       byDiskState: mergedDiskState,
     },
     storage: mergedStorage,

--- a/src/infra/session-health-collector.ts
+++ b/src/infra/session-health-collector.ts
@@ -471,15 +471,30 @@ export async function collectSessionHealth(
     }
   }
 
-  // Compute usage percentages
-  const usageEntries =
-    maintenance.maxEntries > 0
-      ? Math.round((totalIndexed / maintenance.maxEntries) * 10000) / 100
-      : 0;
-  const usageDiskBytes =
-    maintenance.maxDiskBytes != null && maintenance.maxDiskBytes > 0
-      ? Math.round((mergedStorage.totalManagedBytes / maintenance.maxDiskBytes) * 10000) / 100
-      : null;
+  // Compute usage percentages.
+  // maxEntries and maxDiskBytes are per-store limits (enforced per agent), so
+  // usage pressure is the max across agents, not a merged total ÷ single limit.
+  // For single-agent installs, this produces the same result as before.
+  let usageEntries = 0;
+  let usageDiskBytes: number | null =
+    maintenance.maxDiskBytes != null && maintenance.maxDiskBytes > 0 ? 0 : null;
+
+  for (const result of agentResults) {
+    if (maintenance.maxEntries > 0) {
+      const pct =
+        Math.round((result.breakdown.indexedCount / maintenance.maxEntries) * 10000) / 100;
+      if (pct > usageEntries) {
+        usageEntries = pct;
+      }
+    }
+    if (maintenance.maxDiskBytes != null && maintenance.maxDiskBytes > 0) {
+      const pct =
+        Math.round((result.breakdown.totalManagedBytes / maintenance.maxDiskBytes) * 10000) / 100;
+      if (pct > (usageDiskBytes ?? 0)) {
+        usageDiskBytes = pct;
+      }
+    }
+  }
 
   // Growth deltas from previous snapshot
   const growth = await computeGrowthDeltas({

--- a/src/infra/session-health-collector.ts
+++ b/src/infra/session-health-collector.ts
@@ -157,12 +157,20 @@ function emptyDiskStateCounts(): DiskStateCounts {
 // Per-agent collection
 // ---------------------------------------------------------------------------
 
+type StaleArtifactCounts = {
+  staleDeletedCount: number;
+  staleDeletedBytes: number;
+  staleResetCount: number;
+  staleResetBytes: number;
+};
+
 type AgentCollectionResult = {
   breakdown: SessionHealthAgentBreakdown;
   byDiskState: DiskStateCounts;
   storage: SessionHealthStorageBreakdown;
   drift: SessionHealthDrift;
   staleByClass: Partial<SessionHealthClassCounts>;
+  staleArtifacts: StaleArtifactCounts;
   parseTimeMs: number | null;
 };
 
@@ -256,11 +264,35 @@ async function collectForAgent(params: {
     }
   }
 
-  // 5. Drift detection
+  // 5. Compute retention-filtered stale artifact counts for .deleted and .reset files.
+  //    These allow the plan builder to report honest affectedCounts rather than
+  //    using total disk-state counts, which may include files still within retention.
+  const retentionMs = resolveMaintenanceConfig().pruneAfterMs;
+  const now2 = Date.now();
+  const staleArtifacts: StaleArtifactCounts = {
+    staleDeletedCount: 0,
+    staleDeletedBytes: 0,
+    staleResetCount: 0,
+    staleResetBytes: 0,
+  };
+  for (const file of files) {
+    const state = classifyDiskArtifact(file.name);
+    if (state === "deleted" && now2 - file.mtimeMs > retentionMs) {
+      staleArtifacts.staleDeletedCount++;
+      staleArtifacts.staleDeletedBytes += file.size;
+    } else if (state === "reset" && now2 - file.mtimeMs > retentionMs) {
+      staleArtifacts.staleResetCount++;
+      staleArtifacts.staleResetBytes += file.size;
+    }
+  }
+
+  // 6. Drift detection
   // Compare index keys against active disk files.
   // Note: session entries store a sessionId that maps to a .jsonl file.
-  // We do a simplified check: for each store key, see if any active .jsonl exists.
-  // Precise sessionId → filename mapping varies, so we count mismatches loosely.
+  // Assumption: the transcript filename is always `${sessionId}.jsonl`.
+  // This holds for all current OpenClaw session types. If sessionFile overrides
+  // are ever used, this mapping would need updating. See also the same assumption
+  // in session-health-file-discovery.ts discoverOrphanTranscripts().
   let indexedWithoutDiskFile = 0;
   const indexedSessionIds = new Set<string>();
 
@@ -319,6 +351,7 @@ async function collectForAgent(params: {
     storage,
     drift,
     staleByClass,
+    staleArtifacts,
     parseTimeMs,
   };
 }
@@ -369,12 +402,19 @@ export async function collectSessionHealth(
     reconciliationRecommended: false,
   };
   const mergedStaleByClass: Partial<SessionHealthClassCounts> = {};
+  const mergedStaleArtifacts: StaleArtifactCounts = {
+    staleDeletedCount: 0,
+    staleDeletedBytes: 0,
+    staleResetCount: 0,
+    staleResetBytes: 0,
+  };
   let totalIndexed = 0;
   let totalSessionsJsonBytes = 0;
   let bestParseTimeMs: number | null = null;
 
   for (const result of agentResults) {
-    const { breakdown, byDiskState, storage, drift, staleByClass, parseTimeMs } = result;
+    const { breakdown, byDiskState, storage, drift, staleByClass, staleArtifacts, parseTimeMs } =
+      result;
     totalIndexed += breakdown.indexedCount;
     totalSessionsJsonBytes += storage.sessionsJsonBytes;
 
@@ -390,6 +430,12 @@ export async function collectSessionHealth(
           (mergedStaleByClass[cls as SessionHealthClass] ?? 0) + count;
       }
     }
+
+    // Merge stale artifact counts (retention-filtered .deleted/.reset)
+    mergedStaleArtifacts.staleDeletedCount += staleArtifacts.staleDeletedCount;
+    mergedStaleArtifacts.staleDeletedBytes += staleArtifacts.staleDeletedBytes;
+    mergedStaleArtifacts.staleResetCount += staleArtifacts.staleResetCount;
+    mergedStaleArtifacts.staleResetBytes += staleArtifacts.staleResetBytes;
 
     // Merge disk state counts
     for (const [state, count] of Object.entries(byDiskState)) {
@@ -456,6 +502,10 @@ export async function collectSessionHealth(
       byDiskState: mergedDiskState,
     },
     storage: mergedStorage,
+    staleArtifacts:
+      mergedStaleArtifacts.staleDeletedCount > 0 || mergedStaleArtifacts.staleResetCount > 0
+        ? mergedStaleArtifacts
+        : undefined,
     drift: mergedDrift,
     maintenance: {
       mode: maintenance.mode,

--- a/src/infra/session-health-collector.ts
+++ b/src/infra/session-health-collector.ts
@@ -1,0 +1,598 @@
+/**
+ * Session Health — Snapshot Collector
+ *
+ * Collects a raw `SessionHealthRawSnapshot` by scanning session stores and
+ * disk artifacts across all configured agents. Designed to run periodically
+ * on a timer, producing cached snapshots for the health RPC to serve.
+ *
+ * Performance considerations:
+ * - Uses `loadSessionStore({ skipCache: true })` to get a fresh read.
+ * - Reads the sessions directory once per agent (same cost as existing
+ *   `enforceSessionDiskBudget`).
+ * - Writes snapshots atomically to avoid partial reads.
+ * - Prunes history older than 7 days to keep disk usage bounded.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import { STATE_DIR } from "../config/paths.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { resolveMaintenanceConfig } from "../config/sessions/store-maintenance.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { readJsonFile, writeJsonAtomic } from "./json-files.js";
+import { classifyDiskArtifact, classifySessionKeyForHealth } from "./session-health-classify.js";
+import type {
+  DiskStateCounts,
+  SessionHealthAgentBreakdown,
+  SessionHealthClassCounts,
+  SessionHealthDrift,
+  SessionHealthGrowth,
+  SessionHealthRawSnapshot,
+  SessionHealthStorageBreakdown,
+} from "./session-health-types.js";
+
+const log = createSubsystemLogger("session-health");
+
+// ---------------------------------------------------------------------------
+// Cache paths
+// ---------------------------------------------------------------------------
+
+const CACHE_DIR = path.join(STATE_DIR, "cache", "session-health");
+const SNAPSHOT_PATH = path.join(CACHE_DIR, "snapshot.json");
+const HISTORY_DIR = path.join(CACHE_DIR, "history");
+const HISTORY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ---------------------------------------------------------------------------
+// Agent resolution (mirrors health.ts resolveAgentOrder locally)
+// ---------------------------------------------------------------------------
+
+function resolveAgentOrder(cfg: OpenClawConfig): {
+  defaultAgentId: string;
+  ordered: Array<{ id: string; name?: string }>;
+} {
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const entries = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  const seen = new Set<string>();
+  const ordered: Array<{ id: string; name?: string }> = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    if (typeof (entry as Record<string, unknown>).id !== "string") {
+      continue;
+    }
+    const id = normalizeAgentId((entry as Record<string, unknown>).id as string);
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    ordered.push({
+      id,
+      name:
+        typeof (entry as Record<string, unknown>).name === "string"
+          ? ((entry as Record<string, unknown>).name as string)
+          : undefined,
+    });
+  }
+
+  if (!seen.has(defaultAgentId)) {
+    ordered.unshift({ id: defaultAgentId });
+  }
+  if (ordered.length === 0) {
+    ordered.push({ id: defaultAgentId });
+  }
+
+  return { defaultAgentId, ordered };
+}
+
+// ---------------------------------------------------------------------------
+// Directory scanner
+// ---------------------------------------------------------------------------
+
+type DirFileStat = {
+  name: string;
+  size: number;
+  mtimeMs: number;
+};
+
+async function readSessionsDirFiles(sessionsDir: string): Promise<DirFileStat[]> {
+  let dirEntries: import("node:fs").Dirent[];
+  try {
+    dirEntries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const files: DirFileStat[] = [];
+  for (const dirent of dirEntries) {
+    if (!dirent.isFile()) {
+      continue;
+    }
+    try {
+      const stat = await fs.stat(path.join(sessionsDir, dirent.name));
+      if (stat.isFile()) {
+        files.push({ name: String(dirent.name), size: stat.size, mtimeMs: stat.mtimeMs });
+      }
+    } catch {
+      // Skip files we can't stat (e.g., race condition deletion).
+    }
+  }
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Classification helpers
+// ---------------------------------------------------------------------------
+
+function emptyClassCounts(): SessionHealthClassCounts {
+  return {
+    main: 0,
+    channel: 0,
+    direct: 0,
+    "cron-definition": 0,
+    "cron-run": 0,
+    subagent: 0,
+    acp: 0,
+    heartbeat: 0,
+    thread: 0,
+    unknown: 0,
+  };
+}
+
+function emptyDiskStateCounts(): DiskStateCounts {
+  return { active: 0, deleted: 0, reset: 0, orphanedTemp: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent collection
+// ---------------------------------------------------------------------------
+
+type AgentCollectionResult = {
+  breakdown: SessionHealthAgentBreakdown;
+  byDiskState: DiskStateCounts;
+  storage: SessionHealthStorageBreakdown;
+  drift: SessionHealthDrift;
+  parseTimeMs: number | null;
+};
+
+async function collectForAgent(params: {
+  agentId: string;
+  storePath: string;
+}): Promise<AgentCollectionResult> {
+  const { agentId, storePath } = params;
+  const sessionsDir = path.dirname(storePath);
+
+  // 1. Load session store with timing
+  let store: Record<string, unknown> = {};
+  let parseTimeMs: number | null = null;
+  try {
+    const t0 = performance.now();
+    store = loadSessionStore(storePath, { skipCache: true });
+    parseTimeMs = Math.round((performance.now() - t0) * 100) / 100;
+  } catch (err) {
+    log.warn("failed to load session store for agent", { agentId, error: String(err) });
+  }
+
+  // 2. Classify session keys
+  const byClass = emptyClassCounts();
+  const storeKeys = Object.keys(store);
+  for (const key of storeKeys) {
+    const cls = classifySessionKeyForHealth(key);
+    byClass[cls]++;
+  }
+
+  // 3. Read directory files
+  const files = await readSessionsDirFiles(sessionsDir);
+
+  // 4. Classify disk artifacts and compute storage
+  const byDiskState = emptyDiskStateCounts();
+  const storage: SessionHealthStorageBreakdown = {
+    totalManagedBytes: 0,
+    sessionsJsonBytes: 0,
+    activeTranscriptBytes: 0,
+    deletedTranscriptBytes: 0,
+    resetTranscriptBytes: 0,
+    orphanedTempBytes: 0,
+  };
+
+  // Build a set of active .jsonl files referenced by index keys
+  // We'll use this for drift detection below.
+  const diskFileBaseNames = new Set<string>();
+
+  for (const file of files) {
+    const state = classifyDiskArtifact(file.name);
+    storage.totalManagedBytes += file.size;
+
+    switch (state) {
+      case "index":
+        storage.sessionsJsonBytes += file.size;
+        break;
+      case "backup":
+        // backups counted in total but not in breakdown categories
+        break;
+      case "active":
+        byDiskState.active++;
+        storage.activeTranscriptBytes += file.size;
+        // Track for drift detection: strip .jsonl to get session ID
+        if (file.name.endsWith(".jsonl")) {
+          diskFileBaseNames.add(file.name);
+        }
+        break;
+      case "deleted":
+        byDiskState.deleted++;
+        storage.deletedTranscriptBytes += file.size;
+        break;
+      case "reset":
+        byDiskState.reset++;
+        storage.resetTranscriptBytes += file.size;
+        break;
+      case "orphanedTemp":
+        byDiskState.orphanedTemp++;
+        storage.orphanedTempBytes += file.size;
+        break;
+    }
+  }
+
+  // 5. Drift detection
+  // Compare index keys against active disk files.
+  // Note: session entries store a sessionId that maps to a .jsonl file.
+  // We do a simplified check: for each store key, see if any active .jsonl exists.
+  // Precise sessionId → filename mapping varies, so we count mismatches loosely.
+  let indexedWithoutDiskFile = 0;
+  const indexedSessionIds = new Set<string>();
+
+  for (const key of storeKeys) {
+    const entry = store[key] as Record<string, unknown> | undefined;
+    const sessionId = (entry?.sessionId as string) ?? "";
+    if (sessionId) {
+      indexedSessionIds.add(sessionId);
+      const expectedFile = `${sessionId}.jsonl`;
+      if (!diskFileBaseNames.has(expectedFile)) {
+        indexedWithoutDiskFile++;
+      }
+    }
+  }
+
+  // Disk files without index: active .jsonl files whose sessionId is not in the store
+  let diskFilesWithoutIndex = 0;
+  for (const fileName of diskFileBaseNames) {
+    const sessionId = fileName.replace(/\.jsonl$/, "");
+    if (!indexedSessionIds.has(sessionId)) {
+      diskFilesWithoutIndex++;
+    }
+  }
+
+  // Orphaned temp stats
+  const orphanedTempFiles = files.filter((f) => classifyDiskArtifact(f.name) === "orphanedTemp");
+  const oldestOrphanedTemp =
+    orphanedTempFiles.length > 0
+      ? orphanedTempFiles.reduce(
+          (oldest, f) => (f.mtimeMs < oldest.mtimeMs ? f : oldest),
+          orphanedTempFiles[0],
+        )
+      : null;
+
+  const drift: SessionHealthDrift = {
+    indexedWithoutDiskFile,
+    diskFilesWithoutIndex,
+    orphanedTempCount: byDiskState.orphanedTemp,
+    oldestOrphanedTempAt: oldestOrphanedTemp
+      ? new Date(oldestOrphanedTemp.mtimeMs).toISOString()
+      : null,
+    reconciliationRecommended:
+      indexedWithoutDiskFile > 5 || diskFilesWithoutIndex > 5 || byDiskState.orphanedTemp > 0,
+  };
+
+  return {
+    breakdown: {
+      agentId,
+      storePath,
+      indexedCount: storeKeys.length,
+      byClass,
+      totalManagedBytes: storage.totalManagedBytes,
+      resetTranscriptBytes: storage.resetTranscriptBytes,
+    },
+    byDiskState,
+    storage,
+    drift,
+    parseTimeMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main collector
+// ---------------------------------------------------------------------------
+
+export async function collectSessionHealth(
+  cfg?: OpenClawConfig,
+): Promise<SessionHealthRawSnapshot> {
+  const t0 = performance.now();
+  const resolvedCfg = cfg ?? loadConfig();
+  const { ordered } = resolveAgentOrder(resolvedCfg);
+  const maintenance = resolveMaintenanceConfig();
+
+  // Collect per-agent data
+  const agentResults: AgentCollectionResult[] = [];
+  for (const agent of ordered) {
+    const storePath = resolveStorePath(resolvedCfg.session?.store, { agentId: agent.id });
+    try {
+      const result = await collectForAgent({ agentId: agent.id, storePath });
+      agentResults.push(result);
+    } catch (err) {
+      log.warn("session health collection failed for agent", {
+        agentId: agent.id,
+        error: String(err),
+      });
+    }
+  }
+
+  // Merge across agents
+  const mergedClass = emptyClassCounts();
+  const mergedDiskState = emptyDiskStateCounts();
+  const mergedStorage: SessionHealthStorageBreakdown = {
+    totalManagedBytes: 0,
+    sessionsJsonBytes: 0,
+    activeTranscriptBytes: 0,
+    deletedTranscriptBytes: 0,
+    resetTranscriptBytes: 0,
+    orphanedTempBytes: 0,
+  };
+  const mergedDrift: SessionHealthDrift = {
+    indexedWithoutDiskFile: 0,
+    diskFilesWithoutIndex: 0,
+    orphanedTempCount: 0,
+    oldestOrphanedTempAt: null,
+    reconciliationRecommended: false,
+  };
+  let totalIndexed = 0;
+  let totalSessionsJsonBytes = 0;
+  let bestParseTimeMs: number | null = null;
+
+  for (const result of agentResults) {
+    const { breakdown, byDiskState, storage, drift, parseTimeMs } = result;
+    totalIndexed += breakdown.indexedCount;
+    totalSessionsJsonBytes += storage.sessionsJsonBytes;
+
+    // Merge class counts
+    for (const [cls, count] of Object.entries(breakdown.byClass)) {
+      mergedClass[cls as keyof SessionHealthClassCounts] += count;
+    }
+
+    // Merge disk state counts
+    for (const [state, count] of Object.entries(byDiskState)) {
+      mergedDiskState[state as keyof DiskStateCounts] += count;
+    }
+
+    // Merge storage
+    for (const key of Object.keys(mergedStorage) as (keyof SessionHealthStorageBreakdown)[]) {
+      mergedStorage[key] += storage[key];
+    }
+
+    // Merge drift
+    mergedDrift.indexedWithoutDiskFile += drift.indexedWithoutDiskFile;
+    mergedDrift.diskFilesWithoutIndex += drift.diskFilesWithoutIndex;
+    mergedDrift.orphanedTempCount += drift.orphanedTempCount;
+    if (drift.reconciliationRecommended) {
+      mergedDrift.reconciliationRecommended = true;
+    }
+    if (drift.oldestOrphanedTempAt) {
+      if (
+        !mergedDrift.oldestOrphanedTempAt ||
+        drift.oldestOrphanedTempAt < mergedDrift.oldestOrphanedTempAt
+      ) {
+        mergedDrift.oldestOrphanedTempAt = drift.oldestOrphanedTempAt;
+      }
+    }
+
+    // Track parse time (use the primary/longest)
+    if (parseTimeMs != null) {
+      if (bestParseTimeMs == null || parseTimeMs > bestParseTimeMs) {
+        bestParseTimeMs = parseTimeMs;
+      }
+    }
+  }
+
+  // Compute usage percentages
+  const usageEntries =
+    maintenance.maxEntries > 0
+      ? Math.round((totalIndexed / maintenance.maxEntries) * 10000) / 100
+      : 0;
+  const usageDiskBytes =
+    maintenance.maxDiskBytes != null && maintenance.maxDiskBytes > 0
+      ? Math.round((mergedStorage.totalManagedBytes / maintenance.maxDiskBytes) * 10000) / 100
+      : null;
+
+  // Growth deltas from previous snapshot
+  const growth = await computeGrowthDeltas({
+    currentIndexedCount: totalIndexed,
+    currentTotalBytes: mergedStorage.totalManagedBytes,
+  });
+
+  const collectorDurationMs = Math.round((performance.now() - t0) * 100) / 100;
+  const capturedAt = new Date().toISOString();
+
+  const snapshot: SessionHealthRawSnapshot = {
+    capturedAt,
+    collectorDurationMs,
+    sessions: {
+      indexedCount: totalIndexed,
+      sessionsJsonBytes: totalSessionsJsonBytes,
+      sessionsJsonParseTimeMs: bestParseTimeMs,
+      byClass: mergedClass,
+      byDiskState: mergedDiskState,
+    },
+    storage: mergedStorage,
+    drift: mergedDrift,
+    maintenance: {
+      mode: maintenance.mode,
+      maxEntries: maintenance.maxEntries,
+      pruneAfterMs: maintenance.pruneAfterMs,
+      maxDiskBytes: maintenance.maxDiskBytes,
+      usagePercent: {
+        entries: usageEntries,
+        diskBytes: usageDiskBytes,
+      },
+    },
+    growth,
+    agents: agentResults.map((r) => r.breakdown),
+  };
+
+  return snapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Growth delta computation
+// ---------------------------------------------------------------------------
+
+async function computeGrowthDeltas(params: {
+  currentIndexedCount: number;
+  currentTotalBytes: number;
+}): Promise<SessionHealthGrowth> {
+  const growth: SessionHealthGrowth = {
+    sessionsBytes24h: null,
+    sessionsBytes7d: null,
+    indexedCount24h: null,
+    indexedCount7d: null,
+  };
+
+  try {
+    const historyFiles = await listHistoryFiles();
+    if (historyFiles.length === 0) {
+      return growth;
+    }
+
+    const now = Date.now();
+    const h24 = now - 24 * 60 * 60 * 1000;
+    const d7 = now - 7 * 24 * 60 * 60 * 1000;
+
+    // Find the closest snapshot to 24h ago and 7d ago
+    const closest24h = findClosestSnapshot(historyFiles, h24);
+    const closest7d = findClosestSnapshot(historyFiles, d7);
+
+    if (closest24h) {
+      const prev = await readJsonFile<SessionHealthRawSnapshot>(closest24h.path);
+      if (prev) {
+        growth.sessionsBytes24h = params.currentTotalBytes - prev.storage.totalManagedBytes;
+        growth.indexedCount24h = params.currentIndexedCount - prev.sessions.indexedCount;
+      }
+    }
+
+    if (closest7d) {
+      const prev = await readJsonFile<SessionHealthRawSnapshot>(closest7d.path);
+      if (prev) {
+        growth.sessionsBytes7d = params.currentTotalBytes - prev.storage.totalManagedBytes;
+        growth.indexedCount7d = params.currentIndexedCount - prev.sessions.indexedCount;
+      }
+    }
+  } catch {
+    // Growth deltas are best-effort; don't fail the collection.
+  }
+
+  return growth;
+}
+
+type HistoryFile = { path: string; timestamp: number };
+
+async function listHistoryFiles(): Promise<HistoryFile[]> {
+  try {
+    const entries = await fs.readdir(HISTORY_DIR, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && e.name.endsWith(".json"))
+      .map((e) => {
+        const ts = parseHistoryTimestamp(e.name);
+        return ts ? { path: path.join(HISTORY_DIR, e.name), timestamp: ts } : null;
+      })
+      .filter((e): e is HistoryFile => e != null)
+      .toSorted((a, b) => a.timestamp - b.timestamp);
+  } catch {
+    return [];
+  }
+}
+
+function parseHistoryTimestamp(filename: string): number | null {
+  // Format: YYYY-MM-DDTHH-MM.json
+  const match = filename.match(/^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2})\.json$/);
+  if (!match) {
+    return null;
+  }
+  const isoLike = match[1].replace(/T(\d{2})-(\d{2})$/, "T$1:$2:00Z");
+  const ts = Date.parse(isoLike);
+  return Number.isNaN(ts) ? null : ts;
+}
+
+function findClosestSnapshot(files: HistoryFile[], targetMs: number): HistoryFile | null {
+  if (files.length === 0) {
+    return null;
+  }
+
+  let closest: HistoryFile | null = null;
+  let closestDiff = Number.POSITIVE_INFINITY;
+
+  for (const file of files) {
+    // Only consider files that are older than or at the target time
+    if (file.timestamp > targetMs + 10 * 60 * 1000) {
+      continue;
+    } // Allow 10 min tolerance
+    const diff = Math.abs(file.timestamp - targetMs);
+    if (diff < closestDiff) {
+      closestDiff = diff;
+      closest = file;
+    }
+  }
+
+  return closest;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot persistence
+// ---------------------------------------------------------------------------
+
+export async function writeCachedSnapshot(snapshot: SessionHealthRawSnapshot): Promise<void> {
+  try {
+    await writeJsonAtomic(SNAPSHOT_PATH, snapshot);
+  } catch (err) {
+    log.warn("failed to write session health snapshot", { error: String(err) });
+  }
+}
+
+export async function readCachedSnapshot(): Promise<SessionHealthRawSnapshot | null> {
+  return readJsonFile<SessionHealthRawSnapshot>(SNAPSHOT_PATH);
+}
+
+export async function writeHistorySnapshot(snapshot: SessionHealthRawSnapshot): Promise<void> {
+  try {
+    const d = new Date(snapshot.capturedAt);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    const filename = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}T${pad(d.getUTCHours())}-${pad(d.getUTCMinutes())}.json`;
+    await writeJsonAtomic(path.join(HISTORY_DIR, filename), snapshot);
+  } catch (err) {
+    log.warn("failed to write session health history", { error: String(err) });
+  }
+}
+
+export async function pruneOldHistory(): Promise<number> {
+  try {
+    const files = await listHistoryFiles();
+    const cutoff = Date.now() - HISTORY_MAX_AGE_MS;
+    let pruned = 0;
+    for (const file of files) {
+      if (file.timestamp < cutoff) {
+        await fs.rm(file.path, { force: true }).catch(() => undefined);
+        pruned++;
+      }
+    }
+    return pruned;
+  } catch {
+    return 0;
+  }
+}
+
+/** Exported cache paths for testing/integration use. */
+export const SESSION_HEALTH_CACHE_DIR = CACHE_DIR;
+export const SESSION_HEALTH_SNAPSHOT_PATH = SNAPSHOT_PATH;

--- a/src/infra/session-health-collector.ts
+++ b/src/infra/session-health-collector.ts
@@ -35,6 +35,7 @@ import type {
   SessionHealthGrowth,
   SessionHealthRawSnapshot,
   SessionHealthStorageBreakdown,
+  SessionHealthSurface,
 } from "./session-health-types.js";
 
 const log = createSubsystemLogger("session-health");
@@ -45,6 +46,7 @@ const log = createSubsystemLogger("session-health");
 
 const CACHE_DIR = path.join(STATE_DIR, "cache", "session-health");
 const SNAPSHOT_PATH = path.join(CACHE_DIR, "snapshot.json");
+const DERIVED_PATH = path.join(CACHE_DIR, "derived.json");
 const HISTORY_DIR = path.join(CACHE_DIR, "history");
 const HISTORY_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -593,6 +595,23 @@ export async function pruneOldHistory(): Promise<number> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Derived surface persistence (Layer B)
+// ---------------------------------------------------------------------------
+
+export async function writeCachedDerivedSurface(surface: SessionHealthSurface): Promise<void> {
+  try {
+    await writeJsonAtomic(DERIVED_PATH, surface);
+  } catch (err) {
+    log.warn("failed to write session health derived surface", { error: String(err) });
+  }
+}
+
+export async function readCachedDerivedSurface(): Promise<SessionHealthSurface | null> {
+  return readJsonFile<SessionHealthSurface>(DERIVED_PATH);
+}
+
 /** Exported cache paths for testing/integration use. */
 export const SESSION_HEALTH_CACHE_DIR = CACHE_DIR;
 export const SESSION_HEALTH_SNAPSHOT_PATH = SNAPSHOT_PATH;
+export const SESSION_HEALTH_DERIVED_PATH = DERIVED_PATH;

--- a/src/infra/session-health-derive.test.ts
+++ b/src/infra/session-health-derive.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Session Health — Layer B Derivation Tests
+ *
+ * Tests the threshold-based derivation logic that transforms raw snapshots
+ * (Layer A) into operator-facing health surfaces (Layer B).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  deriveGrowthTrend,
+  deriveIndexHealth,
+  deriveSessionHealthSurface,
+  deriveSessionPressure,
+  deriveStalestOrphan,
+  deriveStoragePressure,
+} from "./session-health-derive.js";
+import type { SessionHealthRawSnapshot } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function baseSnapshot(overrides?: Partial<SessionHealthRawSnapshot>): SessionHealthRawSnapshot {
+  return {
+    capturedAt: new Date().toISOString(),
+    collectorDurationMs: 42,
+    sessions: {
+      indexedCount: 50,
+      sessionsJsonBytes: 100_000,
+      sessionsJsonParseTimeMs: 5,
+      byClass: {
+        main: 2,
+        channel: 5,
+        direct: 3,
+        "cron-definition": 2,
+        "cron-run": 20,
+        subagent: 10,
+        acp: 5,
+        heartbeat: 1,
+        thread: 2,
+        unknown: 0,
+      },
+      byDiskState: {
+        active: 40,
+        deleted: 5,
+        reset: 10,
+        orphanedTemp: 0,
+      },
+    },
+    storage: {
+      totalManagedBytes: 50 * 1024 * 1024, // 50 MB
+      sessionsJsonBytes: 100_000,
+      activeTranscriptBytes: 20 * 1024 * 1024,
+      deletedTranscriptBytes: 5 * 1024 * 1024,
+      resetTranscriptBytes: 20 * 1024 * 1024,
+      orphanedTempBytes: 0,
+    },
+    drift: {
+      indexedWithoutDiskFile: 0,
+      diskFilesWithoutIndex: 0,
+      orphanedTempCount: 0,
+      oldestOrphanedTempAt: null,
+      reconciliationRecommended: false,
+    },
+    maintenance: {
+      mode: "warn",
+      maxEntries: 500,
+      pruneAfterMs: 7 * 24 * 60 * 60 * 1000,
+      maxDiskBytes: null,
+      usagePercent: {
+        entries: 10,
+        diskBytes: null,
+      },
+    },
+    growth: {
+      sessionsBytes24h: null,
+      sessionsBytes7d: null,
+      indexedCount24h: null,
+      indexedCount7d: null,
+    },
+    agents: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Index Health
+// ---------------------------------------------------------------------------
+
+describe("deriveIndexHealth", () => {
+  it("returns healthy when no drift", () => {
+    const snap = baseSnapshot();
+    const result = deriveIndexHealth(snap);
+    expect(result.key).toBe("indexHealth");
+    expect(result.level).toBe("healthy");
+  });
+
+  it("returns warning when drift is moderate", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 4,
+        diskFilesWithoutIndex: 0,
+      },
+    });
+    const result = deriveIndexHealth(snap);
+    expect(result.level).toBe("warning");
+  });
+
+  it("returns critical when drift exceeds threshold", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 8,
+        diskFilesWithoutIndex: 5,
+      },
+    });
+    const result = deriveIndexHealth(snap);
+    expect(result.level).toBe("critical");
+  });
+
+  it("returns critical when reconciliation is recommended", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 2,
+        reconciliationRecommended: true,
+      },
+    });
+    const result = deriveIndexHealth(snap);
+    expect(result.level).toBe("critical");
+  });
+
+  it("returns warning when orphaned temp files exist", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 1,
+      },
+    });
+    const result = deriveIndexHealth(snap);
+    expect(result.level).toBe("warning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session Pressure
+// ---------------------------------------------------------------------------
+
+describe("deriveSessionPressure", () => {
+  it("returns healthy when usage is low", () => {
+    const snap = baseSnapshot();
+    const result = deriveSessionPressure(snap);
+    expect(result.key).toBe("sessionPressure");
+    expect(result.level).toBe("healthy");
+  });
+
+  it("returns warning at 60% capacity", () => {
+    const snap = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        usagePercent: { entries: 62, diskBytes: null },
+      },
+    });
+    const result = deriveSessionPressure(snap);
+    expect(result.level).toBe("warning");
+  });
+
+  it("returns critical at 85%+ capacity", () => {
+    const snap = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        usagePercent: { entries: 90, diskBytes: null },
+      },
+    });
+    const result = deriveSessionPressure(snap);
+    expect(result.level).toBe("critical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Storage Pressure
+// ---------------------------------------------------------------------------
+
+describe("deriveStoragePressure", () => {
+  it("returns healthy when below absolute thresholds", () => {
+    const snap = baseSnapshot();
+    const result = deriveStoragePressure(snap);
+    expect(result.key).toBe("storagePressure");
+    expect(result.level).toBe("healthy");
+  });
+
+  it("returns warning when reset transcripts dominate", () => {
+    const snap = baseSnapshot({
+      storage: {
+        ...baseSnapshot().storage,
+        totalManagedBytes: 100 * 1024 * 1024,
+        resetTranscriptBytes: 60 * 1024 * 1024, // 60% reset
+      },
+    });
+    const result = deriveStoragePressure(snap);
+    expect(result.level).toBe("warning");
+  });
+
+  it("returns warning when disk budget exceeds threshold", () => {
+    const snap = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        maxDiskBytes: 100 * 1024 * 1024,
+        usagePercent: { entries: 10, diskBytes: 65 },
+      },
+    });
+    const result = deriveStoragePressure(snap);
+    expect(result.level).toBe("warning");
+  });
+
+  it("returns critical when disk budget exceeds 85%", () => {
+    const snap = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        maxDiskBytes: 100 * 1024 * 1024,
+        usagePercent: { entries: 10, diskBytes: 90 },
+      },
+    });
+    const result = deriveStoragePressure(snap);
+    expect(result.level).toBe("critical");
+  });
+
+  it("returns warning above absolute threshold with no budget", () => {
+    const snap = baseSnapshot({
+      storage: {
+        ...baseSnapshot().storage,
+        totalManagedBytes: 600 * 1024 * 1024, // 600 MB
+      },
+    });
+    const result = deriveStoragePressure(snap);
+    expect(result.level).toBe("warning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Growth Trend
+// ---------------------------------------------------------------------------
+
+describe("deriveGrowthTrend", () => {
+  it("returns unknown when no growth data", () => {
+    const snap = baseSnapshot();
+    const result = deriveGrowthTrend(snap);
+    expect(result.key).toBe("growthTrend");
+    expect(result.level).toBe("unknown");
+  });
+
+  it("returns healthy for minor growth", () => {
+    const snap = baseSnapshot({
+      growth: {
+        sessionsBytes24h: 1024,
+        sessionsBytes7d: 5120,
+        indexedCount24h: 1,
+        indexedCount7d: 5,
+      },
+    });
+    const result = deriveGrowthTrend(snap);
+    expect(result.level).toBe("healthy");
+  });
+
+  it("returns warning for rapid 24h growth", () => {
+    const snap = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        indexedCount: 100,
+      },
+      growth: {
+        sessionsBytes24h: 50 * 1024 * 1024,
+        sessionsBytes7d: null,
+        indexedCount24h: 8, // 8% of 100
+        indexedCount7d: null,
+      },
+    });
+    const result = deriveGrowthTrend(snap);
+    expect(result.level).toBe("warning");
+  });
+
+  it("returns critical for explosive growth", () => {
+    const snap = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        indexedCount: 100,
+      },
+      growth: {
+        sessionsBytes24h: 100 * 1024 * 1024,
+        sessionsBytes7d: null,
+        indexedCount24h: 20, // 20% of 100
+        indexedCount7d: null,
+      },
+    });
+    const result = deriveGrowthTrend(snap);
+    expect(result.level).toBe("critical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stalest Orphan
+// ---------------------------------------------------------------------------
+
+describe("deriveStalestOrphan", () => {
+  it("returns healthy when no orphans", () => {
+    const snap = baseSnapshot();
+    const result = deriveStalestOrphan(snap);
+    expect(result.key).toBe("stalestOrphan");
+    expect(result.level).toBe("healthy");
+  });
+
+  it("returns warning for recent orphans", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 2,
+        oldestOrphanedTempAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2h
+      },
+    });
+    const result = deriveStalestOrphan(snap);
+    expect(result.level).toBe("warning");
+  });
+
+  it("returns critical for old orphans", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 1,
+        oldestOrphanedTempAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(), // 48h
+      },
+    });
+    const result = deriveStalestOrphan(snap);
+    expect(result.level).toBe("critical");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full surface derivation
+// ---------------------------------------------------------------------------
+
+describe("deriveSessionHealthSurface", () => {
+  it("produces a complete surface with all 5 indicators", () => {
+    const snap = baseSnapshot();
+    const surface = deriveSessionHealthSurface(snap);
+    expect(surface.indicators).toHaveLength(5);
+    expect(surface.overallLevel).toBe("unknown"); // growth is unknown
+    expect(surface.diagnosticsAvailable).toBe(true);
+    expect(surface.measuredAt).toBe(snap.capturedAt);
+  });
+
+  it("overall level is healthy when all indicators healthy", () => {
+    const snap = baseSnapshot({
+      growth: {
+        sessionsBytes24h: 0,
+        sessionsBytes7d: 0,
+        indexedCount24h: 0,
+        indexedCount7d: 0,
+      },
+    });
+    const surface = deriveSessionHealthSurface(snap);
+    expect(surface.overallLevel).toBe("healthy");
+  });
+
+  it("overall level is critical when any indicator is critical", () => {
+    const snap = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 20,
+        reconciliationRecommended: true,
+      },
+      growth: {
+        sessionsBytes24h: 0,
+        sessionsBytes7d: 0,
+        indexedCount24h: 0,
+        indexedCount7d: 0,
+      },
+    });
+    const surface = deriveSessionHealthSurface(snap);
+    expect(surface.overallLevel).toBe("critical");
+  });
+
+  it("overall level is stale_data when snapshot is old", () => {
+    const snap = baseSnapshot({
+      capturedAt: new Date(Date.now() - 20 * 60 * 1000).toISOString(), // 20 min ago
+    });
+    const surface = deriveSessionHealthSurface(snap);
+    expect(surface.overallLevel).toBe("stale_data");
+  });
+
+  it("indicator keys match expected set", () => {
+    const snap = baseSnapshot();
+    const surface = deriveSessionHealthSurface(snap);
+    const keys = surface.indicators.map((i) => i.key);
+    expect(keys).toEqual([
+      "indexHealth",
+      "sessionPressure",
+      "storagePressure",
+      "growthTrend",
+      "stalestOrphan",
+    ]);
+  });
+});

--- a/src/infra/session-health-derive.ts
+++ b/src/infra/session-health-derive.ts
@@ -333,6 +333,14 @@ export function deriveStalestOrphan(snapshot: SessionHealthRawSnapshot): Session
  * Derive the overall level from all indicators.
  * Uses worst-case: critical > warning > unknown > healthy.
  * `stale_data` overrides everything when the snapshot is too old.
+ *
+ * TODO: When the collector stalls, the surface permanently shows `stale_data`
+ * and hides the last-known indicator levels. A future improvement could
+ * preserve the last-good indicator data alongside the stale_data override
+ * so operators can still see what the indicators looked like before the
+ * collector stopped. This is a UX honesty gap, not a correctness bug — the
+ * current behavior is safe (it signals "don't trust this data") but not
+ * maximally informative.
  */
 function deriveOverallLevel(
   indicators: SessionHealthIndicator[],

--- a/src/infra/session-health-derive.ts
+++ b/src/infra/session-health-derive.ts
@@ -1,0 +1,408 @@
+/**
+ * Session Health — Layer B Derivation Logic
+ *
+ * Pure functions that transform a raw `SessionHealthRawSnapshot` (Layer A)
+ * into a compact `SessionHealthSurface` (Layer B) suitable for Mission Control.
+ *
+ * Design principles:
+ * - Health STATES over raw counts (~5 indicators, each with a level)
+ * - Thresholds are usage-relative where possible, not brittle absolutes
+ * - `stale_data` overrides when the snapshot is too old to trust
+ * - `unknown` for indicators that lack sufficient data (e.g., growth before 24h of history)
+ * - No cleanup/remediation logic — this is visibility only
+ */
+
+import type {
+  SessionHealthIndicator,
+  SessionHealthIndicatorKey,
+  SessionHealthLevel,
+  SessionHealthRawSnapshot,
+  SessionHealthSurface,
+} from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Thresholds (tunable constants, not yet user-configurable)
+// ---------------------------------------------------------------------------
+
+/** How old a snapshot can be before we mark the entire surface stale. */
+const STALE_SNAPSHOT_MS = 15 * 60 * 1000; // 15 minutes (3× the default 5-min interval)
+
+// Index Health
+const INDEX_DRIFT_WARN = 3;
+const INDEX_DRIFT_CRITICAL = 10;
+
+// Session Pressure (percentage of maxEntries)
+const SESSION_PRESSURE_WARN_PCT = 60;
+const SESSION_PRESSURE_CRITICAL_PCT = 85;
+
+// Storage Pressure
+const STORAGE_PRESSURE_WARN_PCT = 60;
+const STORAGE_PRESSURE_CRITICAL_PCT = 85;
+// Absolute fallbacks when no disk budget is configured
+const STORAGE_ABSOLUTE_WARN_BYTES = 500 * 1024 * 1024; // 500 MB
+const STORAGE_ABSOLUTE_CRITICAL_BYTES = 1024 * 1024 * 1024; // 1 GB
+// Reset transcript bloat threshold (% of total managed bytes)
+const RESET_BLOAT_WARN_PCT = 50;
+
+// Growth Trend (% of current indexed count, 24h window)
+const GROWTH_24H_WARN_PCT = 5;
+const GROWTH_24H_CRITICAL_PCT = 15;
+const GROWTH_7D_WARN_PCT = 50;
+
+// Stalest Orphan
+const _ORPHAN_WARN_AGE_MS = 60 * 60 * 1000; // 1 hour (reserved for future threshold refinement)
+const ORPHAN_CRITICAL_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function indicator(
+  key: SessionHealthIndicatorKey,
+  label: string,
+  level: SessionHealthLevel,
+  summary: string,
+  measuredAt: string,
+  opts?: { valueText?: string; actionHint?: string },
+): SessionHealthIndicator {
+  return {
+    key,
+    label,
+    level,
+    summary,
+    valueText: opts?.valueText ?? null,
+    actionHint: opts?.actionHint ?? null,
+    measuredAt,
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 60_000) {
+    return `${Math.round(ms / 1000)}s`;
+  }
+  if (ms < 3_600_000) {
+    return `${Math.round(ms / 60_000)}m`;
+  }
+  if (ms < 86_400_000) {
+    return `${(ms / 3_600_000).toFixed(1)}h`;
+  }
+  return `${(ms / 86_400_000).toFixed(1)}d`;
+}
+
+// ---------------------------------------------------------------------------
+// Individual indicator derivers
+// ---------------------------------------------------------------------------
+
+export function deriveIndexHealth(snapshot: SessionHealthRawSnapshot): SessionHealthIndicator {
+  const { drift } = snapshot;
+  const totalDrift = drift.indexedWithoutDiskFile + drift.diskFilesWithoutIndex;
+
+  if (totalDrift === 0 && drift.orphanedTempCount === 0) {
+    return indicator(
+      "indexHealth",
+      "Index Health",
+      "healthy",
+      "No drift detected",
+      snapshot.capturedAt,
+    );
+  }
+
+  const parts: string[] = [];
+  if (drift.indexedWithoutDiskFile > 0) {
+    parts.push(`${drift.indexedWithoutDiskFile} index entries without disk file`);
+  }
+  if (drift.diskFilesWithoutIndex > 0) {
+    parts.push(`${drift.diskFilesWithoutIndex} disk files without index entry`);
+  }
+  if (drift.orphanedTempCount > 0) {
+    parts.push(
+      `${drift.orphanedTempCount} orphaned temp file${drift.orphanedTempCount > 1 ? "s" : ""}`,
+    );
+  }
+  const summary = parts.join("; ");
+
+  if (totalDrift > INDEX_DRIFT_CRITICAL || drift.reconciliationRecommended) {
+    return indicator("indexHealth", "Index Health", "critical", summary, snapshot.capturedAt, {
+      valueText: `${totalDrift} drift entries`,
+      actionHint: "Run index reconciliation",
+    });
+  }
+
+  if (totalDrift > INDEX_DRIFT_WARN || drift.orphanedTempCount > 0) {
+    return indicator("indexHealth", "Index Health", "warning", summary, snapshot.capturedAt, {
+      valueText: `${totalDrift} drift entries`,
+    });
+  }
+
+  // Low drift, below warning threshold
+  return indicator("indexHealth", "Index Health", "healthy", "Minimal drift", snapshot.capturedAt, {
+    valueText: `${totalDrift} drift entries`,
+  });
+}
+
+export function deriveSessionPressure(snapshot: SessionHealthRawSnapshot): SessionHealthIndicator {
+  const { sessions, maintenance } = snapshot;
+  const pct = maintenance.usagePercent.entries;
+  const count = sessions.indexedCount;
+  const max = maintenance.maxEntries;
+  const valueText = `${count} / ${max} (${pct.toFixed(0)}%)`;
+
+  if (pct >= SESSION_PRESSURE_CRITICAL_PCT) {
+    return indicator(
+      "sessionPressure",
+      "Session Pressure",
+      "critical",
+      `Session index at ${pct.toFixed(0)}% capacity`,
+      snapshot.capturedAt,
+      { valueText, actionHint: "Consider pruning stale sessions" },
+    );
+  }
+
+  if (pct >= SESSION_PRESSURE_WARN_PCT) {
+    return indicator(
+      "sessionPressure",
+      "Session Pressure",
+      "warning",
+      `Session index at ${pct.toFixed(0)}% capacity`,
+      snapshot.capturedAt,
+      { valueText },
+    );
+  }
+
+  return indicator(
+    "sessionPressure",
+    "Session Pressure",
+    "healthy",
+    `${count} sessions (${pct.toFixed(0)}% of limit)`,
+    snapshot.capturedAt,
+    { valueText },
+  );
+}
+
+export function deriveStoragePressure(snapshot: SessionHealthRawSnapshot): SessionHealthIndicator {
+  const { storage, maintenance } = snapshot;
+  const total = storage.totalManagedBytes;
+  const resetPct = total > 0 ? (storage.resetTranscriptBytes / total) * 100 : 0;
+
+  // Determine base level from budget or absolute thresholds
+  let level: SessionHealthLevel = "healthy";
+  let pctText = "";
+
+  if (maintenance.usagePercent.diskBytes != null) {
+    const pct = maintenance.usagePercent.diskBytes;
+    pctText = `${pct.toFixed(0)}% of budget`;
+    if (pct >= STORAGE_PRESSURE_CRITICAL_PCT) {
+      level = "critical";
+    } else if (pct >= STORAGE_PRESSURE_WARN_PCT) {
+      level = "warning";
+    }
+  } else {
+    // No disk budget configured — use absolute thresholds
+    if (total >= STORAGE_ABSOLUTE_CRITICAL_BYTES) {
+      level = "critical";
+    } else if (total >= STORAGE_ABSOLUTE_WARN_BYTES) {
+      level = "warning";
+    }
+  }
+
+  // Bump severity if reset transcripts dominate storage
+  if (level === "healthy" && resetPct > RESET_BLOAT_WARN_PCT) {
+    level = "warning";
+  }
+
+  const valueText = formatBytes(total);
+  const resetNote =
+    resetPct > RESET_BLOAT_WARN_PCT ? ` (${resetPct.toFixed(0)}% from reset transcripts)` : "";
+
+  const summaryText =
+    level === "healthy"
+      ? `${formatBytes(total)} managed${pctText ? ` — ${pctText}` : ""}`
+      : `Storage at ${pctText || formatBytes(total)}${resetNote}`;
+
+  return indicator("storagePressure", "Storage Pressure", level, summaryText, snapshot.capturedAt, {
+    valueText,
+    actionHint: level !== "healthy" ? "Review session cleanup options" : undefined,
+  });
+}
+
+export function deriveGrowthTrend(snapshot: SessionHealthRawSnapshot): SessionHealthIndicator {
+  const { growth, sessions } = snapshot;
+
+  // No growth data yet — need at least 24h of history
+  if (growth.indexedCount24h == null && growth.sessionsBytes24h == null) {
+    return indicator(
+      "growthTrend",
+      "Growth Trend",
+      "unknown",
+      "Insufficient history — collecting baseline",
+      snapshot.capturedAt,
+    );
+  }
+
+  const currentCount = sessions.indexedCount;
+  const count24h = growth.indexedCount24h ?? 0;
+  const count7d = growth.indexedCount7d;
+
+  // Compute growth as % of current index
+  const growthPct24h = currentCount > 0 ? (count24h / currentCount) * 100 : 0;
+  const growthPct7d = count7d != null && currentCount > 0 ? (count7d / currentCount) * 100 : null;
+
+  let level: SessionHealthLevel = "healthy";
+  if (growthPct24h >= GROWTH_24H_CRITICAL_PCT) {
+    level = "critical";
+  } else if (
+    growthPct24h >= GROWTH_24H_WARN_PCT ||
+    (growthPct7d != null && growthPct7d >= GROWTH_7D_WARN_PCT)
+  ) {
+    level = "warning";
+  }
+
+  const parts: string[] = [];
+  if (count24h !== 0) {
+    const sign = count24h > 0 ? "+" : "";
+    parts.push(`${sign}${count24h} sessions (24h)`);
+  }
+  if (count7d != null && count7d !== 0) {
+    const sign = count7d > 0 ? "+" : "";
+    parts.push(`${sign}${count7d} (7d)`);
+  }
+  if (growth.sessionsBytes24h != null && growth.sessionsBytes24h !== 0) {
+    const sign = growth.sessionsBytes24h > 0 ? "+" : "";
+    parts.push(`${sign}${formatBytes(Math.abs(growth.sessionsBytes24h))} disk (24h)`);
+  }
+
+  const summary = parts.length > 0 ? parts.join(", ") : "Stable — no significant growth";
+
+  return indicator("growthTrend", "Growth Trend", level, summary, snapshot.capturedAt, {
+    valueText: count24h !== 0 ? `${count24h > 0 ? "+" : ""}${count24h}/24h` : "0/24h",
+    actionHint: level !== "healthy" ? "Review cron/background run retention" : undefined,
+  });
+}
+
+export function deriveStalestOrphan(snapshot: SessionHealthRawSnapshot): SessionHealthIndicator {
+  const { drift } = snapshot;
+
+  if (drift.orphanedTempCount === 0 || !drift.oldestOrphanedTempAt) {
+    return indicator(
+      "stalestOrphan",
+      "Stale Artifacts",
+      "healthy",
+      "No orphaned temp files",
+      snapshot.capturedAt,
+    );
+  }
+
+  const orphanAge = Date.now() - new Date(drift.oldestOrphanedTempAt).getTime();
+
+  let level: SessionHealthLevel = "warning";
+  if (orphanAge >= ORPHAN_CRITICAL_AGE_MS) {
+    level = "critical";
+  }
+
+  return indicator(
+    "stalestOrphan",
+    "Stale Artifacts",
+    level,
+    `${drift.orphanedTempCount} orphaned temp file${drift.orphanedTempCount > 1 ? "s" : ""} — oldest ${formatDuration(orphanAge)} ago`,
+    snapshot.capturedAt,
+    {
+      valueText: formatDuration(orphanAge),
+      actionHint: "Safe to remove orphaned .tmp files",
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Overall surface derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the overall level from all indicators.
+ * Uses worst-case: critical > warning > unknown > healthy.
+ * `stale_data` overrides everything when the snapshot is too old.
+ */
+function deriveOverallLevel(
+  indicators: SessionHealthIndicator[],
+  capturedAt: string,
+): SessionHealthLevel {
+  const snapshotAge = Date.now() - new Date(capturedAt).getTime();
+  if (snapshotAge > STALE_SNAPSHOT_MS) {
+    return "stale_data";
+  }
+
+  const levels = new Set(indicators.map((i) => i.level));
+  if (levels.has("critical")) {
+    return "critical";
+  }
+  if (levels.has("warning")) {
+    return "warning";
+  }
+  if (levels.has("unknown")) {
+    return "unknown";
+  }
+  return "healthy";
+}
+
+function buildOverallSummary(
+  level: SessionHealthLevel,
+  indicators: SessionHealthIndicator[],
+): string {
+  switch (level) {
+    case "healthy":
+      return "All session health indicators are healthy";
+    case "stale_data":
+      return "Session health data is stale — collector may have stopped";
+    case "unknown":
+      return "Some indicators are still collecting baseline data";
+    case "warning": {
+      const warns = indicators.filter((i) => i.level === "warning");
+      return `${warns.length} indicator${warns.length > 1 ? "s" : ""} need${warns.length === 1 ? "s" : ""} attention`;
+    }
+    case "critical": {
+      const crits = indicators.filter((i) => i.level === "critical");
+      return `${crits.length} critical indicator${crits.length > 1 ? "s" : ""}`;
+    }
+  }
+}
+
+/**
+ * Derive the full operator-facing Session Health surface from a raw snapshot.
+ *
+ * This is the primary entry point. The result is cached and served through
+ * the health RPC as `sessionHealthSurface`.
+ */
+export function deriveSessionHealthSurface(
+  snapshot: SessionHealthRawSnapshot,
+): SessionHealthSurface {
+  const indicators: SessionHealthIndicator[] = [
+    deriveIndexHealth(snapshot),
+    deriveSessionPressure(snapshot),
+    deriveStoragePressure(snapshot),
+    deriveGrowthTrend(snapshot),
+    deriveStalestOrphan(snapshot),
+  ];
+
+  const overallLevel = deriveOverallLevel(indicators, snapshot.capturedAt);
+
+  return {
+    overallLevel,
+    summary: buildOverallSummary(overallLevel, indicators),
+    indicators,
+    diagnosticsAvailable: true,
+    measuredAt: snapshot.capturedAt,
+    lastHealthyAt: overallLevel === "healthy" ? snapshot.capturedAt : null,
+  };
+}

--- a/src/infra/session-health-file-discovery.test.ts
+++ b/src/infra/session-health-file-discovery.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Session Health — File Discovery Tests
+ *
+ * Tests the shared file-discovery helpers used by both the collector
+ * and the executor.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  discoverOrphanedTmpFiles,
+  discoverOrphanTranscripts,
+  discoverStaleDeletedTranscripts,
+  discoverStaleResetTranscripts,
+  extractIndexedSessionIds,
+  readSessionDirFiles,
+} from "./session-health-file-discovery.js";
+
+// ---------------------------------------------------------------------------
+// Temp directory management
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "session-health-discovery-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeFile(name: string, content = "data", ageMs?: number): Promise<string> {
+  const filePath = path.join(tmpDir, name);
+  await fs.writeFile(filePath, content);
+  if (ageMs != null) {
+    const mtime = new Date(Date.now() - ageMs);
+    await fs.utimes(filePath, mtime, mtime);
+  }
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// readSessionDirFiles
+// ---------------------------------------------------------------------------
+
+describe("readSessionDirFiles", () => {
+  it("returns empty array for non-existent directory", async () => {
+    const files = await readSessionDirFiles("/no/such/directory");
+    expect(files).toEqual([]);
+  });
+
+  it("returns file metadata for files in directory", async () => {
+    await writeFile("test.jsonl", "hello world");
+    const files = await readSessionDirFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("test.jsonl");
+    expect(files[0].size).toBe(11);
+    expect(files[0].absolutePath).toBe(path.join(tmpDir, "test.jsonl"));
+    expect(typeof files[0].mtimeMs).toBe("number");
+  });
+
+  it("ignores directories", async () => {
+    await writeFile("test.jsonl");
+    await fs.mkdir(path.join(tmpDir, "subdir"));
+    const files = await readSessionDirFiles(tmpDir);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("test.jsonl");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverOrphanedTmpFiles
+// ---------------------------------------------------------------------------
+
+describe("discoverOrphanedTmpFiles", () => {
+  it("returns empty array when no tmp files exist", async () => {
+    await writeFile("session-abc.jsonl");
+    const files = await discoverOrphanedTmpFiles(tmpDir);
+    expect(files).toEqual([]);
+  });
+
+  it("discovers .tmp files", async () => {
+    await writeFile("session-abc.tmp", "incomplete");
+    await writeFile("session-def.tmp", "also incomplete");
+    await writeFile("session-ghi.jsonl", "real data");
+    const files = await discoverOrphanedTmpFiles(tmpDir);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => f.name).toSorted()).toEqual(["session-abc.tmp", "session-def.tmp"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverOrphanTranscripts
+// ---------------------------------------------------------------------------
+
+describe("discoverOrphanTranscripts", () => {
+  it("returns empty when all .jsonl files are indexed", async () => {
+    await writeFile("session-abc.jsonl");
+    await writeFile("session-def.jsonl");
+    const indexed = new Set(["session-abc", "session-def"]);
+    const files = await discoverOrphanTranscripts(tmpDir, indexed);
+    expect(files).toEqual([]);
+  });
+
+  it("discovers .jsonl files not in the index", async () => {
+    await writeFile("session-abc.jsonl");
+    await writeFile("session-def.jsonl");
+    await writeFile("session-ghi.jsonl");
+    const indexed = new Set(["session-abc"]);
+    const files = await discoverOrphanTranscripts(tmpDir, indexed);
+    expect(files).toHaveLength(2);
+    expect(files.map((f) => f.name).toSorted()).toEqual(["session-def.jsonl", "session-ghi.jsonl"]);
+  });
+
+  it("ignores non-.jsonl files", async () => {
+    await writeFile("session-abc.tmp");
+    await writeFile("session-def.deleted.123.jsonl");
+    const indexed = new Set<string>();
+    const files = await discoverOrphanTranscripts(tmpDir, indexed);
+    expect(files).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverStaleDeletedTranscripts
+// ---------------------------------------------------------------------------
+
+describe("discoverStaleDeletedTranscripts", () => {
+  const ONE_DAY = 24 * 60 * 60 * 1000;
+  const SEVEN_DAYS = 7 * ONE_DAY;
+
+  it("returns empty when no deleted files exist", async () => {
+    await writeFile("session-abc.jsonl");
+    const files = await discoverStaleDeletedTranscripts(tmpDir, SEVEN_DAYS);
+    expect(files).toEqual([]);
+  });
+
+  it("discovers .deleted files past retention", async () => {
+    // 10 days old — past 7-day retention
+    await writeFile("session-abc.deleted.1710000000000.jsonl", "old", 10 * ONE_DAY);
+    // 1 day old — within retention
+    await writeFile("session-def.deleted.1710800000000.jsonl", "recent", 1 * ONE_DAY);
+    const files = await discoverStaleDeletedTranscripts(tmpDir, SEVEN_DAYS);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toContain("session-abc.deleted");
+  });
+
+  it("returns all deleted files when all are past retention", async () => {
+    await writeFile("a.deleted.1.jsonl", "x", 10 * ONE_DAY);
+    await writeFile("b.deleted.2.jsonl", "x", 8 * ONE_DAY);
+    const files = await discoverStaleDeletedTranscripts(tmpDir, SEVEN_DAYS);
+    expect(files).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// discoverStaleResetTranscripts
+// ---------------------------------------------------------------------------
+
+describe("discoverStaleResetTranscripts", () => {
+  const ONE_DAY = 24 * 60 * 60 * 1000;
+  const SEVEN_DAYS = 7 * ONE_DAY;
+
+  it("returns empty when no reset files exist", async () => {
+    await writeFile("session-abc.jsonl");
+    const files = await discoverStaleResetTranscripts(tmpDir, SEVEN_DAYS);
+    expect(files).toEqual([]);
+  });
+
+  it("discovers .reset files past retention", async () => {
+    await writeFile("session-abc.reset.1710000000000.jsonl", "old", 10 * ONE_DAY);
+    await writeFile("session-def.reset.1710800000000.jsonl", "recent", 1 * ONE_DAY);
+    const files = await discoverStaleResetTranscripts(tmpDir, SEVEN_DAYS);
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toContain("session-abc.reset");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractIndexedSessionIds
+// ---------------------------------------------------------------------------
+
+describe("extractIndexedSessionIds", () => {
+  it("extracts session IDs from a store", () => {
+    const store = {
+      "agent:main:key1": { sessionId: "session-abc" },
+      "agent:main:key2": { sessionId: "session-def" },
+    };
+    const ids = extractIndexedSessionIds(store);
+    expect(ids).toEqual(new Set(["session-abc", "session-def"]));
+  });
+
+  it("ignores entries without sessionId", () => {
+    const store = {
+      "agent:main:key1": { sessionId: "session-abc" },
+      "agent:main:key2": { noSessionId: true },
+      "agent:main:key3": null,
+    };
+    const ids = extractIndexedSessionIds(store as Record<string, unknown>);
+    expect(ids).toEqual(new Set(["session-abc"]));
+  });
+
+  it("returns empty set for empty store", () => {
+    const ids = extractIndexedSessionIds({});
+    expect(ids.size).toBe(0);
+  });
+});

--- a/src/infra/session-health-file-discovery.ts
+++ b/src/infra/session-health-file-discovery.ts
@@ -1,0 +1,181 @@
+/**
+ * Session Health — File Discovery Helpers
+ *
+ * Shared file-discovery logic used by both the collector (for counting) and
+ * the executor (for identifying specific files to act on). Extracted from
+ * the collector to avoid duplicating directory-walking logic.
+ *
+ * All functions are pure scans — they read the filesystem but never mutate.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { classifyDiskArtifact } from "./session-health-classify.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DiscoveredFile = {
+  /** Absolute path to the file. */
+  absolutePath: string;
+
+  /** Filename only (no directory). */
+  name: string;
+
+  /** File size in bytes. */
+  size: number;
+
+  /** Last modification time (ms since epoch). */
+  mtimeMs: number;
+};
+
+// ---------------------------------------------------------------------------
+// Directory scanner (shared primitive)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read all regular files in a sessions directory, returning metadata.
+ * Returns empty array if the directory doesn't exist or can't be read.
+ */
+export async function readSessionDirFiles(sessionsDir: string): Promise<DiscoveredFile[]> {
+  let dirEntries: import("node:fs").Dirent[];
+  try {
+    dirEntries = await fs.readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: DiscoveredFile[] = [];
+  for (const dirent of dirEntries) {
+    if (!dirent.isFile()) {
+      continue;
+    }
+    try {
+      const absPath = path.join(sessionsDir, dirent.name);
+      const stat = await fs.stat(absPath);
+      if (stat.isFile()) {
+        files.push({
+          absolutePath: absPath,
+          name: String(dirent.name),
+          size: stat.size,
+          mtimeMs: stat.mtimeMs,
+        });
+      }
+    } catch {
+      // Skip files we can't stat (e.g., race condition deletion).
+    }
+  }
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// Orphaned .tmp files (Tier 0)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover orphaned .tmp files in a sessions directory.
+ * These are artifacts from crashed atomic writes.
+ */
+export async function discoverOrphanedTmpFiles(sessionsDir: string): Promise<DiscoveredFile[]> {
+  const files = await readSessionDirFiles(sessionsDir);
+  return files.filter((f) => classifyDiskArtifact(f.name) === "orphanedTemp");
+}
+
+// ---------------------------------------------------------------------------
+// Orphan transcripts — .jsonl files not referenced by the index (Tier 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover .jsonl files on disk that have no matching session index entry.
+ * These are "orphan transcripts" — files that exist on disk but aren't
+ * referenced by any session in the store.
+ *
+ * @param sessionsDir - The sessions directory to scan
+ * @param indexedSessionIds - Set of sessionIds referenced by the store
+ */
+export async function discoverOrphanTranscripts(
+  sessionsDir: string,
+  indexedSessionIds: Set<string>,
+): Promise<DiscoveredFile[]> {
+  const files = await readSessionDirFiles(sessionsDir);
+  return files.filter((f) => {
+    if (classifyDiskArtifact(f.name) !== "active") {
+      return false;
+    }
+    if (!f.name.endsWith(".jsonl")) {
+      return false;
+    }
+    const sessionId = f.name.replace(/\.jsonl$/, "");
+    return !indexedSessionIds.has(sessionId);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stale .deleted transcript archives (Tier 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover .deleted transcript files that are past the retention window.
+ *
+ * @param sessionsDir - The sessions directory to scan
+ * @param retentionMs - Retention window in milliseconds
+ */
+export async function discoverStaleDeletedTranscripts(
+  sessionsDir: string,
+  retentionMs: number,
+): Promise<DiscoveredFile[]> {
+  const files = await readSessionDirFiles(sessionsDir);
+  const now = Date.now();
+  return files.filter((f) => {
+    if (classifyDiskArtifact(f.name) !== "deleted") {
+      return false;
+    }
+    return now - f.mtimeMs > retentionMs;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Stale .reset transcript archives (Tier 1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover .reset transcript files that are past the retention window.
+ *
+ * @param sessionsDir - The sessions directory to scan
+ * @param retentionMs - Retention window in milliseconds
+ */
+export async function discoverStaleResetTranscripts(
+  sessionsDir: string,
+  retentionMs: number,
+): Promise<DiscoveredFile[]> {
+  const files = await readSessionDirFiles(sessionsDir);
+  const now = Date.now();
+  return files.filter((f) => {
+    if (classifyDiskArtifact(f.name) !== "reset") {
+      return false;
+    }
+    return now - f.mtimeMs > retentionMs;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract indexed session IDs from a loaded store
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the set of sessionIds from a loaded session store.
+ * Used to identify orphan transcripts.
+ */
+export function extractIndexedSessionIds(store: Record<string, unknown>): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of Object.values(store)) {
+    if (entry && typeof entry === "object") {
+      const sessionId = (entry as Record<string, unknown>).sessionId;
+      if (typeof sessionId === "string" && sessionId) {
+        ids.add(sessionId);
+      }
+    }
+  }
+  return ids;
+}

--- a/src/infra/session-health-file-discovery.ts
+++ b/src/infra/session-health-file-discovery.ts
@@ -91,6 +91,12 @@ export async function discoverOrphanedTmpFiles(sessionsDir: string): Promise<Dis
  * These are "orphan transcripts" — files that exist on disk but aren't
  * referenced by any session in the store.
  *
+ * Filename assumption: transcript files are named `${sessionId}.jsonl`.
+ * This holds for all current OpenClaw session types. If a future session
+ * type uses `sessionFile` overrides to decouple filename from sessionId,
+ * this mapping would need to be updated. The same assumption exists in
+ * the collector's drift detection (session-health-collector.ts).
+ *
  * @param sessionsDir - The sessions directory to scan
  * @param indexedSessionIds - Set of sessionIds referenced by the store
  */
@@ -106,6 +112,7 @@ export async function discoverOrphanTranscripts(
     if (!f.name.endsWith(".jsonl")) {
       return false;
     }
+    // Assumption: filename == sessionId + ".jsonl" (see doc comment above)
     const sessionId = f.name.replace(/\.jsonl$/, "");
     return !indexedSessionIds.has(sessionId);
   });

--- a/src/infra/session-health-remediation-executor.test.ts
+++ b/src/infra/session-health-remediation-executor.test.ts
@@ -69,6 +69,12 @@ function baseSnapshot(overrides?: Partial<SessionHealthRawSnapshot>): SessionHea
       resetTranscriptBytes: 20 * 1024 * 1024,
       orphanedTempBytes: 12700,
     },
+    staleArtifacts: {
+      staleDeletedCount: 3,
+      staleDeletedBytes: 3 * 1024 * 1024,
+      staleResetCount: 7,
+      staleResetBytes: 14 * 1024 * 1024,
+    },
     drift: {
       indexedWithoutDiskFile: 0,
       diskFilesWithoutIndex: 3,

--- a/src/infra/session-health-remediation-executor.test.ts
+++ b/src/infra/session-health-remediation-executor.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Session Health — Remediation Executor Tests (Phase 3C)
+ *
+ * Tests:
+ * - Validation: action ID resolution, tier restrictions, missing actions
+ * - Execution: success, no-op/idempotent reruns, partial failures
+ * - Refusal: contradictory flags, tier violations, scope increases
+ * - Reporting: confirmation block, before/after text and JSON
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ExecutionRefusalError,
+  renderConfirmationBlock,
+  renderExecutionReportText,
+  resolveActionIdsForTier,
+  validateExecutionRequest,
+} from "./session-health-remediation-executor.js";
+import { buildRemediationPlan } from "./session-health-remediation-plan.js";
+import { V1_MAX_EXECUTION_TIER } from "./session-health-remediation-types.js";
+import type { ExecutionResult } from "./session-health-remediation-types.js";
+import type { SessionHealthRawSnapshot } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Snapshot fixture
+// ---------------------------------------------------------------------------
+
+function baseSnapshot(overrides?: Partial<SessionHealthRawSnapshot>): SessionHealthRawSnapshot {
+  return {
+    capturedAt: "2026-03-20T18:00:00.000Z",
+    collectorDurationMs: 42,
+    sessions: {
+      indexedCount: 50,
+      sessionsJsonBytes: 100_000,
+      sessionsJsonParseTimeMs: 5,
+      byClass: {
+        main: 2,
+        channel: 5,
+        direct: 3,
+        "cron-definition": 2,
+        "cron-run": 20,
+        subagent: 10,
+        acp: 5,
+        heartbeat: 1,
+        thread: 2,
+        unknown: 0,
+      },
+      staleByClass: {
+        "cron-run": 12,
+        subagent: 4,
+        acp: 2,
+        heartbeat: 1,
+      },
+      byDiskState: {
+        active: 40,
+        deleted: 5,
+        reset: 10,
+        orphanedTemp: 3,
+      },
+    },
+    storage: {
+      totalManagedBytes: 50 * 1024 * 1024,
+      sessionsJsonBytes: 100_000,
+      activeTranscriptBytes: 20 * 1024 * 1024,
+      deletedTranscriptBytes: 5 * 1024 * 1024,
+      resetTranscriptBytes: 20 * 1024 * 1024,
+      orphanedTempBytes: 12700,
+    },
+    drift: {
+      indexedWithoutDiskFile: 0,
+      diskFilesWithoutIndex: 3,
+      orphanedTempCount: 3,
+      oldestOrphanedTempAt: "2026-03-19T10:00:00.000Z",
+      reconciliationRecommended: true,
+    },
+    maintenance: {
+      mode: "warn",
+      maxEntries: 500,
+      pruneAfterMs: 7 * 24 * 60 * 60 * 1000,
+      maxDiskBytes: null,
+      usagePercent: {
+        entries: 10,
+        diskBytes: null,
+      },
+    },
+    growth: {
+      sessionsBytes24h: null,
+      sessionsBytes7d: null,
+      indexedCount24h: null,
+      indexedCount7d: null,
+    },
+    agents: [],
+    ...overrides,
+  };
+}
+
+function buildPlanFromSnapshot(
+  snapshot?: SessionHealthRawSnapshot,
+): ReturnType<typeof buildRemediationPlan> {
+  return buildRemediationPlan({ snapshot: snapshot ?? baseSnapshot() });
+}
+
+// ---------------------------------------------------------------------------
+// Validation tests
+// ---------------------------------------------------------------------------
+
+describe("validateExecutionRequest", () => {
+  it("validates a valid Tier 0 action ID", () => {
+    const plan = buildPlanFromSnapshot();
+    const result = validateExecutionRequest(["cleanup-orphaned-tmp-1"], plan);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.actions).toHaveLength(1);
+      expect(result.actions[0].kind).toBe("cleanup-orphaned-tmp");
+    }
+  });
+
+  it("validates multiple Tier 0 + Tier 1 action IDs", () => {
+    const plan = buildPlanFromSnapshot();
+    const allT0T1Ids = plan.tiers
+      .filter((t) => t.tier <= 1)
+      .flatMap((t) => t.actions.map((a) => a.id));
+    expect(allT0T1Ids.length).toBeGreaterThan(0);
+
+    const result = validateExecutionRequest(allT0T1Ids, plan);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.actions.length).toBe(allT0T1Ids.length);
+    }
+  });
+
+  it("refuses an action ID that does not exist in the plan", () => {
+    const plan = buildPlanFromSnapshot();
+    const result = validateExecutionRequest(["nonexistent-action-42"], plan);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("nonexistent-action-42");
+      expect(result.error).toContain("not found");
+    }
+  });
+
+  it("refuses a Tier 2 action", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 5,
+      },
+    });
+    const plan = buildPlanFromSnapshot(snapshot);
+
+    // Find a Tier 2 action
+    const tier2Action = plan.tiers.flatMap((t) => t.actions).find((a) => a.tier === 2);
+    expect(tier2Action).toBeDefined();
+
+    const result = validateExecutionRequest([tier2Action!.id], plan);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("Tier 2");
+      expect(result.error).toContain("v1 only supports Tier 0–1");
+    }
+  });
+
+  it("refuses a Tier 3 action", () => {
+    const snapshot = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        maxDiskBytes: 30 * 1024 * 1024,
+        usagePercent: { entries: 10, diskBytes: 167 },
+      },
+    });
+    const plan = buildPlanFromSnapshot(snapshot);
+
+    const tier3Action = plan.tiers.flatMap((t) => t.actions).find((a) => a.tier === 3);
+    expect(tier3Action).toBeDefined();
+
+    const result = validateExecutionRequest([tier3Action!.id], plan);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("Tier 3");
+    }
+  });
+
+  it("refuses when all requested actions have resolved", () => {
+    // Build a clean snapshot with no issues
+    const snapshot = baseSnapshot({
+      drift: {
+        indexedWithoutDiskFile: 0,
+        diskFilesWithoutIndex: 0,
+        orphanedTempCount: 0,
+        oldestOrphanedTempAt: null,
+        reconciliationRecommended: false,
+      },
+      sessions: {
+        ...baseSnapshot().sessions,
+        staleByClass: undefined,
+        byDiskState: { active: 40, deleted: 0, reset: 0, orphanedTemp: 0 },
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        deletedTranscriptBytes: 0,
+        resetTranscriptBytes: 0,
+        orphanedTempBytes: 0,
+      },
+    });
+    const plan = buildPlanFromSnapshot(snapshot);
+
+    // Try to execute an action that doesn't exist in the clean plan
+    const result = validateExecutionRequest(["cleanup-orphaned-tmp-1"], plan);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("not found");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveActionIdsForTier
+// ---------------------------------------------------------------------------
+
+describe("resolveActionIdsForTier", () => {
+  it("returns only Tier 0 actions for tier 0", () => {
+    const plan = buildPlanFromSnapshot();
+    const ids = resolveActionIdsForTier(0, plan);
+    const actions = plan.tiers.flatMap((t) => t.actions);
+    for (const id of ids) {
+      const action = actions.find((a) => a.id === id);
+      expect(action?.tier).toBe(0);
+    }
+  });
+
+  it("returns Tier 0 + Tier 1 actions for tier 1", () => {
+    const plan = buildPlanFromSnapshot();
+    const ids = resolveActionIdsForTier(1, plan);
+    const actions = plan.tiers.flatMap((t) => t.actions);
+    for (const id of ids) {
+      const action = actions.find((a) => a.id === id);
+      expect(action?.tier).toBeLessThanOrEqual(1);
+    }
+    // Should include Tier 0 and Tier 1 actions
+    const tiers = ids.map((id) => actions.find((a) => a.id === id)?.tier);
+    expect(tiers).toContain(0);
+    expect(tiers).toContain(1);
+  });
+
+  it("returns empty array when no actions match the tier", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        indexedWithoutDiskFile: 0,
+        diskFilesWithoutIndex: 0,
+        orphanedTempCount: 0,
+        oldestOrphanedTempAt: null,
+        reconciliationRecommended: false,
+      },
+      sessions: {
+        ...baseSnapshot().sessions,
+        staleByClass: undefined,
+        byDiskState: { active: 40, deleted: 0, reset: 0, orphanedTemp: 0 },
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        deletedTranscriptBytes: 0,
+        resetTranscriptBytes: 0,
+        orphanedTempBytes: 0,
+      },
+    });
+    const plan = buildPlanFromSnapshot(snapshot);
+    const ids = resolveActionIdsForTier(0, plan);
+    expect(ids).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// V1_MAX_EXECUTION_TIER safety
+// ---------------------------------------------------------------------------
+
+describe("V1_MAX_EXECUTION_TIER", () => {
+  it("is 1 (Tier 0 + Tier 1 only)", () => {
+    expect(V1_MAX_EXECUTION_TIER).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Confirmation block rendering
+// ---------------------------------------------------------------------------
+
+describe("renderConfirmationBlock", () => {
+  it("renders a confirmation block with action details", () => {
+    const plan = buildPlanFromSnapshot();
+    const tier0Actions = plan.tiers.filter((t) => t.tier === 0).flatMap((t) => t.actions);
+    expect(tier0Actions.length).toBeGreaterThan(0);
+
+    const text = renderConfirmationBlock(tier0Actions);
+    expect(text).toContain("CONFIRMATION REQUIRED");
+    expect(text).toContain("cleanup-orphaned-tmp-1");
+    expect(text).toContain("Tier 0, auto-safe");
+    expect(text).toContain("artifact(s)");
+    expect(text).toContain("Total:");
+  });
+
+  it("renders Tier 1 actions with the correct label", () => {
+    const plan = buildPlanFromSnapshot();
+    const tier1Actions = plan.tiers.filter((t) => t.tier === 1).flatMap((t) => t.actions);
+    expect(tier1Actions.length).toBeGreaterThan(0);
+
+    const text = renderConfirmationBlock(tier1Actions);
+    expect(text).toContain("Tier 1, retention cleanup");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Execution report rendering
+// ---------------------------------------------------------------------------
+
+describe("renderExecutionReportText", () => {
+  it("renders a successful execution report", () => {
+    const result: ExecutionResult = {
+      executedAt: "2026-03-20T22:00:00.000Z",
+      actions: [
+        {
+          id: "cleanup-orphaned-tmp-1",
+          kind: "cleanup-orphaned-tmp",
+          tier: 0,
+          status: "complete",
+          artifactsRemoved: 3,
+          bytesFreed: 12700,
+          detail: "Removed 3 .tmp file(s).",
+        },
+      ],
+      summary: {
+        executed: 1,
+        skipped: 0,
+        failed: 0,
+        refused: 0,
+        totalBytesFreed: 12700,
+        storageBefore: 50_000_000,
+        storageAfter: 49_987_300,
+      },
+    };
+
+    const text = renderExecutionReportText(result);
+    expect(text).toContain("COMPLETE");
+    expect(text).toContain("Executed: 1 action(s)");
+    expect(text).toContain("✓ complete");
+    expect(text).toContain("cleanup-orphaned-tmp-1");
+    expect(text).toContain("Removed:  3 artifact(s)");
+    expect(text).toContain("Before:");
+    expect(text).toContain("After:");
+    expect(text).toContain("Freed:");
+  });
+
+  it("renders skipped actions correctly", () => {
+    const result: ExecutionResult = {
+      executedAt: "2026-03-20T22:00:00.000Z",
+      actions: [
+        {
+          id: "cleanup-orphaned-tmp-1",
+          kind: "cleanup-orphaned-tmp",
+          tier: 0,
+          status: "skipped",
+          artifactsRemoved: 0,
+          bytesFreed: 0,
+          detail: "No orphaned .tmp files found (condition resolved).",
+        },
+      ],
+      summary: {
+        executed: 0,
+        skipped: 1,
+        failed: 0,
+        refused: 0,
+        totalBytesFreed: 0,
+        storageBefore: 50_000_000,
+        storageAfter: 50_000_000,
+      },
+    };
+
+    const text = renderExecutionReportText(result);
+    expect(text).toContain("Skipped:  1");
+    expect(text).toContain("○ skipped");
+    expect(text).toContain("condition resolved");
+  });
+
+  it("renders failed actions with error", () => {
+    const result: ExecutionResult = {
+      executedAt: "2026-03-20T22:00:00.000Z",
+      actions: [
+        {
+          id: "cleanup-orphaned-tmp-1",
+          kind: "cleanup-orphaned-tmp",
+          tier: 0,
+          status: "failed",
+          artifactsRemoved: 0,
+          bytesFreed: 0,
+          error: "Permission denied for all files.",
+          warnings: ["Could not remove a.tmp: EACCES"],
+        },
+      ],
+      summary: {
+        executed: 0,
+        skipped: 0,
+        failed: 1,
+        refused: 0,
+        totalBytesFreed: 0,
+        storageBefore: 50_000_000,
+        storageAfter: 50_000_000,
+      },
+    };
+
+    const text = renderExecutionReportText(result);
+    expect(text).toContain("Failed:   1");
+    expect(text).toContain("✗ failed");
+    expect(text).toContain("Permission denied");
+    expect(text).toContain("Warning:");
+  });
+
+  it("renders refused actions", () => {
+    const result: ExecutionResult = {
+      executedAt: "2026-03-20T22:00:00.000Z",
+      actions: [
+        {
+          id: "reconcile-index-phantoms-5",
+          kind: "reconcile-index-phantoms",
+          tier: 2,
+          status: "refused",
+          artifactsRemoved: 0,
+          bytesFreed: 0,
+          error: "Tier 2 execution not supported in v1.",
+        },
+      ],
+      summary: {
+        executed: 0,
+        skipped: 0,
+        failed: 0,
+        refused: 1,
+        totalBytesFreed: 0,
+        storageBefore: 50_000_000,
+        storageAfter: 50_000_000,
+      },
+    };
+
+    const text = renderExecutionReportText(result);
+    expect(text).toContain("Refused:  1");
+    expect(text).toContain("✕ refused");
+  });
+
+  it("renders the storage summary with freed percentage", () => {
+    const result: ExecutionResult = {
+      executedAt: "2026-03-20T22:00:00.000Z",
+      actions: [
+        {
+          id: "archive-stale-deleted-transcripts-3",
+          kind: "archive-stale-deleted-transcripts",
+          tier: 1,
+          status: "complete",
+          artifactsRemoved: 7,
+          bytesFreed: 2_202_009,
+        },
+      ],
+      summary: {
+        executed: 1,
+        skipped: 0,
+        failed: 0,
+        refused: 0,
+        totalBytesFreed: 2_202_009,
+        storageBefore: 50_647_040,
+        storageAfter: 48_445_031,
+      },
+    };
+
+    const text = renderExecutionReportText(result);
+    expect(text).toContain("Storage Summary");
+    expect(text).toContain("Freed:");
+    // Should show percentage
+    expect(text).toMatch(/\d+\.\d+%/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ExecutionRefusalError
+// ---------------------------------------------------------------------------
+
+describe("ExecutionRefusalError", () => {
+  it("is an Error subclass", () => {
+    const err = new ExecutionRefusalError("test message");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ExecutionRefusalError");
+    expect(err.message).toBe("test message");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// File-level executor integration (uses real filesystem)
+// ---------------------------------------------------------------------------
+
+describe("executor file-level operations", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "executor-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  // We import the module dynamically to test the individual executors
+  // through the public API, but need to test file operations in isolation.
+  // The executeRemediation function requires full config/collector context,
+  // so we test the individual pieces via validateExecutionRequest + rendering.
+
+  it("idempotent: second validation on clean plan returns not-found", () => {
+    // Simulate idempotent rerun: first execution resolves the condition,
+    // second attempt finds no matching action in the fresh (clean) plan.
+    const cleanSnapshot = baseSnapshot({
+      drift: {
+        indexedWithoutDiskFile: 0,
+        diskFilesWithoutIndex: 0,
+        orphanedTempCount: 0,
+        oldestOrphanedTempAt: null,
+        reconciliationRecommended: false,
+      },
+      sessions: {
+        ...baseSnapshot().sessions,
+        staleByClass: undefined,
+        byDiskState: { active: 40, deleted: 0, reset: 0, orphanedTemp: 0 },
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        deletedTranscriptBytes: 0,
+        resetTranscriptBytes: 0,
+        orphanedTempBytes: 0,
+      },
+    });
+    const freshPlan = buildRemediationPlan({ snapshot: cleanSnapshot });
+    const result = validateExecutionRequest(["cleanup-orphaned-tmp-1"], freshPlan);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("not found");
+      expect(result.error).toContain("Re-run --dry-run");
+    }
+  });
+
+  it("mixed tier request with Tier 2 is refused", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 5,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+
+    // Collect both a Tier 0 and a Tier 2 action
+    const tier0 = plan.tiers.flatMap((t) => t.actions).find((a) => a.tier === 0);
+    const tier2 = plan.tiers.flatMap((t) => t.actions).find((a) => a.tier === 2);
+    expect(tier0).toBeDefined();
+    expect(tier2).toBeDefined();
+
+    // The first Tier 2 action in the list should cause refusal
+    const result = validateExecutionRequest([tier0!.id, tier2!.id], plan);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toContain("Tier 2");
+    }
+  });
+});

--- a/src/infra/session-health-remediation-executor.test.ts
+++ b/src/infra/session-health-remediation-executor.test.ts
@@ -13,6 +13,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  formatSessionArchiveTimestamp,
+  isSessionArchiveArtifactName,
+  parseSessionArchiveTimestamp,
+} from "../config/sessions/artifacts.js";
+import {
   ExecutionRefusalError,
   renderConfirmationBlock,
   renderExecutionReportText,
@@ -569,5 +574,38 @@ describe("executor file-level operations", () => {
     if (!result.valid) {
       expect(result.error).toContain("Tier 2");
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orphan archive naming compatibility with canonical artifacts.ts helpers
+// ---------------------------------------------------------------------------
+
+describe("orphan archive naming compatibility", () => {
+  it("canonical archive format is recognized by isSessionArchiveArtifactName", () => {
+    // The executor now uses formatSessionArchiveTimestamp() and appends
+    // `.deleted.<stamp>` after the full filename, matching the doctor command
+    // and disk-budget helpers.
+    const stamp = formatSessionArchiveTimestamp(1711234567890);
+    const archiveName = `some-session-id.jsonl.deleted.${stamp}`;
+
+    expect(isSessionArchiveArtifactName(archiveName)).toBe(true);
+    expect(parseSessionArchiveTimestamp(archiveName, "deleted")).toBe(1711234567890);
+  });
+
+  it("old epoch-based pattern is NOT recognized by canonical helpers", () => {
+    // Before the fix: `foo.deleted.1711234567890.jsonl`
+    // This format was NOT compatible with artifacts.ts helpers.
+    const oldPattern = "some-session-id.deleted.1711234567890.jsonl";
+    expect(isSessionArchiveArtifactName(oldPattern)).toBe(false);
+  });
+
+  it("canonical format round-trips through parse", () => {
+    const now = Date.now();
+    const stamp = formatSessionArchiveTimestamp(now);
+    const archiveName = `abc-def.jsonl.deleted.${stamp}`;
+
+    const parsed = parseSessionArchiveTimestamp(archiveName, "deleted");
+    expect(parsed).toBe(now);
   });
 });

--- a/src/infra/session-health-remediation-executor.ts
+++ b/src/infra/session-health-remediation-executor.ts
@@ -1,20 +1,21 @@
 /**
  * Session Health — Remediation Executor (Phase 3C)
  *
- * Executes reviewed remediation actions from a plan. The executor:
+ * Executes reviewed remediation actions. The executor:
  * 1. Re-derives a fresh plan from a fresh snapshot
- * 2. Validates that requested actions still exist with compatible parameters
- * 3. Shows a confirmation prompt (unless --yes)
- * 4. Executes actions in tier order
- * 5. Reports before/after results
+ * 2. Validates that requested action IDs still exist in the fresh plan
+ * 3. Executes actions in tier order
+ * 4. Returns a structured execution result with before/after reporting
+ *
+ * The executor is a domain-layer module: it validates and executes, but does
+ * NOT handle CLI concerns (confirmation prompts, JSON vs text output, flag
+ * conflict detection). Those belong in the CLI command layer.
  *
  * Hard safety boundaries:
- * - v1 supports Tier 0 and Tier 1 only
+ * - v1 supports Tier 0 and Tier 1 only (V1_MAX_EXECUTION_TIER = 1)
  * - No Tier 2 or Tier 3 execution
- * - No automation / no background cleanup / no cron cleanup
- * - Selection-based execution only
- * - Confirmation prompt by default
- * - Refuses contradictory flags and scope increases
+ * - Refuses unknown or resolved action IDs
+ * - All v1 actions are idempotent
  */
 
 import fs from "node:fs/promises";
@@ -51,22 +52,11 @@ export type ExecuteRemediationOptions = {
   /** Action IDs to execute (from the plan). */
   actionIds: string[];
 
-  /** Skip interactive confirmation. */
-  skipConfirmation: boolean;
-
-  /** JSON output mode. */
-  json: boolean;
-
   /** Pre-resolved config (optional, for testing). */
   cfg?: OpenClawConfig;
 
   /** Pre-collected snapshot (optional, for testing/reuse). */
   snapshot?: SessionHealthRawSnapshot;
-};
-
-export type ExecutorRefusalError = {
-  type: "refusal";
-  message: string;
 };
 
 export type ExecutorValidationResult =

--- a/src/infra/session-health-remediation-executor.ts
+++ b/src/infra/session-health-remediation-executor.ts
@@ -1,0 +1,710 @@
+/**
+ * Session Health — Remediation Executor (Phase 3C)
+ *
+ * Executes reviewed remediation actions from a plan. The executor:
+ * 1. Re-derives a fresh plan from a fresh snapshot
+ * 2. Validates that requested actions still exist with compatible parameters
+ * 3. Shows a confirmation prompt (unless --yes)
+ * 4. Executes actions in tier order
+ * 5. Reports before/after results
+ *
+ * Hard safety boundaries:
+ * - v1 supports Tier 0 and Tier 1 only
+ * - No Tier 2 or Tier 3 execution
+ * - No automation / no background cleanup / no cron cleanup
+ * - Selection-based execution only
+ * - Confirmation prompt by default
+ * - Refuses contradictory flags and scope increases
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store.js";
+import { collectSessionHealth } from "./session-health-collector.js";
+import {
+  discoverOrphanedTmpFiles,
+  discoverOrphanTranscripts,
+  discoverStaleDeletedTranscripts,
+  discoverStaleResetTranscripts,
+  extractIndexedSessionIds,
+} from "./session-health-file-discovery.js";
+import { buildRemediationPlan } from "./session-health-remediation-plan.js";
+import type {
+  ActionExecutionResult,
+  ExecutionResult,
+  ExecutionSummary,
+  RemediationAction,
+  RemediationActionKind,
+} from "./session-health-remediation-types.js";
+import { V1_MAX_EXECUTION_TIER } from "./session-health-remediation-types.js";
+import type { SessionHealthRawSnapshot } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExecuteRemediationOptions = {
+  /** Action IDs to execute (from the plan). */
+  actionIds: string[];
+
+  /** Skip interactive confirmation. */
+  skipConfirmation: boolean;
+
+  /** JSON output mode. */
+  json: boolean;
+
+  /** Pre-resolved config (optional, for testing). */
+  cfg?: OpenClawConfig;
+
+  /** Pre-collected snapshot (optional, for testing/reuse). */
+  snapshot?: SessionHealthRawSnapshot;
+};
+
+export type ExecutorRefusalError = {
+  type: "refusal";
+  message: string;
+};
+
+export type ExecutorValidationResult =
+  | { valid: true; actions: RemediationAction[] }
+  | { valid: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Action executor registry
+// ---------------------------------------------------------------------------
+
+type ActionExecutorFn = (params: {
+  action: RemediationAction;
+  snapshot: SessionHealthRawSnapshot;
+  sessionsDir: string;
+  store: Record<string, unknown>;
+}) => Promise<ActionExecutionResult>;
+
+const ACTION_EXECUTORS: Partial<Record<RemediationActionKind, ActionExecutorFn>> = {
+  "cleanup-orphaned-tmp": executeCleanupOrphanedTmp,
+  "archive-orphan-transcripts": executeArchiveOrphanTranscripts,
+  "archive-stale-deleted-transcripts": executeArchiveStaleDeletedTranscripts,
+  "archive-stale-reset-transcripts": executeArchiveStaleResetTranscripts,
+};
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that requested action IDs can be executed against a fresh plan.
+ * Returns the actions to execute or an error message.
+ */
+export function validateExecutionRequest(
+  requestedIds: string[],
+  freshPlan: ReturnType<typeof buildRemediationPlan>,
+): ExecutorValidationResult {
+  // Build a lookup of all actions in the fresh plan
+  const planActions = new Map<string, RemediationAction>();
+  for (const tier of freshPlan.tiers) {
+    for (const action of tier.actions) {
+      planActions.set(action.id, action);
+    }
+  }
+
+  // Validate each requested ID
+  const actionsToExecute: RemediationAction[] = [];
+  for (const id of requestedIds) {
+    const action = planActions.get(id);
+    if (!action) {
+      return {
+        valid: false,
+        error: `Action '${id}' not found in current plan. The underlying condition may have resolved. Re-run --dry-run.`,
+      };
+    }
+
+    // Check tier boundary
+    if (action.tier > V1_MAX_EXECUTION_TIER) {
+      const tierLabel = action.tier === 2 ? "Index-Mutating" : "Destructive";
+      return {
+        valid: false,
+        error: `Action '${id}' is Tier ${action.tier} (${tierLabel}). v1 only supports Tier 0–1 execution. Use --dry-run to review.`,
+      };
+    }
+
+    // Check that we have an executor for this action kind
+    if (!ACTION_EXECUTORS[action.kind]) {
+      return {
+        valid: false,
+        error: `No executor available for action kind '${action.kind}'. This is an internal error.`,
+      };
+    }
+
+    actionsToExecute.push(action);
+  }
+
+  if (actionsToExecute.length === 0) {
+    return {
+      valid: false,
+      error: "All requested actions have resolved since the last dry-run. Nothing to execute.",
+    };
+  }
+
+  return { valid: true, actions: actionsToExecute };
+}
+
+/**
+ * Resolve action IDs for a tier-based execution request.
+ * --execute-tier 1 means "execute all Tier 0 + Tier 1 actions" (cumulative).
+ */
+export function resolveActionIdsForTier(
+  tier: number,
+  freshPlan: ReturnType<typeof buildRemediationPlan>,
+): string[] {
+  const ids: string[] = [];
+  for (const tierGroup of freshPlan.tiers) {
+    if (tierGroup.tier <= tier) {
+      for (const action of tierGroup.actions) {
+        ids.push(action.id);
+      }
+    }
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Core executor
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute reviewed remediation actions.
+ *
+ * This is the main entry point for Phase 3C execution.
+ * It re-derives a fresh plan, validates, executes, and reports.
+ */
+export async function executeRemediation(
+  options: ExecuteRemediationOptions,
+): Promise<ExecutionResult> {
+  const cfg = options.cfg ?? loadConfig();
+
+  // 1. Re-collect a fresh snapshot
+  const snapshot = options.snapshot ?? (await collectSessionHealth(cfg));
+
+  // 2. Re-generate the plan
+  const freshPlan = buildRemediationPlan({ snapshot });
+
+  // 3. Validate requested actions against the fresh plan
+  const validation = validateExecutionRequest(options.actionIds, freshPlan);
+  if (!validation.valid) {
+    throw new ExecutionRefusalError(validation.error);
+  }
+
+  const actionsToExecute = [...validation.actions];
+
+  // 4. Sort actions: Tier 0 before Tier 1, then by plan order
+  actionsToExecute.sort((a: RemediationAction, b: RemediationAction) => {
+    if (a.tier !== b.tier) {
+      return a.tier - b.tier;
+    }
+    return 0; // preserve plan order within tier
+  });
+
+  // 5. Resolve sessions directory and store for file operations
+  const agentId = resolveDefaultAgentId(cfg);
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const sessionsDir = path.dirname(storePath);
+  const store = loadSessionStore(storePath, { skipCache: true });
+
+  // 6. Capture "before" storage
+  const storageBefore = snapshot.storage.totalManagedBytes;
+
+  // 7. Execute each action
+  const results: ActionExecutionResult[] = [];
+  for (const action of actionsToExecute) {
+    const executor = ACTION_EXECUTORS[action.kind];
+    if (!executor) {
+      results.push({
+        id: action.id,
+        kind: action.kind,
+        tier: action.tier,
+        status: "refused",
+        artifactsRemoved: 0,
+        bytesFreed: 0,
+        error: `No executor for action kind '${action.kind}'.`,
+      });
+      continue;
+    }
+
+    try {
+      const result = await executor({
+        action,
+        snapshot,
+        sessionsDir,
+        store,
+      });
+      results.push(result);
+    } catch (err) {
+      results.push({
+        id: action.id,
+        kind: action.kind,
+        tier: action.tier,
+        status: "failed",
+        artifactsRemoved: 0,
+        bytesFreed: 0,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // 8. Re-collect snapshot for "after" storage measurement
+  let storageAfter = storageBefore;
+  try {
+    const afterSnapshot = await collectSessionHealth(cfg);
+    storageAfter = afterSnapshot.storage.totalManagedBytes;
+  } catch {
+    // Best-effort: fall back to subtracting freed bytes
+    const totalFreed = results.reduce((sum, r) => sum + r.bytesFreed, 0);
+    storageAfter = storageBefore - totalFreed;
+  }
+
+  // 9. Build summary
+  const summary: ExecutionSummary = {
+    executed: results.filter((r) => r.status === "complete").length,
+    skipped: results.filter((r) => r.status === "skipped").length,
+    failed: results.filter((r) => r.status === "failed").length,
+    refused: results.filter((r) => r.status === "refused").length,
+    totalBytesFreed: results.reduce((sum, r) => sum + r.bytesFreed, 0),
+    storageBefore,
+    storageAfter,
+  };
+
+  return {
+    executedAt: new Date().toISOString(),
+    actions: results,
+    summary,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Execution refusal error
+// ---------------------------------------------------------------------------
+
+export class ExecutionRefusalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExecutionRefusalError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Individual action executors
+// ---------------------------------------------------------------------------
+
+/**
+ * Tier 0: Delete orphaned .tmp files from crashed atomic writes.
+ */
+async function executeCleanupOrphanedTmp(params: {
+  action: RemediationAction;
+  snapshot: SessionHealthRawSnapshot;
+  sessionsDir: string;
+}): Promise<ActionExecutionResult> {
+  const { action, sessionsDir } = params;
+  const files = await discoverOrphanedTmpFiles(sessionsDir);
+
+  if (files.length === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "skipped",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      detail: "No orphaned .tmp files found (condition resolved).",
+    };
+  }
+
+  let removed = 0;
+  let bytesFreed = 0;
+  const warnings: string[] = [];
+
+  for (const file of files) {
+    try {
+      await fs.unlink(file.absolutePath);
+      removed++;
+      bytesFreed += file.size;
+    } catch (err) {
+      warnings.push(
+        `Failed to remove ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (removed === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "failed",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      error: "All file removals failed.",
+      warnings,
+    };
+  }
+
+  return {
+    id: action.id,
+    kind: action.kind,
+    tier: action.tier,
+    status: "complete",
+    artifactsRemoved: removed,
+    bytesFreed,
+    detail: `Removed ${removed} .tmp file(s).`,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+/**
+ * Tier 1: Rename orphan .jsonl files to .deleted.<timestamp>.
+ * This is a reversible operation — files are renamed, not deleted.
+ */
+async function executeArchiveOrphanTranscripts(params: {
+  action: RemediationAction;
+  snapshot: SessionHealthRawSnapshot;
+  sessionsDir: string;
+  store: Record<string, unknown>;
+}): Promise<ActionExecutionResult> {
+  const { action, sessionsDir, store } = params;
+  const indexedIds = extractIndexedSessionIds(store);
+  const files = await discoverOrphanTranscripts(sessionsDir, indexedIds);
+
+  if (files.length === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "skipped",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      detail: "No orphan transcripts found (condition resolved).",
+    };
+  }
+
+  let archived = 0;
+  let bytesFreed = 0;
+  const warnings: string[] = [];
+  const timestamp = Date.now();
+
+  for (const file of files) {
+    try {
+      const newName = file.name.replace(/\.jsonl$/, `.deleted.${timestamp}.jsonl`);
+      const newPath = path.join(sessionsDir, newName);
+      await fs.rename(file.absolutePath, newPath);
+      archived++;
+      // Renaming doesn't free disk space, but it removes the file from "active" accounting
+      // bytesFreed stays 0 for reversible operations
+    } catch (err) {
+      warnings.push(
+        `Failed to archive ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (archived === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "failed",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      error: "All archive operations failed.",
+      warnings,
+    };
+  }
+
+  return {
+    id: action.id,
+    kind: action.kind,
+    tier: action.tier,
+    status: "complete",
+    artifactsRemoved: archived,
+    bytesFreed, // 0 for rename operations
+    detail: `Archived ${archived} orphan transcript(s) to .deleted.${timestamp}.jsonl.`,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+/**
+ * Tier 1: Permanently remove .deleted transcript files past retention.
+ */
+async function executeArchiveStaleDeletedTranscripts(params: {
+  action: RemediationAction;
+  snapshot: SessionHealthRawSnapshot;
+  sessionsDir: string;
+}): Promise<ActionExecutionResult> {
+  const { action, snapshot, sessionsDir } = params;
+  const retentionMs = snapshot.maintenance.pruneAfterMs;
+  const files = await discoverStaleDeletedTranscripts(sessionsDir, retentionMs);
+
+  if (files.length === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "skipped",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      detail: "No stale .deleted transcript files found (condition resolved).",
+    };
+  }
+
+  let removed = 0;
+  let bytesFreed = 0;
+  const warnings: string[] = [];
+
+  for (const file of files) {
+    try {
+      await fs.unlink(file.absolutePath);
+      removed++;
+      bytesFreed += file.size;
+    } catch (err) {
+      warnings.push(
+        `Failed to remove ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (removed === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "failed",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      error: "All file removals failed.",
+      warnings,
+    };
+  }
+
+  return {
+    id: action.id,
+    kind: action.kind,
+    tier: action.tier,
+    status: "complete",
+    artifactsRemoved: removed,
+    bytesFreed,
+    detail: `Removed ${removed} stale .deleted file(s).`,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+/**
+ * Tier 1: Permanently remove .reset transcript archives past retention.
+ */
+async function executeArchiveStaleResetTranscripts(params: {
+  action: RemediationAction;
+  snapshot: SessionHealthRawSnapshot;
+  sessionsDir: string;
+}): Promise<ActionExecutionResult> {
+  const { action, snapshot, sessionsDir } = params;
+  const retentionMs = snapshot.maintenance.pruneAfterMs;
+  const files = await discoverStaleResetTranscripts(sessionsDir, retentionMs);
+
+  if (files.length === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "skipped",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      detail: "No stale .reset transcript files found (condition resolved).",
+    };
+  }
+
+  let removed = 0;
+  let bytesFreed = 0;
+  const warnings: string[] = [];
+
+  for (const file of files) {
+    try {
+      await fs.unlink(file.absolutePath);
+      removed++;
+      bytesFreed += file.size;
+    } catch (err) {
+      warnings.push(
+        `Failed to remove ${file.name}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (removed === 0) {
+    return {
+      id: action.id,
+      kind: action.kind,
+      tier: action.tier,
+      status: "failed",
+      artifactsRemoved: 0,
+      bytesFreed: 0,
+      error: "All file removals failed.",
+      warnings,
+    };
+  }
+
+  return {
+    id: action.id,
+    kind: action.kind,
+    tier: action.tier,
+    status: "complete",
+    artifactsRemoved: removed,
+    bytesFreed,
+    detail: `Removed ${removed} stale .reset file(s).`,
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Confirmation prompt rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the text confirmation block shown before execution.
+ */
+export function renderConfirmationBlock(actions: RemediationAction[]): string {
+  const lines: string[] = [];
+
+  lines.push("══════════════════════════════════════════════════════════");
+  lines.push("  REMEDIATION EXECUTION — CONFIRMATION REQUIRED");
+  lines.push("══════════════════════════════════════════════════════════");
+  lines.push("");
+  lines.push("  Actions to execute:");
+  lines.push("");
+
+  let totalArtifacts = 0;
+  let totalBytes = 0;
+
+  for (const action of actions) {
+    const tierLabel =
+      action.tier === 0
+        ? "Tier 0, auto-safe"
+        : action.tier === 1
+          ? "Tier 1, retention cleanup"
+          : `Tier ${action.tier}`;
+    lines.push(`  ▸ ${action.id} [${tierLabel}]`);
+    lines.push(`    ${action.description}`);
+
+    const impactParts: string[] = [];
+    if (action.estimatedImpact.affectedCount > 0) {
+      impactParts.push(`${action.estimatedImpact.affectedCount} artifact(s)`);
+      totalArtifacts += action.estimatedImpact.affectedCount;
+    }
+    if ((action.estimatedImpact.estimatedBytes ?? 0) > 0) {
+      impactParts.push(formatBytes(action.estimatedImpact.estimatedBytes ?? 0));
+      totalBytes += action.estimatedImpact.estimatedBytes ?? 0;
+    }
+    if (impactParts.length > 0) {
+      lines.push(`    Impact: ${impactParts.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  const summaryParts: string[] = [`${actions.length} action(s)`];
+  if (totalArtifacts > 0) {
+    summaryParts.push(`${totalArtifacts} artifact(s)`);
+  }
+  if (totalBytes > 0) {
+    summaryParts.push(`~${formatBytes(totalBytes)}`);
+  }
+  lines.push(`  Total: ${summaryParts.join(", ")}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Render the execution result report (text mode).
+ */
+export function renderExecutionReportText(result: ExecutionResult): string {
+  const lines: string[] = [];
+
+  lines.push("══════════════════════════════════════════════════════════");
+  lines.push("  REMEDIATION EXECUTION — COMPLETE");
+  lines.push("══════════════════════════════════════════════════════════");
+  lines.push("");
+  lines.push(`  Executed: ${result.summary.executed} action(s)`);
+  lines.push(`  Skipped:  ${result.summary.skipped}`);
+  lines.push(`  Failed:   ${result.summary.failed}`);
+  if (result.summary.refused > 0) {
+    lines.push(`  Refused:  ${result.summary.refused}`);
+  }
+  lines.push("");
+
+  for (const action of result.actions) {
+    lines.push(`  ── ${action.id} ──`);
+
+    const statusIcon =
+      action.status === "complete"
+        ? "✓"
+        : action.status === "skipped"
+          ? "○"
+          : action.status === "refused"
+            ? "✕"
+            : "✗";
+    lines.push(`  Status:   ${statusIcon} ${action.status}`);
+
+    if (action.detail) {
+      lines.push(`  Detail:   ${action.detail}`);
+    }
+    if (action.artifactsRemoved > 0) {
+      lines.push(`  Removed:  ${action.artifactsRemoved} artifact(s)`);
+    }
+    if (action.bytesFreed > 0) {
+      lines.push(`  Freed:    ${formatBytes(action.bytesFreed)}`);
+    }
+    if (action.error) {
+      lines.push(`  Error:    ${action.error}`);
+    }
+    if (action.warnings && action.warnings.length > 0) {
+      for (const w of action.warnings) {
+        lines.push(`  Warning:  ${w}`);
+      }
+    }
+    lines.push("");
+  }
+
+  lines.push("  ── Storage Summary ──");
+  lines.push(`  Before:   ${formatBytes(result.summary.storageBefore)} total managed`);
+  lines.push(`  After:    ${formatBytes(result.summary.storageAfter)} total managed`);
+  const freed = result.summary.storageBefore - result.summary.storageAfter;
+  if (freed > 0) {
+    const pct =
+      result.summary.storageBefore > 0
+        ? ((freed / result.summary.storageBefore) * 100).toFixed(1)
+        : "0.0";
+    lines.push(`  Freed:    ${formatBytes(freed)} (${pct}%)`);
+  } else {
+    lines.push(`  Freed:    0 B`);
+  }
+  lines.push("");
+  lines.push("══════════════════════════════════════════════════════════");
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers (local — same as in remediation-plan.ts)
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}

--- a/src/infra/session-health-remediation-executor.ts
+++ b/src/infra/session-health-remediation-executor.ts
@@ -34,6 +34,7 @@ import path from "node:path";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
+import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store.js";
 import { collectSessionHealth } from "./session-health-collector.js";
@@ -370,7 +371,8 @@ async function executeCleanupOrphanedTmp(params: {
 }
 
 /**
- * Tier 1: Rename orphan .jsonl files to .deleted.<timestamp>.
+ * Tier 1: Rename orphan .jsonl files using the canonical archive format
+ * (e.g. `foo.jsonl.deleted.2026-03-21T18-46-00.123Z`).
  * This is a reversible operation — files are renamed, not deleted.
  */
 async function executeArchiveOrphanTranscripts(params: {
@@ -398,11 +400,18 @@ async function executeArchiveOrphanTranscripts(params: {
   let archived = 0;
   let bytesFreed = 0;
   const warnings: string[] = [];
-  const timestamp = Date.now();
+  // Use the canonical archive timestamp format from artifacts.ts so the
+  // resulting filenames are recognized by isSessionArchiveArtifactName(),
+  // parseSessionArchiveTimestamp(), and the disk-budget helpers.
+  const archiveStamp = formatSessionArchiveTimestamp();
 
   for (const file of files) {
     try {
-      const newName = file.name.replace(/\.jsonl$/, `.deleted.${timestamp}.jsonl`);
+      // Canonical pattern: append `.deleted.<iso-stamp>` after the full
+      // filename (e.g. `foo.jsonl.deleted.2026-03-21T18-46-00.123Z`).
+      // This matches the format used by `doctor --fix` and the disk-budget
+      // sweep, and is recognized by the artifacts.ts helpers.
+      const newName = `${file.name}.deleted.${archiveStamp}`;
       const newPath = path.join(sessionsDir, newName);
       await fs.rename(file.absolutePath, newPath);
       archived++;
@@ -435,7 +444,7 @@ async function executeArchiveOrphanTranscripts(params: {
     status: "complete",
     artifactsRemoved: archived,
     bytesFreed, // 0 for rename operations
-    detail: `Archived ${archived} orphan transcript(s) to .deleted.${timestamp}.jsonl.`,
+    detail: `Archived ${archived} orphan transcript(s) to .deleted.${archiveStamp}.`,
     ...(warnings.length > 0 ? { warnings } : {}),
   };
 }

--- a/src/infra/session-health-remediation-executor.ts
+++ b/src/infra/session-health-remediation-executor.ts
@@ -16,6 +16,17 @@
  * - No Tier 2 or Tier 3 execution
  * - Refuses unknown or resolved action IDs
  * - All v1 actions are idempotent
+ *
+ * v1 scope limitation — default agent only:
+ * The collector scans ALL configured agents and merges counts into one
+ * snapshot. The plan is therefore derived across all agents. However, the
+ * executor resolves a single `sessionsDir` via `resolveDefaultAgentId()`.
+ * This means v1 execution only touches files belonging to the default agent.
+ * Files in other agents' session directories may appear in the plan's
+ * estimated counts but will not be acted on by the executor. The executor
+ * re-discovers files at execution time, so it will naturally skip/report
+ * fewer artifacts than the plan estimated when cross-agent items are involved.
+ * Multi-agent execution is a future enhancement (tracked in the plan).
  */
 
 import fs from "node:fs/promises";
@@ -198,7 +209,11 @@ export async function executeRemediation(
     return 0; // preserve plan order within tier
   });
 
-  // 5. Resolve sessions directory and store for file operations
+  // 5. Resolve sessions directory and store for file operations.
+  //    v1 limitation: executor operates on the default agent only. The plan
+  //    may include counts from other agents' directories, but execution
+  //    only touches files in this single sessionsDir. Re-discovery at
+  //    execution time ensures we never act on stale/mismatched counts.
   const agentId = resolveDefaultAgentId(cfg);
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   const sessionsDir = path.dirname(storePath);
@@ -271,6 +286,7 @@ export async function executeRemediation(
     executedAt: new Date().toISOString(),
     actions: results,
     summary,
+    agentScope: agentId,
   };
 }
 

--- a/src/infra/session-health-remediation-plan.test.ts
+++ b/src/infra/session-health-remediation-plan.test.ts
@@ -606,6 +606,40 @@ describe("renderRemediationPlanText", () => {
     expect(text).toContain("Generated:");
     expect(text).toContain("Snapshot:");
   });
+
+  it("Tier 1 renders with [review list first], not [auto-safe]", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        diskFilesWithoutIndex: 2,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const text = renderRemediationPlanText(plan);
+    // Tier 1 should NOT carry the auto-safe tag
+    expect(text).toContain("Tier 1");
+    expect(text).toContain("[review list first]");
+    // The auto-safe tag should only appear on Tier 0 if present
+    const tier1Section = text.split("Tier 1")[1] ?? "";
+    expect(tier1Section).not.toContain("[auto-safe]");
+  });
+
+  it("remediation plan header explains per-class vs global distinction", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 1,
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        orphanedTempBytes: 512,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const text = renderRemediationPlanText(plan);
+    expect(text).toContain("per-class retention");
+    expect(text).toContain("global age threshold");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/infra/session-health-remediation-plan.test.ts
+++ b/src/infra/session-health-remediation-plan.test.ts
@@ -41,6 +41,13 @@ function baseSnapshot(overrides?: Partial<SessionHealthRawSnapshot>): SessionHea
         thread: 2,
         unknown: 0,
       },
+      // staleByClass reflects age-filtered counts (sessions past retention threshold)
+      staleByClass: {
+        "cron-run": 12,
+        subagent: 4,
+        acp: 2,
+        heartbeat: 1,
+      },
       byDiskState: {
         active: 40,
         deleted: 5,
@@ -105,6 +112,7 @@ describe("buildRemediationPlan", () => {
           thread: 2,
           unknown: 0,
         },
+        staleByClass: undefined,
         byDiskState: {
           active: 14,
           deleted: 0,
@@ -245,7 +253,7 @@ describe("Tier 2: index-mutating actions", () => {
     expect(action?.prerequisites).toContain("archive-orphan-transcripts");
   });
 
-  it("proposes pruning stale cron-run sessions", () => {
+  it("proposes pruning stale cron-run sessions using stale count, not total", () => {
     const snapshot = baseSnapshot();
     const plan = buildRemediationPlan({ snapshot });
     const action = plan.tiers
@@ -254,34 +262,41 @@ describe("Tier 2: index-mutating actions", () => {
     expect(action).toBeDefined();
     expect(action?.tier).toBe(2);
     expect(action?.estimatedImpact.affectedClasses).toContain("cron-run");
-    expect(action?.estimatedImpact.affectedCount).toBe(20); // 20 cron-run sessions
+    // Uses staleByClass count (12), NOT total byClass count (20)
+    expect(action?.estimatedImpact.affectedCount).toBe(12);
   });
 
-  it("proposes pruning stale subagent sessions", () => {
+  it("proposes pruning stale subagent sessions using stale count", () => {
     const snapshot = baseSnapshot();
     const plan = buildRemediationPlan({ snapshot });
     const action = plan.tiers
       .flatMap((t) => t.actions)
       .find((a) => a.kind === "prune-stale-subagents");
     expect(action).toBeDefined();
-    expect(action?.estimatedImpact.affectedCount).toBe(10); // 10 subagent sessions
+    // Uses staleByClass count (4), NOT total byClass count (10)
+    expect(action?.estimatedImpact.affectedCount).toBe(4);
   });
 
-  it("proposes pruning stale ACP sessions", () => {
+  it("proposes pruning stale ACP sessions using stale count", () => {
     const snapshot = baseSnapshot();
     const plan = buildRemediationPlan({ snapshot });
     const action = plan.tiers.flatMap((t) => t.actions).find((a) => a.kind === "prune-stale-acp");
     expect(action).toBeDefined();
-    expect(action?.estimatedImpact.affectedCount).toBe(5); // 5 ACP sessions
+    // Uses staleByClass count (2), NOT total byClass count (5)
+    expect(action?.estimatedImpact.affectedCount).toBe(2);
   });
 
-  it("does not propose pruning when class count is zero", () => {
+  it("does not propose pruning when stale count is zero even if total is nonzero", () => {
     const snapshot = baseSnapshot({
       sessions: {
         ...baseSnapshot().sessions,
         byClass: {
           ...baseSnapshot().sessions.byClass,
-          heartbeat: 0,
+          heartbeat: 5, // 5 total heartbeat sessions...
+        },
+        staleByClass: {
+          ...baseSnapshot().sessions.staleByClass,
+          heartbeat: 0, // ...but none are stale
         },
       },
     });
@@ -290,6 +305,20 @@ describe("Tier 2: index-mutating actions", () => {
       .flatMap((t) => t.actions)
       .find((a) => a.kind === "prune-stale-heartbeats");
     expect(action).toBeUndefined();
+  });
+
+  it("does not propose pruning when staleByClass is missing", () => {
+    const snapshot = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        staleByClass: undefined,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const pruneActions = plan.tiers
+      .flatMap((t) => t.actions)
+      .filter((a) => a.kind.startsWith("prune-stale-"));
+    expect(pruneActions).toHaveLength(0);
   });
 });
 
@@ -361,7 +390,7 @@ describe("plan summary", () => {
 // ---------------------------------------------------------------------------
 
 describe("approval model", () => {
-  it("correctly partitions all action kinds across approval categories", () => {
+  it("only includes action kinds active in the current plan", () => {
     const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
     const allKinds = new Set([
       ...plan.approvalModel.autoApprovable,
@@ -370,35 +399,64 @@ describe("approval model", () => {
       ...plan.approvalModel.neverAutomate,
     ]);
 
-    // Every defined action kind should be in exactly one category
-    for (const kind of Object.keys(ACTION_KIND_TIERS) as (keyof typeof ACTION_KIND_TIERS)[]) {
-      expect(allKinds.has(kind)).toBe(true);
+    // Every kind in the approval model should correspond to an action in the plan
+    const planActionKinds = new Set(plan.tiers.flatMap((t) => t.actions.map((a) => a.kind)));
+    for (const kind of allKinds) {
+      expect(planActionKinds.has(kind)).toBe(true);
     }
+
+    // Inactive kinds (e.g., cleanup-orphaned-tmp when orphanedTempCount=0) should not appear
+    expect(allKinds.has("cleanup-orphaned-tmp")).toBe(false); // No orphaned tmp in base snapshot
   });
 
-  it("cleanup-orphaned-tmp is auto-approvable", () => {
-    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+  it("includes cleanup-orphaned-tmp when orphaned temps exist", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 1,
+        oldestOrphanedTempAt: "2026-03-19T00:00:00.000Z",
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        orphanedTempBytes: 512,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
     expect(plan.approvalModel.autoApprovable).toContain("cleanup-orphaned-tmp");
   });
 
-  it("archive actions are preview-then-automate", () => {
+  it("archive actions are preview-then-automate when present", () => {
     const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
-    expect(plan.approvalModel.previewThenAutomate).toContain("archive-orphan-transcripts");
+    // baseSnapshot has deleted and reset transcripts, so these should be present
     expect(plan.approvalModel.previewThenAutomate).toContain("archive-stale-deleted-transcripts");
     expect(plan.approvalModel.previewThenAutomate).toContain("archive-stale-reset-transcripts");
   });
 
-  it("prune actions require explicit approval", () => {
+  it("prune actions require explicit approval when present", () => {
     const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    // baseSnapshot has staleByClass entries for cron-run
     expect(plan.approvalModel.explicitApprovalRequired).toContain("prune-stale-cron-runs");
-    expect(plan.approvalModel.explicitApprovalRequired).toContain("reconcile-index-phantoms");
   });
 
-  it("destructive actions are never-automate", () => {
-    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+  it("destructive actions are never-automate when present", () => {
+    const snapshot = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        maxDiskBytes: 30 * 1024 * 1024, // 30 MB budget
+        usagePercent: {
+          entries: 10,
+          diskBytes: 167, // way over
+        },
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
     expect(plan.approvalModel.neverAutomate).toContain("enforce-disk-budget");
-    expect(plan.approvalModel.neverAutomate).toContain("purge-archived-artifacts");
-    expect(plan.approvalModel.neverAutomate).toContain("bulk-class-prune");
+  });
+
+  it("does not include inactive kinds like purge-archived-artifacts or bulk-class-prune when no action uses them", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(plan.approvalModel.neverAutomate).not.toContain("purge-archived-artifacts");
+    expect(plan.approvalModel.neverAutomate).not.toContain("bulk-class-prune");
   });
 });
 
@@ -463,6 +521,10 @@ describe("includeNoOpActions", () => {
           ...baseSnapshot().sessions.byClass,
           heartbeat: 0,
         },
+        staleByClass: {
+          ...baseSnapshot().sessions.staleByClass,
+          heartbeat: 0,
+        },
       },
     });
     const plan = buildRemediationPlan({ snapshot });
@@ -494,6 +556,7 @@ describe("renderRemediationPlanText", () => {
           thread: 0,
           unknown: 0,
         },
+        staleByClass: undefined,
         byDiskState: {
           active: 2,
           deleted: 0,

--- a/src/infra/session-health-remediation-plan.test.ts
+++ b/src/infra/session-health-remediation-plan.test.ts
@@ -63,6 +63,14 @@ function baseSnapshot(overrides?: Partial<SessionHealthRawSnapshot>): SessionHea
       resetTranscriptBytes: 20 * 1024 * 1024,
       orphanedTempBytes: 0,
     },
+    // staleArtifacts: retention-filtered counts for .deleted/.reset files.
+    // 3 of 5 deleted and 7 of 10 reset files are past retention.
+    staleArtifacts: {
+      staleDeletedCount: 3,
+      staleDeletedBytes: 3 * 1024 * 1024,
+      staleResetCount: 7,
+      staleResetBytes: 14 * 1024 * 1024,
+    },
     drift: {
       indexedWithoutDiskFile: 0,
       diskFilesWithoutIndex: 0,
@@ -209,7 +217,7 @@ describe("Tier 1: archive actions", () => {
     expect(action?.estimatedImpact.affectedCount).toBe(5);
   });
 
-  it("proposes stale deleted transcript cleanup when present", () => {
+  it("proposes stale deleted transcript cleanup using retention-filtered count", () => {
     const snapshot = baseSnapshot();
     const plan = buildRemediationPlan({ snapshot });
     const action = plan.tiers
@@ -217,10 +225,14 @@ describe("Tier 1: archive actions", () => {
       .find((a) => a.kind === "archive-stale-deleted-transcripts");
     expect(action).toBeDefined();
     expect(action?.tier).toBe(1);
-    expect(action?.estimatedImpact.affectedCount).toBe(5); // 5 deleted files
+    // Uses staleArtifacts.staleDeletedCount (3), NOT total byDiskState.deleted (5)
+    expect(action?.estimatedImpact.affectedCount).toBe(3);
+    expect(action?.estimatedImpact.estimatedBytes).toBe(3 * 1024 * 1024);
+    // Description should mention files within retention
+    expect(action?.description).toContain("2 more within retention");
   });
 
-  it("proposes stale reset transcript cleanup when present", () => {
+  it("proposes stale reset transcript cleanup using retention-filtered count", () => {
     const snapshot = baseSnapshot();
     const plan = buildRemediationPlan({ snapshot });
     const action = plan.tiers
@@ -228,6 +240,11 @@ describe("Tier 1: archive actions", () => {
       .find((a) => a.kind === "archive-stale-reset-transcripts");
     expect(action).toBeDefined();
     expect(action?.tier).toBe(1);
+    // Uses staleArtifacts.staleResetCount (7), NOT total byDiskState.reset (10)
+    expect(action?.estimatedImpact.affectedCount).toBe(7);
+    expect(action?.estimatedImpact.estimatedBytes).toBe(14 * 1024 * 1024);
+    // Description should mention files within retention
+    expect(action?.description).toContain("3 more within retention");
   });
 });
 
@@ -305,6 +322,43 @@ describe("Tier 2: index-mutating actions", () => {
       .flatMap((t) => t.actions)
       .find((a) => a.kind === "prune-stale-heartbeats");
     expect(action).toBeUndefined();
+  });
+
+  it("falls back to total disk-state counts when staleArtifacts is missing", () => {
+    const snapshot = baseSnapshot({
+      staleArtifacts: undefined, // Simulate older snapshot without this field
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const deletedAction = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "archive-stale-deleted-transcripts");
+    expect(deletedAction).toBeDefined();
+    // Falls back to byDiskState.deleted (5)
+    expect(deletedAction?.estimatedImpact.affectedCount).toBe(5);
+
+    const resetAction = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "archive-stale-reset-transcripts");
+    expect(resetAction).toBeDefined();
+    // Falls back to byDiskState.reset (10)
+    expect(resetAction?.estimatedImpact.affectedCount).toBe(10);
+  });
+
+  it("omits stale deleted action when all files are within retention", () => {
+    const snapshot = baseSnapshot({
+      staleArtifacts: {
+        staleDeletedCount: 0,
+        staleDeletedBytes: 0,
+        staleResetCount: 7,
+        staleResetBytes: 14 * 1024 * 1024,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const deletedAction = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "archive-stale-deleted-transcripts");
+    // All .deleted files are within retention, so no action should be proposed
+    expect(deletedAction).toBeUndefined();
   });
 
   it("does not propose pruning when staleByClass is missing", () => {

--- a/src/infra/session-health-remediation-plan.test.ts
+++ b/src/infra/session-health-remediation-plan.test.ts
@@ -1,0 +1,581 @@
+/**
+ * Session Health — Remediation Plan Builder Tests
+ *
+ * Tests the pure plan generation logic. Verifies that:
+ * - Plans are correctly generated from snapshots
+ * - Actions are tiered correctly
+ * - Zero-impact actions are omitted by default
+ * - The approval model is correctly computed
+ * - The text renderer produces readable output
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildRemediationPlan,
+  renderRemediationPlanText,
+} from "./session-health-remediation-plan.js";
+import { ACTION_KIND_TIERS } from "./session-health-remediation-types.js";
+import type { SessionHealthRawSnapshot } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Fixture builder
+// ---------------------------------------------------------------------------
+
+function baseSnapshot(overrides?: Partial<SessionHealthRawSnapshot>): SessionHealthRawSnapshot {
+  return {
+    capturedAt: "2026-03-20T18:00:00.000Z",
+    collectorDurationMs: 42,
+    sessions: {
+      indexedCount: 50,
+      sessionsJsonBytes: 100_000,
+      sessionsJsonParseTimeMs: 5,
+      byClass: {
+        main: 2,
+        channel: 5,
+        direct: 3,
+        "cron-definition": 2,
+        "cron-run": 20,
+        subagent: 10,
+        acp: 5,
+        heartbeat: 1,
+        thread: 2,
+        unknown: 0,
+      },
+      byDiskState: {
+        active: 40,
+        deleted: 5,
+        reset: 10,
+        orphanedTemp: 0,
+      },
+    },
+    storage: {
+      totalManagedBytes: 50 * 1024 * 1024,
+      sessionsJsonBytes: 100_000,
+      activeTranscriptBytes: 20 * 1024 * 1024,
+      deletedTranscriptBytes: 5 * 1024 * 1024,
+      resetTranscriptBytes: 20 * 1024 * 1024,
+      orphanedTempBytes: 0,
+    },
+    drift: {
+      indexedWithoutDiskFile: 0,
+      diskFilesWithoutIndex: 0,
+      orphanedTempCount: 0,
+      oldestOrphanedTempAt: null,
+      reconciliationRecommended: false,
+    },
+    maintenance: {
+      mode: "warn",
+      maxEntries: 500,
+      pruneAfterMs: 7 * 24 * 60 * 60 * 1000,
+      maxDiskBytes: null,
+      usagePercent: {
+        entries: 10,
+        diskBytes: null,
+      },
+    },
+    growth: {
+      sessionsBytes24h: null,
+      sessionsBytes7d: null,
+      indexedCount24h: null,
+      indexedCount7d: null,
+    },
+    agents: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Basic plan generation
+// ---------------------------------------------------------------------------
+
+describe("buildRemediationPlan", () => {
+  it("returns an empty plan when snapshot is clean", () => {
+    const snapshot = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        byClass: {
+          main: 2,
+          channel: 5,
+          direct: 3,
+          "cron-definition": 2,
+          "cron-run": 0,
+          subagent: 0,
+          acp: 0,
+          heartbeat: 0,
+          thread: 2,
+          unknown: 0,
+        },
+        byDiskState: {
+          active: 14,
+          deleted: 0,
+          reset: 0,
+          orphanedTemp: 0,
+        },
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        deletedTranscriptBytes: 0,
+        resetTranscriptBytes: 0,
+        orphanedTempBytes: 0,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    expect(plan.summary.totalActions).toBe(0);
+    expect(plan.tiers).toHaveLength(0);
+    expect(plan.summary.recommendation).toContain("No remediation actions");
+  });
+
+  it("includes generated/snapshot timestamps", () => {
+    const snapshot = baseSnapshot();
+    const plan = buildRemediationPlan({ snapshot });
+    expect(plan.generatedAt).toBeTruthy();
+    expect(plan.snapshotAt).toBe(snapshot.capturedAt);
+  });
+
+  it("always produces a valid approval model", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(plan.approvalModel).toBeDefined();
+    expect(plan.approvalModel.autoApprovable).toBeInstanceOf(Array);
+    expect(plan.approvalModel.previewThenAutomate).toBeInstanceOf(Array);
+    expect(plan.approvalModel.explicitApprovalRequired).toBeInstanceOf(Array);
+    expect(plan.approvalModel.neverAutomate).toBeInstanceOf(Array);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 0 — Auto-Safe
+// ---------------------------------------------------------------------------
+
+describe("Tier 0: cleanup-orphaned-tmp", () => {
+  it("proposes tmp cleanup when orphaned temp files exist", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 3,
+        oldestOrphanedTempAt: "2026-03-19T10:00:00.000Z",
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        orphanedTempBytes: 8192,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const tmpAction = plan.tiers
+      .find((t) => t.tier === 0)
+      ?.actions.find((a) => a.kind === "cleanup-orphaned-tmp");
+    expect(tmpAction).toBeDefined();
+    expect(tmpAction?.tier).toBe(0);
+    expect(tmpAction?.estimatedImpact.affectedCount).toBe(3);
+    expect(tmpAction?.estimatedImpact.estimatedBytes).toBe(8192);
+    expect(tmpAction?.reversible).toBe(false);
+  });
+
+  it("skips tmp cleanup when no orphaned temp files", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    const tmpActions = plan.tiers
+      .flatMap((t) => t.actions)
+      .filter((a) => a.kind === "cleanup-orphaned-tmp");
+    expect(tmpActions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 1 — Reversible
+// ---------------------------------------------------------------------------
+
+describe("Tier 1: archive actions", () => {
+  it("proposes orphan transcript archival when drift exists", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        diskFilesWithoutIndex: 5,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "archive-orphan-transcripts");
+    expect(action).toBeDefined();
+    expect(action?.tier).toBe(1);
+    expect(action?.reversible).toBe(true);
+    expect(action?.estimatedImpact.affectedCount).toBe(5);
+  });
+
+  it("proposes stale deleted transcript cleanup when present", () => {
+    const snapshot = baseSnapshot();
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "archive-stale-deleted-transcripts");
+    expect(action).toBeDefined();
+    expect(action?.tier).toBe(1);
+    expect(action?.estimatedImpact.affectedCount).toBe(5); // 5 deleted files
+  });
+
+  it("proposes stale reset transcript cleanup when present", () => {
+    const snapshot = baseSnapshot();
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "archive-stale-reset-transcripts");
+    expect(action).toBeDefined();
+    expect(action?.tier).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2 — Index-Mutating
+// ---------------------------------------------------------------------------
+
+describe("Tier 2: index-mutating actions", () => {
+  it("proposes phantom reconciliation when index drift exists", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 8,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "reconcile-index-phantoms");
+    expect(action).toBeDefined();
+    expect(action?.tier).toBe(2);
+    expect(action?.estimatedImpact.affectedCount).toBe(8);
+    expect(action?.prerequisites).toContain("archive-orphan-transcripts");
+  });
+
+  it("proposes pruning stale cron-run sessions", () => {
+    const snapshot = baseSnapshot();
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "prune-stale-cron-runs");
+    expect(action).toBeDefined();
+    expect(action?.tier).toBe(2);
+    expect(action?.estimatedImpact.affectedClasses).toContain("cron-run");
+    expect(action?.estimatedImpact.affectedCount).toBe(20); // 20 cron-run sessions
+  });
+
+  it("proposes pruning stale subagent sessions", () => {
+    const snapshot = baseSnapshot();
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "prune-stale-subagents");
+    expect(action).toBeDefined();
+    expect(action?.estimatedImpact.affectedCount).toBe(10); // 10 subagent sessions
+  });
+
+  it("proposes pruning stale ACP sessions", () => {
+    const snapshot = baseSnapshot();
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers.flatMap((t) => t.actions).find((a) => a.kind === "prune-stale-acp");
+    expect(action).toBeDefined();
+    expect(action?.estimatedImpact.affectedCount).toBe(5); // 5 ACP sessions
+  });
+
+  it("does not propose pruning when class count is zero", () => {
+    const snapshot = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        byClass: {
+          ...baseSnapshot().sessions.byClass,
+          heartbeat: 0,
+        },
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "prune-stale-heartbeats");
+    expect(action).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 3 — Destructive
+// ---------------------------------------------------------------------------
+
+describe("Tier 3: destructive actions", () => {
+  it("proposes disk budget enforcement only when over budget", () => {
+    const snapshot = baseSnapshot({
+      maintenance: {
+        ...baseSnapshot().maintenance,
+        maxDiskBytes: 30 * 1024 * 1024, // 30 MB budget
+        usagePercent: {
+          entries: 10,
+          diskBytes: 167, // way over
+        },
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "enforce-disk-budget");
+    expect(action).toBeDefined();
+    expect(action?.tier).toBe(3);
+    expect(action?.reversible).toBe(false);
+  });
+
+  it("does not propose disk budget when not configured", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    const action = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "enforce-disk-budget");
+    expect(action).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Summary and recommendation
+// ---------------------------------------------------------------------------
+
+describe("plan summary", () => {
+  it("counts actions by tier", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 2,
+        oldestOrphanedTempAt: "2026-03-19T10:00:00.000Z",
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        orphanedTempBytes: 1024,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    // Should have Tier 0 (orphaned tmp) + Tier 1 (deleted/reset archives) + Tier 2 (cron/subagent prune)
+    expect(plan.summary.totalActions).toBeGreaterThan(0);
+    expect(plan.summary.actionCountByTier[0]).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes recoverable bytes estimate", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(typeof plan.summary.estimatedRecoverableBytes).toBe("number");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approval model
+// ---------------------------------------------------------------------------
+
+describe("approval model", () => {
+  it("correctly partitions all action kinds across approval categories", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    const allKinds = new Set([
+      ...plan.approvalModel.autoApprovable,
+      ...plan.approvalModel.previewThenAutomate,
+      ...plan.approvalModel.explicitApprovalRequired,
+      ...plan.approvalModel.neverAutomate,
+    ]);
+
+    // Every defined action kind should be in exactly one category
+    for (const kind of Object.keys(ACTION_KIND_TIERS) as (keyof typeof ACTION_KIND_TIERS)[]) {
+      expect(allKinds.has(kind)).toBe(true);
+    }
+  });
+
+  it("cleanup-orphaned-tmp is auto-approvable", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(plan.approvalModel.autoApprovable).toContain("cleanup-orphaned-tmp");
+  });
+
+  it("archive actions are preview-then-automate", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(plan.approvalModel.previewThenAutomate).toContain("archive-orphan-transcripts");
+    expect(plan.approvalModel.previewThenAutomate).toContain("archive-stale-deleted-transcripts");
+    expect(plan.approvalModel.previewThenAutomate).toContain("archive-stale-reset-transcripts");
+  });
+
+  it("prune actions require explicit approval", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(plan.approvalModel.explicitApprovalRequired).toContain("prune-stale-cron-runs");
+    expect(plan.approvalModel.explicitApprovalRequired).toContain("reconcile-index-phantoms");
+  });
+
+  it("destructive actions are never-automate", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    expect(plan.approvalModel.neverAutomate).toContain("enforce-disk-budget");
+    expect(plan.approvalModel.neverAutomate).toContain("purge-archived-artifacts");
+    expect(plan.approvalModel.neverAutomate).toContain("bulk-class-prune");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier groups
+// ---------------------------------------------------------------------------
+
+describe("tier groups", () => {
+  it("groups are sorted by tier ascending", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 1,
+        oldestOrphanedTempAt: "2026-03-19T00:00:00.000Z",
+        indexedWithoutDiskFile: 3,
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        orphanedTempBytes: 512,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const tierNumbers = plan.tiers.map((t) => t.tier);
+    expect(tierNumbers).toEqual([...tierNumbers].toSorted((a, b) => a - b));
+  });
+
+  it("tier 0 and 1 do not require approval", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    for (const tier of plan.tiers) {
+      if (tier.tier <= 1) {
+        expect(tier.approvalRequired).toBe(false);
+      }
+    }
+  });
+
+  it("tier 2 and 3 require approval", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        indexedWithoutDiskFile: 10,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    for (const tier of plan.tiers) {
+      if (tier.tier >= 2) {
+        expect(tier.approvalRequired).toBe(true);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// includeNoOpActions option
+// ---------------------------------------------------------------------------
+
+describe("includeNoOpActions", () => {
+  it("omits zero-impact actions by default", () => {
+    const snapshot = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        byClass: {
+          ...baseSnapshot().sessions.byClass,
+          heartbeat: 0,
+        },
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const heartbeatAction = plan.tiers
+      .flatMap((t) => t.actions)
+      .find((a) => a.kind === "prune-stale-heartbeats");
+    expect(heartbeatAction).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Text renderer
+// ---------------------------------------------------------------------------
+
+describe("renderRemediationPlanText", () => {
+  it("renders a clean plan", () => {
+    const snapshot = baseSnapshot({
+      sessions: {
+        ...baseSnapshot().sessions,
+        byClass: {
+          main: 2,
+          channel: 0,
+          direct: 0,
+          "cron-definition": 0,
+          "cron-run": 0,
+          subagent: 0,
+          acp: 0,
+          heartbeat: 0,
+          thread: 0,
+          unknown: 0,
+        },
+        byDiskState: {
+          active: 2,
+          deleted: 0,
+          reset: 0,
+          orphanedTemp: 0,
+        },
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        deletedTranscriptBytes: 0,
+        resetTranscriptBytes: 0,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const text = renderRemediationPlanText(plan);
+    expect(text).toContain("DRY RUN");
+    expect(text).toContain("No remediation actions needed");
+  });
+
+  it("renders a plan with actions", () => {
+    const snapshot = baseSnapshot({
+      drift: {
+        ...baseSnapshot().drift,
+        orphanedTempCount: 2,
+        oldestOrphanedTempAt: "2026-03-19T00:00:00.000Z",
+        diskFilesWithoutIndex: 3,
+      },
+      storage: {
+        ...baseSnapshot().storage,
+        orphanedTempBytes: 4096,
+      },
+    });
+    const plan = buildRemediationPlan({ snapshot });
+    const text = renderRemediationPlanText(plan);
+    expect(text).toContain("DRY RUN");
+    expect(text).toContain("Tier 0");
+    expect(text).toContain("Auto-Safe");
+    expect(text).toContain("orphaned temp");
+    expect(text).toContain("Approval Model");
+    expect(text).toContain("No changes have been made");
+  });
+
+  it("includes tier descriptions and labels", () => {
+    const plan = buildRemediationPlan({ snapshot: baseSnapshot() });
+    const text = renderRemediationPlanText(plan);
+    expect(text).toContain("REMEDIATION PLAN");
+    expect(text).toContain("Generated:");
+    expect(text).toContain("Snapshot:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action kind tier mapping is complete
+// ---------------------------------------------------------------------------
+
+describe("ACTION_KIND_TIERS completeness", () => {
+  it("every action kind has a defined tier", () => {
+    const allKinds: string[] = [
+      "cleanup-orphaned-tmp",
+      "archive-orphan-transcripts",
+      "archive-stale-deleted-transcripts",
+      "archive-stale-reset-transcripts",
+      "reconcile-index-phantoms",
+      "prune-stale-cron-runs",
+      "prune-stale-subagents",
+      "prune-stale-heartbeats",
+      "prune-stale-acp",
+      "enforce-disk-budget",
+      "purge-archived-artifacts",
+      "bulk-class-prune",
+    ];
+    for (const kind of allKinds) {
+      expect(ACTION_KIND_TIERS).toHaveProperty(kind);
+      const tier = ACTION_KIND_TIERS[kind as keyof typeof ACTION_KIND_TIERS];
+      expect(tier).toBeGreaterThanOrEqual(0);
+      expect(tier).toBeLessThanOrEqual(3);
+    }
+  });
+
+  it("all defined tiers are valid", () => {
+    for (const [_kind, tier] of Object.entries(ACTION_KIND_TIERS)) {
+      expect([0, 1, 2, 3]).toContain(tier);
+    }
+  });
+});

--- a/src/infra/session-health-remediation-plan.ts
+++ b/src/infra/session-health-remediation-plan.ts
@@ -428,9 +428,7 @@ function buildRecommendation(
     parts.push(`${countByTier[0]} auto-safe action(s) can run immediately`);
   }
   if (countByTier[1] > 0) {
-    parts.push(
-      `${countByTier[1]} Tier 1 archive/retention action(s) should be previewed before enabling`,
-    );
+    parts.push(`${countByTier[1]} retention cleanup action(s) — review list before enabling`);
   }
   if (countByTier[2] > 0) {
     parts.push(`${countByTier[2]} index-mutating action(s) require explicit approval`);
@@ -532,7 +530,9 @@ export function renderRemediationPlanText(plan: RemediationPlan): string {
   const lines: string[] = [];
 
   lines.push("═══════════════════════════════════════════════════════════════");
-  lines.push("  SESSION HEALTH — REMEDIATION PLAN (DRY RUN)");
+  lines.push("  REMEDIATION PLAN (DRY RUN)");
+  lines.push("  Lifecycle review — uses per-class retention, may differ from");
+  lines.push("  the global age threshold in the maintenance preview above");
   lines.push("═══════════════════════════════════════════════════════════════");
   lines.push("");
   lines.push(`  Generated:  ${plan.generatedAt}`);
@@ -550,7 +550,11 @@ export function renderRemediationPlanText(plan: RemediationPlan): string {
   }
 
   for (const tierGroup of plan.tiers) {
-    const approvalNote = tierGroup.approvalRequired ? " [REQUIRES APPROVAL]" : " [auto-safe]";
+    const approvalNote = tierGroup.approvalRequired
+      ? " [REQUIRES APPROVAL]"
+      : tierGroup.tier === 0
+        ? " [auto-safe]"
+        : " [review list first]";
     lines.push(`── Tier ${tierGroup.tier}: ${tierGroup.label}${approvalNote} ──`);
     lines.push(`   ${tierGroup.description}`);
     lines.push("");
@@ -593,7 +597,7 @@ export function renderRemediationPlanText(plan: RemediationPlan): string {
     lines.push("");
   }
   if (plan.approvalModel.previewThenAutomate.length > 0) {
-    lines.push("  Preview-then-automate (dry-run first, then automate):");
+    lines.push("  Review-then-automate (review list before enabling automation):");
     for (const kind of plan.approvalModel.previewThenAutomate) {
       lines.push(`    • ${kind}`);
     }

--- a/src/infra/session-health-remediation-plan.ts
+++ b/src/infra/session-health-remediation-plan.ts
@@ -28,23 +28,7 @@ import {
   REMEDIATION_TIER_LABELS,
 } from "./session-health-remediation-types.js";
 import type { SessionHealthClass, SessionHealthRawSnapshot } from "./session-health-types.js";
-
-// ---------------------------------------------------------------------------
-// Retention defaults (from Phase 1 taxonomy)
-// ---------------------------------------------------------------------------
-
-const DEFAULT_RETENTION_MS: Record<SessionHealthClass, number | null> = {
-  main: null, // permanent — never auto-pruned
-  channel: null, // permanent
-  direct: null, // permanent
-  "cron-definition": null, // retain while cron job exists
-  "cron-run": 7 * 24 * 60 * 60 * 1000, // 7 days
-  subagent: 7 * 24 * 60 * 60 * 1000, // 7 days
-  acp: 14 * 24 * 60 * 60 * 1000, // 14 days
-  heartbeat: 3 * 24 * 60 * 60 * 1000, // 3 days
-  thread: null, // inherits parent
-  unknown: 30 * 24 * 60 * 60 * 1000, // 30 days (existing pruneAfterMs default)
-};
+import { DEFAULT_CLASS_RETENTION_MS } from "./session-health-types.js";
 
 // ---------------------------------------------------------------------------
 // Action builders (one per action kind)
@@ -131,14 +115,14 @@ function buildArchiveStaleDeletedTranscripts(
     kind: "archive-stale-deleted-transcripts",
     tier: 1,
     label: "Purge aged .deleted transcript archives",
-    description: `Remove ${sessions.byDiskState.deleted} soft-deleted transcript file(s) that have exceeded their archive retention window (${formatMs(snapshot.maintenance.pruneAfterMs)}). These are already-deleted session transcripts that were retained as safety backups.`,
-    reason: "Stale .deleted transcript archives consuming storage",
+    description: `Permanently remove ${sessions.byDiskState.deleted} .deleted transcript file(s) (${formatBytes(storage.deletedTranscriptBytes)}) that have exceeded the archive retention window (${formatMs(snapshot.maintenance.pruneAfterMs)}). These are already soft-deleted session transcripts kept as safety backups; the original sessions were previously removed from the index.`,
+    reason: "Stale .deleted transcript archives consuming storage beyond retention window",
     estimatedImpact: {
       affectedCount: sessions.byDiskState.deleted,
       estimatedBytes: storage.deletedTranscriptBytes,
       affectedClasses: [],
     },
-    reversible: false, // These are already the archived version
+    reversible: false, // These are already the archived version — no further backup exists
     prerequisites: [],
   };
 }
@@ -160,14 +144,14 @@ function buildArchiveStaleResetTranscripts(
     kind: "archive-stale-reset-transcripts",
     tier: 1,
     label: "Purge aged .reset transcript archives",
-    description: `Remove ${sessions.byDiskState.reset} reset transcript file(s) consuming ${formatBytes(storage.resetTranscriptBytes)} (${resetPct}% of total managed storage). These are session-reset snapshots retained for recovery.`,
-    reason: "Reset transcript archives are the dominant storage consumer",
+    description: `Permanently remove ${sessions.byDiskState.reset} .reset transcript archive(s) consuming ${formatBytes(storage.resetTranscriptBytes)} (${resetPct}% of total managed storage). These are already archived session-reset snapshots retained for recovery and now recommended for final purge.`,
+    reason: "Aged .reset transcript archives are the dominant storage consumer",
     estimatedImpact: {
       affectedCount: sessions.byDiskState.reset,
       estimatedBytes: storage.resetTranscriptBytes,
       affectedClasses: [],
     },
-    reversible: false, // These are already the archived version
+    reversible: false, // These are already the archived version — no further backup exists
     prerequisites: [],
   };
 }
@@ -187,7 +171,7 @@ function buildReconcileIndexPhantoms(snapshot: SessionHealthRawSnapshot): Remedi
     reason: "Index entries found without matching disk file (index drift)",
     estimatedImpact: {
       affectedCount: drift.indexedWithoutDiskFile,
-      estimatedBytes: 0, // Index compaction savings are minimal
+      estimatedBytes: null, // Honest estimate unavailable from current snapshot
       affectedClasses: [],
     },
     reversible: false, // Index entry removal is not reversible, but the transcript is already gone
@@ -200,8 +184,13 @@ function buildPruneStaleSessionsByClass(
   sessionClass: SessionHealthClass,
   retentionMs: number,
 ): RemediationAction | null {
-  const count = snapshot.sessions.byClass[sessionClass];
-  if (count === 0) {
+  const totalCount = snapshot.sessions.byClass[sessionClass];
+  // Use age-filtered stale counts from the collector when available.
+  // Fall back to 0 if staleByClass is absent or has no entry for this class —
+  // never fall back to totalCount, which would overstate stale sessions.
+  const staleCount = snapshot.sessions.staleByClass?.[sessionClass] ?? 0;
+
+  if (staleCount === 0) {
     return null;
   }
 
@@ -224,16 +213,22 @@ function buildPruneStaleSessionsByClass(
     acp: "ACP",
   };
 
+  const humanLabel = labelMap[sessionClass] ?? sessionClass;
+  const contextNote =
+    totalCount > staleCount
+      ? ` (${totalCount - staleCount} of ${totalCount} total are within retention)`
+      : "";
+
   return {
     id: nextActionId(kind),
     kind,
     tier: 2,
-    label: `Prune stale ${labelMap[sessionClass] ?? sessionClass} sessions`,
-    description: `Remove session index entries for ${count} ${labelMap[sessionClass] ?? sessionClass} session(s) older than ${formatMs(retentionMs)} and their associated transcript files. This reduces index bloat from ephemeral session types.`,
-    reason: `${count} ${labelMap[sessionClass] ?? sessionClass} session(s) in index (retention policy: ${formatMs(retentionMs)})`,
+    label: `Prune stale ${humanLabel} sessions`,
+    description: `Remove session index entries for ${staleCount} ${humanLabel} session(s) older than ${formatMs(retentionMs)} and their associated transcript files${contextNote}. This reduces index bloat from ephemeral session types.`,
+    reason: `${staleCount} of ${totalCount} ${humanLabel} session(s) exceed retention policy (${formatMs(retentionMs)})`,
     estimatedImpact: {
-      affectedCount: count,
-      estimatedBytes: 0, // Would need per-class byte accounting to estimate
+      affectedCount: staleCount,
+      estimatedBytes: null, // Honest estimate unavailable without per-class byte accounting
       affectedClasses: [sessionClass],
     },
     reversible: false,
@@ -292,7 +287,7 @@ export function buildRemediationPlan(options: BuildRemediationPlanOptions): Reme
   const { snapshot, retentionOverrides, includeNoOpActions } = options;
 
   // Resolve retention per class (merge overrides with defaults)
-  const retention: Record<SessionHealthClass, number | null> = { ...DEFAULT_RETENTION_MS };
+  const retention: Record<SessionHealthClass, number | null> = { ...DEFAULT_CLASS_RETENTION_MS };
   if (retentionOverrides) {
     for (const [cls, ms] of Object.entries(retentionOverrides)) {
       if (ms != null) {
@@ -327,7 +322,7 @@ export function buildRemediationPlan(options: BuildRemediationPlanOptions): Reme
     if (
       !includeNoOpActions &&
       a.estimatedImpact.affectedCount === 0 &&
-      a.estimatedImpact.estimatedBytes === 0
+      (a.estimatedImpact.estimatedBytes ?? 0) === 0
     ) {
       return false;
     }
@@ -340,8 +335,9 @@ export function buildRemediationPlan(options: BuildRemediationPlanOptions): Reme
   // Compute summary
   const summary = buildPlanSummary(actions);
 
-  // Build approval model
-  const approvalModel = buildApprovalModel();
+  // Build approval model — only include action kinds that are active in this plan
+  const activeKinds = new Set(actions.map((a) => a.kind));
+  const approvalModel = buildApprovalModel(activeKinds);
 
   return {
     generatedAt: new Date().toISOString(),
@@ -400,7 +396,7 @@ function buildPlanSummary(actions: RemediationAction[]): RemediationPlanSummary 
 
   for (const action of actions) {
     countByTier[action.tier]++;
-    estimatedRecoverableBytes += action.estimatedImpact.estimatedBytes;
+    estimatedRecoverableBytes += action.estimatedImpact.estimatedBytes ?? 0;
     if (action.tier > highestTier) {
       highestTier = action.tier;
     }
@@ -432,7 +428,9 @@ function buildRecommendation(
     parts.push(`${countByTier[0]} auto-safe action(s) can run immediately`);
   }
   if (countByTier[1] > 0) {
-    parts.push(`${countByTier[1]} reversible action(s) should be previewed before enabling`);
+    parts.push(
+      `${countByTier[1]} Tier 1 archive/retention action(s) should be previewed before enabling`,
+    );
   }
   if (countByTier[2] > 0) {
     parts.push(`${countByTier[2]} index-mutating action(s) require explicit approval`);
@@ -448,7 +446,13 @@ function buildRecommendation(
   return parts.join(". ") + ".";
 }
 
-function buildApprovalModel(): ApprovalModel {
+/**
+ * Build the approval model. When `activeKinds` is provided, only include
+ * action kinds that appear in the current plan — this avoids listing
+ * inactive/irrelevant action kinds in the dry-run output, reducing noise
+ * and improving operator trust.
+ */
+function buildApprovalModel(activeKinds?: Set<RemediationActionKind>): ApprovalModel {
   const autoApprovable: RemediationActionKind[] = [];
   const previewThenAutomate: RemediationActionKind[] = [];
   const explicitApprovalRequired: RemediationActionKind[] = [];
@@ -458,6 +462,10 @@ function buildApprovalModel(): ApprovalModel {
     RemediationActionKind,
     RemediationRiskTier,
   ][]) {
+    // When filtering to active kinds, skip kinds not in the plan
+    if (activeKinds && !activeKinds.has(kind)) {
+      continue;
+    }
     switch (tier) {
       case 0:
         autoApprovable.push(kind);
@@ -552,13 +560,19 @@ export function renderRemediationPlanText(plan: RemediationPlan): string {
       lines.push(`  ▸ ${action.label}${reversibleTag}`);
       lines.push(`    ${action.description}`);
       lines.push(`    Reason: ${action.reason}`);
-      if (action.estimatedImpact.affectedCount > 0 || action.estimatedImpact.estimatedBytes > 0) {
+      if (
+        action.estimatedImpact.affectedCount > 0 ||
+        (action.estimatedImpact.estimatedBytes ?? 0) > 0 ||
+        action.estimatedImpact.estimatedBytes == null
+      ) {
         const parts: string[] = [];
         if (action.estimatedImpact.affectedCount > 0) {
           parts.push(`${action.estimatedImpact.affectedCount} artifact(s)`);
         }
-        if (action.estimatedImpact.estimatedBytes > 0) {
-          parts.push(formatBytes(action.estimatedImpact.estimatedBytes));
+        if ((action.estimatedImpact.estimatedBytes ?? 0) > 0) {
+          parts.push(formatBytes(action.estimatedImpact.estimatedBytes ?? 0));
+        } else if (action.estimatedImpact.estimatedBytes == null) {
+          parts.push("byte estimate unavailable");
         }
         lines.push(`    Impact: ${parts.join(", ")}`);
       }

--- a/src/infra/session-health-remediation-plan.ts
+++ b/src/infra/session-health-remediation-plan.ts
@@ -105,21 +105,35 @@ function estimateOrphanTranscriptBytes(snapshot: SessionHealthRawSnapshot): numb
 function buildArchiveStaleDeletedTranscripts(
   snapshot: SessionHealthRawSnapshot,
 ): RemediationAction | null {
-  const { storage, sessions } = snapshot;
+  const { storage, sessions, staleArtifacts } = snapshot;
   if (sessions.byDiskState.deleted === 0 || storage.deletedTranscriptBytes === 0) {
     return null;
   }
+
+  // Use retention-filtered counts when available (honest count of files
+  // actually past the retention window). Fall back to total disk-state counts
+  // for snapshots collected before the staleArtifacts field was added.
+  const staleCount = staleArtifacts?.staleDeletedCount ?? sessions.byDiskState.deleted;
+  const staleBytes = staleArtifacts?.staleDeletedBytes ?? storage.deletedTranscriptBytes;
+
+  if (staleCount === 0) {
+    return null; // All .deleted files are still within retention
+  }
+
+  const withinRetention = sessions.byDiskState.deleted - staleCount;
+  const retentionNote =
+    withinRetention > 0 ? ` (${withinRetention} more within retention window, not affected)` : "";
 
   return {
     id: nextActionId("archive-stale-deleted-transcripts"),
     kind: "archive-stale-deleted-transcripts",
     tier: 1,
     label: "Purge aged .deleted transcript archives",
-    description: `Permanently remove ${sessions.byDiskState.deleted} .deleted transcript file(s) (${formatBytes(storage.deletedTranscriptBytes)}) that have exceeded the archive retention window (${formatMs(snapshot.maintenance.pruneAfterMs)}). These are already soft-deleted session transcripts kept as safety backups; the original sessions were previously removed from the index.`,
+    description: `Permanently remove ${staleCount} .deleted transcript file(s) (${formatBytes(staleBytes)}) that have exceeded the archive retention window (${formatMs(snapshot.maintenance.pruneAfterMs)})${retentionNote}. These are already soft-deleted session transcripts kept as safety backups; the original sessions were previously removed from the index.`,
     reason: "Stale .deleted transcript archives consuming storage beyond retention window",
     estimatedImpact: {
-      affectedCount: sessions.byDiskState.deleted,
-      estimatedBytes: storage.deletedTranscriptBytes,
+      affectedCount: staleCount,
+      estimatedBytes: staleBytes,
       affectedClasses: [],
     },
     reversible: false, // These are already the archived version — no further backup exists
@@ -130,25 +144,38 @@ function buildArchiveStaleDeletedTranscripts(
 function buildArchiveStaleResetTranscripts(
   snapshot: SessionHealthRawSnapshot,
 ): RemediationAction | null {
-  const { storage, sessions } = snapshot;
+  const { storage, sessions, staleArtifacts } = snapshot;
   if (sessions.byDiskState.reset === 0 || storage.resetTranscriptBytes === 0) {
     return null;
   }
 
+  // Use retention-filtered counts when available (honest count of files
+  // actually past the retention window). Fall back to total disk-state counts
+  // for snapshots collected before the staleArtifacts field was added.
+  const staleCount = staleArtifacts?.staleResetCount ?? sessions.byDiskState.reset;
+  const staleBytes = staleArtifacts?.staleResetBytes ?? storage.resetTranscriptBytes;
+
+  if (staleCount === 0) {
+    return null; // All .reset files are still within retention
+  }
+
   const totalBytes = storage.totalManagedBytes;
-  const resetPct =
-    totalBytes > 0 ? ((storage.resetTranscriptBytes / totalBytes) * 100).toFixed(0) : "0";
+  const resetPct = totalBytes > 0 ? ((staleBytes / totalBytes) * 100).toFixed(0) : "0";
+
+  const withinRetention = sessions.byDiskState.reset - staleCount;
+  const retentionNote =
+    withinRetention > 0 ? ` (${withinRetention} more within retention window, not affected)` : "";
 
   return {
     id: nextActionId("archive-stale-reset-transcripts"),
     kind: "archive-stale-reset-transcripts",
     tier: 1,
     label: "Purge aged .reset transcript archives",
-    description: `Permanently remove ${sessions.byDiskState.reset} .reset transcript archive(s) consuming ${formatBytes(storage.resetTranscriptBytes)} (${resetPct}% of total managed storage). These are already archived session-reset snapshots retained for recovery and now recommended for final purge.`,
+    description: `Permanently remove ${staleCount} .reset transcript archive(s) consuming ${formatBytes(staleBytes)} (${resetPct}% of total managed storage)${retentionNote}. These are already archived session-reset snapshots retained for recovery and now recommended for final purge.`,
     reason: "Aged .reset transcript archives are the dominant storage consumer",
     estimatedImpact: {
-      affectedCount: sessions.byDiskState.reset,
-      estimatedBytes: storage.resetTranscriptBytes,
+      affectedCount: staleCount,
+      estimatedBytes: staleBytes,
       affectedClasses: [],
     },
     reversible: false, // These are already the archived version — no further backup exists

--- a/src/infra/session-health-remediation-plan.ts
+++ b/src/infra/session-health-remediation-plan.ts
@@ -425,7 +425,7 @@ function buildRecommendation(
   const parts: string[] = [];
 
   if (countByTier[0] > 0) {
-    parts.push(`${countByTier[0]} auto-safe action(s) can run immediately`);
+    parts.push(`${countByTier[0]} auto-safe action(s) safe to execute`);
   }
   if (countByTier[1] > 0) {
     parts.push(`${countByTier[1]} retention cleanup action(s) — review list before enabling`);

--- a/src/infra/session-health-remediation-plan.ts
+++ b/src/infra/session-health-remediation-plan.ts
@@ -1,0 +1,608 @@
+/**
+ * Session Health — Remediation Plan Builder
+ *
+ * Generates a structured, human-reviewable remediation plan from a raw
+ * health snapshot. This is a PURE function — it reads snapshot data and
+ * produces a plan. It never touches disk, never deletes anything, never
+ * mutates any state.
+ *
+ * Phase 3A safety contract:
+ * - This module is report-only / dry-run-only / preview-only.
+ * - It produces a plan describing what WOULD happen.
+ * - Actual execution is deferred to a future phase with explicit approval gates.
+ */
+
+import type {
+  ApprovalModel,
+  BuildRemediationPlanOptions,
+  RemediationAction,
+  RemediationActionKind,
+  RemediationPlan,
+  RemediationPlanSummary,
+  RemediationRiskTier,
+  RemediationTierGroup,
+} from "./session-health-remediation-types.js";
+import {
+  ACTION_KIND_TIERS,
+  REMEDIATION_TIER_DESCRIPTIONS,
+  REMEDIATION_TIER_LABELS,
+} from "./session-health-remediation-types.js";
+import type { SessionHealthClass, SessionHealthRawSnapshot } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Retention defaults (from Phase 1 taxonomy)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RETENTION_MS: Record<SessionHealthClass, number | null> = {
+  main: null, // permanent — never auto-pruned
+  channel: null, // permanent
+  direct: null, // permanent
+  "cron-definition": null, // retain while cron job exists
+  "cron-run": 7 * 24 * 60 * 60 * 1000, // 7 days
+  subagent: 7 * 24 * 60 * 60 * 1000, // 7 days
+  acp: 14 * 24 * 60 * 60 * 1000, // 14 days
+  heartbeat: 3 * 24 * 60 * 60 * 1000, // 3 days
+  thread: null, // inherits parent
+  unknown: 30 * 24 * 60 * 60 * 1000, // 30 days (existing pruneAfterMs default)
+};
+
+// ---------------------------------------------------------------------------
+// Action builders (one per action kind)
+// ---------------------------------------------------------------------------
+
+let actionIdCounter = 0;
+
+function nextActionId(kind: RemediationActionKind): string {
+  actionIdCounter++;
+  return `${kind}-${actionIdCounter}`;
+}
+
+function buildCleanupOrphanedTmp(snapshot: SessionHealthRawSnapshot): RemediationAction | null {
+  const { drift, storage } = snapshot;
+  if (drift.orphanedTempCount === 0) {
+    return null;
+  }
+
+  const ageNote = drift.oldestOrphanedTempAt ? ` (oldest: ${drift.oldestOrphanedTempAt})` : "";
+
+  return {
+    id: nextActionId("cleanup-orphaned-tmp"),
+    kind: "cleanup-orphaned-tmp",
+    tier: 0,
+    label: "Remove orphaned temp files",
+    description: `Delete ${drift.orphanedTempCount} orphaned .tmp file(s) from crashed atomic writes${ageNote}. These are incomplete write artifacts that serve no purpose.`,
+    reason: "Orphaned temp files detected in session directory",
+    estimatedImpact: {
+      affectedCount: drift.orphanedTempCount,
+      estimatedBytes: storage.orphanedTempBytes,
+      affectedClasses: [],
+    },
+    reversible: false, // .tmp files are garbage; no need to archive
+    prerequisites: [],
+  };
+}
+
+function buildArchiveOrphanTranscripts(
+  snapshot: SessionHealthRawSnapshot,
+): RemediationAction | null {
+  const { drift } = snapshot;
+  if (drift.diskFilesWithoutIndex === 0) {
+    return null;
+  }
+
+  return {
+    id: nextActionId("archive-orphan-transcripts"),
+    kind: "archive-orphan-transcripts",
+    tier: 1,
+    label: "Archive orphan transcript files",
+    description: `Rename ${drift.diskFilesWithoutIndex} .jsonl file(s) that are not referenced by any session index entry to .deleted.<timestamp>. Original files are preserved for the configured deleted-artifact retention window.`,
+    reason: "Disk files found without matching session index entry (index drift)",
+    estimatedImpact: {
+      affectedCount: drift.diskFilesWithoutIndex,
+      // We don't have per-file byte data in the snapshot; estimate from active transcript average
+      estimatedBytes: estimateOrphanTranscriptBytes(snapshot),
+      affectedClasses: [],
+    },
+    reversible: true,
+    prerequisites: [],
+  };
+}
+
+function estimateOrphanTranscriptBytes(snapshot: SessionHealthRawSnapshot): number {
+  const activeCount = snapshot.sessions.byDiskState.active;
+  const activeBytes = snapshot.storage.activeTranscriptBytes;
+  if (activeCount === 0) {
+    return 0;
+  }
+  const avgBytes = activeBytes / activeCount;
+  return Math.round(avgBytes * snapshot.drift.diskFilesWithoutIndex);
+}
+
+function buildArchiveStaleDeletedTranscripts(
+  snapshot: SessionHealthRawSnapshot,
+): RemediationAction | null {
+  const { storage, sessions } = snapshot;
+  if (sessions.byDiskState.deleted === 0 || storage.deletedTranscriptBytes === 0) {
+    return null;
+  }
+
+  return {
+    id: nextActionId("archive-stale-deleted-transcripts"),
+    kind: "archive-stale-deleted-transcripts",
+    tier: 1,
+    label: "Purge aged .deleted transcript archives",
+    description: `Remove ${sessions.byDiskState.deleted} soft-deleted transcript file(s) that have exceeded their archive retention window (${formatMs(snapshot.maintenance.pruneAfterMs)}). These are already-deleted session transcripts that were retained as safety backups.`,
+    reason: "Stale .deleted transcript archives consuming storage",
+    estimatedImpact: {
+      affectedCount: sessions.byDiskState.deleted,
+      estimatedBytes: storage.deletedTranscriptBytes,
+      affectedClasses: [],
+    },
+    reversible: false, // These are already the archived version
+    prerequisites: [],
+  };
+}
+
+function buildArchiveStaleResetTranscripts(
+  snapshot: SessionHealthRawSnapshot,
+): RemediationAction | null {
+  const { storage, sessions } = snapshot;
+  if (sessions.byDiskState.reset === 0 || storage.resetTranscriptBytes === 0) {
+    return null;
+  }
+
+  const totalBytes = storage.totalManagedBytes;
+  const resetPct =
+    totalBytes > 0 ? ((storage.resetTranscriptBytes / totalBytes) * 100).toFixed(0) : "0";
+
+  return {
+    id: nextActionId("archive-stale-reset-transcripts"),
+    kind: "archive-stale-reset-transcripts",
+    tier: 1,
+    label: "Purge aged .reset transcript archives",
+    description: `Remove ${sessions.byDiskState.reset} reset transcript file(s) consuming ${formatBytes(storage.resetTranscriptBytes)} (${resetPct}% of total managed storage). These are session-reset snapshots retained for recovery.`,
+    reason: "Reset transcript archives are the dominant storage consumer",
+    estimatedImpact: {
+      affectedCount: sessions.byDiskState.reset,
+      estimatedBytes: storage.resetTranscriptBytes,
+      affectedClasses: [],
+    },
+    reversible: false, // These are already the archived version
+    prerequisites: [],
+  };
+}
+
+function buildReconcileIndexPhantoms(snapshot: SessionHealthRawSnapshot): RemediationAction | null {
+  const { drift } = snapshot;
+  if (drift.indexedWithoutDiskFile === 0) {
+    return null;
+  }
+
+  return {
+    id: nextActionId("reconcile-index-phantoms"),
+    kind: "reconcile-index-phantoms",
+    tier: 2,
+    label: "Remove phantom index entries",
+    description: `Remove ${drift.indexedWithoutDiskFile} session index entry/entries that reference transcript files no longer on disk. These phantom entries inflate the session list and prevent accurate health metrics.`,
+    reason: "Index entries found without matching disk file (index drift)",
+    estimatedImpact: {
+      affectedCount: drift.indexedWithoutDiskFile,
+      estimatedBytes: 0, // Index compaction savings are minimal
+      affectedClasses: [],
+    },
+    reversible: false, // Index entry removal is not reversible, but the transcript is already gone
+    prerequisites: ["archive-orphan-transcripts"], // Reconcile after orphan archival to avoid double-counting
+  };
+}
+
+function buildPruneStaleSessionsByClass(
+  snapshot: SessionHealthRawSnapshot,
+  sessionClass: SessionHealthClass,
+  retentionMs: number,
+): RemediationAction | null {
+  const count = snapshot.sessions.byClass[sessionClass];
+  if (count === 0) {
+    return null;
+  }
+
+  const kindMap: Partial<Record<SessionHealthClass, RemediationActionKind>> = {
+    "cron-run": "prune-stale-cron-runs",
+    subagent: "prune-stale-subagents",
+    heartbeat: "prune-stale-heartbeats",
+    acp: "prune-stale-acp",
+  };
+
+  const kind = kindMap[sessionClass];
+  if (!kind) {
+    return null;
+  }
+
+  const labelMap: Record<string, string> = {
+    "cron-run": "cron run",
+    subagent: "subagent",
+    heartbeat: "heartbeat",
+    acp: "ACP",
+  };
+
+  return {
+    id: nextActionId(kind),
+    kind,
+    tier: 2,
+    label: `Prune stale ${labelMap[sessionClass] ?? sessionClass} sessions`,
+    description: `Remove session index entries for ${count} ${labelMap[sessionClass] ?? sessionClass} session(s) older than ${formatMs(retentionMs)} and their associated transcript files. This reduces index bloat from ephemeral session types.`,
+    reason: `${count} ${labelMap[sessionClass] ?? sessionClass} session(s) in index (retention policy: ${formatMs(retentionMs)})`,
+    estimatedImpact: {
+      affectedCount: count,
+      estimatedBytes: 0, // Would need per-class byte accounting to estimate
+      affectedClasses: [sessionClass],
+    },
+    reversible: false,
+    prerequisites: [],
+  };
+}
+
+function buildEnforceDiskBudget(snapshot: SessionHealthRawSnapshot): RemediationAction | null {
+  const { maintenance, storage } = snapshot;
+  if (maintenance.maxDiskBytes == null || maintenance.usagePercent.diskBytes == null) {
+    return null;
+  }
+  if (maintenance.usagePercent.diskBytes <= 100) {
+    return null; // Not over budget
+  }
+
+  const overBytes = storage.totalManagedBytes - maintenance.maxDiskBytes;
+
+  return {
+    id: nextActionId("enforce-disk-budget"),
+    kind: "enforce-disk-budget",
+    tier: 3,
+    label: "Enforce disk budget",
+    description: `Session storage (${formatBytes(storage.totalManagedBytes)}) exceeds disk budget (${formatBytes(maintenance.maxDiskBytes)}). Would need to free ${formatBytes(overBytes)} by removing oldest artifacts and session entries.`,
+    reason: `Disk budget exceeded (${maintenance.usagePercent.diskBytes.toFixed(0)}% of limit)`,
+    estimatedImpact: {
+      affectedCount: 0, // Cannot estimate without detailed sweep
+      estimatedBytes: overBytes,
+      affectedClasses: [],
+    },
+    reversible: false,
+    prerequisites: [
+      "cleanup-orphaned-tmp",
+      "archive-stale-deleted-transcripts",
+      "archive-stale-reset-transcripts",
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plan builder — the main pure function
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a complete remediation plan from a raw health snapshot.
+ *
+ * This is a PURE FUNCTION. It reads snapshot data and produces a plan.
+ * It never touches disk, never deletes anything, never mutates state.
+ *
+ * @param options - Snapshot and optional overrides
+ * @returns A structured plan describing what WOULD be cleaned and why
+ */
+export function buildRemediationPlan(options: BuildRemediationPlanOptions): RemediationPlan {
+  actionIdCounter = 0; // Reset for deterministic IDs
+
+  const { snapshot, retentionOverrides, includeNoOpActions } = options;
+
+  // Resolve retention per class (merge overrides with defaults)
+  const retention: Record<SessionHealthClass, number | null> = { ...DEFAULT_RETENTION_MS };
+  if (retentionOverrides) {
+    for (const [cls, ms] of Object.entries(retentionOverrides)) {
+      if (ms != null) {
+        retention[cls as SessionHealthClass] = ms;
+      }
+    }
+  }
+
+  // Build all candidate actions
+  const allActions: (RemediationAction | null)[] = [
+    // Tier 0
+    buildCleanupOrphanedTmp(snapshot),
+
+    // Tier 1
+    buildArchiveOrphanTranscripts(snapshot),
+    buildArchiveStaleDeletedTranscripts(snapshot),
+    buildArchiveStaleResetTranscripts(snapshot),
+
+    // Tier 2
+    buildReconcileIndexPhantoms(snapshot),
+    ...buildPruneStaleClassActions(snapshot, retention),
+
+    // Tier 3
+    buildEnforceDiskBudget(snapshot),
+  ];
+
+  // Filter to non-null actions; optionally include zero-impact actions
+  const actions = allActions.filter((a): a is RemediationAction => {
+    if (a == null) {
+      return false;
+    }
+    if (
+      !includeNoOpActions &&
+      a.estimatedImpact.affectedCount === 0 &&
+      a.estimatedImpact.estimatedBytes === 0
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  // Group by tier
+  const tiers = buildTierGroups(actions);
+
+  // Compute summary
+  const summary = buildPlanSummary(actions);
+
+  // Build approval model
+  const approvalModel = buildApprovalModel();
+
+  return {
+    generatedAt: new Date().toISOString(),
+    snapshotAt: snapshot.capturedAt,
+    summary,
+    tiers,
+    approvalModel,
+  };
+}
+
+function buildPruneStaleClassActions(
+  snapshot: SessionHealthRawSnapshot,
+  retention: Record<SessionHealthClass, number | null>,
+): (RemediationAction | null)[] {
+  const pruneClasses: SessionHealthClass[] = ["cron-run", "subagent", "heartbeat", "acp"];
+  return pruneClasses.map((cls) => {
+    const retentionMs = retention[cls];
+    if (retentionMs == null) {
+      return null;
+    }
+    return buildPruneStaleSessionsByClass(snapshot, cls, retentionMs);
+  });
+}
+
+function buildTierGroups(actions: RemediationAction[]): RemediationTierGroup[] {
+  const tierMap = new Map<RemediationRiskTier, RemediationAction[]>();
+
+  for (const action of actions) {
+    const existing = tierMap.get(action.tier) ?? [];
+    existing.push(action);
+    tierMap.set(action.tier, existing);
+  }
+
+  const tiers: RemediationTierGroup[] = [];
+  for (const tier of [0, 1, 2, 3] as RemediationRiskTier[]) {
+    const tierActions = tierMap.get(tier);
+    if (!tierActions || tierActions.length === 0) {
+      continue;
+    }
+    tiers.push({
+      tier,
+      label: REMEDIATION_TIER_LABELS[tier],
+      description: REMEDIATION_TIER_DESCRIPTIONS[tier],
+      approvalRequired: tier >= 2,
+      actions: tierActions,
+    });
+  }
+
+  return tiers;
+}
+
+function buildPlanSummary(actions: RemediationAction[]): RemediationPlanSummary {
+  const countByTier: Record<RemediationRiskTier, number> = { 0: 0, 1: 0, 2: 0, 3: 0 };
+  let estimatedRecoverableBytes = 0;
+  let highestTier: RemediationRiskTier = 0;
+
+  for (const action of actions) {
+    countByTier[action.tier]++;
+    estimatedRecoverableBytes += action.estimatedImpact.estimatedBytes;
+    if (action.tier > highestTier) {
+      highestTier = action.tier;
+    }
+  }
+
+  const recommendation = buildRecommendation(actions, countByTier, estimatedRecoverableBytes);
+
+  return {
+    totalActions: actions.length,
+    estimatedRecoverableBytes,
+    actionCountByTier: countByTier,
+    highestTierRequired: highestTier,
+    recommendation,
+  };
+}
+
+function buildRecommendation(
+  actions: RemediationAction[],
+  countByTier: Record<RemediationRiskTier, number>,
+  estimatedRecoverableBytes: number,
+): string {
+  if (actions.length === 0) {
+    return "No remediation actions recommended. Session health is clean.";
+  }
+
+  const parts: string[] = [];
+
+  if (countByTier[0] > 0) {
+    parts.push(`${countByTier[0]} auto-safe action(s) can run immediately`);
+  }
+  if (countByTier[1] > 0) {
+    parts.push(`${countByTier[1]} reversible action(s) should be previewed before enabling`);
+  }
+  if (countByTier[2] > 0) {
+    parts.push(`${countByTier[2]} index-mutating action(s) require explicit approval`);
+  }
+  if (countByTier[3] > 0) {
+    parts.push(`${countByTier[3]} destructive action(s) require manual review and confirmation`);
+  }
+
+  if (estimatedRecoverableBytes > 0) {
+    parts.push(`Estimated recoverable: ${formatBytes(estimatedRecoverableBytes)}`);
+  }
+
+  return parts.join(". ") + ".";
+}
+
+function buildApprovalModel(): ApprovalModel {
+  const autoApprovable: RemediationActionKind[] = [];
+  const previewThenAutomate: RemediationActionKind[] = [];
+  const explicitApprovalRequired: RemediationActionKind[] = [];
+  const neverAutomate: RemediationActionKind[] = [];
+
+  for (const [kind, tier] of Object.entries(ACTION_KIND_TIERS) as [
+    RemediationActionKind,
+    RemediationRiskTier,
+  ][]) {
+    switch (tier) {
+      case 0:
+        autoApprovable.push(kind);
+        break;
+      case 1:
+        previewThenAutomate.push(kind);
+        break;
+      case 2:
+        explicitApprovalRequired.push(kind);
+        break;
+      case 3:
+        neverAutomate.push(kind);
+        break;
+    }
+  }
+
+  return {
+    autoApprovable,
+    previewThenAutomate,
+    explicitApprovalRequired,
+    neverAutomate,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatMs(ms: number): string {
+  const days = ms / (24 * 60 * 60 * 1000);
+  if (days >= 1) {
+    return `${Math.round(days)}d`;
+  }
+  const hours = ms / (60 * 60 * 1000);
+  if (hours >= 1) {
+    return `${Math.round(hours)}h`;
+  }
+  return `${Math.round(ms / 60_000)}m`;
+}
+
+// ---------------------------------------------------------------------------
+// Plan renderer (human-readable text output for CLI / dry-run reports)
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a remediation plan as a human-readable text report.
+ *
+ * Suitable for CLI output, dry-run previews, and operator review.
+ */
+export function renderRemediationPlanText(plan: RemediationPlan): string {
+  const lines: string[] = [];
+
+  lines.push("═══════════════════════════════════════════════════════════════");
+  lines.push("  SESSION HEALTH — REMEDIATION PLAN (DRY RUN)");
+  lines.push("═══════════════════════════════════════════════════════════════");
+  lines.push("");
+  lines.push(`  Generated:  ${plan.generatedAt}`);
+  lines.push(`  Snapshot:   ${plan.snapshotAt}`);
+  lines.push(`  Actions:    ${plan.summary.totalActions}`);
+  lines.push(`  Estimated:  ${formatBytes(plan.summary.estimatedRecoverableBytes)} recoverable`);
+  lines.push("");
+  lines.push(`  ${plan.summary.recommendation}`);
+  lines.push("");
+
+  if (plan.tiers.length === 0) {
+    lines.push("  ✓ No remediation actions needed.");
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  for (const tierGroup of plan.tiers) {
+    const approvalNote = tierGroup.approvalRequired ? " [REQUIRES APPROVAL]" : " [auto-safe]";
+    lines.push(`── Tier ${tierGroup.tier}: ${tierGroup.label}${approvalNote} ──`);
+    lines.push(`   ${tierGroup.description}`);
+    lines.push("");
+
+    for (const action of tierGroup.actions) {
+      const reversibleTag = action.reversible ? " [reversible]" : "";
+      lines.push(`  ▸ ${action.label}${reversibleTag}`);
+      lines.push(`    ${action.description}`);
+      lines.push(`    Reason: ${action.reason}`);
+      if (action.estimatedImpact.affectedCount > 0 || action.estimatedImpact.estimatedBytes > 0) {
+        const parts: string[] = [];
+        if (action.estimatedImpact.affectedCount > 0) {
+          parts.push(`${action.estimatedImpact.affectedCount} artifact(s)`);
+        }
+        if (action.estimatedImpact.estimatedBytes > 0) {
+          parts.push(formatBytes(action.estimatedImpact.estimatedBytes));
+        }
+        lines.push(`    Impact: ${parts.join(", ")}`);
+      }
+      if (action.prerequisites.length > 0) {
+        lines.push(`    Prerequisite: ${action.prerequisites.join(", ")}`);
+      }
+      lines.push("");
+    }
+  }
+
+  lines.push("── Approval Model ──");
+  lines.push("");
+  if (plan.approvalModel.autoApprovable.length > 0) {
+    lines.push("  Auto-safe (can automate without approval):");
+    for (const kind of plan.approvalModel.autoApprovable) {
+      lines.push(`    • ${kind}`);
+    }
+    lines.push("");
+  }
+  if (plan.approvalModel.previewThenAutomate.length > 0) {
+    lines.push("  Preview-then-automate (dry-run first, then automate):");
+    for (const kind of plan.approvalModel.previewThenAutomate) {
+      lines.push(`    • ${kind}`);
+    }
+    lines.push("");
+  }
+  if (plan.approvalModel.explicitApprovalRequired.length > 0) {
+    lines.push("  Explicit approval (requires confirmation per execution):");
+    for (const kind of plan.approvalModel.explicitApprovalRequired) {
+      lines.push(`    • ${kind}`);
+    }
+    lines.push("");
+  }
+  if (plan.approvalModel.neverAutomate.length > 0) {
+    lines.push("  Never automate (always manual review + confirmation):");
+    for (const kind of plan.approvalModel.neverAutomate) {
+      lines.push(`    • ${kind}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("═══════════════════════════════════════════════════════════════");
+  lines.push("  THIS IS A DRY-RUN REPORT. No changes have been made.");
+  lines.push("═══════════════════════════════════════════════════════════════");
+
+  return lines.join("\n");
+}

--- a/src/infra/session-health-remediation-types.ts
+++ b/src/infra/session-health-remediation-types.ts
@@ -316,6 +316,13 @@ export type ExecutionResult = {
   executedAt: string;
   actions: ActionExecutionResult[];
   summary: ExecutionSummary;
+
+  /**
+   * v1: executor only operates on the default agent's session directory.
+   * The plan may include cross-agent counts; this field makes the actual
+   * execution scope explicit for programmatic consumers.
+   */
+  agentScope?: string;
 };
 
 /**

--- a/src/infra/session-health-remediation-types.ts
+++ b/src/infra/session-health-remediation-types.ts
@@ -26,9 +26,9 @@ import type { SessionHealthClass, SessionHealthRawSnapshot } from "./session-hea
  * - **0 — Auto-Safe:** Only affects definitional garbage (crashed temp files).
  *   Can be automated without data loss risk. Operator may approve bulk automation.
  *
- * - **1 — Reversible:** Renames/archives artifacts instead of deleting them.
- *   Original data survives for a configurable retention window. Requires a
- *   dry-run preview before first execution. Safe to automate after initial review.
+ * - **1 — Archive / Retention Cleanup:** Either archives orphaned artifacts or
+ *   removes artifacts that are already archived and past their retention window.
+ *   Requires a dry-run preview before first execution.
  *
  * - **2 — Index-Mutating:** Modifies the session index (sessions.json).
  *   Changes which sessions are visible/loadable. Transcript files may or may
@@ -41,14 +41,14 @@ export type RemediationRiskTier = 0 | 1 | 2 | 3;
 
 export const REMEDIATION_TIER_LABELS: Record<RemediationRiskTier, string> = {
   0: "Auto-Safe",
-  1: "Reversible",
+  1: "Archive / Retention Cleanup",
   2: "Index-Mutating",
   3: "Destructive",
 };
 
 export const REMEDIATION_TIER_DESCRIPTIONS: Record<RemediationRiskTier, string> = {
   0: "Only affects definitional garbage. Safe to automate without data loss risk.",
-  1: "Archives/renames artifacts instead of deleting. Original data survives for a retention window.",
+  1: "Archives orphaned artifacts or removes artifacts that are already archived and past retention.",
   2: "Modifies the session index. Changes which sessions are visible/loadable.",
   3: "Permanently removes data. Cannot be undone. Always requires explicit confirmation.",
 };
@@ -153,8 +153,11 @@ export type RemediationImpact = {
   /** Number of artifacts (files or index entries) affected. */
   affectedCount: number;
 
-  /** Estimated bytes that would be freed or archived. */
-  estimatedBytes: number;
+  /**
+   * Estimated bytes that would be freed or archived.
+   * Null means no honest estimate is available from the current snapshot.
+   */
+  estimatedBytes: number | null;
 
   /** Session classes affected by this action (if applicable). */
   affectedClasses: SessionHealthClass[];

--- a/src/infra/session-health-remediation-types.ts
+++ b/src/infra/session-health-remediation-types.ts
@@ -26,9 +26,9 @@ import type { SessionHealthClass, SessionHealthRawSnapshot } from "./session-hea
  * - **0 — Auto-Safe:** Only affects definitional garbage (crashed temp files).
  *   Can be automated without data loss risk. Operator may approve bulk automation.
  *
- * - **1 — Archive / Retention Cleanup:** Either archives orphaned artifacts or
- *   removes artifacts that are already archived and past their retention window.
- *   Requires a dry-run preview before first execution.
+ * - **1 — Retention Cleanup:** Either archives orphaned artifacts or
+ *   permanently removes artifacts that are already archived and past their
+ *   retention window. Review the action list before enabling automation.
  *
  * - **2 — Index-Mutating:** Modifies the session index (sessions.json).
  *   Changes which sessions are visible/loadable. Transcript files may or may
@@ -41,14 +41,14 @@ export type RemediationRiskTier = 0 | 1 | 2 | 3;
 
 export const REMEDIATION_TIER_LABELS: Record<RemediationRiskTier, string> = {
   0: "Auto-Safe",
-  1: "Archive / Retention Cleanup",
+  1: "Retention Cleanup (review list first)",
   2: "Index-Mutating",
   3: "Destructive",
 };
 
 export const REMEDIATION_TIER_DESCRIPTIONS: Record<RemediationRiskTier, string> = {
   0: "Only affects definitional garbage. Safe to automate without data loss risk.",
-  1: "Archives orphaned artifacts or removes artifacts that are already archived and past retention.",
+  1: "Archives orphans or permanently removes already-archived artifacts past retention. Review the list before enabling.",
   2: "Modifies the session index. Changes which sessions are visible/loadable.",
   3: "Permanently removes data. Cannot be undone. Always requires explicit confirmation.",
 };

--- a/src/infra/session-health-remediation-types.ts
+++ b/src/infra/session-health-remediation-types.ts
@@ -261,6 +261,70 @@ export type ApprovalModel = {
 };
 
 // ---------------------------------------------------------------------------
+// Execution Types (Phase 3C)
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-action execution result produced by an action executor.
+ */
+export type ActionExecutionResult = {
+  /** The action ID from the plan. */
+  id: string;
+
+  /** The action kind. */
+  kind: RemediationActionKind;
+
+  /** Risk tier. */
+  tier: RemediationRiskTier;
+
+  /** Outcome of execution. */
+  status: "complete" | "skipped" | "failed" | "refused";
+
+  /** Number of artifacts actually removed/renamed. */
+  artifactsRemoved: number;
+
+  /** Actual bytes freed (measured, not estimated). */
+  bytesFreed: number;
+
+  /** Human-readable detail message. */
+  detail?: string;
+
+  /** Warning messages (e.g., partial failures). */
+  warnings?: string[];
+
+  /** Error message when status is "failed" or "refused". */
+  error?: string;
+};
+
+/**
+ * Summary of a full execution run.
+ */
+export type ExecutionSummary = {
+  executed: number;
+  skipped: number;
+  failed: number;
+  refused: number;
+  totalBytesFreed: number;
+  storageBefore: number;
+  storageAfter: number;
+};
+
+/**
+ * Complete result from a remediation execution pass.
+ */
+export type ExecutionResult = {
+  executedAt: string;
+  actions: ActionExecutionResult[];
+  summary: ExecutionSummary;
+};
+
+/**
+ * Maximum risk tier the v1 executor supports.
+ * Hard safety boundary — anything above this is refused.
+ */
+export const V1_MAX_EXECUTION_TIER: RemediationRiskTier = 1;
+
+// ---------------------------------------------------------------------------
 // Plan Generator Input
 // ---------------------------------------------------------------------------
 

--- a/src/infra/session-health-remediation-types.ts
+++ b/src/infra/session-health-remediation-types.ts
@@ -1,0 +1,283 @@
+/**
+ * Session Health — Remediation Types
+ *
+ * Defines the action taxonomy, tier model, and remediation plan structure
+ * for session lifecycle cleanup. This is the Phase 3A safety-first model:
+ * report-only, preview-only, no mutations.
+ *
+ * Design principles:
+ * - Every remediation action has a risk tier (0–3)
+ * - Lower tiers are safer and can be automated earlier
+ * - Higher tiers require explicit human approval
+ * - Actions are either reversible (archive-first) or destructive
+ * - The plan is generated from a raw snapshot — never executes anything
+ * - The approval model is explicit: what can run unattended vs what needs review
+ */
+
+import type { SessionHealthClass, SessionHealthRawSnapshot } from "./session-health-types.js";
+
+// ---------------------------------------------------------------------------
+// Risk Tiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Risk tier for a remediation action.
+ *
+ * - **0 — Auto-Safe:** Only affects definitional garbage (crashed temp files).
+ *   Can be automated without data loss risk. Operator may approve bulk automation.
+ *
+ * - **1 — Reversible:** Renames/archives artifacts instead of deleting them.
+ *   Original data survives for a configurable retention window. Requires a
+ *   dry-run preview before first execution. Safe to automate after initial review.
+ *
+ * - **2 — Index-Mutating:** Modifies the session index (sessions.json).
+ *   Changes which sessions are visible/loadable. Transcript files may or may
+ *   not be affected. Requires operator preview and confirmation per execution.
+ *
+ * - **3 — Destructive:** Permanently removes data. Cannot be undone.
+ *   Always requires explicit operator confirmation. Never automated by default.
+ */
+export type RemediationRiskTier = 0 | 1 | 2 | 3;
+
+export const REMEDIATION_TIER_LABELS: Record<RemediationRiskTier, string> = {
+  0: "Auto-Safe",
+  1: "Reversible",
+  2: "Index-Mutating",
+  3: "Destructive",
+};
+
+export const REMEDIATION_TIER_DESCRIPTIONS: Record<RemediationRiskTier, string> = {
+  0: "Only affects definitional garbage. Safe to automate without data loss risk.",
+  1: "Archives/renames artifacts instead of deleting. Original data survives for a retention window.",
+  2: "Modifies the session index. Changes which sessions are visible/loadable.",
+  3: "Permanently removes data. Cannot be undone. Always requires explicit confirmation.",
+};
+
+// ---------------------------------------------------------------------------
+// Action Kinds
+// ---------------------------------------------------------------------------
+
+/**
+ * Specific remediation action kinds. Each maps to exactly one risk tier.
+ *
+ * Naming convention: `{verb}-{target}` where verb indicates the operation
+ * and target indicates what is affected.
+ */
+export type RemediationActionKind =
+  // Tier 0 — Auto-Safe
+  | "cleanup-orphaned-tmp"
+
+  // Tier 1 — Reversible
+  | "archive-orphan-transcripts"
+  | "archive-stale-deleted-transcripts"
+  | "archive-stale-reset-transcripts"
+
+  // Tier 2 — Index-Mutating
+  | "reconcile-index-phantoms"
+  | "prune-stale-cron-runs"
+  | "prune-stale-subagents"
+  | "prune-stale-heartbeats"
+  | "prune-stale-acp"
+
+  // Tier 3 — Destructive
+  | "enforce-disk-budget"
+  | "purge-archived-artifacts"
+  | "bulk-class-prune";
+
+/**
+ * Static mapping from action kind to its risk tier.
+ * This is the source of truth for tier classification.
+ */
+export const ACTION_KIND_TIERS: Record<RemediationActionKind, RemediationRiskTier> = {
+  // Tier 0
+  "cleanup-orphaned-tmp": 0,
+
+  // Tier 1
+  "archive-orphan-transcripts": 1,
+  "archive-stale-deleted-transcripts": 1,
+  "archive-stale-reset-transcripts": 1,
+
+  // Tier 2
+  "reconcile-index-phantoms": 2,
+  "prune-stale-cron-runs": 2,
+  "prune-stale-subagents": 2,
+  "prune-stale-heartbeats": 2,
+  "prune-stale-acp": 2,
+
+  // Tier 3
+  "enforce-disk-budget": 3,
+  "purge-archived-artifacts": 3,
+  "bulk-class-prune": 3,
+};
+
+// ---------------------------------------------------------------------------
+// Remediation Action
+// ---------------------------------------------------------------------------
+
+/**
+ * A single proposed remediation action.
+ *
+ * This is a *recommendation* — it describes what WOULD happen, not what DID happen.
+ * No action in a RemediationPlan mutates state.
+ */
+export type RemediationAction = {
+  /** Unique identifier for this action within the plan. */
+  id: string;
+
+  /** The kind of action. Determines behavior and tier. */
+  kind: RemediationActionKind;
+
+  /** Risk tier (derived from kind, included for convenience). */
+  tier: RemediationRiskTier;
+
+  /** Human-readable label for display. */
+  label: string;
+
+  /** Detailed description of what this action would do. */
+  description: string;
+
+  /** Why this action is being recommended (linked to health indicator). */
+  reason: string;
+
+  /** Estimated impact of executing this action. */
+  estimatedImpact: RemediationImpact;
+
+  /** Whether the action is reversible (archive-first) or permanent. */
+  reversible: boolean;
+
+  /** Action kinds that should run before this one (if any). */
+  prerequisites: RemediationActionKind[];
+};
+
+export type RemediationImpact = {
+  /** Number of artifacts (files or index entries) affected. */
+  affectedCount: number;
+
+  /** Estimated bytes that would be freed or archived. */
+  estimatedBytes: number;
+
+  /** Session classes affected by this action (if applicable). */
+  affectedClasses: SessionHealthClass[];
+};
+
+// ---------------------------------------------------------------------------
+// Remediation Plan
+// ---------------------------------------------------------------------------
+
+/**
+ * A complete remediation plan generated from a health snapshot.
+ *
+ * This is the Phase 3A output: a structured, human-reviewable report
+ * that describes what WOULD be cleaned and why. It never executes anything.
+ */
+export type RemediationPlan = {
+  /** When this plan was generated. */
+  generatedAt: string;
+
+  /** When the source snapshot was captured. */
+  snapshotAt: string;
+
+  /** Summary statistics. */
+  summary: RemediationPlanSummary;
+
+  /** Actions grouped by risk tier. */
+  tiers: RemediationTierGroup[];
+
+  /** The approval model: what can run automatically vs what needs review. */
+  approvalModel: ApprovalModel;
+};
+
+export type RemediationPlanSummary = {
+  /** Total number of proposed actions. */
+  totalActions: number;
+
+  /** Total estimated bytes that could be recovered across all actions. */
+  estimatedRecoverableBytes: number;
+
+  /** Count of actions per tier. */
+  actionCountByTier: Record<RemediationRiskTier, number>;
+
+  /** Highest tier present in the plan (determines overall approval requirement). */
+  highestTierRequired: RemediationRiskTier;
+
+  /** Human-readable recommendation for what to do next. */
+  recommendation: string;
+};
+
+export type RemediationTierGroup = {
+  /** Risk tier (0–3). */
+  tier: RemediationRiskTier;
+
+  /** Human-readable tier label. */
+  label: string;
+
+  /** Tier description. */
+  description: string;
+
+  /** Whether operator approval is required before execution. */
+  approvalRequired: boolean;
+
+  /** Actions in this tier. */
+  actions: RemediationAction[];
+};
+
+// ---------------------------------------------------------------------------
+// Approval Model
+// ---------------------------------------------------------------------------
+
+/**
+ * Defines the approval boundaries for remediation actions.
+ *
+ * This model is the safety contract between the system and the operator.
+ * It explicitly separates what can be automated from what requires human review.
+ */
+export type ApprovalModel = {
+  /**
+   * Actions that can run without any confirmation once the operator
+   * enables automated cleanup. Currently: Tier 0 only.
+   */
+  autoApprovable: RemediationActionKind[];
+
+  /**
+   * Actions that require a dry-run preview before first execution,
+   * but can be automated after initial review. Currently: Tier 1.
+   */
+  previewThenAutomate: RemediationActionKind[];
+
+  /**
+   * Actions that require explicit operator confirmation every time.
+   * Currently: Tier 2.
+   */
+  explicitApprovalRequired: RemediationActionKind[];
+
+  /**
+   * Actions that should never be automated. Always require manual review
+   * and explicit confirmation. Currently: Tier 3.
+   */
+  neverAutomate: RemediationActionKind[];
+};
+
+// ---------------------------------------------------------------------------
+// Plan Generator Input
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for the plan generator.
+ * Snapshot is the only required input — the generator is a pure function.
+ */
+export type BuildRemediationPlanOptions = {
+  /** The raw health snapshot to analyze. */
+  snapshot: SessionHealthRawSnapshot;
+
+  /**
+   * Override retention defaults per session class (milliseconds).
+   * If not provided, uses the built-in defaults from the Phase 1 taxonomy.
+   */
+  retentionOverrides?: Partial<Record<SessionHealthClass, number>>;
+
+  /**
+   * Whether to include actions that have zero estimated impact.
+   * Default: false (omit no-op actions for cleaner reports).
+   */
+  includeNoOpActions?: boolean;
+};

--- a/src/infra/session-health-runner.ts
+++ b/src/infra/session-health-runner.ts
@@ -1,0 +1,104 @@
+/**
+ * Session Health — Periodic Timer Runner
+ *
+ * Follows the exact pattern established by `heartbeat-runner.ts`:
+ * - Registers a `setTimeout` + `unref()` timer so it won't prevent clean shutdown.
+ * - Runs the collector periodically and writes cached snapshots.
+ * - First collection happens after a startup delay (not in the critical path).
+ * - Config-reactive: can update the interval on config reload.
+ */
+
+import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  collectSessionHealth,
+  pruneOldHistory,
+  writeCachedSnapshot,
+  writeHistorySnapshot,
+} from "./session-health-collector.js";
+
+const log = createSubsystemLogger("session-health");
+
+/** Default interval: 5 minutes. */
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000;
+/** Startup delay: 30 seconds (don't block gateway startup). */
+const STARTUP_DELAY_MS = 30_000;
+
+export type SessionHealthRunner = {
+  stop: () => void;
+  updateConfig: (cfg: OpenClawConfig) => void;
+};
+
+export function startSessionHealthCollector(opts?: {
+  cfg?: OpenClawConfig;
+  intervalMs?: number;
+  startupDelayMs?: number;
+}): SessionHealthRunner {
+  const state = {
+    cfg: opts?.cfg ?? loadConfig(),
+    intervalMs: opts?.intervalMs ?? DEFAULT_INTERVAL_MS,
+    timer: null as ReturnType<typeof setTimeout> | null,
+    stopped: false,
+    running: false,
+  };
+
+  const runCollection = async () => {
+    if (state.stopped || state.running) {
+      return;
+    }
+    state.running = true;
+    try {
+      const snapshot = await collectSessionHealth(state.cfg);
+      await writeCachedSnapshot(snapshot);
+      await writeHistorySnapshot(snapshot);
+      await pruneOldHistory();
+      log.info("session health snapshot collected", {
+        durationMs: snapshot.collectorDurationMs,
+        indexed: snapshot.sessions.indexedCount,
+        agents: snapshot.agents.length,
+      });
+    } catch (err) {
+      log.warn("session health collection failed", { error: String(err) });
+    } finally {
+      state.running = false;
+      scheduleNext();
+    }
+  };
+
+  const scheduleNext = () => {
+    if (state.stopped) {
+      return;
+    }
+    if (state.timer) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+    state.timer = setTimeout(() => {
+      state.timer = null;
+      void runCollection();
+    }, state.intervalMs);
+    state.timer.unref?.();
+  };
+
+  // Schedule first run after startup delay
+  state.timer = setTimeout(() => {
+    state.timer = null;
+    void runCollection();
+  }, opts?.startupDelayMs ?? STARTUP_DELAY_MS);
+  state.timer.unref?.();
+
+  const stop = () => {
+    state.stopped = true;
+    if (state.timer) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+  };
+
+  const updateConfig = (cfg: OpenClawConfig) => {
+    state.cfg = cfg;
+  };
+
+  return { stop, updateConfig };
+}

--- a/src/infra/session-health-runner.ts
+++ b/src/infra/session-health-runner.ts
@@ -14,9 +14,11 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   collectSessionHealth,
   pruneOldHistory,
+  writeCachedDerivedSurface,
   writeCachedSnapshot,
   writeHistorySnapshot,
 } from "./session-health-collector.js";
+import { deriveSessionHealthSurface } from "./session-health-derive.js";
 
 const log = createSubsystemLogger("session-health");
 
@@ -53,10 +55,16 @@ export function startSessionHealthCollector(opts?: {
       await writeCachedSnapshot(snapshot);
       await writeHistorySnapshot(snapshot);
       await pruneOldHistory();
+
+      // Derive and cache the operator-facing health surface (Layer B)
+      const surface = deriveSessionHealthSurface(snapshot);
+      await writeCachedDerivedSurface(surface);
+
       log.info("session health snapshot collected", {
         durationMs: snapshot.collectorDurationMs,
         indexed: snapshot.sessions.indexedCount,
         agents: snapshot.agents.length,
+        overallLevel: surface.overallLevel,
       });
     } catch (err) {
       log.warn("session health collection failed", { error: String(err) });

--- a/src/infra/session-health-types.ts
+++ b/src/infra/session-health-types.ts
@@ -103,6 +103,16 @@ export type SessionHealthRawSnapshot = {
     sessionsJsonBytes: number;
     sessionsJsonParseTimeMs: number | null;
     byClass: SessionHealthClassCounts;
+    /**
+     * Per-class counts of sessions whose `updatedAt` exceeds the class
+     * retention threshold. Only populated for prunable classes (cron-run,
+     * subagent, acp, heartbeat). Null/missing values mean the class has
+     * no retention policy (permanent) or no stale sessions.
+     *
+     * Added in the trust-fix pass to avoid overstating stale counts in
+     * the remediation plan.
+     */
+    staleByClass?: Partial<SessionHealthClassCounts>;
     byDiskState: DiskStateCounts;
   };
 
@@ -115,6 +125,30 @@ export type SessionHealthRawSnapshot = {
   growth: SessionHealthGrowth;
 
   agents: SessionHealthAgentBreakdown[];
+};
+
+// ---------------------------------------------------------------------------
+// Per-Class Retention Defaults (Phase 1 taxonomy)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default retention thresholds per session class.
+ *
+ * `null` means permanent (never auto-pruned by retention policy).
+ * Used by both the collector (to compute stale-per-class counts) and
+ * the remediation plan builder (to determine pruning targets).
+ */
+export const DEFAULT_CLASS_RETENTION_MS: Record<SessionHealthClass, number | null> = {
+  main: null, // permanent — never auto-pruned
+  channel: null, // permanent
+  direct: null, // permanent
+  "cron-definition": null, // retain while cron job exists
+  "cron-run": 7 * 24 * 60 * 60 * 1000, // 7 days
+  subagent: 7 * 24 * 60 * 60 * 1000, // 7 days
+  acp: 14 * 24 * 60 * 60 * 1000, // 14 days
+  heartbeat: 3 * 24 * 60 * 60 * 1000, // 3 days
+  thread: null, // inherits parent
+  unknown: 30 * 24 * 60 * 60 * 1000, // 30 days (existing pruneAfterMs default)
 };
 
 // ---------------------------------------------------------------------------

--- a/src/infra/session-health-types.ts
+++ b/src/infra/session-health-types.ts
@@ -118,6 +118,21 @@ export type SessionHealthRawSnapshot = {
 
   storage: SessionHealthStorageBreakdown;
 
+  /**
+   * Counts of .deleted and .reset files that are past the retention
+   * window (pruneAfterMs). These allow the plan builder to report
+   * honest affectedCounts rather than using the total disk-state counts,
+   * which may include files still within retention.
+   *
+   * Added in the count-honesty fixup pass.
+   */
+  staleArtifacts?: {
+    staleDeletedCount: number;
+    staleDeletedBytes: number;
+    staleResetCount: number;
+    staleResetBytes: number;
+  };
+
   drift: SessionHealthDrift;
 
   maintenance: SessionHealthMaintenance;

--- a/src/infra/session-health-types.ts
+++ b/src/infra/session-health-types.ts
@@ -1,0 +1,150 @@
+/**
+ * Session Health — Type Definitions
+ *
+ * These types define the raw diagnostic snapshot (Layer A) and the derived
+ * operator-facing health surface (Layer B) for session lifecycle management.
+ *
+ * Architectural rule: `sessionHealth` is a *sibling* health domain alongside
+ * existing health/heartbeat infrastructure. It does NOT live inside the
+ * workflow/job state model.
+ */
+
+// ---------------------------------------------------------------------------
+// Axis 1 — Session Class (identity derived from session key)
+// ---------------------------------------------------------------------------
+
+export type SessionHealthClass =
+  | "main"
+  | "channel"
+  | "direct"
+  | "cron-definition"
+  | "cron-run"
+  | "subagent"
+  | "acp"
+  | "heartbeat"
+  | "thread"
+  | "unknown";
+
+// ---------------------------------------------------------------------------
+// Axis 2 — Disk Artifact State (derived from filename on disk)
+// ---------------------------------------------------------------------------
+
+export type DiskArtifactState =
+  | "active"
+  | "deleted"
+  | "reset"
+  | "orphanedTemp"
+  | "backup"
+  | "index";
+
+// ---------------------------------------------------------------------------
+// Layer A — Raw Diagnostic Snapshot
+// ---------------------------------------------------------------------------
+
+export type SessionHealthClassCounts = Record<SessionHealthClass, number>;
+
+export type DiskStateCounts = {
+  active: number;
+  deleted: number;
+  reset: number;
+  orphanedTemp: number;
+};
+
+export type SessionHealthStorageBreakdown = {
+  totalManagedBytes: number;
+  sessionsJsonBytes: number;
+  activeTranscriptBytes: number;
+  deletedTranscriptBytes: number;
+  resetTranscriptBytes: number;
+  orphanedTempBytes: number;
+};
+
+export type SessionHealthDrift = {
+  indexedWithoutDiskFile: number;
+  diskFilesWithoutIndex: number;
+  orphanedTempCount: number;
+  oldestOrphanedTempAt: string | null;
+  reconciliationRecommended: boolean;
+};
+
+export type SessionHealthMaintenance = {
+  mode: "warn" | "enforce";
+  maxEntries: number;
+  pruneAfterMs: number;
+  maxDiskBytes: number | null;
+  usagePercent: {
+    entries: number;
+    diskBytes: number | null;
+  };
+};
+
+export type SessionHealthGrowth = {
+  sessionsBytes24h: number | null;
+  sessionsBytes7d: number | null;
+  indexedCount24h: number | null;
+  indexedCount7d: number | null;
+};
+
+export type SessionHealthAgentBreakdown = {
+  agentId: string;
+  storePath: string;
+  indexedCount: number;
+  byClass: SessionHealthClassCounts;
+  totalManagedBytes: number;
+  resetTranscriptBytes: number;
+};
+
+export type SessionHealthRawSnapshot = {
+  capturedAt: string;
+  collectorDurationMs: number;
+
+  sessions: {
+    indexedCount: number;
+    sessionsJsonBytes: number;
+    sessionsJsonParseTimeMs: number | null;
+    byClass: SessionHealthClassCounts;
+    byDiskState: DiskStateCounts;
+  };
+
+  storage: SessionHealthStorageBreakdown;
+
+  drift: SessionHealthDrift;
+
+  maintenance: SessionHealthMaintenance;
+
+  growth: SessionHealthGrowth;
+
+  agents: SessionHealthAgentBreakdown[];
+};
+
+// ---------------------------------------------------------------------------
+// Layer B — Derived Operator-Facing Health Surface
+// ---------------------------------------------------------------------------
+
+export type SessionHealthLevel = "healthy" | "warning" | "critical" | "unknown" | "stale_data";
+
+export type SessionHealthIndicatorKey =
+  | "indexHealth"
+  | "sessionPressure"
+  | "storagePressure"
+  | "growthTrend"
+  | "stalestOrphan";
+
+export type SessionHealthIndicator = {
+  key: SessionHealthIndicatorKey;
+  label: string;
+  level: SessionHealthLevel;
+  summary: string;
+  valueText?: string | null;
+  actionHint?: string | null;
+  measuredAt: string;
+};
+
+export type SessionHealthSurface = {
+  overallLevel: SessionHealthLevel;
+  summary: string;
+  indicators: SessionHealthIndicator[];
+  diagnosticsAvailable: boolean;
+  measuredAt: string;
+  lastHealthyAt?: string | null;
+};

--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -25,51 +25,164 @@ function writeExecutable(dir: string, name: string, contents: string): void {
   });
 }
 
-describe("git-hooks/pre-commit (integration)", () => {
-  it("does not treat staged filenames as git-add flags (e.g. --all)", () => {
-    const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-pre-commit-"));
-    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+/**
+ * Scaffold a temp git repo with the real pre-commit hook symlinked in and
+ * lightweight stubs for the helper scripts.  Returns the temp dir path, the
+ * fake-bin directory (prepended to PATH), and a pnpm stub that logs its
+ * invocations so tests can assert whether the gate ran.
+ */
+function scaffoldHookRepo(): { dir: string; fakeBinDir: string; pnpmLog: string } {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-pre-commit-"));
+  run(dir, "git", ["init", "-q", "--initial-branch=main"]);
 
-    // Use the real hook script and lightweight helper stubs.
-    mkdirSync(path.join(dir, "git-hooks"), { recursive: true });
-    mkdirSync(path.join(dir, "scripts", "pre-commit"), { recursive: true });
-    symlinkSync(
-      path.join(process.cwd(), "git-hooks", "pre-commit"),
-      path.join(dir, "git-hooks", "pre-commit"),
-    );
-    writeFileSync(
-      path.join(dir, "scripts", "pre-commit", "run-node-tool.sh"),
-      "#!/usr/bin/env bash\nexit 0\n",
-      {
-        encoding: "utf8",
-        mode: 0o755,
-      },
-    );
-    writeFileSync(
-      path.join(dir, "scripts", "pre-commit", "filter-staged-files.mjs"),
-      "process.exit(0);\n",
-      "utf8",
-    );
-    const fakeBinDir = path.join(dir, "bin");
-    mkdirSync(fakeBinDir, { recursive: true });
-    writeExecutable(fakeBinDir, "node", "#!/usr/bin/env bash\nexit 0\n");
-    // The hook ends with `pnpm check`, but this fixture is only exercising staged-file handling.
-    // Stub pnpm too so Windows CI does not invoke a real package-manager command in the temp repo.
-    writeExecutable(fakeBinDir, "pnpm", "#!/usr/bin/env bash\nexit 0\n");
+  mkdirSync(path.join(dir, "git-hooks"), { recursive: true });
+  mkdirSync(path.join(dir, "scripts", "pre-commit"), { recursive: true });
+  symlinkSync(
+    path.join(process.cwd(), "git-hooks", "pre-commit"),
+    path.join(dir, "git-hooks", "pre-commit"),
+  );
+  writeFileSync(
+    path.join(dir, "scripts", "pre-commit", "run-node-tool.sh"),
+    "#!/usr/bin/env bash\nexit 0\n",
+    { encoding: "utf8", mode: 0o755 },
+  );
+  // The real filter-staged-files.mjs emits NUL-delimited output.  Use a stub
+  // that faithfully echoes back the inputs it receives so the hook's arrays
+  // populate correctly for non-code files (empty) vs code files (non-empty).
+  symlinkSync(
+    path.join(process.cwd(), "scripts", "pre-commit", "filter-staged-files.mjs"),
+    path.join(dir, "scripts", "pre-commit", "filter-staged-files.mjs"),
+  );
+
+  const fakeBinDir = path.join(dir, "bin");
+  mkdirSync(fakeBinDir, { recursive: true });
+  // node must be the real node so the filter script can actually run.
+  const realNode = process.execPath;
+  symlinkSync(realNode, path.join(fakeBinDir, "node"));
+
+  const pnpmLog = path.join(dir, "pnpm-invocations.log");
+  writeExecutable(fakeBinDir, "pnpm", `#!/usr/bin/env bash\necho "$@" >> "${pnpmLog}"\nexit 0\n`);
+
+  return { dir, fakeBinDir, pnpmLog };
+}
+
+/** Build a PATH string with the fake bin dir at the front. */
+function hookEnv(fakeBinDir: string, extra?: Record<string, string>): NodeJS.ProcessEnv {
+  return {
+    PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+    ...extra,
+  };
+}
+
+describe("git-hooks/pre-commit (integration)", () => {
+  // ── Security regression ────────────────────────────────────────────────────
+  it("does not treat staged filenames as git-add flags (e.g. --all)", () => {
+    const { dir, fakeBinDir } = scaffoldHookRepo();
 
     // Create an untracked file that should NOT be staged by the hook.
     writeFileSync(path.join(dir, "secret.txt"), "do-not-stage\n", "utf8");
 
-    // Stage a maliciously-named file. Older hooks using `xargs git add` could run `git add --all`.
+    // Stage a maliciously-named file. Older hooks using `xargs git add` could
+    // run `git add --all`.
     writeFileSync(path.join(dir, "--all"), "flag\n", "utf8");
     run(dir, "git", ["add", "--", "--all"]);
 
     // Run the hook directly (same logic as when installed via core.hooksPath).
-    run(dir, "bash", ["git-hooks/pre-commit"], {
-      PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
-    });
+    run(dir, "bash", ["git-hooks/pre-commit"], hookEnv(fakeBinDir));
 
     const staged = run(dir, "git", ["diff", "--cached", "--name-only"]).split("\n").filter(Boolean);
     expect(staged).toEqual(["--all"]);
+  });
+
+  // ── Gate gating: non-code commits skip pnpm check ─────────────────────────
+  it("skips repo-wide gate when only non-code files are staged", () => {
+    const { dir, fakeBinDir, pnpmLog } = scaffoldHookRepo();
+
+    // Provide package.json + pnpm-lock.yaml so the real-checkout condition is met.
+    writeFileSync(path.join(dir, "package.json"), "{}\n", "utf8");
+    writeFileSync(path.join(dir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+
+    // Stage a non-code file (image-like extension — not in lint or format sets).
+    writeFileSync(path.join(dir, "photo.png"), "img\n", "utf8");
+    run(dir, "git", ["add", "--", "photo.png"]);
+
+    run(dir, "bash", ["git-hooks/pre-commit"], hookEnv(fakeBinDir));
+
+    // pnpm should NOT have been invoked.
+    let pnpmInvoked = false;
+    try {
+      readFileSync(pnpmLog, "utf8");
+      pnpmInvoked = true;
+    } catch {
+      // File doesn't exist → pnpm was never called.
+    }
+    expect(pnpmInvoked).toBe(false);
+  });
+
+  // ── Gate gating: code commits DO run pnpm check ───────────────────────────
+  it("runs repo-wide gate when code files are staged in a real checkout", () => {
+    const { dir, fakeBinDir, pnpmLog } = scaffoldHookRepo();
+
+    writeFileSync(path.join(dir, "package.json"), "{}\n", "utf8");
+    writeFileSync(path.join(dir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+
+    // Stage a TypeScript file (lint + format target).
+    writeFileSync(path.join(dir, "index.ts"), "export {};\n", "utf8");
+    run(dir, "git", ["add", "--", "index.ts"]);
+
+    run(dir, "bash", ["git-hooks/pre-commit"], hookEnv(fakeBinDir));
+
+    const invocations = readFileSync(pnpmLog, "utf8").trim();
+    expect(invocations).toContain("check");
+  });
+
+  // ── OPENCLAW_SKIP_CHECK bypass ─────────────────────────────────────────────
+  it("skips repo-wide gate when OPENCLAW_SKIP_CHECK is set", () => {
+    const { dir, fakeBinDir, pnpmLog } = scaffoldHookRepo();
+
+    writeFileSync(path.join(dir, "package.json"), "{}\n", "utf8");
+    writeFileSync(path.join(dir, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+
+    // Stage a code file that would normally trigger the gate.
+    writeFileSync(path.join(dir, "index.ts"), "export {};\n", "utf8");
+    run(dir, "git", ["add", "--", "index.ts"]);
+
+    run(
+      dir,
+      "bash",
+      ["git-hooks/pre-commit"],
+      hookEnv(fakeBinDir, {
+        OPENCLAW_SKIP_CHECK: "1",
+      }),
+    );
+
+    // pnpm should NOT have been invoked despite code files being staged.
+    let pnpmInvoked = false;
+    try {
+      readFileSync(pnpmLog, "utf8");
+      pnpmInvoked = true;
+    } catch {
+      // File doesn't exist → pnpm was never called.
+    }
+    expect(pnpmInvoked).toBe(false);
+  });
+
+  // ── Re-stage gating: git-add only runs when tools ran ─────────────────────
+  it("does not re-stage files when no tools ran", () => {
+    const { dir, fakeBinDir } = scaffoldHookRepo();
+
+    // Stage only a non-code file — neither lint nor format tools will run.
+    writeFileSync(path.join(dir, "notes.txt"), "hello\n", "utf8");
+    run(dir, "git", ["add", "--", "notes.txt"]);
+
+    // Also create an unstaged modification to ensure `git add` is not called
+    // (which would re-stage any worktree changes to the same file).
+    writeFileSync(path.join(dir, "notes.txt"), "modified\n", "utf8");
+
+    run(dir, "bash", ["git-hooks/pre-commit"], hookEnv(fakeBinDir));
+
+    // The staged content should still be "hello", not "modified".
+    const stagedContent = run(dir, "git", ["show", ":notes.txt"]);
+    expect(stagedContent).toBe("hello");
   });
 });

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3916,6 +3916,147 @@
   }
 }
 
+/* ── Session Health card ─────────────────────────────────── */
+
+.sh-card {
+  margin-top: 18px;
+}
+
+.sh-card .card-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sh-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm, 4px);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.sh-badge.sh-healthy {
+  color: var(--success, #22c55e);
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.sh-badge.sh-warning {
+  color: var(--warning, #eab308);
+  background: rgba(234, 179, 8, 0.1);
+}
+
+.sh-badge.sh-critical {
+  color: var(--danger, #ef4444);
+  background: rgba(239, 68, 68, 0.1);
+}
+
+.sh-badge.sh-stale {
+  color: var(--muted);
+  background: var(--bg-hover);
+}
+
+.sh-badge.sh-unknown {
+  color: var(--muted);
+  background: var(--bg-hover);
+}
+
+.sh-summary {
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.sh-indicators {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.sh-indicator {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: var(--radius-md, 6px);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.sh-indicator.sh-healthy {
+  border-color: var(--border);
+}
+
+.sh-indicator.sh-warning {
+  border-color: var(--warning-subtle, rgba(234, 179, 8, 0.25));
+  background: rgba(234, 179, 8, 0.04);
+}
+
+.sh-indicator.sh-critical {
+  border-color: var(--danger-subtle, rgba(239, 68, 68, 0.25));
+  background: rgba(239, 68, 68, 0.04);
+}
+
+.sh-indicator.sh-stale,
+.sh-indicator.sh-unknown {
+  border-color: var(--border);
+  opacity: 0.7;
+}
+
+.sh-indicator__icon {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.sh-indicator.sh-healthy .sh-indicator__icon {
+  color: var(--success, #22c55e);
+}
+
+.sh-indicator.sh-warning .sh-indicator__icon {
+  color: var(--warning, #eab308);
+}
+
+.sh-indicator.sh-critical .sh-indicator__icon {
+  color: var(--danger, #ef4444);
+}
+
+.sh-indicator__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.sh-indicator__label {
+  font-weight: 500;
+  font-size: 13px;
+}
+
+.sh-indicator__summary {
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.sh-indicator__value {
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.sh-measured {
+  font-size: 11px;
+  margin-top: 10px;
+  text-align: right;
+}
+
 @media (max-width: 600px) {
   .ov-cards {
     grid-template-columns: repeat(2, 1fr);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -634,6 +634,7 @@ export function renderApp(state: AppViewState) {
                 cronJobs: state.cronJobs,
                 cronStatus: state.cronStatus,
                 attentionItems: state.attentionItems,
+                sessionHealthSurface: state.healthResult?.sessionHealthSurface ?? null,
                 eventLog: state.eventLog,
                 overviewLogLines: state.overviewLogLines,
                 showGatewayToken: state.overviewShowGatewayToken,

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -36,6 +36,7 @@ import { startThemeTransition, type ThemeTransitionContext } from "./theme-trans
 import { resolveTheme, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type { AgentsListResult, AttentionItem } from "./types.ts";
 import { resetChatViewState } from "./views/chat.ts";
+import { extractSessionHealthAttentionItems } from "./views/overview-session-health.ts";
 
 type SettingsHost = {
   settings: UiSettings;
@@ -629,6 +630,13 @@ function buildAttentionItems(host: OpenClawApp) {
       title: `${overdue.length} overdue job${overdue.length > 1 ? "s" : ""}`,
       description: overdue.map((j) => j.name).join(", "),
     });
+  }
+
+  // Session Health attention items (from derived Layer B surface)
+  const sessionHealthSurface = host.healthResult?.sessionHealthSurface ?? null;
+  const sessionHealthItems = extractSessionHealthAttentionItems(sessionHealthSurface);
+  for (const item of sessionHealthItems) {
+    items.push(item);
   }
 
   host.attentionItems = items;

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -618,6 +618,31 @@ export type StatusSummary = Record<string, unknown>;
 
 export type HealthSnapshot = Record<string, unknown>;
 
+// ---------------------------------------------------------------------------
+// Session Health types (mirrors src/infra/session-health-types.ts Layer B)
+// ---------------------------------------------------------------------------
+
+export type SessionHealthLevel = "healthy" | "warning" | "critical" | "unknown" | "stale_data";
+
+export type SessionHealthIndicator = {
+  key: string;
+  label: string;
+  level: SessionHealthLevel;
+  summary: string;
+  valueText?: string | null;
+  actionHint?: string | null;
+  measuredAt: string;
+};
+
+export type SessionHealthSurface = {
+  overallLevel: SessionHealthLevel;
+  summary: string;
+  indicators: SessionHealthIndicator[];
+  diagnosticsAvailable: boolean;
+  measuredAt: string;
+  lastHealthyAt?: string | null;
+};
+
 /** Strongly-typed health response from the gateway (richer than HealthSnapshot). */
 export type HealthSummary = {
   ok: boolean;
@@ -635,6 +660,8 @@ export type HealthSummary = {
       age: number | null;
     }>;
   };
+  /** Derived operator-facing session health surface (Layer B). */
+  sessionHealthSurface?: SessionHealthSurface | null;
 };
 
 /** A model entry returned by the gateway model-catalog endpoint. */

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -233,6 +233,7 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
     cronJobs: [],
     cronStatus: null,
     attentionItems: [],
+    sessionHealthSurface: null,
     eventLog: [],
     overviewLogLines: [],
     showGatewayToken: false,

--- a/ui/src/ui/views/overview-session-health.ts
+++ b/ui/src/ui/views/overview-session-health.ts
@@ -1,0 +1,187 @@
+/**
+ * Overview — Session Health Card
+ *
+ * Renders the derived SessionHealthSurface (Layer B) as a compact health
+ * card in the Mission Control overview. Shows overall status + individual
+ * indicators with health states (healthy/warning/critical).
+ *
+ * Design principles:
+ * - Health states over raw counts
+ * - High-signal: ~5 indicators max
+ * - Warning/critical states surface as attention items
+ * - Graceful when no data exists yet (collector hasn't run)
+ */
+
+import { html, nothing } from "lit";
+import { formatRelativeTimestamp } from "../format.ts";
+import type { SessionHealthSurface, SessionHealthIndicator, SessionHealthLevel } from "../types.ts";
+
+export type OverviewSessionHealthProps = {
+  surface: SessionHealthSurface | null | undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Level → presentation mapping
+// ---------------------------------------------------------------------------
+
+function levelIcon(level: SessionHealthLevel): string {
+  switch (level) {
+    case "healthy":
+      return "✓";
+    case "warning":
+      return "⚠";
+    case "critical":
+      return "✗";
+    case "stale_data":
+      return "⏳";
+    case "unknown":
+      return "?";
+  }
+}
+
+function levelClass(level: SessionHealthLevel): string {
+  switch (level) {
+    case "healthy":
+      return "sh-healthy";
+    case "warning":
+      return "sh-warning";
+    case "critical":
+      return "sh-critical";
+    case "stale_data":
+      return "sh-stale";
+    case "unknown":
+      return "sh-unknown";
+  }
+}
+
+function levelLabel(level: SessionHealthLevel): string {
+  switch (level) {
+    case "healthy":
+      return "Healthy";
+    case "warning":
+      return "Warning";
+    case "critical":
+      return "Critical";
+    case "stale_data":
+      return "Stale Data";
+    case "unknown":
+      return "Unknown";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Indicator row
+// ---------------------------------------------------------------------------
+
+function renderIndicator(ind: SessionHealthIndicator) {
+  return html`
+    <div class="sh-indicator ${levelClass(ind.level)}">
+      <span class="sh-indicator__icon">${levelIcon(ind.level)}</span>
+      <div class="sh-indicator__body">
+        <div class="sh-indicator__label">${ind.label}</div>
+        <div class="sh-indicator__summary muted">${ind.summary}</div>
+      </div>
+      ${ind.valueText ? html`<span class="sh-indicator__value">${ind.valueText}</span>` : nothing}
+    </div>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Main render
+// ---------------------------------------------------------------------------
+
+export function renderOverviewSessionHealth(props: OverviewSessionHealthProps) {
+  const { surface } = props;
+
+  if (!surface) {
+    return nothing; // No data yet — collector hasn't run
+  }
+
+  const overall = surface.overallLevel;
+  const measuredAt = surface.measuredAt
+    ? formatRelativeTimestamp(new Date(surface.measuredAt).getTime())
+    : "";
+
+  return html`
+    <section class="card sh-card ${levelClass(overall)}">
+      <div class="card-title">
+        <span>Session Health</span>
+        <span class="sh-badge ${levelClass(overall)}">${levelIcon(overall)} ${levelLabel(overall)}</span>
+      </div>
+      <div class="sh-summary muted">${surface.summary}</div>
+      <div class="sh-indicators">
+        ${surface.indicators.map(renderIndicator)}
+      </div>
+      ${measuredAt ? html`<div class="sh-measured muted">Last checked ${measuredAt}</div>` : nothing}
+    </section>
+  `;
+}
+
+/**
+ * Extract session health attention items for the overview attention bar.
+ *
+ * Only surfaces warning/critical indicators — healthy/unknown don't generate
+ * attention items to keep the UI high-signal.
+ */
+export function extractSessionHealthAttentionItems(
+  surface: SessionHealthSurface | null | undefined,
+): Array<{ severity: "warning" | "error"; icon: string; title: string; description: string }> {
+  if (!surface) {
+    return [];
+  }
+
+  const items: Array<{
+    severity: "warning" | "error";
+    icon: string;
+    title: string;
+    description: string;
+  }> = [];
+
+  // Overall stale data warning
+  if (surface.overallLevel === "stale_data") {
+    items.push({
+      severity: "warning",
+      icon: "clock",
+      title: "Session health data is stale",
+      description: "The session health collector may have stopped. Check gateway logs.",
+    });
+    return items; // Don't add per-indicator items when data is stale
+  }
+
+  for (const ind of surface.indicators) {
+    if (ind.level === "critical") {
+      items.push({
+        severity: "error",
+        icon: indicatorIcon(ind.key),
+        title: `Session Health: ${ind.label}`,
+        description: ind.summary + (ind.actionHint ? ` — ${ind.actionHint}` : ""),
+      });
+    } else if (ind.level === "warning") {
+      items.push({
+        severity: "warning",
+        icon: indicatorIcon(ind.key),
+        title: `Session Health: ${ind.label}`,
+        description: ind.summary + (ind.actionHint ? ` — ${ind.actionHint}` : ""),
+      });
+    }
+  }
+
+  return items;
+}
+
+function indicatorIcon(key: string): string {
+  switch (key) {
+    case "indexHealth":
+      return "database";
+    case "sessionPressure":
+      return "activity";
+    case "storagePressure":
+      return "hard-drive";
+    case "growthTrend":
+      return "trending-up";
+    case "stalestOrphan":
+      return "archive";
+    default:
+      return "radio";
+  }
+}

--- a/ui/src/ui/views/overview.ts
+++ b/ui/src/ui/views/overview.ts
@@ -10,6 +10,7 @@ import type {
   AttentionItem,
   CronJob,
   CronStatus,
+  SessionHealthSurface,
   SessionsListResult,
   SessionsUsageResult,
   SkillStatusReport,
@@ -23,6 +24,7 @@ import {
   shouldShowPairingHint,
 } from "./overview-hints.ts";
 import { renderOverviewLogTail } from "./overview-log-tail.ts";
+import { renderOverviewSessionHealth } from "./overview-session-health.ts";
 
 export type OverviewProps = {
   connected: boolean;
@@ -43,6 +45,7 @@ export type OverviewProps = {
   cronJobs: CronJob[];
   cronStatus: CronStatus | null;
   attentionItems: AttentionItem[];
+  sessionHealthSurface: SessionHealthSurface | null | undefined;
   eventLog: EventLogEntry[];
   overviewLogLines: string[];
   showGatewayToken: boolean;
@@ -392,6 +395,8 @@ export function renderOverview(props: OverviewProps) {
     })}
 
     ${renderOverviewAttention({ items: props.attentionItems })}
+
+    ${renderOverviewSessionHealth({ surface: props.sessionHealthSurface })}
 
     <div class="ov-section-divider"></div>
 


### PR DESCRIPTION
## What this ships

This PR preserves the local session-health work on a reviewable branch and proposes it upstream.

### Session health chain
- classification + collection + lifecycle runner
- Layer B derived operator-facing health surface
- Mission Control visibility groundwork
- remediation planning + `cleanup --dry-run`
- stale-count honesty fix
- UX honesty pass
- manual remediation executor
- Phase 3C hardening

### Follow-up infra improvement
- smarter pre-commit gate behavior
- `OPENCLAW_SKIP_CHECK` escape hatch
- expanded hook test coverage

## Why it matters

This is the foundation for making session lifecycle/storage health legible before any cleanup path is trusted. It also preserves the local machine work that was already activated and tested in practice.

## Notes
- branch pushed from `amzzzzzzz/openclaw:feat/session-health`
- Mission Control currently bridges the derived session-health cache on the live machine; that local bridge lives outside this repo
- direct push to upstream was not available, so this follows the normal fork + PR flow
