### PR TITLE
fix(onboard): remove setup-token prefix and length validation

### DIFF
--- a/src/plugins/provider-auth-token.ts
+++ b/src/plugins/provider-auth-token.ts
@@ -28,11 +28,5 @@ export function validateAnthropicSetupToken(raw: string): string | undefined {
   if (!trimmed) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
-    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX}`;
-  }
-  if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
-    return "Token looks too short; paste the full setup-token";
-  }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- Anthropic has randomized setup-token prefixes, so the hardcoded `sk-ant-oat01-` check in `validateAnthropicSetupToken` rejects valid tokens during onboarding
- Removes the prefix and minimum-length checks, keeping only the empty-string guard

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check` passes (via committer)
- [x] `pnpm test -- src/commands/onboard` — 227 tests pass (212 base + 15 e2e)
- [ ] Manual: `openclaw onboard` → Anthropic → token → paste a valid setup-token with new prefix format