### PR TITLE
feat(extensions): add Blender plugin for game asset pipelines

### DIFF
--- a/extensions/blender/index.ts
+++ b/extensions/blender/index.ts
@@ -1,0 +1,72 @@
+import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  createImportAssetTool,
+  createExportAssetTool,
+  createLibraryAssetTool,
+} from "./src/tools/assets.js";
+import {
+  createGenerateLodTool,
+  createCollisionMeshTool,
+  createUvUnwrapTool,
+  createGameExportTool,
+  createCheckGameReadinessTool,
+} from "./src/tools/game.js";
+import {
+  createApplyMaterialTool,
+  createBakeTexturesTool,
+  createAssignTextureTool,
+} from "./src/tools/materials.js";
+import { createExecutePythonTool } from "./src/tools/python.js";
+import {
+  createRenderTool,
+  createBatchRenderTool,
+  createScreenshotTool,
+} from "./src/tools/render.js";
+import {
+  createGetSceneInfoTool,
+  createCreateObjectTool,
+  createManageCollectionTool,
+  createSetRenderSettingsTool,
+} from "./src/tools/scene.js";
+
+export default definePluginEntry({
+  id: "blender",
+  name: "Blender Plugin",
+  description:
+    "Deep Blender integration for technical artists building games. " +
+    "Control Blender via the Python API, manage rendering pipelines, import/export game assets, " +
+    "bake textures, generate LODs, create collision meshes, and export to Unreal, Unity, and Godot.",
+
+  register(api) {
+    // Python scripting
+    api.registerTool(createExecutePythonTool(api) as AnyAgentTool);
+
+    // Scene management
+    api.registerTool(createGetSceneInfoTool(api) as AnyAgentTool);
+    api.registerTool(createCreateObjectTool(api) as AnyAgentTool);
+    api.registerTool(createManageCollectionTool(api) as AnyAgentTool);
+    api.registerTool(createSetRenderSettingsTool(api) as AnyAgentTool);
+
+    // Rendering
+    api.registerTool(createRenderTool(api) as AnyAgentTool);
+    api.registerTool(createBatchRenderTool(api) as AnyAgentTool);
+    api.registerTool(createScreenshotTool(api) as AnyAgentTool);
+
+    // Asset management
+    api.registerTool(createImportAssetTool(api) as AnyAgentTool);
+    api.registerTool(createExportAssetTool(api) as AnyAgentTool);
+    api.registerTool(createLibraryAssetTool(api) as AnyAgentTool);
+
+    // Materials & textures
+    api.registerTool(createApplyMaterialTool(api) as AnyAgentTool);
+    api.registerTool(createBakeTexturesTool(api) as AnyAgentTool);
+    api.registerTool(createAssignTextureTool(api) as AnyAgentTool);
+
+    // Game-specific tools
+    api.registerTool(createGenerateLodTool(api) as AnyAgentTool);
+    api.registerTool(createCollisionMeshTool(api) as AnyAgentTool);
+    api.registerTool(createUvUnwrapTool(api) as AnyAgentTool);
+    api.registerTool(createGameExportTool(api) as AnyAgentTool);
+    api.registerTool(createCheckGameReadinessTool(api) as AnyAgentTool);
+  },
+});

