### PR TITLE
Agents: raise default timeout to 48h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.
 - CLI/Ollama onboarding: keep the interactive model picker for explicit `openclaw onboard --auth-choice ollama` runs so setup still selects a default model without reintroducing pre-picker auto-pulls. (#49249) Thanks @BruceMacD.

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
-import { resolveAgentTimeoutMs } from "./timeout.js";
+import { resolveAgentTimeoutMs, resolveAgentTimeoutSeconds } from "./timeout.js";
 
 describe("getSubagentDepthFromSessionStore", () => {
   it("uses spawnDepth from the session store when available", () => {
@@ -115,6 +115,11 @@ describe("getSubagentDepthFromSessionStore", () => {
 });
 
 describe("resolveAgentTimeoutMs", () => {
+  it("defaults to 48 hours when config does not override the timeout", () => {
+    expect(resolveAgentTimeoutSeconds()).toBe(48 * 60 * 60);
+    expect(resolveAgentTimeoutMs({})).toBe(48 * 60 * 60 * 1000);
+  });
+
   it("uses a timer-safe sentinel for no-timeout overrides", () => {
     expect(resolveAgentTimeoutMs({ overrideSeconds: 0 })).toBe(2_147_000_000);
     expect(resolveAgentTimeoutMs({ overrideMs: 0 })).toBe(2_147_000_000);

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 
-const DEFAULT_AGENT_TIMEOUT_SECONDS = 600;
+const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 const normalizeNumber = (value: unknown): number | undefined =>


### PR DESCRIPTION
## Summary

- Problem: ACP and other agent runs without an explicit timeout inherit the shared default agent timeout of 600 seconds.
- Why it matters: long-running bound sessions like `#codex-1` can fail after 10 minutes even when no shorter limit was configured.
- What changed: raised the shared default in `src/agents/timeout.ts` from 600s to 48h and added regression coverage for the default-resolution path.
- What did NOT change (scope boundary): explicit `agents.defaults.timeoutSeconds`, ACP session runtime timeout overrides, and `0 = no timeout` behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51816

## User-visible / Behavior Changes

- The default agent timeout is now 48 hours instead of 600 seconds when no explicit timeout is configured.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm
- Model/provider: codex / ACP
- Integration/channel (if any): Discord `#codex-1`
- Relevant config (redacted): no ACP session timeout override; shared default path in `src/agents/timeout.ts`

### Steps

1. Start an ACP-bound session without `runtimeOptions.timeoutSeconds`.
2. Let the run rely on the shared default timeout path.
3. Observe the bound session error after 600 seconds.

### Expected

- The session should use a long-lived default timeout unless explicitly configured shorter.

### Actual

- The session failed with `ACP_TURN_FAILED: ACP turn timed out after 600s.`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the live `#codex-1` bound session state showing `ACP turn timed out after 600s.`, then changed the default timeout path and added a regression test asserting the new 48h default.
- Edge cases checked: `overrideSeconds: 0` / `overrideMs: 0` still map to the timer-safe no-timeout sentinel; large overrides still clamp safely.
- What you did **not** verify: a full 48-hour live run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `agents.defaults.timeoutSeconds` explicitly in config, or revert this commit.
- Files/config to restore: `src/agents/timeout.ts`
- Known bad symptoms reviewers should watch for: unexpectedly long-lived runs where operators depended on the implicit 600s default.

## Risks and Mitigations

- Risk: the shared default applies beyond ACP, so some unattended agent runs will stay alive much longer by default.
- Mitigation: explicit per-agent and per-session timeout overrides still take precedence, and the PR keeps those paths unchanged.
