### PR TITLE
fix(cli): route logs to stderr when --json flag is active

### DIFF
--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { routeLogsToStderr } from "../../logging/console.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -144,6 +145,9 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+    if (suppressDoctorStdout) {
+      routeLogsToStderr();
+    }
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
-import { routeLogsToStderr } from "../../logging/console.js";
+import { restoreLogsToStdout, routeLogsToStderr } from "../../logging/console.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -144,20 +144,27 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (shouldBypassConfigGuard(commandPath)) {
       return;
     }
-    const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
-    if (suppressDoctorStdout) {
-      routeLogsToStderr();
-    }
+    const isJsonMode = isJsonOutputMode(commandPath, argv);
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,
       commandPath,
-      ...(suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
+      ...(isJsonMode ? { suppressDoctorStdout: true } : {}),
     });
-    // Load plugins for commands that need channel access
+    // Load plugins for commands that need channel access.
+    // Temporarily route logs to stderr during plugin loading so that
+    // plugin console.log noise does not pollute --json stdout output.
+    // The routing is restored afterwards so that command handlers can
+    // still emit their JSON payload via runtime.log (→ console.log).
     if (shouldLoadPluginsForCommand(commandPath, argv)) {
+      if (isJsonMode) {
+        routeLogsToStderr();
+      }
       const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
       ensurePluginRegistryLoaded({ scope: resolvePluginRegistryScope(commandPath) });
+      if (isJsonMode) {
+        restoreLogsToStdout();
+      }
     }
   });
 }

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -160,10 +160,13 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       if (isJsonMode) {
         routeLogsToStderr();
       }
-      const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
-      ensurePluginRegistryLoaded({ scope: resolvePluginRegistryScope(commandPath) });
-      if (isJsonMode) {
-        restoreLogsToStdout();
+      try {
+        const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
+        ensurePluginRegistryLoaded({ scope: resolvePluginRegistryScope(commandPath) });
+      } finally {
+        if (isJsonMode) {
+          restoreLogsToStdout();
+        }
       }
     }
   });

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -25,16 +25,19 @@ async function prepareRoutedCommand(params: {
       const { routeLogsToStderr } = await import("../logging/console.js");
       routeLogsToStderr();
     }
-    const { ensurePluginRegistryLoaded } = await import("./plugin-registry.js");
-    ensurePluginRegistryLoaded({
-      scope:
-        params.commandPath[0] === "status" || params.commandPath[0] === "health"
-          ? "channels"
-          : "all",
-    });
-    if (suppressDoctorStdout) {
-      const { restoreLogsToStdout } = await import("../logging/console.js");
-      restoreLogsToStdout();
+    try {
+      const { ensurePluginRegistryLoaded } = await import("./plugin-registry.js");
+      ensurePluginRegistryLoaded({
+        scope:
+          params.commandPath[0] === "status" || params.commandPath[0] === "health"
+            ? "channels"
+            : "all",
+      });
+    } finally {
+      if (suppressDoctorStdout) {
+        const { restoreLogsToStdout } = await import("../logging/console.js");
+        restoreLogsToStdout();
+      }
     }
   }
 }

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -21,6 +21,10 @@ async function prepareRoutedCommand(params: {
   const shouldLoadPlugins =
     typeof params.loadPlugins === "function" ? params.loadPlugins(params.argv) : params.loadPlugins;
   if (shouldLoadPlugins) {
+    if (suppressDoctorStdout) {
+      const { routeLogsToStderr } = await import("../logging/console.js");
+      routeLogsToStderr();
+    }
     const { ensurePluginRegistryLoaded } = await import("./plugin-registry.js");
     ensurePluginRegistryLoaded({
       scope:
@@ -28,6 +32,10 @@ async function prepareRoutedCommand(params: {
           ? "channels"
           : "all",
     });
+    if (suppressDoctorStdout) {
+      const { restoreLogsToStdout } = await import("../logging/console.js");
+      restoreLogsToStdout();
+    }
   }
 }
 

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -116,6 +116,11 @@ export function routeLogsToStderr(): void {
   loggingState.forceConsoleToStderr = true;
 }
 
+// Restore console output to stdout after a temporary stderr routing window.
+export function restoreLogsToStdout(): void {
+  loggingState.forceConsoleToStderr = false;
+}
+
 export function setConsoleSubsystemFilter(filters?: string[] | null): void {
   if (!filters || filters.length === 0) {
     loggingState.consoleSubsystemFilter = null;


### PR DESCRIPTION
## Summary

- Call `routeLogsToStderr()` in the CLI preAction hook when `--json` mode is detected, before plugin loading
- Plugin loading emits `console.log` messages that corrupt stdout JSON output for commands like `openclaw agents list --json`
- Follows the existing pattern in `src/cli/completion-cli.ts`

## Root Cause

`src/cli/program/preaction.ts` detects `--json` mode via `isJsonOutputMode()` but only uses it to suppress doctor output. It never calls `routeLogsToStderr()`, so plugin loading logs pollute stdout.

## Test plan

- [x] `npm run build` passes
- [ ] `openclaw agents list --json | jq .` parses cleanly without plugin log pollution

Fixes #52032

🤖 Generated with [Claude Code](https://claude.com/claude-code)