### PR TITLE
fix(audit): recognize dangerous node commands in denyCommands validation

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -218,6 +218,12 @@ function listKnownNodeCommands(cfg: OpenClawConfig): Set<string> {
       }
     }
   }
+  for (const cmd of DEFAULT_DANGEROUS_NODE_COMMANDS) {
+    const normalized = normalizeNodeCommand(cmd);
+    if (normalized) {
+      out.add(normalized);
+    }
+  }
   return out;
 }
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1303,6 +1303,20 @@ description: test skill
       },
     ] as const;
 
+    // Dangerous commands in denyCommands should NOT be flagged as unknown.
+    const dangerousCfg: OpenClawConfig = {
+      gateway: {
+        nodes: {
+          denyCommands: ["camera.snap", "camera.clip", "screen.record", "contacts.add", "calendar.add", "sms.send"],
+        },
+      },
+    };
+    const dangerousRes = await audit(dangerousCfg);
+    const dangerousFinding = dangerousRes.findings.find(
+      (f) => f.checkId === "gateway.nodes.deny_commands_ineffective",
+    );
+    expect(dangerousFinding, "dangerous commands in denyCommands should not trigger warning").toBeUndefined();
+
     await Promise.all(
       cases.map(async (testCase) => {
         const res = await audit(testCase.cfg);


### PR DESCRIPTION
Fixes false positive security audit warnings for valid  entries.

**Root cause:** `listKnownNodeCommands()` in `src/security/audit-extra.sync.ts` only checked platform default allowlists, which exclude dangerous commands like `camera.snap`, `screen.record`, `contacts.add`, etc. When users correctly add these to `denyCommands`, the audit incorrectly flagged them as 'unknown command names.'

**Fix:** Added iteration over `DEFAULT_DANGEROUS_NODE_COMMANDS` in `listKnownNodeCommands()` so the audit recognizes them as valid.

**Changes:**
- `src/security/audit-extra.sync.ts`: +6 lines
- `src/security/audit.test.ts`: +14 lines (new test case)

Closes #51865