### PR TITLE
fix(telegram): use openclaw/plugin-sdk subpath imports (#51815)

### DIFF
--- a/extensions/telegram/runtime-api.ts
+++ b/extensions/telegram/runtime-api.ts
@@ -7,7 +7,7 @@ export type {
   TelegramAccountConfig,
   TelegramActionConfig,
   TelegramNetworkConfig,
-} from "../../src/plugin-sdk/telegram.js";
+} from "openclaw/plugin-sdk/telegram";
 export type {
   OpenClawPluginService,
   OpenClawPluginServiceContext,
@@ -37,7 +37,7 @@ export {
   projectCredentialSnapshotFields,
   resolveConfiguredFromCredentialStatuses,
   resolveTelegramPollVisibility,
-} from "../../src/plugin-sdk/telegram.js";
+} from "openclaw/plugin-sdk/telegram";
 export {
   buildChannelConfigSchema,
   getChatChannelMeta,
@@ -49,7 +49,7 @@ export {
   readStringParam,
   resolvePollMaxSelections,
   TelegramConfigSchema,
-} from "../../src/plugin-sdk/telegram-core.js";
+} from "openclaw/plugin-sdk/telegram-core";
 export type { TelegramProbe } from "./src/probe.js";
 export { auditTelegramGroupMembership, collectTelegramUnmentionedGroupIds } from "./src/audit.js";
 export { telegramMessageActions } from "./src/channel-actions.js";

--- a/package.json
+++ b/package.json
@@ -437,6 +437,14 @@
       "types": "./dist/plugin-sdk/tool-send.d.ts",
       "default": "./dist/plugin-sdk/tool-send.js"
     },
+    "./plugin-sdk/telegram": {
+      "types": "./dist/plugin-sdk/telegram.d.ts",
+      "default": "./dist/plugin-sdk/telegram.js"
+    },
+    "./plugin-sdk/telegram-core": {
+      "types": "./dist/plugin-sdk/telegram-core.d.ts",
+      "default": "./dist/plugin-sdk/telegram-core.js"
+    },
     "./extension-api": "./dist/extensionAPI.js",
     "./cli-entry": "./openclaw.mjs"
   },

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -98,5 +98,7 @@
   "zalouser",
   "speech",
   "state-paths",
-  "tool-send"
+  "tool-send",
+  "telegram",
+  "telegram-core"
 ]


### PR DESCRIPTION
## Summary

Fixes #51815 - Telegram plugin fails to load in Docker containers.

## Problem

The Telegram plugin was using relative imports (`../../src/plugin-sdk/telegram.js`) which don't work in Docker containers where the source directory structure is not available.

## Solution

Replace relative imports with the proper `openclaw/plugin-sdk/telegram` subpath imports:

- `extensions/telegram/runtime-api.ts` now imports from `openclaw/plugin-sdk/telegram` and `openclaw/plugin-sdk/telegram-core`
- Added `telegram` and `telegram-core` to the plugin-sdk entrypoints
- Added corresponding exports to `package.json`

## Testing

- TypeScript compilation passes
- Plugin loader tests pass (80 tests)

## Impact

- Minimal change, no breaking changes
- Plugin will now load correctly in Docker environments