### PR TITLE
fix(discord): dedupe inbound message deliveries

### DIFF
--- a/extensions/discord/src/monitor.tool-result.sends-status-replies-responseprefix.test.ts
+++ b/extensions/discord/src/monitor.tool-result.sends-status-replies-responseprefix.test.ts
@@ -33,6 +33,9 @@ const BASE_CFG: Config = {
       workspace: "/tmp/openclaw",
     },
   },
+  messages: {
+    inbound: { debounceMs: 0 },
+  },
   session: { store: "/tmp/openclaw-sessions.json" },
 };
 

--- a/extensions/discord/src/monitor/message-handler.queue.test.ts
+++ b/extensions/discord/src/monitor/message-handler.queue.test.ts
@@ -156,6 +156,22 @@ describe("createDiscordMessageHandler queue behavior", () => {
     });
   });
 
+  it("drops duplicate inbound message deliveries before they reach preflight", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const handler = createHandlerWithDefaultPreflight();
+    const duplicate = createMessageData("m-dup");
+
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+    await expect(handler(duplicate as never, {} as never)).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(processDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+    expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+  });
+
   it("applies explicit inbound worker timeout to queued runs so stalled runs do not block the queue", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -4,6 +4,7 @@ import {
   shouldDebounceTextInbound,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
+import { createDedupeCache } from "openclaw/plugin-sdk/infra-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { buildDiscordInboundJob } from "./inbound-job.js";
 import { createDiscordInboundWorker } from "./inbound-worker.js";
@@ -30,6 +31,27 @@ export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
 };
 
+const RECENT_DISCORD_MESSAGE_TTL_MS = 5 * 60_000;
+const RECENT_DISCORD_MESSAGE_MAX = 5000;
+
+function buildDiscordInboundDedupeKey(params: {
+  accountId: string;
+  data: DiscordMessageEvent;
+}): string | null {
+  const messageId = params.data.message?.id?.trim();
+  if (!messageId) {
+    return null;
+  }
+  const channelId = resolveDiscordMessageChannelId({
+    message: params.data.message,
+    eventChannelId: params.data.channel_id,
+  });
+  if (!channelId) {
+    return null;
+  }
+  return `${params.accountId}:${channelId}:${messageId}`;
+}
+
 export function createDiscordMessageHandler(
   params: DiscordMessageHandlerParams,
 ): DiscordMessageHandlerWithLifecycle {
@@ -47,6 +69,10 @@ export function createDiscordMessageHandler(
     setStatus: params.setStatus,
     abortSignal: params.abortSignal,
     runTimeoutMs: params.workerRunTimeoutMs,
+  });
+  const recentInboundMessages = createDedupeCache({
+    ttlMs: RECENT_DISCORD_MESSAGE_TTL_MS,
+    maxSize: RECENT_DISCORD_MESSAGE_MAX,
   });
 
   const { debouncer } = createChannelInboundDebouncer<{
@@ -171,6 +197,13 @@ export function createDiscordMessageHandler(
       // slowdown (see #15874).
       const msgAuthorId = data.message?.author?.id ?? data.author?.id;
       if (params.botUserId && msgAuthorId === params.botUserId) {
+        return;
+      }
+      const dedupeKey = buildDiscordInboundDedupeKey({
+        accountId: params.accountId,
+        data,
+      });
+      if (dedupeKey && recentInboundMessages.check(dedupeKey)) {
         return;
       }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: duplicate Discord deliveries were being marked as seen before preflight and queued worker execution, so a transient failure could suppress retries for the same message for the full dedupe TTL.
- Why it matters: that creates at-most-once behavior for inbound Discord handling and can drop legitimate redeliveries after preflight or worker errors.
- What changed: added a scoped inbound dedupe guard keyed by `accountId:channelId:messageId`, and now release the dedupe claim when preflight fails or when the queued inbound worker errors; added focused queue regressions for duplicate suppression and both retry-after-failure paths.
- What did NOT change (scope boundary): this does not change Discord routing, debounce grouping semantics, or outbound reply behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # none
- Related #41145

## User-visible / Behavior Changes

Discord inbound message handling now suppresses duplicate deliveries earlier in the pipeline, but retries the same delivery after transient preflight or queued-worker failures instead of dropping it for the dedupe TTL.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): default test config with Discord inbound debounce disabled in handler tests

### Steps

1. Send the same Discord message delivery twice.
2. Fail either preflight or the queued inbound worker on the first attempt.
3. Redeliver the same message and observe whether it is retried or suppressed.

### Expected

- Duplicate deliveries are suppressed when the first delivery is accepted successfully.
- The same delivery can retry after a transient preflight or queued-worker failure.

### Actual

- This PR makes the handler release the dedupe claim on those failure paths, and the focused queue regressions now cover both cases.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm exec vitest run extensions/discord/src/monitor/message-handler.queue.test.ts`
- Edge cases checked: duplicate suppression for identical deliveries, retry after preflight failure, and retry after queued inbound worker failure.
- What you did **not** verify: live end-to-end Discord delivery behavior outside the focused queue tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the new dedupe-claim release paths in the Discord handler and inbound worker callback wiring.
- Files/config to restore: `extensions/discord/src/monitor/message-handler.ts`, `extensions/discord/src/monitor/inbound-worker.ts`, `extensions/discord/src/monitor/message-handler.queue.test.ts`
- Known bad symptoms reviewers should watch for: duplicate Discord inbound processing returning, or legitimate redeliveries being suppressed after transient failures.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: releasing the dedupe claim on worker failure could let a real duplicate retry while the failing delivery is being retried externally.
  - Mitigation: the release only happens on explicit preflight or worker failure paths; successful accepted deliveries still retain the short-TTL dedupe guard.
