### PR TITLE
fix(plugins): require host floor for new sdk subpaths

### DIFF
--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -12,11 +12,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -16,11 +16,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -15,11 +15,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -13,11 +13,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "zod": "^4.3.6"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -10,11 +10,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -17,11 +17,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -13,11 +13,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -14,11 +14,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -12,11 +12,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -13,11 +13,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -16,11 +16,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -9,6 +9,9 @@
     "@twurple/chat": "^8.0.3",
     "zod": "^4.3.6"
   },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.14"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -15,11 +15,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -12,11 +12,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -13,11 +13,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -14,11 +14,6 @@
   "peerDependencies": {
     "openclaw": ">=2026.3.14"
   },
-  "peerDependenciesMeta": {
-    "openclaw": {
-      "optional": true
-    }
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/src/plugins/install-host-peer-guardrails.test.ts
+++ b/src/plugins/install-host-peer-guardrails.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MIN_HOST_VERSION = ">=2026.3.14";
+const INSTALLABLE_PLUGIN_IDS_REQUIRING_HOST_FLOOR = [
+  "bluebubbles",
+  "discord",
+  "feishu",
+  "googlechat",
+  "irc",
+  "line",
+  "matrix",
+  "mattermost",
+  "msteams",
+  "nextcloud-talk",
+  "nostr",
+  "tlon",
+  "twitch",
+  "voice-call",
+  "whatsapp",
+  "zalo",
+  "zalouser",
+] as const;
+
+function readPackageManifest(pluginId: string) {
+  return JSON.parse(
+    readFileSync(resolve(process.cwd(), "extensions", pluginId, "package.json"), "utf8"),
+  ) as {
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  };
+}
+
+describe("installable plugin host peer guardrails", () => {
+  it("requires a non-optional openclaw peer floor for plugins that rely on new plugin-sdk subpaths", () => {
+    for (const pluginId of INSTALLABLE_PLUGIN_IDS_REQUIRING_HOST_FLOOR) {
+      const manifest = readPackageManifest(pluginId);
+      expect(
+        manifest.peerDependencies?.openclaw,
+        `${pluginId} should declare an openclaw peer`,
+      ).toBe(MIN_HOST_VERSION);
+      expect(
+        manifest.peerDependenciesMeta?.openclaw?.optional,
+        `${pluginId} should not mark the openclaw peer optional`,
+      ).not.toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: several installable channel plugins that now depend on new `openclaw/plugin-sdk/*` subpaths still marked the `openclaw` peer optional, and `irc` / `twitch` had no host peer floor at all.
- Why it matters: the plugin install path runs `npm install --omit=dev` in the unpacked plugin directory, so optional-or-missing host peers let older OpenClaw releases accept the install and only fail later at runtime when the new subpaths cannot resolve.
- What changed: removed `peerDependenciesMeta.openclaw.optional` from the affected installable channel plugins, added the missing mandatory `openclaw >=2026.3.14` peer to `irc` and `twitch`, and added a guardrail test that locks this host-version gate in place.
- What did NOT change (scope boundary): no runtime plugin behavior, no SDK surface changes, and no changes to private/non-installable plugin manifests outside this install-compatibility fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51939

## User-visible / Behavior Changes

Older OpenClaw hosts now fail plugin installation earlier for the affected npm-installable channel plugins instead of accepting the package and failing later when the new plugin-sdk subpaths are loaded.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, pnpm 10
- Model/provider: n/a
- Integration/channel (if any): plugin install manifests
- Relevant config (redacted): none

### Steps

1. Inspect installable plugin manifests that now use new `openclaw/plugin-sdk/*` subpaths.
2. Remove `peerDependenciesMeta.openclaw.optional` where present and add the missing mandatory `openclaw >=2026.3.14` peer where absent.
3. Re-run the manifest guardrail and install-path tests.

### Expected

- Affected installable plugins require a non-optional `openclaw >=2026.3.14` host peer.
- The install-path tests still pass.

### Actual

- Local validation is green, and a fresh `pnpm install` in the clean worktree fails on unpublished `openclaw@>=2026.3.14`, which is the intended early gate for older npm-host installs.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/plugins/install-host-peer-guardrails.test.ts` and `pnpm test -- src/infra/install-package-dir.test.ts` in the clean worktree.
- Edge cases checked: confirmed the new host floor stays mandatory for every affected installable channel plugin, and confirmed `irc` / `twitch` now declare the peer explicitly.
- What you did **not** verify: broader runtime behavior after installation on a released `2026.3.14` host, because that package is not published yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `cb0ef3f49f` and `f55ea62b7d` if needed.
- Files/config to restore: the touched `extensions/*/package.json` manifests and `src/plugins/install-host-peer-guardrails.test.ts`.
- Known bad symptoms reviewers should watch for: plugin install failures on hosts that should satisfy `>=2026.3.14`, or guardrail-test drift if another installable plugin starts using new plugin-sdk subpaths without a mandatory host peer floor.

## Risks and Mitigations

- Risk: hosts that previously installed these plugins despite being too old will now fail at install time.
  - Mitigation: that is the intended behavior; it moves failure to the package-manager boundary instead of a later runtime crash.

AI-assisted: Yes. Tested locally.
