### PR TITLE
fix(session-manager-cache): evict expired entries from SESSION_MANAGER_CACHE

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-cache.ts
+++ b/src/agents/pi-embedded-runner/session-manager-cache.ts
@@ -42,7 +42,11 @@ function isSessionManagerCached(sessionFile: string): boolean {
   }
   const now = Date.now();
   const ttl = getSessionManagerTtl();
-  return now - entry.loadedAt <= ttl;
+  if (now - entry.loadedAt > ttl) {
+    SESSION_MANAGER_CACHE.delete(sessionFile);
+    return false;
+  }
+  return true;
 }
 
 export async function prewarmSessionFile(sessionFile: string): Promise<void> {


### PR DESCRIPTION
## Problem

The `SESSION_MANAGER_CACHE` Map in `src/agents/pi-embedded-runner/session-manager-cache.ts` stores one entry per unique session file path. When `isSessionManagerCached()` finds a stale entry (TTL exceeded), it returned `false` but **never deleted the expired entry** from the Map. Entries accumulated indefinitely since `trackSessionManagerAccess()` only adds/updates and no code path ever calls `.delete()`.

On long-running gateways, this contributes to gradual heap growth.

## Fix

Delete the expired entry in `isSessionManagerCached()` before returning `false`. This keeps the Map bounded to the number of active (non-expired) session files — essentially a lazy-eviction strategy.

## Diff

```diff
 function isSessionManagerCached(sessionFile: string): boolean {
   ...
   const now = Date.now();
   const ttl = getSessionManagerTtl();
-  return now - entry.loadedAt <= ttl;
+  if (now - entry.loadedAt > ttl) {
+    SESSION_MANAGER_CACHE.delete(sessionFile);
+    return false;
+  }
+  return true;
 }
```

Closes #51820