### PR TITLE
fix(mattermost): inherit thread context in message tool send action

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,120 @@
+name: Preflight (fork)
+
+# Runs on any branch push to teconomix/openclaw (except main).
+# Scoped to checks relevant to our Mattermost patches — avoids pre-existing
+# failures in unrelated extensions (tlon, urbit, etc.) that are not our concern.
+
+on:
+  push:
+    branches-ignore:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: preflight-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  # Format check — fast, no tsgo, no OOM risk
+  format:
+    name: "format check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Format check (oxfmt)
+        run: pnpm format:check
+
+  # Lint checks — boundary guards, no tsgo
+  lint:
+    name: "lint"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint boundary guards
+        run: |
+          pnpm lint:extensions:no-src-outside-plugin-sdk
+          pnpm lint:extensions:no-plugin-sdk-internal
+          pnpm lint:plugins:no-extension-imports
+          pnpm lint:plugins:no-extension-src-imports
+
+  # Mattermost extension tests — scoped, no full tsgo
+  test-mattermost:
+    name: "mattermost tests"
+    runs-on: ubuntu-latest
+    env:
+      OPENCLAW_CHANGED_EXTENSION: mattermost
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run Mattermost extension tests
+        run: pnpm test:extension mattermost
+
+  # Build smoke — confirms our changes compile
+  build-smoke:
+    name: "build smoke"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: "10.23.0"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24.x"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build dist
+        run: pnpm build
+
+      - name: Smoke test CLI
+        run: node openclaw.mjs --help

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -301,6 +301,201 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    it("falls back to toolContext.currentThreadTs when no replyTo param is provided", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: "thread-root-id" }),
+      );
+    });
+
+    it("explicit replyTo param wins over toolContext.currentThreadTs", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello", replyTo: "explicit-root" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "session-thread-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: "explicit-root" }),
+      );
+    });
+
+    it("does not inherit thread context when sending to a different channel", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:OTHER", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:OTHER",
+        "hello",
+        expect.objectContaining({ replyToId: undefined }),
+      );
+    });
+
+    it("inherits thread context for replyToMode=first before first reply", async () => {
+      const cfg = createMattermostTestConfig();
+      const hasRepliedRef = { value: false };
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "first",
+          hasRepliedRef,
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: "thread-root-id" }),
+      );
+    });
+
+    it("does not inherit thread context for replyToMode=first after first reply", async () => {
+      const cfg = createMattermostTestConfig();
+      const hasRepliedRef = { value: true };
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "first",
+          hasRepliedRef,
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: undefined }),
+      );
+    });
+
+    it("does not inherit thread context when replyToMode is off", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "off",
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: undefined }),
+      );
+    });
+
+    it("inherits thread context when replyToMode=off is promoted to all by existing thread", async () => {
+      // buildToolContext promotes off->all when an existing thread is detected
+      // (MessageThreadId set on the inbound post). handleAction receives the
+      // already-promoted toolContext from the agent runner.
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "all", // promoted from off by buildToolContext
+        },
+      } as any);
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: "thread-root-id" }),
+      );
+    });
+
+    it("preserves replyToMode=first when thread exists (does not promote to all)", async () => {
+      // replyToMode=first must NOT be upgraded to all — hasRepliedRef gates further sends.
+      const cfg = createMattermostTestConfig();
+      const hasRepliedRef = { value: true }; // first reply already done
+
+      await mattermostPlugin.actions?.handleAction?.({
+        channel: "mattermost",
+        action: "send",
+        params: { to: "channel:CHAN1", message: "hello" },
+        cfg,
+        accountId: "default",
+        toolContext: {
+          currentThreadTs: "thread-root-id",
+          currentChannelId: "channel:CHAN1",
+          replyToMode: "first",
+          hasRepliedRef,
+        },
+      } as any);
+
+      // second send with replyToMode=first should go to root, not inherit thread
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({ replyToId: undefined }),
+      );
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -103,7 +103,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   supportsAction: ({ action }) => {
     return action === "send" || action === "react";
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
+  handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
     if (action === "react") {
       // Check reactions gate: per-account config takes precedence over base config
       const mmBase = cfg?.channels?.mattermost as Record<string, unknown> | undefined;
@@ -187,7 +187,31 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const message = typeof params.message === "string" ? params.message : "";
     // Match the shared runner semantics: trim empty reply IDs away before
     // falling back from replyToId to replyTo on direct plugin calls.
-    const replyToId = readMattermostReplyToId(params);
+    // When no explicit reply target is set, inherit the thread context from
+    // the active session — but only when:
+    //   1. The send target is the same channel as the active session (same channelId),
+    //      to avoid injecting a foreign root_id into a different Mattermost channel.
+    //   2. replyToMode is "all", or "first" and the first reply has not yet been sent.
+    const sessionThreadTs = toolContext?.currentThreadTs?.trim() || undefined;
+    const normalizedTo = normalizeMattermostMessagingTarget(to) ?? to;
+    const normalizedCurrentChannelId = toolContext?.currentChannelId
+      ? (normalizeMattermostMessagingTarget(toolContext.currentChannelId) ??
+        toolContext.currentChannelId)
+      : undefined;
+    const isSameChannel =
+      sessionThreadTs !== undefined &&
+      normalizedCurrentChannelId !== undefined &&
+      normalizedTo === normalizedCurrentChannelId;
+    // For replyToMode=first, only inherit if a hasRepliedRef exists AND it hasn't fired yet.
+    // Fail-closed: absent ref → don't inherit (avoids every send threading like replyToMode=all).
+    const replyToModeAllowsThread =
+      toolContext?.replyToMode === "all" ||
+      (toolContext?.replyToMode === "first" &&
+        toolContext.hasRepliedRef !== undefined &&
+        toolContext.hasRepliedRef.value !== true);
+    const replyToId =
+      readMattermostReplyToId(params) ??
+      (isSameChannel && replyToModeAllowsThread ? sessionThreadTs : undefined);
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =
@@ -321,6 +345,40 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = {
             : "channel",
         ),
     }),
+    buildToolContext: ({ cfg, accountId, context, hasRepliedRef }) => {
+      // Resolve replyToMode from account config so the message tool can respect it.
+      const account = resolveMattermostAccount({ cfg, accountId: accountId ?? "default" });
+      const chatType =
+        context.ChatType === "direct" ||
+        context.ChatType === "group" ||
+        context.ChatType === "channel"
+          ? context.ChatType
+          : "channel";
+      const configuredReplyToMode = resolveMattermostReplyToMode(account, chatType);
+      // currentThreadTs is the Mattermost root post ID of the active thread.
+      // MessageThreadId is set when the inbound message is already part of a thread.
+      const threadTs =
+        typeof context.MessageThreadId === "string" && context.MessageThreadId.trim()
+          ? context.MessageThreadId.trim()
+          : typeof context.ReplyToId === "string" && context.ReplyToId.trim()
+            ? context.ReplyToId.trim()
+            : undefined;
+      // When the session is already inside a thread and the configured mode is
+      // "off", promote to "all" so that tool sends stay in the thread (mirrors
+      // Slack's threading-tool-context.ts effective-mode promotion).
+      // For "first", preserve it so hasRepliedRef can gate subsequent sends.
+      // For "all", it stays "all" naturally.
+      const effectiveReplyToMode =
+        configuredReplyToMode === "off" && threadTs != null ? "all" : configuredReplyToMode;
+      return {
+        currentChannelId: context.To?.trim() || undefined,
+        currentChannelProvider: "mattermost",
+        currentThreadTs: threadTs,
+        currentMessageId: context.CurrentMessageId,
+        replyToMode: effectiveReplyToMode,
+        hasRepliedRef,
+      };
+    },
   },
   reload: { configPrefixes: ["channels.mattermost"] },
   configSchema: buildChannelConfigSchema(MattermostConfigSchema),


### PR DESCRIPTION
Superseded by #52120 — replaced with a squashed single-commit PR on top of latest upstream main.