### PR TITLE
fix(telegram): surface sticker file_id in inbound context

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -101,6 +101,24 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["sender_id"]).toBeUndefined();
   });
 
+  it("does not include sticker_file_id in stable system metadata", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      OriginatingTo: "telegram:5494292670",
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      ChatType: "direct",
+      Sticker: {
+        fileId: "CAACAgIAAxkBAAI...sticker_file_id",
+        emoji: "🎉",
+        setName: "PartyPack",
+      },
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["sticker_file_id"]).toBeUndefined();
+  });
+
   it("includes Slack mrkdwn response format hints for Slack chats", () => {
     const prompt = buildInboundMetaSystemPrompt({
       OriginatingTo: "channel:C123",
@@ -153,6 +171,18 @@ describe("buildInboundUserContextPrefix", () => {
       OriginatingChannel: "webchat",
       MessageSid: "short-id",
       MessageSidFull: "provider-full-id",
+    } as TemplateContext);
+
+    expect(text).toBe("");
+  });
+
+  it("does not emit conversation metadata for direct webchat sticker-only turns", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "webchat",
+      Sticker: {
+        fileId: "CAACAgIAAxkBAAI...sticker_file_id",
+      },
     } as TemplateContext);
 
     expect(text).toBe("");
@@ -240,6 +270,23 @@ describe("buildInboundUserContextPrefix", () => {
     const senderInfo = parseSenderInfoPayload(text);
     expect(senderInfo["label"]).toBe("Tyler (+15551234567)");
     expect(senderInfo["id"]).toBe("+15551234567");
+  });
+
+  it("includes sticker_file_id in per-turn conversation info for direct chats", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "telegram",
+      MessageSid: "123",
+      Sticker: {
+        fileId: "CAACAgIAAxkBAAI...sticker_file_id",
+        emoji: "🎉",
+        setName: "PartyPack",
+      },
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["message_id"]).toBe("123");
+    expect(conversationInfo["sticker_file_id"]).toBe("CAACAgIAAxkBAAI...sticker_file_id");
   });
 
   it("includes formatted timestamp in conversation info when provided", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -121,6 +121,7 @@ export function buildInboundUserContextPrefix(
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
     sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
+    sticker_file_id: shouldIncludeConversationInfo ? safeTrim(ctx.Sticker?.fileId) : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),
     sender: shouldIncludeConversationInfo
       ? (safeTrim(ctx.SenderName) ??


### PR DESCRIPTION
## Summary

- Problem: Telegram ingress already captures `TemplateContext.Sticker.fileId`, but agent-visible inbound prompt context did not surface a replayable sticker handle.
- Why it matters: native sticker turns could reach the agent without the exact `file_id` needed to send the same sticker back, which blocked sticker echo and curated native-sticker reply workflows.
- What changed: add `sticker_file_id` to per-turn `Conversation info (untrusted metadata)` in `buildInboundUserContextPrefix()`, keep it out of stable inbound system metadata, and lock the behavior with focused tests.
- What did NOT change (scope boundary): this PR does **not** add sticker media passthrough/downloads, animated/video sticker handling, or broader sticker-ingress redesign.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #8758
- Related #21984
- Related PR #19056
- [x] This PR fixes a bug or regression


## Root Cause / Regression History (if applicable)

- Root cause: `ctx.Sticker.fileId` was already populated by Telegram ingress, but inbound prompt construction did not project a replayable sticker identifier into the agent-visible per-turn context.
- Missing detection / guardrail: there was no focused test asserting the intended split between stable system metadata (must exclude per-turn sticker data) and per-turn conversation info (must include `sticker_file_id` for eligible chats).
- Prior context (`git blame`, prior PR, issue, or refactor if known): prior PR #19056 proposed exposing sticker metadata in the stable system prompt. This branch intentionally takes the narrower safer route: conversation info only. Related product context also exists in #8758 and #21984.
- Why this regressed now: not a new regression; it is a long-standing Telegram prompt-context gap that became more obvious once native sticker send/reuse workflows were in play.
- If unknown, what was ruled out: ruled out Telegram Bot API limitations and provider-ingress absence; the missing piece was prompt projection, not sticker capture.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/inbound-meta.test.ts`
- Scenario the test should lock in: direct Telegram chats include `sticker_file_id`; direct webchat sticker-only turns still emit no conversation metadata; stable system metadata never includes `sticker_file_id`.
- Why this is the smallest reliable guardrail: the bug lives in prompt-shaping logic and can be verified deterministically without network IO or live Telegram.
- Existing test that already covers this (if any): none before this branch.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram sticker turns can now expose a replayable `sticker_file_id` to the agent in per-turn conversation info, enabling native sticker reply workflows that depend on Telegram sticker file IDs.
- Stable inbound system metadata remains unchanged; `sticker_file_id` is intentionally excluded there.
- Direct webchat turns still omit conversation metadata, including sticker-only turns.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation:
  - This adds one existing Telegram per-turn identifier (`sticker_file_id`) to the untrusted conversation-info block only when conversation info is already included. It remains excluded from stable system metadata and direct webchat sessions, which limits prompt-prefix churn and avoids broadening trusted metadata.

## Repro + Verification

### Environment

- OS: Ubuntu (local dev host)
- Runtime/container: local Node/pnpm repo checkout
- Model/provider: N/A (prompt-shaping path)
- Integration/channel (if any): Telegram
- Relevant config (redacted): standard Telegram bot ingress; no sticker-specific config required

### Steps

1. Build inbound context for a Telegram message with `TemplateContext.Sticker.fileId` set.
2. Inspect `buildInboundMetaSystemPrompt()` and `buildInboundUserContextPrefix()` output, or run `pnpm exec vitest run src/auto-reply/reply/inbound-meta.test.ts`.
3. Confirm `sticker_file_id` appears only in per-turn conversation info for eligible chats and not in the stable system metadata block.

### Expected

- `sticker_file_id` is available to the agent in per-turn conversation info for Telegram chats where conversation info is included.
- `sticker_file_id` is omitted from stable inbound system metadata.
- Direct webchat sticker-only turns still emit no conversation metadata.

### Actual

- Before this branch: `sticker_file_id` was not surfaced to the agent at all.
- On this branch: the field is present in per-turn conversation info, excluded from stable system metadata, and covered by focused regression tests.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- clean rebased branch now diffing as the intended 2 files only
- `pnpm exec vitest run src/auto-reply/reply/inbound-meta.test.ts` ✅
- `pnpm check` ✅
- current branch tip: `281769a4f0`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - rebuilt the branch cleanly on top of current `upstream/main`
  - confirmed the PR diff collapsed back to the intended 2 files
  - re-ran `src/auto-reply/reply/inbound-meta.test.ts`
  - re-ran `pnpm check`
  - confirmed the implementation still keeps `sticker_file_id` out of `buildInboundMetaSystemPrompt()` and includes it in `buildInboundUserContextPrefix()` for eligible chats
- Edge cases checked:
  - direct webchat sticker-only omission
  - stable system-metadata path remains unchanged
- What you did **not** verify:
  - live Telegram retest after this clean rebase
  - animated/video sticker variants
  - sticker media download/passthrough flows

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: future cleanup could accidentally move `sticker_file_id` into stable system metadata and reintroduce prompt-prefix churn.
  - Mitigation: tests explicitly assert that stable system metadata excludes `sticker_file_id`.
- Risk: reviewers may assume this PR also solves broader sticker ingestion/media parity.
  - Mitigation: scope is explicitly limited in this PR body and tests to per-turn `sticker_file_id` exposure only.


