### PR TITLE
fix(poll-params): treat zero-valued numeric poll params as unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/security: add regression coverage proving pinned fallback host overrides stay bound to Telegram and delegate non-matching hostnames back to the original lookup path. Thanks @vincentkoc.
 - Secrets/exec refs: require explicit `--allow-exec` for `secrets apply` write plans that contain exec SecretRefs/providers, and align audit/configure/apply dry-run behavior to skip exec checks unless opted in to prevent unexpected command side effects. (#49417) Thanks @restriction and @joshavant.
 - Tools/image generation: add bundled fal image generation support so `image_generate` can target `fal/*` models with `FAL_KEY`, including single-image edit flows via FLUX image-to-image. Thanks @vincentkoc.
+- Messages/polls: treat zero-valued poll params on `message.send` as unset defaults while keeping non-zero poll params on the poll validation path. (#52150) Fixes #52118. Thanks @Bartok9.
 - xAI/web search: add missing Grok credential metadata so the bundled provider registration type-checks again. (#49472) thanks @scoootscooob.
 - Signal/runtime API: re-export `SignalAccountConfig` so Signal account resolution type-checks again. (#49470) Thanks @scoootscooob.
 - Google Chat/runtime API: thin the private runtime barrel onto the curated public SDK surface while keeping public Google Chat exports intact. (#49504) Thanks @scoootscooob.

--- a/src/infra/outbound/message-action-runner.context.test.ts
+++ b/src/infra/outbound/message-action-runner.context.test.ts
@@ -347,6 +347,15 @@ describe("runMessageAction context isolation", () => {
         poll_public: "true",
       },
     },
+    {
+      name: "negative poll duration params",
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "hi",
+        pollDurationSeconds: -5,
+      },
+    },
   ])("rejects send actions that include $name", async ({ actionParams }) => {
     await expect(
       runDrySend({

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -217,6 +217,66 @@ describe("runMessageAction plugin dispatch", () => {
         }),
       );
     });
+
+    it("does not misclassify send as poll when zero-valued poll params are present", async () => {
+      const sendMedia = vi.fn().mockResolvedValue({
+        channel: "testchat",
+        messageId: "m2",
+        chatId: "c1",
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "testchat",
+            source: "test",
+            plugin: createOutboundTestPlugin({
+              id: "testchat",
+              outbound: {
+                deliveryMode: "direct",
+                sendText: vi.fn().mockResolvedValue({
+                  channel: "testchat",
+                  messageId: "t2",
+                  chatId: "c1",
+                }),
+                sendMedia,
+              },
+            }),
+          },
+        ]),
+      );
+      const cfg = {
+        channels: {
+          testchat: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = await runMessageAction({
+        cfg,
+        action: "send",
+        params: {
+          channel: "testchat",
+          target: "channel:abc",
+          media: "https://example.com/file.txt",
+          message: "hello",
+          pollDurationHours: 0,
+          pollDurationSeconds: 0,
+          pollMulti: false,
+          pollQuestion: "",
+          pollOption: [],
+        },
+        dryRun: false,
+      });
+
+      expect(result.kind).toBe("send");
+      expect(sendMedia).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: "hello",
+          mediaUrl: "https://example.com/file.txt",
+        }),
+      );
+    });
   });
 
   describe("card-only send behavior", () => {

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -23,14 +23,23 @@ describe("poll params", () => {
     },
   );
 
-  it("treats finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(true);
+  it("treats positive numeric poll params as poll creation intent", () => {
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);
+  });
+
+  it("does not treat zero-valued numeric poll params as poll creation intent", () => {
+    // Zero values are typically defaults/unset values from tool schemas,
+    // not intentional poll creation. Fixes #52118.
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: "0" })).toBe(false);
+    expect(hasPollCreationParams({ poll_duration_seconds: 0 })).toBe(false);
+    expect(hasPollCreationParams({ poll_duration_hours: "0" })).toBe(false);
   });
 
   it("treats string-encoded boolean poll params as poll creation intent when true", () => {

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -23,10 +23,12 @@ describe("poll params", () => {
     },
   );
 
-  it("treats positive numeric poll params as poll creation intent", () => {
+  it("treats non-zero finite numeric poll params as poll creation intent", () => {
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);
+    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(true);
+    expect(hasPollCreationParams({ pollDurationSeconds: "-5" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationHours: Number.NaN })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: Infinity })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: "60abc" })).toBe(false);

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -69,16 +69,16 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
       }
     }
     if (def.kind === "number") {
-      // Treat 0 as unset/default, not as poll creation intent.
-      // This prevents callers with zero-valued numeric defaults from
-      // accidentally triggering poll validation during normal sends.
-      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      // Treat zero-valued numeric defaults as unset, but preserve any non-zero
+      // numeric value as explicit poll intent so invalid durations still hit
+      // the poll-only validation path.
+      if (typeof value === "number" && Number.isFinite(value) && value !== 0) {
         return true;
       }
       if (typeof value === "string") {
         const trimmed = value.trim();
         const parsed = Number(trimmed);
-        if (trimmed.length > 0 && Number.isFinite(parsed) && parsed > 0) {
+        if (trimmed.length > 0 && Number.isFinite(parsed) && parsed !== 0) {
           return true;
         }
       }

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -69,12 +69,16 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
       }
     }
     if (def.kind === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
+      // Treat 0 as unset/default, not as poll creation intent.
+      // This prevents callers with zero-valued numeric defaults from
+      // accidentally triggering poll validation during normal sends.
+      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
         return true;
       }
       if (typeof value === "string") {
         const trimmed = value.trim();
-        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
+        const parsed = Number(trimmed);
+        if (trimmed.length > 0 && Number.isFinite(parsed) && parsed > 0) {
           return true;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #52118

References #52141

Zero values (`pollDurationHours: 0`, `pollDurationSeconds: 0`, etc.) are typically defaults/unset values from tool schemas, not intentional poll creation requests.

Previously, any finite number including 0 was treated as poll creation intent, causing normal `message.send` calls to fail with:

```
Poll fields require action "poll"; use action "poll" instead of "send"
```

This was observed when callers included zero-valued numeric defaults (for example from serialized schemas).

This PR keeps zero-valued poll params treated as unset for normal sends, while preserving the existing behavior that non-zero poll params still count as poll intent. That means invalid negative durations continue to hit the poll-only validation path instead of being silently ignored.

## Changes

- Updated `hasPollCreationParams()` so zero-valued numeric poll params are treated as unset/defaults during `message.send`
- Preserved the non-zero poll-intent behavior so invalid negative durations still route through the poll validation path
- Added explicit tests for zero-valued poll params on both the helper and send path
- Added a regression test showing negative poll durations still fail on the poll-only guard path

## Testing

- `pnpm test -- src/poll-params.test.ts src/infra/outbound/message-action-runner.context.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- `pnpm tsgo`
- `pnpm check`
