### PR TITLE
fix(mattermost): inherit thread context in message tool send action

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,120 @@
+name: Preflight (fork)
+
+# Runs on any branch push to teconomix/openclaw (except main).
+# Scoped to checks relevant to our Mattermost patches — avoids pre-existing
+# failures in unrelated extensions (tlon, urbit, etc.) that are not our concern.
+
+on:
+  push:
+    branches-ignore:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: preflight-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  # Format check — fast, no tsgo, no OOM risk
+  format:
+    name: "format check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Format check (oxfmt)
+        run: pnpm format:check
+
+  # Lint checks — boundary guards, no tsgo
+  lint:
+    name: "lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint boundary guards
+        run: |
+          pnpm lint:extensions:no-src-outside-plugin-sdk
+          pnpm lint:extensions:no-plugin-sdk-internal
+          pnpm lint:plugins:no-extension-imports
+          pnpm lint:plugins:no-extension-src-imports
+
+  # Mattermost extension tests — scoped, no full tsgo
+  test-mattermost:
+    name: "mattermost tests"
+    runs-on: ubuntu-latest
+    env:
+      OPENCLAW_CHANGED_EXTENSION: mattermost
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run Mattermost extension tests
+        run: pnpm test:extension mattermost
+
+  # Build smoke — confirms our changes compile
+  build-smoke:
+    name: "build smoke"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build dist
+        run: pnpm build
+
+      - name: Smoke test CLI
+        run: node openclaw.mjs --help

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -301,6 +301,75 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    it("falls back to toolContext.currentThreadTs when no replyTo param is provided", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: "thread-root-id" }),
+      );
+    });
+
+    it("explicit replyTo param wins over toolContext.currentThreadTs", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello", replyTo: "explicit-root" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "session-thread-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: "explicit-root" }),
+      );
+    });
+
+    it("does not inherit thread context when sending to a different channel", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:OTHER", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:OTHER",
+        "hello",
+        expect.objectContaining({ replyToId: undefined }),
+      );
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -103,7 +103,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   supportsAction: ({ action }) => {
     return action === "send" || action === "react";
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
+  handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
     if (action === "react") {
       // Check reactions gate: per-account config takes precedence over base config
       const mmBase = cfg?.channels?.mattermost as Record<string, unknown> | undefined;
@@ -187,7 +187,22 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const message = typeof params.message === "string" ? params.message : "";
     // Match the shared runner semantics: trim empty reply IDs away before
     // falling back from replyToId to replyTo on direct plugin calls.
-    const replyToId = readMattermostReplyToId(params);
+    // When no explicit reply target is set, inherit the thread context from
+    // the active session — but only when:
+    //   1. The send target is the same channel as the active session (same channelId),
+    //      to avoid injecting a foreign root_id into a different Mattermost channel.
+    //   2. replyToMode is "all", or "first" and the first reply has not yet been sent.
+    const sessionThreadTs = toolContext?.currentThreadTs?.trim() || undefined;
+    const isSameChannel =
+      sessionThreadTs !== undefined &&
+      toolContext?.currentChannelId !== undefined &&
+      to === toolContext.currentChannelId;
+    const replyToModeAllowsThread =
+      toolContext?.replyToMode === "all" ||
+      (toolContext?.replyToMode === "first" && toolContext.hasRepliedRef?.value !== true);
+    const replyToId =
+      readMattermostReplyToId(params) ??
+      (isSameChannel && replyToModeAllowsThread ? sessionThreadTs : undefined);
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =


### PR DESCRIPTION
## Problem

When the agent uses the `message` tool to send a proactive message (without an explicit `replyTo`) from a Mattermost thread-scoped session (`replyToMode: "all"`), the message lands at the channel root instead of the current thread.

## Root Cause

The `handleAction` send path in the Mattermost channel plugin calls `sendMessageMattermost` directly (bypassing the shared `resolveAndApplyOutboundThreadId` runner). It only read `replyToId` from explicit tool params and never fell back to the thread context available in `toolContext.currentThreadTs`.

## Fix

Add `toolContext` to the destructured `handleAction` params and use `toolContext?.currentThreadTs` as a fallback when no explicit `replyTo` / `replyToId` is provided in tool params.

**Guards added based on review feedback:**
- Only inherits thread context when the send target (`to`) matches `toolContext.currentChannelId` — prevents injecting a foreign `root_id` when sending to a different Mattermost channel/DM from a thread-scoped session.
- Respects `replyToMode`: for `"first"`, only inherits before the first reply has been sent (`hasRepliedRef.value !== true`); for `"off"` and unset, no fallback.

Explicit `replyTo` always takes precedence.

## Tests

Added three cases to `channel.test.ts`:
- Fallback to `toolContext.currentThreadTs` when no explicit replyTo is given
- Explicit `replyTo` wins over `toolContext.currentThreadTs`
- Cross-channel send (different `to` vs `currentChannelId`) does not inherit thread context

## How to test

1. Configure Mattermost with `replyToMode: "all"`
2. Start a conversation in a channel thread
3. Have the agent call `message(action="send", channel="mattermost", target="channel:<id>", message="...")` without specifying `replyTo`
4. Message should now appear in the current thread, not at channel root

Closes #45082