### PR TITLE
refactor(doctor): extract flow finalization

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -7,6 +7,7 @@ import { noteOpencodeProviderOverrides } from "./doctor-config-analysis.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
+import { finalizeDoctorConfigFlow } from "./doctor/finalize-config-flow.js";
 import { runMatrixDoctorSequence } from "./doctor/providers/matrix.js";
 import { runDoctorRepairSequence } from "./doctor/repair-sequencing.js";
 import {
@@ -35,7 +36,6 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   let cfg: OpenClawConfig = baseCfg;
   let candidate = structuredClone(baseCfg);
   let pendingChanges = false;
-  let shouldWriteConfig = false;
   let fixHints: string[] = [];
   const doctorFixCommand = formatCliCommand("openclaw doctor --fix");
 
@@ -134,29 +134,23 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     note(lines, shouldRepair ? "Doctor changes" : "Unknown config keys");
   }
 
-  if (!shouldRepair && pendingChanges) {
-    const shouldApply = await params.confirm({
-      message: "Apply recommended config repairs now?",
-      initialValue: true,
-    });
-    if (shouldApply) {
-      cfg = candidate;
-      shouldWriteConfig = true;
-    } else if (fixHints.length > 0) {
-      note(fixHints.join("\n"), "Doctor");
-    }
-  }
-
-  if (shouldRepair && pendingChanges) {
-    shouldWriteConfig = true;
-  }
+  const finalized = await finalizeDoctorConfigFlow({
+    cfg,
+    candidate,
+    pendingChanges,
+    shouldRepair,
+    fixHints,
+    confirm: params.confirm,
+    note,
+  });
+  cfg = finalized.cfg;
 
   noteOpencodeProviderOverrides(cfg);
 
   return {
     cfg,
     path: snapshot.path ?? CONFIG_PATH,
-    shouldWriteConfig,
+    shouldWriteConfig: finalized.shouldWriteConfig,
     sourceConfigValid: snapshot.valid,
   };
 }

--- a/src/commands/doctor/finalize-config-flow.test.ts
+++ b/src/commands/doctor/finalize-config-flow.test.ts
@@ -46,7 +46,7 @@ describe("doctor finalize config flow", () => {
   it("writes automatically in repair mode when changes exist", async () => {
     const result = await finalizeDoctorConfigFlow({
       cfg: { channels: { signal: { enabled: true } } },
-      candidate: { channels: { signal: { enabled: true } } },
+      candidate: { channels: { signal: { enabled: false } } },
       pendingChanges: true,
       shouldRepair: true,
       fixHints: [],

--- a/src/commands/doctor/finalize-config-flow.test.ts
+++ b/src/commands/doctor/finalize-config-flow.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { finalizeDoctorConfigFlow } from "./finalize-config-flow.js";
+
+describe("doctor finalize config flow", () => {
+  it("writes the candidate when preview changes are confirmed", async () => {
+    const note = vi.fn();
+    const result = await finalizeDoctorConfigFlow({
+      cfg: { channels: {} },
+      candidate: { channels: { signal: { enabled: true } } },
+      pendingChanges: true,
+      shouldRepair: false,
+      fixHints: ['Run "openclaw doctor --fix" to apply these changes.'],
+      confirm: async () => true,
+      note,
+    });
+
+    expect(result).toEqual({
+      cfg: { channels: { signal: { enabled: true } } },
+      shouldWriteConfig: true,
+    });
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("emits fix hints when preview changes are declined", async () => {
+    const note = vi.fn();
+    const result = await finalizeDoctorConfigFlow({
+      cfg: { channels: {} },
+      candidate: { channels: { signal: { enabled: true } } },
+      pendingChanges: true,
+      shouldRepair: false,
+      fixHints: ['Run "openclaw doctor --fix" to apply these changes.'],
+      confirm: async () => false,
+      note,
+    });
+
+    expect(result).toEqual({
+      cfg: { channels: {} },
+      shouldWriteConfig: false,
+    });
+    expect(note).toHaveBeenCalledWith(
+      'Run "openclaw doctor --fix" to apply these changes.',
+      "Doctor",
+    );
+  });
+
+  it("writes automatically in repair mode when changes exist", async () => {
+    const result = await finalizeDoctorConfigFlow({
+      cfg: { channels: { signal: { enabled: true } } },
+      candidate: { channels: { signal: { enabled: true } } },
+      pendingChanges: true,
+      shouldRepair: true,
+      fixHints: [],
+      confirm: async () => true,
+      note: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      cfg: { channels: { signal: { enabled: true } } },
+      shouldWriteConfig: true,
+    });
+  });
+});

--- a/src/commands/doctor/finalize-config-flow.ts
+++ b/src/commands/doctor/finalize-config-flow.ts
@@ -1,0 +1,43 @@
+import type { OpenClawConfig } from "../../config/config.js";
+
+export async function finalizeDoctorConfigFlow(params: {
+  cfg: OpenClawConfig;
+  candidate: OpenClawConfig;
+  pendingChanges: boolean;
+  shouldRepair: boolean;
+  fixHints: string[];
+  confirm: (p: { message: string; initialValue: boolean }) => Promise<boolean>;
+  note: (message: string, title?: string) => void;
+}): Promise<{ cfg: OpenClawConfig; shouldWriteConfig: boolean }> {
+  if (!params.shouldRepair && params.pendingChanges) {
+    const shouldApply = await params.confirm({
+      message: "Apply recommended config repairs now?",
+      initialValue: true,
+    });
+    if (shouldApply) {
+      return {
+        cfg: params.candidate,
+        shouldWriteConfig: true,
+      };
+    }
+    if (params.fixHints.length > 0) {
+      params.note(params.fixHints.join("\n"), "Doctor");
+    }
+    return {
+      cfg: params.cfg,
+      shouldWriteConfig: false,
+    };
+  }
+
+  if (params.shouldRepair && params.pendingChanges) {
+    return {
+      cfg: params.cfg,
+      shouldWriteConfig: true,
+    };
+  }
+
+  return {
+    cfg: params.cfg,
+    shouldWriteConfig: false,
+  };
+}


### PR DESCRIPTION
## Summary
- extract the final doctor config confirm/write policy into a doctor-layer finalizer
- thin doctor-config-flow further by removing the pendingChanges and shouldWriteConfig tail
- add targeted coverage for preview accept/decline and repair-mode auto-write behavior

## Testing
- pnpm exec vitest run src/commands/doctor/finalize-config-flow.test.ts src/commands/doctor-config-flow.test.ts
- pnpm build
- pnpm check

Thanks @vincentkoc