### PR TITLE
fix(message): ignore zero-valued poll defaults in send path

### DIFF
--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -217,6 +217,66 @@ describe("runMessageAction plugin dispatch", () => {
         }),
       );
     });
+
+    it("does not misclassify send as poll when zero-valued poll params are present", async () => {
+      const sendMedia = vi.fn().mockResolvedValue({
+        channel: "testchat",
+        messageId: "m2",
+        chatId: "c1",
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "testchat",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "testchat",
+              outbound: {
+                deliveryMode: "direct",
+                sendText: vi.fn().mockResolvedValue({
+                  channel: "testchat",
+                  messageId: "t2",
+                  chatId: "c1",
+                }),
+                sendMedia,
+              },
+            }),
+          },
+        ]),
+      );
+      const cfg = {
+        channels: {
+          testchat: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = await runMessageAction({
+        cfg,
+        action: "send",
+        params: {
+          channel: "testchat",
+          target: "channel:abc",
+          media: "https://example.com/file.txt",
+          message: "hello",
+          pollDurationHours: 0,
+          pollDurationSeconds: 0,
+          pollMulti: false,
+          pollQuestion: "",
+          pollOption: [],
+        },
+        dryRun: false,
+      });
+
+      expect(result.kind).toBe("send");
+      expect(sendMedia).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "hello",
+          mediaUrl: "https://example.com/file.txt",
+        }),
+      );
+    });
   });
 
   describe("card-only send behavior", () => {

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -23,11 +23,13 @@ describe("poll params", () => {
     },
   );
 
-  it("treats finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(true);
+  it("treats only non-zero finite numeric poll params as poll creation intent", () => {
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: "0" })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
+    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);
@@ -46,6 +48,7 @@ describe("poll params", () => {
     expect(hasPollCreationParams({ poll_question: "Lunch?" })).toBe(true);
     expect(hasPollCreationParams({ poll_option: ["Pizza", "Sushi"] })).toBe(true);
     expect(hasPollCreationParams({ poll_duration_seconds: "60" })).toBe(true);
+    expect(hasPollCreationParams({ poll_duration_seconds: "0" })).toBe(false);
     expect(hasPollCreationParams({ poll_public: "true" })).toBe(true);
   });
 

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -69,13 +69,16 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
       }
     }
     if (def.kind === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
+      if (typeof value === "number" && Number.isFinite(value) && value !== 0) {
         return true;
       }
       if (typeof value === "string") {
         const trimmed = value.trim();
-        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
-          return true;
+        if (trimmed.length > 0) {
+          const numericValue = Number(trimmed);
+          if (Number.isFinite(numericValue) && numericValue !== 0) {
+            return true;
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #52118.

## Summary
- treat zero-valued numeric poll params as unset in `hasPollCreationParams()`
- keep non-zero numeric poll params as poll intent
- add regression coverage for `message.send` with zero-valued poll defaults present

## Why
`message.send` currently rejects normal send/file operations when callers include poll numeric defaults like:
- `pollDurationHours: 0`
- `pollDurationSeconds: 0`

Those zero values are currently interpreted as poll creation intent, which is too broad for send-path validation.

## Changes
- `src/poll-params.ts`
  - numeric poll params now count as poll intent only when non-zero
- `src/poll-params.test.ts`
  - update helper expectations for `0` / `"0"`
- `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
  - add regression test proving `send` still uses the send path when zero-valued poll defaults are present

## Validation
Ran targeted tests:
- `src/poll-params.test.ts`
- `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`

Both passed locally.

## Related
Related: #48928 #51830 #48870 #48730 #42820 #43015
