### PR TITLE
fix(mattermost): inherit thread context in message tool send action

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -399,6 +399,233 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    describe("thread context inheritance", () => {
+      it("falls back to toolContext.currentThreadTs when no replyTo param is provided", async () => {
+        const cfg = createMattermostTestConfig();
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "all",
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: "thread-root-id" }),
+        );
+      });
+
+      it("explicit replyTo param wins over toolContext.currentThreadTs", async () => {
+        const cfg = createMattermostTestConfig();
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello", replyTo: "explicit-root" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "session-thread-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "all",
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: "explicit-root" }),
+        );
+      });
+
+      it("does not inherit thread context when sending to a different channel", async () => {
+        const cfg = createMattermostTestConfig();
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:OTHER", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "all",
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:OTHER",
+          "hello",
+          expect.objectContaining({ replyToId: undefined }),
+        );
+      });
+
+      it("inherits thread context for replyToMode=first before first reply", async () => {
+        const cfg = createMattermostTestConfig();
+        const hasRepliedRef = { value: false };
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "first",
+            hasRepliedRef,
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: "thread-root-id" }),
+        );
+        // hasRepliedRef must be flipped so the next tool send goes to channel root
+        expect(hasRepliedRef.value).toBe(true);
+      });
+
+      it("does not inherit thread context for replyToMode=first after first reply", async () => {
+        const cfg = createMattermostTestConfig();
+        const hasRepliedRef = { value: true };
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "first",
+            hasRepliedRef,
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: undefined }),
+        );
+      });
+
+      it("does not inherit thread context when replyToMode is off", async () => {
+        const cfg = createMattermostTestConfig();
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "off",
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: undefined }),
+        );
+      });
+
+      it("inherits thread context when replyToMode=off is promoted to all by existing thread", async () => {
+        // buildToolContext promotes off→all when an existing thread is detected
+        // (MessageThreadId set on the inbound post). handleAction receives the
+        // already-promoted toolContext from the agent runner.
+        const cfg = createMattermostTestConfig();
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "all", // promoted from off by buildToolContext
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: "thread-root-id" }),
+        );
+      });
+
+      it("preserves replyToMode=first when thread exists (does not promote to all)", async () => {
+        // replyToMode=first must NOT be upgraded to all — hasRepliedRef gates further sends.
+        const cfg = createMattermostTestConfig();
+        const hasRepliedRef = { value: true }; // first reply already done
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "first",
+            hasRepliedRef,
+          },
+        } as any);
+
+        // After first reply, subsequent sends go to channel root, not thread
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: undefined }),
+        );
+      });
+
+      it("flips hasRepliedRef when explicit replyTo is used under replyToMode=first", async () => {
+        // Explicit replyTo should also consume the first-reply slot
+        const cfg = createMattermostTestConfig();
+        const hasRepliedRef = { value: false };
+
+        await mattermostPlugin.actions?.handleAction?.({
+          channel: "mattermost",
+          action: "send",
+          params: { to: "channel:CHAN1", message: "hello", replyTo: "explicit-root" },
+          cfg,
+          accountId: "default",
+          toolContext: {
+            currentThreadTs: "thread-root-id",
+            currentChannelId: "channel:CHAN1",
+            replyToMode: "first",
+            hasRepliedRef,
+          },
+        } as any);
+
+        expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+          "channel:CHAN1",
+          "hello",
+          expect.objectContaining({ replyToId: "explicit-root" }),
+        );
+        // Explicit threaded send must also flip hasRepliedRef
+        expect(hasRepliedRef.value).toBe(true);
+      });
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -112,7 +112,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
   supportsAction: ({ action }) => {
     return action === "send" || action === "react";
   },
