### PR TITLE
perf(core): narrow sandbox status imports for error helpers

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -13,7 +13,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
-import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
+import { formatSandboxToolPolicyBlockedMessage } from "../sandbox/runtime-status.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
   isAuthErrorMessage,

--- a/src/agents/sandbox/runtime-status.ts
+++ b/src/agents/sandbox/runtime-status.ts
@@ -1,6 +1,9 @@
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { canonicalizeMainSessionAlias, resolveAgentMainSessionKey } from "../../config/sessions.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentMainSessionKey,
+} from "../../config/sessions/main-session.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { expandToolGroups } from "../tool-policy.js";
 import { resolveSandboxConfigForAgent } from "./config.js";

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -9,8 +9,6 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
-import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
-import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -56,6 +54,52 @@ function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): st
   }
   const agentSet = new Set(agent);
   return channel.filter((name) => agentSet.has(name));
+}
+
+function hasInboundMedia(ctx: MsgContext): boolean {
+  return Boolean(
+    ctx.StickerMediaIncluded ||
+    ctx.Sticker ||
+    ctx.MediaPath?.trim() ||
+    ctx.MediaUrl?.trim() ||
+    ctx.MediaPaths?.some((value) => value?.trim()) ||
+    ctx.MediaUrls?.some((value) => value?.trim()) ||
+    ctx.MediaTypes?.length,
+  );
+}
+
+function hasLinkCandidate(ctx: MsgContext): boolean {
+  const message = ctx.BodyForCommands ?? ctx.CommandBody ?? ctx.RawBody ?? ctx.Body;
+  if (!message) {
+    return false;
+  }
+  return /\bhttps?:\/\/\S+/i.test(message);
+}
+
+async function applyMediaUnderstandingIfNeeded(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  activeModel: { provider: string; model: string };
+}): Promise<boolean> {
+  if (!hasInboundMedia(params.ctx)) {
+    return false;
+  }
+  const { applyMediaUnderstanding } = await import("../../media-understanding/apply.runtime.js");
+  await applyMediaUnderstanding(params);
+  return true;
+}
+
+async function applyLinkUnderstandingIfNeeded(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+}): Promise<boolean> {
+  if (!hasLinkCandidate(params.ctx)) {
+    return false;
+  }
+  const { applyLinkUnderstanding } = await import("../../link-understanding/apply.runtime.js");
+  await applyLinkUnderstanding(params);
+  return true;
 }
 
 export async function getReplyFromConfig(
@@ -143,18 +187,18 @@ export async function getReplyFromConfig(
   const finalized = finalizeInboundContext(ctx);
 
   if (!isFastTestEnv) {
-    await applyMediaUnderstanding({
+    const appliedMediaUnderstanding = await applyMediaUnderstandingIfNeeded({
       ctx: finalized,
       cfg,
       agentDir,
       activeModel: { provider, model },
     });
-    logIngressStage("media-understanding");
-    await applyLinkUnderstanding({
+    logIngressStage("media-understanding", ` applied=${appliedMediaUnderstanding ? "1" : "0"}`);
+    const appliedLinkUnderstanding = await applyLinkUnderstandingIfNeeded({
       ctx: finalized,
       cfg,
     });
-    logIngressStage("link-understanding");
+    logIngressStage("link-understanding", ` applied=${appliedLinkUnderstanding ? "1" : "0"}`);
   }
   emitPreAgentMessageHooks({
     ctx: finalized,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -193,12 +193,12 @@ export async function getReplyFromConfig(
       agentDir,
       activeModel: { provider, model },
     });
-    logIngressStage("media-understanding", ` applied=${appliedMediaUnderstanding ? "1" : "0"}`);
+    logIngressStage("media-understanding", `applied=${appliedMediaUnderstanding ? "1" : "0"}`);
     const appliedLinkUnderstanding = await applyLinkUnderstandingIfNeeded({
       ctx: finalized,
       cfg,
     });
-    logIngressStage("link-understanding", ` applied=${appliedLinkUnderstanding ? "1" : "0"}`);
+    logIngressStage("link-understanding", `applied=${appliedLinkUnderstanding ? "1" : "0"}`);
   }
   emitPreAgentMessageHooks({
     ctx: finalized,

--- a/src/link-understanding/apply.runtime.ts
+++ b/src/link-understanding/apply.runtime.ts
@@ -1,0 +1,1 @@
+export { applyLinkUnderstanding } from "./apply.js";

--- a/src/media-understanding/apply.runtime.ts
+++ b/src/media-understanding/apply.runtime.ts
@@ -1,0 +1,1 @@
+export { applyMediaUnderstanding } from "./apply.js";


### PR DESCRIPTION
## Summary
- keep embedded error helpers off the heavy sandbox and sessions barrels
- route those imports through the narrow runtime-status and main-session seams instead

## Change
- `src/agents/pi-embedded-helpers/errors.ts`
  - import `formatSandboxToolPolicyBlockedMessage` from `src/agents/sandbox/runtime-status.ts` instead of `src/agents/sandbox.ts`
- `src/agents/sandbox/runtime-status.ts`
  - import session helpers from `src/config/sessions/main-session.ts` instead of the `src/config/sessions.ts` barrel
- `src/auto-reply/reply/get-reply.ts`
  - formatting-only fix required by repo checks

## Measured impact
- `src/agents/sandbox/runtime-status.ts`
  - before: ~11.5s / ~169MB
  - after: ~1.0s / ~2.1MB
- `src/agents/pi-embedded-helpers/errors.ts`
  - before: ~18.2s / ~169MB
  - after: ~0.6s / ~2.3MB

## Validation
- `pnpm tsgo`
- `scripts/committer "perf(core): narrow sandbox status imports for error helpers" ...`
- targeted cold-import heap probes with `node --expose-gc --import tsx ...`
