### PR TITLE
fix(config): coerce boolean retry.jitter to number

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -224,4 +224,24 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("coerces boolean retry.jitter to number (#52130)", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          retry: { jitter: true as unknown as number },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+
+    const resFalse = validateConfigObject({
+      channels: {
+        telegram: {
+          retry: { jitter: false as unknown as number },
+        },
+      },
+    });
+    expect(resFalse.ok).toBe(true);
+  });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -243,5 +243,10 @@ describe("config schema regressions", () => {
       },
     });
     expect(resFalse.ok).toBe(true);
+
+    const resWeb = validateConfigObject({
+      web: { reconnect: { jitter: true as unknown as number } },
+    });
+    expect(resWeb.ok).toBe(true);
   });
 });

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -572,7 +572,9 @@ export const RetryConfigSchema = z
     attempts: z.number().int().min(1).optional(),
     minDelayMs: z.number().int().min(0).optional(),
     maxDelayMs: z.number().int().min(0).optional(),
-    jitter: z.number().min(0).max(1).optional(),
+    jitter: z
+      .preprocess((v) => (typeof v === "boolean" ? (v ? 0.1 : 0) : v), z.number().min(0).max(1))
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -613,7 +613,12 @@ export const OpenClawSchema = z
             initialMs: z.number().positive().optional(),
             maxMs: z.number().positive().optional(),
             factor: z.number().positive().optional(),
-            jitter: z.number().min(0).max(1).optional(),
+            jitter: z
+              .preprocess(
+                (v) => (typeof v === "boolean" ? (v ? 0.1 : 0) : v),
+                z.number().min(0).max(1),
+              )
+              .optional(),
             maxAttempts: z.number().int().min(0).optional(),
           })
           .strict()


### PR DESCRIPTION
## Summary

**Problem**: Setting `channels.telegram.retry.jitter` to `true` (boolean) instead of a number causes `Invalid input: expected number, received boolean` validation error on every gateway startup, triggering a restart storm. The user's gateway becomes permanently stuck in a crash loop.

**Why it matters**: The `jitter` field semantically supports enable/disable (`true`/`false`) but the schema only accepts numbers. Users who set `jitter: true` (reasonable intent: "enable jitter") get an unrecoverable crash loop that requires manual config editing to fix.

**What changed**:
- Added `z.preprocess()` to `RetryConfigSchema.jitter` in `zod-schema.core.ts` to coerce `true` → `0.1` (default jitter factor) and `false` → `0` (no jitter)
- Applied the same coercion to `web.reconnect.jitter` in `zod-schema.ts`
- Added regression test in `config.schema-regressions.test.ts` verifying both `true` and `false` are accepted

**What did NOT change**:
- `RetryConfigSchema` shape is unchanged — numeric jitter values still validated with `min(0).max(1)` as before
- Runtime jitter calculation in `src/infra/retry.ts` is untouched — `applyJitter()` and `resolveRetryConfig()` already handle 0 correctly
- No migration needed — `z.preprocess` runs at parse time before validation, handling both existing and new configs
- Discord retry config automatically covered since it shares `RetryConfigSchema`
- Default jitter values (`TELEGRAM_RETRY_DEFAULTS.jitter = 0.1`) are untouched

## Change Type
- [x] Bug fix (non-breaking)

## Scope
Gateway (config schema validation)

## Linked Issue
Closes #52130

## Security Impact
- New permissions requested: none
- Secrets handling changes: none
- New network calls: none
- New command/tool execution: none
- Data access changes: none

## Human Verification
I personally verified:
- [x] `pnpm tsgo` passes
- [x] `pnpm test -- src/config/config.schema-regressions.test.ts` — 17/17 tests pass (16 existing + 1 new)
- [x] `pnpm config:docs:check` — no baseline drift (preprocess doesn't change schema surface)
- [x] `validateConfigObject({ channels: { telegram: { retry: { jitter: true } } } })` returns `{ ok: true }`
- [x] `validateConfigObject({ channels: { telegram: { retry: { jitter: false } } } })` returns `{ ok: true }`
- [x] Numeric jitter values (0, 0.5, 1) still accepted; values outside 0-1 still rejected

## Evidence

```
Test Files  1 passed (1)
     Tests  17 passed (17)
  Duration  751ms
```

## What I Did NOT Verify
- Not verified: end-to-end gateway restart with a real `jitter: true` config (tested validation layer only)
- Not verified: doctor output — the issue mentions misleading doctor messaging, but that's a separate concern from the crash-loop fix

## Failure Recovery
If this breaks in production:
- **Detection**: Config validation errors for retry.jitter would reappear
- **Rollback**: Remove the `z.preprocess` wrapper, reverting to bare `z.number().min(0).max(1)`
- **Blast radius**: Only affects users with boolean jitter values — zero impact on users with numeric values or no jitter config

---
Generated with Claude Code