### PR TITLE
fix: three memory leak fixes (seqByRun, session-manager-cache, orphaned chat buffers)

### DIFF
--- a/src/agents/pi-embedded-runner/session-manager-cache.ts
+++ b/src/agents/pi-embedded-runner/session-manager-cache.ts
@@ -42,7 +42,13 @@ function isSessionManagerCached(sessionFile: string): boolean {
   }
   const now = Date.now();
   const ttl = getSessionManagerTtl();
-  return now - entry.loadedAt <= ttl;
+  const isFresh = now - entry.loadedAt <= ttl;
+  if (!isFresh) {
+    // Expired entry — delete it to prevent unbounded map growth (memory leak fix)
+    SESSION_MANAGER_CACHE.delete(sessionFile);
+    return false;
+  }
+  return true;
 }
 
 export async function prewarmSessionFile(sessionFile: string): Promise<void> {

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -26,6 +26,7 @@ function createMaintenanceTimerDeps() {
     chatRunState: { abortedRuns: new Map() },
     chatRunBuffers: new Map(),
     chatDeltaSentAt: new Map(),
+    chatDeltaLastBroadcastLen: new Map(),
     removeChatRun: () => undefined,
     agentRunSeq: new Map(),
     nodeSendToSession: () => {},

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -31,6 +31,7 @@ export function startGatewayMaintenanceTimers(params: {
   chatRunState: { abortedRuns: Map<string, number> };
   chatRunBuffers: Map<string, string>;
   chatDeltaSentAt: Map<string, number>;
+  chatDeltaLastBroadcastLen: Map<string, number>;
   removeChatRun: (
     sessionId: string,
     clientRunId: string,
@@ -129,6 +130,22 @@ export function startGatewayMaintenanceTimers(params: {
       params.chatRunState.abortedRuns.delete(runId);
       params.chatRunBuffers.delete(runId);
       params.chatDeltaSentAt.delete(runId);
+    }
+
+    // Sweep orphaned buffers for runs that were never explicitly aborted but have
+    // gone stale (deltaSentAt older than ABORTED_RUN_TTL_MS). These represent stuck
+    // runs where emitChatFinal never fired, causing chatRunState.buffers to leak.
+    for (const [clientRunId, lastSentAt] of params.chatDeltaSentAt) {
+      if (now - lastSentAt <= ABORTED_RUN_TTL_MS) {
+        continue;
+      }
+      // Skip if this runId is still tracked as active in abortedRuns
+      if (params.chatRunState.abortedRuns.has(clientRunId)) {
+        continue;
+      }
+      params.chatRunBuffers.delete(clientRunId);
+      params.chatDeltaSentAt.delete(clientRunId);
+      params.chatDeltaLastBroadcastLen.delete(clientRunId);
     }
   }, 60_000);
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -814,6 +814,7 @@ export async function startGatewayServer(
       chatRunState,
       chatRunBuffers,
       chatDeltaSentAt,
+      chatDeltaLastBroadcastLen: chatRunState.deltaLastBroadcastLen,
       removeChatRun,
       agentRunSeq,
       nodeSendToSession,

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -63,6 +63,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   state.runContextById.delete(runId);
+  state.seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {


### PR DESCRIPTION
## Summary

Three memory leak fixes identified from community issue reports:

### 1. fix(agent-events): delete seqByRun entry in clearAgentRunContext
**Issue:** #51819 - `seqByRun` Map in `src/infra/agent-events.ts` stores one entry per `runId` but was never cleaned up, causing unbounded Map growth.

**Fix:** Added `state.seqByRun.delete(runId)` in `clearAgentRunContext()` alongside the existing `runContextById` cleanup.

### 2. fix(session-manager-cache): delete expired entries
**Issue:** #51820 - `SESSION_MANAGER_CACHE` entries were checked for TTL but never deleted when expired, causing the Map to grow indefinitely.

**Fix:** When TTL check fails in `isSessionManagerCached()`, the expired entry is now deleted inline.

### 3. fix(server): sweep orphaned chat buffers and deltaLastBroadcastLen
**Issue:** #51821 - `chatRunState.buffers` entries for stuck runs (where `emitChatFinal` never fired, e.g. LLM timeout) were never cleaned up, contributing to V8 heap exhaustion.

**Fix:** Added orphaned buffer sweep in the maintenance timer: entries in `chatDeltaSentAt` older than `ABORTED_RUN_TTL_MS` that are not tracked in `abortedRuns` are now cleaned up. Also added `deltaLastBroadcastLen` sweep (previously only cleaned in `emitChatFinal`).

## Tests
- `src/infra/agent-events.test.ts`: 8/8 passed
- `src/gateway/server-maintenance.test.ts`: 3/3 passed
