### PR TITLE
Security/audit: know default dangerous node commands in denyCommands check (#51865) (#51865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/audit: treat default high-risk node command IDs as recognized spellings for `gateway.nodes.denyCommands`, and warn when those denies are redundant (not on default or configured allowlists). (#51865)
+- Security/audit: treat default high-risk node command IDs as recognized spellings for `gateway.nodes.denyCommands`, warn when those denies are redundant (not on default or configured allowlists), and skip redundant noise for the new-gateway wizard baseline deny list. (#51865)
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Security/audit: treat default high-risk node command ids (for example `camera.snap`) as known names for `gateway.nodes.denyCommands` validation. (#51865)
+- Security/audit: treat default high-risk node command IDs as recognized spellings for `gateway.nodes.denyCommands`, and warn when those denies are redundant (not on default or configured allowlists). (#51865)
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/audit: treat default high-risk node command ids (for example `camera.snap`) as known names for `gateway.nodes.denyCommands` validation. (#51865)
 - Agents/default timeout: raise the shared default agent timeout from `600s` to `48h` so long-running ACP and agent sessions do not fail unless you configure a shorter limit.
 - Gateway/Linux: auto-detect nvm-managed Node TLS CA bundle needs before CLI startup and refresh installed services that are missing `NODE_EXTRA_CA_CERTS`. (#51146) Thanks @GodsBoy.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -218,6 +218,12 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
       }
     }
   }
+  for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    const normalized = normalizeNodeCommand(cmd);
+    if (normalized) {
+      out.add(normalized);
+    }
+  }
   return out;
 }
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1071,7 +1071,7 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
   if (redundantForFinding.length > 0) {
     detailParts.push(
       "Redundant deny entries (real command IDs that are not on any platform default or configured allowlist, so deny has no effect unless you also enable them via allowCommands): " +
-        `${redundantForFinding.join(", ")}`,
+        redundantForFinding.join(", "),
     );
   }
   const examples = Array.from(recognizedIds).slice(0, 8);

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -237,6 +237,28 @@ function listRecognizedNodeCommandIds(allowUnionDenyCleared: Set<string>): Set<s
   return out;
 }
 
