### PR TITLE
Telegram: retry when transient errno is nested under HttpError.cause (#51525)

### DIFF
--- a/src/infra/retry-policy.test.ts
+++ b/src/infra/retry-policy.test.ts
@@ -97,6 +97,25 @@ describe("createTelegramRetryRunner", () => {
         expectedCalls: 3,
         expectedError: "connection timeout",
       },
+      {
+        name: "retries grammY-style HttpError when errno lives on error.cause",
+        runnerOptions: {
+          retry: { ...ZERO_DELAY_RETRY, attempts: 2 },
+        },
+        fnSteps: [
+          {
+            type: "reject" as const,
+            value: Object.assign(new Error("Network request for 'sendMessage' failed!"), {
+              cause: Object.assign(new Error("read ECONNRESET"), {
+                code: "ECONNRESET",
+              }),
+            }),
+          },
+          { type: "resolve" as const, value: "ok" },
+        ],
+        expectedCalls: 2,
+        expectedValue: "ok",
+      },
     ])("$name", async ({ runnerOptions, fnSteps, expectedCalls, expectedValue, expectedError }) => {
       vi.useFakeTimers();
       const runner = createTelegramRetryRunner(runnerOptions);

--- a/src/infra/retry-policy.ts
+++ b/src/infra/retry-policy.ts
@@ -1,5 +1,5 @@
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { formatErrorMessage } from "./errors.js";
+import { formatErrorMessage, isErrno } from "./errors.js";
 import { type RetryConfig, resolveRetryConfig, retryAsync } from "./retry.js";
 
 export type RetryRunner = <T>(fn: () => Promise<T>, label?: string) => Promise<T>;
@@ -14,18 +14,35 @@ export const TELEGRAM_RETRY_DEFAULTS = {
 const TELEGRAM_RETRY_RE = /429|timeout|connect|reset|closed|unavailable|temporarily/i;
 const log = createSubsystemLogger("retry-policy");
 
+function formatErrorMessageWithCauses(err: unknown): string {
+  if (!(err instanceof Error)) {
+    return formatErrorMessage(err);
+  }
+  const parts: string[] = [formatErrorMessage(err)];
+  let cursor: unknown = err.cause;
+  let depth = 0;
+  while (cursor instanceof Error && depth < 8) {
+    const msg = formatErrorMessage(cursor);
+    const code = isErrno(cursor) && cursor.code ? String(cursor.code) : "";
+    parts.push(code ? `${msg} ${code}` : msg);
+    cursor = cursor.cause;
+    depth += 1;
+  }
+  return parts.join(" ");
+}
+
 function resolveTelegramShouldRetry(params: {
   shouldRetry?: (err: unknown) => boolean;
   strictShouldRetry?: boolean;
 }) {
   if (!params.shouldRetry) {
-    return (err: unknown) => TELEGRAM_RETRY_RE.test(formatErrorMessage(err));
+    return (err: unknown) => TELEGRAM_RETRY_RE.test(formatErrorMessageWithCauses(err));
   }
   if (params.strictShouldRetry) {
     return params.shouldRetry;
   }
   return (err: unknown) =>
-    params.shouldRetry?.(err) || TELEGRAM_RETRY_RE.test(formatErrorMessage(err));
+    params.shouldRetry?.(err) || TELEGRAM_RETRY_RE.test(formatErrorMessageWithCauses(err));
 }
 
 function getTelegramRetryAfterMs(err: unknown): number | undefined {


### PR DESCRIPTION
## Summary
Include `Error.cause` messages and `code` fields when evaluating the default Telegram retry regex, so grammY `Network request for … failed!` errors still retry when the root cause is `ECONNRESET` / similar.

## Test plan
- `pnpm test -- src/infra/retry-policy.test.ts`

Fixes #51525

Made with [Cursor](https://cursor.com)