### PR TITLE
fix(utils): reduce maskApiKey exposure from 16 to 4 characters

### DIFF
--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -7,14 +7,32 @@ describe("maskApiKey", () => {
     expect(maskApiKey("   ")).toBe("missing");
   });
 
-  it("masks short and medium values without returning raw secrets", () => {
-    expect(maskApiKey(" abcdefghijklmnop ")).toBe("ab...op");
-    expect(maskApiKey(" short ")).toBe("s...t");
-    expect(maskApiKey(" a ")).toBe("a...a");
-    expect(maskApiKey(" ab ")).toBe("a...b");
+  it("masks short keys (<=4 chars) with first 1 char only", () => {
+    expect(maskApiKey("a")).toBe("a...");
+    expect(maskApiKey("ab")).toBe("a...");
+    expect(maskApiKey("abcd")).toBe("a...");
+    expect(maskApiKey(" short ")).toBe("shor...");
   });
 
-  it("masks long values with first and last 8 chars", () => {
-    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop"); // pragma: allowlist secret
+  it("masks longer keys with first 4 chars only", () => {
+    expect(maskApiKey("abcdefghijklmnop")).toBe("abcd...");
+    expect(maskApiKey("sk-ant-api03-abcxyz1234")).toBe("sk-a...");
+  });
+
+  it("never exposes the last 8 characters of the key", () => {
+    const key = "sk-ant-api03-abcdefghWXYZ5678"; // pragma: allowlist secret
+    const lastEight = key.slice(-8);
+    const masked = maskApiKey(key);
+    expect(masked).not.toContain(lastEight);
+    // Also verify no tail chars leak individually beyond position 4
+    for (const char of key.slice(4)) {
+      if (!key.slice(0, 4).includes(char)) {
+        expect(masked).not.toContain(char);
+      }
+    }
+  });
+
+  it("trims whitespace before masking", () => {
+    expect(maskApiKey("  sk-ant-api03-abc  ")).toBe("sk-a...");
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -3,11 +3,8 @@ export const maskApiKey = (value: string): string => {
   if (!trimmed) {
     return "missing";
   }
-  if (trimmed.length <= 6) {
-    return `${trimmed.slice(0, 1)}...${trimmed.slice(-1)}`;
+  if (trimmed.length <= 4) {
+    return `${trimmed.slice(0, 1)}...`;
   }
-  if (trimmed.length <= 16) {
-    return `${trimmed.slice(0, 2)}...${trimmed.slice(-2)}`;
-  }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${trimmed.slice(0, 4)}...`;
 };


### PR DESCRIPTION
## Summary

`maskApiKey()` exposes up to 16 characters of API keys when displaying `/models list` output in chat channels. For keys with 16 or fewer characters, the masked output may reveal most or all of the key.

**Before:**

```
sk-ant-api03-abc...wxyz1234   ← 16 chars exposed
abcdefghijklmnop              ← ab...op (4 chars exposed — may be most of key)
```

**After:**

```
sk-a...   ← only 4 chars, never the end
abcd...   ← only 4 chars, never the end
```

## Details

Simplified `maskApiKey()` to two branches:

- Keys ≤ 4 chars: show first 1 char + `...`
- Keys > 4 chars: show first 4 chars + `...`

The end of the key is **never** exposed. This follows the same pattern used by GitHub, npm, and other credential-handling systems.

Updated tests to match the new behavior and added assertions that verify the last 8 characters of a key are never present in masked output.

## Related Issues

Fixes #34452

## How to Validate

Run `/models list` in any channel — confirm API keys show only the first 4 characters followed by `...`.

Run unit tests: `pnpm test -- --testPathPattern=mask-api-key`

## Pre-Merge Checklist

- [x] Updated relevant documentation and README (if needed)
- [x] Added/updated tests (if needed)
- [ ] Noted breaking changes (if any)
- [x] Validated on required platforms/methods:
  - [x] Windows
    - [x] npm run
