### PR TITLE
fix(ui): preserve history image attachments after chat reload

### DIFF
--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -23,37 +23,106 @@ type ImageBlock = {
   alt?: string;
 };
 
+function normalizeImageDataUrl(data: string, mimeType?: string): string | null {
+  const trimmed = data.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith("data:")) {
+    return trimmed;
+  }
+  const normalizedMimeType = mimeType?.trim() || "image/png";
+  return `data:${normalizedMimeType};base64,${trimmed}`;
+}
+
+function extractImageUrlFromContentBlock(block: Record<string, unknown>): ImageBlock | null {
+  if (block.type === "image") {
+    const source = block.source as Record<string, unknown> | undefined;
+    if (source?.type === "base64" && typeof source.data === "string") {
+      const url = normalizeImageDataUrl(
+        source.data,
+        typeof source.media_type === "string" ? source.media_type : undefined,
+      );
+      return url ? { url } : null;
+    }
+    if (typeof block.url === "string" && block.url.trim()) {
+      return { url: block.url.trim() };
+    }
+    return null;
+  }
+
+  if (block.type === "image_url") {
+    const imageUrl = block.image_url;
+    if (typeof imageUrl === "string" && imageUrl.trim()) {
+      return { url: imageUrl.trim() };
+    }
+    if (
+      imageUrl &&
+      typeof imageUrl === "object" &&
+      typeof (imageUrl as { url?: unknown }).url === "string" &&
+      (imageUrl as { url: string }).url.trim()
+    ) {
+      return { url: (imageUrl as { url: string }).url.trim() };
+    }
+  }
+
+  return null;
+}
+
+function extractImageUrlFromAttachment(attachment: Record<string, unknown>): ImageBlock | null {
+  const mimeType = typeof attachment.mimeType === "string" ? attachment.mimeType.trim() : undefined;
+  if (mimeType && !mimeType.toLowerCase().startsWith("image/")) {
+    return null;
+  }
+  if (typeof attachment.url === "string" && attachment.url.trim()) {
+    return {
+      url: attachment.url.trim(),
+      alt: typeof attachment.fileName === "string" ? attachment.fileName : undefined,
+    };
+  }
+  if (typeof attachment.content !== "string") {
+    return null;
+  }
+  const url = normalizeImageDataUrl(attachment.content, mimeType);
+  if (!url) {
+    return null;
+  }
+  return {
+    url,
+    alt: typeof attachment.fileName === "string" ? attachment.fileName : undefined,
+  };
+}
+
 function extractImages(message: unknown): ImageBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
   const images: ImageBlock[] = [];
+  const seenUrls = new Set<string>();
+
+  const pushImage = (image: ImageBlock | null) => {
+    if (!image || seenUrls.has(image.url)) {
+      return;
+    }
+    seenUrls.add(image.url);
+    images.push(image);
+  };
 
   if (Array.isArray(content)) {
     for (const block of content) {
       if (typeof block !== "object" || block === null) {
         continue;
       }
-      const b = block as Record<string, unknown>;
+      pushImage(extractImageUrlFromContentBlock(block as Record<string, unknown>));
+    }
+  }
 
-      if (b.type === "image") {
-        // Handle source object format (from sendChatMessage)
-        const source = b.source as Record<string, unknown> | undefined;
-        if (source?.type === "base64" && typeof source.data === "string") {
-          const data = source.data;
-          const mediaType = (source.media_type as string) || "image/png";
-          // If data is already a data URL, use it directly
-          const url = data.startsWith("data:") ? data : `data:${mediaType};base64,${data}`;
-          images.push({ url });
-        } else if (typeof b.url === "string") {
-          images.push({ url: b.url });
-        }
-      } else if (b.type === "image_url") {
-        // OpenAI format
-        const imageUrl = b.image_url as Record<string, unknown> | undefined;
-        if (typeof imageUrl?.url === "string") {
-          images.push({ url: imageUrl.url });
-        }
+  const attachments = m.attachments;
+  if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      if (typeof attachment !== "object" || attachment === null) {
+        continue;
       }
+      pushImage(extractImageUrlFromAttachment(attachment as Record<string, unknown>));
     }
   }
 

--- a/ui/src/ui/views/chat-image-open.browser.test.ts
+++ b/ui/src/ui/views/chat-image-open.browser.test.ts
@@ -15,7 +15,45 @@ function renderAssistantImage(url: string) {
   };
 }
 
+function renderUserHistoryAttachment(base64: string) {
+  return {
+    role: "user",
+    content: [{ type: "text", text: "see image" }],
+    attachments: [
+      {
+        type: "image",
+        mimeType: "image/png",
+        fileName: "dot.png",
+        content: base64,
+      },
+    ],
+    timestamp: Date.now(),
+  };
+}
+
 describe("chat image open safety", () => {
+  it("keeps history-backed image attachments visible after the assistant reply lands", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    app.chatMessages = [
+      renderUserHistoryAttachment(pngBase64),
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        timestamp: Date.now() + 1,
+      },
+    ];
+    await app.updateComplete;
+
+    const image = app.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
+    expect(image?.getAttribute("alt")).toBe("dot.png");
+  });
+
   it("opens safe image URLs in a hardened new tab", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -693,6 +693,44 @@ describe("chat view", () => {
     expect(senderLabels).not.toContain("You");
   });
 
+  it("renders history attachments inline for user messages after chat reload", () => {
+    const container = document.createElement("div");
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    render(
+      renderChat(
+        createProps({
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: "see image" }],
+              attachments: [
+                {
+                  type: "image",
+                  mimeType: "image/png",
+                  fileName: "dot.png",
+                  content: pngBase64,
+                },
+              ],
+              timestamp: 1000,
+            },
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "got it" }],
+              timestamp: 1001,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const image = container.querySelector<HTMLImageElement>(".chat-group.user .chat-message-image");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("src")).toBe(`data:image/png;base64,${pngBase64}`);
+    expect(image?.getAttribute("alt")).toBe("dot.png");
+  });
+
   it("keeps consecutive user messages from different senders in separate groups", () => {
     const container = document.createElement("div");
     render(


### PR DESCRIPTION
Fixes #45807

AI-assisted: yes

## Summary
History-backed user messages can carry images in top-level `attachments`, but the chat renderer only extracted images from `content` blocks. That made uploaded images disappear after the assistant reply landed and the UI reloaded chat history.

This change teaches the renderer to read top-level image attachments as well, preserves attachment filenames as image alt text, and deduplicates rendered images by URL.

## Testing
- `npm exec --yes pnpm@10.23.0 -- test -- ui/src/ui/views/chat.test.ts`
- `npm exec --yes pnpm@10.23.0 -- vitest run --config vitest.config.ts --project browser src/ui/views/chat-image-open.browser.test.ts` (run from `ui/`)
- `npm exec --yes pnpm@10.23.0 -- exec oxfmt --check ui/src/ui/chat/grouped-render.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/chat-image-open.browser.test.ts`
- `npm exec --yes pnpm@10.23.0 -- exec oxlint ui/src/ui/chat/grouped-render.ts ui/src/ui/views/chat.test.ts ui/src/ui/views/chat-image-open.browser.test.ts`
- `/Users/jamesavery/.openclaw/openclaw-pr-check.sh`
  - `build` reached unrelated baseline extension dependency/type failures outside this change
  - `check` reached the same unrelated baseline failures in untouched extension files

The browser regression covers the real UI path where a user image attachment should remain visible after the assistant reply appears.