### PR TITLE
Update: fix false update-available for calver build installs (#51662)

### DIFF
--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -3,6 +3,7 @@ import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import {
   checkUpdateStatus,
   compareSemverStrings,
+  shouldTreatCalVerBuildAsUpToDate,
   type UpdateCheckResult,
 } from "../infra/update-check.js";
 import { VERSION } from "../version.js";
@@ -35,7 +36,15 @@ export type UpdateAvailability = {
 
 export function resolveUpdateAvailability(update: UpdateCheckResult): UpdateAvailability {
   const latestVersion = update.registry?.latestVersion ?? null;
-  const registryCmp = latestVersion ? compareSemverStrings(VERSION, latestVersion) : null;
+  let registryCmp = latestVersion ? compareSemverStrings(VERSION, latestVersion) : null;
+  if (
+    registryCmp != null &&
+    registryCmp < 0 &&
+    latestVersion &&
+    shouldTreatCalVerBuildAsUpToDate(VERSION, latestVersion)
+  ) {
+    registryCmp = 0;
+  }
   const hasRegistryUpdate = registryCmp != null && registryCmp < 0;
   const gitBehind =
     update.installKind === "git" && typeof update.git?.behind === "number"

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -10,7 +10,27 @@ import {
   fetchNpmTagVersion,
   formatGitInstallLabel,
   resolveNpmChannelTag,
+  shouldTreatCalVerBuildAsUpToDate,
 } from "./update-check.js";
+
+describe("shouldTreatCalVerBuildAsUpToDate", () => {
+  it("treats numeric calver build suffix as up to date vs plain release", () => {
+    expect(shouldTreatCalVerBuildAsUpToDate("2026.3.13-1", "2026.3.13")).toBe(true);
+    expect(compareSemverStrings("2026.3.13-1", "2026.3.13")).toBe(-1);
+  });
+
+  it("returns false when latest is itself a prerelease", () => {
+    expect(shouldTreatCalVerBuildAsUpToDate("2026.3.13-1", "2026.3.13-beta.1")).toBe(false);
+  });
+
+  it("returns false when patch line differs", () => {
+    expect(shouldTreatCalVerBuildAsUpToDate("2026.3.13-1", "2026.3.14")).toBe(false);
+  });
+
+  it("returns false when install has no numeric-only build suffix", () => {
+    expect(shouldTreatCalVerBuildAsUpToDate("2026.3.13-beta.1", "2026.3.13")).toBe(false);
+  });
+});
 
 describe("compareSemverStrings", () => {
   it("handles stable and prerelease precedence for both legacy and beta formats", () => {

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -341,6 +341,37 @@ export async function resolveNpmChannelTag(params: {
   return { tag: channelTag, version: channelStatus.version };
 }
 
+/**
+ * OpenClaw publishes CalVer builds like `2026.3.13-1`. Semver ordering treats any prerelease
+ * as older than a plain release, so `compareSemverStrings("2026.3.13-1", "2026.3.13")` is `< 0`
+ * even when the install is already on the same published line. Use this helper to suppress
+ * false "update available" when the only difference is a numeric build suffix on the install.
+ */
+export function shouldTreatCalVerBuildAsUpToDate(
+  installedVersion: string,
+  latestVersion: string | null | undefined,
+): boolean {
+  if (!latestVersion) {
+    return false;
+  }
+  const inst = parseComparableSemver(installedVersion);
+  const latest = parseComparableSemver(latestVersion);
+  if (!inst || !latest) {
+    return false;
+  }
+  if (inst.major !== latest.major || inst.minor !== latest.minor || inst.patch !== latest.patch) {
+    return false;
+  }
+  if (latest.prerelease != null && latest.prerelease.length > 0) {
+    return false;
+  }
+  if (!inst.prerelease || inst.prerelease.length !== 1) {
+    return false;
+  }
+  const token = inst.prerelease[0] ?? "";
+  return /^[0-9]+$/.test(token);
+}
+
 export function compareSemverStrings(a: string | null, b: string | null): number | null {
   const pa = parseComparableSemver(a);
   const pb = parseComparableSemver(b);


### PR DESCRIPTION
## Summary
When the installed version is `YYYY.M.D-N` (numeric build suffix) and npm `latest` is `YYYY.M.D`, semver compares the install as *older* and we incorrectly flagged an update. Suppress that case in `resolveUpdateAvailability`.

## Test plan
- `pnpm test -- src/infra/update-check.test.ts src/commands/status.update.test.ts`

Fixes #51662

Made with [Cursor](https://cursor.com)