### PR TITLE
Add bad-barnacle label to prevent barnacle closures.

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -42,7 +42,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale
-          exempt-pr-labels: maintainer,no-stale
+          exempt-pr-labels: maintainer,no-stale,bad-barnacle
           operations-per-run: 2000
           ascending: true
           exempt-all-assignees: true
@@ -98,7 +98,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale
-          exempt-pr-labels: maintainer,no-stale
+          exempt-pr-labels: maintainer,no-stale,bad-barnacle
           operations-per-run: 2000
           ascending: true
           exempt-all-assignees: true


### PR DESCRIPTION
## Summary
- exempt PRs labeled `bad-barnacle` from the stale auto-close workflow
- apply the exemption in both the primary and fallback stale jobs

## Verification
- pnpm check