### PR TITLE
fix(agents): extend transcript turn-order sanitization to the affec...

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -308,6 +308,67 @@ describe("sanitizeSessionHistory", () => {
     ).toBe(false);
   });
 
+  it("prepends a bootstrap user turn for non-OpenAI openai-responses assistant-first history (#37546)", async () => {
+    setNonGoogleModelApi();
+    const sessionEntries: Array<{ type: string; customType: string; data: unknown }> = [];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "compacted reply" }],
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "custom",
+      modelId: "custom-model",
+      sessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[0]?.role).toBe("user");
+    expect((result[0] as { content?: unknown } | undefined)?.content).toBe("(session bootstrap)");
+    expect(result[1]?.role).toBe("assistant");
+    expect(
+      sessionEntries.some((entry) => entry.customType === "google-turn-ordering-bootstrap"),
+    ).toBe(false);
+  });
+
+  it("prepends bootstrap after model switch from anthropic to non-OpenAI responses provider (#37546)", async () => {
+    setNonGoogleModelApi();
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "anthropic",
+        modelApi: "anthropic-messages",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "reply from previous anthropic session" }],
+      },
+      { role: "user", content: "new message after model switch" },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "custom",
+      modelId: "custom-model",
+      sessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[0]?.role).toBe("user");
+    expect((result[0] as { content?: unknown } | undefined)?.content).toBe("(session bootstrap)");
+    expect(result[1]?.role).toBe("assistant");
+    expect(result[2]?.role).toBe("user");
+  });
+
   it("annotates inter-session user messages before context sanitization", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -604,9 +604,9 @@ export async function sanitizeSessionHistory(params: {
     }).messages;
   }
 
-  // Strict OpenAI-compatible providers (vLLM, Gemma, etc.) also reject
-  // conversations that start with an assistant turn (e.g. delivery-mirror
-  // messages after /new).  Apply the same ordering fix without the
-  // Google-specific session markers.  See #38962.
+  // Strict OpenAI-compatible providers (vLLM, Gemma, non-OpenAI responses
+  // hosts, etc.) also reject conversations that start with an assistant turn
+  // (e.g. after compaction or model switching).  Apply the same ordering fix
+  // without Google-specific session markers.  See #38962, #37546.
   return sanitizeGoogleTurnOrdering(sanitizedOpenAI);
 }

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -143,6 +143,37 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.validateAnthropicTurns).toBe(true);
   });
 
+  it.each([
+    {
+      title: "non-OpenAI openai-responses provider",
+      provider: "custom",
+      modelId: "custom-model",
+      modelApi: "openai-responses" as const,
+    },
+    {
+      title: "non-OpenAI openai-codex-responses provider",
+      provider: "custom",
+      modelId: "codex-model",
+      modelApi: "openai-codex-responses" as const,
+    },
+  ])("enables turn-ordering for $title (#37546)", ({ provider, modelId, modelApi }) => {
+    const policy = resolveTranscriptPolicy({ provider, modelId, modelApi });
+    expect(policy.applyGoogleTurnOrdering).toBe(true);
+    expect(policy.validateGeminiTurns).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(true);
+  });
+
+  it("does not enable turn-ordering for native OpenAI openai-responses provider (#37546)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      modelApi: "openai-responses",
+    });
+    expect(policy.applyGoogleTurnOrdering).toBe(false);
+    expect(policy.validateGeminiTurns).toBe(false);
+    expect(policy.validateAnthropicTurns).toBe(false);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -68,9 +68,11 @@ export function resolveTranscriptPolicy(params: {
   const isAnthropic = isAnthropicApi(params.modelApi, provider);
   const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
   const isStrictOpenAiCompatible =
-    params.modelApi === "openai-completions" &&
     !isOpenAi &&
-    supportsOpenAiCompatTurnValidation(provider);
+    supportsOpenAiCompatTurnValidation(provider) &&
+    (params.modelApi === "openai-completions" ||
+      params.modelApi === "openai-responses" ||
+      params.modelApi === "openai-codex-responses");
   const providerToolCallIdMode = resolveTranscriptToolCallIdMode(provider, modelId);
   const isMistral = providerToolCallIdMode === "strict9";
   const shouldSanitizeGeminiThoughtSignaturesForProvider =


### PR DESCRIPTION
Strict OpenAI-compatible provider paths replay assistant-first transcript state after compaction or model switching, causing persistent role-ordering failures instead of recovering to a fresh turn.

Closes #37546

Changes:
- Reproduce the failure with a persisted transcript that starts on an assistant turn after compaction or model switching.
- Update transcript policy so the affected OpenAI-compatible provider path enables turn-order validation/sanitization.
- Apply the assistant-first bootstrap fix during session-history sanitization for that path without adding Google-only marker behavior.
- Add regression tests covering assistant-first persisted history and model-switch scenarios that previously returned the repeated ordering-conflict message.

Testing:
- pnpm build && pnpm check && pnpm test
- Run targeted Vitest coverage for transcript-policy and session-history sanitization, focusing on assistant-first strict OpenAI-compatible cases and model-switch regression; add an end-to-end chat/session reset test if feasible to confirm fresh messages succeed after the conflict.

---
AI-assisted (Claude + Codex committee consensus, fully tested).

---

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved