### PR TITLE
fix(plugins): cache snapshot plugin registries

### DIFF
--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -380,12 +380,12 @@ describe("ensureChannelSetupPluginInstalled", () => {
       expect.objectContaining({
         config: cfg,
         workspaceDir: "/tmp/openclaw-workspace",
-        cache: false,
         onlyPluginIds: ["telegram"],
         includeSetupOnlyChannelPlugins: true,
         activate: false,
       }),
     );
+    expect(clearPluginDiscoveryCache).not.toHaveBeenCalled();
   });
 
   it("scopes snapshots by plugin id when channel and plugin ids differ", () => {
@@ -404,11 +404,11 @@ describe("ensureChannelSetupPluginInstalled", () => {
       expect.objectContaining({
         config: cfg,
         workspaceDir: "/tmp/openclaw-workspace",
-        cache: false,
         onlyPluginIds: ["@openclaw/msteams-plugin"],
         includeSetupOnlyChannelPlugins: true,
         activate: false,
       }),
     );
+    expect(clearPluginDiscoveryCache).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/channel-setup/plugin-install.ts
+++ b/src/commands/channel-setup/plugin-install.ts
@@ -240,14 +240,16 @@ function loadChannelSetupPluginRegistry(params: {
   onlyPluginIds?: string[];
   activate?: boolean;
 }): PluginRegistry {
-  clearPluginDiscoveryCache();
+  if (params.activate !== false) {
+    clearPluginDiscoveryCache();
+  }
   const workspaceDir =
     params.workspaceDir ?? resolveAgentWorkspaceDir(params.cfg, resolveDefaultAgentId(params.cfg));
   const log = createSubsystemLogger("plugins");
   return loadOpenClawPlugins({
     config: params.cfg,
     workspaceDir,
-    cache: false,
+    ...(params.activate === false ? {} : { cache: false }),
     logger: createPluginLoaderLogger(log),
     onlyPluginIds: params.onlyPluginIds,
     includeSetupOnlyChannelPlugins: true,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -954,6 +954,46 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
           expect(getGlobalHookRunner()).toBeNull();
         },
       },
+      {
+        label: "reuses cached non-activating scoped registries without re-running register",
+        run: () => {
+          useNoBundledPlugins();
+          const marker = path.join(makeTempDir(), "snapshot-register-count.txt");
+          const plugin = writePlugin({
+            id: "cached-snapshot-register",
+            filename: "cached-snapshot-register.cjs",
+            body: `const fs = require("node:fs");
+module.exports = {
+  id: "cached-snapshot-register",
+  register() {
+    const previous = fs.existsSync(${JSON.stringify(marker)})
+      ? Number.parseInt(fs.readFileSync(${JSON.stringify(marker)}, "utf-8"), 10) || 0
+      : 0;
+    fs.writeFileSync(${JSON.stringify(marker)}, String(previous + 1), "utf-8");
+  },
+};`,
+          });
+
+          const options = {
+            activate: false as const,
+            workspaceDir: plugin.dir,
+            config: {
+              plugins: {
+                load: { paths: [plugin.file] },
+                allow: ["cached-snapshot-register"],
+              },
+            },
+            onlyPluginIds: ["cached-snapshot-register"],
+          };
+
+          const first = loadOpenClawPlugins(options);
+          const second = loadOpenClawPlugins(options);
+
+          expect(first.plugins.map((entry) => entry.id)).toEqual(["cached-snapshot-register"]);
+          expect(second).toBe(first);
+          expect(fs.readFileSync(marker, "utf-8")).toBe("1");
+        },
+      },
     ] as const;
 
     for (const scenario of scenarios) {
@@ -1088,13 +1128,43 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toEqual([]);
   });
 
-  it("throws when activate:false is used without cache:false", () => {
-    expect(() => loadOpenClawPlugins({ activate: false })).toThrow(
-      "activate:false requires cache:false",
-    );
-    expect(() => loadOpenClawPlugins({ activate: false, cache: true })).toThrow(
-      "activate:false requires cache:false",
-    );
+  it("keeps activating and non-activating caches separate", () => {
+    useNoBundledPlugins();
+    const marker = path.join(makeTempDir(), "activation-cache-mode.txt");
+    const plugin = writePlugin({
+      id: "activation-cache-mode",
+      filename: "activation-cache-mode.cjs",
+      body: `const fs = require("node:fs");
+module.exports = {
+  id: "activation-cache-mode",
+  register() {
+    const previous = fs.existsSync(${JSON.stringify(marker)})
+      ? Number.parseInt(fs.readFileSync(${JSON.stringify(marker)}, "utf-8"), 10) || 0
+      : 0;
+    fs.writeFileSync(${JSON.stringify(marker)}, String(previous + 1), "utf-8");
+  },
+};`,
+    });
+
+    const baseOptions = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["activation-cache-mode"],
+        },
+      },
+      onlyPluginIds: ["activation-cache-mode"],
+    };
+
+    const snapshot = loadOpenClawPlugins({
+      ...baseOptions,
+      activate: false,
+    });
+    const active = loadOpenClawPlugins(baseOptions);
+
+    expect(snapshot).not.toBe(active);
+    expect(fs.readFileSync(marker, "utf-8")).toBe("2");
   });
 
   it("re-initializes global hook runner when serving registry from cache", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -185,6 +185,7 @@ function buildCacheKey(params: {
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  activate?: boolean;
 }): string {
   const { roots, loadPaths } = resolvePluginCacheInputs({
     workspaceDir: params.workspaceDir,
@@ -211,11 +212,12 @@ function buildCacheKey(params: {
   const setupOnlyKey = params.includeSetupOnlyChannelPlugins === true ? "setup-only" : "runtime";
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
+  const activationMode = params.activate === false ? "snapshot" : "active";
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
     ...params.plugins,
     installs,
     loadPaths,
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}::${activationMode}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -663,13 +665,6 @@ function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): voi
 }
 
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {
-  // Snapshot (non-activating) loads must disable the cache to avoid storing a registry
-  // whose commands were never globally registered.
-  if (options.activate === false && options.cache !== false) {
-    throw new Error(
-      "loadOpenClawPlugins: activate:false requires cache:false to prevent command registry divergence",
-    );
-  }
   const env = options.env ?? process.env;
   // Test env: default-disable plugins unless explicitly configured.
   // This keeps unit/gateway suites fast and avoids loading heavyweight plugin deps by accident.
@@ -682,10 +677,6 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
   const shouldActivate = options.activate !== false;
-  // NOTE: `activate` is intentionally excluded from the cache key. All non-activating
-  // (snapshot) callers pass `cache: false` via loadOnboardingPluginRegistry(), so they
-  // never read from or write to the cache. Including `activate` here would be misleading
-  // — it would imply mixed-activate caching is supported, when in practice it is not.
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: normalized,
@@ -700,13 +691,14 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         : options.runtimeOptions?.subagent
           ? "explicit"
           : "default",
+    activate: options.activate,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
     const cached = getCachedPluginRegistry(cacheKey);
     if (cached) {
-      restoreMemoryPromptSection(cached.memoryPromptBuilder);
       if (shouldActivate) {
+        restoreMemoryPromptSection(cached.memoryPromptBuilder);
         activatePluginRegistry(cached.registry, cacheKey);
       }
       return cached.registry;


### PR DESCRIPTION
## Summary
- reuse cached plugin registries for non-activating snapshot loads
- keep activating and snapshot cache entries isolated via the loader cache key
- cover snapshot caching behavior with loader regression tests

## Testing
- pnpm test -- src/plugins/loader.test.ts *(fails in this environment because node_modules/vitest are missing)*