### PR TITLE
fix(telegram): retry network errors wrapped in grammY HttpError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/install: forward `--dangerously-force-unsafe-install` through archive and npm-spec plugin installs so the documented override reaches the security scanner on those install paths. (#58879) Thanks @ryanlee-gemini.
 - Chat/error replies: stop leaking raw provider/runtime failures into external chat channels, return a friendly retry message instead, and add a specific `/new` hint for Bedrock toolResult/toolUse session mismatches. (#58831) Thanks @ImLukeF.
 - Memory/session indexing: keep full reindexes from skipping session transcripts when sync is triggered by `session-start` or `watch`, so restart-driven reindexes preserve session memory (#39732) thanks @upupc
+- Telegram/retries: keep non-idempotent sends on the strict safe-send path, retry wrapped pre-connect failures, and preserve `429` / `retry_after` backoff for safe delivery retries. (#51895) Thanks @chinar-amrutkar
 
 ## 2026.3.31
 

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -223,6 +223,14 @@ describe("isTelegramRateLimitError", () => {
     expect(isTelegramRateLimitError(errorWithTelegramCode("Too Many Requests", 429))).toBe(true);
   });
 
+  it("detects wrapped 429 retry_after errors without error_code", () => {
+    const wrapped = {
+      message: "429 Too Many Requests",
+      response: { parameters: { retry_after: 1 } },
+    };
+    expect(isTelegramRateLimitError(wrapped)).toBe(true);
+  });
+
   it("detects error_code in nested cause", () => {
     const inner = Object.assign(new Error("Too Many Requests"), { error_code: 429 });
     const outer = Object.assign(new Error("wrapped"), { cause: inner });

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -160,6 +160,16 @@ describe("isRecoverableTelegramNetworkError", () => {
 });
 
 describe("isSafeToRetrySendError", () => {
+  class MockHttpError extends Error {
+    constructor(
+      message: string,
+      public readonly error: unknown,
+    ) {
+      super(message);
+      this.name = "HttpError";
+    }
+  }
+
   it.each([
     ["ECONNREFUSED", "connect ECONNREFUSED", true],
     ["ENOTFOUND", "getaddrinfo ENOTFOUND", true],
@@ -182,6 +192,13 @@ describe("isSafeToRetrySendError", () => {
   it("detects pre-connect error nested in cause chain", () => {
     const root = Object.assign(new Error("ECONNREFUSED"), { code: "ECONNREFUSED" });
     const wrapped = Object.assign(new Error("fetch failed"), { cause: root });
+    expect(isSafeToRetrySendError(wrapped)).toBe(true);
+  });
+
+  it("detects pre-connect error wrapped in grammY HttpError", () => {
+    const root = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const fetchError = Object.assign(new TypeError("fetch failed"), { cause: root });
+    const wrapped = new MockHttpError("Network request for 'sendMessage' failed!", fetchError);
     expect(isSafeToRetrySendError(wrapped)).toBe(true);
   });
 });

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getTelegramNetworkErrorOrigin,
   isRecoverableTelegramNetworkError,
+  isTelegramRateLimitError,
   isSafeToRetrySendError,
   isTelegramClientRejection,
   isTelegramPollingNetworkError,
@@ -214,6 +215,18 @@ describe("isTelegramServerError", () => {
 
   it("returns false for plain Error", () => {
     expect(isTelegramServerError(new Error("500: Internal Server Error"))).toBe(false);
+  });
+});
+
+describe("isTelegramRateLimitError", () => {
+  it("returns true for Telegram 429 errors", () => {
+    expect(isTelegramRateLimitError(errorWithTelegramCode("Too Many Requests", 429))).toBe(true);
+  });
+
+  it("detects error_code in nested cause", () => {
+    const inner = Object.assign(new Error("Too Many Requests"), { error_code: 429 });
+    const outer = Object.assign(new Error("wrapped"), { cause: inner });
+    expect(isTelegramRateLimitError(outer)).toBe(true);
   });
 });
 

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -188,6 +188,10 @@ export function isTelegramServerError(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 500);
 }
 
+export function isTelegramRateLimitError(err: unknown): boolean {
+  return hasTelegramErrorCode(err, (code) => code === 429);
+}
+
 /** Returns true for HTTP 4xx client errors (Telegram explicitly rejected, not applied). */
 export function isTelegramClientRejection(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 400 && code < 500);

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -183,13 +183,47 @@ function hasTelegramErrorCode(err: unknown, matches: (code: number) => boolean):
   return false;
 }
 
+function hasTelegramRetryAfter(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const retryAfter =
+      "parameters" in candidate && candidate.parameters && typeof candidate.parameters === "object"
+        ? (candidate.parameters as { retry_after?: unknown }).retry_after
+        : "response" in candidate &&
+            candidate.response &&
+            typeof candidate.response === "object" &&
+            "parameters" in candidate.response
+          ? (
+              candidate.response as {
+                parameters?: { retry_after?: unknown };
+              }
+            ).parameters?.retry_after
+          : "error" in candidate &&
+              candidate.error &&
+              typeof candidate.error === "object" &&
+              "parameters" in candidate.error
+            ? (candidate.error as { parameters?: { retry_after?: unknown } }).parameters
+                ?.retry_after
+            : undefined;
+    if (typeof retryAfter === "number" && Number.isFinite(retryAfter)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Returns true for HTTP 5xx server errors (error may have been processed). */
 export function isTelegramServerError(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 500);
 }
 
 export function isTelegramRateLimitError(err: unknown): boolean {
-  return hasTelegramErrorCode(err, (code) => code === 429);
+  return (
+    hasTelegramErrorCode(err, (code) => code === 429) ||
+    (hasTelegramRetryAfter(err) && /(?:^|\b)429\b|too many requests/i.test(formatErrorMessage(err)))
+  );
 }
 
 /** Returns true for HTTP 4xx client errors (Telegram explicitly rejected, not applied). */

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -940,6 +940,40 @@ describe("sendMessageTelegram", () => {
     vi.useRealTimers();
   });
 
+  it("retries wrapped pre-connect HttpError sends", async () => {
+    vi.useFakeTimers();
+    const chatId = "123";
+    const root = Object.assign(new Error("connect ECONNREFUSED api.telegram.org"), {
+      code: "ECONNREFUSED",
+    });
+    const fetchError = Object.assign(new TypeError("fetch failed"), { cause: root });
+    const err = Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+      name: "HttpError",
+      error: fetchError,
+    });
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({
+        message_id: 1,
+        chat: { id: chatId },
+      });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    const promise = sendMessageTelegram(chatId, "hi", {
+      token: "tok",
+      api,
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1000, jitter: 0 },
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toEqual({ messageId: "1", chatId });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it("does not retry on non-transient errors", async () => {
     const chatId = "123";
     const sendMessage = vi.fn().mockRejectedValue(new Error("400: Bad Request"));

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1921,8 +1921,7 @@ describe("sendStickerTelegram", () => {
     const sendSticker = vi
       .fn()
       .mockRejectedValueOnce({
-        error_code: 429,
-        description: "Too Many Requests",
+        message: "429 Too Many Requests",
         response: { parameters: { retry_after: 1 } },
       })
       .mockResolvedValueOnce({

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1861,6 +1861,25 @@ describe("sendStickerTelegram", () => {
       }),
     ).rejects.toThrow(/returned no message_id/i);
   });
+
+  it("does not retry generic grammY failed envelopes for sticker sends", async () => {
+    const chatId = "123";
+    const sendSticker = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Network request for 'sendSticker' failed!"));
+    const api = { sendSticker } as unknown as {
+      sendSticker: typeof sendSticker;
+    };
+
+    await expect(
+      sendStickerTelegram(chatId, "fileId123", {
+        token: "tok",
+        api,
+        retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+      }),
+    ).rejects.toThrow(/Network request for 'sendSticker' failed!/i);
+    expect(sendSticker).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("shared send behaviors", () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1914,6 +1914,39 @@ describe("sendStickerTelegram", () => {
     ).rejects.toThrow(/Network request for 'sendSticker' failed!/i);
     expect(sendSticker).toHaveBeenCalledTimes(1);
   });
+
+  it("retries rate-limited sticker sends and honors retry_after", async () => {
+    vi.useFakeTimers();
+    const chatId = "123";
+    const sendSticker = vi
+      .fn()
+      .mockRejectedValueOnce({
+        error_code: 429,
+        description: "Too Many Requests",
+        response: { parameters: { retry_after: 1 } },
+      })
+      .mockResolvedValueOnce({
+        message_id: 109,
+        chat: { id: chatId },
+      });
+    const api = { sendSticker } as unknown as {
+      sendSticker: typeof sendSticker;
+    };
+    const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+    const promise = sendStickerTelegram(chatId, "fileId123", {
+      token: "tok",
+      api,
+      retry: { attempts: 2, minDelayMs: 0, maxDelayMs: 1000, jitter: 0 },
+    });
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toEqual({ messageId: "109", chatId });
+    expect(setTimeoutSpy.mock.calls[0]?.[1]).toBe(1000);
+    expect(sendSticker).toHaveBeenCalledTimes(2);
+    setTimeoutSpy.mockRestore();
+    vi.useRealTimers();
+  });
 });
 
 describe("shared send behaviors", () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -31,6 +31,7 @@ import { resolveTelegramApiBase, resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText, splitTelegramHtmlChunks } from "./format.js";
 import {
   isRecoverableTelegramNetworkError,
+  isTelegramRateLimitError,
   isSafeToRetrySendError,
   isTelegramServerError,
 } from "./network-errors.js";
@@ -606,7 +607,7 @@ function createTelegramNonIdempotentRequestWithDiag(params: {
     retry: params.retry,
     verbose: params.verbose,
     useApiErrorLogging: params.useApiErrorLogging,
-    shouldRetry: (err) => isSafeToRetrySendError(err),
+    shouldRetry: (err) => isSafeToRetrySendError(err) || isTelegramRateLimitError(err),
     strictShouldRetry: true,
   });
 }

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1523,7 +1523,7 @@ export async function sendStickerTelegram(
   });
   const hasThreadParams = Object.keys(threadParams).length > 0;
 
-  const requestWithDiag = createTelegramRequestWithDiag({
+  const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({
     cfg,
     account,
     retry: opts.retry,

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -84,8 +84,7 @@ describe("error helpers", () => {
     a.cause = b;
     b.cause = a;
     const formatted = formatErrorMessage(a);
-    expect(formatted).toContain("error A");
-    expect(formatted).toContain("error B");
+    expect(formatted).toBe("error A | error B");
   });
 
   it("redacts sensitive tokens from formatted error messages", () => {

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -68,6 +68,26 @@ describe("error helpers", () => {
     expect(formatErrorMessage(value)).toBe(expected);
   });
 
+  it("traverses .cause chain to include nested error messages", () => {
+    const rootCause = new Error("ECONNRESET");
+    const httpError = Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+      cause: rootCause,
+    });
+    const formatted = formatErrorMessage(httpError);
+    expect(formatted).toContain("Network request for 'sendMessage' failed!");
+    expect(formatted).toContain("ECONNRESET");
+  });
+
+  it("handles circular .cause references without infinite loop", () => {
+    const a: Error & { cause?: unknown } = new Error("error A");
+    const b: Error & { cause?: unknown } = new Error("error B");
+    a.cause = b;
+    b.cause = a;
+    const formatted = formatErrorMessage(a);
+    expect(formatted).toContain("error A");
+    expect(formatted).toContain("error B");
+  });
+
   it("redacts sensitive tokens from formatted error messages", () => {
     const token = "sk-abcdefghijklmnopqrstuv";
     const formatted = formatErrorMessage(new Error(`Authorization: Bearer ${token}`));

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -75,7 +75,9 @@ export function formatErrorMessage(err: unknown): string {
     while (cause && !seen.has(cause)) {
       seen.add(cause);
       if (cause instanceof Error) {
-        if (cause.message) formatted += ` | ${cause.message}`;
+        if (cause.message) {
+          formatted += ` | ${cause.message}`;
+        }
         cause = cause.cause;
       } else if (typeof cause === "string") {
         formatted += ` | ${cause}`;

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -69,6 +69,21 @@ export function formatErrorMessage(err: unknown): string {
   let formatted: string;
   if (err instanceof Error) {
     formatted = err.message || err.name || "Error";
+    // Traverse .cause chain to include nested error messages (e.g. grammY HttpError wraps network errors in .cause)
+    let cause: unknown = err.cause;
+    const seen = new Set<unknown>();
+    while (cause && !seen.has(cause)) {
+      seen.add(cause);
+      if (cause instanceof Error) {
+        if (cause.message) formatted += ` | ${cause.message}`;
+        cause = cause.cause;
+      } else if (typeof cause === "string") {
+        formatted += ` | ${cause}`;
+        break;
+      } else {
+        break;
+      }
+    }
   } else if (typeof err === "string") {
     formatted = err;
   } else if (typeof err === "number" || typeof err === "boolean" || typeof err === "bigint") {

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -71,7 +71,7 @@ export function formatErrorMessage(err: unknown): string {
     formatted = err.message || err.name || "Error";
     // Traverse .cause chain to include nested error messages (e.g. grammY HttpError wraps network errors in .cause)
     let cause: unknown = err.cause;
-    const seen = new Set<unknown>();
+    const seen = new Set<unknown>([err]);
     while (cause && !seen.has(cause)) {
       seen.add(cause);
       if (cause instanceof Error) {

--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -118,6 +118,36 @@ describe("createTelegramRetryRunner", () => {
         expectedError: "permission denied",
       },
       {
+        name: "retries grammY HttpError wrapping network error via .cause traversal",
+        runnerOptions: {
+          retry: { ...ZERO_DELAY_RETRY, attempts: 2 },
+        },
+        fnSteps: [
+          {
+            type: "reject" as const,
+            value: Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+              cause: new Error("ECONNRESET"),
+            }),
+          },
+        ],
+        expectedCalls: 2,
+        expectedError: "Network request",
+      },
+      {
+        name: "retries grammY HttpError via regex 'Network request' match",
+        runnerOptions: {
+          retry: { ...ZERO_DELAY_RETRY, attempts: 2 },
+        },
+        fnSteps: [
+          {
+            type: "reject" as const,
+            value: new Error("Network request for 'sendMessage' failed!"),
+          },
+        ],
+        expectedCalls: 2,
+        expectedError: "Network request",
+      },
+      {
         name: "keeps retrying retriable errors until attempts are exhausted",
         runnerOptions: {
           retry: ZERO_DELAY_RETRY,

--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -134,20 +134,6 @@ describe("createTelegramRetryRunner", () => {
         expectedError: "Network request",
       },
       {
-        name: "retries grammY HttpError via regex 'Network request' match",
-        runnerOptions: {
-          retry: { ...ZERO_DELAY_RETRY, attempts: 2 },
-        },
-        fnSteps: [
-          {
-            type: "reject" as const,
-            value: new Error("Network request for 'sendMessage' failed!"),
-          },
-        ],
-        expectedCalls: 2,
-        expectedError: "Network request",
-      },
-      {
         name: "keeps retrying retriable errors until attempts are exhausted",
         runnerOptions: {
           retry: ZERO_DELAY_RETRY,

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -11,8 +11,7 @@ export const TELEGRAM_RETRY_DEFAULTS = {
   jitter: 0.1,
 };
 
-const TELEGRAM_RETRY_RE =
-  /429|timeout|connect|reset|closed|unavailable|temporarily|Network request/i;
+const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
 const log = createSubsystemLogger("retry-policy");
 
 function resolveTelegramShouldRetry(params: {

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -11,7 +11,8 @@ export const TELEGRAM_RETRY_DEFAULTS = {
   jitter: 0.1,
 };
 
-const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily|Network request/i;
+const TELEGRAM_RETRY_RE =
+  /429|timeout|connect|reset|closed|unavailable|temporarily|Network request/i;
 const log = createSubsystemLogger("retry-policy");
 
 function resolveTelegramShouldRetry(params: {

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -11,7 +11,7 @@ export const TELEGRAM_RETRY_DEFAULTS = {
   jitter: 0.1,
 };
 
-const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
+const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily|Network request/i;
 const log = createSubsystemLogger("retry-policy");
 
 function resolveTelegramShouldRetry(params: {


### PR DESCRIPTION
## Summary

- Problem: grammY wraps network failures (ECONNRESET, ETIMEDOUT) in HttpError with message `Network request for 'sendMessage' failed!` and the original error in `.cause`. `formatErrorMessage` only checked `err.message`, so `shouldRetry` never fired — ~40 silent failures/day on high-latency paths.
- What changed: `formatErrorMessage` traverses `.cause` chain (with cycle protection). Added `Network request` to `TELEGRAM_RETRY_RE`.
- What did NOT change: Retry timing, attempt counts, Discord retry logic, public API surface.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #51525

## User-visible / Behavior Changes

Telegram message sends now retry on transient network errors that grammY wraps in HttpError. Previously silently dropped.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Throw grammY HttpError wrapping ECONNRESET: `throw Object.assign(new Error("Network request for 'sendMessage' failed!"), { cause: new Error("ECONNRESET") })`
2. Observe retry fires

### Expected

shouldRetry returns true, retry executes.

### Actual (before fix)

shouldRetry returns false, no retry.

## Evidence

- [x] Failing test before + passing after
- [x] Log snippets from #51525

## Human Verification

- Verified: formatErrorMessage traverses .cause chain, TELEGRAM_RETRY_RE matches grammY HttpError
- Edge cases: circular .cause (cycle protection), 3+ nesting levels
- Not verified: live Telegram integration (needs production setup)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert: `git revert HEAD` on branch
- Bad symptoms: retry storms (unlikely — only affects previously-failing paths)