### PR TITLE
ci(actions): restore audit lane and cache Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,6 +492,83 @@ jobs:
       - name: Test skill Python scripts
         run: python -m pytest -q skills
 
+  secrets:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Ensure secrets base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+          install-deps: "false"
+
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            .pre-commit-config.yaml
+            .github/workflows/ci.yml
+
+      - name: Restore pre-commit cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+
+      - name: Detect committed private keys
+        run: pre-commit run --all-files detect-private-key
+
+      - name: Audit changed GitHub workflows with zizmor
+        env:
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${BASE_SHA:-}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            echo "No usable base SHA detected; skipping zizmor."
+            exit 0
+          fi
+
+          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            echo "Base SHA ${BASE_SHA} is unavailable; skipping zizmor."
+            exit 0
+          fi
+
+          mapfile -t workflow_files < <(
+            git diff --name-only "${BASE_SHA}" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml'
+          )
+          if [ "${#workflow_files[@]}" -eq 0 ]; then
+            echo "No workflow changes detected; skipping zizmor."
+            exit 0
+          fi
+
+          printf 'Auditing workflow files:\n%s\n' "${workflow_files[@]}"
+          pre-commit run zizmor --files "${workflow_files[@]}"
+
+      - name: Audit production dependencies
+        run: pre-commit run --all-files pnpm-audit-prod
+
   checks-windows:
     needs: [docs-scope, changed-scope]
     if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true'

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -159,6 +159,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
+          cache-from: type=gha,scope=docker-release-amd64
+          cache-to: type=gha,mode=max,scope=docker-release-amd64
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
@@ -171,6 +173,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
+          cache-from: type=gha,scope=docker-release-amd64
+          cache-to: type=gha,mode=max,scope=docker-release-amd64
           build-args: |
             OPENCLAW_VARIANT=slim
           tags: ${{ steps.tags.outputs.slim }}
@@ -272,6 +276,8 @@ jobs:
         with:
           context: .
           platforms: linux/arm64
+          cache-from: type=gha,scope=docker-release-arm64
+          cache-to: type=gha,mode=max,scope=docker-release-arm64
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
           provenance: false
@@ -284,6 +290,8 @@ jobs:
         with:
           context: .
           platforms: linux/arm64
+          cache-from: type=gha,scope=docker-release-arm64
+          cache-to: type=gha,mode=max,scope=docker-release-arm64
           build-args: |
             OPENCLAW_VARIANT=slim
           tags: ${{ steps.tags.outputs.slim }}


### PR DESCRIPTION
## Summary

- Problem: the CI `secrets` audit lane needs to remain active, and Docker Release currently has no explicit cross-run Buildx cache.
- Why it matters: removing `secrets` drops `detect-private-key`, `zizmor`, and `pnpm-audit-prod`; missing Docker layer cache leaves the expensive image builds cold on each run.
- What changed: restored the `secrets` job in `ci.yml` and added GitHub Actions Buildx cache scopes to `docker-release.yml` for amd64 and arm64 image builds.
- What did NOT change (scope boundary): branch-protection policy, Docker tags/manifest flow, and the rest of the CI matrix.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51912

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: local repo worktree
- Model/provider: n/a
- Integration/channel (if any): GitHub Actions
- Relevant config (redacted): n/a

### Steps

1. Restore the `secrets` audit job in `.github/workflows/ci.yml`.
2. Add `type=gha` Buildx cache scopes in `.github/workflows/docker-release.yml` for amd64 and arm64 image builds.
3. Validate the workflow files locally.

### Expected

- CI keeps the private-key, workflow, and production dependency audit coverage.
- Docker Release can reuse GitHub-hosted Buildx cache across runs per architecture.

### Actual

- Matches expected in local validation.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Referenced runs:
- Docker Release run inspected: https://github.com/openclaw/openclaw/actions/runs/23391043932

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `actionlint` on `.github/workflows/ci.yml` and `.github/workflows/docker-release.yml`; repo `scripts/committer` on touched files.
- Edge cases checked: audit lane restored exactly; Docker cache scopes split by architecture so amd64 and arm64 caches do not collide.
- What you did **not** verify: a live completed Docker Release run after the cache change lands.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `.github/workflows/ci.yml`, `.github/workflows/docker-release.yml`
- Known bad symptoms reviewers should watch for: missing `secrets` check, or Docker Release builds failing to read/write Buildx cache.

## Risks and Mitigations

- Risk: GitHub Actions cache for Buildx can be flaky under cache pressure.
  - Mitigation: cache is additive only; the build still works without hits.
- Risk: restored `secrets` lane increases CI time slightly.
  - Mitigation: it restores previously required audit coverage and remains lightweight compared with test lanes.

## AI Assistance

- [x] AI-assisted
- Testing: locally validated with workflow lint and repo commit wrapper checks
