### PR TITLE
perf(inbound): narrow reply startup imports

### DIFF
--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -1,11 +1,18 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
-import {
-  ensureAuthProfileStore,
-  isProfileInCooldown,
-  resolveAuthProfileOrder,
-} from "../auth-profiles.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
+import { ensureAuthProfileStore } from "../auth-profiles/store.js";
+import { isProfileInCooldown } from "../auth-profiles/usage.js";
 import { normalizeProviderId } from "../model-selection.js";
+
+let sessionStoreRuntimePromise:
+  | Promise<typeof import("../../config/sessions/store.runtime.js")>
+  | undefined;
+
+function loadSessionStoreRuntime() {
+  sessionStoreRuntimePromise ??= import("../../config/sessions/store.runtime.js");
+  return sessionStoreRuntimePromise;
+}
 
 function isProfileForProvider(params: {
   provider: string;
@@ -32,7 +39,9 @@ export async function clearSessionAuthProfileOverride(params: {
   sessionEntry.updatedAt = Date.now();
   sessionStore[sessionKey] = sessionEntry;
   if (storePath) {
-    await updateSessionStore(storePath, (store) => {
+    await (
+      await loadSessionStoreRuntime()
+    ).updateSessionStore(storePath, (store) => {
       store[sessionKey] = sessionEntry;
     });
   }
@@ -141,7 +150,9 @@ export async function resolveSessionAuthProfileOverride(params: {
     sessionEntry.updatedAt = Date.now();
     sessionStore[sessionKey] = sessionEntry;
     if (storePath) {
-      await updateSessionStore(storePath, (store) => {
+      await (
+        await loadSessionStoreRuntime()
+      ).updateSessionStore(storePath, (store) => {
         store[sessionKey] = sessionEntry;
       });
     }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -8,7 +8,6 @@ import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
 import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { normalizeProviderId } from "./model-selection.js";
-import { ensureOpenClawModelsJson } from "./models-config.js";
 
 type ModelEntry = { id: string; contextWindow?: number };
 type ModelRegistryLike = {
@@ -84,6 +83,12 @@ let loadPromise: Promise<void> | null = null;
 let configuredConfig: OpenClawConfig | undefined;
 let configLoadFailures = 0;
 let nextConfigLoadAttemptAtMs = 0;
+let modelsConfigRuntimePromise: Promise<typeof import("./models-config.runtime.js")> | undefined;
+
+function loadModelsConfigRuntime() {
+  modelsConfigRuntimePromise ??= import("./models-config.runtime.js");
+  return modelsConfigRuntimePromise;
+}
 
 function isLikelyOpenClawCliProcess(argv: string[] = process.argv): boolean {
   const entryBasename = path
@@ -192,7 +197,7 @@ function ensureContextWindowCacheLoaded(): Promise<void> {
 
   loadPromise = (async () => {
     try {
-      await ensureOpenClawModelsJson(cfg);
+      await (await loadModelsConfigRuntime()).ensureOpenClawModelsJson(cfg);
     } catch {
       // Continue with best-effort discovery/overrides.
     }

--- a/src/agents/fast-mode.ts
+++ b/src/agents/fast-mode.ts
@@ -1,4 +1,4 @@
-import { normalizeFastMode } from "../auto-reply/thinking.js";
+import { normalizeFastMode } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 

--- a/src/agents/model-catalog.runtime.ts
+++ b/src/agents/model-catalog.runtime.ts
@@ -1,0 +1,1 @@
+export { loadModelCatalog } from "./model-catalog.js";

--- a/src/agents/models-config.runtime.ts
+++ b/src/agents/models-config.runtime.ts
@@ -1,0 +1,1 @@
+export { ensureOpenClawModelsJson } from "./models-config.js";

--- a/src/auto-reply/commands-registry.runtime.ts
+++ b/src/auto-reply/commands-registry.runtime.ts
@@ -1,0 +1,1 @@
+export { listChatCommands, normalizeCommandBody } from "./commands-registry.js";

--- a/src/auto-reply/commands-text-routing.ts
+++ b/src/auto-reply/commands-text-routing.ts
@@ -1,21 +1,12 @@
-import { listChannelPlugins } from "../channels/plugins/index.js";
+import { getNativeCommandSurfaces } from "./commands-registry.data.js";
 import type { ShouldHandleTextCommandsParams } from "./commands-registry.types.js";
-
-let cachedNativeCommandSurfaces: Set<string> | null = null;
 
 export function isNativeCommandSurface(surface?: string): boolean {
   const normalized = surface?.trim().toLowerCase();
   if (!normalized) {
     return false;
   }
-  if (!cachedNativeCommandSurfaces) {
-    cachedNativeCommandSurfaces = new Set(
-      listChannelPlugins()
-        .filter((plugin) => plugin.capabilities.nativeCommands)
-        .map((plugin) => plugin.id),
-    );
-  }
-  return cachedNativeCommandSurfaces.has(normalized);
+  return getNativeCommandSurfaces().has(normalized);
 }
 
 export function shouldHandleTextCommands(params: ShouldHandleTextCommandsParams): boolean {

--- a/src/auto-reply/commands-text-routing.ts
+++ b/src/auto-reply/commands-text-routing.ts
@@ -1,0 +1,29 @@
+import { listChannelPlugins } from "../channels/plugins/index.js";
+import type { ShouldHandleTextCommandsParams } from "./commands-registry.types.js";
+
+let cachedNativeCommandSurfaces: Set<string> | null = null;
+
+export function isNativeCommandSurface(surface?: string): boolean {
+  const normalized = surface?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (!cachedNativeCommandSurfaces) {
+    cachedNativeCommandSurfaces = new Set(
+      listChannelPlugins()
+        .filter((plugin) => plugin.capabilities.nativeCommands)
+        .map((plugin) => plugin.id),
+    );
+  }
+  return cachedNativeCommandSurfaces.has(normalized);
+}
+
+export function shouldHandleTextCommands(params: ShouldHandleTextCommandsParams): boolean {
+  if (params.commandSource === "native") {
+    return true;
+  }
+  if (params.cfg.commands?.text !== false) {
+    return true;
+  }
+  return !isNativeCommandSurface(params.surface);
+}

--- a/src/auto-reply/group-activation.ts
+++ b/src/auto-reply/group-activation.ts
@@ -1,5 +1,3 @@
-import { normalizeCommandBody } from "./commands-registry.js";
-
 export type GroupActivationMode = "mention" | "always";
 
 export function normalizeGroupActivation(raw?: string | null): GroupActivationMode | undefined {
@@ -24,7 +22,7 @@ export function parseActivationCommand(raw?: string): {
   if (!trimmed) {
     return { hasCommand: false };
   }
-  const normalized = normalizeCommandBody(trimmed);
+  const normalized = trimmed.replace(/^\/([^@\s:]+)@[^:\s]+/, "/$1");
   const match = normalized.match(/^\/activation(?:\s+([a-zA-Z]+))?\s*$/i);
   if (!match) {
     return { hasCommand: false };

--- a/src/auto-reply/group-activation.ts
+++ b/src/auto-reply/group-activation.ts
@@ -22,7 +22,10 @@ export function parseActivationCommand(raw?: string): {
   if (!trimmed) {
     return { hasCommand: false };
   }
-  const normalized = trimmed.replace(/^\/([^@\s:]+)@[^:\s]+/, "/$1");
+  const normalized = trimmed.replace(/^\/([^\s:]+)\s*:(.*)$/, (_, cmd: string, rest: string) => {
+    const trimmedRest = rest.trimStart();
+    return trimmedRest ? `/${cmd} ${trimmedRest}` : `/${cmd}`;
+  });
   const match = normalized.match(/^\/activation(?:\s+([a-zA-Z]+))?\s*$/i);
   if (!match) {
     return { hasCommand: false };

--- a/src/auto-reply/reply/commands-context.ts
+++ b/src/auto-reply/reply/commands-context.ts
@@ -25,9 +25,13 @@ function normalizeCommandBodyLite(raw: string, botUsername?: string): string {
   const mentionMatch = normalizedBotUsername
     ? normalized.match(/^\/([^\s@]+)@([^\s]+)(.*)$/)
     : null;
-  return mentionMatch && mentionMatch[2].toLowerCase() === normalizedBotUsername
-    ? `/${mentionMatch[1]}${mentionMatch[3] ?? ""}`
-    : normalized;
+  const mentionNormalized =
+    mentionMatch && mentionMatch[2].toLowerCase() === normalizedBotUsername
+      ? `/${mentionMatch[1]}${mentionMatch[3] ?? ""}`
+      : normalized;
+  return mentionNormalized.replace(/^\/([^\s]+)(.*)$/, (_, command: string, rest: string) => {
+    return `/${command.toLowerCase()}${rest ?? ""}`;
+  });
 }
 
 export function buildCommandContext(params: {

--- a/src/auto-reply/reply/commands-context.ts
+++ b/src/auto-reply/reply/commands-context.ts
@@ -1,9 +1,34 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
-import { normalizeCommandBody } from "../commands-registry.js";
 import type { MsgContext } from "../templating.js";
 import type { CommandContext } from "./commands-types.js";
 import { stripMentions } from "./mentions.js";
+
+function normalizeCommandBodyLite(raw: string, botUsername?: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("/")) {
+    return trimmed;
+  }
+
+  const newline = trimmed.indexOf("\n");
+  const singleLine = newline === -1 ? trimmed : trimmed.slice(0, newline).trim();
+  const colonMatch = singleLine.match(/^\/([^\s:]+)\s*:(.*)$/);
+  const normalized = colonMatch
+    ? (() => {
+        const [, command, rest] = colonMatch;
+        const normalizedRest = rest.trimStart();
+        return normalizedRest ? `/${command} ${normalizedRest}` : `/${command}`;
+      })()
+    : singleLine;
+
+  const normalizedBotUsername = botUsername?.trim().toLowerCase();
+  const mentionMatch = normalizedBotUsername
+    ? normalized.match(/^\/([^\s@]+)@([^\s]+)(.*)$/)
+    : null;
+  return mentionMatch && mentionMatch[2].toLowerCase() === normalizedBotUsername
+    ? `/${mentionMatch[1]}${mentionMatch[3] ?? ""}`
+    : normalized;
+}
 
 export function buildCommandContext(params: {
   ctx: MsgContext;
@@ -24,9 +49,9 @@ export function buildCommandContext(params: {
   const channel = (ctx.Provider ?? surface).trim().toLowerCase();
   const abortKey = sessionKey ?? (auth.from || undefined) ?? (auth.to || undefined);
   const rawBodyNormalized = triggerBodyNormalized;
-  const commandBodyNormalized = normalizeCommandBody(
+  const commandBodyNormalized = normalizeCommandBodyLite(
     isGroup ? stripMentions(rawBodyNormalized, ctx, cfg, agentId) : rawBodyNormalized,
-    { botUsername: ctx.BotUsername },
+    ctx.BotUsername,
   );
 
   return {

--- a/src/auto-reply/reply/commands-status.runtime.ts
+++ b/src/auto-reply/reply/commands-status.runtime.ts
@@ -1,0 +1,1 @@
+export { buildStatusReply } from "./commands-status.js";

--- a/src/auto-reply/reply/directive-handling.persist.runtime.ts
+++ b/src/auto-reply/reply/directive-handling.persist.runtime.ts
@@ -1,0 +1,1 @@
+export { persistInlineDirectives } from "./directive-handling.persist.js";

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -1,22 +1,50 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionEntry } from "../../config/sessions.js";
+import type { SessionEntry, SessionScope } from "../../config/sessions/types.js";
 import type { MsgContext } from "../templating.js";
 import type { ElevatedLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
-import { buildStatusReply } from "./commands.js";
-import {
-  applyInlineDirectivesFastLane,
-  handleDirectiveOnly,
-  type InlineDirectives,
-  isDirectiveOnly,
-  persistInlineDirectives,
-} from "./directive-handling.js";
-import { resolveCurrentDirectiveLevels } from "./directive-handling.levels.js";
+import type { CommandContext } from "./commands-types.js";
+import type { ApplyInlineDirectivesFastLaneParams } from "./directive-handling.params.js";
+import { isDirectiveOnly, type InlineDirectives } from "./directive-handling.parse.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
+
+let commandsStatusPromise: Promise<typeof import("./commands-status.runtime.js")> | null = null;
+let directiveLevelsPromise: Promise<typeof import("./directive-handling.levels.js")> | null = null;
+let directiveImplPromise: Promise<typeof import("./directive-handling.impl.js")> | null = null;
+let directiveFastLanePromise: Promise<typeof import("./directive-handling.fast-lane.js")> | null =
+  null;
+let directivePersistPromise: Promise<
+  typeof import("./directive-handling.persist.runtime.js")
+> | null = null;
+
+function loadCommandsStatus() {
+  commandsStatusPromise ??= import("./commands-status.runtime.js");
+  return commandsStatusPromise;
+}
+
+function loadDirectiveLevels() {
+  directiveLevelsPromise ??= import("./directive-handling.levels.js");
+  return directiveLevelsPromise;
+}
+
+function loadDirectiveImpl() {
+  directiveImplPromise ??= import("./directive-handling.impl.js");
+  return directiveImplPromise;
+}
+
+function loadDirectiveFastLane() {
+  directiveFastLanePromise ??= import("./directive-handling.fast-lane.js");
+  return directiveFastLanePromise;
+}
+
+function loadDirectivePersist() {
+  directivePersistPromise ??= import("./directive-handling.persist.runtime.js");
+  return directivePersistPromise;
+}
 
 export type ApplyDirectiveResult =
   | { kind: "reply"; reply: ReplyPayload | ReplyPayload[] | undefined }
@@ -45,10 +73,10 @@ export async function applyInlineDirectiveOverrides(params: {
   sessionStore: Record<string, SessionEntry>;
   sessionKey: string;
   storePath?: string;
-  sessionScope: Parameters<typeof buildStatusReply>[0]["sessionScope"];
+  sessionScope: SessionScope | undefined;
   isGroup: boolean;
   allowTextCommands: boolean;
-  command: Parameters<typeof buildStatusReply>[0]["command"];
+  command: CommandContext;
   directives: InlineDirectives;
   messageProviderKey: string;
   elevatedEnabled: boolean;
@@ -56,16 +84,14 @@ export async function applyInlineDirectiveOverrides(params: {
   elevatedFailures: Array<{ gate: string; key: string }>;
   defaultProvider: string;
   defaultModel: string;
-  aliasIndex: Parameters<typeof applyInlineDirectivesFastLane>[0]["aliasIndex"];
+  aliasIndex: ApplyInlineDirectivesFastLaneParams["aliasIndex"];
   provider: string;
   model: string;
   modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   initialModelLabel: string;
   formatModelSwitchEvent: (label: string, alias?: string) => string;
   resolvedElevatedLevel: ElevatedLevel;
-  defaultActivation: () => ReturnType<
-    Parameters<typeof buildStatusReply>[0]["defaultGroupActivation"]
-  >;
+  defaultActivation: () => "always" | "mention";
   contextTokens: number;
   effectiveModelDirective?: string;
   typing: TypingController;
@@ -154,13 +180,17 @@ export async function applyInlineDirectiveOverrides(params: {
       currentVerboseLevel,
       currentReasoningLevel,
       currentElevatedLevel,
-    } = await resolveCurrentDirectiveLevels({
+    } = await (
+      await loadDirectiveLevels()
+    ).resolveCurrentDirectiveLevels({
       sessionEntry,
       agentCfg,
       resolveDefaultThinkingLevel: () => modelState.resolveDefaultThinkingLevel(),
     });
     const currentThinkLevel = resolvedDefaultThinkLevel;
-    const directiveReply = await handleDirectiveOnly({
+    const directiveReply = await (
+      await loadDirectiveImpl()
+    ).handleDirectiveOnly({
       ...createDirectiveHandlingBase(),
       currentThinkLevel,
       currentFastMode,
@@ -171,6 +201,7 @@ export async function applyInlineDirectiveOverrides(params: {
     });
     let statusReply: ReplyPayload | undefined;
     if (directives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender) {
+      const { buildStatusReply } = await loadCommandsStatus();
       statusReply = await buildStatusReply({
         cfg,
         command,
@@ -213,7 +244,9 @@ export async function applyInlineDirectiveOverrides(params: {
     directives.hasStatusDirective;
 
   if (hasAnyDirective && command.isAuthorizedSender) {
-    const fastLane = await applyInlineDirectivesFastLane({
+    const fastLane = await (
+      await loadDirectiveFastLane()
+    ).applyInlineDirectivesFastLane({
       directives,
       commandAuthorized: command.isAuthorizedSender,
       ctx,
@@ -247,7 +280,9 @@ export async function applyInlineDirectiveOverrides(params: {
     model = fastLane.model;
   }
 
-  const persisted = await persistInlineDirectives({
+  const persisted = await (
+    await loadDirectivePersist()
+  ).persistInlineDirectives({
     directives,
     effectiveModelDirective,
     cfg,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -1,17 +1,16 @@
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
-import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
+import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { listChatCommands, shouldHandleTextCommands } from "../commands-registry.js";
-import { listSkillCommandsForWorkspace } from "../skill-commands.js";
+import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "../thinking.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveBlockStreamingChunking } from "./block-streaming.js";
-import { buildCommandContext } from "./commands.js";
+import { buildCommandContext } from "./commands-context.js";
 import { type InlineDirectives, parseInlineDirectives } from "./directive-handling.parse.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { clearExecInlineDirectives, clearInlineDirectives } from "./get-reply-directives-utils.js";
@@ -24,6 +23,20 @@ import type { TypingController } from "./typing.js";
 
 type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
+
+let commandsRegistryPromise: Promise<typeof import("../commands-registry.runtime.js")> | null =
+  null;
+let skillCommandsPromise: Promise<typeof import("../skill-commands.runtime.js")> | null = null;
+
+function loadCommandsRegistry() {
+  commandsRegistryPromise ??= import("../commands-registry.runtime.js");
+  return commandsRegistryPromise;
+}
+
+function loadSkillCommands() {
+  skillCommandsPromise ??= import("../skill-commands.runtime.js");
+  return skillCommandsPromise;
+}
 
 function shouldLogDirectiveTiming(): boolean {
   return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
@@ -186,22 +199,29 @@ export async function resolveReplyDirectives(params: {
     surface: command.surface,
     commandSource: ctx.CommandSource,
   });
-  const reservedCommands = new Set(
-    listChatCommands().flatMap((cmd) =>
-      cmd.textAliases.map((a) => a.replace(/^\//, "").toLowerCase()),
-    ),
-  );
+  const commandTextHasSlash = commandText.includes("/");
+  const reservedCommands = new Set<string>();
+  if (commandTextHasSlash) {
+    const { listChatCommands } = await loadCommandsRegistry();
+    for (const chatCommand of listChatCommands()) {
+      for (const alias of chatCommand.textAliases) {
+        reservedCommands.add(alias.replace(/^\//, "").toLowerCase());
+      }
+    }
+  }
 
-  const rawAliases = Object.values(cfg.agents?.defaults?.models ?? {})
-    .map((entry) => entry.alias?.trim())
-    .filter((alias): alias is string => Boolean(alias))
-    .filter((alias) => !reservedCommands.has(alias.toLowerCase()));
+  const rawAliases = commandTextHasSlash
+    ? Object.values(cfg.agents?.defaults?.models ?? {})
+        .map((entry) => entry.alias?.trim())
+        .filter((alias): alias is string => Boolean(alias))
+        .filter((alias) => !reservedCommands.has(alias.toLowerCase()))
+    : [];
 
   // Only load workspace skill commands when we actually need them to filter aliases.
-  // This avoids scanning skills for messages that only use inline directives like /think:/verbose:.
+  // This avoids scanning skills for messages that only use plain text with no slash syntax.
   const skillCommands =
-    allowTextCommands && rawAliases.length > 0
-      ? listSkillCommandsForWorkspace({
+    allowTextCommands && commandTextHasSlash && rawAliases.length > 0
+      ? (await loadSkillCommands()).listSkillCommandsForWorkspace({
           workspaceDir,
           cfg,
           skillFilter,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,7 +1,7 @@
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { loadModelCatalog } from "../../agents/model-catalog.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import {
   buildConfiguredModelCatalog,
   buildAllowedModelSet,
@@ -14,7 +14,7 @@ import {
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { resolveThreadParentSessionKey } from "../../sessions/session-key-utils.js";
 import type { ThinkLevel } from "./directives.js";
@@ -26,7 +26,7 @@ export type ModelDirectiveSelection = {
   alias?: string;
 };
 
-type ModelCatalog = Awaited<ReturnType<typeof loadModelCatalog>>;
+type ModelCatalog = ModelCatalogEntry[];
 
 type ModelSelectionState = {
   provider: string;
@@ -42,6 +42,23 @@ type ModelSelectionState = {
 
 function shouldLogModelSelectionTiming(): boolean {
   return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
+}
+
+let modelCatalogRuntimePromise:
+  | Promise<typeof import("../../agents/model-catalog.runtime.js")>
+  | undefined;
+let sessionStoreRuntimePromise:
+  | Promise<typeof import("../../config/sessions/store.runtime.js")>
+  | undefined;
+
+function loadModelCatalogRuntime() {
+  modelCatalogRuntimePromise ??= import("../../agents/model-catalog.runtime.js");
+  return modelCatalogRuntimePromise;
+}
+
+function loadSessionStoreRuntime() {
+  sessionStoreRuntimePromise ??= import("../../config/sessions/store.runtime.js");
+  return sessionStoreRuntimePromise;
 }
 
 const FUZZY_VARIANT_TOKENS = [
@@ -328,7 +345,7 @@ export async function createModelSelectionState(params: {
   let resetModelOverride = false;
 
   if (needsModelCatalog) {
-    modelCatalog = await loadModelCatalog({ config: cfg });
+    modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
     logStage("catalog-loaded", `entries=${modelCatalog.length}`);
     const allowed = buildAllowedModelSet({
       cfg,
@@ -375,7 +392,9 @@ export async function createModelSelectionState(params: {
         if (updated) {
           sessionStore[sessionKey] = sessionEntry;
           if (storePath) {
-            await updateSessionStore(storePath, (store) => {
+            await (
+              await loadSessionStoreRuntime()
+            ).updateSessionStore(storePath, (store) => {
               store[sessionKey] = sessionEntry;
             });
           }
@@ -432,7 +451,7 @@ export async function createModelSelectionState(params: {
     }
     let catalogForThinking = modelCatalog ?? allowedModelCatalog;
     if (!catalogForThinking || catalogForThinking.length === 0) {
-      modelCatalog = await loadModelCatalog({ config: cfg });
+      modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
       logStage("catalog-loaded-for-thinking", `entries=${modelCatalog.length}`);
       catalogForThinking = modelCatalog;
     }
@@ -450,7 +469,7 @@ export async function createModelSelectionState(params: {
   const resolveDefaultReasoningLevel = async (): Promise<"on" | "off"> => {
     let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
     if (!catalogForReasoning || catalogForReasoning.length === 0) {
-      modelCatalog = await loadModelCatalog({ config: cfg });
+      modelCatalog = await (await loadModelCatalogRuntime()).loadModelCatalog({ config: cfg });
       logStage("catalog-loaded-for-reasoning", `entries=${modelCatalog.length}`);
       catalogForReasoning = modelCatalog;
     }

--- a/src/auto-reply/skill-commands.runtime.ts
+++ b/src/auto-reply/skill-commands.runtime.ts
@@ -1,0 +1,5 @@
+export {
+  listReservedChatSlashCommandNames,
+  listSkillCommandsForWorkspace,
+  resolveSkillCommandInvocation,
+} from "./skill-commands.js";

--- a/src/config/sessions/store.runtime.ts
+++ b/src/config/sessions/store.runtime.ts
@@ -1,0 +1,1 @@
+export { updateSessionStore } from "./store.js";


### PR DESCRIPTION
## Summary
- narrow core inbound startup imports behind real runtime boundaries
- remove several eager reply-path barrel imports that were pulling heavy auth, session, model, and sandbox graphs into cold startup
- keep the remaining work focused on `get-reply-directives.ts`, which is still the main unresolved hotspot

## What changed
- added runtime seams for model catalog, models config, session store, command registry, skill commands, status reply, and directive persistence
- narrowed inbound reply imports in auth profile session override, context lookup, fast mode, group activation, command context, directive apply, directive resolve, and reply model selection
- kept the change scoped away from unrelated Telegram polling WIP in the local worktree

## Validation
- `pnpm tsgo`
- `pnpm build`
- targeted cold-import probes on the touched startup modules

## Measured wins
- `src/agents/auth-profiles/session-override.ts`: ~18.1s / 169MB -> ~225ms / 2.3MB
- `src/agents/context.ts`: ~11.2s / 169MB -> ~884ms / 54.9MB
- `src/agents/fast-mode.ts`: ~16.8s / 169MB -> ~313ms / ~0MB
- `src/auto-reply/reply/model-selection.ts`: ~12.0s / 169MB -> ~3.5s / 55.4MB
- `src/auto-reply/reply/groups.ts`: ~32.9s / 169MB -> ~251ms / 0.4MB
- `src/auto-reply/reply/get-reply-directives-apply.ts`: ~39.7s / 168MB -> ~53ms / 0.06MB

## Remaining gap
- `src/auto-reply/reply/get-reply-directives.ts` is still the dominant cold-import hotspot at roughly ~15.8s / 169MB standalone
- follow-up work should split its cheap parse/gating path from its heavier model/default-resolution path