+/** Matches the new-gateway wizard baseline: denyCommands is exactly the default dangerous set. */
+function denyListMatchesDefaultDangerousDenyBaseline(denyList: readonly string[]): boolean {
+  const normalizedDeny = new Set(denyList);
+  const normalizedDangerous = new Set(
+    DEFAULT_DANGEROUS_NODE_COMMANDS.map((c) => normalizeNodeCommand(c)).filter(Boolean),
+  );
+  if (normalizedDeny.size !== normalizedDangerous.size) {
+    return false;
+  }
+  for (const cmd of normalizedDangerous) {
+    if (!normalizedDeny.has(cmd)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function hasNonemptyGatewayAllowCommands(cfg: OpenClawConfig): boolean {
+  const raw = cfg.gateway?.nodes?.allowCommands;
+  return Array.isArray(raw) && raw.some((x) => Boolean(normalizeNodeCommand(x)));
+}
+
 function looksLikeNodeCommandPattern(value: string): boolean {
   if (!value) {
     return false;
@@ -1019,7 +1041,11 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
       recognizedIds.has(entry) &&
       !allowUnionDenyCleared.has(entry),
   );
-  if (patternLike.length === 0 && unknownExact.length === 0 && redundantExact.length === 0) {
+  const redundantForFinding =
+    denyListMatchesDefaultDangerousDenyBaseline(denyList) && !hasNonemptyGatewayAllowCommands(cfg)
+      ? []
+      : redundantExact;
+  if (patternLike.length === 0 && unknownExact.length === 0 && redundantForFinding.length === 0) {
     return findings;
   }
 
@@ -1042,10 +1068,10 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
 
     detailParts.push(`Unknown command names (not in defaults/allowCommands): ${unknownDetails}`);
   }
-  if (redundantExact.length > 0) {
+  if (redundantForFinding.length > 0) {
     detailParts.push(
       "Redundant deny entries (real command IDs that are not on any platform default or configured allowlist, so deny has no effect unless you also enable them via allowCommands): " +
-        `${redundantExact.join(", ")}`,
+        `${redundantForFinding.join(", ")}`,
     );
   }
   const examples = Array.from(recognizedIds).slice(0, 8);

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -197,7 +197,11 @@ function normalizeNodeCommand(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
+/**
+ * Union of commands that appear on any platform allowlist when denyCommands is cleared.
+ * User allowCommands are included; this is the pre-deny effective allow surface.
+ */
+function listNodeAllowUnionDenyCleared(cfg: OpenClawConfig): Set<string> {
   const baseCfg: OpenClawConfig = {
     ...cfg,
     gateway: {
@@ -218,6 +222,12 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
       }
     }
   }
+  return out;
+}
+
+/** Valid node command identifiers for denyCommands spelling (includes opt-in dangerous IDs). */
+function listRecognizedNodeCommandIds(allowUnionDenyCleared: Set<string>): Set<string> {
+  const out = new Set(allowUnionDenyCleared);
   for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
     const normalized = normalizeNodeCommand(cmd);
     if (normalized) {
@@ -997,12 +1007,19 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
     return findings;
   }
 
-  const knownCommands = listKnownNodeCommands(cfg);
+  const allowUnionDenyCleared = listNodeAllowUnionDenyCleared(cfg);
+  const recognizedIds = listRecognizedNodeCommandIds(allowUnionDenyCleared);
   const patternLike = denyList.filter((entry) => looksLikeNodeCommandPattern(entry));
   const unknownExact = denyList.filter(
-    (entry) => !looksLikeNodeCommandPattern(entry) && !knownCommands.has(entry),
+    (entry) => !looksLikeNodeCommandPattern(entry) && !recognizedIds.has(entry),
   );
-  if (patternLike.length === 0 && unknownExact.length === 0) {
+  const redundantExact = denyList.filter(
+    (entry) =>
+      !looksLikeNodeCommandPattern(entry) &&
+      recognizedIds.has(entry) &&
+      !allowUnionDenyCleared.has(entry),
+  );
+  if (patternLike.length === 0 && unknownExact.length === 0 && redundantExact.length === 0) {
     return findings;
   }
 
@@ -1015,7 +1032,7 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
   if (unknownExact.length > 0) {
     const unknownDetails = unknownExact
       .map((entry) => {
-        const suggestions = suggestKnownNodeCommands(entry, knownCommands);
+        const suggestions = suggestKnownNodeCommands(entry, recognizedIds);
         if (suggestions.length === 0) {
           return entry;
         }
@@ -1025,7 +1042,13 @@ export function collectNodeDenyCommandPatternFindings(cfg: OpenClawConfig): Secu
 
     detailParts.push(`Unknown command names (not in defaults/allowCommands): ${unknownDetails}`);
   }
-  const examples = Array.from(knownCommands).slice(0, 8);
+  if (redundantExact.length > 0) {
+    detailParts.push(
+      "Redundant deny entries (real command IDs that are not on any platform default or configured allowlist, so deny has no effect unless you also enable them via allowCommands): " +
+        `${redundantExact.join(", ")}`,
+    );
+  }
+  const examples = Array.from(recognizedIds).slice(0, 8);
 
   findings.push({
     checkId: "gateway.nodes.deny_commands_ineffective",

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { DEFAULT_DANGEROUS_NODE_COMMANDS } from "../gateway/node-command-policy.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   collectInstalledSkillsCodeSafetyFindings,
@@ -1335,6 +1336,17 @@ description: test skill
             nodes: {
               allowCommands: ["camera.snap"],
               denyCommands: ["camera.snap"],
+            },
+          },
+        } satisfies OpenClawConfig,
+      },
+      {
+        kind: "absent",
+        name: "does not flag redundant denies for new-gateway wizard default dangerous deny baseline",
+        cfg: {
+          gateway: {
+            nodes: {
+              denyCommands: [...DEFAULT_DANGEROUS_NODE_COMMANDS],
             },
           },
         } satisfies OpenClawConfig,

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1266,8 +1266,19 @@ description: test skill
   });
 
   it("evaluates ineffective gateway.nodes.denyCommands entries", async () => {
-    const cases = [
+    type DenyCommandsIneffectiveCase =
+      | {
+          kind: "warn";
+          name: string;
+          cfg: OpenClawConfig;
+          detailIncludes: readonly string[];
+          detailExcludes?: readonly string[];
+        }
+      | { kind: "absent"; name: string; cfg: OpenClawConfig };
+
+    const cases: DenyCommandsIneffectiveCase[] = [
       {
+        kind: "warn",
         name: "flags ineffective gateway.nodes.denyCommands entries",
         cfg: {
           gateway: {
@@ -1279,6 +1290,7 @@ description: test skill
         detailIncludes: ["system.*", "system.runx", "did you mean", "system.run"],
       },
       {
+        kind: "warn",
         name: "suggests prefix-matching commands for unknown denyCommands entries",
         cfg: {
           gateway: {
@@ -1290,6 +1302,7 @@ description: test skill
         detailIncludes: ["system.run.prep", "did you mean", "system.run.prepare"],
       },
       {
+        kind: "warn",
         name: "keeps unknown denyCommands entries without suggestions when no close command exists",
         cfg: {
           gateway: {
@@ -1302,6 +1315,7 @@ description: test skill
         detailExcludes: ["did you mean"],
       },
       {
+        kind: "absent",
         name: "does not flag denyCommands that name default dangerous node commands",
         cfg: {
           gateway: {
@@ -1310,9 +1324,8 @@ description: test skill
             },
           },
         } satisfies OpenClawConfig,
-        expectAbsent: true,
       },
-    ] as const;
+    ];
 
     await Promise.all(
       cases.map(async (testCase) => {
@@ -1320,7 +1333,7 @@ description: test skill
         const finding = res.findings.find(
           (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
         );
-        if ("expectAbsent" in testCase && testCase.expectAbsent) {
+        if (testCase.kind === "absent") {
           expect(finding, testCase.name).toBeUndefined();
           return;
         }
@@ -1328,7 +1341,7 @@ description: test skill
         for (const text of testCase.detailIncludes) {
           expect(finding?.detail, `${testCase.name}:${text}`).toContain(text);
         }
-        const detailExcludes = "detailExcludes" in testCase ? testCase.detailExcludes : [];
+        const detailExcludes = testCase.detailExcludes ?? [];
         for (const text of detailExcludes) {
           expect(finding?.detail, `${testCase.name}:${text}`).not.toContain(text);
         }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1301,6 +1301,17 @@ description: test skill
         detailIncludes: ["zzzzzzzzzzzzzz"],
         detailExcludes: ["did you mean"],
       },
+      {
+        name: "does not flag denyCommands that name default dangerous node commands",
+        cfg: {
+          gateway: {
+            nodes: {
+              denyCommands: ["camera.snap"],
+            },
+          },
+        } satisfies OpenClawConfig,
+        expectAbsent: true,
+      },
     ] as const;
 
     await Promise.all(
@@ -1309,6 +1320,10 @@ description: test skill
         const finding = res.findings.find(
           (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
         );
+        if ("expectAbsent" in testCase && testCase.expectAbsent) {
+          expect(finding, testCase.name).toBeUndefined();
+          return;
+        }
         expect(finding?.severity, testCase.name).toBe("warn");
         for (const text of testCase.detailIncludes) {
           expect(finding?.detail, `${testCase.name}:${text}`).toContain(text);

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1315,11 +1315,25 @@ description: test skill
         detailExcludes: ["did you mean"],
       },
       {
-        kind: "absent",
-        name: "does not flag denyCommands that name default dangerous node commands",
+        kind: "warn",
+        name: "flags redundant deny for default-off dangerous command IDs",
         cfg: {
           gateway: {
             nodes: {
+              denyCommands: ["camera.snap"],
+            },
+          },
+        } satisfies OpenClawConfig,
+        detailIncludes: ["Redundant deny", "camera.snap"],
+        detailExcludes: ["Unknown command names"],
+      },
+      {
+        kind: "absent",
+        name: "does not flag deny when allowCommands enables the command (deny is meaningful)",
+        cfg: {
+          gateway: {
+            nodes: {
+              allowCommands: ["camera.snap"],
               denyCommands: ["camera.snap"],
             },
           },


### PR DESCRIPTION
## Summary
See commit message on branch `fix/51865-audit-known-dangerous-node-commands`.

## Test plan
- [ ] CI / targeted tests as noted in commit

Fixes #51865

Made with [Cursor](https://cursor.com)