### PR TITLE
fix(agent): treat Anthropic long-context usage errors as context overflow for compact+retry

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -3,6 +3,7 @@ import {
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
   extractObservedOverflowTokenCount,
+  isAnthropicLongContextUsageError,
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
@@ -418,6 +419,28 @@ describe("error classifiers", () => {
   });
 });
 
+describe("isAnthropicLongContextUsageError", () => {
+  it("detects Anthropic long-context usage errors", () => {
+    expect(
+      isAnthropicLongContextUsageError("Extra usage is required for long context requests."),
+    ).toBe(true);
+    expect(
+      isAnthropicLongContextUsageError("extra usage is required for long context requests"),
+    ).toBe(true);
+    expect(
+      isAnthropicLongContextUsageError(
+        "429 Extra usage is required for long context requests. Please contact support.",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated rate limit messages", () => {
+    expect(isAnthropicLongContextUsageError("Rate limit exceeded")).toBe(false);
+    expect(isAnthropicLongContextUsageError("429 Too Many Requests")).toBe(false);
+    expect(isAnthropicLongContextUsageError("context length exceeded")).toBe(false);
+  });
+});
+
 describe("isLikelyContextOverflowError", () => {
   it("matches context overflow hints", () => {
     const samples = [
@@ -483,6 +506,20 @@ describe("isLikelyContextOverflowError", () => {
       expect(isBillingErrorMessage(sample)).toBe(true);
       expect(isLikelyContextOverflowError(sample)).toBe(false);
     }
+  });
+
+  it("treats Anthropic long-context 429 as context overflow (not rate limit)", () => {
+    // Anthropic returns HTTP 429 for this message, but it is semantically a context
+    // overflow — the session is too large. It should route to compact+retry, not
+    // model fallback.
+    expect(isLikelyContextOverflowError("Extra usage is required for long context requests.")).toBe(
+      true,
+    );
+    expect(isLikelyContextOverflowError("extra usage is required for long context requests")).toBe(
+      true,
+    );
+    // Standard rate limit messages must still be excluded
+    expect(isLikelyContextOverflowError("Rate limit exceeded")).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -29,6 +29,7 @@ export {
   isCloudflareOrHtmlErrorPage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
+  isAnthropicLongContextUsageError,
   isContextOverflowError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -188,6 +188,17 @@ const CONTEXT_OVERFLOW_HINT_RE =
 const RATE_LIMIT_HINT_RE =
   /rate limit|too many requests|requests per (?:minute|hour|day)|quota|throttl|429\b|tokens per day/i;
 
+/**
+ * Detects Anthropic's 429 "Extra usage is required for long context requests." error.
+ *
+ * Anthropic returns HTTP 429 for this case, but it is semantically a context overflow
+ * (the session is too large for the standard usage tier), not a transient rate limit.
+ * It should be routed to the compact+retry path instead of the model fallback chain.
+ */
+export function isAnthropicLongContextUsageError(errorMessage: string): boolean {
+  return errorMessage.toLowerCase().includes("extra usage is required for long context");
+}
+
 export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
@@ -212,6 +223,14 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) {
     return false;
   }
+
+  // Anthropic returns HTTP 429 for "Extra usage is required for long context requests."
+  // This is semantically a context overflow (session too large), not a transient rate limit.
+  // Detect it before the isRateLimitErrorMessage exclusion so it routes to compact+retry.
+  if (isAnthropicLongContextUsageError(errorMessage)) {
+    return true;
+  }
+
   // Rate limit errors can match the broad CONTEXT_OVERFLOW_HINT_RE pattern
   // (e.g., "request reached organization TPD rate limit" matches request.*limit).
   // Exclude them before checking context overflow heuristics.


### PR DESCRIPTION
## Problem

When Anthropic returns a 429 with the message `"Extra usage is required for long context requests."`, OpenClaw treats it as a rate limit error and cascades through all model fallbacks — which also fail for the same reason. The user sees a hard failure with all 3 models reporting `rate_limit`.

The real cause is the session context is too large for the standard usage tier. The correct fix is to detect this specific error and route it to the existing compact+retry path.

## Root Cause

`isLikelyContextOverflowError()` in `src/agents/pi-embedded-helpers/errors.ts` correctly excludes rate limit errors (via `isRateLimitErrorMessage()`) before checking context overflow patterns. But Anthropic returns HTTP 429 for the long-context usage error — which is semantically a context overflow, not a transient rate limit — so it was falling through to the `isRateLimitErrorMessage()` exclusion and returning `false`.

## Fix

- Add `isAnthropicLongContextUsageError(errorMessage: string): boolean` — case-insensitive substring match on `"extra usage is required for long context"`
- In `isLikelyContextOverflowError()`, check the new helper **before** the `isRateLimitErrorMessage()` exclusion; if it matches, return `true` immediately
- Export the new function from the `pi-embedded-helpers` barrel
- Add test cases in `pi-embedded-helpers.isbillingerrormessage.test.ts` under both the new `isAnthropicLongContextUsageError` describe block and the existing `isLikelyContextOverflowError` block

The existing compact+retry path in `src/agents/pi-embedded-runner/run.ts` already calls `isLikelyContextOverflowError()` — no changes needed there.

## Testing

All 74 tests in `pi-embedded-helpers.isbillingerrormessage.test.ts` pass, including the 3 new cases.