### PR TITLE
Web UI: fix code block copy on Edge via clipboard fallback (#51664)

### DIFF
--- a/ui/src/ui/clipboard.ts
+++ b/ui/src/ui/clipboard.ts
@@ -1,0 +1,27 @@
+/** Best-effort clipboard write; falls back for browsers where Clipboard API rejects (e.g. some Edge setups). */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  try {
+    if (globalThis.navigator?.clipboard?.writeText) {
+      await globalThis.navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // fall through to execCommand
+  }
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.left = "-9999px";
+    ta.style.top = "0";
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -26,6 +26,7 @@ import {
   type SlashCommandDef,
 } from "../chat/slash-commands.ts";
 import { isSttSupported, startStt, stopStt } from "../chat/speech.ts";
+import { copyTextToClipboard } from "../clipboard.ts";
 import { icons } from "../icons.ts";
 import { detectTextDirection } from "../text-direction.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
@@ -878,13 +879,12 @@ export function renderChat(props: ChatProps) {
       return;
     }
     const code = (btn as HTMLElement).dataset.code ?? "";
-    navigator.clipboard.writeText(code).then(
-      () => {
+    void copyTextToClipboard(code).then((ok) => {
+      if (ok) {
         btn.classList.add("copied");
         setTimeout(() => btn.classList.remove("copied"), 1500);
-      },
-      () => {},
-    );
+      }
+    });
   };
 
   const chatItems = buildChatItems(props);


### PR DESCRIPTION
## Summary
Add `copyTextToClipboard` helper that tries the Clipboard API then falls back to `execCommand('copy')`, and use it for markdown code-block Copy in WebChat.

## Test plan
- Manual: WebChat in Microsoft Edge, click Copy on a code block
- Pre-commit: `pnpm check` (includes UI lint path for touched files)

Fixes #51664

Made with [Cursor](https://cursor.com)