### PR TITLE
Media: fix PNG mis-sniffed as image/apng (#51881)

### DIFF
--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -2,6 +2,7 @@ import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
 import { mediaKindFromMime } from "./constants.js";
 import {
+  coerceApngSniffToPng,
   detectMime,
   extensionForMime,
   imageMimeFromFormat,
@@ -67,6 +68,13 @@ describe("mime detection", () => {
       filePath: "/tmp/a2ui.bundle.js",
     });
     expect(mime).toBe("text/javascript");
+  });
+
+  it("coerces apng sniff to png when path or header says png", () => {
+    expect(coerceApngSniffToPng("image/apng", ".png", undefined)).toBe("image/png");
+    expect(coerceApngSniffToPng("image/apng", ".jpg", "image/png")).toBe("image/png");
+    expect(coerceApngSniffToPng("image/apng", ".jpg", undefined)).toBe("image/apng");
+    expect(coerceApngSniffToPng("image/png", ".png", undefined)).toBe("image/png");
   });
 });
 

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -77,6 +77,18 @@ async function sniffMime(buffer?: Buffer): Promise<string | undefined> {
   }
 }
 
+/** `file-type` may return `image/apng` for PNG payloads; normalize when PNG is clearly intended. */
+export function coerceApngSniffToPng(
+  sniffed: string | undefined,
+  ext: string | undefined,
+  headerMime: string | undefined,
+): string | undefined {
+  if (sniffed === "image/apng" && (ext === ".png" || headerMime === "image/png")) {
+    return "image/png";
+  }
+  return sniffed;
+}
+
 export function getFileExtension(filePath?: string | null): string | undefined {
   if (!filePath) {
     return undefined;
@@ -126,7 +138,7 @@ async function detectMimeImpl(opts: {
   const extMime = ext ? MIME_BY_EXT[ext] : undefined;
 
   const headerMime = normalizeMimeType(opts.headerMime);
-  const sniffed = await sniffMime(opts.buffer);
+  let sniffed = coerceApngSniffToPng(await sniffMime(opts.buffer), ext, headerMime);
 
   // Prefer sniffed types, but don't let generic container types override a more
   // specific extension mapping (e.g. XLSX vs ZIP).


### PR DESCRIPTION
## Summary
Normalize `image/apng` sniff results to `image/png` when the file path uses `.png` or the declared header MIME is `image/png`.

## Test plan
- `pnpm test -- src/media/mime.test.ts`

Fixes #51881

Made with [Cursor](https://cursor.com)