### PR TITLE
fix(ui): catch unhandled errors in slash command dispatch

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -311,7 +311,10 @@ async function dispatchSlashCommand(
   try {
     result = await executeSlashCommand(host.client, targetSessionKey, name, args);
   } catch (err) {
-    injectCommandResult(host, `Command \`/${name}\` failed: ${String(err)}`);
+    injectCommandResult(
+      host,
+      `Command \`/${name}\` failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
     return;
   }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -3,7 +3,7 @@ import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
 import { setLastActiveSessionKey } from "./app-settings.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
 import type { OpenClawApp } from "./app.ts";
-import { executeSlashCommand } from "./chat/slash-command-executor.ts";
+import { executeSlashCommand, type SlashCommandResult } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand } from "./chat/slash-commands.ts";
 import { abortChatRun, loadChatHistory, sendChatMessage } from "./controllers/chat.ts";
 import { loadModels } from "./controllers/models.ts";
@@ -301,11 +301,20 @@ async function dispatchSlashCommand(
   }
 
   if (!host.client) {
+    injectCommandResult(host, `Cannot execute \`/${name}\`: not connected to gateway.`);
+    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
     return;
   }
 
   const targetSessionKey = host.sessionKey;
-  const result = await executeSlashCommand(host.client, targetSessionKey, name, args);
+  let result: SlashCommandResult;
+  try {
+    result = await executeSlashCommand(host.client, targetSessionKey, name, args);
+  } catch (err) {
+    injectCommandResult(host, `Command \`/${name}\` failed: ${String(err)}`);
+    scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
+    return;
+  }
 
   if (result.content) {
     injectCommandResult(host, result.content);


### PR DESCRIPTION
## Summary
- Wrap `executeSlashCommand()` in a try/catch inside `dispatchSlashCommand()` so unhandled errors are displayed as inline system messages instead of being silently swallowed
- Show an explicit "not connected" message when `host.client` is null instead of returning silently

## Root Cause
When `executeSlashCommand()` threw an unhandled error (e.g. from a disconnected WebSocket, unexpected RPC response shape, or provider-specific failures), the user's input was already cleared (line 230–232) but no result was injected into the chat. The command appeared to vanish — the error was only visible in the browser DevTools console.

This affected `/think`, `/model`, `/compact`, `/status`, `/usage`, and all other locally-executed slash commands.

## Test plan
- [ ] Type `/think` when gateway is disconnected → should show "not connected" message
- [ ] Type `/think` when gateway returns unexpected response → should show inline error
- [ ] Type `/model` normally → should still work as before
- [ ] Type `/think high` → should still set thinking level

Fixes #52105

🤖 Generated with [Claude Code](https://claude.com/claude-code)