### PR TITLE
fix(security): exclude logical OR (||) from pipe-to-shell obfuscation detector

### DIFF
--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -55,6 +55,28 @@ describe("detectCommandObfuscation", () => {
       expect(result.detected).toBe(true);
       expect(result.matchedPatterns).toContain("pipe-to-shell");
     });
+
+    it("does NOT flag logical OR (||) with bash as false positive", () => {
+      const result = detectCommandObfuscation(
+        "python3 bin/garmin_health.py 2>/dev/null || bash bin/garmin-health.sh 2>/dev/null",
+      );
+      expect(result.matchedPatterns).not.toContain("pipe-to-shell");
+    });
+
+    it("does NOT flag || sh as a pipe-to-shell false positive", () => {
+      const result = detectCommandObfuscation("do_thing || sh -c 'echo fallback'");
+      expect(result.matchedPatterns).not.toContain("pipe-to-shell");
+    });
+
+    it("does NOT flag || zsh fallback patterns", () => {
+      const result = detectCommandObfuscation("./run.sh || zsh ./fallback.sh");
+      expect(result.matchedPatterns).not.toContain("pipe-to-shell");
+    });
+
+    it("still detects real pipe-to-shell after a logical OR earlier in the command", () => {
+      const result = detectCommandObfuscation("check || cat evil.sh | sh");
+      expect(result.matchedPatterns).toContain("pipe-to-shell");
+    });
   });
 
   describe("escape sequence obfuscation", () => {

--- a/src/infra/exec-obfuscation-detect.ts
+++ b/src/infra/exec-obfuscation-detect.ts
@@ -118,7 +118,7 @@ const OBFUSCATION_PATTERNS: ObfuscationPattern[] = [
   {
     id: "pipe-to-shell",
     description: "Content piped directly to shell interpreter",
-    regex: /\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b(?:\s+[^|;\n\r]+)?\s*$/im,
+    regex: /(?<!\|)\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b(?:\s+[^|;\n\r]+)?\s*$/im,
   },
   {
     id: "command-substitution-decode-exec",


### PR DESCRIPTION
## Summary

Fixes a false-positive in the `pipe-to-shell` obfuscation detection pattern where `||` (logical OR) was being matched as a pipe-to-shell construct.

The existing regex `/\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b.../` matched the second `|` in `||`, causing commands like:

```
python3 bin/garmin_health.py 2>/dev/null || bash bin/garmin-health.sh 2>/dev/null
```

...to be flagged as obfuscated, forcing approval prompts even with `security: full` / `ask: off` configured.

The fix adds a negative lookbehind `(?<!\|)` so only a real single-pipe character triggers the pattern. Logical OR (`||`) is left unaffected.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue

Fixes #51908

## User-visible / Behavior Changes

- Commands using `|| bash`, `|| sh`, `|| zsh` etc. as logical OR fallbacks no longer trigger the pipe-to-shell obfuscation detector
- Real pipe-to-shell patterns (`cat evil.sh | sh`) continue to be detected correctly, including when they appear after a `||` in the same command

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — the fix narrows false-positive detection; all genuine pipe-to-shell patterns remain detected
- Data access scope changed? No

## Evidence

```
pnpm vitest run src/infra/exec-obfuscation-detect.test.ts
# 35 tests pass, 0 failures
```

Added 4 regression tests:
- `|| bash` not flagged
- `|| sh` not flagged  
- `|| zsh` not flagged
- `check || cat evil.sh | sh` still flagged (real pipe after logical OR)