### PR TITLE
fix(agents): allow nodes tool describe action without explicit node param

### DIFF
--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -189,8 +189,8 @@ export function createNodesTool(options?: {
           case "status":
             return jsonResult(await callGatewayTool("node.list", gatewayOpts, {}));
           case "describe": {
-            const node = readStringParam(params, "node", { required: true });
-            const nodeId = await resolveNodeId(gatewayOpts, node);
+            const node = readStringParam(params, "node");
+            const nodeId = await resolveNodeId(gatewayOpts, node, true);
             return jsonResult(await callGatewayTool("node.describe", gatewayOpts, { nodeId }));
           }
           case "pending":


### PR DESCRIPTION
lobster-biscuit

Closes #51903

## Problem

The `nodes` tool `describe` action fails with "node required" when an LLM calls it without a `node` parameter. The tool schema (`NodesToolSchema`) declares `node` as `Type.Optional(Type.String())`, so the LLM correctly omits it for discovery. But the implementation calls `readStringParam(params, "node", { required: true })` — rejecting the valid call.

This causes an error loop: agent tries `describe` for discovery → "node required" → retries → same error.

## Root cause

`src/agents/tools/nodes-tool.ts:192` — `readStringParam` uses `{ required: true }` for the `describe` action, contradicting the schema.

`resolveNodeId()` in `nodes-utils.ts:151` already supports `allowDefault=true` which picks the default/only available node when no query is given.

## User impact

Agents cannot discover nodes via `describe` — the intended discovery entry point. They get stuck in an error loop logging:


## Fix

Remove `{ required: true }` from the `describe` case and pass `allowDefault=true` to `resolveNodeId()`. 1 file, 2 lines changed.

Other actions (notify, run, invoke, etc.) correctly keep `required: true` — they target a specific node and need it.

## How to verify

1. Configure a single node
2. Let agent call `nodes describe` without specifying `node`
3. Before: "node required" error. After: returns node description.

## Tests

`resolveNodeId` with `allowDefault=true` is covered by existing tests in `nodes-utils.test.ts`. The schema/execute mismatch is a wiring issue — the functions themselves are correct, only the call site had the wrong parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)