-  handleAction: async ({ action, params, cfg, accountId }) => {
+  handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
     if (action === "react") {
       const resolvedAccountId = accountId ?? resolveDefaultMattermostAccountId(cfg);
       const mattermostConfig = cfg.channels?.mattermost as MattermostConfig | undefined;
@@ -176,7 +176,41 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const message = typeof params.message === "string" ? params.message : "";
     // Match the shared runner semantics: trim empty reply IDs away before
     // falling back from replyToId to replyTo on direct plugin calls.
-    const replyToId = readMattermostReplyToId(params);
+    // When no explicit reply target is set, inherit the thread context from
+    // the active session — but only when:
+    //   1. The send target is the same channel as the active session (same channelId),
+    //      to avoid injecting a foreign root_id into a different Mattermost channel.
+    //   2. replyToMode is "all", or "first" and the first reply has not yet been sent.
+    const sessionThreadTs = toolContext?.currentThreadTs?.trim() || undefined;
+    const normalizedTo = normalizeMattermostMessagingTarget(to) ?? to;
+    const normalizedCurrentChannelId = toolContext?.currentChannelId
+      ? (normalizeMattermostMessagingTarget(toolContext.currentChannelId) ??
+        toolContext.currentChannelId)
+      : undefined;
+    const isSameChannel =
+      sessionThreadTs !== undefined &&
+      normalizedCurrentChannelId !== undefined &&
+      normalizedTo === normalizedCurrentChannelId;
+    // For replyToMode=first, only inherit if a hasRepliedRef exists AND it hasn't fired yet.
+    // Fail-closed: absent ref → don't inherit (avoids every send threading like replyToMode=all).
+    const replyToModeAllowsThread =
+      toolContext?.replyToMode === "all" ||
+      (toolContext?.replyToMode === "first" &&
+        toolContext.hasRepliedRef !== undefined &&
+        toolContext.hasRepliedRef.value !== true);
+    const implicitReplyToId =
+      isSameChannel && replyToModeAllowsThread ? sessionThreadTs : undefined;
+    const replyToId = readMattermostReplyToId(params) ?? implicitReplyToId;
+    // For replyToMode=first: flip hasRepliedRef after any threaded send (implicit or
+    // explicit) so subsequent tool sends in the same turn go to the channel root.
+    // This covers both implicit fallback and explicit replyTo/replyToId params.
+    if (
+      replyToId !== undefined &&
+      toolContext?.replyToMode === "first" &&
+      toolContext.hasRepliedRef !== undefined
+    ) {
+      toolContext.hasRepliedRef.value = true;
+    }
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =
@@ -434,6 +468,43 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
             ? chatType
             : "channel",
         ),
+    },
+    buildToolContext: ({ cfg, accountId, context, hasRepliedRef }) => {
+      // Resolve replyToMode from account config so the message tool can respect it.
+      const account = resolveMattermostAccount({ cfg, accountId: accountId ?? "default" });
+      const chatType =
+        context.ChatType === "direct" ||
+        context.ChatType === "group" ||
+        context.ChatType === "channel"
+          ? context.ChatType
+          : "channel";
+      const configuredReplyToMode = resolveMattermostReplyToMode(account, chatType);
+      // currentThreadTs is the Mattermost root post ID of the active thread.
+      // MessageThreadId is set when the inbound message is already part of a thread.
+      const threadTs =
+        typeof context.MessageThreadId === "string" && context.MessageThreadId.trim()
+          ? context.MessageThreadId.trim()
+          : typeof context.ReplyToId === "string" && context.ReplyToId.trim()
+            ? context.ReplyToId.trim()
+            : undefined;
+      // When the session is already inside a thread and the configured mode is
+      // "off", promote to "all" so that tool sends stay in the thread (mirrors
+      // Slack's threading-tool-context.ts effective-mode promotion).
+      // For "first", preserve it so hasRepliedRef can gate subsequent sends.
+      // For "all", it stays "all" naturally.
+      const effectiveReplyToMode =
+        configuredReplyToMode === "off" && threadTs != null ? "all" : configuredReplyToMode;
+      return {
+        // context.To is "channel:<id>" or "user:<id>" (no mattermost: prefix).
+        // Strip any platform prefix defensively to ensure it matches the
+        // tool's `to` param format used in normalizeMattermostMessagingTarget.
+        currentChannelId: context.To?.trim().replace(/^mattermost:/i, "") || undefined,
+        currentChannelProvider: "mattermost",
+        currentThreadTs: threadTs,
+        currentMessageId: context.CurrentMessageId,
+        replyToMode: effectiveReplyToMode,
+        hasRepliedRef,
+      };
     },
   },
   security: mattermostSecurityAdapter,


### PR DESCRIPTION
## Problem

When the agent uses the `message` tool to send a proactive message (without an explicit `replyTo`) from a Mattermost thread-scoped session, the message lands at the channel root instead of the current thread.

## Root Cause

Two issues:

1. The Mattermost plugin did not implement `threading.buildToolContext`, so the message tool never received `currentThreadTs` or `replyToMode` from the active session. The generic fallback only supplied `currentChannelId` — thread context was never propagated.

2. `context.To` is `channel:<id>` format from monitor.ts, but there is a potential mismatch if any intermediate layer adds the `mattermost:` prefix. The fix strips any such prefix defensively before storing as `currentChannelId`.

## Fix

### 1. Add `threading.buildToolContext` to the Mattermost plugin

Supplies the message tool with:
- `currentChannelId` — platform prefix stripped defensively (`.replace(/^mattermost:/i, "")`) for correct comparison
- `currentThreadTs` — from `MessageThreadId` or `ReplyToId`
- `replyToMode` — resolved from account config, with `off→all` promotion when already inside a thread (mirrors `extensions/slack/src/threading-tool-context.ts`)
- `hasRepliedRef` — passed through

### 2. Inherit thread context in `handleAction` send path

`replyToId` falls back to `toolContext.currentThreadTs` with guards:
- Both `to` and `currentChannelId` normalized via `normalizeMattermostMessagingTarget` before comparison
- `replyToMode` gate: `all` always inherits; `first` inherits only with explicit `hasRepliedRef` present and false (absent ref fails-closed); `off` + existing thread promoted to `all`
- `hasRepliedRef.value` flipped to `true` after any threaded send (implicit or explicit) under `replyToMode=first`

Explicit `replyTo` always takes precedence.

## Tests

9 unit test cases in `channel.test.ts` covering all guard branches and edge cases.

## How to test

1. Configure Mattermost with `replyToMode: "all"`
2. Start a conversation in a channel thread
3. Have the agent call `message(action="send", channel="mattermost", message="...")` **without specifying `replyTo` or `target`** (letting routing decide implicitly)
4. Before: message appears at channel root
5. After: message appears in the current thread

A good reproduction is the cron/heartbeat wake case: set a cron job that wakes a thread-scoped session and has the agent send a message — before this fix the reply would land as a DM or channel root.

## Note on `.github/workflows/preflight.yml`

This file is fork-specific CI scaffolding that lives in the teconomix/openclaw fork. It is not included in this PR's diff (the PR diff covers only `channel.ts` and `channel.test.ts`).

## Rebased on current main (2026-03-25)

Previously based on a stale merge base. Rebased cleanly onto upstream/main as a single commit.

Closes #45082
