### PR TITLE
fix(auth): accept connectAuth.token as password fallback in password mode

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -275,6 +275,35 @@ describe("gateway auth", () => {
     expect(res.reason).toBe("password_missing_config");
   });
 
+
+  it("accepts connectAuth.token as password fallback in password mode (Rabbit R1 compat)", async () => {
+    // Devices like Rabbit R1 send credentials via connectAuth.token in the QR-pairing
+    // flow and have no mechanism to send connectAuth.password. Password mode should
+    // fall back to token when password is absent.
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false }, // pragma: allowlist secret
+      connectAuth: { token: "secret" }, // pragma: allowlist secret
+    });
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("password");
+
+    // Wrong token in token field should still fail
+    const mismatch = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false }, // pragma: allowlist secret
+      connectAuth: { token: "wrong" },
+    });
+    expect(mismatch.ok).toBe(false);
+    expect(mismatch.reason).toBe("password_mismatch");
+
+    // Explicit password takes precedence over token
+    const withBoth = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "right-pw", allowTailscale: false }, // pragma: allowlist secret
+      connectAuth: { password: "right-pw", token: "other-token" }, // pragma: allowlist secret
+    });
+    expect(withBoth.ok).toBe(true);
+  });
+
+
   it("treats local tailscale serve hostnames as direct", async () => {
     const res = await authorizeGatewayConnect({
       auth: { mode: "token", token: "secret", allowTailscale: true },

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -455,7 +455,7 @@ export async function authorizeGatewayConnect(
   }
 
   if (auth.mode === "password") {
-    const password = connectAuth?.password;
+    const password = connectAuth?.password ?? connectAuth?.token;
     if (!auth.password) {
       return { ok: false, reason: "password_missing_config" };
     }


### PR DESCRIPTION
## Summary

Fixes #51953

Devices like the **Rabbit R1** use the `clawdbot-gateway` QR-pairing format and place the gateway credential into `connectAuth.token` during the WebSocket handshake. They have no mechanism to send `connectAuth.password`. When the gateway is configured with `gateway.auth.mode = "password"` (typically required with Tailscale Funnel), these devices are rejected with `reason=password_missing`.

## Change

In `authorizeGatewayConnect`, when `auth.mode === "password"`, fall back to `connectAuth.token` when `connectAuth.password` is absent:

```ts
// Before
const password = connectAuth?.password;

// After
const password = connectAuth?.password ?? connectAuth?.token;
```

If `connectAuth.password` is present it is still used first, so all existing password-mode behaviour is unchanged.

## Tests

Added three new assertions to `src/gateway/auth.test.ts`:

1. **Token-only auth succeeds** — `connectAuth: { token: "secret" }` authenticates against a password-mode gateway (Rabbit R1 use case)
2. **Wrong token still fails** — returns `password_mismatch` as expected
3. **Explicit password takes precedence** — when both `password` and `token` are present, `password` wins

## Impact

- ✅ No breaking change — `connectAuth.password` is checked first
- ✅ Removes the need for users to manually patch dist files after every update
- ✅ Extends to any future device that sends credentials via `connectAuth.token` in QR-pairing flows