### PR TITLE
fix(doctor): honor --repair in non-interactive mode

### DIFF
--- a/src/commands/doctor-prompter.test.ts
+++ b/src/commands/doctor-prompter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { createDoctorPrompter } from "./doctor-prompter.js";
+
+const stubRuntime = {} as Parameters<typeof createDoctorPrompter>[0]["runtime"];
+
+describe("createDoctorPrompter", () => {
+  describe("confirmDefault (confirm)", () => {
+    it("returns true when --repair is passed in non-interactive mode", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { repair: true, nonInteractive: true },
+      });
+      const result = await prompter.confirm({ message: "repair?" });
+      expect(result).toBe(true);
+    });
+
+    it("returns false in non-interactive mode without --repair", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { nonInteractive: true },
+      });
+      const result = await prompter.confirm({ message: "repair?" });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("confirmRepair", () => {
+    it("returns true when --repair is passed in non-interactive mode", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { repair: true, nonInteractive: true },
+      });
+      const result = await prompter.confirmRepair({ message: "repair?" });
+      expect(result).toBe(true);
+    });
+
+    it("returns false in non-interactive mode without --repair", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { nonInteractive: true },
+      });
+      const result = await prompter.confirmRepair({ message: "repair?" });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("confirmAggressive", () => {
+    it("returns true when --repair --force is passed in non-interactive mode", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { repair: true, force: true, nonInteractive: true },
+      });
+      const result = await prompter.confirmAggressive({ message: "aggressive?" });
+      expect(result).toBe(true);
+    });
+
+    it("returns false when --repair without --force in non-interactive mode", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { repair: true, nonInteractive: true },
+      });
+      const result = await prompter.confirmAggressive({ message: "aggressive?" });
+      expect(result).toBe(false);
+    });
+
+    it("returns false in non-interactive mode without --repair", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { nonInteractive: true },
+      });
+      const result = await prompter.confirmAggressive({ message: "aggressive?" });
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("confirmSkipInNonInteractive", () => {
+    it("returns false in non-interactive mode even with --repair", async () => {
+      const prompter = createDoctorPrompter({
+        runtime: stubRuntime,
+        options: { repair: true, nonInteractive: true },
+      });
+      const result = await prompter.confirmSkipInNonInteractive({ message: "skip?" });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -36,11 +36,11 @@ export function createDoctorPrompter(params: {
 
   const canPrompt = isTty && !yes && !nonInteractive;
   const confirmDefault = async (p: Parameters<typeof confirm>[0]) => {
-    if (nonInteractive) {
-      return false;
-    }
     if (shouldRepair) {
       return true;
+    }
+    if (nonInteractive) {
+      return false;
     }
     if (!canPrompt) {
       return Boolean(p.initialValue ?? false);
@@ -57,19 +57,22 @@ export function createDoctorPrompter(params: {
   return {
     confirm: confirmDefault,
     confirmRepair: async (p) => {
+      if (shouldRepair) {
+        return true;
+      }
       if (nonInteractive) {
         return false;
       }
       return confirmDefault(p);
     },
     confirmAggressive: async (p) => {
-      if (nonInteractive) {
-        return false;
-      }
       if (shouldRepair && shouldForce) {
         return true;
       }
       if (shouldRepair && !shouldForce) {
+        return false;
+      }
+      if (nonInteractive) {
         return false;
       }
       if (!canPrompt) {


### PR DESCRIPTION
## Summary

`doctor --repair --non-interactive` silently skips repairs because `confirmDefault` checks `nonInteractive` before `shouldRepair` — the early return prevents `--repair` from taking effect in CI/cron pipelines.

The same priority inversion exists in `confirmRepair` and `confirmAggressive`.

Fixes #44185

## Changes

- `confirmDefault`: check `shouldRepair` before `nonInteractive`
- `confirmRepair`: check `shouldRepair` before `nonInteractive`
- `confirmAggressive`: check `shouldRepair && shouldForce` before `nonInteractive`
- `confirmSkipInNonInteractive`: intentionally unchanged — those operations (state integrity, daemon management) should always skip without a TTY

## Testing

- Added `doctor-prompter.test.ts` with 8 test cases covering all four confirm methods in non-interactive + repair combinations
- `pnpm vitest run src/commands/doctor-prompter.test.ts` — 8/8 pass
- `pnpm check` — 0 errors, 0 warnings

## Prior art

#44282 and #46206 addressed the same bug but were closed due to PR queue limits, not rejection. #46206's Greptile review identified the `confirmRepair` sibling bug — this PR addresses that as well.

AI-assisted (Claude). Lightly tested (unit tests, type check). I understand the guard order logic and why `confirmSkipInNonInteractive` should remain unchanged.