### PR TITLE
refactor(doctor): extract preview warning collection

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -10,11 +10,7 @@ import { noteOpencodeProviderOverrides } from "./doctor-config-analysis.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
-import {
-  collectDiscordNumericIdWarnings,
-  maybeRepairDiscordNumericIds,
-  scanDiscordNumericIdEntries,
-} from "./doctor/providers/discord.js";
+import { maybeRepairDiscordNumericIds } from "./doctor/providers/discord.js";
 import {
   applyMatrixDoctorRepair,
   collectMatrixInstallPathWarnings,
@@ -22,10 +18,8 @@ import {
   formatMatrixLegacyStatePreview,
 } from "./doctor/providers/matrix.js";
 import {
-  collectTelegramAllowFromUsernameWarnings,
   collectTelegramEmptyAllowlistExtraWarnings,
   maybeRepairTelegramAllowFromUsernames,
-  scanTelegramAllowFromUsernameEntries,
 } from "./doctor/providers/telegram.js";
 import { maybeRepairAllowlistPolicyAllowFrom } from "./doctor/shared/allowlist-policy-repair.js";
 import {
@@ -38,26 +32,14 @@ import {
   collectMissingExplicitDefaultAccountWarnings,
 } from "./doctor/shared/default-account-warnings.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./doctor/shared/empty-allowlist-scan.js";
-import {
-  collectExecSafeBinCoverageWarnings,
-  collectExecSafeBinTrustedDirHintWarnings,
-  maybeRepairExecSafeBinProfiles,
-  scanExecSafeBinCoverage,
-  scanExecSafeBinTrustedDirHints,
-} from "./doctor/shared/exec-safe-bins.js";
-import {
-  collectLegacyToolsBySenderWarnings,
-  maybeRepairLegacyToolsBySenderKeys,
-  scanLegacyToolsBySenderKeys,
-} from "./doctor/shared/legacy-tools-by-sender.js";
+import { maybeRepairExecSafeBinProfiles } from "./doctor/shared/exec-safe-bins.js";
+import { maybeRepairLegacyToolsBySenderKeys } from "./doctor/shared/legacy-tools-by-sender.js";
 import {
   collectMutableAllowlistWarnings,
   scanMutableAllowlistEntries,
 } from "./doctor/shared/mutable-allowlist.js";
-import {
-  collectOpenPolicyAllowFromWarnings,
-  maybeRepairOpenPolicyAllowFrom,
-} from "./doctor/shared/open-policy-allowfrom.js";
+import { maybeRepairOpenPolicyAllowFrom } from "./doctor/shared/open-policy-allowfrom.js";
+import { collectDoctorPreviewWarnings } from "./doctor/shared/preview-warnings.js";
 
 export async function loadAndMaybeMigrateDoctorConfig(params: {
   options: DoctorOptions;
@@ -238,78 +220,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       note(safeBinProfileRepair.warnings.join("\n"), "Doctor warnings");
     }
   } else {
-    const hits = scanTelegramAllowFromUsernameEntries(candidate);
-    if (hits.length > 0) {
-      note(
-        collectTelegramAllowFromUsernameWarnings({
-          hits,
-          doctorFixCommand,
-        }).join("\n"),
-        "Doctor warnings",
-      );
-    }
-
-    const discordHits = scanDiscordNumericIdEntries(candidate);
-    if (discordHits.length > 0) {
-      note(
-        collectDiscordNumericIdWarnings({
-          hits: discordHits,
-          doctorFixCommand,
-        }).join("\n"),
-        "Doctor warnings",
-      );
-    }
-
-    const allowFromScan = maybeRepairOpenPolicyAllowFrom(candidate);
-    if (allowFromScan.changes.length > 0) {
-      note(
-        collectOpenPolicyAllowFromWarnings({
-          changes: allowFromScan.changes,
-          doctorFixCommand,
-        }).join("\n"),
-        "Doctor warnings",
-      );
-    }
-
-    const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(candidate, {
-      doctorFixCommand: formatCliCommand("openclaw doctor --fix"),
-      extraWarningsForAccount: collectTelegramEmptyAllowlistExtraWarnings,
-    });
-    if (emptyAllowlistWarnings.length > 0) {
-      note(
-        emptyAllowlistWarnings.map((line) => sanitizeForLog(line)).join("\n"),
-        "Doctor warnings",
-      );
-    }
-
-    const toolsBySenderHits = scanLegacyToolsBySenderKeys(candidate);
-    if (toolsBySenderHits.length > 0) {
-      note(
-        collectLegacyToolsBySenderWarnings({
-          hits: toolsBySenderHits,
-          doctorFixCommand,
-        }).join("\n"),
-        "Doctor warnings",
-      );
-    }
-
-    const safeBinCoverage = scanExecSafeBinCoverage(candidate);
-    if (safeBinCoverage.length > 0) {
-      note(
-        collectExecSafeBinCoverageWarnings({
-          hits: safeBinCoverage,
-          doctorFixCommand,
-        }).join("\n"),
-        "Doctor warnings",
-      );
-    }
-
-    const safeBinTrustedDirHints = scanExecSafeBinTrustedDirHints(candidate);
-    if (safeBinTrustedDirHints.length > 0) {
-      note(
-        collectExecSafeBinTrustedDirHintWarnings(safeBinTrustedDirHints).join("\n"),
-        "Doctor warnings",
-      );
+    for (const warning of collectDoctorPreviewWarnings({
+      cfg: candidate,
+      doctorFixCommand,
+    })) {
+      note(warning, "Doctor warnings");
     }
   }
 

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { collectDoctorPreviewWarnings } from "./preview-warnings.js";
+
+describe("doctor preview warnings", () => {
+  it("collects provider and shared preview warnings", () => {
+    const warnings = collectDoctorPreviewWarnings({
+      cfg: {
+        channels: {
+          telegram: {
+            allowFrom: ["@alice"],
+          },
+          signal: {
+            dmPolicy: "open",
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining("Telegram allowFrom contains 1 non-numeric entries"),
+      expect.stringContaining('channels.signal.allowFrom: set to ["*"]'),
+    ]);
+  });
+});

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -22,4 +22,27 @@ describe("doctor preview warnings", () => {
       expect.stringContaining('channels.signal.allowFrom: set to ["*"]'),
     ]);
   });
+
+  it("sanitizes empty-allowlist warning paths before returning preview output", () => {
+    const warnings = collectDoctorPreviewWarnings({
+      cfg: {
+        channels: {
+          signal: {
+            accounts: {
+              "ops\u001B[31m-team\u001B[0m\r\nnext": {
+                dmPolicy: "allowlist",
+              },
+            },
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining("channels.signal.accounts.ops-teamnext.dmPolicy"),
+    ]);
+    expect(warnings[0]).not.toContain("\u001B");
+    expect(warnings[0]).not.toContain("\r");
+  });
 });

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../../config/config.js";
+import { sanitizeForLog } from "../../../terminal/ansi.js";
 import {
   collectDiscordNumericIdWarnings,
   scanDiscordNumericIdEntries,
@@ -65,7 +66,7 @@ export function collectDoctorPreviewWarnings(params: {
     extraWarningsForAccount: collectTelegramEmptyAllowlistExtraWarnings,
   });
   if (emptyAllowlistWarnings.length > 0) {
-    warnings.push(emptyAllowlistWarnings.join("\n"));
+    warnings.push(emptyAllowlistWarnings.map((line) => sanitizeForLog(line)).join("\n"));
   }
 
   const toolsBySenderHits = scanLegacyToolsBySenderKeys(params.cfg);

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -1,0 +1,97 @@
+import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  collectDiscordNumericIdWarnings,
+  scanDiscordNumericIdEntries,
+} from "../providers/discord.js";
+import {
+  collectTelegramAllowFromUsernameWarnings,
+  collectTelegramEmptyAllowlistExtraWarnings,
+  scanTelegramAllowFromUsernameEntries,
+} from "../providers/telegram.js";
+import { scanEmptyAllowlistPolicyWarnings } from "./empty-allowlist-scan.js";
+import {
+  collectExecSafeBinCoverageWarnings,
+  collectExecSafeBinTrustedDirHintWarnings,
+  scanExecSafeBinCoverage,
+  scanExecSafeBinTrustedDirHints,
+} from "./exec-safe-bins.js";
+import {
+  collectLegacyToolsBySenderWarnings,
+  scanLegacyToolsBySenderKeys,
+} from "./legacy-tools-by-sender.js";
+import {
+  collectOpenPolicyAllowFromWarnings,
+  maybeRepairOpenPolicyAllowFrom,
+} from "./open-policy-allowfrom.js";
+
+export function collectDoctorPreviewWarnings(params: {
+  cfg: OpenClawConfig;
+  doctorFixCommand: string;
+}): string[] {
+  const warnings: string[] = [];
+
+  const telegramHits = scanTelegramAllowFromUsernameEntries(params.cfg);
+  if (telegramHits.length > 0) {
+    warnings.push(
+      collectTelegramAllowFromUsernameWarnings({
+        hits: telegramHits,
+        doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
+  const discordHits = scanDiscordNumericIdEntries(params.cfg);
+  if (discordHits.length > 0) {
+    warnings.push(
+      collectDiscordNumericIdWarnings({
+        hits: discordHits,
+        doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
+  const allowFromScan = maybeRepairOpenPolicyAllowFrom(params.cfg);
+  if (allowFromScan.changes.length > 0) {
+    warnings.push(
+      collectOpenPolicyAllowFromWarnings({
+        changes: allowFromScan.changes,
+        doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
+  const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(params.cfg, {
+    doctorFixCommand: params.doctorFixCommand,
+    extraWarningsForAccount: collectTelegramEmptyAllowlistExtraWarnings,
+  });
+  if (emptyAllowlistWarnings.length > 0) {
+    warnings.push(emptyAllowlistWarnings.join("\n"));
+  }
+
+  const toolsBySenderHits = scanLegacyToolsBySenderKeys(params.cfg);
+  if (toolsBySenderHits.length > 0) {
+    warnings.push(
+      collectLegacyToolsBySenderWarnings({
+        hits: toolsBySenderHits,
+        doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
+  const safeBinCoverage = scanExecSafeBinCoverage(params.cfg);
+  if (safeBinCoverage.length > 0) {
+    warnings.push(
+      collectExecSafeBinCoverageWarnings({
+        hits: safeBinCoverage,
+        doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
+  const safeBinTrustedDirHints = scanExecSafeBinTrustedDirHints(params.cfg);
+  if (safeBinTrustedDirHints.length > 0) {
+    warnings.push(collectExecSafeBinTrustedDirHintWarnings(safeBinTrustedDirHints).join("\n"));
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary
- extract doctor preview warning collection into a shared helper
- keep provider and shared warning assembly close to the owning modules
- thin doctor-config-flow further toward orchestration only

## Testing
- pnpm exec vitest run src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor-config-flow.test.ts
- pnpm build
- pnpm check

Thanks @vincentkoc