### PR TITLE
fix(exec-approval): skip external delivery for webchat-only followups

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -40,18 +40,26 @@ export async function sendExecApprovalFollowup(
       ? String(params.turnSourceThreadId)
       : undefined;
 
+  // When the turn originated from webchat (internal channel) and there is
+  // no external "to" address, skip external delivery.  The agent result
+  // still reaches the user through the active WebSocket stream.
+  // When no channel info is present at all, keep deliver=true so the
+  // gateway can fall back to the session's last external route.
+  const isWebchatOnly = channel === "webchat" && !to;
+  const hasExplicitTarget = Boolean(channel && to);
+
   await callGatewayTool(
     "agent",
     { timeoutMs: 60_000 },
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
+      deliver: !isWebchatOnly,
       bestEffortDeliver: true,
-      channel: channel && to ? channel : undefined,
-      to: channel && to ? to : undefined,
-      accountId: channel && to ? params.turnSourceAccountId?.trim() || undefined : undefined,
-      threadId: channel && to ? threadId : undefined,
+      channel: hasExplicitTarget ? channel : undefined,
+      to: hasExplicitTarget ? to : undefined,
+      accountId: hasExplicitTarget ? params.turnSourceAccountId?.trim() || undefined : undefined,
+      threadId: hasExplicitTarget ? threadId : undefined,
       idempotencyKey: `exec-approval-followup:${params.approvalId}`,
     },
     { expectFinal: true },

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -40,11 +40,13 @@ export async function sendExecApprovalFollowup(
       ? String(params.turnSourceThreadId)
       : undefined;
 
-  // Always request delivery so the gateway routes the agent result to
-  // the appropriate channel.  bestEffortDeliver lets the gateway degrade
-  // gracefully: when the resolved channel is internal (webchat) and no
-  // external channel can be found, the agent still runs and its output
-  // reaches the user through the session transcript / WebSocket stream.
+  // Only request external delivery when there is an explicit channel+to
+  // target.  When the turn originated from webchat (no external target),
+  // setting deliver=false avoids the "Channel is required" gateway error.
+  // The agent still runs and its output reaches the webchat user through
+  // the session transcript / WebSocket stream (session-tool-result-guard
+  // emits transcript updates with message payloads that server.impl
+  // forwards to subscribed webchat connections).
   const hasExplicitTarget = Boolean(channel && to);
 
   await callGatewayTool(
@@ -53,7 +55,7 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: true,
+      deliver: hasExplicitTarget,
       bestEffortDeliver: true,
       channel: hasExplicitTarget ? channel : undefined,
       to: hasExplicitTarget ? to : undefined,

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -40,12 +40,11 @@ export async function sendExecApprovalFollowup(
       ? String(params.turnSourceThreadId)
       : undefined;
 
-  // When the turn originated from webchat (internal channel) and there is
-  // no external "to" address, skip external delivery.  The agent result
-  // still reaches the user through the active WebSocket stream.
-  // When no channel info is present at all, keep deliver=true so the
-  // gateway can fall back to the session's last external route.
-  const isWebchatOnly = channel === "webchat" && !to;
+  // Always request delivery so the gateway routes the agent result to
+  // the appropriate channel.  bestEffortDeliver lets the gateway degrade
+  // gracefully: when the resolved channel is internal (webchat) and no
+  // external channel can be found, the agent still runs and its output
+  // reaches the user through the session transcript / WebSocket stream.
   const hasExplicitTarget = Boolean(channel && to);
 
   await callGatewayTool(
@@ -54,7 +53,7 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: !isWebchatOnly,
+      deliver: true,
       bestEffortDeliver: true,
       channel: hasExplicitTarget ? channel : undefined,
       to: hasExplicitTarget ? to : undefined,

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -40,13 +40,16 @@ export async function sendExecApprovalFollowup(
       ? String(params.turnSourceThreadId)
       : undefined;
 
-  // Only request external delivery when there is an explicit channel+to
-  // target.  When the turn originated from webchat (no external target),
-  // setting deliver=false avoids the "Channel is required" gateway error.
-  // The agent still runs and its output reaches the webchat user through
-  // the session transcript / WebSocket stream (session-tool-result-guard
-  // emits transcript updates with message payloads that server.impl
-  // forwards to subscribed webchat connections).
+  // Suppress external delivery only when the turn explicitly came from
+  // webchat (internal channel, no external "to" address).  In that case
+  // the gateway would fail with "Channel is required" because no external
+  // route can be resolved.  The agent still runs and its output reaches
+  // the webchat user through the session transcript / WebSocket stream.
+  //
+  // When channel info is absent entirely (e.g. CLI / automation), keep
+  // deliver=true so the gateway can fall back to the session's last
+  // external route.
+  const isWebchatOnly = channel === "webchat" && !to;
   const hasExplicitTarget = Boolean(channel && to);
 
   await callGatewayTool(
@@ -55,7 +58,7 @@ export async function sendExecApprovalFollowup(
     {
       sessionKey,
       message: buildExecApprovalFollowupPrompt(resultText),
-      deliver: hasExplicitTarget,
+      deliver: !isWebchatOnly,
       bestEffortDeliver: true,
       channel: hasExplicitTarget ? channel : undefined,
       to: hasExplicitTarget ? to : undefined,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -582,13 +582,8 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedAccountId,
         };
       } catch (err) {
-        if (!bestEffortDeliver) {
-          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
-          return;
-        }
-        // bestEffortDeliver: proceed without external delivery – the agent
-        // still runs and its output reaches webchat subscribers through the
-        // session transcript stream.
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+        return;
       }
     }
 
@@ -605,7 +600,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !bestEffortDeliver) {
+    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       respond(
         false,
         undefined,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -582,8 +582,13 @@ export const agentHandlers: GatewayRequestHandlers = {
           resolvedAccountId,
         };
       } catch (err) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
-        return;
+        if (!bestEffortDeliver) {
+          respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+          return;
+        }
+        // bestEffortDeliver: proceed without external delivery – the agent
+        // still runs and its output reaches webchat subscribers through the
+        // session transcript stream.
       }
     }
 
@@ -600,7 +605,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       }
     }
 
-    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
+    if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL && !bestEffortDeliver) {
       respond(
         false,
         undefined,


### PR DESCRIPTION
## Summary
- Fix exec approval followup failing with `INVALID_REQUEST: Channel is required` in webchat-only setups
- Only set `deliver: true` when a concrete delivery target (channel + to) exists
- For webchat-originated turns, the agent result streams back through the active WebSocket connection without needing external channel delivery

## Root Cause
`sendExecApprovalFollowup()` always set `deliver: true`, which caused the gateway to call `resolveMessageChannelSelection()`. In setups with no external channels (Discord, Telegram, etc.), this threw "Channel is required (no configured channels detected)".

For webchat turns, `turnSourceTo` is undefined (webchat has no addressable "to"), so the channel/to fields were already set to `undefined`. The gateway then tried to auto-resolve an external channel and failed.

## Test plan
- [ ] Start OpenClaw with control-ui only (no external channels)
- [ ] Ask the agent to execute an elevated command
- [ ] Approve via the approval popup
- [ ] Verify the agent executes and reports back in webchat without errors

Fixes #51936

🤖 Generated with [Claude Code](https://claude.com/claude-code)