--- a/extensions/blender/openclaw.plugin.json
+++ b/extensions/blender/openclaw.plugin.json
@@ -1,0 +1,41 @@
+{
+  "id": "blender",
+  "name": "Blender Plugin",
+  "description": "Deep Blender integration for technical artists — scene control, rendering pipelines, asset management, and game export via the Blender Python API.",
+  "uiHints": {
+    "blender.executablePath": {
+      "label": "Blender Executable Path",
+      "help": "Absolute path to the Blender executable (e.g. /Applications/Blender.app/Contents/MacOS/Blender).",
+      "placeholder": "/Applications/Blender.app/Contents/MacOS/Blender"
+    },
+    "blender.bridgeHost": {
+      "label": "Bridge Host",
+      "help": "Host where the OpenClaw Blender addon bridge is listening (default: 127.0.0.1)."
+    },
+    "blender.bridgePort": {
+      "label": "Bridge Port",
+      "help": "Port where the OpenClaw Blender addon bridge is listening (default: 7428)."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "blender": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "executablePath": {
+            "type": "string"
+          },
+          "bridgeHost": {
+            "type": "string"
+          },
+          "bridgePort": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/blender/package.json
+++ b/extensions/blender/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/blender-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OpenClaw Blender plugin — deep Blender integration for technical artists building games",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/blender/src/addon/openclaw_bridge.py
+++ b/extensions/blender/src/addon/openclaw_bridge.py
@@ -1,0 +1,530 @@
+"""
+OpenClaw Blender Bridge Addon
+=============================
+Install this as a Blender addon (Edit > Preferences > Add-ons > Install).
+It starts a local HTTP server inside Blender that the OpenClaw gateway
+communicates with to control Blender in real time.
+
+Default port: 7428 (configurable in addon preferences).
+"""
+
+bl_info = {
+    "name": "OpenClaw Bridge",
+    "author": "OpenClaw",
+    "version": (1, 0, 0),
+    "blender": (4, 0, 0),
+    "location": "System > OpenClaw Bridge",
+    "description": "Local HTTP bridge that lets the OpenClaw AI gateway control Blender via the Python API",
+    "category": "System",
+}
+
+import bpy
+import json
+import threading
+import traceback
+import io
+import sys
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from contextlib import redirect_stdout, redirect_stderr
+
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+
+_server: HTTPServer | None = None
+_server_thread: threading.Thread | None = None
+ADDON_VERSION = "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Request handlers
+# ---------------------------------------------------------------------------
+
+class BlenderBridgeHandler(BaseHTTPRequestHandler):
+    """Handles incoming JSON requests from the OpenClaw gateway."""
+
+    def log_message(self, format, *args):
+        # Suppress default noisy HTTP logging
+        pass
+
+    def send_json(self, status: int, data: dict):
+        body = json.dumps(data).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def read_body(self) -> dict:
+        length = int(self.headers.get("Content-Length", 0))
+        if length == 0:
+            return {}
+        return json.loads(self.rfile.read(length).decode("utf-8"))
+
+    def do_GET(self):
+        if self.path == "/status":
+            self.handle_status()
+        elif self.path == "/scene":
+            self.handle_scene()
+        else:
+            self.send_json(404, {"error": f"Unknown path: {self.path}"})
+
+    def do_POST(self):
+        try:
+            body = self.read_body()
+        except Exception as e:
+            self.send_json(400, {"error": f"Invalid JSON body: {e}"})
+            return
+
+        if self.path == "/execute":
+            self.handle_execute(body)
+        elif self.path == "/render":
+            self.handle_render(body)
+        elif self.path == "/import":
+            self.handle_import(body)
+        elif self.path == "/export":
+            self.handle_export(body)
+        elif self.path == "/screenshot":
+            self.handle_screenshot(body)
+        else:
+            self.send_json(404, {"error": f"Unknown path: {self.path}"})
+
+    # -----------------------------------------------------------------------
+    # Handlers
+    # -----------------------------------------------------------------------
+
+    def handle_status(self):
+        self.send_json(200, {
+            "running": True,
+            "blenderVersion": ".".join(str(v) for v in bpy.app.version),
+            "addonVersion": ADDON_VERSION,
+            "activeFile": bpy.data.filepath or None,
+        })
+
+    def handle_scene(self):
+        scene = bpy.context.scene
+        objects = []
+        for obj in scene.objects:
+            mat_names = [m.name for m in obj.data.materials] if hasattr(obj.data, "materials") and obj.data.materials else []
+            info = {
+                "name": obj.name,
+                "type": obj.type,
+                "collection": obj.users_collection[0].name if obj.users_collection else "",
+                "location": list(obj.location),
+                "rotation": list(obj.rotation_euler),
+                "scale": list(obj.scale),
+                "visible": obj.visible_get(),
+                "materials": mat_names,
+            }
+            if obj.type == "MESH" and obj.data:
+                info["vertexCount"] = len(obj.data.vertices)
+                info["faceCount"] = len(obj.data.polygons)
+            objects.append(info)
+
+        self.send_json(200, {
+            "name": scene.name,
+            "objects": objects,
+            "collections": [c.name for c in bpy.data.collections],
+            "activeCamera": scene.camera.name if scene.camera else None,
+            "renderEngine": scene.render.engine,
+            "frameStart": scene.frame_start,
+            "frameEnd": scene.frame_end,
+            "fps": scene.render.fps,
+        })
+
+    def handle_execute(self, body: dict):
+        code = body.get("code", "")
+        if not code:
+            self.send_json(400, {"error": "No code provided"})
+            return
+
+        stdout_capture = io.StringIO()
+        result_value = None
+        error_msg = None
+
+        def _run():
+            nonlocal result_value, error_msg
+            try:
+                local_ns: dict = {}
+                with redirect_stdout(stdout_capture), redirect_stderr(stdout_capture):
+                    exec(compile(code, "<openclaw>", "exec"), local_ns)
+                result_value = local_ns.get("_result", None)
+            except Exception:
+                error_msg = traceback.format_exc()
+
+        # Execute on the main thread via bpy.app.timers to avoid threading issues
+        _run_on_main_thread(_run)
+
+        if error_msg:
+            self.send_json(200, {"ok": False, "error": error_msg, "output": stdout_capture.getvalue()})
+        else:
+            self.send_json(200, {
+                "ok": True,
+                "output": stdout_capture.getvalue(),
+                "result": _safe_json(result_value),
+            })
+
+    def handle_render(self, body: dict):
+        error_msg = None
+
+        def _run():
+            nonlocal error_msg
+            try:
+                scene = bpy.context.scene
+                if body.get("engine"):
+                    scene.render.engine = body["engine"]
+                if body.get("resolutionX"):
+                    scene.render.resolution_x = int(body["resolutionX"])
+                if body.get("resolutionY"):
+                    scene.render.resolution_y = int(body["resolutionY"])
+                if body.get("samples"):
+                    samples = int(body["samples"])
+                    if scene.render.engine == "CYCLES":
+                        scene.cycles.samples = samples
+                    elif scene.render.engine == "BLENDER_EEVEE_NEXT":
+                        scene.eevee.taa_render_samples = samples
+                if body.get("camera"):
+                    cam = bpy.data.objects.get(body["camera"])
+                    if cam:
+                        scene.camera = cam
+                if body.get("outputPath"):
+                    scene.render.filepath = body["outputPath"]
+                frame_start = body.get("frameStart")
+                frame_end = body.get("frameEnd")
+                if frame_start is not None and frame_end is not None:
+                    scene.frame_start = int(frame_start)
+                    scene.frame_end = int(frame_end)
+                    bpy.ops.render.render(animation=True)
+                else:
+                    bpy.ops.render.render(write_still=True)
+            except Exception:
+                error_msg = traceback.format_exc()
+
+        _run_on_main_thread(_run)
+
+        if error_msg:
+            self.send_json(200, {"ok": False, "error": error_msg})
+        else:
+            self.send_json(200, {
+                "ok": True,
+                "outputPath": body.get("outputPath"),
+            })
+
+    def handle_import(self, body: dict):
+        file_path = body.get("filePath", "")
+        fmt = body.get("format", "").upper()
+        collection_name = body.get("collection")
+        error_msg = None
+
+        def _run():
+            nonlocal error_msg
+            try:
+                import_ops = {
+                    "FBX": lambda: bpy.ops.import_scene.fbx(filepath=file_path),
+                    "GLTF": lambda: bpy.ops.import_scene.gltf(filepath=file_path),
+                    "GLB": lambda: bpy.ops.import_scene.gltf(filepath=file_path),
+                    "OBJ": lambda: bpy.ops.wm.obj_import(filepath=file_path),
+                    "USD": lambda: bpy.ops.wm.usd_import(filepath=file_path),
+                    "USDC": lambda: bpy.ops.wm.usd_import(filepath=file_path),
+                    "USDA": lambda: bpy.ops.wm.usd_import(filepath=file_path),
+                    "ABC": lambda: bpy.ops.wm.alembic_import(filepath=file_path),
+                    "STL": lambda: bpy.ops.wm.stl_import(filepath=file_path),
+                    "PLY": lambda: bpy.ops.wm.ply_import(filepath=file_path),
+                }
+                op = import_ops.get(fmt)
+                if not op:
+                    raise ValueError(f"Unsupported format: {fmt}")
+                op()
+
+                if collection_name:
+                    col = bpy.data.collections.get(collection_name)
+                    if not col:
+                        col = bpy.data.collections.new(collection_name)
+                        bpy.context.scene.collection.children.link(col)
+                    for obj in bpy.context.selected_objects:
+                        for c in obj.users_collection:
+                            c.objects.unlink(obj)
+                        col.objects.link(obj)
+            except Exception:
+                error_msg = traceback.format_exc()
+
+        _run_on_main_thread(_run)
+
+        if error_msg:
+            self.send_json(200, {"ok": False, "error": error_msg})
+        else:
+            self.send_json(200, {"ok": True})
+
+    def handle_export(self, body: dict):
+        file_path = body.get("filePath", "")
+        fmt = body.get("format", "").upper()
+        selection_only = bool(body.get("selectionOnly", False))
+        apply_modifiers = bool(body.get("applyModifiers", True))
+        export_animations = bool(body.get("exportAnimations", False))
+        error_msg = None
+
+        def _run():
+            nonlocal error_msg
+            try:
+                if fmt == "FBX":
+                    bpy.ops.export_scene.fbx(
+                        filepath=file_path,
+                        use_selection=selection_only,
+                        use_mesh_modifiers=apply_modifiers,
+                        bake_anim=export_animations,
+                    )
+                elif fmt in ("GLTF", "GLB"):
+                    bpy.ops.export_scene.gltf(
+                        filepath=file_path,
+                        export_format="GLB" if fmt == "GLB" else "GLTF_EMBEDDED",
+                        use_selection=selection_only,
+                        export_apply=apply_modifiers,
+                        export_animations=export_animations,
+                    )
+                elif fmt == "OBJ":
+                    bpy.ops.wm.obj_export(
+                        filepath=file_path,
+                        export_selected_objects=selection_only,
+                        apply_modifiers=apply_modifiers,
+                    )
+                elif fmt in ("USD", "USDC", "USDA"):
+                    bpy.ops.wm.usd_export(
+                        filepath=file_path,
+                        selected_objects_only=selection_only,
+                        export_animation=export_animations,
+                    )
+                elif fmt == "ABC":
+                    bpy.ops.wm.alembic_export(
+                        filepath=file_path,
+                        selected=selection_only,
+                    )
+                else:
+                    raise ValueError(f"Unsupported export format: {fmt}")
+            except Exception:
+                error_msg = traceback.format_exc()
+
+        _run_on_main_thread(_run)
+
+        if error_msg:
+            self.send_json(200, {"ok": False, "error": error_msg})
+        else:
+            self.send_json(200, {"ok": True})
+
+    def handle_screenshot(self, body: dict):
+        output_path = body.get("outputPath", "/tmp/openclaw_screenshot.png")
+        error_msg = None
+
+        def _run():
+            nonlocal error_msg
+            try:
+                # Override render settings temporarily for screenshot
+                bpy.ops.screen.screenshot(filepath=output_path, full=False)
+            except Exception:
+                error_msg = traceback.format_exc()
+
+        _run_on_main_thread(_run)
+
+        if error_msg:
+            self.send_json(200, {"ok": False, "error": error_msg})
+        else:
+            self.send_json(200, {"ok": True, "outputPath": output_path})
+
+
+# ---------------------------------------------------------------------------
+# Thread-safe main-thread execution
+# ---------------------------------------------------------------------------
+
+_pending_fn = None
+_pending_done = threading.Event()
+
+
+def _run_on_main_thread(fn):
+    """Schedule fn to run on Blender's main thread and block until complete."""
+    global _pending_fn, _pending_done
+    _pending_fn = fn
+    _pending_done.clear()
+    bpy.app.timers.register(_execute_pending, first_interval=0.0)
+    _pending_done.wait(timeout=300)  # 5-minute timeout
+
+
+def _execute_pending():
+    global _pending_fn, _pending_done
+    if _pending_fn:
+        try:
+            _pending_fn()
+        finally:
+            _pending_fn = None
+            _pending_done.set()
+    return None  # Don't reschedule
+
+
+# ---------------------------------------------------------------------------
+# JSON safety helper
+# ---------------------------------------------------------------------------
+
+def _safe_json(value):
+    """Convert value to something JSON-serialisable."""
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+
+def start_server(host: str, port: int):
+    global _server, _server_thread
+    if _server is not None:
+        return
+
+    _server = HTTPServer((host, port), BlenderBridgeHandler)
+    _server.timeout = 1.0
+
+    def serve():
+        print(f"[OpenClaw Bridge] Listening on http://{host}:{port}")
+        while _server is not None:
+            _server.handle_request()
+
+    _server_thread = threading.Thread(target=serve, daemon=True, name="OpenClawBridge")
+    _server_thread.start()
+
+
+def stop_server():
+    global _server, _server_thread
+    if _server:
+        _server.server_close()
+        _server = None
+        _server_thread = None
+        print("[OpenClaw Bridge] Server stopped.")
+
+
+# ---------------------------------------------------------------------------
+# Addon preferences
+# ---------------------------------------------------------------------------
+
+class OpenClawBridgePreferences(bpy.types.AddonPreferences):
+    bl_idname = __name__
+
+    host: bpy.props.StringProperty(
+        name="Host",
+        description="Host to bind the HTTP server to",
+        default="127.0.0.1",
+    )  # type: ignore
+    port: bpy.props.IntProperty(
+        name="Port",
+        description="Port for the OpenClaw Bridge HTTP server",
+        default=7428,
+        min=1024,
+        max=65535,
+    )  # type: ignore
+    auto_start: bpy.props.BoolProperty(
+        name="Auto-start on launch",
+        description="Automatically start the bridge when Blender opens",
+        default=True,
+    )  # type: ignore
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.prop(self, "host")
+        row.prop(self, "port")
+        layout.prop(self, "auto_start")
+
+        status = "Running" if _server is not None else "Stopped"
+        layout.label(text=f"Bridge status: {status}", icon="LINKED" if _server else "UNLINKED")
+
+        row = layout.row()
+        row.operator("openclaw.start_bridge", text="Start Bridge")
+        row.operator("openclaw.stop_bridge", text="Stop Bridge")
+
+
+# ---------------------------------------------------------------------------
+# Operators
+# ---------------------------------------------------------------------------
+
+class OPENCLAW_OT_StartBridge(bpy.types.Operator):
+    bl_idname = "openclaw.start_bridge"
+    bl_label = "Start OpenClaw Bridge"
+    bl_description = "Start the OpenClaw HTTP bridge server"
+
+    def execute(self, context):
+        prefs = context.preferences.addons[__name__].preferences
+        start_server(prefs.host, prefs.port)
+        self.report({"INFO"}, f"OpenClaw Bridge started on {prefs.host}:{prefs.port}")
+        return {"FINISHED"}
+
+
+class OPENCLAW_OT_StopBridge(bpy.types.Operator):
+    bl_idname = "openclaw.stop_bridge"
+    bl_label = "Stop OpenClaw Bridge"
+    bl_description = "Stop the OpenClaw HTTP bridge server"
+
+    def execute(self, context):
+        stop_server()
+        self.report({"INFO"}, "OpenClaw Bridge stopped")
+        return {"FINISHED"}
+
+
+# ---------------------------------------------------------------------------
+# Status panel in the sidebar
+# ---------------------------------------------------------------------------
+
+class OPENCLAW_PT_BridgePanel(bpy.types.Panel):
+    bl_label = "OpenClaw Bridge"
+    bl_idname = "OPENCLAW_PT_bridge"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "OpenClaw"
+
+    def draw(self, context):
+        layout = self.layout
+        prefs = context.preferences.addons[__name__].preferences
+        status = "● Running" if _server is not None else "○ Stopped"
+        col = layout.column()
+        col.label(text=status, icon="LINKED" if _server else "UNLINKED")
+        if _server is not None:
+            col.label(text=f"http://{prefs.host}:{prefs.port}", icon="URL")
+        row = col.row()
+        row.operator("openclaw.start_bridge", text="Start")
+        row.operator("openclaw.stop_bridge", text="Stop")
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+classes = (
+    OpenClawBridgePreferences,
+    OPENCLAW_OT_StartBridge,
+    OPENCLAW_OT_StopBridge,
+    OPENCLAW_PT_BridgePanel,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+    # Auto-start if preference is set
+    def _auto_start():
+        prefs = bpy.context.preferences.addons.get(__name__)
+        if prefs and prefs.preferences.auto_start:
+            start_server(prefs.preferences.host, prefs.preferences.port)
+        return None  # Don't reschedule
+
+    bpy.app.timers.register(_auto_start, first_interval=0.5)
+
+
+def unregister():
+    stop_server()
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+
+
+if __name__ == "__main__":
+    register()

--- a/extensions/blender/src/addon/openclaw_bridge.py
+++ b/extensions/blender/src/addon/openclaw_bridge.py
@@ -155,9 +155,11 @@ class BlenderBridgeHandler(BaseHTTPRequestHandler):
                 error_msg = traceback.format_exc()
 
         # Execute on the main thread via bpy.app.timers to avoid threading issues
-        _run_on_main_thread(_run)
+        completed = _run_on_main_thread(_run)
 
-        if error_msg:
+        if not completed:
+            self.send_json(200, {"ok": False, "error": "Timed out waiting for Blender main thread (300s)"})
+        elif error_msg:
             self.send_json(200, {"ok": False, "error": error_msg, "output": stdout_capture.getvalue()})
         else:
             self.send_json(200, {
@@ -202,9 +204,11 @@ class BlenderBridgeHandler(BaseHTTPRequestHandler):
             except Exception:
                 error_msg = traceback.format_exc()
 
-        _run_on_main_thread(_run)
+        completed = _run_on_main_thread(_run)
 
-        if error_msg:
+        if not completed:
+            self.send_json(200, {"ok": False, "error": "Timed out waiting for Blender main thread (300s)"})
+        elif error_msg:
             self.send_json(200, {"ok": False, "error": error_msg})
         else:
             self.send_json(200, {
@@ -250,9 +254,11 @@ class BlenderBridgeHandler(BaseHTTPRequestHandler):
             except Exception:
                 error_msg = traceback.format_exc()
 
-        _run_on_main_thread(_run)
+        completed = _run_on_main_thread(_run)
 
-        if error_msg:
+        if not completed:
+            self.send_json(200, {"ok": False, "error": "Timed out waiting for Blender main thread (300s)"})
+        elif error_msg:
             self.send_json(200, {"ok": False, "error": error_msg})
         else:
             self.send_json(200, {"ok": True})
@@ -305,28 +311,52 @@ class BlenderBridgeHandler(BaseHTTPRequestHandler):
             except Exception:
                 error_msg = traceback.format_exc()
 
-        _run_on_main_thread(_run)
+        completed = _run_on_main_thread(_run)
 
-        if error_msg:
+        if not completed:
+            self.send_json(200, {"ok": False, "error": "Timed out waiting for Blender main thread (300s)"})
+        elif error_msg:
             self.send_json(200, {"ok": False, "error": error_msg})
         else:
             self.send_json(200, {"ok": True})
 
     def handle_screenshot(self, body: dict):
-        output_path = body.get("outputPath", "/tmp/openclaw_screenshot.png")
+        import tempfile
+        default_path = os.path.join(tempfile.gettempdir(), "openclaw_screenshot.png")
+        output_path = body.get("outputPath") or default_path
+        width = body.get("width")
+        height = body.get("height")
         error_msg = None
 
         def _run():
             nonlocal error_msg
             try:
-                # Override render settings temporarily for screenshot
-                bpy.ops.screen.screenshot(filepath=output_path, full=False)
+                scene = bpy.context.scene
+                if width and height:
+                    # Temporarily override render resolution so the offscreen
+                    # screenshot honours the requested dimensions.
+                    orig_x = scene.render.resolution_x
+                    orig_y = scene.render.resolution_y
+                    orig_pct = scene.render.resolution_percentage
+                    scene.render.resolution_x = int(width)
+                    scene.render.resolution_y = int(height)
+                    scene.render.resolution_percentage = 100
+                    try:
+                        bpy.ops.screen.screenshot(filepath=output_path, full=False)
+                    finally:
+                        scene.render.resolution_x = orig_x
+                        scene.render.resolution_y = orig_y
+                        scene.render.resolution_percentage = orig_pct
+                else:
+                    bpy.ops.screen.screenshot(filepath=output_path, full=False)
             except Exception:
                 error_msg = traceback.format_exc()
 
-        _run_on_main_thread(_run)
+        completed = _run_on_main_thread(_run)
 
-        if error_msg:
+        if not completed:
+            self.send_json(200, {"ok": False, "error": "Timed out waiting for Blender main thread (300s)"})
+        elif error_msg:
             self.send_json(200, {"ok": False, "error": error_msg})
         else:
             self.send_json(200, {"ok": True, "outputPath": output_path})
@@ -340,13 +370,20 @@ _pending_fn = None
 _pending_done = threading.Event()
 
 
-def _run_on_main_thread(fn):
-    """Schedule fn to run on Blender's main thread and block until complete."""
+def _run_on_main_thread(fn) -> bool:
+    """Schedule fn to run on Blender's main thread and block until complete.
+
+    Returns True if fn completed within the timeout, False if it timed out.
+    """
     global _pending_fn, _pending_done
     _pending_fn = fn
     _pending_done.clear()
     bpy.app.timers.register(_execute_pending, first_interval=0.0)
-    _pending_done.wait(timeout=300)  # 5-minute timeout
+    completed = _pending_done.wait(timeout=300)  # 5-minute timeout
+    if not completed:
+        # Timed out — cancel any still-pending work so the slot is not left dirty.
+        _pending_fn = None
+    return completed
 
 
 def _execute_pending():

--- a/extensions/blender/src/background.ts
+++ b/extensions/blender/src/background.ts
@@ -1,0 +1,192 @@
+/**
+ * Run Blender in headless background mode for batch operations.
+ * Used when no interactive Blender session is open.
+ */
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { writeFile, unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export type BackgroundResult = {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+};
+
+/**
+ * Execute a Python script in Blender background mode.
+ * Optionally open an existing .blend file first.
+ */
+export async function runBlenderBackground(params: {
+  blenderExecutable: string;
+  blendFile?: string;
+  pythonCode: string;
+  timeoutMs?: number;
+}): Promise<BackgroundResult> {
+  const { blenderExecutable, blendFile, pythonCode, timeoutMs = 120_000 } = params;
+
+  // Write python code to a temp file
+  const scriptPath = join(tmpdir(), `openclaw_blender_${randomUUID()}.py`);
+  await writeFile(scriptPath, pythonCode, "utf-8");
+
+  const args: string[] = ["--background"];
+  if (blendFile) args.push(blendFile);
+  args.push("--python", scriptPath);
+
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const proc = spawn(blenderExecutable, args, { env: process.env });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGTERM");
+    }, timeoutMs);
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on("close", (exitCode) => {
+      clearTimeout(timer);
+      unlink(scriptPath).catch(() => {});
+      resolve({
+        ok: !timedOut && exitCode === 0,
+        stdout,
+        stderr: timedOut ? `Timed out after ${timeoutMs}ms\n${stderr}` : stderr,
+        exitCode,
+      });
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timer);
+      unlink(scriptPath).catch(() => {});
+      resolve({
+        ok: false,
+        stdout,
+        stderr: `Failed to spawn Blender: ${err.message}\n${stderr}`,
+        exitCode: null,
+      });
+    });
+  });
+}
+
+/** Build Python code to render a scene in background mode. */
+export function buildBackgroundRenderScript(params: {
+  outputPath: string;
+  frameStart?: number;
+  frameEnd?: number;
+  engine?: string;
+  resolutionX?: number;
+  resolutionY?: number;
+  samples?: number;
+  camera?: string;
+}): string {
+  const lines: string[] = ["import bpy", "scene = bpy.context.scene"];
+
+  if (params.engine) lines.push(`scene.render.engine = ${JSON.stringify(params.engine)}`);
+  if (params.resolutionX) lines.push(`scene.render.resolution_x = ${params.resolutionX}`);
+  if (params.resolutionY) lines.push(`scene.render.resolution_y = ${params.resolutionY}`);
+  if (params.camera) {
+    lines.push(
+      `cam = bpy.data.objects.get(${JSON.stringify(params.camera)})`,
+      `if cam: scene.camera = cam`,
+    );
+  }
+  if (params.samples) {
+    lines.push(
+      `if scene.render.engine == 'CYCLES': scene.cycles.samples = ${params.samples}`,
+      `elif scene.render.engine == 'BLENDER_EEVEE_NEXT': scene.eevee.taa_render_samples = ${params.samples}`,
+    );
+  }
+
+  lines.push(`scene.render.filepath = ${JSON.stringify(params.outputPath)}`);
+
+  if (params.frameStart !== undefined && params.frameEnd !== undefined) {
+    lines.push(
+      `scene.frame_start = ${params.frameStart}`,
+      `scene.frame_end = ${params.frameEnd}`,
+      `bpy.ops.render.render(animation=True)`,
+    );
+  } else {
+    lines.push(`bpy.ops.render.render(write_still=True)`);
+  }
+
+  return lines.join("\n");
+}
+
+/** Build Python code to export an asset in background mode. */
+export function buildBackgroundExportScript(params: {
+  outputPath: string;
+  format: string;
+  selectionOnly?: boolean;
+  applyModifiers?: boolean;
+  exportAnimations?: boolean;
+}): string {
+  const {
+    outputPath,
+    format,
+    selectionOnly = false,
+    applyModifiers = true,
+    exportAnimations = false,
+  } = params;
+
+  switch (format.toUpperCase()) {
+    case "FBX":
+      return [
+        "import bpy",
+        `bpy.ops.export_scene.fbx(`,
+        `  filepath=${JSON.stringify(outputPath)},`,
+        `  use_selection=${selectionOnly ? "True" : "False"},`,
+        `  use_mesh_modifiers=${applyModifiers ? "True" : "False"},`,
+        `  bake_anim=${exportAnimations ? "True" : "False"},`,
+        `)`,
+      ].join("\n");
+
+    case "GLTF":
+    case "GLB":
+      return [
+        "import bpy",
+        `bpy.ops.export_scene.gltf(`,
+        `  filepath=${JSON.stringify(outputPath)},`,
+        `  export_format=${"GLB" === format.toUpperCase() ? "'GLB'" : "'GLTF_EMBEDDED'"},`,
+        `  use_selection=${selectionOnly ? "True" : "False"},`,
+        `  export_apply=${applyModifiers ? "True" : "False"},`,
+        `  export_animations=${exportAnimations ? "True" : "False"},`,
+        `)`,
+      ].join("\n");
+
+    case "OBJ":
+      return [
+        "import bpy",
+        `bpy.ops.wm.obj_export(`,
+        `  filepath=${JSON.stringify(outputPath)},`,
+        `  export_selected_objects=${selectionOnly ? "True" : "False"},`,
+        `  apply_modifiers=${applyModifiers ? "True" : "False"},`,
+        `)`,
+      ].join("\n");
+
+    case "USD":
+    case "USDC":
+    case "USDA":
+      return [
+        "import bpy",
+        `bpy.ops.wm.usd_export(`,
+        `  filepath=${JSON.stringify(outputPath)},`,
+        `  selected_objects_only=${selectionOnly ? "True" : "False"},`,
+        `  export_animation=${exportAnimations ? "True" : "False"},`,
+        `)`,
+      ].join("\n");
+
+    default:
+      throw new Error(`Unsupported export format: ${format}`);
+  }
+}

--- a/extensions/blender/src/blender-plugin.test.ts
+++ b/extensions/blender/src/blender-plugin.test.ts
@@ -1,0 +1,251 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildBackgroundRenderScript, buildBackgroundExportScript } from "./background.js";
+import { createBlenderClient, resolveBlenderConfig } from "./client.js";
+import { createImportAssetTool, createExportAssetTool } from "./tools/assets.js";
+import {
+  createGenerateLodTool,
+  createCollisionMeshTool,
+  createUvUnwrapTool,
+  createGameExportTool,
+  createCheckGameReadinessTool,
+} from "./tools/game.js";
+import { createApplyMaterialTool, createBakeTexturesTool } from "./tools/materials.js";
+import { createExecutePythonTool } from "./tools/python.js";
+import { createRenderTool, createBatchRenderTool } from "./tools/render.js";
+import { createGetSceneInfoTool, createCreateObjectTool } from "./tools/scene.js";
+
+// Minimal mock of the plugin API
+function makeApi(pluginConfig?: Record<string, unknown>): OpenClawPluginApi {
+  return {
+    pluginConfig,
+    config: {} as never,
+    id: "blender",
+    name: "Blender Plugin",
+    source: "test",
+    registrationMode: "full",
+    runtime: {} as never,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    registerTool: vi.fn(),
+    registerChannel: vi.fn(),
+    registerProvider: vi.fn(),
+    registerSpeechProvider: vi.fn(),
+    registerMediaUnderstandingProvider: vi.fn(),
+    registerImageGenerationProvider: vi.fn(),
+    registerWebSearchProvider: vi.fn(),
+    registerHook: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerService: vi.fn(),
+    registerCli: vi.fn(),
+    registerCommand: vi.fn(),
+    registerContextEngine: vi.fn(),
+    registerMemoryPromptSection: vi.fn(),
+    on: vi.fn(),
+    onConversationBindingResolved: vi.fn(),
+    resolvePath: (p: string) => p,
+  } as never;
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+describe("resolveBlenderConfig", () => {
+  it("returns defaults when no config provided", () => {
+    const cfg = resolveBlenderConfig(undefined);
+    expect(cfg.host).toBe("127.0.0.1");
+    expect(cfg.port).toBe(7428);
+    expect(typeof cfg.executablePath).toBe("string");
+    expect(cfg.executablePath.length).toBeGreaterThan(0);
+  });
+
+  it("respects overrides from pluginConfig", () => {
+    const cfg = resolveBlenderConfig({
+      blender: { bridgeHost: "192.168.1.5", bridgePort: 9999, executablePath: "/usr/bin/blender" },
+    });
+    expect(cfg.host).toBe("192.168.1.5");
+    expect(cfg.port).toBe(9999);
+    expect(cfg.executablePath).toBe("/usr/bin/blender");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool registration — every tool must have name, description, parameters, execute
+// ---------------------------------------------------------------------------
+
+describe("tool registration", () => {
+  const api = makeApi();
+
+  const tools = [
+    createExecutePythonTool(api),
+    createGetSceneInfoTool(api),
+    createCreateObjectTool(api),
+    createRenderTool(api),
+    createBatchRenderTool(api),
+    createImportAssetTool(api),
+    createExportAssetTool(api),
+    createApplyMaterialTool(api),
+    createBakeTexturesTool(api),
+    createGenerateLodTool(api),
+    createCollisionMeshTool(api),
+    createUvUnwrapTool(api),
+    createGameExportTool(api),
+    createCheckGameReadinessTool(api),
+  ];
+
+  it("all tools have unique names", () => {
+    const names = tools.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  for (const tool of tools) {
+    it(`${tool.name} has required fields`, () => {
+      expect(typeof tool.name).toBe("string");
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(typeof tool.description).toBe("string");
+      expect(tool.description.length).toBeGreaterThan(10);
+      expect(tool.parameters).toBeDefined();
+      expect(tool.parameters.type).toBe("object");
+      expect(typeof tool.execute).toBe("function");
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Background script builders
+// ---------------------------------------------------------------------------
+
+describe("buildBackgroundRenderScript", () => {
+  it("generates still render code", () => {
+    const code = buildBackgroundRenderScript({ outputPath: "/tmp/out.png" });
+    expect(code).toContain("import bpy");
+    expect(code).toContain("/tmp/out.png");
+    expect(code).toContain("write_still=True");
+    expect(code).not.toContain("animation=True");
+  });
+
+  it("generates animation render code", () => {
+    const code = buildBackgroundRenderScript({
+      outputPath: "/tmp/frames/",
+      frameStart: 1,
+      frameEnd: 24,
+    });
+    expect(code).toContain("animation=True");
+    expect(code).toContain("frame_start = 1");
+    expect(code).toContain("frame_end = 24");
+  });
+
+  it("applies engine override", () => {
+    const code = buildBackgroundRenderScript({ outputPath: "/tmp/out.png", engine: "CYCLES" });
+    expect(code).toContain("CYCLES");
+  });
+
+  it("applies resolution overrides", () => {
+    const code = buildBackgroundRenderScript({
+      outputPath: "/tmp/out.png",
+      resolutionX: 3840,
+      resolutionY: 2160,
+    });
+    expect(code).toContain("resolution_x = 3840");
+    expect(code).toContain("resolution_y = 2160");
+  });
+});
+
+describe("buildBackgroundExportScript", () => {
+  it("generates FBX export code", () => {
+    const code = buildBackgroundExportScript({ outputPath: "/tmp/mesh.fbx", format: "FBX" });
+    expect(code).toContain("export_scene.fbx");
+    expect(code).toContain("/tmp/mesh.fbx");
+  });
+
+  it("generates GLTF export code", () => {
+    const code = buildBackgroundExportScript({ outputPath: "/tmp/mesh.gltf", format: "GLTF" });
+    expect(code).toContain("export_scene.gltf");
+  });
+
+  it("generates GLB export code", () => {
+    const code = buildBackgroundExportScript({ outputPath: "/tmp/mesh.glb", format: "GLB" });
+    expect(code).toContain("GLB");
+  });
+
+  it("generates OBJ export code", () => {
+    const code = buildBackgroundExportScript({ outputPath: "/tmp/mesh.obj", format: "OBJ" });
+    expect(code).toContain("wm.obj_export");
+  });
+
+  it("generates USD export code", () => {
+    const code = buildBackgroundExportScript({ outputPath: "/tmp/scene.usd", format: "USD" });
+    expect(code).toContain("wm.usd_export");
+  });
+
+  it("throws on unsupported format", () => {
+    expect(() =>
+      buildBackgroundExportScript({ outputPath: "/tmp/bad.xyz", format: "XYZ" }),
+    ).toThrow("Unsupported export format");
+  });
+
+  it("respects selectionOnly flag", () => {
+    const code = buildBackgroundExportScript({
+      outputPath: "/tmp/mesh.fbx",
+      format: "FBX",
+      selectionOnly: true,
+    });
+    expect(code).toContain("use_selection=True");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tool execution — bridge-down path (no live Blender required)
+// ---------------------------------------------------------------------------
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+  const item = result.content[0];
+  return item?.type === "text" ? (item.text ?? "") : "";
+}
+
+describe("tool execution when bridge is offline", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("Connection refused");
+    });
+  });
+
+  it("blender_execute_python returns helpful message", async () => {
+    const api = makeApi();
+    const tool = createExecutePythonTool(api);
+    const result = await tool.execute("call1", { code: "print('hello')", mode: "live" });
+    expect(firstText(result)).toContain("not running");
+  });
+
+  it("blender_get_scene_info returns helpful message", async () => {
+    const api = makeApi();
+    const tool = createGetSceneInfoTool(api);
+    const result = await tool.execute("call2", {});
+    expect(firstText(result)).toContain("not running");
+  });
+
+  it("blender_render live mode returns helpful message", async () => {
+    const api = makeApi();
+    const tool = createRenderTool(api);
+    const result = await tool.execute("call3", { outputPath: "/tmp/out.png", mode: "live" });
+    expect(firstText(result)).toContain("not running");
+  });
+
+  it("blender_import returns helpful message", async () => {
+    const api = makeApi();
+    const tool = createImportAssetTool(api);
+    const result = await tool.execute("call4", { filePath: "/tmp/asset.fbx", format: "FBX" });
+    expect(firstText(result)).toContain("not running");
+  });
+
+  it("blender_apply_material returns helpful message", async () => {
+    const api = makeApi();
+    const tool = createApplyMaterialTool(api);
+    const result = await tool.execute("call5", {
+      objectName: "Cube",
+      materialName: "TestMat",
+    });
+    expect(firstText(result)).toContain("not running");
+  });
+});

--- a/extensions/blender/src/client.ts
+++ b/extensions/blender/src/client.ts
@@ -1,0 +1,178 @@
+/**
+ * HTTP client for communicating with the OpenClaw Blender bridge addon.
+ * The addon runs an HTTP server inside Blender on a configurable port.
+ */
+
+export type BlenderClientConfig = {
+  host: string;
+  port: number;
+  timeoutMs?: number;
+};
+
+export type BlenderExecuteResult = {
+  ok: boolean;
+  output?: string;
+  error?: string;
+  result?: unknown;
+};
+
+export type BlenderSceneInfo = {
+  name: string;
+  objects: BlenderObjectInfo[];
+  collections: string[];
+  activeCamera?: string;
+  renderEngine: string;
+  frameStart: number;
+  frameEnd: number;
+  fps: number;
+};
+
+export type BlenderObjectInfo = {
+  name: string;
+  type: string;
+  collection: string;
+  location: [number, number, number];
+  rotation: [number, number, number];
+  scale: [number, number, number];
+  visible: boolean;
+  materials: string[];
+  vertexCount?: number;
+  faceCount?: number;
+};
+
+export type BlenderRenderResult = {
+  ok: boolean;
+  outputPath?: string;
+  framesRendered?: number;
+  error?: string;
+};
+
+export type BlenderAddonStatus = {
+  running: boolean;
+  blenderVersion?: string;
+  addonVersion?: string;
+  activeFile?: string;
+};
+
+export function createBlenderClient(config: BlenderClientConfig) {
+  const baseUrl = `http://${config.host}:${config.port}`;
+  const timeoutMs = config.timeoutMs ?? 60_000;
+
+  async function post<T>(path: string, body: unknown): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Blender bridge HTTP ${res.status}: ${text}`);
+      }
+      return res.json() as Promise<T>;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function get<T>(path: string): Promise<T> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(`${baseUrl}${path}`, { signal: controller.signal });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Blender bridge HTTP ${res.status}: ${text}`);
+      }
+      return res.json() as Promise<T>;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  return {
+    /** Check if the Blender bridge addon is running. */
+    async status(): Promise<BlenderAddonStatus> {
+      try {
+        return await get<BlenderAddonStatus>("/status");
+      } catch {
+        return { running: false };
+      }
+    },
+
+    /** Execute arbitrary Python code inside Blender. */
+    async execute(code: string): Promise<BlenderExecuteResult> {
+      return post<BlenderExecuteResult>("/execute", { code });
+    },
+
+    /** Get scene info including all objects, collections, and render settings. */
+    async sceneInfo(): Promise<BlenderSceneInfo> {
+      return get<BlenderSceneInfo>("/scene");
+    },
+
+    /** Trigger a render with optional overrides. */
+    async render(params: {
+      outputPath?: string;
+      frameStart?: number;
+      frameEnd?: number;
+      engine?: string;
+      resolutionX?: number;
+      resolutionY?: number;
+      samples?: number;
+      camera?: string;
+    }): Promise<BlenderRenderResult> {
+      return post<BlenderRenderResult>("/render", params);
+    },
+
+    /** Import an asset file into the current scene. */
+    async importAsset(params: {
+      filePath: string;
+      format: string;
+      collection?: string;
+    }): Promise<BlenderExecuteResult> {
+      return post<BlenderExecuteResult>("/import", params);
+    },
+
+    /** Export the scene or selection to a file. */
+    async exportAsset(params: {
+      filePath: string;
+      format: string;
+      selectionOnly?: boolean;
+      applyModifiers?: boolean;
+      exportAnimations?: boolean;
+    }): Promise<BlenderExecuteResult> {
+      return post<BlenderExecuteResult>("/export", params);
+    },
+
+    /** Capture a viewport screenshot. */
+    async screenshot(params: {
+      outputPath: string;
+      width?: number;
+      height?: number;
+    }): Promise<BlenderExecuteResult> {
+      return post<BlenderExecuteResult>("/screenshot", params);
+    },
+  };
+}
+
+export type BlenderClient = ReturnType<typeof createBlenderClient>;
+
+/** Resolve config values with sensible defaults. */
+export function resolveBlenderConfig(pluginConfig: Record<string, unknown> | undefined) {
+  const cfg = (pluginConfig?.["blender"] ?? {}) as Record<string, unknown>;
+  return {
+    executablePath: (cfg["executablePath"] as string | undefined) ?? findDefaultBlenderPath(),
+    host: (cfg["bridgeHost"] as string | undefined) ?? "127.0.0.1",
+    port: (cfg["bridgePort"] as number | undefined) ?? 7428,
+  };
+}
+
+function findDefaultBlenderPath(): string {
+  const platform = process.platform;
+  if (platform === "darwin") return "/Applications/Blender.app/Contents/MacOS/Blender";
+  if (platform === "win32") return "C:\\Program Files\\Blender Foundation\\Blender\\blender.exe";
+  return "blender"; // expect on PATH for Linux
+}

--- a/extensions/blender/src/tools/assets.ts
+++ b/extensions/blender/src/tools/assets.ts
@@ -1,0 +1,342 @@
+import { Type } from "@sinclair/typebox";
+import {
+  jsonResult,
+  readStringParam,
+  stringEnum,
+  optionalStringEnum,
+} from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { runBlenderBackground, buildBackgroundExportScript } from "../background.js";
+import { createBlenderClient, resolveBlenderConfig } from "../client.js";
+
+const IMPORT_FORMATS = [
+  "FBX",
+  "GLTF",
+  "GLB",
+  "OBJ",
+  "USD",
+  "USDC",
+  "USDA",
+  "ABC",
+  "STL",
+  "PLY",
+  "SVG",
+] as const;
+const EXPORT_FORMATS = [
+  "FBX",
+  "GLTF",
+  "GLB",
+  "OBJ",
+  "USD",
+  "USDC",
+  "USDA",
+  "ABC",
+  "STL",
+  "PLY",
+] as const;
+const ASSET_TYPES = ["Object", "Material", "Mesh", "Collection", "NodeTree", "Action"] as const;
+
+const ImportAssetSchema = Type.Object({
+  filePath: Type.String({ description: "Absolute path to the asset file to import." }),
+  format: stringEnum(IMPORT_FORMATS, { description: "File format of the asset." }),
+  collection: Type.Optional(
+    Type.String({ description: "Destination collection. Creates it if it doesn't exist." }),
+  ),
+  scaleFactor: Type.Optional(
+    Type.Number({
+      description:
+        "Uniform scale factor applied on import (default: 1.0). Use 0.01 when importing cm-scaled FBX.",
+      minimum: 0.0001,
+    }),
+  ),
+});
+
+const ExportAssetSchema = Type.Object({
+  filePath: Type.String({ description: "Absolute path where the exported file will be written." }),
+  format: stringEnum(EXPORT_FORMATS, { description: "Export format." }),
+  mode: optionalStringEnum(["live", "background"] as const, {
+    description:
+      "'live' exports from the open Blender session (default). 'background' uses a headless process.",
+  }),
+  blendFile: Type.Optional(
+    Type.String({ description: "Path to a .blend file (required in background mode)." }),
+  ),
+  selectionOnly: Type.Optional(
+    Type.Boolean({
+      description: "Export only selected objects (default: false — exports everything).",
+    }),
+  ),
+  applyModifiers: Type.Optional(
+    Type.Boolean({
+      description:
+        "Apply modifiers before exporting (default: true). Recommended for game engines.",
+    }),
+  ),
+  exportAnimations: Type.Optional(
+    Type.Boolean({ description: "Include animations / skeletal data in export (default: false)." }),
+  ),
+});
+
+const LibraryAssetSchema = Type.Object({
+  action: stringEnum(["list", "append", "link"] as const, {
+    description:
+      "'list' shows assets in a .blend library. 'append' copies assets into the current file. " +
+      "'link' creates a live link to assets in the library.",
+  }),
+  libraryPath: Type.String({ description: "Path to the .blend file used as an asset library." }),
+  assetType: optionalStringEnum(ASSET_TYPES, {
+    description: "Type of asset to list/append/link (required for append/link).",
+  }),
+  assetName: Type.Optional(
+    Type.String({
+      description: "Name of the specific asset to append/link (required for append/link).",
+    }),
+  ),
+});
+
+function getClient(api: OpenClawPluginApi) {
+  const cfg = resolveBlenderConfig(api.pluginConfig);
+  return { client: createBlenderClient({ host: cfg.host, port: cfg.port }), cfg };
+}
+
+function buildImportCode(params: {
+  filePath: string;
+  format: string;
+  collection?: string | null;
+  scaleFactor?: number;
+}): string {
+  const { filePath, format, collection, scaleFactor } = params;
+  const lines: string[] = ["import bpy"];
+  const scale = scaleFactor ?? 1.0;
+
+  switch (format.toUpperCase()) {
+    case "FBX":
+      lines.push(
+        `bpy.ops.import_scene.fbx(filepath=${JSON.stringify(filePath)}, global_scale=${scale})`,
+      );
+      break;
+    case "GLTF":
+    case "GLB":
+      lines.push(`bpy.ops.import_scene.gltf(filepath=${JSON.stringify(filePath)})`);
+      break;
+    case "OBJ":
+      lines.push(
+        `bpy.ops.wm.obj_import(filepath=${JSON.stringify(filePath)}, global_scale=${scale})`,
+      );
+      break;
+    case "USD":
+    case "USDC":
+    case "USDA":
+      lines.push(`bpy.ops.wm.usd_import(filepath=${JSON.stringify(filePath)})`);
+      break;
+    case "ABC":
+      lines.push(`bpy.ops.wm.alembic_import(filepath=${JSON.stringify(filePath)})`);
+      break;
+    case "STL":
+      lines.push(`bpy.ops.wm.stl_import(filepath=${JSON.stringify(filePath)})`);
+      break;
+    case "PLY":
+      lines.push(`bpy.ops.wm.ply_import(filepath=${JSON.stringify(filePath)})`);
+      break;
+    default:
+      throw new Error(`Unsupported import format: ${format}`);
+  }
+
+  if (collection) {
+    lines.push(
+      `col = bpy.data.collections.get(${JSON.stringify(collection)})`,
+      `if not col:`,
+      `    col = bpy.data.collections.new(${JSON.stringify(collection)})`,
+      `    bpy.context.scene.collection.children.link(col)`,
+      `for obj in bpy.context.selected_objects:`,
+      `    for c in obj.users_collection: c.objects.unlink(obj)`,
+      `    col.objects.link(obj)`,
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export function createImportAssetTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_import",
+    label: "Blender: Import Asset",
+    description:
+      "Import an asset file (FBX, GLTF/GLB, OBJ, USD, Alembic, STL, PLY) into the current Blender scene. " +
+      "Optionally place imported objects into a named collection. " +
+      "FBX is the most common format from game-engine pipelines (Unreal, Unity).",
+    parameters: ImportAssetSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const filePath = readStringParam(rawParams, "filePath", { required: true })!;
+      const format = readStringParam(rawParams, "format", { required: true })!;
+      const collection = readStringParam(rawParams, "collection");
+      const scaleFactor = rawParams["scaleFactor"] as number | undefined;
+      const { client } = getClient(api);
+
+      const status = await client.status();
+      if (!status.running) {
+        return jsonResult("Blender bridge is not running. Import requires a live Blender session.");
+      }
+
+      const code = buildImportCode({
+        filePath,
+        format,
+        collection: collection ?? null,
+        scaleFactor,
+      });
+      const result = await client.execute(code);
+      if (!result.ok) return jsonResult(`Import failed: ${result.error}`);
+
+      return jsonResult(
+        `Imported ${format} from: ${filePath}` +
+          (collection ? ` -> collection '${collection}'` : ""),
+      );
+    },
+  };
+}
+
+export function createExportAssetTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_export",
+    label: "Blender: Export Asset",
+    description:
+      "Export the Blender scene or selection to a game-engine-ready format: FBX (Unreal/Unity), " +
+      "GLTF/GLB (Godot/web), OBJ (general), USD (DCC pipeline), or Alembic (VFX/animation). " +
+      "Supports live session export and headless background export from a .blend file.",
+    parameters: ExportAssetSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const filePath = readStringParam(rawParams, "filePath", { required: true })!;
+      const format = readStringParam(rawParams, "format", { required: true })!;
+      const mode = (readStringParam(rawParams, "mode") ?? "live") as "live" | "background";
+      const blendFile = readStringParam(rawParams, "blendFile");
+      const selectionOnly = (rawParams["selectionOnly"] as boolean | undefined) ?? false;
+      const applyModifiers = (rawParams["applyModifiers"] as boolean | undefined) ?? true;
+      const exportAnimations = (rawParams["exportAnimations"] as boolean | undefined) ?? false;
+      const { client, cfg } = getClient(api);
+
+      if (mode === "background") {
+        const pythonCode = buildBackgroundExportScript({
+          outputPath: filePath,
+          format,
+          selectionOnly,
+          applyModifiers,
+          exportAnimations,
+        });
+        const result = await runBlenderBackground({
+          blenderExecutable: cfg.executablePath,
+          blendFile: blendFile ?? undefined,
+          pythonCode,
+        });
+        if (!result.ok)
+          return jsonResult(`Export failed:\n${result.stderr || result.stdout}`.trim());
+        return jsonResult(`Exported ${format} -> ${filePath}`);
+      }
+
+      const status = await client.status();
+      if (!status.running) {
+        return jsonResult(
+          "Blender bridge is not running. Enable the OpenClaw Bridge addon or use mode='background'.",
+        );
+      }
+
+      const result = await client.exportAsset({
+        filePath,
+        format,
+        selectionOnly,
+        applyModifiers,
+        exportAnimations,
+      });
+      if (!result.ok) return jsonResult(`Export failed: ${result.error}`);
+      return jsonResult(`Exported ${format} -> ${filePath}`);
+    },
+  };
+}
+
+export function createLibraryAssetTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_library_assets",
+    label: "Blender: Library Assets",
+    description:
+      "List, append, or link assets from a Blender asset library (.blend file). " +
+      "Use 'append' to copy assets into your scene (self-contained). " +
+      "Use 'link' to reference them from the library (updates propagate). " +
+      "Great for shared material libraries, prop kits, and character rigs in game projects.",
+    parameters: LibraryAssetSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const action = readStringParam(rawParams, "action", { required: true })!;
+      const libraryPath = readStringParam(rawParams, "libraryPath", { required: true })!;
+      const assetType = readStringParam(rawParams, "assetType");
+      const assetName = readStringParam(rawParams, "assetName");
+      const { client } = getClient(api);
+
+      const status = await client.status();
+      if (!status.running) {
+        return jsonResult(
+          "Blender bridge is not running. Library operations require a live Blender session.",
+        );
+      }
+
+      let code: string;
+
+      if (action === "list") {
+        code = [
+          "import bpy",
+          `with bpy.data.libraries.load(${JSON.stringify(libraryPath)}, link=False) as (data_from, _):`,
+          `    result = {`,
+          `        'objects': list(data_from.objects),`,
+          `        'materials': list(data_from.materials),`,
+          `        'collections': list(data_from.collections),`,
+          `        'meshes': list(data_from.meshes),`,
+          `        'node_groups': list(data_from.node_groups),`,
+          `        'actions': list(data_from.actions),`,
+          `    }`,
+          `print(result)`,
+        ].join("\n");
+      } else if (action === "append" || action === "link") {
+        if (!assetType || !assetName) {
+          return jsonResult("assetType and assetName are required for append/link actions.");
+        }
+        const isLink = action === "link";
+        const typeMap: Record<string, string> = {
+          Object: "objects",
+          Material: "materials",
+          Mesh: "meshes",
+          Collection: "collections",
+          NodeTree: "node_groups",
+          Action: "actions",
+        };
+        const attr = typeMap[assetType] ?? "objects";
+        code = [
+          "import bpy",
+          `with bpy.data.libraries.load(${JSON.stringify(libraryPath)}, link=${isLink ? "True" : "False"}) as (data_from, data_to):`,
+          `    if ${JSON.stringify(assetName)} in data_from.${attr}:`,
+          `        data_to.${attr} = [${JSON.stringify(assetName)}]`,
+          `    else:`,
+          `        raise ValueError(f"Asset '${assetName}' not found in library")`,
+          ...(assetType === "Object" && !isLink
+            ? [
+                `for obj in data_to.objects:`,
+                `    if obj is not None:`,
+                `        bpy.context.collection.objects.link(obj)`,
+              ]
+            : []),
+        ].join("\n");
+      } else {
+        return jsonResult(`Unknown action: ${action}`);
+      }
+
+      const result = await client.execute(code);
+      if (!result.ok) return jsonResult(`Library operation failed: ${result.error}`);
+
+      if (action === "list") {
+        return jsonResult(`Library assets in ${libraryPath}:\n${result.output ?? "(none)"}`);
+      }
+      return jsonResult(
+        `${action === "append" ? "Appended" : "Linked"} ${assetType} '${assetName}' from library.`,
+      );
+    },
+  };
+}

--- a/extensions/blender/src/tools/game.ts
+++ b/extensions/blender/src/tools/game.ts
@@ -1,0 +1,573 @@
+import { Type } from "@sinclair/typebox";
+import {
+  jsonResult,
+  readStringParam,
+  stringEnum,
+  optionalStringEnum,
+} from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { createBlenderClient, resolveBlenderConfig } from "../client.js";
+
+const COLLISION_TYPES = ["BOX", "SPHERE", "CAPSULE", "CONVEX", "MESH"] as const;
+const TARGET_ENGINES = ["UNREAL", "UNITY", "GODOT", "GENERIC"] as const;
+const UV_METHODS = [
+  "SMART_UV_PROJECT",
+  "UNWRAP",
+  "LIGHTMAP_PACK",
+  "CUBE_PROJECTION",
+  "CYLINDER_PROJECTION",
+  "SPHERE_PROJECTION",
+] as const;
+
+const GenerateLodSchema = Type.Object({
+  objectName: Type.String({ description: "Name of the source mesh object." }),
+  levels: Type.Optional(
+    Type.Array(
+      Type.Object({
+        ratio: Type.Number({
+          description:
+            "Decimate ratio for this LOD level (0.0-1.0). 0.5 = 50% of original polygons.",
+          minimum: 0.01,
+          maximum: 1.0,
+        }),
+        suffix: Type.Optional(
+          Type.String({
+            description: "Suffix appended to the object name (default: '_LOD1', '_LOD2', etc.).",
+          }),
+        ),
+      }),
+      { description: "LOD levels to generate. Default: 3 levels at 0.5, 0.25, 0.1." },
+    ),
+  ),
+  collection: Type.Optional(
+    Type.String({
+      description: "Collection to place LOD objects in (default: '<ObjectName>_LODs').",
+    }),
+  ),
+  applyModifiers: Type.Optional(
+    Type.Boolean({ description: "Apply existing modifiers before decimating (default: true)." }),
+  ),
+});
+
+const CollisionMeshSchema = Type.Object({
+  objectName: Type.String({ description: "Name of the source mesh object." }),
+  collisionType: stringEnum(COLLISION_TYPES, {
+    description:
+      "Collision shape: BOX/SPHERE/CAPSULE = primitive (cheapest). " +
+      "CONVEX = convex hull (good for non-concave props). " +
+      "MESH = exact mesh collision (only for static geometry).",
+  }),
+  prefix: Type.Optional(
+    Type.String({
+      description:
+        "Naming prefix for the collision mesh. " +
+        "Defaults: 'UCX_' (Unreal convex), 'UBX_' (Unreal box), 'USP_' (Unreal sphere), 'COL_' (Godot/generic).",
+    }),
+  ),
+  targetEngine: optionalStringEnum(TARGET_ENGINES, {
+    description:
+      "Game engine to name collision meshes for (sets the prefix convention). Default: GENERIC.",
+  }),
+});
+
+const UvUnwrapSchema = Type.Object({
+  objectName: Type.String({ description: "Name of the mesh object to unwrap." }),
+  method: optionalStringEnum(UV_METHODS, {
+    description: "UV unwrapping method. SMART_UV_PROJECT is recommended for most game assets.",
+  }),
+  angle: Type.Optional(
+    Type.Number({
+      description: "Island angle limit in degrees for Smart UV Project (default: 66).",
+      minimum: 0,
+      maximum: 89,
+    }),
+  ),
+  margin: Type.Optional(
+    Type.Number({
+      description: "UV island margin (spacing between islands, default: 0.02).",
+      minimum: 0,
+      maximum: 1,
+    }),
+  ),
+  uvMapName: Type.Optional(
+    Type.String({
+      description: "Name for the UV map. Creates it if it doesn't exist (default: 'UVMap').",
+    }),
+  ),
+});
+
+const GameExportSchema = Type.Object({
+  objectNames: Type.Array(Type.String(), {
+    description:
+      "Names of objects to export. Can include meshes, armatures, empties for hierarchy.",
+  }),
+  outputPath: Type.String({
+    description: "Output file path (include extension: .fbx, .glb, .gltf, .obj).",
+  }),
+  targetEngine: stringEnum(TARGET_ENGINES, {
+    description: "Target game engine -- sets axis, scale, and format conventions.",
+  }),
+  includeAnimations: Type.Optional(
+    Type.Boolean({ description: "Export skeletal animations (default: false)." }),
+  ),
+  includeCollisions: Type.Optional(
+    Type.Boolean({
+      description: "Include UCX_/COL_ collision meshes if present in the scene (default: true).",
+    }),
+  ),
+  includeLods: Type.Optional(
+    Type.Boolean({ description: "Include _LOD objects if present (default: false)." }),
+  ),
+});
+
+const CheckGameReadinessSchema = Type.Object({
+  objectName: Type.String({ description: "Object to check." }),
+});
+
+function getClient(api: OpenClawPluginApi) {
+  const cfg = resolveBlenderConfig(api.pluginConfig);
+  return createBlenderClient({ host: cfg.host, port: cfg.port });
+}
+
+export function createGenerateLodTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_generate_lod",
+    label: "Blender: Generate LODs",
+    description:
+      "Automatically generate Level of Detail (LOD) meshes from a source object using the Decimate modifier. " +
+      "Creates LOD0 (full detail), LOD1, LOD2, LOD3 variants at configurable polygon ratios. " +
+      "LODs are placed in a dedicated collection and named per game-engine conventions.",
+    parameters: GenerateLodSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const levels = (rawParams["levels"] as
+        | Array<{ ratio: number; suffix?: string }>
+        | undefined) ?? [
+        { ratio: 0.5, suffix: "_LOD1" },
+        { ratio: 0.25, suffix: "_LOD2" },
+        { ratio: 0.1, suffix: "_LOD3" },
+      ];
+      const collection = readStringParam(rawParams, "collection") ?? `${objectName}_LODs`;
+      const applyModifiers = (rawParams["applyModifiers"] as boolean | undefined) ?? true;
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      const lines: string[] = [
+        "import bpy",
+        `src = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+        `if not src: raise ValueError(f"Object not found: ${objectName}")`,
+        `if src.type != 'MESH': raise ValueError(f"Object is not a mesh: ${objectName}")`,
+        `col = bpy.data.collections.get(${JSON.stringify(collection)})`,
+        `if not col:`,
+        `    col = bpy.data.collections.new(${JSON.stringify(collection)})`,
+        `    bpy.context.scene.collection.children.link(col)`,
+        `lod0 = src.copy()`,
+        `lod0.data = src.data.copy()`,
+        `lod0.name = ${JSON.stringify(objectName + "_LOD0")}`,
+        `col.objects.link(lod0)`,
+        `results = [${JSON.stringify(objectName + "_LOD0")} + ' (LOD0 = original)']`,
+      ];
+
+      for (const [i, level] of levels.entries()) {
+        const suffix = level.suffix ?? `_LOD${i + 1}`;
+        const lodName = objectName + suffix;
+        lines.push(
+          `lod = src.copy()`,
+          `lod.data = src.data.copy()`,
+          `lod.name = ${JSON.stringify(lodName)}`,
+          `col.objects.link(lod)`,
+          ...(applyModifiers
+            ? [
+                `bpy.context.view_layer.objects.active = lod`,
+                `bpy.ops.object.select_all(action='DESELECT')`,
+                `lod.select_set(True)`,
+                `for mod in lod.modifiers: bpy.ops.object.modifier_apply(modifier=mod.name)`,
+              ]
+            : []),
+          `dec = lod.modifiers.new(name='LOD_Decimate', type='DECIMATE')`,
+          `dec.ratio = ${level.ratio}`,
+          `bpy.context.view_layer.objects.active = lod`,
+          `bpy.ops.object.modifier_apply(modifier='LOD_Decimate')`,
+          `face_count = len(lod.data.polygons)`,
+          `results.append(${JSON.stringify(lodName)} + f' (ratio=${level.ratio}, faces={face_count})')`,
+        );
+      }
+
+      lines.push(`print('\\n'.join(results))`);
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`LOD generation failed: ${result.error}`);
+      return jsonResult(
+        `Generated ${levels.length} LOD levels for '${objectName}' -> collection '${collection}'.\n${result.output ?? ""}`.trim(),
+      );
+    },
+  };
+}
+
+export function createCollisionMeshTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_create_collision",
+    label: "Blender: Create Collision Mesh",
+    description:
+      "Generate a collision mesh for a game object -- box, sphere, capsule, convex hull, or exact mesh. " +
+      "Names follow game-engine conventions: UCX_ (Unreal convex), UBX_ (Unreal box), COL_ (Godot/generic). " +
+      "The collision mesh is placed adjacent to the source object in the scene.",
+    parameters: CollisionMeshSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const collisionType = readStringParam(rawParams, "collisionType", { required: true })!;
+      const targetEngine = (readStringParam(rawParams, "targetEngine") ?? "GENERIC") as string;
+      const customPrefix = readStringParam(rawParams, "prefix");
+
+      const prefixMap: Record<string, Record<string, string>> = {
+        UNREAL: { BOX: "UBX_", SPHERE: "USP_", CAPSULE: "UCP_", CONVEX: "UCX_", MESH: "UCX_" },
+        UNITY: { BOX: "COL_", SPHERE: "COL_", CAPSULE: "COL_", CONVEX: "COL_", MESH: "COL_" },
+        GODOT: { BOX: "COL_", SPHERE: "COL_", CAPSULE: "COL_", CONVEX: "COL_", MESH: "COL_" },
+        GENERIC: { BOX: "COL_", SPHERE: "COL_", CAPSULE: "COL_", CONVEX: "COL_", MESH: "COL_" },
+      };
+      const prefix = customPrefix ?? prefixMap[targetEngine]?.[collisionType] ?? "COL_";
+      const colName = `${prefix}${objectName}`;
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      let code: string;
+
+      if (collisionType === "BOX") {
+        code = [
+          "import bpy",
+          `src = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+          `if not src: raise ValueError(f"Object not found: ${objectName}")`,
+          `dims = src.dimensions`,
+          `loc = src.location`,
+          `bpy.ops.mesh.primitive_cube_add(location=loc)`,
+          `col = bpy.context.active_object`,
+          `col.name = ${JSON.stringify(colName)}`,
+          `col.dimensions = dims`,
+          `col.display_type = 'WIRE'`,
+        ].join("\n");
+      } else if (collisionType === "SPHERE") {
+        code = [
+          "import bpy",
+          `src = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+          `if not src: raise ValueError(f"Object not found: ${objectName}")`,
+          `radius = max(src.dimensions) / 2`,
+          `loc = src.location`,
+          `bpy.ops.mesh.primitive_uv_sphere_add(radius=radius, location=loc)`,
+          `col = bpy.context.active_object`,
+          `col.name = ${JSON.stringify(colName)}`,
+          `col.display_type = 'WIRE'`,
+        ].join("\n");
+      } else if (collisionType === "CONVEX" || collisionType === "MESH") {
+        code = [
+          "import bpy",
+          `src = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+          `if not src: raise ValueError(f"Object not found: ${objectName}")`,
+          `col = src.copy()`,
+          `col.data = src.data.copy()`,
+          `col.name = ${JSON.stringify(colName)}`,
+          `bpy.context.collection.objects.link(col)`,
+          ...(collisionType === "CONVEX"
+            ? [
+                `col.modifiers.clear()`,
+                `bpy.context.view_layer.objects.active = col`,
+                `bpy.ops.object.select_all(action='DESELECT')`,
+                `col.select_set(True)`,
+                `bpy.ops.object.mode_set(mode='EDIT')`,
+                `bpy.ops.mesh.select_all(action='SELECT')`,
+                `bpy.ops.mesh.convex_hull()`,
+                `bpy.ops.object.mode_set(mode='OBJECT')`,
+              ]
+            : []),
+          `col.display_type = 'WIRE'`,
+        ].join("\n");
+      } else if (collisionType === "CAPSULE") {
+        code = [
+          "import bpy",
+          `src = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+          `if not src: raise ValueError(f"Object not found: ${objectName}")`,
+          `height = src.dimensions[2]`,
+          `radius = max(src.dimensions[0], src.dimensions[1]) / 2`,
+          `loc = src.location`,
+          `bpy.ops.mesh.primitive_cylinder_add(radius=radius, depth=height, location=loc)`,
+          `col = bpy.context.active_object`,
+          `col.name = ${JSON.stringify(colName)}`,
+          `col.display_type = 'WIRE'`,
+        ].join("\n");
+      } else {
+        return jsonResult(`Unknown collision type: ${collisionType}`);
+      }
+
+      const result = await client.execute(code);
+      if (!result.ok) return jsonResult(`Collision mesh creation failed: ${result.error}`);
+      return jsonResult(
+        `Created ${collisionType} collision mesh '${colName}' for '${objectName}' (${targetEngine} naming).`,
+      );
+    },
+  };
+}
+
+export function createUvUnwrapTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_uv_unwrap",
+    label: "Blender: UV Unwrap",
+    description:
+      "UV unwrap a mesh object for texture baking or painting. " +
+      "SMART_UV_PROJECT is the best default for game props. " +
+      "LIGHTMAP_PACK generates a second UV channel optimized for lightmap baking.",
+    parameters: UvUnwrapSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const method = (readStringParam(rawParams, "method") ?? "SMART_UV_PROJECT") as string;
+      const angle = (rawParams["angle"] as number | undefined) ?? 66;
+      const margin = (rawParams["margin"] as number | undefined) ?? 0.02;
+      const uvMapName = readStringParam(rawParams, "uvMapName") ?? "UVMap";
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      const lines: string[] = [
+        "import bpy",
+        `obj = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+        `if not obj: raise ValueError(f"Object not found: ${objectName}")`,
+        `if obj.type != 'MESH': raise ValueError("Object must be a mesh")`,
+        `bpy.context.view_layer.objects.active = obj`,
+        `bpy.ops.object.select_all(action='DESELECT')`,
+        `obj.select_set(True)`,
+        `if ${JSON.stringify(uvMapName)} not in obj.data.uv_layers:`,
+        `    obj.data.uv_layers.new(name=${JSON.stringify(uvMapName)})`,
+        `obj.data.uv_layers.active = obj.data.uv_layers[${JSON.stringify(uvMapName)}]`,
+        `bpy.ops.object.mode_set(mode='EDIT')`,
+        `bpy.ops.mesh.select_all(action='SELECT')`,
+      ];
+
+      switch (method) {
+        case "SMART_UV_PROJECT":
+          lines.push(`bpy.ops.uv.smart_project(angle_limit=${angle}, island_margin=${margin})`);
+          break;
+        case "UNWRAP":
+          lines.push(`bpy.ops.uv.unwrap(method='ANGLE_BASED', margin=${margin})`);
+          break;
+        case "LIGHTMAP_PACK":
+          lines.push(`bpy.ops.uv.lightmap_pack(PREF_MARGIN_DIV=${margin})`);
+          break;
+        case "CUBE_PROJECTION":
+          lines.push(`bpy.ops.uv.cube_project(scale_to_bounds=True)`);
+          break;
+        case "CYLINDER_PROJECTION":
+          lines.push(`bpy.ops.uv.cylinder_project()`);
+          break;
+        case "SPHERE_PROJECTION":
+          lines.push(`bpy.ops.uv.sphere_project()`);
+          break;
+        default:
+          lines.push(`bpy.ops.uv.smart_project(angle_limit=${angle}, island_margin=${margin})`);
+      }
+
+      lines.push(`bpy.ops.object.mode_set(mode='OBJECT')`);
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`UV unwrap failed: ${result.error}`);
+      return jsonResult(`UV unwrapped '${objectName}' using ${method} into UV map '${uvMapName}'.`);
+    },
+  };
+}
+
+export function createGameExportTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_game_export",
+    label: "Blender: Game Engine Export",
+    description:
+      "One-click export of game assets with correct axis orientation, scale, and naming for Unreal Engine, " +
+      "Unity, Godot, or generic pipelines. Selects the specified objects, applies engine-correct axis/scale, " +
+      "and exports as FBX (Unreal/Unity) or GLTF (Godot/web). Collision meshes and LODs can be included.",
+    parameters: GameExportSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectNames = rawParams["objectNames"] as string[];
+      const outputPath = readStringParam(rawParams, "outputPath", { required: true })!;
+      const targetEngine = readStringParam(rawParams, "targetEngine", { required: true })!;
+      const includeAnimations = (rawParams["includeAnimations"] as boolean | undefined) ?? false;
+      const includeCollisions = (rawParams["includeCollisions"] as boolean | undefined) ?? true;
+      const includeLods = (rawParams["includeLods"] as boolean | undefined) ?? false;
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      if (!Array.isArray(objectNames) || objectNames.length === 0) {
+        return jsonResult("objectNames must be a non-empty array.");
+      }
+
+      const engineConfig: Record<
+        string,
+        { format: string; axisForward: string; axisUp: string; globalScale: number }
+      > = {
+        UNREAL: { format: "FBX", axisForward: "-Z", axisUp: "Y", globalScale: 1.0 },
+        UNITY: { format: "FBX", axisForward: "Z", axisUp: "Y", globalScale: 1.0 },
+        GODOT: { format: "GLTF", axisForward: "-Z", axisUp: "Y", globalScale: 1.0 },
+        GENERIC: { format: "GLTF", axisForward: "-Z", axisUp: "Y", globalScale: 1.0 },
+      };
+      const ec = engineConfig[targetEngine] ?? engineConfig["GENERIC"]!;
+
+      const lines: string[] = [
+        "import bpy",
+        `bpy.ops.object.select_all(action='DESELECT')`,
+        `target_names = ${JSON.stringify(objectNames)}`,
+        ...(includeCollisions
+          ? [
+              `collision_prefixes = ('UCX_', 'UBX_', 'USP_', 'UCP_', 'COL_')`,
+              `for obj in bpy.context.scene.objects:`,
+              `    if any(obj.name.startswith(p) for p in collision_prefixes):`,
+              `        target_names.append(obj.name)`,
+            ]
+          : []),
+        ...(includeLods
+          ? [
+              `for obj in bpy.context.scene.objects:`,
+              `    if any(obj.name.endswith(f'_LOD{i}') for i in range(1, 8)):`,
+              `        target_names.append(obj.name)`,
+            ]
+          : []),
+        `for name in set(target_names):`,
+        `    obj = bpy.data.objects.get(name)`,
+        `    if obj: obj.select_set(True)`,
+      ];
+
+      if (ec.format === "FBX") {
+        lines.push(
+          `bpy.ops.export_scene.fbx(`,
+          `    filepath=${JSON.stringify(outputPath)},`,
+          `    use_selection=True,`,
+          `    axis_forward=${JSON.stringify(ec.axisForward)},`,
+          `    axis_up=${JSON.stringify(ec.axisUp)},`,
+          `    global_scale=${ec.globalScale},`,
+          `    use_mesh_modifiers=True,`,
+          `    bake_anim=${includeAnimations ? "True" : "False"},`,
+          `    add_leaf_bones=False,`,
+          `)`,
+        );
+      } else {
+        lines.push(
+          `bpy.ops.export_scene.gltf(`,
+          `    filepath=${JSON.stringify(outputPath)},`,
+          `    export_format='GLTF_EMBEDDED',`,
+          `    use_selection=True,`,
+          `    export_apply=True,`,
+          `    export_animations=${includeAnimations ? "True" : "False"},`,
+          `)`,
+        );
+      }
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`Game export failed: ${result.error}`);
+      return jsonResult(
+        `Exported ${objectNames.length} object(s) for ${targetEngine} -> ${outputPath} (${ec.format}, axis: ${ec.axisForward}/${ec.axisUp})`,
+      );
+    },
+  };
+}
+
+export function createCheckGameReadinessTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_check_game_readiness",
+    label: "Blender: Check Game Readiness",
+    description:
+      "Audit a mesh object for common game-export issues: missing UV maps, non-applied transforms, " +
+      "N-gons, non-manifold geometry, overlapping UVs, zero-area faces, and missing materials. " +
+      "Returns a list of issues and recommendations.",
+    parameters: CheckGameReadinessSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      const code = `
+import bpy
+import bmesh
+
+obj = bpy.data.objects.get(${JSON.stringify(objectName)})
+if not obj:
+    raise ValueError(f"Object not found: ${objectName}")
+if obj.type != 'MESH':
+    raise ValueError(f"Object is not a mesh: ${objectName}")
+
+issues = []
+recommendations = []
+
+if any(abs(v - 1.0) > 0.0001 for v in obj.scale):
+    issues.append(f"Non-unit scale: {tuple(round(v,4) for v in obj.scale)}")
+    recommendations.append("Apply scale with Ctrl+A > Scale before exporting")
+if any(abs(v) > 0.0001 for v in obj.location):
+    issues.append(f"Non-zero location: {tuple(round(v,4) for v in obj.location)}")
+    recommendations.append("Consider applying location if the asset should be origin-centred")
+
+if not obj.data.uv_layers:
+    issues.append("No UV maps found")
+    recommendations.append("Run UV Unwrap before exporting for game engines")
+else:
+    print(f"UV maps: {[uv.name for uv in obj.data.uv_layers]}")
+
+if not obj.data.materials:
+    issues.append("No materials assigned")
+    recommendations.append("Assign at least one material for correct texture export")
+
+bm = bmesh.new()
+bm.from_mesh(obj.data)
+bm.normal_update()
+
+ngons = [f for f in bm.faces if len(f.verts) > 4]
+if ngons:
+    issues.append(f"N-gons found: {len(ngons)} faces with >4 vertices")
+    recommendations.append("Triangulate or quadrangulate N-gons before game export")
+
+zero_area = [f for f in bm.faces if f.calc_area() < 1e-8]
+if zero_area:
+    issues.append(f"Zero-area faces: {len(zero_area)}")
+    recommendations.append("Remove degenerate faces")
+
+non_manifold = [e for e in bm.edges if not e.is_manifold]
+if non_manifold:
+    issues.append(f"Non-manifold edges: {len(non_manifold)}")
+    recommendations.append("Fix non-manifold geometry for correct collision and export")
+
+bm.free()
+
+poly_count = len(obj.data.polygons)
+vert_count = len(obj.data.vertices)
+
+summary = [
+    f"Object: {obj.name}",
+    f"Polygons: {poly_count}, Vertices: {vert_count}",
+    f"Materials: {len(obj.data.materials)}",
+    f"UV Maps: {len(obj.data.uv_layers)}",
+    "",
+]
+
+if issues:
+    summary.append("ISSUES FOUND:")
+    summary.extend(f"  x {i}" for i in issues)
+    summary.append("")
+    summary.append("RECOMMENDATIONS:")
+    summary.extend(f"  -> {r}" for r in recommendations)
+else:
+    summary.append("No issues found -- object appears game-ready.")
+
+print("\\n".join(summary))
+`.trim();
+
+      const result = await client.execute(code);
+      if (!result.ok) return jsonResult(`Readiness check failed: ${result.error}`);
+      return jsonResult(result.output ?? "(no output)");
+    },
+  };
+}

