### PR TITLE
docs: Add Lia Memory Engine to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -56,6 +56,18 @@ while reducing token usage.
 openclaw plugins install @martian-engineering/lossless-claw
 ```
 
+### Lia Memory Engine
+
+Context engine plugin with structured compaction via Haiku, auto-flush to daily
+transcripts, and hybrid BM25 + vector auto-retrieval powered by QMD.
+
+- **npm:** `@kavinbmittal/lia-memory-engine`
+- **repo:** [github.com/kavinbmittal/lia-memory-engine](https://github.com/kavinbmittal/lia-memory-engine)
+
+```bash
+openclaw plugins install @kavinbmittal/lia-memory-engine
+```
+
 ### Opik
 
 Official plugin that exports agent traces to Opik. Monitor agent behavior,


### PR DESCRIPTION
## Summary
- Adds Lia Memory Engine to the community plugins listing
- Published on npm as `@kavinbmittal/lia-memory-engine`
- Source at [github.com/kavinbmittal/lia-memory-engine](https://github.com/kavinbmittal/lia-memory-engine)

Context engine plugin with structured compaction via Haiku, auto-flush to daily transcripts, and hybrid BM25 + vector auto-retrieval powered by QMD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)