### PR TITLE
refactor(usage): drop empty detail placeholder state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Models/OpenAI: switch the default OpenAI setup model to `openai/gpt-5.4`, keep Codex on `openai-codex/gpt-5.4`, and centralize OpenAI chat, image, TTS, transcription, and embedding defaults in one shared module so future default-model updates stay low-churn. Thanks @vincentkoc.
 - Memory/plugins: let the active memory plugin register its own system-prompt section while preserving cache-clear and snapshot-load prompt isolation. (#40126) Thanks @jarimustonen.
 - Control UI/usage: improve usage overview styling, localization, and responsive chat/context-notice presentation, including safer theme color handling and unclipped usage-header menus. (#51951) Thanks @BunsDev.
+- Control UI/usage: drop the empty session-detail placeholder card so the usage view stays single-column until a real session detail panel is selected. (#52013) Thanks @BunsDev.
 
 ### Fixes
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -314,12 +314,6 @@ export const en: TranslationMap = {
       limitReached: "Showing first 1,000 sessions. Narrow date range for complete results.",
     },
     details: {
-      emptyTitle: "Select a session",
-      emptySubtitle:
-        "Pick a session to inspect the timeline, conversation, and prompt context for a single run.",
-      emptyTimeline: "Turn-by-turn timeline",
-      emptyConversation: "Conversation logs",
-      emptyContext: "Prompt breakdown",
       noUsageData: "No usage data for this session.",
       duration: "Duration",
       modelMix: "Model Mix",

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -11,7 +11,6 @@
 .usage-page .card,
 .usage-page .stat,
 .usage-page .usage-insight-card,
-.usage-page .session-detail-empty,
 .usage-page .context-details-panel,
 .usage-page .session-logs-compact,
 .usage-page .session-timeseries-compact {
@@ -54,8 +53,7 @@
 .usage-mosaic,
 .usage-left-card,
 .sessions-card,
-.session-detail-panel,
-.session-detail-empty {
+.session-detail-panel {
   position: relative;
   overflow: clip;
 }
@@ -471,7 +469,6 @@ details.usage-filter-select summary::-webkit-details-marker,
 .usage-query-chips,
 .usage-query-suggestions,
 .usage-badges,
-.session-detail-empty__features,
 .usage-empty-state__features {
   display: flex;
   flex-wrap: wrap;
@@ -481,7 +478,6 @@ details.usage-filter-select summary::-webkit-details-marker,
 .usage-query-chip,
 .usage-query-suggestion,
 .usage-badge,
-.session-detail-empty__feature,
 .usage-empty-state__feature {
   display: inline-flex;
   align-items: center;
@@ -532,22 +528,19 @@ details.usage-filter-select summary::-webkit-details-marker,
   color: var(--text);
 }
 
-.usage-empty-state,
-.session-detail-empty {
+.usage-empty-state {
   display: grid;
   gap: 12px;
   justify-items: start;
 }
 
-.usage-empty-state__title,
-.session-detail-empty__title {
+.usage-empty-state__title {
   font-size: 20px;
   font-weight: 700;
   color: var(--text-strong);
 }
 
-.usage-empty-state__subtitle,
-.session-detail-empty__subtitle {
+.usage-empty-state__subtitle {
   max-width: 640px;
 }
 
@@ -892,9 +885,14 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .usage-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: 16px;
   align-items: start;
+}
+
+/* Expand to two columns when the detail panel column is present */
+.usage-grid:has(.usage-grid-column:nth-child(2)) {
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
 }
 
 .usage-grid-column {

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -26,20 +26,6 @@ function pct(part: number, total: number): number {
   return (part / total) * 100;
 }
 
-function renderEmptyDetailState() {
-  return html`
-    <section class="card session-detail-empty">
-      <div class="session-detail-empty__title">${t("usage.details.emptyTitle")}</div>
-      <div class="card-sub session-detail-empty__subtitle">${t("usage.details.emptySubtitle")}</div>
-      <div class="session-detail-empty__features">
-        <span class="session-detail-empty__feature">${t("usage.details.emptyTimeline")}</span>
-        <span class="session-detail-empty__feature">${t("usage.details.emptyConversation")}</span>
-        <span class="session-detail-empty__feature">${t("usage.details.emptyContext")}</span>
-      </div>
-    </section>
-  `;
-}
-
 /** Normalize a log timestamp to milliseconds (handles seconds vs ms). */
 function normalizeLogTimestamp(ts: number): number {
   return ts < 1e12 ? ts * 1000 : ts;
@@ -1140,7 +1126,6 @@ function renderSessionLogsCompact(
 export {
   computeFilteredUsage,
   renderContextPanel,
-  renderEmptyDetailState,
   renderSessionDetailPanel,
   renderSessionLogsCompact,
   renderSessionSummary,

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -23,7 +23,7 @@ import {
   removeQueryToken,
   setQueryTokensForKey,
 } from "./usage-query.ts";
-import { renderEmptyDetailState, renderSessionDetailPanel } from "./usage-render-details.ts";
+import { renderSessionDetailPanel } from "./usage-render-details.ts";
 import {
   renderCostBreakdownCompact,
   renderDailyChartCompact,
@@ -815,10 +815,10 @@ export function renderUsage(props: UsageProps) {
                     filterActions.onClearSessions,
                   )}
                 </div>
-                <div class="usage-grid-column">
-                  ${
-                    primarySelectedEntry
-                      ? renderSessionDetailPanel(
+                ${
+                  primarySelectedEntry
+                    ? html`<div class="usage-grid-column">
+                        ${renderSessionDetailPanel(
                           primarySelectedEntry,
                           detail.timeSeries,
                           detail.timeSeriesLoading,
@@ -845,10 +845,10 @@ export function renderUsage(props: UsageProps) {
                           display.contextExpanded,
                           detailActions.onToggleContextExpanded,
                           filterActions.onClearSessions,
-                        )
-                      : renderEmptyDetailState()
-                  }
-                </div>
+                        )}
+                      </div>`
+                    : nothing
+                }
               </div>
             `
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the usage view still carries an empty right-column placeholder state that adds copy, styling, and layout complexity even when no session is selected.
- Why it matters: the detail column should only appear when there is an actual selected session to inspect, keeping the usage layout simpler and reducing dead UI.
- What changed: removed the empty session-detail placeholder state, dropped its unused i18n strings/export, and made the usage grid expand to two columns only when a detail column is actually present.
- What did NOT change (scope boundary): no backend usage data changes, no gateway/API contract changes, and no cron/config/theme work in this PR.

## Change Type (select all)

- [ ] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51951

## User-visible / Behavior Changes

- The usage page no longer shows an empty detail placeholder card when no session is selected.
- The usage layout stays single-column until a real detail panel is present.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: n/a
- Integration/channel (if any): OpenClaw Control UI
- Relevant config (redacted): default local dev setup

### Steps

1. Open the Usage page with no session selected.
2. Confirm no empty detail placeholder renders.
3. Select a session and confirm the detail column appears as expected.

### Expected

- No empty placeholder card when no session is selected.
- Detail column appears only when a session is selected.

### Actual

- Matches expected based on the current branch state.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:
- `pnpm check` ✅

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reduced the branch to a minimal four-file usage-only diff on top of current `main` and ran `pnpm check` successfully.
- Edge cases checked: ensured the detail column is conditionally rendered rather than replaced by a placeholder state.
- What you did **not** verify: fresh screenshot capture or browser-recorded walkthrough in this pass.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `ui/src/i18n/locales/en.ts`, `ui/src/styles/usage.css`, `ui/src/ui/views/usage-render-details.ts`, `ui/src/ui/views/usage.ts`.
- Known bad symptoms reviewers should watch for: missing detail column when a session is selected, or broken usage grid layout.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the `:has(...)`-based grid expansion rule could behave differently in unsupported environments.
  - Mitigation: this affects the Control UI’s browser surface only, and the fallback remains a usable single-column layout.
