### PR TITLE
fix(control-ui): add missing operator.read and operator.write scopes to connect params

### DIFF
--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -143,7 +143,13 @@ describe("GatewayBrowserClient", () => {
       deviceId: "device-1",
       role: "operator",
       token: "stored-device-token",
-      scopes: ["operator.admin", "operator.approvals", "operator.pairing"],
+      scopes: [
+        "operator.admin",
+        "operator.read",
+        "operator.write",
+        "operator.approvals",
+        "operator.pairing",
+      ],
     });
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -242,7 +242,13 @@ export class GatewayBrowserClient {
     // Gateways may reject this unless gateway.controlUi.allowInsecureAuth is enabled.
     const isSecureContext = typeof crypto !== "undefined" && !!crypto.subtle;
 
-    const scopes = ["operator.admin", "operator.approvals", "operator.pairing"];
+    const scopes = [
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+      "operator.pairing",
+    ];
     const role = "operator";
     const explicitGatewayToken = this.opts.token?.trim() || undefined;
     const explicitPassword = this.opts.password?.trim() || undefined;


### PR DESCRIPTION
## Summary

- Add `operator.read` and `operator.write` to the Control UI websocket connect params scope array
- The dashboard webchat was missing these scopes, causing all `agent` RPC calls to fail with `missing scope: operator.write`

## Root Cause

`ui/src/ui/gateway.ts` line 245 declared connect scopes as only `["operator.admin", "operator.approvals", "operator.pairing"]`, omitting `operator.read` and `operator.write`. The gateway enforces scope-based access control, so the dashboard webchat couldn't send messages or read session state.

## Test plan

- [x] `npm run build` passes
- [ ] `openclaw dashboard` → webchat can send messages without "missing scope: operator.write" error

Fixes #52087

🤖 Generated with [Claude Code](https://claude.com/claude-code)