### PR TITLE
WhatsApp: ignore quotedMessage mentions for requireMention (#51804)

### DIFF
--- a/extensions/whatsapp/src/inbound/extract.mention.test.ts
+++ b/extensions/whatsapp/src/inbound/extract.mention.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { extractMentionedJids } from "./extract.js";
+
+describe("extractMentionedJids", () => {
+  it("ignores mentionedJid carried only on quotedMessage context (reply-to-mention false positive)", () => {
+    const raw = {
+      extendedTextMessage: {
+        text: "reply text",
+        contextInfo: {
+          quotedMessage: {
+            extendedTextMessage: {
+              contextInfo: { mentionedJid: ["15551234567@s.whatsapp.net"] },
+            },
+          },
+        },
+      },
+    };
+    expect(extractMentionedJids(raw as never)).toBeUndefined();
+  });
+
+  it("still returns top-level mentions on the reply itself", () => {
+    const raw = {
+      extendedTextMessage: {
+        text: "@bot hi",
+        contextInfo: {
+          mentionedJid: ["15551234567@s.whatsapp.net"],
+        },
+      },
+    };
+    expect(extractMentionedJids(raw as never)).toEqual(["15551234567@s.whatsapp.net"]);
+  });
+});

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -66,8 +66,6 @@ export function extractMentionedJids(rawMessage: proto.IMessage | undefined): st
 
   const candidates: Array<string[] | null | undefined> = [
     message.extendedTextMessage?.contextInfo?.mentionedJid,
-    message.extendedTextMessage?.contextInfo?.quotedMessage?.extendedTextMessage?.contextInfo
-      ?.mentionedJid,
     message.imageMessage?.contextInfo?.mentionedJid,
     message.videoMessage?.contextInfo?.mentionedJid,
     message.documentMessage?.contextInfo?.mentionedJid,


### PR DESCRIPTION
## Summary
Stop merging `quotedMessage.extendedTextMessage.contextInfo.mentionedJid` into `extractMentionedJids` so group `requireMention` only considers mentions on the inbound message itself.

## Test plan
- `pnpm test -- extensions/whatsapp/src/inbound/extract.mention.test.ts`

Fixes #51804

Made with [Cursor](https://cursor.com)