### PR TITLE
fix(ui): slash command menu rendered off-screen due to overflow:hidden

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -373,7 +373,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   flex-shrink: 0;
-  overflow: hidden;
+  overflow: visible;
   transition:
     border-color var(--duration-fast) ease,
     box-shadow var(--duration-fast) ease;


### PR DESCRIPTION
## Summary
- Fix slash command menu (`/`) being rendered off-screen at `top: -324px` in the Control UI chat interface
- The `.agent-chat__input` container had `overflow: hidden` which clips the absolutely-positioned `.slash-menu` element (positioned above the input with `bottom: 100%`)
- This regression was introduced during the CSS refactor in f4227e278

## Changes
- Changed `overflow: hidden` to `overflow: visible` on `.agent-chat__input` in `ui/src/styles/chat/layout.css`

## Test plan
- [ ] Open Control UI chat interface
- [ ] Type `/` in the message input
- [ ] Verify the slash command menu appears above the input box (not off-screen)
- [ ] Verify the input box border-radius and visual appearance are preserved

Fixes #52089

🤖 Generated with [Claude Code](https://claude.com/claude-code)