### PR TITLE
Exec: fix pipe-to-shell false positive on || before shell (#51908)

### DIFF
--- a/src/infra/exec-obfuscation-detect.test.ts
+++ b/src/infra/exec-obfuscation-detect.test.ts
@@ -44,6 +44,13 @@ describe("detectCommandObfuscation", () => {
       expect(result.detected).toBe(false);
     });
 
+    it("does NOT treat logical OR (||) before a shell as pipe-to-shell", () => {
+      const cmd =
+        "python3 bin/garmin_health.py 2>/dev/null || bash bin/garmin-health.sh 2>/dev/null";
+      const result = detectCommandObfuscation(cmd);
+      expect(result.matchedPatterns).not.toContain("pipe-to-shell");
+    });
+
     it("detects shell piped execution with flags", () => {
       const result = detectCommandObfuscation("cat script.sh | bash -x");
       expect(result.detected).toBe(true);

--- a/src/infra/exec-obfuscation-detect.ts
+++ b/src/infra/exec-obfuscation-detect.ts
@@ -118,7 +118,8 @@ const OBFUSCATION_PATTERNS: ObfuscationPattern[] = [
   {
     id: "pipe-to-shell",
     description: "Content piped directly to shell interpreter",
-    regex: /\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b(?:\s+[^|;\n\r]+)?\s*$/im,
+    // Avoid matching the second `|` in `||` (logical OR) before `bash`/`sh`.
+    regex: /(?<!\|)\|\s*(?:sh|bash|zsh|dash|ksh|fish)\b(?:\s+[^|;\n\r]+)?\s*$/im,
   },
   {
     id: "command-substitution-decode-exec",


### PR DESCRIPTION
## Summary
Tighten the `pipe-to-shell` obfuscation regex with a negative lookbehind so `|| bash` / `|| sh` (logical OR) is not treated as piping into a shell.

## Test plan
- `pnpm test -- src/infra/exec-obfuscation-detect.test.ts`

Fixes #51908

Made with [Cursor](https://cursor.com)