### PR TITLE
Config: add azure-openai-responses to model provider API enum (#51735)

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -36,6 +36,7 @@ const OPENAI_MODEL_APIS = new Set([
   "openai-completions",
   "openai-responses",
   "openai-codex-responses",
+  "azure-openai-responses",
 ]);
 
 function isOpenAiApi(modelApi?: string | null): boolean {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -6,6 +6,7 @@ export const MODEL_APIS = [
   "openai-responses",
   "openai-codex-responses",
   "anthropic-messages",
+  "azure-openai-responses",
   "google-generative-ai",
   "github-copilot",
   "bedrock-converse-stream",


### PR DESCRIPTION
## Summary
Add `azure-openai-responses` to `MODEL_APIS` / zod schema and include it in OpenAI-family transcript API handling.

## Test plan
- Pre-commit `pnpm check` (includes tsgo + lint)

Fixes #51735

Made with [Cursor](https://cursor.com)