### PR TITLE
fix(skills): propagate abort signal to download pipeline

### DIFF
--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -74,9 +74,18 @@ async function downloadFile(params: {
     boundaryLabel: "skill tools directory",
   });
   const tempPath = path.join(stagingDir, `${randomUUID()}.tmp`);
+
+  // Use a single AbortController that covers the entire download lifecycle
+  // (fetch + stream piping). Previously the timeout from fetchWithSsrFGuard
+  // only aborted the initial fetch — if the server responded with headers but
+  // then stalled mid-stream, `pipeline()` would hang indefinitely.
+  const controller = new AbortController();
+  const timeoutMs = Math.max(1_000, params.timeoutMs);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
   const { response, release } = await fetchWithSsrFGuard({
     url: params.url,
-    timeoutMs: Math.max(1_000, params.timeoutMs),
+    signal: controller.signal,
   });
   try {
     if (!response.ok || !response.body) {
@@ -87,7 +96,7 @@ async function downloadFile(params: {
     const readable = isNodeReadableStream(body)
       ? body
       : Readable.fromWeb(body as NodeReadableStream);
-    await pipeline(readable, file);
+    await pipeline(readable, file, { signal: controller.signal });
     await writeFileFromPathWithinRoot({
       rootDir: params.rootDir,
       relativePath: params.relativePath,
@@ -96,6 +105,7 @@ async function downloadFile(params: {
     const stat = await fs.promises.stat(destPath);
     return { bytes: stat.size };
   } finally {
+    clearTimeout(timeoutId);
     await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
     await release();
   }

--- a/src/agents/skills-install-download.ts
+++ b/src/agents/skills-install-download.ts
@@ -83,11 +83,14 @@ async function downloadFile(params: {
   const timeoutMs = Math.max(1_000, params.timeoutMs);
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
-  const { response, release } = await fetchWithSsrFGuard({
-    url: params.url,
-    signal: controller.signal,
-  });
+  let release: () => Promise<void> = async () => {};
   try {
+    const fetched = await fetchWithSsrFGuard({
+      url: params.url,
+      signal: controller.signal,
+    });
+    release = fetched.release;
+    const { response } = fetched;
     if (!response.ok || !response.body) {
       throw new Error(`Download failed (${response.status} ${response.statusText})`);
     }


### PR DESCRIPTION
## Summary
- The download timeout from `fetchWithSsrFGuard` only aborted the initial HTTP request
- If the server responded with headers but stalled mid-stream, `await pipeline(readable, file)` hung indefinitely, making the agent unresponsive during skill installation
- Moved timeout to a single `AbortController` covering both fetch and pipeline, passing the signal to `pipeline()` via its `signal` option

## Test plan
- [ ] Install a skill with a large download — verify it completes normally
- [ ] Simulate a stalled mid-stream response (e.g. `nc` server that sends headers then pauses) — verify timeout fires and the agent recovers
- [ ] Verify the timeout cleanup (`clearTimeout`) runs in the `finally` block

Fixes #52073

🤖 Generated with [Claude Code](https://claude.com/claude-code)