--- a/extensions/blender/src/tools/game.ts
+++ b/extensions/blender/src/tools/game.ts
@@ -184,7 +184,10 @@ export function createGenerateLodTool(api: OpenClawPluginApi) {
                 `bpy.context.view_layer.objects.active = lod`,
                 `bpy.ops.object.select_all(action='DESELECT')`,
                 `lod.select_set(True)`,
-                `for mod in lod.modifiers: bpy.ops.object.modifier_apply(modifier=mod.name)`,
+                // Snapshot names before iterating — modifier_apply removes each element from
+                // the C-backed collection as it runs, shifting indices and silently skipping
+                // every other modifier when iterating the live collection.
+                `for mod_name in [m.name for m in lod.modifiers]: bpy.ops.object.modifier_apply(modifier=mod_name)`,
               ]
             : []),
           `dec = lod.modifiers.new(name='LOD_Decimate', type='DECIMATE')`,

--- a/extensions/blender/src/tools/materials.ts
+++ b/extensions/blender/src/tools/materials.ts
@@ -1,0 +1,340 @@
+import { Type } from "@sinclair/typebox";
+import {
+  jsonResult,
+  readStringParam,
+  stringEnum,
+  optionalStringEnum,
+} from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { createBlenderClient, resolveBlenderConfig } from "../client.js";
+
+const BAKE_TYPES = ["DIFFUSE", "AO", "NORMAL", "ROUGHNESS", "EMIT", "COMBINED"] as const;
+const TEXTURE_TYPES = ["BASE_COLOR", "NORMAL", "ROUGHNESS", "METALLIC", "AO", "EMISSION"] as const;
+const COLOR_SPACES = ["sRGB", "Non-Color", "Linear"] as const;
+const ALPHA_MODES = ["OPAQUE", "CLIP", "BLEND"] as const;
+
+const ApplyMaterialSchema = Type.Object({
+  objectName: Type.String({ description: "Name of the object to apply the material to." }),
+  materialName: Type.String({
+    description: "Name of the material. Creates a new PBR material if it doesn't exist.",
+  }),
+  baseColor: Type.Optional(
+    Type.Tuple([Type.Number(), Type.Number(), Type.Number(), Type.Number()], {
+      description:
+        "Base color as RGBA values in linear space (0.0-1.0). Example: [1.0, 0.2, 0.2, 1.0] for red.",
+    }),
+  ),
+  metallic: Type.Optional(
+    Type.Number({
+      description: "Metallic value (0.0 = dielectric, 1.0 = full metal).",
+      minimum: 0,
+      maximum: 1,
+    }),
+  ),
+  roughness: Type.Optional(
+    Type.Number({
+      description: "Roughness value (0.0 = mirror, 1.0 = fully diffuse).",
+      minimum: 0,
+      maximum: 1,
+    }),
+  ),
+  emissionColor: Type.Optional(
+    Type.Tuple([Type.Number(), Type.Number(), Type.Number()], {
+      description: "Emission color [R, G, B] in linear space.",
+    }),
+  ),
+  emissionStrength: Type.Optional(
+    Type.Number({ description: "Emission strength multiplier (0 = off).", minimum: 0 }),
+  ),
+  alphaMode: optionalStringEnum(ALPHA_MODES, {
+    description: "Alpha blending mode for transparency.",
+  }),
+  useNodes: Type.Optional(
+    Type.Boolean({
+      description: "Use Principled BSDF shader nodes (default: true).",
+    }),
+  ),
+});
+
+const BakeTexturesSchema = Type.Object({
+  objectName: Type.String({ description: "Name of the mesh object to bake." }),
+  outputDir: Type.String({ description: "Directory where baked textures will be saved." }),
+  resolution: Type.Optional(
+    Type.Number({
+      description: "Texture resolution in pixels (e.g. 1024, 2048, 4096). Default: 2048.",
+      minimum: 64,
+    }),
+  ),
+  bakeTypes: Type.Optional(
+    Type.Array(stringEnum(BAKE_TYPES, { description: "Bake map type." }), {
+      description:
+        "Which maps to bake. Defaults to ['DIFFUSE', 'AO', 'NORMAL', 'ROUGHNESS']. " +
+        "COMBINED = full beauty bake (requires light setup).",
+    }),
+  ),
+  margin: Type.Optional(
+    Type.Number({
+      description: "Pixel margin around UV islands to prevent seam bleeding (default: 16).",
+      minimum: 0,
+    }),
+  ),
+  selectedToActive: Type.Optional(
+    Type.Boolean({
+      description:
+        "Bake from high-poly (selected) to low-poly (active object). Select high-poly objects first, then run.",
+    }),
+  ),
+});
+
+const TextureAssignSchema = Type.Object({
+  objectName: Type.String({ description: "Name of the object." }),
+  materialName: Type.String({ description: "Name of the material to modify." }),
+  textureType: stringEnum(TEXTURE_TYPES, {
+    description: "Which PBR slot to connect the texture to.",
+  }),
+  texturePath: Type.String({ description: "Absolute path to the texture image file." }),
+  colorSpace: optionalStringEnum(COLOR_SPACES, {
+    description:
+      "Color space override. Auto-detected by default: color textures = sRGB, data textures = Non-Color.",
+  }),
+});
+
+function getClient(api: OpenClawPluginApi) {
+  const cfg = resolveBlenderConfig(api.pluginConfig);
+  return createBlenderClient({ host: cfg.host, port: cfg.port });
+}
+
+export function createApplyMaterialTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_apply_material",
+    label: "Blender: Apply Material",
+    description:
+      "Create or update a Principled BSDF material and apply it to a mesh object. " +
+      "Set base color, metallic, roughness, emission, and transparency in one call. " +
+      "Ideal for quickly setting up game-ready PBR materials.",
+    parameters: ApplyMaterialSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const materialName = readStringParam(rawParams, "materialName", { required: true })!;
+      const baseColor = rawParams["baseColor"] as [number, number, number, number] | undefined;
+      const metallic = rawParams["metallic"] as number | undefined;
+      const roughness = rawParams["roughness"] as number | undefined;
+      const emissionColor = rawParams["emissionColor"] as [number, number, number] | undefined;
+      const emissionStrength = rawParams["emissionStrength"] as number | undefined;
+      const alphaMode = readStringParam(rawParams, "alphaMode");
+      const useNodes = (rawParams["useNodes"] as boolean | undefined) ?? true;
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      const lines: string[] = [
+        "import bpy",
+        `obj = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+        `if not obj: raise ValueError(f"Object not found: ${objectName}")`,
+        `mat = bpy.data.materials.get(${JSON.stringify(materialName)})`,
+        `if not mat:`,
+        `    mat = bpy.data.materials.new(name=${JSON.stringify(materialName)})`,
+        `mat.use_nodes = ${useNodes ? "True" : "False"}`,
+      ];
+
+      if (useNodes) {
+        lines.push(
+          `bsdf = mat.node_tree.nodes.get('Principled BSDF')`,
+          `if not bsdf:`,
+          `    mat.node_tree.nodes.clear()`,
+          `    bsdf = mat.node_tree.nodes.new('ShaderNodeBsdfPrincipled')`,
+          `    out = mat.node_tree.nodes.new('ShaderNodeOutputMaterial')`,
+          `    mat.node_tree.links.new(bsdf.outputs['BSDF'], out.inputs['Surface'])`,
+        );
+
+        if (baseColor) {
+          lines.push(`bsdf.inputs['Base Color'].default_value = (${baseColor.join(", ")})`);
+        }
+        if (metallic !== undefined) {
+          lines.push(`bsdf.inputs['Metallic'].default_value = ${metallic}`);
+        }
+        if (roughness !== undefined) {
+          lines.push(`bsdf.inputs['Roughness'].default_value = ${roughness}`);
+        }
+        if (emissionColor) {
+          lines.push(
+            `bsdf.inputs['Emission Color'].default_value = (${emissionColor.join(", ")}, 1.0)`,
+          );
+        }
+        if (emissionStrength !== undefined) {
+          lines.push(`bsdf.inputs['Emission Strength'].default_value = ${emissionStrength}`);
+        }
+      }
+
+      if (alphaMode) {
+        lines.push(`mat.blend_method = ${JSON.stringify(alphaMode)}`);
+      }
+
+      lines.push(
+        `if obj.data.materials:`,
+        `    obj.data.materials[0] = mat`,
+        `else:`,
+        `    obj.data.materials.append(mat)`,
+      );
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`Failed to apply material: ${result.error}`);
+      return jsonResult(`Applied material '${materialName}' to '${objectName}'.`);
+    },
+  };
+}
+
+export function createBakeTexturesTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_bake_textures",
+    label: "Blender: Bake Textures",
+    description:
+      "Bake texture maps (Diffuse, AO, Normal, Roughness, Emission, Combined) from a Blender material " +
+      "to UV-unwrapped image textures. Produces game-engine-ready PBR texture sets. " +
+      "Supports high-poly to low-poly baking (selectedToActive mode).",
+    parameters: BakeTexturesSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const outputDir = readStringParam(rawParams, "outputDir", { required: true })!;
+      const resolution = (rawParams["resolution"] as number | undefined) ?? 2048;
+      const bakeTypes = (rawParams["bakeTypes"] as string[] | undefined) ?? [
+        "DIFFUSE",
+        "AO",
+        "NORMAL",
+        "ROUGHNESS",
+      ];
+      const margin = (rawParams["margin"] as number | undefined) ?? 16;
+      const selectedToActive = (rawParams["selectedToActive"] as boolean | undefined) ?? false;
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      const lines: string[] = [
+        "import bpy, os",
+        "scene = bpy.context.scene",
+        "scene.render.engine = 'CYCLES'",
+        `obj = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+        `if not obj: raise ValueError(f"Object not found: ${objectName}")`,
+        `os.makedirs(${JSON.stringify(outputDir)}, exist_ok=True)`,
+        `bpy.ops.object.select_all(action='DESELECT')`,
+        `obj.select_set(True)`,
+        `bpy.context.view_layer.objects.active = obj`,
+        `baked = []`,
+      ];
+
+      for (const bakeType of bakeTypes) {
+        const imgName = `${objectName}_${bakeType.toLowerCase()}_${resolution}`;
+        const outPath = `${outputDir}/${imgName}.png`;
+        lines.push(
+          `img = bpy.data.images.new(${JSON.stringify(imgName)}, width=${resolution}, height=${resolution})`,
+          `img.filepath_raw = ${JSON.stringify(outPath)}`,
+          `for mat in obj.data.materials:`,
+          `    if mat and mat.use_nodes:`,
+          `        nodes = mat.node_tree.nodes`,
+          `        tex_node = nodes.new('ShaderNodeTexImage')`,
+          `        tex_node.image = img`,
+          `        nodes.active = tex_node`,
+          `bpy.ops.object.bake(`,
+          `    type=${JSON.stringify(bakeType)},`,
+          `    use_selected_to_active=${selectedToActive ? "True" : "False"},`,
+          `    margin=${margin},`,
+          `    use_clear=True,`,
+          `)`,
+          `img.save_render(${JSON.stringify(outPath)})`,
+          `baked.append(${JSON.stringify(outPath)})`,
+          `for mat in obj.data.materials:`,
+          `    if mat and mat.use_nodes:`,
+          `        for n in [n for n in mat.node_tree.nodes if n.type == 'TEX_IMAGE' and n.image == img]:`,
+          `            mat.node_tree.nodes.remove(n)`,
+        );
+      }
+
+      lines.push(`print('Baked:', baked)`);
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`Bake failed: ${result.error}`);
+      return jsonResult(
+        `Baked ${bakeTypes.length} map(s) for '${objectName}' at ${resolution}px -> ${outputDir}\n` +
+          bakeTypes.map((t) => `  - ${t}`).join("\n"),
+      );
+    },
+  };
+}
+
+export function createAssignTextureTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_assign_texture",
+    label: "Blender: Assign Texture",
+    description:
+      "Connect a texture image file to a specific PBR slot (Base Color, Normal, Roughness, etc.) " +
+      "in a Principled BSDF material. Automatically sets the correct color space. " +
+      "Use after importing assets or baking textures to wire up your material graph.",
+    parameters: TextureAssignSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const objectName = readStringParam(rawParams, "objectName", { required: true })!;
+      const materialName = readStringParam(rawParams, "materialName", { required: true })!;
+      const textureType = readStringParam(rawParams, "textureType", { required: true })!;
+      const texturePath = readStringParam(rawParams, "texturePath", { required: true })!;
+      const colorSpace = readStringParam(rawParams, "colorSpace");
+
+      const dataTextures = new Set(["NORMAL", "ROUGHNESS", "METALLIC", "AO"]);
+      const autoColorSpace = dataTextures.has(textureType) ? "Non-Color" : "sRGB";
+      const cs = colorSpace ?? autoColorSpace;
+
+      const bsdfInputMap: Record<string, string> = {
+        BASE_COLOR: "Base Color",
+        NORMAL: "Normal",
+        ROUGHNESS: "Roughness",
+        METALLIC: "Metallic",
+        AO: "Base Color",
+        EMISSION: "Emission Color",
+      };
+      const bsdfInput = bsdfInputMap[textureType] ?? "Base Color";
+      const isNormal = textureType === "NORMAL";
+
+      const lines: string[] = [
+        "import bpy",
+        `obj = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+        `if not obj: raise ValueError(f"Object not found: ${objectName}")`,
+        `mat = obj.data.materials.get(${JSON.stringify(materialName)})`,
+        `if not mat: raise ValueError(f"Material not found: ${materialName}")`,
+        `if not mat.use_nodes: mat.use_nodes = True`,
+        `nodes = mat.node_tree.nodes`,
+        `links = mat.node_tree.links`,
+        `bsdf = nodes.get('Principled BSDF')`,
+        `if not bsdf: raise ValueError("Principled BSDF node not found in material")`,
+        `img = bpy.data.images.load(${JSON.stringify(texturePath)}, check_existing=True)`,
+        `img.colorspace_settings.name = ${JSON.stringify(cs)}`,
+        `tex_node = nodes.new('ShaderNodeTexImage')`,
+        `tex_node.image = img`,
+      ];
+
+      if (isNormal) {
+        lines.push(
+          `nm = nodes.new('ShaderNodeNormalMap')`,
+          `links.new(tex_node.outputs['Color'], nm.inputs['Color'])`,
+          `links.new(nm.outputs['Normal'], bsdf.inputs['Normal'])`,
+        );
+      } else {
+        lines.push(
+          `links.new(tex_node.outputs['Color'], bsdf.inputs[${JSON.stringify(bsdfInput)}])`,
+        );
+      }
+
+      const client = getClient(api);
+      const status = await client.status();
+      if (!status.running) return jsonResult("Blender bridge is not running.");
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`Failed to assign texture: ${result.error}`);
+      return jsonResult(
+        `Assigned ${textureType} texture to '${materialName}' on '${objectName}'. Color space: ${cs}.`,
+      );
+    },
+  };
+}

--- a/extensions/blender/src/tools/python.ts
+++ b/extensions/blender/src/tools/python.ts
@@ -1,0 +1,76 @@
+import { Type } from "@sinclair/typebox";
+import { jsonResult, readStringParam, optionalStringEnum } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { runBlenderBackground } from "../background.js";
+import { createBlenderClient, resolveBlenderConfig } from "../client.js";
+
+const ExecutePythonSchema = Type.Object({
+  code: Type.String({
+    description: "Python code to execute inside Blender. Has full access to the `bpy` module.",
+  }),
+  blendFile: Type.Optional(
+    Type.String({
+      description:
+        "Path to a .blend file to open before executing. If omitted, uses the currently open file in the live session or an empty scene in background mode.",
+    }),
+  ),
+  mode: optionalStringEnum(["live", "background"] as const, {
+    description:
+      "'live' sends code to a running Blender session via the bridge addon (default). 'background' spawns a headless Blender process — useful for batch work when no Blender UI is open.",
+  }),
+});
+
+export function createExecutePythonTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_execute_python",
+    label: "Blender: Execute Python",
+    description:
+      "Execute arbitrary Python code inside Blender with full access to the `bpy` API. " +
+      "Use 'live' mode to control an open Blender session, or 'background' for headless batch execution. " +
+      "Useful for scripting mesh edits, modifier stacks, material nodes, scene setup, and more.",
+    parameters: ExecutePythonSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const code = readStringParam(rawParams, "code", { required: true });
+      const blendFile = readStringParam(rawParams, "blendFile");
+      const mode = (readStringParam(rawParams, "mode") ?? "live") as "live" | "background";
+      const cfg = resolveBlenderConfig(api.pluginConfig);
+
+      if (mode === "background") {
+        const result = await runBlenderBackground({
+          blenderExecutable: cfg.executablePath,
+          blendFile: blendFile ?? undefined,
+          pythonCode: code,
+        });
+        const lines: string[] = [
+          result.ok
+            ? "Blender background execution succeeded."
+            : "Blender background execution failed.",
+        ];
+        if (result.stdout) lines.push(`STDOUT:\n${result.stdout}`);
+        if (result.stderr) lines.push(`STDERR:\n${result.stderr}`);
+        return jsonResult(lines.join("\n").trim());
+      }
+
+      const client = createBlenderClient({ host: cfg.host, port: cfg.port });
+      const status = await client.status();
+      if (!status.running) {
+        return jsonResult(
+          "Blender bridge is not running. Open Blender, enable the OpenClaw Bridge addon, " +
+            "or switch to mode='background' for headless execution.",
+        );
+      }
+
+      const result = await client.execute(code);
+      if (!result.ok) {
+        return jsonResult(`Blender returned an error:\n${result.error ?? "(no details)"}`);
+      }
+
+      const parts: string[] = ["Python executed successfully."];
+      if (result.output) parts.push(`Output:\n${result.output}`);
+      if (result.result !== undefined)
+        parts.push(`Return value: ${JSON.stringify(result.result, null, 2)}`);
+      return jsonResult(parts.join("\n"));
+    },
+  };
+}

--- a/extensions/blender/src/tools/render.ts
+++ b/extensions/blender/src/tools/render.ts
@@ -1,0 +1,216 @@
+import { Type } from "@sinclair/typebox";
+import { jsonResult, readStringParam, optionalStringEnum } from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { runBlenderBackground, buildBackgroundRenderScript } from "../background.js";
+import { createBlenderClient, resolveBlenderConfig } from "../client.js";
+
+const RenderSchema = Type.Object({
+  outputPath: Type.String({
+    description:
+      "File path for the render output. For animations use a directory path or token like //renders/frame_. " +
+      "Format is inferred from extension: .png, .jpg, .exr, .mp4.",
+  }),
+  mode: optionalStringEnum(["live", "background"] as const, {
+    description:
+      "'live' renders in the open Blender session (default). 'background' spawns a headless process.",
+  }),
+  blendFile: Type.Optional(
+    Type.String({
+      description:
+        "Path to a .blend file to open (required in background mode without open session).",
+    }),
+  ),
+  frameStart: Type.Optional(Type.Number({ description: "Start frame for animation render." })),
+  frameEnd: Type.Optional(
+    Type.Number({ description: "End frame for animation render. Omit for a single still." }),
+  ),
+  engine: optionalStringEnum(["CYCLES", "BLENDER_EEVEE_NEXT"] as const, {
+    description: "Render engine override.",
+  }),
+  resolutionX: Type.Optional(Type.Number({ minimum: 1 })),
+  resolutionY: Type.Optional(Type.Number({ minimum: 1 })),
+  samples: Type.Optional(Type.Number({ minimum: 1 })),
+  camera: Type.Optional(Type.String({ description: "Name of the camera object to render from." })),
+});
+
+const BatchRenderSchema = Type.Object({
+  blendFile: Type.String({ description: "Path to the .blend file to open." }),
+  jobs: Type.Array(
+    Type.Object({
+      outputPath: Type.String({ description: "Output path for this render job." }),
+      camera: Type.Optional(Type.String({ description: "Camera name for this job." })),
+      frameStart: Type.Optional(Type.Number()),
+      frameEnd: Type.Optional(Type.Number()),
+      engine: Type.Optional(Type.String()),
+      resolutionX: Type.Optional(Type.Number()),
+      resolutionY: Type.Optional(Type.Number()),
+      samples: Type.Optional(Type.Number()),
+    }),
+    { description: "List of render jobs to execute sequentially." },
+  ),
+});
+
+const ScreenshotSchema = Type.Object({
+  outputPath: Type.String({ description: "File path to save the viewport screenshot (.png)." }),
+  width: Type.Optional(Type.Number({ description: "Viewport width in pixels.", minimum: 1 })),
+  height: Type.Optional(Type.Number({ description: "Viewport height in pixels.", minimum: 1 })),
+});
+
+export function createRenderTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_render",
+    label: "Blender: Render",
+    description:
+      "Render the current scene (still frame or animation) using Cycles or EEVEE. " +
+      "Supports both live (interactive session) and background (headless) modes. " +
+      "Returns the output file path when complete.",
+    parameters: RenderSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const outputPath = readStringParam(rawParams, "outputPath", { required: true });
+      const mode = (readStringParam(rawParams, "mode") ?? "live") as "live" | "background";
+      const blendFile = readStringParam(rawParams, "blendFile");
+      const frameStart = rawParams["frameStart"] as number | undefined;
+      const frameEnd = rawParams["frameEnd"] as number | undefined;
+      const engine = readStringParam(rawParams, "engine");
+      const resolutionX = rawParams["resolutionX"] as number | undefined;
+      const resolutionY = rawParams["resolutionY"] as number | undefined;
+      const samples = rawParams["samples"] as number | undefined;
+      const camera = readStringParam(rawParams, "camera");
+
+      const cfg = resolveBlenderConfig(api.pluginConfig);
+      const isAnimation = frameStart !== undefined && frameEnd !== undefined;
+
+      if (mode === "background") {
+        const pythonCode = buildBackgroundRenderScript({
+          outputPath: outputPath!,
+          frameStart,
+          frameEnd,
+          engine: engine ?? undefined,
+          resolutionX,
+          resolutionY,
+          samples,
+          camera: camera ?? undefined,
+        });
+        const result = await runBlenderBackground({
+          blenderExecutable: cfg.executablePath,
+          blendFile: blendFile ?? undefined,
+          pythonCode,
+          timeoutMs: 600_000,
+        });
+        if (!result.ok) {
+          return jsonResult(`Render failed.\n${result.stderr || result.stdout}`.trim());
+        }
+        return jsonResult(
+          `Render complete. Output: ${outputPath}${isAnimation ? ` (frames ${frameStart}-${frameEnd})` : ""}`,
+        );
+      }
+
+      const client = createBlenderClient({ host: cfg.host, port: cfg.port, timeoutMs: 600_000 });
+      const status = await client.status();
+      if (!status.running) {
+        return jsonResult(
+          "Blender bridge is not running. Open Blender, enable the OpenClaw Bridge addon, or use mode='background'.",
+        );
+      }
+
+      const result = await client.render({
+        outputPath: outputPath!,
+        frameStart,
+        frameEnd,
+        engine: engine ?? undefined,
+        resolutionX,
+        resolutionY,
+        samples,
+        camera: camera ?? undefined,
+      });
+
+      if (!result.ok) return jsonResult(`Render failed: ${result.error}`);
+      return jsonResult(
+        `Render complete. Output: ${result.outputPath ?? outputPath}` +
+          (result.framesRendered ? ` (${result.framesRendered} frames)` : ""),
+      );
+    },
+  };
+}
+
+export function createBatchRenderTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_batch_render",
+    label: "Blender: Batch Render",
+    description:
+      "Run multiple render jobs from a single .blend file in background mode — useful for rendering " +
+      "the same scene from multiple cameras, multiple frame ranges, or with different engine settings.",
+    parameters: BatchRenderSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const blendFile = readStringParam(rawParams, "blendFile", { required: true });
+      const jobs = rawParams["jobs"] as Array<Record<string, unknown>>;
+
+      if (!Array.isArray(jobs) || jobs.length === 0) {
+        return jsonResult("No jobs provided.");
+      }
+
+      const cfg = resolveBlenderConfig(api.pluginConfig);
+      const results: string[] = [];
+
+      for (let i = 0; i < jobs.length; i++) {
+        const job = jobs[i]!;
+        const outputPath = job["outputPath"] as string;
+        const pythonCode = buildBackgroundRenderScript({
+          outputPath,
+          frameStart: job["frameStart"] as number | undefined,
+          frameEnd: job["frameEnd"] as number | undefined,
+          engine: job["engine"] as string | undefined,
+          resolutionX: job["resolutionX"] as number | undefined,
+          resolutionY: job["resolutionY"] as number | undefined,
+          samples: job["samples"] as number | undefined,
+          camera: job["camera"] as string | undefined,
+        });
+
+        const result = await runBlenderBackground({
+          blenderExecutable: cfg.executablePath,
+          blendFile: blendFile!,
+          pythonCode,
+          timeoutMs: 600_000,
+        });
+
+        results.push(
+          `Job ${i + 1}/${jobs.length} -> ${outputPath}: ${result.ok ? "OK" : `FAILED\n${result.stderr.slice(0, 500)}`}`,
+        );
+      }
+
+      return jsonResult(results.join("\n"));
+    },
+  };
+}
+
+export function createScreenshotTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_viewport_screenshot",
+    label: "Blender: Viewport Screenshot",
+    description:
+      "Capture the current Blender 3D viewport as a PNG image. " +
+      "Useful for quickly previewing scene state without a full render.",
+    parameters: ScreenshotSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const outputPath = readStringParam(rawParams, "outputPath", { required: true });
+      const width = rawParams["width"] as number | undefined;
+      const height = rawParams["height"] as number | undefined;
+      const cfg = resolveBlenderConfig(api.pluginConfig);
+      const client = createBlenderClient({ host: cfg.host, port: cfg.port });
+
+      const status = await client.status();
+      if (!status.running) {
+        return jsonResult(
+          "Blender bridge is not running. Viewport screenshot requires a live Blender session.",
+        );
+      }
+
+      const result = await client.screenshot({ outputPath: outputPath!, width, height });
+      if (!result.ok) return jsonResult(`Screenshot failed: ${result.error}`);
+      return jsonResult(`Screenshot saved to: ${outputPath}`);
+    },
+  };
+}

--- a/extensions/blender/src/tools/scene.ts
+++ b/extensions/blender/src/tools/scene.ts
@@ -1,0 +1,358 @@
+import { Type } from "@sinclair/typebox";
+import {
+  jsonResult,
+  readStringParam,
+  stringEnum,
+  optionalStringEnum,
+} from "openclaw/plugin-sdk/agent-runtime";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import { createBlenderClient, resolveBlenderConfig } from "../client.js";
+
+const GetSceneInfoSchema = Type.Object({});
+
+const CreateObjectSchema = Type.Object({
+  type: stringEnum(
+    [
+      "MESH_CUBE",
+      "MESH_SPHERE",
+      "MESH_PLANE",
+      "MESH_CYLINDER",
+      "MESH_CONE",
+      "MESH_TORUS",
+      "CAMERA",
+      "LIGHT_POINT",
+      "LIGHT_SUN",
+      "LIGHT_SPOT",
+      "LIGHT_AREA",
+      "EMPTY",
+      "ARMATURE",
+    ] as const,
+    { description: "Type of object to create." },
+  ),
+  name: Type.Optional(Type.String({ description: "Name for the new object." })),
+  location: Type.Optional(
+    Type.Tuple([Type.Number(), Type.Number(), Type.Number()], {
+      description: "World-space location [x, y, z] in meters.",
+    }),
+  ),
+  collection: Type.Optional(
+    Type.String({ description: "Collection to add the object to. Creates it if missing." }),
+  ),
+});
+
+const ManageCollectionSchema = Type.Object({
+  action: stringEnum(["create", "delete", "hide", "show", "move_object"] as const, {
+    description: "Action to perform on the collection.",
+  }),
+  collectionName: Type.String({ description: "Name of the collection." }),
+  objectName: Type.Optional(
+    Type.String({ description: "Object to move (required when action='move_object')." }),
+  ),
+  parentCollection: Type.Optional(
+    Type.String({ description: "Parent collection for nesting (used with 'create')." }),
+  ),
+});
+
+const SetRenderSettingsSchema = Type.Object({
+  engine: optionalStringEnum(["CYCLES", "BLENDER_EEVEE_NEXT", "BLENDER_WORKBENCH"] as const, {
+    description: "Render engine.",
+  }),
+  resolutionX: Type.Optional(Type.Number({ description: "Render width in pixels.", minimum: 1 })),
+  resolutionY: Type.Optional(Type.Number({ description: "Render height in pixels.", minimum: 1 })),
+  resolutionPercent: Type.Optional(
+    Type.Number({ description: "Resolution scale percentage (1-200).", minimum: 1, maximum: 200 }),
+  ),
+  samples: Type.Optional(Type.Number({ description: "Render samples.", minimum: 1 })),
+  fps: Type.Optional(Type.Number({ description: "Frames per second.", minimum: 1 })),
+  frameStart: Type.Optional(Type.Number({ description: "Start frame." })),
+  frameEnd: Type.Optional(Type.Number({ description: "End frame." })),
+  outputPath: Type.Optional(
+    Type.String({ description: "Output file path (supports Blender tokens like //render/)." }),
+  ),
+  outputFormat: optionalStringEnum(
+    ["PNG", "JPEG", "EXR", "OPEN_EXR_MULTILAYER", "FFMPEG"] as const,
+    { description: "Output file format." },
+  ),
+  useDenoising: Type.Optional(Type.Boolean({ description: "Enable denoising (Cycles only)." })),
+  transparentBackground: Type.Optional(
+    Type.Boolean({ description: "Render with transparent background (RGBA)." }),
+  ),
+});
+
+function getClient(api: OpenClawPluginApi) {
+  const cfg = resolveBlenderConfig(api.pluginConfig);
+  return createBlenderClient({ host: cfg.host, port: cfg.port });
+}
+
+async function requireLiveBridge(api: OpenClawPluginApi) {
+  const client = getClient(api);
+  const status = await client.status();
+  if (!status.running) {
+    return {
+      client: null,
+      error: "Blender bridge is not running. Open Blender and enable the OpenClaw Bridge addon.",
+    };
+  }
+  return { client, error: null };
+}
+
+export function createGetSceneInfoTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_get_scene_info",
+    label: "Blender: Get Scene Info",
+    description:
+      "Retrieve the current Blender scene hierarchy — all objects with their types, locations, materials, " +
+      "polygon counts, collections, render settings, active camera, and frame range. " +
+      "Essential first step before making changes to a scene.",
+    parameters: GetSceneInfoSchema,
+
+    execute: async (_toolCallId: string, _rawParams: Record<string, unknown>) => {
+      const { client, error } = await requireLiveBridge(api);
+      if (!client) return jsonResult(error!);
+
+      const scene = await client.sceneInfo();
+      return jsonResult(scene);
+    },
+  };
+}
+
+export function createCreateObjectTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_create_object",
+    label: "Blender: Create Object",
+    description:
+      "Add a new object (mesh primitive, camera, light, empty, or armature) to the current Blender scene. " +
+      "Use this to scaffold scenes, set up cameras for render pipelines, or add lighting rigs.",
+    parameters: CreateObjectSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const { client, error } = await requireLiveBridge(api);
+      if (!client) return jsonResult(error!);
+
+      const type = readStringParam(rawParams, "type", { required: true });
+      const name = readStringParam(rawParams, "name");
+      const location = rawParams["location"] as [number, number, number] | undefined;
+      const collection = readStringParam(rawParams, "collection");
+
+      const lines: string[] = ["import bpy"];
+
+      const meshTypes: Record<string, string> = {
+        MESH_CUBE: "bpy.ops.mesh.primitive_cube_add",
+        MESH_SPHERE: "bpy.ops.mesh.primitive_uv_sphere_add",
+        MESH_PLANE: "bpy.ops.mesh.primitive_plane_add",
+        MESH_CYLINDER: "bpy.ops.mesh.primitive_cylinder_add",
+        MESH_CONE: "bpy.ops.mesh.primitive_cone_add",
+        MESH_TORUS: "bpy.ops.mesh.primitive_torus_add",
+      };
+      const lightTypes: Record<string, string> = {
+        LIGHT_POINT: "POINT",
+        LIGHT_SUN: "SUN",
+        LIGHT_SPOT: "SPOT",
+        LIGHT_AREA: "AREA",
+      };
+
+      const loc = location ? `location=(${location.join(", ")})` : "location=(0,0,0)";
+
+      if (meshTypes[type!]) {
+        lines.push(`${meshTypes[type!]}(${loc})`);
+      } else if (lightTypes[type!]) {
+        lines.push(`bpy.ops.object.light_add(type=${JSON.stringify(lightTypes[type!])}, ${loc})`);
+      } else if (type === "CAMERA") {
+        lines.push(`bpy.ops.object.camera_add(${loc})`);
+      } else if (type === "EMPTY") {
+        lines.push(`bpy.ops.object.empty_add(${loc})`);
+      } else if (type === "ARMATURE") {
+        lines.push(`bpy.ops.object.armature_add(${loc})`);
+      }
+
+      lines.push(`obj = bpy.context.active_object`);
+      if (name) lines.push(`obj.name = ${JSON.stringify(name)}`);
+
+      if (collection) {
+        lines.push(
+          `col = bpy.data.collections.get(${JSON.stringify(collection)})`,
+          `if not col:`,
+          `    col = bpy.data.collections.new(${JSON.stringify(collection)})`,
+          `    bpy.context.scene.collection.children.link(col)`,
+          `for c in obj.users_collection: c.objects.unlink(obj)`,
+          `col.objects.link(obj)`,
+        );
+      }
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`Failed to create object: ${result.error}`);
+      return jsonResult(
+        `Created ${type}${name ? ` named "${name}"` : ""} at ${JSON.stringify(location ?? [0, 0, 0])}.`,
+      );
+    },
+  };
+}
+
+export function createManageCollectionTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_manage_collections",
+    label: "Blender: Manage Collections",
+    description:
+      "Create, delete, show, hide, or move objects between collections (layers) in the Blender scene. " +
+      "Collections are the primary organisational unit in Blender, equivalent to layers in game engines.",
+    parameters: ManageCollectionSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const { client, error } = await requireLiveBridge(api);
+      if (!client) return jsonResult(error!);
+
+      const action = readStringParam(rawParams, "action", { required: true });
+      const collectionName = readStringParam(rawParams, "collectionName", { required: true });
+      const objectName = readStringParam(rawParams, "objectName");
+      const parentCollection = readStringParam(rawParams, "parentCollection");
+
+      let code: string;
+      switch (action) {
+        case "create":
+          code = [
+            "import bpy",
+            `col = bpy.data.collections.new(${JSON.stringify(collectionName)})`,
+            parentCollection
+              ? `parent = bpy.data.collections.get(${JSON.stringify(parentCollection)}) or bpy.context.scene.collection\nparent.children.link(col)`
+              : `bpy.context.scene.collection.children.link(col)`,
+          ].join("\n");
+          break;
+        case "delete":
+          code = [
+            "import bpy",
+            `col = bpy.data.collections.get(${JSON.stringify(collectionName)})`,
+            `if col: bpy.data.collections.remove(col)`,
+          ].join("\n");
+          break;
+        case "hide":
+          code = [
+            "import bpy",
+            `layer_col = bpy.context.view_layer.layer_collection.children.get(${JSON.stringify(collectionName)})`,
+            `if layer_col: layer_col.hide_viewport = True`,
+          ].join("\n");
+          break;
+        case "show":
+          code = [
+            "import bpy",
+            `layer_col = bpy.context.view_layer.layer_collection.children.get(${JSON.stringify(collectionName)})`,
+            `if layer_col: layer_col.hide_viewport = False`,
+          ].join("\n");
+          break;
+        case "move_object":
+          if (!objectName) return jsonResult("objectName is required for move_object action.");
+          code = [
+            "import bpy",
+            `obj = bpy.data.objects.get(${JSON.stringify(objectName)})`,
+            `col = bpy.data.collections.get(${JSON.stringify(collectionName)})`,
+            `if not obj: raise ValueError(f"Object not found: ${objectName}")`,
+            `if not col: raise ValueError(f"Collection not found: ${collectionName}")`,
+            `for c in obj.users_collection: c.objects.unlink(obj)`,
+            `col.objects.link(obj)`,
+          ].join("\n");
+          break;
+        default:
+          return jsonResult(`Unknown action: ${action}`);
+      }
+
+      const result = await client.execute(code);
+      if (!result.ok) return jsonResult(`Collection action failed: ${result.error}`);
+      return jsonResult(`Collection '${collectionName}': ${action} succeeded.`);
+    },
+  };
+}
+
+export function createSetRenderSettingsTool(api: OpenClawPluginApi) {
+  return {
+    name: "blender_set_render_settings",
+    label: "Blender: Set Render Settings",
+    description:
+      "Configure the Blender render engine, resolution, sample count, output path, format, frame range, " +
+      "denoising, and transparency. Use this to set up render pipelines before calling blender_render.",
+    parameters: SetRenderSettingsSchema,
+
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const { client, error } = await requireLiveBridge(api);
+      if (!client) return jsonResult(error!);
+
+      const lines: string[] = ["import bpy", "scene = bpy.context.scene", "r = scene.render"];
+      const applied: string[] = [];
+
+      const engine = readStringParam(rawParams, "engine");
+      if (engine) {
+        lines.push(`r.engine = ${JSON.stringify(engine)}`);
+        applied.push(`engine=${engine}`);
+      }
+
+      const rx = rawParams["resolutionX"] as number | undefined;
+      const ry = rawParams["resolutionY"] as number | undefined;
+      if (rx) {
+        lines.push(`r.resolution_x = ${rx}`);
+        applied.push(`resolution_x=${rx}`);
+      }
+      if (ry) {
+        lines.push(`r.resolution_y = ${ry}`);
+        applied.push(`resolution_y=${ry}`);
+      }
+
+      const rp = rawParams["resolutionPercent"] as number | undefined;
+      if (rp) {
+        lines.push(`r.resolution_percentage = ${rp}`);
+        applied.push(`resolution_percent=${rp}`);
+      }
+
+      const samples = rawParams["samples"] as number | undefined;
+      if (samples) {
+        lines.push(
+          `if r.engine == 'CYCLES': scene.cycles.samples = ${samples}`,
+          `elif r.engine == 'BLENDER_EEVEE_NEXT': scene.eevee.taa_render_samples = ${samples}`,
+        );
+        applied.push(`samples=${samples}`);
+      }
+
+      const fps = rawParams["fps"] as number | undefined;
+      if (fps) {
+        lines.push(`scene.render.fps = ${fps}`);
+        applied.push(`fps=${fps}`);
+      }
+
+      const fs = rawParams["frameStart"] as number | undefined;
+      const fe = rawParams["frameEnd"] as number | undefined;
+      if (fs !== undefined) {
+        lines.push(`scene.frame_start = ${fs}`);
+        applied.push(`frame_start=${fs}`);
+      }
+      if (fe !== undefined) {
+        lines.push(`scene.frame_end = ${fe}`);
+        applied.push(`frame_end=${fe}`);
+      }
+
+      const outputPath = readStringParam(rawParams, "outputPath");
+      if (outputPath) {
+        lines.push(`r.filepath = ${JSON.stringify(outputPath)}`);
+        applied.push(`output=${outputPath}`);
+      }
+
+      const outputFormat = readStringParam(rawParams, "outputFormat");
+      if (outputFormat) {
+        lines.push(`r.image_settings.file_format = ${JSON.stringify(outputFormat)}`);
+        applied.push(`format=${outputFormat}`);
+      }
+
+      const denoising = rawParams["useDenoising"] as boolean | undefined;
+      if (denoising !== undefined) {
+        lines.push(`scene.cycles.use_denoising = ${denoising ? "True" : "False"}`);
+        applied.push(`denoising=${denoising}`);
+      }
+
+      const transparent = rawParams["transparentBackground"] as boolean | undefined;
+      if (transparent !== undefined) {
+        lines.push(`r.film_transparent = ${transparent ? "True" : "False"}`);
+        applied.push(`transparent=${transparent}`);
+      }
+
+      const result = await client.execute(lines.join("\n"));
+      if (!result.ok) return jsonResult(`Failed to apply render settings: ${result.error}`);
+      return jsonResult(`Render settings applied: ${applied.join(", ") || "(none changed)"}`);
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,6 +245,8 @@ importers:
 
   extensions/anthropic: {}
 
+  extensions/blender: {}
+
   extensions/bluebubbles:
     dependencies:
       zod:


### PR DESCRIPTION
## Summary

- Adds a new `@openclaw/blender-plugin` extension with deep Blender integration for technical artists building games
- Communicates with a bundled Python addon (`openclaw_bridge.py`) that runs an HTTP server inside Blender on port 7428, with fallback to headless background mode via `blender --background`
- 20 agent tools covering the full game art pipeline

## Tools

| Category | Tools |
|---|---|
| Python scripting | `blender_execute_python` (live + background modes) |
| Scene management | `blender_get_scene_info`, `blender_create_object`, `blender_manage_collections`, `blender_set_render_settings` |
| Rendering | `blender_render`, `blender_batch_render`, `blender_viewport_screenshot` |
| Asset I/O | `blender_import`, `blender_export`, `blender_library_assets` |
| Materials & textures | `blender_apply_material`, `blender_bake_textures`, `blender_assign_texture` |
| Game-specific | `blender_generate_lod`, `blender_create_collision`, `blender_uv_unwrap`, `blender_game_export`, `blender_check_game_readiness` |

## Highlights

- **Live mode**: controls an open Blender session in real time via the bridge addon
- **Background mode**: spawns headless Blender for batch rendering and exports without a UI
- **Game engine export**: correct axis/scale conventions for Unreal Engine, Unity, and Godot
- **LOD generation**: auto-generates LOD0–LOD3 via Decimate modifier
- **Collision meshes**: BOX/SPHERE/CAPSULE/CONVEX/MESH with UE (`UCX_`, `UBX_`) and Godot (`COL_`) naming
- **Texture baking**: Diffuse, AO, Normal, Roughness, Emission, Combined maps
- **Game readiness audit**: checks N-gons, non-manifold geometry, missing UVs, unapplied transforms

## Test plan

- [ ] 33-test suite passes (`pnpm test -- extensions/blender`)
- [ ] `pnpm tsgo` — 0 type errors
- [ ] `pnpm check` — 0 lint errors
- [ ] Install `src/addon/openclaw_bridge.py` in Blender 4.0+, enable addon, verify bridge starts on port 7428
- [ ] Test `blender_execute_python` in live mode against an open Blender session
- [ ] Test `blender_render` in background mode with a .blend file
- [ ] Test `blender_game_export` targeting Unreal Engine (FBX) and Godot (GLTF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)