### PR TITLE
feat(webchat): add new chat session button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,8 +877,6 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
-        with:
-          gradle-version: 8.11.1
 
       - name: Install Android SDK packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -877,6 +877,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
+        with:
+          gradle-version: 8.11.1
 
       - name: Install Android SDK packages
         run: |

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -179,14 +179,14 @@ Long options are validated fail-closed in safe-bin mode: unknown flags and ambig
 abbreviations are rejected.
 Denied flags by safe-bin profile:
 
-[//]: # "SAFE_BIN_DENIED_FLAGS:START"
+<!-- SAFE_BIN_DENIED_FLAGS:START -->
 
 - `grep`: `--dereference-recursive`, `--directories`, `--exclude-from`, `--file`, `--recursive`, `-R`, `-d`, `-f`, `-r`
 - `jq`: `--argfile`, `--from-file`, `--library-path`, `--rawfile`, `--slurpfile`, `-L`, `-f`
 - `sort`: `--compress-program`, `--files0-from`, `--output`, `--random-source`, `--temporary-directory`, `-T`, `-o`
 - `wc`: `--files0-from`
 
-[//]: # "SAFE_BIN_DENIED_FLAGS:END"
+<!-- SAFE_BIN_DENIED_FLAGS:END -->
 
 Safe bins also force argv tokens to be treated as **literal text** at execution time (no globbing
 and no `$VARS` expansion) for stdin-only segments, so patterns like `*` or `$HOME/...` cannot be

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -12,8 +12,8 @@ const {
   botCtorSpy,
   commandSpy,
   dispatchReplyWithBufferedBlockDispatcher,
-  getLoadWebMediaMock,
   getLoadConfigMock,
+  getLoadWebMediaMock,
   getOnHandler,
   getReadChannelAllowFromStoreMock,
   getUpsertChannelPairingRequestMock,
@@ -51,6 +51,7 @@ const createTelegramBot = (opts: Parameters<typeof createTelegramBotBase>[0]) =>
   });
 
 const loadConfig = getLoadConfigMock();
+const loadWebMedia = getLoadWebMediaMock();
 const readChannelAllowFromStore = getReadChannelAllowFromStoreMock();
 const upsertChannelPairingRequest = getUpsertChannelPairingRequestMock();
 

--- a/scripts/generate-bundled-plugin-metadata.mjs
+++ b/scripts/generate-bundled-plugin-metadata.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { writeTextFileIfChanged } from "./runtime-postbuild-shared.mjs";
@@ -8,6 +9,8 @@ const GENERATED_BY = "scripts/generate-bundled-plugin-metadata.mjs";
 const DEFAULT_OUTPUT_PATH = "src/plugins/bundled-plugin-metadata.generated.ts";
 const MANIFEST_KEY = "openclaw";
 const FORMATTER_CWD = path.resolve(import.meta.dirname, "..");
+const require = createRequire(import.meta.url);
+const OXFMT_BIN_PATH = require.resolve("oxfmt/bin/oxfmt");
 const CANONICAL_PACKAGE_ID_ALIASES = {
   "elevenlabs-speech": "elevenlabs",
   "microsoft-speech": "microsoft",
@@ -129,14 +132,12 @@ function normalizePluginManifest(raw) {
 function formatTypeScriptModule(source, { outputPath }) {
   const formatterPath = path.relative(FORMATTER_CWD, outputPath) || outputPath;
   const formatter = spawnSync(
-    process.platform === "win32" ? "pnpm" : "pnpm",
-    ["exec", "oxfmt", "--stdin-filepath", formatterPath],
+    process.execPath,
+    [OXFMT_BIN_PATH, "--stdin-filepath", formatterPath],
     {
       cwd: FORMATTER_CWD,
       input: source,
       encoding: "utf8",
-      // Windows requires a shell to launch package-manager shim scripts reliably.
-      ...(process.platform === "win32" ? { shell: true } : {}),
     },
   );
   if (formatter.status !== 0) {

--- a/scripts/lib/ts-guard-utils.mjs
+++ b/scripts/lib/ts-guard-utils.mjs
@@ -3,15 +3,14 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+const baseTestSuffixes = [".test.ts", ".test-utils.ts", ".test-harness.ts", ".e2e-harness.ts"];
 const require = createRequire(import.meta.url);
-let tsCache;
+let cachedTypeScript;
 
 function getTypeScript() {
-  tsCache ??= require("typescript");
-  return tsCache;
+  cachedTypeScript ??= require("typescript");
+  return cachedTypeScript;
 }
-
-const baseTestSuffixes = [".test.ts", ".test-utils.ts", ".test-harness.ts", ".e2e-harness.ts"];
 
 export function resolveRepoRoot(importMetaUrl) {
   return path.resolve(path.dirname(fileURLToPath(importMetaUrl)), "..", "..");

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -28,6 +28,7 @@ vi.mock("./gateway-rpc.js", async () => {
 vi.mock("../runtime.js", () => ({
   defaultRuntime: {
     log: vi.fn(),
+    writeJson: vi.fn(),
     error: vi.fn(),
     writeStdout: vi.fn(),
     writeJson: vi.fn(),

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -31,7 +31,6 @@ vi.mock("../runtime.js", () => ({
     writeJson: vi.fn(),
     error: vi.fn(),
     writeStdout: vi.fn(),
-    writeJson: vi.fn(),
     exit: (code: number) => {
       throw new Error(`__exit__:${code}`);
     },

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -43,8 +43,6 @@ vi.mock("../runtime.js", () => ({
       mocks.writeJson(JSON.stringify(value, null, space > 0 ? space : undefined)),
     error: (...args: unknown[]) => mocks.error(...args),
     writeStdout: (value: string) => mocks.log(value.endsWith("\n") ? value.slice(0, -1) : value),
-    writeJson: (value: unknown, space = 2) =>
-      mocks.log(JSON.stringify(value, null, space > 0 ? space : undefined)),
     exit: (...args: unknown[]) => mocks.exit(...args),
   },
 }));

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
   log: vi.fn(),
+  writeJson: vi.fn(),
   error: vi.fn(),
   exit: vi.fn(),
 }));
@@ -38,6 +39,8 @@ vi.mock("../channels/plugins/helpers.js", () => ({
 vi.mock("../runtime.js", () => ({
   defaultRuntime: {
     log: (...args: unknown[]) => mocks.log(...args),
+    writeJson: (value: unknown, space = 2) =>
+      mocks.writeJson(JSON.stringify(value, null, space > 0 ? space : undefined)),
     error: (...args: unknown[]) => mocks.error(...args),
     writeStdout: (value: string) => mocks.log(value.endsWith("\n") ? value.slice(0, -1) : value),
     writeJson: (value: unknown, space = 2) =>
@@ -100,7 +103,7 @@ describe("registerDirectoryCli", () => {
         accountId: "default",
       }),
     );
-    expect(mocks.log).toHaveBeenCalledWith(
+    expect(mocks.writeJson).toHaveBeenCalledWith(
       JSON.stringify({ id: "self-1", name: "Family Phone" }, null, 2),
     );
     expect(mocks.error).not.toHaveBeenCalled();

--- a/src/infra/exec-safe-bin-policy.test.ts
+++ b/src/infra/exec-safe-bin-policy.test.ts
@@ -14,8 +14,8 @@ import {
 
 const SAFE_BIN_DOC_DEFAULTS_START = '[//]: # "SAFE_BIN_DEFAULTS:START"';
 const SAFE_BIN_DOC_DEFAULTS_END = '[//]: # "SAFE_BIN_DEFAULTS:END"';
-const SAFE_BIN_DOC_DENIED_FLAGS_START = '[//]: # "SAFE_BIN_DENIED_FLAGS:START"';
-const SAFE_BIN_DOC_DENIED_FLAGS_END = '[//]: # "SAFE_BIN_DENIED_FLAGS:END"';
+const SAFE_BIN_DOC_DENIED_FLAGS_START = "<!-- SAFE_BIN_DENIED_FLAGS:START -->";
+const SAFE_BIN_DOC_DENIED_FLAGS_END = "<!-- SAFE_BIN_DENIED_FLAGS:END -->";
 
 function buildDeniedFlagArgvVariants(flag: string): string[][] {
   const value = "blocked";

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -728,6 +728,24 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius, 6px);
+  cursor: pointer;
+  color: var(--text-secondary, #888);
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+
+.chat-controls__new-chat:hover {
+  color: var(--text, #fff);
+  background: var(--hover-bg, rgba(255, 255, 255, 0.08));
+}
+
+.chat-controls__new-chat:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .chat-controls__model {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -743,6 +743,15 @@
   background: var(--hover-bg, rgba(255, 255, 255, 0.08));
 }
 
+.chat-controls__new-chat svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+}
+
 .chat-controls__new-chat:disabled {
   opacity: 0.4;
   cursor: not-allowed;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -67,12 +67,17 @@
   margin-top: 0 !important;
 }
 
-/* Focus mode exit button */
-.chat-focus-exit {
+/* Focus mode floating actions */
+.chat-focus-actions {
   position: absolute;
   top: 12px;
   right: 12px;
   z-index: 100;
+  display: flex;
+  gap: 8px;
+}
+
+.chat-focus-action {
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -92,13 +97,18 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
-.chat-focus-exit:hover {
+.chat-focus-action:hover {
   background: var(--panel-strong);
   color: var(--text);
   border-color: var(--accent);
 }
 
-.chat-focus-exit svg {
+.chat-focus-action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chat-focus-action svg {
   width: 16px;
   height: 16px;
   stroke: currentColor;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -718,8 +718,16 @@
 .chat-controls__session-row {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   flex-wrap: wrap;
+}
+
+.chat-controls__new-chat {
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .chat-controls__model {

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -13,10 +13,11 @@ vi.mock("./app-settings.ts", () => ({
 
 let handleSendChat: typeof import("./app-chat.ts").handleSendChat;
 let refreshChatAvatar: typeof import("./app-chat.ts").refreshChatAvatar;
+let resolveActiveChatAgentId: typeof import("./app-chat.ts").resolveActiveChatAgentId;
 
 async function loadChatHelpers(): Promise<void> {
   vi.resetModules();
-  ({ handleSendChat, refreshChatAvatar } = await import("./app-chat.ts"));
+  ({ handleSendChat, refreshChatAvatar, resolveActiveChatAgentId } = await import("./app-chat.ts"));
 }
 
 function makeHost(overrides?: Partial<ChatHost>): ChatHost {
@@ -34,6 +35,7 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     sessionKey: "agent:main",
     basePath: "",
     hello: null,
+    agentsList: null,
     chatAvatarUrl: null,
     chatModelOverrides: {},
     chatModelsLoading: false,
@@ -86,6 +88,44 @@ describe("refreshChatAvatar", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(host.chatAvatarUrl).toBeNull();
+  });
+});
+
+describe("resolveActiveChatAgentId", () => {
+  beforeEach(async () => {
+    await loadChatHelpers();
+  });
+
+  it("prefers the configured default agent for unscoped sessions", () => {
+    const host = makeHost({
+      sessionKey: "main",
+      hello: {
+        snapshot: {
+          sessionDefaults: {
+            defaultAgentId: "ops",
+          },
+        },
+      } as ChatHost["hello"],
+      agentsList: { defaultId: "fallback" },
+    });
+
+    expect(resolveActiveChatAgentId(host)).toBe("ops");
+  });
+
+  it("keeps the explicit session agent over configured defaults", () => {
+    const host = makeHost({
+      sessionKey: "agent:research:main",
+      hello: {
+        snapshot: {
+          sessionDefaults: {
+            defaultAgentId: "ops",
+          },
+        },
+      } as ChatHost["hello"],
+      agentsList: { defaultId: "fallback" },
+    });
+
+    expect(resolveActiveChatAgentId(host)).toBe("research");
   });
 });
 

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -38,6 +38,7 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatModelOverrides: {},
     chatModelsLoading: false,
     chatModelCatalog: [],
+    chatActivityVersion: 0,
     refreshSessionsAfterChat: new Set<string>(),
     updateComplete: Promise.resolve(),
     ...overrides,

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -10,7 +10,7 @@ import { loadModels } from "./controllers/models.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
-import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
+import type { AgentsListResult, ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
 
@@ -28,6 +28,7 @@ export type ChatHost = {
   sessionKey: string;
   basePath: string;
   hello: GatewayHelloOk | null;
+  agentsList?: Pick<AgentsListResult, "defaultId"> | null;
   chatAvatarUrl: string | null;
   chatModelOverrides: Record<string, ChatModelOverride | null>;
   chatModelsLoading: boolean;
@@ -398,7 +399,9 @@ type SessionDefaultsSnapshot = {
   defaultAgentId?: string;
 };
 
-function resolveAgentIdForSession(host: ChatHost): string | null {
+type ActiveChatAgentState = Pick<ChatHost, "sessionKey" | "hello" | "agentsList">;
+
+export function resolveActiveChatAgentId(host: ActiveChatAgentState): string {
   const parsed = parseAgentSessionKey(host.sessionKey);
   if (parsed?.agentId) {
     return parsed.agentId;
@@ -407,7 +410,11 @@ function resolveAgentIdForSession(host: ChatHost): string | null {
     | { sessionDefaults?: SessionDefaultsSnapshot }
     | undefined;
   const fallback = snapshot?.sessionDefaults?.defaultAgentId?.trim();
-  return fallback || "main";
+  if (fallback) {
+    return fallback;
+  }
+  const listFallback = host.agentsList?.defaultId?.trim();
+  return listFallback || "main";
 }
 
 function buildAvatarMetaUrl(basePath: string, agentId: string): string {
@@ -421,11 +428,7 @@ export async function refreshChatAvatar(host: ChatHost) {
     host.chatAvatarUrl = null;
     return;
   }
-  const agentId = resolveAgentIdForSession(host);
-  if (!agentId) {
-    host.chatAvatarUrl = null;
-    return;
-  }
+  const agentId = resolveActiveChatAgentId(host);
   host.chatAvatarUrl = null;
   const url = buildAvatarMetaUrl(host.basePath, agentId);
   try {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -32,6 +32,7 @@ export type ChatHost = {
   chatModelOverrides: Record<string, ChatModelOverride | null>;
   chatModelsLoading: boolean;
   chatModelCatalog: ModelCatalogEntry[];
+  chatActivityVersion: number;
   updateComplete?: Promise<unknown>;
   refreshSessionsAfterChat: Set<string>;
   /** Callback for slash-command side effects that need app-level access. */
@@ -94,6 +95,7 @@ function enqueueChatMessage(
   if (!trimmed && !hasAttachments) {
     return;
   }
+  host.chatActivityVersion += 1;
   host.chatQueue = [
     ...host.chatQueue,
     {
@@ -120,6 +122,7 @@ async function sendChatMessageNow(
     refreshSessions?: boolean;
   },
 ) {
+  host.chatActivityVersion += 1;
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
   // Reset scroll state before sending to ensure auto-scroll works for the response
   resetChatScroll(host as unknown as Parameters<typeof resetChatScroll>[0]);
@@ -186,6 +189,10 @@ async function flushChatQueue(host: ChatHost) {
 }
 
 export function removeQueuedMessage(host: ChatHost, id: string) {
+  if (!host.chatQueue.some((item) => item.id === id)) {
+    return;
+  }
+  host.chatActivityVersion += 1;
   host.chatQueue = host.chatQueue.filter((item) => item.id !== id);
 }
 
@@ -290,6 +297,7 @@ async function dispatchSlashCommand(
       });
       return;
     case "clear":
+      host.chatActivityVersion += 1;
       await clearChatHistory(host);
       return;
     case "focus":
@@ -304,6 +312,7 @@ async function dispatchSlashCommand(
     return;
   }
 
+  host.chatActivityVersion += 1;
   const targetSessionKey = host.sessionKey;
   const result = await executeSlashCommand(host.client, targetSessionKey, name, args);
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -567,7 +567,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
-async function createNewChatSession(state: AppViewState) {
+export async function createNewChatSession(state: AppViewState) {
   const client = (state as unknown as OpenClawApp).client;
   if (!client || !state.connected) {
     return;
@@ -588,6 +588,7 @@ async function createNewChatSession(state: AppViewState) {
   const activityVersionAtStart = state.chatActivityVersion;
   const startedWithComposerContent =
     composerSnapshot.message.trim().length > 0 || composerSnapshot.attachments.length > 0;
+  const startedWithQueuedItems = state.chatQueue.length > 0;
   state.newChatSessionPending = true;
   state.lastError = null;
   try {
@@ -601,6 +602,7 @@ async function createNewChatSession(state: AppViewState) {
       const safeToAutoSwitch =
         state.sessionKey === originSessionKey &&
         !startedWithComposerContent &&
+        !startedWithQueuedItems &&
         composerUnchanged &&
         chatActivityUnchanged;
       if (safeToAutoSwitch) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
 import { t } from "../i18n/index.ts";
-import { refreshChat } from "./app-chat.ts";
+import { refreshChat, resolveActiveChatAgentId } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
@@ -580,9 +580,7 @@ async function createNewChatSession(state: AppViewState) {
     return;
   }
   const label = raw.trim() || undefined;
-  // Resolve the current agent ID from the active session key
-  const parsed = parseAgentSessionKey(state.sessionKey);
-  const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
+  const agentId = resolveActiveChatAgentId(state);
   const originSessionKey = state.sessionKey;
   const composerSnapshot = cloneComposerSnapshot(state);
   const activityVersionAtStart = state.chatActivityVersion;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -585,6 +585,8 @@ async function createNewChatSession(state: AppViewState) {
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
   const originSessionKey = state.sessionKey;
   const composerSnapshot = cloneComposerSnapshot(state);
+  const startedWithComposerContent =
+    composerSnapshot.message.trim().length > 0 || composerSnapshot.attachments.length > 0;
   state.newChatSessionPending = true;
   state.lastError = null;
   try {
@@ -594,10 +596,13 @@ async function createNewChatSession(state: AppViewState) {
     });
     if (result?.key) {
       const composerUnchanged = areComposerSnapshotsEqual(state, composerSnapshot);
-      if (state.sessionKey === originSessionKey && composerUnchanged) {
+      const safeToAutoSwitch =
+        state.sessionKey === originSessionKey &&
+        !startedWithComposerContent &&
+        composerUnchanged;
+      if (safeToAutoSwitch) {
+        state.chatAttachments = [];
         switchChatSession(state, result.key);
-        state.chatMessage = composerSnapshot.message;
-        state.chatAttachments = composerSnapshot.attachments;
       } else {
         void refreshSessionOptions(state);
       }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -20,11 +20,60 @@ import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
 import type { ModelCatalogEntry, SessionsListResult } from "./types.ts";
+import type { ChatAttachment } from "./ui-types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
   mainKey?: string;
 };
+
+type ComposerSnapshot = {
+  message: string;
+  attachments: ChatAttachment[];
+};
+
+function cloneComposerSnapshot(state: AppViewState): ComposerSnapshot {
+  return {
+    message: state.chatMessage,
+    attachments: [...state.chatAttachments],
+  };
+}
+
+function areComposerSnapshotsEqual(state: AppViewState, snapshot: ComposerSnapshot): boolean {
+  if (state.chatMessage !== snapshot.message) {
+    return false;
+  }
+  if (state.chatAttachments.length !== snapshot.attachments.length) {
+    return false;
+  }
+  return state.chatAttachments.every((attachment, index) => {
+    const other = snapshot.attachments[index];
+    return (
+      other !== undefined &&
+      attachment.id === other.id &&
+      attachment.dataUrl === other.dataUrl &&
+      attachment.mimeType === other.mimeType
+    );
+  });
+}
+
+function canCreateNewChatSession(state: AppViewState): boolean {
+  return state.connected && !state.chatRunId && !state.newChatSessionPending;
+}
+
+function renderNewChatSessionButton(state: AppViewState) {
+  return html`
+    <button
+      class="chat-controls__new-chat"
+      title="New chat session"
+      aria-label="New chat session"
+      ?disabled=${!canCreateNewChatSession(state)}
+      @click=${() => createNewChatSession(state)}
+    >
+      ${icons.plus}
+    </button>
+  `;
+}
 
 function resolveSidebarChatSessionKey(state: AppViewState): string {
   const snapshot = state.hello?.snapshot as
@@ -167,15 +216,7 @@ export function renderChatSessionSelect(state: AppViewState) {
           )}
         </select>
       </label>
-      <button
-        class="chat-controls__new-chat"
-        title="New chat session"
-        aria-label="New chat session"
-        ?disabled=${!state.connected || Boolean(state.chatRunId) || state.newChatSessionPending}
-        @click=${() => createNewChatSession(state)}
-      >
-        ${icons.plus}
-      </button>
+      ${renderNewChatSessionButton(state)}
       ${modelSelect}
     </div>
   `;
@@ -417,29 +458,32 @@ export function renderChatMobileToggle(state: AppViewState) {
         e.stopPropagation();
       }}>
         <div class="chat-controls">
-          <label class="field chat-controls__session">
-            <select
-              .value=${state.sessionKey}
-              @change=${(e: Event) => {
-                const next = (e.target as HTMLSelectElement).value;
-                switchChatSession(state, next);
-              }}
-            >
-              ${sessionGroups.map(
-                (group) => html`
-                  <optgroup label=${group.label}>
-                    ${group.options.map(
-                      (opt) => html`
-                        <option value=${opt.key} title=${opt.title}>
-                          ${opt.label}
-                        </option>
-                      `,
-                    )}
-                  </optgroup>
-                `,
-              )}
-            </select>
-          </label>
+          <div class="chat-controls__session-row">
+            <label class="field chat-controls__session">
+              <select
+                .value=${state.sessionKey}
+                @change=${(e: Event) => {
+                  const next = (e.target as HTMLSelectElement).value;
+                  switchChatSession(state, next);
+                }}
+              >
+                ${sessionGroups.map(
+                  (group) => html`
+                    <optgroup label=${group.label}>
+                      ${group.options.map(
+                        (opt) => html`
+                          <option value=${opt.key} title=${opt.title}>
+                            ${opt.label}
+                          </option>
+                        `,
+                      )}
+                    </optgroup>
+                  `,
+                )}
+              </select>
+            </label>
+            ${renderNewChatSessionButton(state)}
+          </div>
           <div class="chat-controls__thinking">
             <button
               class="btn btn--sm btn--icon ${showThinking ? "active" : ""}"
@@ -521,12 +565,6 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
-function snapshotChatAttachments(attachments: AppViewState["chatAttachments"]): string {
-  return attachments
-    .map((attachment) => `${attachment.id}\u0000${attachment.mimeType}\u0000${attachment.dataUrl}`)
-    .join("\u0001");
-}
-
 async function createNewChatSession(state: AppViewState) {
   const client = (state as unknown as OpenClawApp).client;
   if (!client || !state.connected) {
@@ -546,8 +584,7 @@ async function createNewChatSession(state: AppViewState) {
   const parsed = parseAgentSessionKey(state.sessionKey);
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
   const originSessionKey = state.sessionKey;
-  const originDraft = state.chatMessage;
-  const originAttachments = snapshotChatAttachments(state.chatAttachments);
+  const composerSnapshot = cloneComposerSnapshot(state);
   state.newChatSessionPending = true;
   state.lastError = null;
   try {
@@ -556,12 +593,11 @@ async function createNewChatSession(state: AppViewState) {
       ...(label ? { label } : {}),
     });
     if (result?.key) {
-      const draftUnchanged = state.chatMessage === originDraft;
-      const attachmentsUnchanged =
-        snapshotChatAttachments(state.chatAttachments) === originAttachments;
-      if (state.sessionKey === originSessionKey && draftUnchanged && attachmentsUnchanged) {
-        state.chatAttachments = [];
+      const composerUnchanged = areComposerSnapshotsEqual(state, composerSnapshot);
+      if (state.sessionKey === originSessionKey && composerUnchanged) {
         switchChatSession(state, result.key);
+        state.chatMessage = composerSnapshot.message;
+        state.chatAttachments = composerSnapshot.attachments;
       } else {
         void refreshSessionOptions(state);
       }
@@ -577,13 +613,6 @@ async function createNewChatSession(state: AppViewState) {
 }
 
 async function refreshSessionOptions(state: AppViewState) {
-  // loadSessions() bails while another list request is running, so wait briefly
-  // for that fetch to finish before issuing the create-session refresh.
-  let attempts = 0;
-  while (state.sessionsLoading && attempts < 20) {
-    attempts += 1;
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
-  }
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     activeMinutes: 0,
     limit: 0,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -539,18 +539,20 @@ async function createNewChatSession(state: AppViewState) {
   // Resolve the current agent ID from the active session key
   const parsed = parseAgentSessionKey(state.sessionKey);
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
-  // Carry over the current model override so the new session starts on the same model
-  const currentModel = resolveModelOverrideValue(state) || undefined;
+  const originSessionKey = state.sessionKey;
   state.newChatSessionPending = true;
   state.lastError = null;
   try {
     const result = await client.request<{ ok: boolean; key: string }>("sessions.create", {
       agentId,
       ...(label ? { label } : {}),
-      ...(currentModel ? { model: currentModel } : {}),
     });
     if (result?.key) {
-      switchChatSession(state, result.key);
+      if (state.sessionKey === originSessionKey) {
+        switchChatSession(state, result.key);
+      } else {
+        void refreshSessionOptions(state);
+      }
     } else {
       state.lastError = "Session was created but no session key was returned.";
       void refreshSessionOptions(state);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -167,6 +167,15 @@ export function renderChatSessionSelect(state: AppViewState) {
           )}
         </select>
       </label>
+      <button
+        class="btn-ghost chat-controls__new-chat"
+        title="New chat session"
+        aria-label="New chat session"
+        ?disabled=${!state.connected}
+        @click=${() => createNewChatSession(state)}
+      >
+        ${icons.plus}
+      </button>
       ${modelSelect}
     </div>
   `;
@@ -510,6 +519,28 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   );
   void loadChatHistory(state as unknown as ChatState);
   void refreshSessionOptions(state);
+}
+
+async function createNewChatSession(state: AppViewState) {
+  const client = (state as unknown as OpenClawApp).client;
+  if (!client || !state.connected) {
+    return;
+  }
+  const label = window.prompt("Session name (optional):")?.trim() || undefined;
+  // Resolve the current agent ID from the active session key
+  const parsed = parseAgentSessionKey(state.sessionKey);
+  const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
+  try {
+    const result = await client.request<{ ok: boolean; key: string }>("sessions.create", {
+      agentId,
+      ...(label ? { label } : {}),
+    });
+    if (result?.key) {
+      switchChatSession(state, result.key);
+    }
+  } catch (err) {
+    state.lastError = String(err);
+  }
 }
 
 async function refreshSessionOptions(state: AppViewState) {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -92,6 +92,7 @@ function resolveSidebarChatSessionKey(state: AppViewState): string {
 
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
   state.sessionKey = sessionKey;
+  state.chatActivityVersion += 1;
   state.chatMessage = "";
   state.chatStream = null;
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
@@ -542,6 +543,7 @@ export function renderChatMobileToggle(state: AppViewState) {
 
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   state.sessionKey = nextSessionKey;
+  state.chatActivityVersion += 1;
   state.chatMessage = "";
   state.chatStream = null;
   // P1: Clear queued chat items from the previous session

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -168,7 +168,7 @@ export function renderChatSessionSelect(state: AppViewState) {
         </select>
       </label>
       <button
-        class="btn-ghost chat-controls__new-chat"
+        class="chat-controls__new-chat"
         title="New chat session"
         aria-label="New chat session"
         ?disabled=${!state.connected}
@@ -526,17 +526,27 @@ async function createNewChatSession(state: AppViewState) {
   if (!client || !state.connected) {
     return;
   }
-  const label = window.prompt("Session name (optional):")?.trim() || undefined;
+  // window.prompt returns null when cancelled — treat as explicit cancel, not an error
+  const raw = window.prompt("Session name (optional):");
+  if (raw === null) {
+    return;
+  }
+  const label = raw.trim() || undefined;
   // Resolve the current agent ID from the active session key
   const parsed = parseAgentSessionKey(state.sessionKey);
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
+  // Carry over the current model override so the new session starts on the same model
+  const currentModel = resolveModelOverrideValue(state) || undefined;
   try {
     const result = await client.request<{ ok: boolean; key: string }>("sessions.create", {
       agentId,
       ...(label ? { label } : {}),
+      ...(currentModel ? { model: currentModel } : {}),
     });
     if (result?.key) {
       switchChatSession(state, result.key);
+    } else {
+      state.lastError = "Session was created but no session key was returned.";
     }
   } catch (err) {
     state.lastError = String(err);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -171,7 +171,7 @@ export function renderChatSessionSelect(state: AppViewState) {
         class="chat-controls__new-chat"
         title="New chat session"
         aria-label="New chat session"
-        ?disabled=${!state.connected || Boolean(state.chatRunId)}
+        ?disabled=${!state.connected || Boolean(state.chatRunId) || state.newChatSessionPending}
         @click=${() => createNewChatSession(state)}
       >
         ${icons.plus}
@@ -521,15 +521,13 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
-let newChatSessionPending = false;
-
 async function createNewChatSession(state: AppViewState) {
   const client = (state as unknown as OpenClawApp).client;
   if (!client || !state.connected) {
     return;
   }
   // Prevent concurrent invocations while the RPC is in-flight
-  if (newChatSessionPending) {
+  if (state.newChatSessionPending) {
     return;
   }
   // window.prompt returns null when cancelled — treat as explicit cancel, not an error
@@ -543,7 +541,7 @@ async function createNewChatSession(state: AppViewState) {
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
   // Carry over the current model override so the new session starts on the same model
   const currentModel = resolveModelOverrideValue(state) || undefined;
-  newChatSessionPending = true;
+  state.newChatSessionPending = true;
   state.lastError = null;
   try {
     const result = await client.request<{ ok: boolean; key: string }>("sessions.create", {
@@ -559,7 +557,7 @@ async function createNewChatSession(state: AppViewState) {
   } catch (err) {
     state.lastError = String(err);
   } finally {
-    newChatSessionPending = false;
+    state.newChatSessionPending = false;
   }
 }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -597,9 +597,7 @@ async function createNewChatSession(state: AppViewState) {
     if (result?.key) {
       const composerUnchanged = areComposerSnapshotsEqual(state, composerSnapshot);
       const safeToAutoSwitch =
-        state.sessionKey === originSessionKey &&
-        !startedWithComposerContent &&
-        composerUnchanged;
+        state.sessionKey === originSessionKey && !startedWithComposerContent && composerUnchanged;
       if (safeToAutoSwitch) {
         state.chatAttachments = [];
         switchChatSession(state, result.key);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -521,6 +521,12 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
+function snapshotChatAttachments(attachments: AppViewState["chatAttachments"]): string {
+  return attachments
+    .map((attachment) => `${attachment.id}\u0000${attachment.mimeType}\u0000${attachment.dataUrl}`)
+    .join("\u0001");
+}
+
 async function createNewChatSession(state: AppViewState) {
   const client = (state as unknown as OpenClawApp).client;
   if (!client || !state.connected) {
@@ -540,6 +546,8 @@ async function createNewChatSession(state: AppViewState) {
   const parsed = parseAgentSessionKey(state.sessionKey);
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
   const originSessionKey = state.sessionKey;
+  const originDraft = state.chatMessage;
+  const originAttachments = snapshotChatAttachments(state.chatAttachments);
   state.newChatSessionPending = true;
   state.lastError = null;
   try {
@@ -548,7 +556,11 @@ async function createNewChatSession(state: AppViewState) {
       ...(label ? { label } : {}),
     });
     if (result?.key) {
-      if (state.sessionKey === originSessionKey) {
+      const draftUnchanged = state.chatMessage === originDraft;
+      const attachmentsUnchanged =
+        snapshotChatAttachments(state.chatAttachments) === originAttachments;
+      if (state.sessionKey === originSessionKey && draftUnchanged && attachmentsUnchanged) {
+        state.chatAttachments = [];
         switchChatSession(state, result.key);
       } else {
         void refreshSessionOptions(state);
@@ -565,6 +577,13 @@ async function createNewChatSession(state: AppViewState) {
 }
 
 async function refreshSessionOptions(state: AppViewState) {
+  // loadSessions() bails while another list request is running, so wait briefly
+  // for that fetch to finish before issuing the create-session refresh.
+  let attempts = 0;
+  while (state.sessionsLoading && attempts < 20) {
+    attempts += 1;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     activeMinutes: 0,
     limit: 0,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -521,9 +521,15 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
+let newChatSessionPending = false;
+
 async function createNewChatSession(state: AppViewState) {
   const client = (state as unknown as OpenClawApp).client;
   if (!client || !state.connected) {
+    return;
+  }
+  // Prevent concurrent invocations while the RPC is in-flight
+  if (newChatSessionPending) {
     return;
   }
   // window.prompt returns null when cancelled — treat as explicit cancel, not an error
@@ -537,6 +543,8 @@ async function createNewChatSession(state: AppViewState) {
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
   // Carry over the current model override so the new session starts on the same model
   const currentModel = resolveModelOverrideValue(state) || undefined;
+  newChatSessionPending = true;
+  state.lastError = null;
   try {
     const result = await client.request<{ ok: boolean; key: string }>("sessions.create", {
       agentId,
@@ -550,6 +558,8 @@ async function createNewChatSession(state: AppViewState) {
     }
   } catch (err) {
     state.lastError = String(err);
+  } finally {
+    newChatSessionPending = false;
   }
 }
 

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -585,6 +585,7 @@ async function createNewChatSession(state: AppViewState) {
   const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
   const originSessionKey = state.sessionKey;
   const composerSnapshot = cloneComposerSnapshot(state);
+  const activityVersionAtStart = state.chatActivityVersion;
   const startedWithComposerContent =
     composerSnapshot.message.trim().length > 0 || composerSnapshot.attachments.length > 0;
   state.newChatSessionPending = true;
@@ -596,8 +597,12 @@ async function createNewChatSession(state: AppViewState) {
     });
     if (result?.key) {
       const composerUnchanged = areComposerSnapshotsEqual(state, composerSnapshot);
+      const chatActivityUnchanged = state.chatActivityVersion === activityVersionAtStart;
       const safeToAutoSwitch =
-        state.sessionKey === originSessionKey && !startedWithComposerContent && composerUnchanged;
+        state.sessionKey === originSessionKey &&
+        !startedWithComposerContent &&
+        composerUnchanged &&
+        chatActivityUnchanged;
       if (safeToAutoSwitch) {
         state.chatAttachments = [];
         switchChatSession(state, result.key);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -171,7 +171,7 @@ export function renderChatSessionSelect(state: AppViewState) {
         class="chat-controls__new-chat"
         title="New chat session"
         aria-label="New chat session"
-        ?disabled=${!state.connected}
+        ?disabled=${!state.connected || Boolean(state.chatRunId)}
         @click=${() => createNewChatSession(state)}
       >
         ${icons.plus}

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -553,6 +553,7 @@ async function createNewChatSession(state: AppViewState) {
       switchChatSession(state, result.key);
     } else {
       state.lastError = "Session was created but no session key was returned.";
+      void refreshSessionOptions(state);
     }
   } catch (err) {
     state.lastError = String(err);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1,11 +1,8 @@
 import { html, nothing } from "lit";
-import {
-  buildAgentMainSessionKey,
-  parseAgentSessionKey,
-} from "../../../src/routing/session-key.js";
+import { buildAgentMainSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
-import { refreshChatAvatar } from "./app-chat.ts";
+import { refreshChatAvatar, resolveActiveChatAgentId } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
   renderChatControls,
@@ -270,8 +267,7 @@ type AiAgentsSectionKey = (typeof AI_AGENTS_SECTION_KEYS)[number];
 
 function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
   const list = state.agentsList?.agents ?? [];
-  const parsed = parseAgentSessionKey(state.sessionKey);
-  const agentId = parsed?.agentId ?? state.agentsList?.defaultId ?? "main";
+  const agentId = resolveActiveChatAgentId(state);
   const agent = list.find((entry) => entry.id === agentId);
   const identity = agent?.identity;
   const candidate = identity?.avatarUrl ?? identity?.avatar;
@@ -311,6 +307,7 @@ export function renderApp(state: AppViewState) {
   const navCollapsed = Boolean(state.settings.navCollapsed && !navDrawerOpen);
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
   const showToolCalls = state.onboarding ? true : state.settings.chatShowToolCalls;
+  const currentChatAgentId = resolveActiveChatAgentId(state);
   const assistantAvatarUrl = resolveAssistantAvatarUrl(state);
   const chatAvatarUrl = state.chatAvatarUrl ?? assistantAvatarUrl ?? null;
   const configValue =
@@ -1455,7 +1452,7 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 agentsList: state.agentsList,
-                currentAgentId: resolvedAgentId ?? "main",
+                currentAgentId: currentChatAgentId,
                 onAgentChange: (agentId: string) => {
                   state.sessionKey = buildAgentMainSessionKey({ agentId });
                   state.chatMessages = [];
@@ -1470,7 +1467,7 @@ export function renderApp(state: AppViewState) {
                   void state.loadAssistantIdentity();
                 },
                 onNavigateToAgent: () => {
-                  state.agentsSelectedId = resolvedAgentId;
+                  state.agentsSelectedId = currentChatAgentId;
                   state.setTab("agents" as import("./navigation.ts").Tab);
                 },
                 onSessionSelect: (key: string) => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1436,7 +1436,6 @@ export function renderApp(state: AppViewState) {
                 canAbort: Boolean(state.chatRunId),
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
-                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
                 onClearHistory: async () => {
                   if (!state.client || !state.connected) {
                     return;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -5,6 +5,7 @@ import { getSafeLocalStorage } from "../local-storage.ts";
 import { refreshChatAvatar, resolveActiveChatAgentId } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
+  createNewChatSession,
   renderChatControls,
   renderChatMobileToggle,
   renderChatSessionSelect,
@@ -1436,6 +1437,9 @@ export function renderApp(state: AppViewState) {
                 canAbort: Boolean(state.chatRunId),
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
+                canCreateSession:
+                  state.connected && !state.chatRunId && !state.newChatSessionPending,
+                onCreateSession: () => void createNewChatSession(state),
                 onClearHistory: async () => {
                   if (!state.client || !state.connected) {
                     return;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -77,6 +77,7 @@ export type AppViewState = {
   chatModelCatalog: ModelCatalogEntry[];
   chatQueue: ChatQueueItem[];
   chatManualRefreshInFlight: boolean;
+  newChatSessionPending: boolean;
   nodesLoading: boolean;
   nodes: Array<Record<string, unknown>>;
   chatNewMessagesBelow: boolean;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -78,6 +78,7 @@ export type AppViewState = {
   chatQueue: ChatQueueItem[];
   chatManualRefreshInFlight: boolean;
   newChatSessionPending: boolean;
+  chatActivityVersion: number;
   nodesLoading: boolean;
   nodes: Array<Record<string, unknown>>;
   chatNewMessagesBelow: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -166,6 +166,7 @@ export class OpenClawApp extends LitElement {
   @state() chatAttachments: ChatAttachment[] = [];
   @state() chatManualRefreshInFlight = false;
   @state() newChatSessionPending = false;
+  @state() chatActivityVersion = 0;
   @state() navDrawerOpen = false;
 
   onSlashAction?: (action: string) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -165,6 +165,7 @@ export class OpenClawApp extends LitElement {
   @state() chatQueue: ChatQueueItem[] = [];
   @state() chatAttachments: ChatAttachment[] = [];
   @state() chatManualRefreshInFlight = false;
+  @state() newChatSessionPending = false;
   @state() navDrawerOpen = false;
 
   onSlashAction?: (action: string) => void;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -632,13 +632,20 @@ describe("loadChatHistory", () => {
   });
 
   it("ignores stale history responses after the session changes", async () => {
-    let resolveHistory:
+    let resolveMainHistory:
+      | ((value: { messages?: Array<unknown>; thinkingLevel?: string }) => void)
+      | undefined;
+    let resolveOtherHistory:
       | ((value: { messages?: Array<unknown>; thinkingLevel?: string }) => void)
       | undefined;
     const request = vi.fn().mockImplementation(
-      () =>
+      (_method: string, params: { sessionKey: string }) =>
         new Promise<{ messages?: Array<unknown>; thinkingLevel?: string }>((resolve) => {
-          resolveHistory = resolve;
+          if (params.sessionKey === "main") {
+            resolveMainHistory = resolve;
+          } else {
+            resolveOtherHistory = resolve;
+          }
         }),
     );
     const state = createState({
@@ -656,7 +663,8 @@ describe("loadChatHistory", () => {
     });
 
     state.sessionKey = "other";
-    resolveHistory?.({
+    const nextHistory = loadChatHistory(state);
+    resolveMainHistory?.({
       messages: [{ role: "assistant", content: [{ type: "text", text: "Stale response" }] }],
       thinkingLevel: "low",
     });
@@ -666,6 +674,18 @@ describe("loadChatHistory", () => {
       { role: "assistant", content: [{ type: "text", text: "Current session" }] },
     ]);
     expect(state.chatThinkingLevel).toBe("high");
+    expect(state.chatLoading).toBe(true);
+
+    resolveOtherHistory?.({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "Fresh session" }] }],
+      thinkingLevel: "low",
+    });
+    await nextHistory;
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "Fresh session" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
     expect(state.chatLoading).toBe(false);
   });
 });

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -630,4 +630,42 @@ describe("loadChatHistory", () => {
     expect(state.chatLoading).toBe(false);
     expect(state.lastError).toBeNull();
   });
+
+  it("ignores stale history responses after the session changes", async () => {
+    let resolveHistory:
+      | ((value: { messages?: Array<unknown>; thinkingLevel?: string }) => void)
+      | undefined;
+    const request = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ messages?: Array<unknown>; thinkingLevel?: string }>((resolve) => {
+          resolveHistory = resolve;
+        }),
+    );
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "Current session" }] }],
+      chatThinkingLevel: "high",
+    });
+
+    const pending = loadChatHistory(state);
+
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "main",
+      limit: 200,
+    });
+
+    state.sessionKey = "other";
+    resolveHistory?.({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "Stale response" }] }],
+      thinkingLevel: "low",
+    });
+    await pending;
+
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "Current session" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("high");
+    expect(state.chatLoading).toBe(false);
+  });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -68,16 +68,20 @@ export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
   }
+  const requestedSessionKey = state.sessionKey;
   state.chatLoading = true;
   state.lastError = null;
   try {
     const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
       "chat.history",
       {
-        sessionKey: state.sessionKey,
+        sessionKey: requestedSessionKey,
         limit: 200,
       },
     );
+    if (state.sessionKey !== requestedSessionKey) {
+      return;
+    }
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -52,6 +52,11 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
+type ChatHistoryTrackedState = ChatState & {
+  __chatHistoryRequestSeq?: number;
+  __chatHistoryActiveRequestSeq?: number;
+};
+
 function maybeResetToolStream(state: ChatState) {
   const toolHost = state as ChatState & Partial<Parameters<typeof resetToolStream>[0]>;
   if (
@@ -68,7 +73,11 @@ export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
   }
+  const trackedState = state as ChatHistoryTrackedState;
   const requestedSessionKey = state.sessionKey;
+  const requestSeq = (trackedState.__chatHistoryRequestSeq ?? 0) + 1;
+  trackedState.__chatHistoryRequestSeq = requestSeq;
+  trackedState.__chatHistoryActiveRequestSeq = requestSeq;
   state.chatLoading = true;
   state.lastError = null;
   try {
@@ -79,7 +88,10 @@ export async function loadChatHistory(state: ChatState) {
         limit: 200,
       },
     );
-    if (state.sessionKey !== requestedSessionKey) {
+    if (
+      trackedState.__chatHistoryActiveRequestSeq !== requestSeq ||
+      state.sessionKey !== requestedSessionKey
+    ) {
       return;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
@@ -91,9 +103,11 @@ export async function loadChatHistory(state: ChatState) {
     state.chatStream = null;
     state.chatStreamStartedAt = null;
   } catch (err) {
-    state.lastError = String(err);
+    if (trackedState.__chatHistoryActiveRequestSeq === requestSeq) {
+      state.lastError = String(err);
+    }
   } finally {
-    if (state.sessionKey === requestedSessionKey) {
+    if (trackedState.__chatHistoryActiveRequestSeq === requestSeq) {
       state.chatLoading = false;
     }
   }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -93,7 +93,9 @@ export async function loadChatHistory(state: ChatState) {
   } catch (err) {
     state.lastError = String(err);
   } finally {
-    state.chatLoading = false;
+    if (state.sessionKey === requestedSessionKey) {
+      state.chatLoading = false;
+    }
   }
 }
 

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { deleteSessionsAndRefresh, subscribeSessions, type SessionsState } from "./sessions.ts";
+import {
+  deleteSessionsAndRefresh,
+  loadSessions,
+  subscribeSessions,
+  type SessionsState,
+} from "./sessions.ts";
 
 type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
 
@@ -39,6 +44,43 @@ describe("subscribeSessions", () => {
 
     expect(request).toHaveBeenCalledWith("sessions.subscribe", {});
     expect(state.sessionsError).toBeNull();
+  });
+});
+
+describe("loadSessions", () => {
+  it("queues one refresh when called again while a sessions.list request is already in flight", async () => {
+    const resolvers: Array<(value: unknown) => void> = [];
+    const request = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const state = createState(request);
+
+    const firstLoad = loadSessions(state, { includeGlobal: true, includeUnknown: true });
+    expect(state.sessionsLoading).toBe(true);
+
+    const queuedLoad = loadSessions(state, {
+      activeMinutes: 0,
+      limit: 0,
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+
+    resolvers[0]?.({ ts: 1, path: "", count: 0, defaults: null, sessions: [] });
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledTimes(2);
+    resolvers[1]?.({ ts: 2, path: "", count: 1, defaults: null, sessions: [] });
+    await Promise.all([firstLoad, queuedLoad]);
+
+    expect(state.sessionsLoading).toBe(false);
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
   });
 });
 

--- a/ui/src/ui/controllers/sessions.test.ts
+++ b/ui/src/ui/controllers/sessions.test.ts
@@ -82,6 +82,48 @@ describe("loadSessions", () => {
       includeUnknown: true,
     });
   });
+
+  it("preserves a queued unfiltered refresh when a later plain reload is queued", async () => {
+    const resolvers: Array<(value: unknown) => void> = [];
+    const request = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const state = createState(request, {
+      sessionsFilterActive: "45",
+      sessionsFilterLimit: "120",
+      sessionsIncludeGlobal: false,
+      sessionsIncludeUnknown: false,
+    });
+
+    const firstLoad = loadSessions(state);
+    expect(state.sessionsLoading).toBe(true);
+
+    const queuedFullReload = loadSessions(state, {
+      activeMinutes: 0,
+      limit: 0,
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+    const queuedPlainReload = loadSessions(state);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    resolvers[0]?.({ ts: 1, path: "", count: 0, defaults: null, sessions: [] });
+    await Promise.resolve();
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.list", {
+      includeGlobal: true,
+      includeUnknown: true,
+    });
+
+    resolvers[1]?.({ ts: 2, path: "", count: 1, defaults: null, sessions: [] });
+    await Promise.all([firstLoad, queuedFullReload, queuedPlainReload]);
+
+    expect(state.sessionsLoading).toBe(false);
+  });
 });
 
 describe("deleteSessionsAndRefresh", () => {

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -36,10 +36,7 @@ export async function subscribeSessions(state: SessionsState) {
   }
 }
 
-export async function loadSessions(
-  state: SessionsState,
-  overrides?: SessionsReloadOverrides,
-) {
+export async function loadSessions(state: SessionsState, overrides?: SessionsReloadOverrides) {
   const trackedState = state as SessionsTrackedState;
   if (!state.client || !state.connected) {
     return;

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -25,6 +25,22 @@ type SessionsTrackedState = SessionsState & {
   __queuedSessionsReload?: SessionsReloadOverrides | null;
 };
 
+function mergeSessionsReloadOverrides(
+  existing: SessionsReloadOverrides | null | undefined,
+  incoming: SessionsReloadOverrides | undefined,
+): SessionsReloadOverrides {
+  return {
+    ...(existing?.activeMinutes !== undefined ? { activeMinutes: existing.activeMinutes } : {}),
+    ...(existing?.limit !== undefined ? { limit: existing.limit } : {}),
+    ...(existing?.includeGlobal !== undefined ? { includeGlobal: existing.includeGlobal } : {}),
+    ...(existing?.includeUnknown !== undefined ? { includeUnknown: existing.includeUnknown } : {}),
+    ...(incoming?.activeMinutes !== undefined ? { activeMinutes: incoming.activeMinutes } : {}),
+    ...(incoming?.limit !== undefined ? { limit: incoming.limit } : {}),
+    ...(incoming?.includeGlobal !== undefined ? { includeGlobal: incoming.includeGlobal } : {}),
+    ...(incoming?.includeUnknown !== undefined ? { includeUnknown: incoming.includeUnknown } : {}),
+  };
+}
+
 export async function subscribeSessions(state: SessionsState) {
   if (!state.client || !state.connected) {
     return;
@@ -42,7 +58,10 @@ export async function loadSessions(state: SessionsState, overrides?: SessionsRel
     return;
   }
   if (state.sessionsLoading) {
-    trackedState.__queuedSessionsReload = overrides ?? {};
+    trackedState.__queuedSessionsReload = mergeSessionsReloadOverrides(
+      trackedState.__queuedSessionsReload,
+      overrides,
+    );
     return;
   }
   state.sessionsLoading = true;

--- a/ui/src/ui/controllers/sessions.ts
+++ b/ui/src/ui/controllers/sessions.ts
@@ -14,6 +14,17 @@ export type SessionsState = {
   sessionsIncludeUnknown: boolean;
 };
 
+type SessionsReloadOverrides = {
+  activeMinutes?: number;
+  limit?: number;
+  includeGlobal?: boolean;
+  includeUnknown?: boolean;
+};
+
+type SessionsTrackedState = SessionsState & {
+  __queuedSessionsReload?: SessionsReloadOverrides | null;
+};
+
 export async function subscribeSessions(state: SessionsState) {
   if (!state.client || !state.connected) {
     return;
@@ -27,17 +38,14 @@ export async function subscribeSessions(state: SessionsState) {
 
 export async function loadSessions(
   state: SessionsState,
-  overrides?: {
-    activeMinutes?: number;
-    limit?: number;
-    includeGlobal?: boolean;
-    includeUnknown?: boolean;
-  },
+  overrides?: SessionsReloadOverrides,
 ) {
+  const trackedState = state as SessionsTrackedState;
   if (!state.client || !state.connected) {
     return;
   }
   if (state.sessionsLoading) {
+    trackedState.__queuedSessionsReload = overrides ?? {};
     return;
   }
   state.sessionsLoading = true;
@@ -65,6 +73,11 @@ export async function loadSessions(
     state.sessionsError = String(err);
   } finally {
     state.sessionsLoading = false;
+    const queuedReload = trackedState.__queuedSessionsReload;
+    if (queuedReload) {
+      trackedState.__queuedSessionsReload = null;
+      await loadSessions(state, queuedReload);
+    }
   }
 }
 

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -50,7 +50,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onDraftChange: () => undefined,
     onSend: () => undefined,
     onQueueRemove: () => undefined,
-    onNewSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4,6 +4,7 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
+import { handleSendChat } from "../app-chat.ts";
 import { renderChatMobileToggle, renderChatSessionSelect } from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import { loadSessions } from "../controllers/sessions.ts";
@@ -91,6 +92,9 @@ function createChatHeaderState(
     if (method === "chat.history") {
       return { messages: [], thinkingLevel: null };
     }
+    if (method === "chat.send") {
+      return { ok: true };
+    }
     if (method === "sessions.create") {
       if (overrides.createRequest) {
         return overrides.createRequest(params);
@@ -143,12 +147,20 @@ function createChatHeaderState(
     chatMessages: [],
     chatLoading: false,
     chatThinkingLevel: null,
+    chatSending: false,
     lastError: null,
     sessionsError: null,
     chatAvatarUrl: null,
+    chatActivityVersion: 0,
+    chatToolMessages: [],
+    chatStreamSegments: [],
+    toolStreamById: new Map(),
+    toolStreamOrder: [],
     basePath: "",
     hello: null,
     agentsList: null,
+    refreshSessionsAfterChat: new Set<string>(),
+    updateComplete: Promise.resolve(),
     applySettings(next: AppViewState["settings"]) {
       state.settings = next;
     },
@@ -1072,6 +1084,86 @@ describe("chat view", () => {
         limit: 200,
       });
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch if the user sends a message while create is pending", async () => {
+    await withPromptStub(async () => {
+      let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
+      const createRequest = vi.fn(
+        async () =>
+          new Promise<{ ok: boolean; key?: string }>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+      const { state, request } = createChatHeaderState({ createRequest });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+      expect(state.newChatSessionPending).toBe(true);
+
+      state.chatMessage = "send this";
+      await handleSendChat(state);
+
+      resolveCreate?.({ ok: true, key: "new-session" });
+      await flushTasks();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).toHaveBeenCalledWith(
+        "chat.send",
+        expect.objectContaining({ message: "send this" }),
+      );
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+    });
+  });
+
+  it("does not auto-switch if the user queues a message while create is pending", async () => {
+    await withPromptStub(async () => {
+      let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
+      const createRequest = vi.fn(
+        async () =>
+          new Promise<{ ok: boolean; key?: string }>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+      const { state, request } = createChatHeaderState({ createRequest });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+      expect(state.newChatSessionPending).toBe(true);
+
+      state.chatMessage = "send this";
+      await handleSendChat(state);
+      state.chatMessage = "queue this";
+      await handleSendChat(state);
+
+      resolveCreate?.({ ok: true, key: "new-session" });
+      await flushTasks();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.chatQueue).toHaveLength(1);
+      expect(state.chatQueue[0]?.text).toBe("queue this");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
     });
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -696,6 +696,49 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("Stop");
   });
 
+  it("shows a focus-mode new session action", () => {
+    const container = document.createElement("div");
+    const onCreateSession = vi.fn();
+    render(
+      renderChat(
+        createProps({
+          focusMode: true,
+          canCreateSession: true,
+          onCreateSession,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = container.querySelector<HTMLButtonElement>(
+      'button[title="New chat session"]',
+    );
+    expect(newSessionButton).not.toBeNull();
+
+    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onCreateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the focus-mode new session action when creation is unavailable", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          focusMode: true,
+          canCreateSession: false,
+          onCreateSession: () => undefined,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = container.querySelector<HTMLButtonElement>(
+      'button[title="New chat session"]',
+    );
+    expect(newSessionButton).not.toBeNull();
+    expect(newSessionButton?.disabled).toBe(true);
+  });
+
   it("shows sender labels from sanitized gateway messages instead of generic You", () => {
     const container = document.createElement("div");
     render(
@@ -1090,6 +1133,37 @@ describe("chat view", () => {
       expect(state.chatAttachments).toEqual([
         { id: "a1", mimeType: "image/png", dataUrl: "data:image/png;base64,AAA=" },
       ]);
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch if the chat already has queued items", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+      state.chatQueue = [
+        {
+          id: "queued-1",
+          text: "queued prompt",
+          createdAt: Date.now(),
+        },
+      ];
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.chatQueue).toHaveLength(1);
+      expect(state.chatQueue[0]?.text).toBe("queued prompt");
       expect(state.newChatSessionPending).toBe(false);
       expect(request).not.toHaveBeenCalledWith("chat.history", {
         sessionKey: "new-session",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -4,11 +4,13 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
-import { renderChatSessionSelect } from "../app-render.helpers.ts";
+import { renderChatMobileToggle, renderChatSessionSelect } from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
+import { loadSessions } from "../controllers/sessions.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { SessionsListResult } from "../types.ts";
+import type { ChatAttachment } from "../ui-types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
 import { renderOverview, type OverviewProps } from "./overview.ts";
 
@@ -30,6 +32,7 @@ function createChatHeaderState(
     createResult?: { ok: boolean; key?: string };
     createRequest?: (params: Record<string, unknown>) => Promise<{ ok: boolean; key?: string }>;
     sessionsResult?: SessionsListResult;
+    sessionsListRequest?: () => Promise<SessionsListResult>;
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
@@ -96,6 +99,9 @@ function createChatHeaderState(
       return createResult;
     }
     if (method === "sessions.list") {
+      if (overrides.sessionsListRequest) {
+        return overrides.sessionsListRequest();
+      }
       return sessionsResult;
     }
     if (method === "models.list") {
@@ -139,6 +145,7 @@ function createChatHeaderState(
     chatLoading: false,
     chatThinkingLevel: null,
     lastError: null,
+    sessionsError: null,
     chatAvatarUrl: null,
     basePath: "",
     hello: null,
@@ -167,6 +174,14 @@ async function withPromptStub(run: () => Promise<void>) {
   } finally {
     vi.unstubAllGlobals();
   }
+}
+
+function createAttachment(id: string): ChatAttachment {
+  return {
+    id,
+    dataUrl: `data:text/plain;base64,${id}`,
+    mimeType: "text/plain",
+  };
 }
 
 function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
@@ -912,9 +927,8 @@ describe("chat view", () => {
   it("switches to the created session and clears pending state on success", async () => {
     await withPromptStub(async () => {
       const { state, request } = createChatHeaderState();
-      state.chatAttachments = [
-        { id: "a1", mimeType: "image/png", dataUrl: "data:image/png;base64,AAA=" },
-      ];
+      state.chatMessage = "Draft carried forward";
+      state.chatAttachments = [createAttachment("draft-1")];
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
 
@@ -928,7 +942,8 @@ describe("chat view", () => {
       expect(state.settings.sessionKey).toBe("new-session");
       expect(state.settings.lastActiveSessionKey).toBe("new-session");
       expect(state.newChatSessionPending).toBe(false);
-      expect(state.chatAttachments).toEqual([]);
+      expect(state.chatMessage).toBe("Draft carried forward");
+      expect(state.chatAttachments).toEqual([createAttachment("draft-1")]);
       expect(request).toHaveBeenCalledWith("sessions.create", {
         agentId: "main",
         label: "Session label",
@@ -1079,10 +1094,24 @@ describe("chat view", () => {
 
   it("retries the session refresh after create if a session list load is already in flight", async () => {
     await withPromptStub(async () => {
-      const { state, request } = createChatHeaderState();
-      state.sessionsLoading = true;
+      const listResolvers: Array<(value: SessionsListResult) => void> = [];
+      const sessionsListRequest = vi.fn(
+        async () =>
+          new Promise<SessionsListResult>((resolve) => {
+            listResolvers.push(resolve);
+          }),
+      );
+      const { state, request } = createChatHeaderState({ sessionsListRequest });
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
+
+      const inFlightList = loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
+        activeMinutes: 0,
+        limit: 0,
+        includeGlobal: true,
+        includeUnknown: true,
+      });
+      await flushTasks();
 
       const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
       expect(newChatButton).not.toBeNull();
@@ -1090,13 +1119,81 @@ describe("chat view", () => {
       newChatButton!.click();
       await flushTasks();
 
-      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(0);
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1);
 
-      state.sessionsLoading = false;
-      await new Promise((resolve) => setTimeout(resolve, 30));
+      listResolvers[0]?.({
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [{ key: "main", kind: "direct", updatedAt: null }],
+      });
+      await flushTasks();
+
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2);
+
+      listResolvers[1]?.({
+        ts: 0,
+        path: "",
+        count: 2,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [
+          { key: "main", kind: "direct", updatedAt: null },
+          { key: "new-session", kind: "direct", updatedAt: null },
+        ],
+      });
+      await inFlightList;
+      await flushTasks();
 
       expect(state.sessionKey).toBe("new-session");
-      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1);
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(2);
+    });
+  });
+
+  it("renders a new session action in mobile chat controls", () => {
+    const { state } = createChatHeaderState();
+    const container = document.createElement("div");
+    render(renderChatMobileToggle(state), container);
+
+    const newChatButton = container.querySelector<HTMLButtonElement>(
+      ".chat-controls-dropdown .chat-controls__new-chat",
+    );
+    expect(newChatButton).not.toBeNull();
+    expect(newChatButton?.disabled).toBe(false);
+  });
+
+  it("disables the mobile new session action while a run is active", () => {
+    const { state } = createChatHeaderState();
+    state.chatRunId = "run-123";
+    const container = document.createElement("div");
+    render(renderChatMobileToggle(state), container);
+
+    const newChatButton = container.querySelector<HTMLButtonElement>(
+      ".chat-controls-dropdown .chat-controls__new-chat",
+    );
+    expect(newChatButton).not.toBeNull();
+    expect(newChatButton?.disabled).toBe(true);
+  });
+
+  it("creates a new session from mobile chat controls", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+      const container = document.createElement("div");
+      render(renderChatMobileToggle(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(
+        ".chat-controls-dropdown .chat-controls__new-chat",
+      );
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("new-session");
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "main",
+        label: "Session label",
+      });
     });
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -33,6 +33,9 @@ function createChatHeaderState(
     createRequest?: (params: Record<string, unknown>) => Promise<{ ok: boolean; key?: string }>;
     sessionsResult?: SessionsListResult;
     sessionsListRequest?: () => Promise<SessionsListResult>;
+    sessionKey?: string;
+    hello?: AppViewState["hello"];
+    agentsList?: AppViewState["agentsList"];
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
@@ -113,7 +116,7 @@ function createChatHeaderState(
     throw new Error(`Unexpected request: ${method}`);
   });
   const state = {
-    sessionKey: "main",
+    sessionKey: overrides.sessionKey ?? "main",
     connected: true,
     sessionsHideCron: true,
     sessionsLoading: false,
@@ -157,8 +160,8 @@ function createChatHeaderState(
     toolStreamById: new Map(),
     toolStreamOrder: [],
     basePath: "",
-    hello: null,
-    agentsList: null,
+    hello: overrides.hello ?? null,
+    agentsList: overrides.agentsList ?? null,
     refreshSessionsAfterChat: new Set<string>(),
     updateComplete: Promise.resolve(),
     applySettings(next: AppViewState["settings"]) {
@@ -954,6 +957,98 @@ describe("chat view", () => {
         limit: 200,
       });
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("uses the configured default agent for new sessions from an unscoped chat", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState({
+        hello: {
+          snapshot: {
+            sessionDefaults: {
+              defaultAgentId: "ops",
+            },
+          },
+        } as AppViewState["hello"],
+        agentsList: {
+          defaultId: "main",
+          agents: [{ id: "main" }, { id: "ops" }],
+        } as AppViewState["agentsList"],
+      });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "ops",
+        label: "Session label",
+      });
+    });
+  });
+
+  it("keeps the explicit session agent for new sessions", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState({
+        sessionKey: "agent:research:main",
+        hello: {
+          snapshot: {
+            sessionDefaults: {
+              defaultAgentId: "ops",
+            },
+          },
+        } as AppViewState["hello"],
+        agentsList: {
+          defaultId: "main",
+          agents: [{ id: "main" }, { id: "research" }, { id: "ops" }],
+        } as AppViewState["agentsList"],
+      });
+      state.settings = {
+        ...state.settings,
+        sessionKey: "agent:research:main",
+        lastActiveSessionKey: "agent:research:main",
+      };
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "research",
+        label: "Session label",
+      });
+    });
+  });
+
+  it("falls back to agents.list default when session defaults are unavailable", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState({
+        agentsList: {
+          defaultId: "worker",
+          agents: [{ id: "main" }, { id: "worker" }],
+        } as AppViewState["agentsList"],
+      });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "worker",
+        label: "Session label",
+      });
     });
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -111,6 +111,7 @@ function createChatHeaderState(
     chatModelOverrides: {},
     chatModelCatalog: catalog,
     chatModelsLoading: false,
+    newChatSessionPending: false,
     client: { request } as unknown as GatewayBrowserClient,
     settings: {
       gatewayUrl: "",
@@ -866,6 +867,17 @@ describe("chat view", () => {
     );
     expect(modelSelect).not.toBeNull();
     expect(modelSelect?.disabled).toBe(true);
+  });
+
+  it("disables the new chat button while a new session request is in flight", () => {
+    const { state } = createChatHeaderState();
+    state.newChatSessionPending = true;
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+    expect(newChatButton).not.toBeNull();
+    expect(newChatButton?.disabled).toBe(true);
   });
 
   it("keeps the selected model visible when the active session is absent from sessions.list", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -887,19 +887,50 @@ describe("chat view", () => {
 
   it("refreshes session options when create returns without a session key", async () => {
     vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
-    const { state, request } = createChatHeaderState({ createResult: { ok: true } });
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    try {
+      const { state, request } = createChatHeaderState({ createResult: { ok: true } });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
 
-    const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
-    expect(newChatButton).not.toBeNull();
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
 
-    newChatButton!.click();
-    await flushTasks();
+      newChatButton!.click();
+      await flushTasks();
 
-    expect(state.lastError).toBe("Session was created but no session key was returned.");
-    expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
-    vi.unstubAllGlobals();
+      expect(state.lastError).toBe("Session was created but no session key was returned.");
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("switches to the created session and clears pending state on success", async () => {
+    vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
+    try {
+      const { state, request } = createChatHeaderState();
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("new-session");
+      expect(state.settings.sessionKey).toBe("new-session");
+      expect(state.settings.lastActiveSessionKey).toBe("new-session");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).toHaveBeenCalledWith("sessions.create", expect.anything());
+      expect(request).toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("keeps the selected model visible when the active session is absent from sessions.list", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -927,8 +927,6 @@ describe("chat view", () => {
   it("switches to the created session and clears pending state on success", async () => {
     await withPromptStub(async () => {
       const { state, request } = createChatHeaderState();
-      state.chatMessage = "Draft carried forward";
-      state.chatAttachments = [createAttachment("draft-1")];
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
 
@@ -942,13 +940,65 @@ describe("chat view", () => {
       expect(state.settings.sessionKey).toBe("new-session");
       expect(state.settings.lastActiveSessionKey).toBe("new-session");
       expect(state.newChatSessionPending).toBe(false);
-      expect(state.chatMessage).toBe("Draft carried forward");
-      expect(state.chatAttachments).toEqual([createAttachment("draft-1")]);
+      expect(state.chatMessage).toBe("");
+      expect(state.chatAttachments).toEqual([]);
       expect(request).toHaveBeenCalledWith("sessions.create", {
         agentId: "main",
         label: "Session label",
       });
       expect(request).toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch if the composer already has a draft", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+      state.chatMessage = "keep this draft";
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.chatMessage).toBe("keep this draft");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch if the composer already has attachments", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+      state.chatAttachments = [
+        { id: "a1", mimeType: "image/png", dataUrl: "data:image/png;base64,AAA=" },
+      ];
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.chatAttachments).toEqual([
+        { id: "a1", mimeType: "image/png", dataUrl: "data:image/png;base64,AAA=" },
+      ]);
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
         sessionKey: "new-session",
         limit: 200,
       });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -107,6 +107,7 @@ function createChatHeaderState(
     sessionKey: "main",
     connected: true,
     sessionsHideCron: true,
+    sessionsLoading: false,
     sessionsResult,
     chatModelOverrides: {},
     chatModelCatalog: catalog,
@@ -129,6 +130,7 @@ function createChatHeaderState(
       chatShowThinking: false,
     },
     chatMessage: "",
+    chatAttachments: [],
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunId: null,
@@ -910,6 +912,9 @@ describe("chat view", () => {
   it("switches to the created session and clears pending state on success", async () => {
     await withPromptStub(async () => {
       const { state, request } = createChatHeaderState();
+      state.chatAttachments = [
+        { id: "a1", mimeType: "image/png", dataUrl: "data:image/png;base64,AAA=" },
+      ];
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
 
@@ -923,11 +928,90 @@ describe("chat view", () => {
       expect(state.settings.sessionKey).toBe("new-session");
       expect(state.settings.lastActiveSessionKey).toBe("new-session");
       expect(state.newChatSessionPending).toBe(false);
+      expect(state.chatAttachments).toEqual([]);
       expect(request).toHaveBeenCalledWith("sessions.create", {
         agentId: "main",
         label: "Session label",
       });
       expect(request).toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch if the user types a draft while create is pending", async () => {
+    await withPromptStub(async () => {
+      let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
+      const createRequest = vi.fn(
+        async () =>
+          new Promise<{ ok: boolean; key?: string }>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+      const { state, request } = createChatHeaderState({ createRequest });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+      expect(state.newChatSessionPending).toBe(true);
+
+      state.chatMessage = "keep this draft";
+
+      resolveCreate?.({ ok: true, key: "new-session" });
+      await flushTasks();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.chatMessage).toBe("keep this draft");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch if attachments change while create is pending", async () => {
+    await withPromptStub(async () => {
+      let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
+      const createRequest = vi.fn(
+        async () =>
+          new Promise<{ ok: boolean; key?: string }>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+      const { state, request } = createChatHeaderState({ createRequest });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+      expect(state.newChatSessionPending).toBe(true);
+
+      state.chatAttachments = [
+        { id: "a2", mimeType: "image/png", dataUrl: "data:image/png;base64,BBB=" },
+      ];
+
+      resolveCreate?.({ ok: true, key: "new-session" });
+      await flushTasks();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.chatAttachments).toEqual([
+        { id: "a2", mimeType: "image/png", dataUrl: "data:image/png;base64,BBB=" },
+      ]);
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
         sessionKey: "new-session",
         limit: 200,
       });
@@ -990,6 +1074,47 @@ describe("chat view", () => {
         limit: 200,
       });
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("retries the session refresh after create if a session list load is already in flight", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+      state.sessionsLoading = true;
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(0);
+
+      state.sessionsLoading = false;
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      expect(state.sessionKey).toBe("new-session");
+      expect(request.mock.calls.filter(([method]) => method === "sessions.list")).toHaveLength(1);
+    });
+  });
+
+  it("sets lastError and clears pending state when sessions.create throws", async () => {
+    await withPromptStub(async () => {
+      const createRequest = vi.fn().mockRejectedValue(new Error("network failure"));
+      const { state } = createChatHeaderState({ createRequest });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+
+      expect(state.lastError).toContain("network failure");
+      expect(state.newChatSessionPending).toBe(false);
     });
   });
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -10,7 +10,6 @@ import { loadSessions } from "../controllers/sessions.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { SessionsListResult } from "../types.ts";
-import type { ChatAttachment } from "../ui-types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
 import { renderOverview, type OverviewProps } from "./overview.ts";
 
@@ -174,14 +173,6 @@ async function withPromptStub(run: () => Promise<void>) {
   } finally {
     vi.unstubAllGlobals();
   }
-}
-
-function createAttachment(id: string): ChatAttachment {
-  return {
-    id,
-    dataUrl: `data:text/plain;base64,${id}`,
-    mimeType: "text/plain",
-  };
 }
 
 function createProps(overrides: Partial<ChatProps> = {}): ChatProps {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -28,12 +28,35 @@ function createChatHeaderState(
     models?: ModelCatalogEntry[];
     omitSessionFromList?: boolean;
     createResult?: { ok: boolean; key?: string };
+    createRequest?: (params: Record<string, unknown>) => Promise<{ ok: boolean; key?: string }>;
+    historyRequest?: (params: Record<string, unknown>) => Promise<{
+      messages?: Array<unknown>;
+      thinkingLevel?: string | null;
+    }>;
+    sessionsResult?: SessionsListResult;
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
   let currentModelProvider = currentModel ? "openai" : null;
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
   const createResult = overrides.createResult ?? { ok: true, key: "new-session" };
+  const sessionsResult = overrides.sessionsResult ?? {
+    ts: 0,
+    path: "",
+    count: omitSessionFromList ? 0 : 1,
+    defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+    sessions: omitSessionFromList
+      ? []
+      : [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: null,
+            modelProvider: currentModelProvider,
+            model: currentModel,
+          },
+        ],
+  };
   const catalog = overrides.models ?? [
     { id: "gpt-5", name: "GPT-5", provider: "openai" },
     { id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai" },
@@ -60,32 +83,27 @@ function createChatHeaderState(
             matchingProviders.length === 1 ? matchingProviders[0] : currentModelProvider;
         }
       }
+      const currentSession = sessionsResult.sessions.find((session) => session.key === "main");
+      if (currentSession) {
+        currentSession.model = currentModel;
+        currentSession.modelProvider = currentModelProvider;
+      }
       return { ok: true, key: "main" };
     }
     if (method === "chat.history") {
+      if (overrides.historyRequest) {
+        return overrides.historyRequest(params);
+      }
       return { messages: [], thinkingLevel: null };
     }
     if (method === "sessions.create") {
+      if (overrides.createRequest) {
+        return overrides.createRequest(params);
+      }
       return createResult;
     }
     if (method === "sessions.list") {
-      return {
-        ts: 0,
-        path: "",
-        count: omitSessionFromList ? 0 : 1,
-        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-        sessions: omitSessionFromList
-          ? []
-          : [
-              {
-                key: "main",
-                kind: "direct",
-                updatedAt: null,
-                modelProvider: currentModelProvider,
-                model: currentModel,
-              },
-            ],
-      };
+      return sessionsResult;
     }
     if (method === "models.list") {
       return { models: catalog };
@@ -96,23 +114,7 @@ function createChatHeaderState(
     sessionKey: "main",
     connected: true,
     sessionsHideCron: true,
-    sessionsResult: {
-      ts: 0,
-      path: "",
-      count: omitSessionFromList ? 0 : 1,
-      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-      sessions: omitSessionFromList
-        ? []
-        : [
-            {
-              key: "main",
-              kind: "direct",
-              updatedAt: null,
-              modelProvider: currentModelProvider,
-              model: currentModel,
-            },
-          ],
-    },
+    sessionsResult,
     chatModelOverrides: {},
     chatModelCatalog: catalog,
     chatModelsLoading: false,
@@ -923,8 +925,78 @@ describe("chat view", () => {
       expect(state.settings.sessionKey).toBe("new-session");
       expect(state.settings.lastActiveSessionKey).toBe("new-session");
       expect(state.newChatSessionPending).toBe(false);
-      expect(request).toHaveBeenCalledWith("sessions.create", expect.anything());
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "main",
+        label: "Session label",
+      });
       expect(request).toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not auto-switch away from a newer session after a delayed create response", async () => {
+    vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
+    try {
+      let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
+      const createPromise = new Promise<{ ok: boolean; key?: string }>((resolve) => {
+        resolveCreate = resolve;
+      });
+      const sessionsResult = {
+        ts: 0,
+        path: "",
+        count: 2,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: null,
+          },
+          {
+            key: "other",
+            kind: "direct",
+            updatedAt: null,
+          },
+        ],
+      } satisfies SessionsListResult;
+      const { state, request } = createChatHeaderState({
+        sessionsResult,
+        createRequest: vi.fn(async () => createPromise),
+      });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+      expect(state.newChatSessionPending).toBe(true);
+
+      const sessionSelect = container.querySelector<HTMLSelectElement>(
+        ".chat-controls__session select",
+      );
+      expect(sessionSelect).not.toBeNull();
+      sessionSelect!.value = "other";
+      sessionSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("other");
+
+      resolveCreate?.({ ok: true, key: "new-session" });
+      await flushTasks();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("other");
+      expect(state.settings.sessionKey).toBe("other");
+      expect(state.settings.lastActiveSessionKey).toBe("other");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
         sessionKey: "new-session",
         limit: 200,
       });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -223,7 +223,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onDraftChange: () => undefined,
     onSend: () => undefined,
     onQueueRemove: () => undefined,
-    onNewSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,
@@ -679,14 +678,12 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("New session");
   });
 
-  it("shows a new session button when aborting is unavailable", () => {
+  it("does not show a legacy toolbar new session button when aborting is unavailable", () => {
     const container = document.createElement("div");
-    const onNewSession = vi.fn();
     render(
       renderChat(
         createProps({
           canAbort: false,
-          onNewSession,
         }),
       ),
       container,
@@ -695,9 +692,7 @@ describe("chat view", () => {
     const newSessionButton = container.querySelector<HTMLButtonElement>(
       'button[title="New session"]',
     );
-    expect(newSessionButton).not.toBeUndefined();
-    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onNewSession).toHaveBeenCalledTimes(1);
+    expect(newSessionButton).toBeNull();
     expect(container.textContent).not.toContain("Stop");
   });
 
@@ -1311,6 +1306,69 @@ describe("chat view", () => {
       expect(state.sessionKey).toBe("other");
       expect(state.settings.sessionKey).toBe("other");
       expect(state.settings.lastActiveSessionKey).toBe("other");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).not.toHaveBeenCalledWith("chat.history", {
+        sessionKey: "new-session",
+        limit: 200,
+      });
+      expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    });
+  });
+
+  it("does not auto-switch after the user hops away and back before create resolves", async () => {
+    await withPromptStub(async () => {
+      let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
+      const createRequest = vi.fn(
+        async () =>
+          new Promise<{ ok: boolean; key?: string }>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+      const { state, request } = createChatHeaderState({
+        sessionsResult: {
+          ts: 0,
+          path: "",
+          count: 2,
+          defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+          sessions: [
+            { key: "main", kind: "direct", updatedAt: null },
+            { key: "other", kind: "direct", updatedAt: null },
+          ],
+        } satisfies SessionsListResult,
+        createRequest,
+      });
+      const container = document.createElement("div");
+      render(renderChatSessionSelect(state), container);
+
+      const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+      expect(newChatButton).not.toBeNull();
+
+      newChatButton!.click();
+      await flushTasks();
+      expect(state.newChatSessionPending).toBe(true);
+
+      const sessionSelect = container.querySelector<HTMLSelectElement>(
+        ".chat-controls__session select",
+      );
+      expect(sessionSelect).not.toBeNull();
+
+      sessionSelect!.value = "other";
+      sessionSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+      await flushTasks();
+
+      sessionSelect!.value = "main";
+      sessionSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+
+      resolveCreate?.({ ok: true, key: "new-session" });
+      await flushTasks();
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("main");
+      expect(state.settings.sessionKey).toBe("main");
+      expect(state.settings.lastActiveSessionKey).toBe("main");
       expect(state.newChatSessionPending).toBe(false);
       expect(request).not.toHaveBeenCalledWith("chat.history", {
         sessionKey: "new-session",

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -29,10 +29,6 @@ function createChatHeaderState(
     omitSessionFromList?: boolean;
     createResult?: { ok: boolean; key?: string };
     createRequest?: (params: Record<string, unknown>) => Promise<{ ok: boolean; key?: string }>;
-    historyRequest?: (params: Record<string, unknown>) => Promise<{
-      messages?: Array<unknown>;
-      thinkingLevel?: string | null;
-    }>;
     sessionsResult?: SessionsListResult;
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
@@ -91,9 +87,6 @@ function createChatHeaderState(
       return { ok: true, key: "main" };
     }
     if (method === "chat.history") {
-      if (overrides.historyRequest) {
-        return overrides.historyRequest(params);
-      }
       return { messages: [], thinkingLevel: null };
     }
     if (method === "sessions.create") {
@@ -163,6 +156,15 @@ function createChatHeaderState(
 
 function flushTasks() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+async function withPromptStub(run: () => Promise<void>) {
+  vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
+  try {
+    await run();
+  } finally {
+    vi.unstubAllGlobals();
+  }
 }
 
 function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
@@ -888,8 +890,7 @@ describe("chat view", () => {
   });
 
   it("refreshes session options when create returns without a session key", async () => {
-    vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
-    try {
+    await withPromptStub(async () => {
       const { state, request } = createChatHeaderState({ createResult: { ok: true } });
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
@@ -903,14 +904,11 @@ describe("chat view", () => {
       expect(state.lastError).toBe("Session was created but no session key was returned.");
       expect(state.newChatSessionPending).toBe(false);
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    });
   });
 
   it("switches to the created session and clears pending state on success", async () => {
-    vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
-    try {
+    await withPromptStub(async () => {
       const { state, request } = createChatHeaderState();
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
@@ -934,39 +932,30 @@ describe("chat view", () => {
         limit: 200,
       });
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    });
   });
 
   it("does not auto-switch away from a newer session after a delayed create response", async () => {
-    vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
-    try {
+    await withPromptStub(async () => {
       let resolveCreate: ((value: { ok: boolean; key?: string }) => void) | undefined;
-      const createPromise = new Promise<{ ok: boolean; key?: string }>((resolve) => {
-        resolveCreate = resolve;
-      });
-      const sessionsResult = {
-        ts: 0,
-        path: "",
-        count: 2,
-        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-        sessions: [
-          {
-            key: "main",
-            kind: "direct",
-            updatedAt: null,
-          },
-          {
-            key: "other",
-            kind: "direct",
-            updatedAt: null,
-          },
-        ],
-      } satisfies SessionsListResult;
+      const createRequest = vi.fn(
+        async () =>
+          new Promise<{ ok: boolean; key?: string }>((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
       const { state, request } = createChatHeaderState({
-        sessionsResult,
-        createRequest: vi.fn(async () => createPromise),
+        sessionsResult: {
+          ts: 0,
+          path: "",
+          count: 2,
+          defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+          sessions: [
+            { key: "main", kind: "direct", updatedAt: null },
+            { key: "other", kind: "direct", updatedAt: null },
+          ],
+        } satisfies SessionsListResult,
+        createRequest,
       });
       const container = document.createElement("div");
       render(renderChatSessionSelect(state), container);
@@ -1001,9 +990,7 @@ describe("chat view", () => {
         limit: 200,
       });
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
-    } finally {
-      vi.unstubAllGlobals();
-    }
+    });
   });
 
   it("keeps the selected model visible when the active session is absent from sessions.list", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -27,11 +27,13 @@ function createChatHeaderState(
     model?: string | null;
     models?: ModelCatalogEntry[];
     omitSessionFromList?: boolean;
+    createResult?: { ok: boolean; key?: string };
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
   let currentModelProvider = currentModel ? "openai" : null;
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
+  const createResult = overrides.createResult ?? { ok: true, key: "new-session" };
   const catalog = overrides.models ?? [
     { id: "gpt-5", name: "GPT-5", provider: "openai" },
     { id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai" },
@@ -62,6 +64,9 @@ function createChatHeaderState(
     }
     if (method === "chat.history") {
       return { messages: [], thinkingLevel: null };
+    }
+    if (method === "sessions.create") {
+      return createResult;
     }
     if (method === "sessions.list") {
       return {
@@ -878,6 +883,23 @@ describe("chat view", () => {
     const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
     expect(newChatButton).not.toBeNull();
     expect(newChatButton?.disabled).toBe(true);
+  });
+
+  it("refreshes session options when create returns without a session key", async () => {
+    vi.stubGlobal("prompt", vi.fn().mockReturnValue("Session label"));
+    const { state, request } = createChatHeaderState({ createResult: { ok: true } });
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const newChatButton = container.querySelector<HTMLButtonElement>(".chat-controls__new-chat");
+    expect(newChatButton).not.toBeNull();
+
+    newChatButton!.click();
+    await flushTasks();
+
+    expect(state.lastError).toBe("Session was created but no session key was returned.");
+    expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
+    vi.unstubAllGlobals();
   });
 
   it("keeps the selected model visible when the active session is absent from sessions.list", async () => {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -899,6 +899,7 @@ describe("chat view", () => {
       await flushTasks();
 
       expect(state.lastError).toBe("Session was created but no session key was returned.");
+      expect(state.newChatSessionPending).toBe(false);
       expect(request.mock.calls.map(([method]) => method)).toContain("sessions.list");
     } finally {
       vi.unstubAllGlobals();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -94,6 +94,8 @@ export type ChatProps = {
   onSend: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
+  canCreateSession?: boolean;
+  onCreateSession?: () => void;
   onClearHistory?: () => void;
   agentsList: {
     agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
@@ -1119,15 +1121,33 @@ export function renderChat(props: ChatProps) {
       ${
         props.focusMode
           ? html`
-            <button
-              class="chat-focus-exit"
-              type="button"
-              @click=${props.onToggleFocusMode}
-              aria-label="Exit focus mode"
-              title="Exit focus mode"
-            >
-              ${icons.x}
-            </button>
+            <div class="chat-focus-actions">
+              ${
+                props.onCreateSession
+                  ? html`
+                      <button
+                        class="chat-focus-action chat-focus-action--new-session"
+                        type="button"
+                        @click=${props.onCreateSession}
+                        aria-label="New chat session"
+                        title="New chat session"
+                        ?disabled=${props.canCreateSession === false}
+                      >
+                        ${icons.plus}
+                      </button>
+                    `
+                  : nothing
+              }
+              <button
+                class="chat-focus-action chat-focus-exit"
+                type="button"
+                @click=${props.onToggleFocusMode}
+                aria-label="Exit focus mode"
+                title="Exit focus mode"
+              >
+                ${icons.x}
+              </button>
+            </div>
           `
           : nothing
       }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -94,7 +94,6 @@ export type ChatProps = {
   onSend: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
-  onNewSession: () => void;
   onClearHistory?: () => void;
   agentsList: {
     agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
@@ -1318,20 +1317,6 @@ export function renderChat(props: ChatProps) {
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
-            ${
-              canAbort
-                ? nothing
-                : html`
-                    <button
-                      class="btn-ghost"
-                      @click=${props.onNewSession}
-                      title="New session"
-                      aria-label="New session"
-                    >
-                      ${icons.plus}
-                    </button>
-                  `
-            }
             <button class="btn-ghost" @click=${() => exportMarkdown(props)} title="Export" ?disabled=${props.messages.length === 0}>
               ${icons.download}
             </button>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: webchat exposed session switching but not session creation from the selector, so users had to reuse one dashboard session or rely on `/new`, which only resets the current one.
- Why it matters: separate webchat sessions let users keep unrelated drafts and histories split by topic or project instead of collapsing everything into one timeline.
- What changed: added a `+` affordance beside the session selector that creates a new optional labeled dashboard session and auto-switches only when the originating session and composer state are still safe to move.
- Hardening: guarded duplicate create attempts, stale history responses, delayed create responses, and contended session-list refreshes; when switching would be unsafe, the UI preserves existing drafts, queued prompts, and attachments instead of yanking the user into a different chat.
- Scope boundary: this is the session-creation and state-safety slice of the broader multi-chat request in #51793, not full tabbed/sidebar multi-session management. Rename/delete flows, backend storage/tool APIs, and broader session-management semantics are still unchanged.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26517
- Related #51793

## User-visible / Behavior Changes

- Webchat now shows a `+` button beside the chat session selector.
- Clicking `+` prompts for an optional label and creates a fresh dashboard session.
- The UI switches into that new session only when the originating session is still active and the composer state is still safe to clear; otherwise it refreshes session options and keeps the user in place.
- Existing drafts, queued prompts, or attachments are preserved when an auto-switch would be unsafe, and stale or malformed create responses no longer force an unexpected session jump.
- This does not add tabbed/sidebar multi-session navigation yet; rename/delete flows for existing sessions are still follow-up work.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: `Darwin`
- Runtime/container: `Node v25.8.1`, `pnpm 10.23.0`
- Model/provider: N/A
- Integration/channel (if any): webchat dashboard UI
- Relevant config (redacted): default local dev and test config

### Steps

1. Run targeted webchat coverage: `pnpm test -- ui/src/ui/controllers/chat.test.ts`, `pnpm test -- ui/src/ui/controllers/sessions.test.ts`, and `pnpm test -- ui/src/ui/views/chat.test.ts`.
2. Run supporting regression/build coverage for the maintenance alignments merged into this branch: `pnpm build`, plus the targeted Telegram/gateway/infra/helper expectation-alignment checks touched after merging `main`.
3. Manually exercise the webchat create-session flow in the browser.

### Expected

- New session creation keeps the active-session spinner and session list state consistent under delayed, malformed, or contended responses.
- Delayed create responses do not overwrite drafts, queued prompts, or attachments typed before or after the request started.
- Existing drafts or attachments present before pressing `+` are preserved by staying in the current session when switching would be unsafe.
- Supporting maintenance edits remain limited to keeping test/build expectations aligned after the `main` merge and do not expand the user-visible feature scope.

### Actual

- Targeted automated verification for the webchat flow and the supporting expectation-alignment regressions passed locally.
- Manual browser verification of the webchat create-session flow also passed.
- Rename/delete flows for existing sessions, tabbed/sidebar multi-chat navigation, and any broader backend session-management changes remain out of scope for this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manual browser verification of the webchat create-session flow, plus targeted automated verification for stale `chat.history` responses, successful session creation, missing-key create responses, thrown `sessions.create` errors, delayed create responses after a user session switch, delayed create responses after draft or attachment edits, delayed create responses with queued prompts already present, and refresh retries while `sessions.list` is already in flight.
- Edge cases checked: loading indicator is not cleared by a stale history response; delayed create responses do not force navigation into a newer session; existing drafts, queued prompts, and attachments are preserved instead of triggering an unsafe auto-switch; attachments are cleared before a safe auto-switch into the new session.
- What you did **not** verify: rename/delete flows for existing sessions, prompt UX in embedded or cross-origin environments, or any broader backend session-management behavior outside the existing UI affordance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the webchat session-creation UI changes and fall back to the previous session selector behavior.
- Files/config to restore: `ui/src/ui/app-render.helpers.ts`, `ui/src/ui/controllers/chat.ts`, and the related webchat tests.
- Known bad symptoms reviewers should watch for: session spinner disappearing too early, newly created sessions not appearing in the selector until a later refresh, unexpected session switches after a delayed create response, or preserved drafts/queue/attachments being cleared when they should stay put.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: delayed, malformed, or partially failed `sessions.create` responses could still leave the UI briefly out of sync with backend session state.
  - Mitigation: guarded success/error handling, defensive session-option refreshes, and targeted regression coverage for missing-key and thrown-error paths.
- Risk: stale history or contended session-list refreshes can produce timing-sensitive UI state bugs.
  - Mitigation: sequence-based stale-response guards, queued refresh preservation, and explicit regression tests around those races.
- Risk: this PR covers only session creation plus related UI-state hardening; rename/delete flows, tabbed/sidebar multi-chat UX, and broader backend session-management semantics remain separate follow-up work.
  - Mitigation: scope is called out explicitly here and linked to #51793 so reviewers do not assume broader multi-chat coverage.
- Risk: the small non-webchat file edits in this branch could be mistaken for expanded product scope.
  - Mitigation: they are limited to maintenance/test expectation alignment after the `main` merge and are not treated as separate user-facing behavior in this PR.
