### PR TITLE
fix: prefer Body over BodyForAgent in BodyStripped fallback chain

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -302,6 +302,7 @@ export async function processMessage(params: {
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     BodyForAgent: params.msg.body,
+    Timestamp: params.msg.timestamp,
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -350,7 +350,7 @@ describe("createInboundDebouncer", () => {
 });
 
 describe("initSessionState BodyStripped", () => {
-  it("prefers BodyForAgent over Body for group chats", async () => {
+  it("prefers Body over BodyForAgent for group chats (Body includes envelope)", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sender-meta-"));
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as OpenClawConfig;
@@ -369,10 +369,10 @@ describe("initSessionState BodyStripped", () => {
       commandAuthorized: true,
     });
 
-    expect(result.sessionCtx.BodyStripped).toBe("ping");
+    expect(result.sessionCtx.BodyStripped).toBe("[WhatsApp 123@g.us] ping");
   });
 
-  it("prefers BodyForAgent over Body for direct chats", async () => {
+  it("prefers Body over BodyForAgent for direct chats (Body includes envelope)", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sender-meta-direct-"));
     const storePath = path.join(root, "sessions.json");
     const cfg = { session: { store: storePath } } as OpenClawConfig;
@@ -390,7 +390,7 @@ describe("initSessionState BodyStripped", () => {
       commandAuthorized: true,
     });
 
-    expect(result.sessionCtx.BodyStripped).toBe("ping");
+    expect(result.sessionCtx.BodyStripped).toBe("[WhatsApp +1] ping");
   });
 });
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -571,11 +571,13 @@ export async function initSessionState(params: {
   const sessionCtx: TemplateContext = {
     ...ctx,
     // Keep BodyStripped aligned with Body (best default for agent prompts).
+    // Body may include envelope metadata (e.g. timestamps from formatInboundEnvelope),
+    // so it takes priority over BodyForAgent (raw text without envelope).
     // RawBody is reserved for command/directive parsing and may omit context.
     BodyStripped: normalizeInboundTextNewlines(
       bodyStripped ??
-        ctx.BodyForAgent ??
         ctx.Body ??
+        ctx.BodyForAgent ??
         ctx.CommandBody ??
         ctx.RawBody ??
         ctx.BodyForCommands ??


### PR DESCRIPTION
## Problem

`envelopeTimestamp: "on"` is configured but envelope timestamps never reach the model. Two root causes:

### 1. `BodyForAgent` takes priority over `Body` in `initSessionState` (all channels)

`formatInboundEnvelope()` correctly wraps the message with timestamp metadata and assigns it to `ctx.Body`. But `initSessionState` computes `BodyStripped` with `ctx.BodyForAgent ?? ctx.Body`, so the raw body (no envelope) always wins.

**Confirmed by @piazzatron** on Telegram (#50098 comment) — even though Telegram correctly passes `Timestamp`, the envelope prefix never reaches the model because `BodyForAgent` short-circuits.

### 2. WhatsApp never passes `Timestamp` to `finalizeInboundContext` (WhatsApp-only)

Every other channel plugin (Discord, Telegram, Signal, Slack, LINE, iMessage, TUI) passes `Timestamp` into the context payload. WhatsApp was the only one missing it, despite having `params.msg.timestamp` available.

(Previously identified in @arkyu2077's #50119, which was auto-closed due to PR queue limits.)

## Fix

1. **Swap priority** in `initSessionState` (`session.ts`): `ctx.Body ?? ctx.BodyForAgent` instead of `ctx.BodyForAgent ?? ctx.Body` — ensures envelope-wrapped Body is used when available.
2. **Add `Timestamp`** to WhatsApp's `finalizeInboundContext` call (`process-message.ts`).
3. **Update tests** in `inbound.test.ts` — two assertions that encoded the old (broken) priority.

## Testing

- Traced every setter and reader of `BodyForAgent` across the codebase (~10 direct assignments, 30+ channel initializations, 5 readers). No downstream code depends on the old priority order.
- `Body` is always a superset of `BodyForAgent` across every channel (same text plus envelope metadata).
- Directive/command parsing (`get-reply-directives.ts`) reads `BodyForAgent` directly, bypassing `BodyStripped` — unaffected.
- Updated 2 test assertions in `inbound.test.ts` that previously asserted the broken behavior.

Fixes #50098
Related to #16442, #25334