### PR TITLE
fix(google): strip empty required arrays from tool schemas for Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/mentions: stop treating mentions embedded in quoted messages as direct mentions so replying to a message that @mentioned the bot no longer falsely triggers mention gating. (#52711) Thanks @lurebat.
 - Agents/ollama fallback: surface non-2xx Ollama HTTP errors with a leading status code so HTTP 503 responses trigger model fallback again. (#55214) Thanks @bugkill3r.
 - Feishu/tools: stop synthetic agent ids like `agent-spawner` from being treated as Feishu account ids during tool execution, so tools fall back to the configured/default Feishu account unless the contextual id is a real enabled Feishu account. (#55627) Thanks @MonkeyLeeT.
+- Google/tools: strip empty `required: []` arrays from Gemini tool schemas so optional-only tool parameters no longer trigger Google validator 400s. (#52106) Thanks @oliviareid-svg.
 
 ## 2026.3.24
 

--- a/src/agents/schema/clean-for-gemini.test.ts
+++ b/src/agents/schema/clean-for-gemini.test.ts
@@ -52,4 +52,48 @@ describe("cleanSchemaForGemini", () => {
     expect(cleaned.properties?.bad?.properties).toEqual({});
     expect(cleaned.properties?.good?.type).toBe("string");
   });
+
+  it("strips empty required arrays", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      required: [],
+    }) as Record<string, unknown>;
+
+    expect(cleaned).not.toHaveProperty("required");
+    expect(cleaned.type).toBe("object");
+  });
+
+  it("preserves non-empty required arrays", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      required: ["name"],
+    }) as Record<string, unknown>;
+
+    expect(cleaned.required).toEqual(["name"]);
+  });
+
+  it("strips empty required arrays in nested schemas", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        nested: {
+          type: "object",
+          properties: {
+            optional: { type: "string" },
+          },
+          required: [],
+        },
+      },
+      required: ["nested"],
+    }) as { properties?: { nested?: Record<string, unknown> }; required?: string[] };
+
+    expect(cleaned.required).toEqual(["nested"]);
+    expect(cleaned.properties?.nested).not.toHaveProperty("required");
+  });
 });

--- a/src/agents/schema/clean-for-gemini.ts
+++ b/src/agents/schema/clean-for-gemini.ts
@@ -291,6 +291,11 @@ function cleanSchemaForGeminiWithDefs(
       continue;
     }
 
+    // Google's schema validator rejects `"required": []` — omit empty arrays.
+    if (key === "required" && Array.isArray(value) && value.length === 0) {
+      continue;
+    }
+
     if (key === "type" && (hasAnyOf || hasOneOf)) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Google's schema validator rejects `"required": []` in tool parameter schemas, causing 400 errors when tools with optional-only parameters are sent to the Google/Gemini endpoint
- The `cleanSchemaForGemini` function already strips many unsupported keywords but was passing through empty `required` arrays as-is
- This fix omits `required` when it is an empty array, both at the top level and in nested object schemas

Fixes #51774 (Bug 2: empty `required: []` arrays rejected by Google's validator)

## Test plan

- [x] Added test: strips empty `required: []` arrays from top-level schemas
- [x] Added test: preserves non-empty `required` arrays
- [x] Added test: strips empty `required: []` in nested object schemas
- [x] All existing `cleanSchemaForGemini` tests pass (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)