### PR TITLE
perf(core): trim provider and inbound startup imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - CLI: avoid loading provider discovery during startup model normalization. (#46522) Thanks @ItsAditya-xyz and @vincentkoc.
 - Agents/Telegram: avoid rebuilding the full model catalog on ordinary inbound replies so Telegram message handling no longer pays multi-second core startup latency before reply generation. Thanks @vincentkoc.
 - Agents/inbound: lazy-load media and link understanding for plain-text turns and cache synced auth stores by auth-file state so ordinary inbound replies avoid unnecessary startup churn. Thanks @vincentkoc.
+- Telegram/polling: hard-timeout stuck `getUpdates` requests so wedged network paths fail over sooner instead of waiting for the polling stall watchdog. Thanks @vincentkoc.
 - Security/device pairing: harden `device.token.rotate` deny handling by keeping public failures generic while logging internal deny reasons and preserving approved-baseline enforcement. (`GHSA-7jrw-x62h-64p8`)
 - Inbound policy hardening: tighten callback and webhook sender checks across Mattermost and Google Chat, match Nextcloud Talk rooms by stable room token, and treat explicit empty Twitch allowlists as deny-all. (#46787) Thanks @zpbrent, @ijxpwastaken and @vincentkoc.
 - Webhooks/runtime: move auth earlier and tighten pre-auth body limits and timeouts across bundled webhook handlers, including slow-body handling for Mattermost slash commands. (#46802) Thanks @vincentkoc.

--- a/extensions/telegram/src/bot.fetch-abort.test.ts
+++ b/extensions/telegram/src/bot.fetch-abort.test.ts
@@ -70,6 +70,26 @@ describe("createTelegramBot fetch abort", () => {
     });
   });
 
+  it("aborts wrapped getUpdates fetch after the hard polling timeout", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<AbortSignal>((resolve) => {
+          const signal = init?.signal as AbortSignal;
+          signal.addEventListener("abort", () => resolve(signal), { once: true });
+        }),
+    );
+    const { clientFetch } = createWrappedTelegramClientFetch(fetchSpy as unknown as typeof fetch);
+
+    const observedSignalPromise = clientFetch("https://api.telegram.org/bot123456:ABC/getUpdates");
+    await vi.advanceTimersByTimeAsync(45_000);
+    const observedSignal = (await observedSignalPromise) as AbortSignal;
+
+    expect(observedSignal).toBeInstanceOf(AbortSignal);
+    expect(observedSignal.aborted).toBe(true);
+    vi.useRealTimers();
+  });
+
   it("preserves the original fetch error when tagging cannot attach metadata", async () => {
     const frozenError = Object.freeze(
       Object.assign(new TypeError("fetch failed"), {

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -81,6 +81,8 @@ const DEFAULT_TELEGRAM_BOT_RUNTIME: TelegramBotRuntime = {
   apiThrottler,
 };
 
+const TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS = 45_000;
+
 let telegramBotRuntimeForTest: TelegramBotRuntime | undefined;
 
 export function setTelegramBotRuntimeForTest(runtime?: TelegramBotRuntime): void {
@@ -114,7 +116,8 @@ function extractTelegramApiMethod(input: TelegramFetchInput): string | null {
   try {
     const pathname = new URL(url).pathname;
     const segments = pathname.split("/").filter(Boolean);
-    return segments.length > 0 ? (segments.at(-1) ?? null) : null;
+    const method = segments.length > 0 ? (segments.at(-1) ?? null) : null;
+    return method?.toLowerCase() ?? null;
   } catch {
     return null;
   }
@@ -164,15 +167,12 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     ApiClientOptions["fetch"]
   >;
 
-  // When a shutdown abort signal is provided, wrap fetch so every Telegram API request
-  // (especially long-polling getUpdates) aborts immediately on shutdown. Without this,
-  // the in-flight getUpdates hangs for up to 30s, and a new gateway instance starting
-  // its own poll triggers a 409 Conflict from Telegram.
+  // Wrap fetch so polling requests cannot hang indefinitely on a wedged network path,
+  // and so shutdown still aborts in-flight Telegram API requests immediately.
   let finalFetch = shouldProvideFetch ? fetchForClient : undefined;
-  if (opts.fetchAbortSignal) {
+  if (finalFetch || opts.fetchAbortSignal) {
     const baseFetch =
       finalFetch ?? (globalThis.fetch as unknown as NonNullable<ApiClientOptions["fetch"]>);
-    const shutdownSignal = opts.fetchAbortSignal;
     // Cast baseFetch to global fetch to avoid node-fetch ↔ global-fetch type divergence;
     // they are runtime-compatible (the codebase already casts at every fetch boundary).
     const callFetch = baseFetch as unknown as typeof globalThis.fetch;
@@ -182,11 +182,16 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     finalFetch = ((input: TelegramFetchInput, init?: TelegramFetchInit) => {
       const controller = new AbortController();
       const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);
-      const onShutdown = () => abortWith(shutdownSignal);
+      const shutdownSignal = opts.fetchAbortSignal;
+      const onShutdown = () => abortWith(shutdownSignal as AbortSignal);
+      const method = extractTelegramApiMethod(input);
+      const requestTimeoutMs =
+        method === "getupdates" ? TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS : undefined;
+      let requestTimeout: ReturnType<typeof setTimeout> | undefined;
       let onRequestAbort: (() => void) | undefined;
-      if (shutdownSignal.aborted) {
+      if (shutdownSignal?.aborted) {
         abortWith(shutdownSignal);
-      } else {
+      } else if (shutdownSignal) {
         shutdownSignal.addEventListener("abort", onShutdown, { once: true });
       }
       if (init?.signal) {
@@ -197,11 +202,20 @@ export function createTelegramBot(opts: TelegramBotOptions) {
           init.signal.addEventListener("abort", onRequestAbort);
         }
       }
+      if (requestTimeoutMs) {
+        requestTimeout = setTimeout(() => {
+          controller.abort(new Error(`Telegram ${method} timed out after ${requestTimeoutMs}ms`));
+        }, requestTimeoutMs);
+        requestTimeout.unref?.();
+      }
       return callFetch(input as GlobalFetchInput, {
         ...(init as GlobalFetchInit),
         signal: controller.signal,
       }).finally(() => {
-        shutdownSignal.removeEventListener("abort", onShutdown);
+        if (requestTimeout) {
+          clearTimeout(requestTimeout);
+        }
+        shutdownSignal?.removeEventListener("abort", onShutdown);
         if (init?.signal && onRequestAbort) {
           init.signal.removeEventListener("abort", onRequestAbort);
         }

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -12,7 +12,7 @@ import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "..
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveBlockStreamingChunking } from "./block-streaming.js";
 import { buildCommandContext } from "./commands.js";
-import { type InlineDirectives, parseInlineDirectives } from "./directive-handling.js";
+import { type InlineDirectives, parseInlineDirectives } from "./directive-handling.parse.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { clearExecInlineDirectives, clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -25,8 +25,8 @@ import {
 } from "./abort-cutoff.js";
 import { getAbortMemory, isAbortRequestText } from "./abort.js";
 import { buildStatusReply, handleCommands } from "./commands.js";
-import type { InlineDirectives } from "./directive-handling.js";
-import { isDirectiveOnly } from "./directive-handling.js";
+import type { InlineDirectives } from "./directive-handling.parse.js";
+import { isDirectiveOnly } from "./directive-handling.parse.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import { extractInlineSimpleCommand } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -16,7 +16,7 @@ import type { MsgContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-core.js";
-import { resolveDefaultModel } from "./directive-handling.js";
+import { resolveDefaultModel } from "./directive-handling.persist.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { runPreparedReply } from "./get-reply-run.js";

--- a/src/media-understanding/providers/image-runtime.ts
+++ b/src/media-understanding/providers/image-runtime.ts
@@ -1,1 +1,12 @@
-export { describeImageWithModel } from "./image.js";
+import {
+  createLazyRuntimeMethodBinder,
+  createLazyRuntimeModule,
+} from "../../shared/lazy-runtime.js";
+
+const loadImageRuntime = createLazyRuntimeModule(() => import("./image.js"));
+const bindImageRuntime = createLazyRuntimeMethodBinder(loadImageRuntime);
+
+export const describeImageWithModel = bindImageRuntime((runtime) => runtime.describeImageWithModel);
+export const describeImagesWithModel = bindImageRuntime(
+  (runtime) => runtime.describeImagesWithModel,
+);

--- a/src/plugin-sdk/media-understanding.ts
+++ b/src/plugin-sdk/media-understanding.ts
@@ -16,7 +16,7 @@ export type {
 export {
   describeImageWithModel,
   describeImagesWithModel,
-} from "../media-understanding/providers/image.js";
+} from "../media-understanding/providers/image-runtime.js";
 export { transcribeOpenAiCompatibleAudio } from "../media-understanding/providers/openai-compatible-audio.js";
 export {
   assertOkOrThrowHttpError,

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -6,14 +6,10 @@ export type { ProviderAuthResult } from "../plugins/types.js";
 export type { ProviderAuthContext } from "../plugins/types.js";
 export type { AuthProfileStore, OAuthCredential } from "../agents/auth-profiles/types.js";
 
-export {
-  CLAUDE_CLI_PROFILE_ID,
-  CODEX_CLI_PROFILE_ID,
-  ensureAuthProfileStore,
-  listProfilesForProvider,
-  suggestOAuthProfileIdForLegacyDefault,
-  upsertAuthProfile,
-} from "../agents/auth-profiles.js";
+export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
+export { ensureAuthProfileStore } from "../agents/auth-profiles/store.js";
+export { listProfilesForProvider, upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
+export { suggestOAuthProfileIdForLegacyDefault } from "../agents/auth-profiles/repair.js";
 export {
   MINIMAX_OAUTH_MARKER,
   resolveOAuthApiKeyMarker,

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
-import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
 import { normalizeProviderIdForAuth } from "../agents/provider-id.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";


### PR DESCRIPTION
## Summary

- Problem: provider plugin startup and inbound reply startup were still paying large cold-import costs from broad SDK/barrel surfaces.
- Why it matters: these imports sit on common startup paths and were adding multi-second latency plus large RSS spikes before real work started.
- What changed: narrowed provider auth imports, moved media-understanding image helpers behind a lazy runtime seam, and rewired inbound reply files to import directive parser/default-model helpers directly instead of the full directive-handling barrel.
- What did NOT change (scope boundary): no behavior change to auth flows, media understanding behavior, or directive semantics; this is import-boundary/runtime-loading work only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51891
- Related #51897

## User-visible / Behavior Changes

- Lower cold-start latency on provider/plugin startup paths.
- Lower cold-start latency on inbound reply startup paths.
- No intended user-facing behavior or config changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + `tsx`
- Model/provider: import-cost probes only
- Integration/channel (if any): none
- Relevant config (redacted): none

### Steps

1. Measure cold import cost for targeted modules with `node --expose-gc --import tsx -e 'await import(...)'`.
2. Narrow auth/media/inbound import surfaces.
3. Re-run the same targeted measurements.
4. Run `pnpm tsgo` and `pnpm build`.

### Expected

- Common startup modules import faster and retain less RSS.

### Actual

- Measured cold import reductions on provider auth/media surfaces and partial reduction on inbound reply startup.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Key measurements:

- `src/plugin-sdk/provider-auth.ts`: about `3.6s / 92MB` -> about `0.37-0.9s / 47-50MB`
- `src/plugins/provider-auth-helpers.ts`: about `1.7s / 64MB` -> about `0.34s / 18MB`
- `src/plugin-sdk/media-understanding.ts`: about `9.2s / 285MB` -> about `0.38-0.55s / 13-36MB`
- `extensions/anthropic/index.ts`: about `6.3s / 322MB` -> about `0.58-0.68s / 61-74MB`
- `src/auto-reply/reply/get-reply-inline-actions.ts`: about `12.3s / 315MB` -> about `6.3-7.5s / 323-337MB`
- `src/auto-reply/reply/get-reply.ts`: timeout / very slow -> about `5.0-8.5s`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - targeted cold-import measurements before/after on affected modules
  - `pnpm tsgo`
  - `pnpm build`
- Edge cases checked:
  - lazy runtime export path remains type/build clean
  - provider/plugin SDK exports still build correctly
- What you did **not** verify:
  - full `pnpm test`
  - live channel roundtrips

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ad79672007`
- Files/config to restore: revert the touched import-boundary files in this PR
- Known bad symptoms reviewers should watch for:
  - lazy media-understanding exports failing at first invocation
  - provider plugin auth setup paths missing expected exports

## Risks and Mitigations

- Risk: lazy runtime export wiring could change when errors surface from import time to first call.
  - Mitigation: build/typecheck passed, and the lazy seam uses the existing shared runtime-loader pattern already used elsewhere in the repo.
- Risk: inbound startup still has remaining heavy surfaces, so this PR may only be a partial latency reduction.
  - Mitigation: scope is explicit; next pass will target `get-reply-directives.ts` and `get-reply-inline-actions.ts` directly.
