### PR TITLE
fix(gateway-client): restore stored scopes on device-token reconnect

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -418,11 +418,14 @@ export class GatewayClient {
     // When reconnecting with a stored device token, honour the scopes that
     // were persisted alongside it so restricted tokens (e.g. operator.read)
     // are not silently upgraded to the operator.admin default.
+    // Note: an explicitly stored empty array (`[]`) is a valid default-deny
+    // session and must be preserved — only fall back to `["operator.admin"]`
+    // when no stored scopes exist at all (`undefined`).
     const usesStoredDeviceToken =
       resolvedDeviceToken != null && resolvedDeviceToken === storedToken;
     const scopes =
       this.opts.scopes ??
-      (usesStoredDeviceToken && storedScopes?.length ? storedScopes : ["operator.admin"]);
+      (usesStoredDeviceToken && storedScopes != null ? storedScopes : ["operator.admin"]);
     const platform = this.opts.platform ?? process.platform;
     const device = (() => {
       if (!this.opts.deviceIdentity) {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -61,6 +61,7 @@ type SelectedConnectAuth = {
   signatureToken?: string;
   resolvedDeviceToken?: string;
   storedToken?: string;
+  storedScopes?: string[];
 };
 
 class GatewayClientRequestError extends Error {
@@ -399,6 +400,7 @@ export class GatewayClient {
       signatureToken,
       resolvedDeviceToken,
       storedToken,
+      storedScopes,
     } = this.selectConnectAuth(role);
     if (this.pendingDeviceTokenRetry && authDeviceToken) {
       this.pendingDeviceTokenRetry = false;
@@ -413,7 +415,14 @@ export class GatewayClient {
           }
         : undefined;
     const signedAtMs = Date.now();
-    const scopes = this.opts.scopes ?? ["operator.admin"];
+    // When reconnecting with a stored device token, honour the scopes that
+    // were persisted alongside it so restricted tokens (e.g. operator.read)
+    // are not silently upgraded to the operator.admin default.
+    const usesStoredDeviceToken =
+      resolvedDeviceToken != null && resolvedDeviceToken === storedToken;
+    const scopes =
+      this.opts.scopes ??
+      (usesStoredDeviceToken && storedScopes?.length ? storedScopes : ["operator.admin"]);
     const platform = this.opts.platform ?? process.platform;
     const device = (() => {
       if (!this.opts.deviceIdentity) {
@@ -599,9 +608,10 @@ export class GatewayClient {
     const explicitBootstrapToken = this.opts.bootstrapToken?.trim() || undefined;
     const explicitDeviceToken = this.opts.deviceToken?.trim() || undefined;
     const authPassword = this.opts.password?.trim() || undefined;
-    const storedToken = this.opts.deviceIdentity
-      ? loadDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role })?.token
+    const storedEntry = this.opts.deviceIdentity
+      ? loadDeviceAuthToken({ deviceId: this.opts.deviceIdentity.deviceId, role })
       : null;
+    const storedToken = storedEntry?.token ?? null;
     const shouldUseDeviceRetryToken =
       this.pendingDeviceTokenRetry &&
       !explicitDeviceToken &&
@@ -627,6 +637,7 @@ export class GatewayClient {
       signatureToken: authToken ?? authBootstrapToken ?? undefined,
       resolvedDeviceToken,
       storedToken: storedToken ?? undefined,
+      storedScopes: storedEntry?.scopes,
     };
   }
 


### PR DESCRIPTION
## Summary
- When the gateway-client falls back to a stored device token (e.g. after a shared-token auth failure), it previously loaded only the token and defaulted scopes to `["operator.admin"]`, silently upgrading restricted tokens (e.g. `operator.read`).
- Now the full `DeviceAuthEntry` is loaded so the scopes persisted alongside the token are honoured on reconnect.

Fixes #51887

## Test plan
- [ ] Verify restricted-scope device tokens keep their scopes after reconnect
- [ ] Verify explicit `opts.scopes` still takes precedence over stored scopes
- [ ] Verify default `["operator.admin"]` fallback works when no stored scopes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)