### PR TITLE
fix(cron): write delivered cron output back into main session transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,7 @@ Docs: https://docs.openclaw.ai
 - Discord/ACP: forward worker abort signals into ACP turns so timed-out Discord jobs cancel the running turn instead of silently leaving the bound ACP session working in the background.
 - Gateway/openresponses: preserve assistant commentary and session continuity across hosted-tool `/v1/responses` turns, and emit streamed tool-call payloads before finalization so client tool loops stay resumable. (#52171) Thanks @CharZhou.
 - Android/Talk: serialize `TalkModeManager` player teardown so rapid interrupt/restart cycles stop double-releasing or overlapping TTS playback. (#52310) Thanks @Kaneki-x.
+- Cron/awareness: append successful isolated announce deliveries back into the routed main or thread transcript with idempotency, so the agent can later recall what cron already sent externally without duplicating the outbound message. Fixes #52136. Thanks @sparkyrider.
 
 ### Breaking
 

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3644,21 +3644,25 @@ public struct ChatInjectParams: Codable, Sendable {
     public let sessionkey: String
     public let message: String
     public let label: String?
+    public let idempotencykey: String?
 
     public init(
         sessionkey: String,
         message: String,
-        label: String?)
+        label: String?,
+        idempotencykey: String?)
     {
         self.sessionkey = sessionkey
         self.message = message
         self.label = label
+        self.idempotencykey = idempotencykey
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case message
         case label
+        case idempotencykey = "idempotencyKey"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -3644,21 +3644,25 @@ public struct ChatInjectParams: Codable, Sendable {
     public let sessionkey: String
     public let message: String
     public let label: String?
+    public let idempotencykey: String?
 
     public init(
         sessionkey: String,
         message: String,
-        label: String?)
+        label: String?,
+        idempotencykey: String?)
     {
         self.sessionkey = sessionkey
         self.message = message
         self.label = label
+        self.idempotencykey = idempotencykey
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case message
         case label
+        case idempotencykey = "idempotencyKey"
     }
 }
 

--- a/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
+++ b/src/cron/isolated-agent.delivers-response-has-heartbeat-ok-but-includes.test.ts
@@ -248,7 +248,17 @@ describe("runCronIsolatedAgentTurn", () => {
         "HEARTBEAT_OK 🦞",
         expect.objectContaining({ accountId: undefined }),
       );
-      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(callGateway).toHaveBeenCalledTimes(2);
+      expect(callGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "agent:main:main",
+            message: "HEARTBEAT_OK 🦞",
+            label: "Cron delivery",
+          }),
+        }),
+      );
       expect(callGateway).toHaveBeenCalledWith(
         expect.objectContaining({
           method: "sessions.delete",

--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -1,0 +1,106 @@
+import "./isolated-agent.mocks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { callGateway } from "../gateway/call.js";
+import { createCliDeps, mockAgentPayloads } from "./isolated-agent.delivery.test-helpers.js";
+import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
+import {
+  makeCfg,
+  makeJob,
+  withTempCronHome,
+  writeSessionStoreEntries,
+} from "./isolated-agent.test-harness.js";
+import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+
+async function runAnnounceTurn(params: { home: string; storePath: string; sessionKey?: string }) {
+  return await runCronIsolatedAgentTurn({
+    cfg: makeCfg(params.home, params.storePath),
+    deps: createCliDeps(),
+    job: {
+      ...makeJob({ kind: "agentTurn", message: "do it" }),
+      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      delivery: {
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+      },
+    },
+    message: "do it",
+    sessionKey: "cron:job-1",
+    lane: "cron",
+  });
+}
+
+describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
+  beforeEach(() => {
+    setupIsolatedAgentTurnMocks();
+  });
+
+  it("injects delivered cron text back into the main session transcript", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "hello from cron" }]);
+
+      const res = await runAnnounceTurn({ home, storePath });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(true);
+      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "agent:main:main",
+            message: "hello from cron",
+            label: "Cron delivery",
+            idempotencyKey: expect.stringContaining("cron-awareness:v1:"),
+          }),
+        }),
+      ]);
+    });
+  });
+
+  it("uses the routed thread session when the cron job is bound to one", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+        "agent:main:main:thread:42": {
+          sessionId: "thread-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "thread digest" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        sessionKey: "agent:main:main:thread:42",
+      });
+
+      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "agent:main:main:thread:42",
+            message: "thread digest",
+          }),
+        }),
+      ]);
+    });
+  });
+});

--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -1,5 +1,7 @@
+import fs from "node:fs/promises";
 import "./isolated-agent.mocks.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
 import { callGateway } from "../gateway/call.js";
 import { createCliDeps, mockAgentPayloads } from "./isolated-agent.delivery.test-helpers.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
@@ -10,23 +12,36 @@ import {
   writeSessionStoreEntries,
 } from "./isolated-agent.test-harness.js";
 import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
+import type { CronSessionTarget } from "./types.js";
 
-async function runAnnounceTurn(params: { home: string; storePath: string; sessionKey?: string }) {
+async function runAnnounceTurn(params: {
+  home: string;
+  storePath: string;
+  jobSessionKey?: string;
+  runtimeSessionKey?: string;
+  sessionTarget?: CronSessionTarget;
+  deliveryContract?: "cron-owned" | "shared";
+  deps?: CliDeps;
+  deliveryChannel?: "telegram" | "last";
+  deliveryTo?: string | null;
+}) {
   return await runCronIsolatedAgentTurn({
     cfg: makeCfg(params.home, params.storePath),
-    deps: createCliDeps(),
+    deps: params.deps ?? createCliDeps(),
     job: {
       ...makeJob({ kind: "agentTurn", message: "do it" }),
-      ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+      ...(params.jobSessionKey ? { sessionKey: params.jobSessionKey } : {}),
+      ...(params.sessionTarget ? { sessionTarget: params.sessionTarget } : {}),
       delivery: {
         mode: "announce",
-        channel: "telegram",
-        to: "123",
+        channel: params.deliveryChannel ?? "telegram",
+        ...(params.deliveryTo === null ? {} : { to: params.deliveryTo ?? "123" }),
       },
     },
     message: "do it",
-    sessionKey: "cron:job-1",
+    sessionKey: params.runtimeSessionKey ?? params.jobSessionKey ?? "cron:job-1",
     lane: "cron",
+    deliveryContract: params.deliveryContract,
   });
 }
 
@@ -36,51 +51,62 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
   });
 
   it("injects delivered cron text back into the main session transcript", async () => {
-    await withTempCronHome(async (home) => {
-      const storePath = await writeSessionStoreEntries(home, {
-        "agent:main:main": {
-          sessionId: "main-session",
-          updatedAt: Date.now(),
-          lastProvider: "telegram",
-          lastTo: "123",
-          lastChannel: "telegram",
-        },
-      });
-      mockAgentPayloads([{ text: "hello from cron" }]);
+    const previousFast = process.env.OPENCLAW_TEST_FAST;
+    delete process.env.OPENCLAW_TEST_FAST;
+    try {
+      await withTempCronHome(async (home) => {
+        const storePath = await writeSessionStoreEntries(home, {
+          "agent:main:main": {
+            sessionId: "main-session",
+            updatedAt: Date.now(),
+            lastProvider: "telegram",
+            lastTo: "123",
+            lastChannel: "telegram",
+          },
+        });
+        mockAgentPayloads([{ text: "hello from cron" }]);
 
-      const res = await runAnnounceTurn({ home, storePath });
+        const res = await runAnnounceTurn({ home, storePath });
 
-      expect(res.status).toBe("ok");
-      expect(res.delivered).toBe(true);
-      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
-        expect.objectContaining({
-          method: "chat.inject",
-          params: expect.objectContaining({
-            sessionKey: "agent:main:main",
-            message: "hello from cron",
-            label: "Cron delivery",
-            idempotencyKey: expect.stringContaining("cron-awareness:v1:"),
+        expect(res.status).toBe("ok");
+        expect(res.delivered).toBe(true);
+        expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+          expect.objectContaining({
+            method: "chat.inject",
+            params: expect.objectContaining({
+              sessionKey: "agent:main:main",
+              message: "hello from cron",
+              label: "Cron delivery",
+              idempotencyKey: expect.stringContaining("cron-awareness:v2:"),
+            }),
           }),
-        }),
-      ]);
-    });
+        ]);
+      });
+    } finally {
+      if (previousFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousFast;
+      }
+    }
   });
 
-  it("uses the routed thread session when the cron job is bound to one", async () => {
+  it("uses the routed thread session for implicit delivery and awareness when the job is bound to one", async () => {
     await withTempCronHome(async (home) => {
+      const deps = createCliDeps();
       const storePath = await writeSessionStoreEntries(home, {
         "agent:main:main": {
           sessionId: "main-session",
           updatedAt: Date.now(),
           lastProvider: "telegram",
-          lastTo: "123",
+          lastTo: "-100111",
           lastChannel: "telegram",
         },
         "agent:main:main:thread:42": {
           sessionId: "thread-session",
           updatedAt: Date.now(),
           lastProvider: "telegram",
-          lastTo: "123",
+          lastTo: "-100222",
           lastChannel: "telegram",
         },
       });
@@ -89,8 +115,17 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
       await runAnnounceTurn({
         home,
         storePath,
-        sessionKey: "agent:main:main:thread:42",
+        deps,
+        jobSessionKey: "agent:main:main:thread:42",
+        deliveryChannel: "last",
+        deliveryTo: null,
       });
+
+      expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
+        "-100222",
+        "thread digest",
+        expect.any(Object),
+      );
 
       expect(vi.mocked(callGateway).mock.calls).toContainEqual([
         expect.objectContaining({
@@ -102,5 +137,189 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
         }),
       ]);
     });
+  });
+
+  it("normalizes the runtime session key when the job does not carry one", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+        "agent:main:slack:channel:c123": {
+          sessionId: "slack-channel-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "hook delivery digest" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        runtimeSessionKey: "slack:channel:c123",
+        deliveryContract: "shared",
+      });
+
+      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "agent:main:slack:channel:c123",
+            message: "hook delivery digest",
+          }),
+        }),
+      ]);
+    });
+  });
+
+  it("creates the main awareness session when none exists yet", async () => {
+    const previousFast = process.env.OPENCLAW_TEST_FAST;
+    delete process.env.OPENCLAW_TEST_FAST;
+    try {
+      await withTempCronHome(async (home) => {
+        const storePath = await writeSessionStoreEntries(home, {});
+        mockAgentPayloads([{ text: "first cron memory" }]);
+
+        const res = await runAnnounceTurn({ home, storePath });
+
+        expect(res.status).toBe("ok");
+        expect(res.delivered).toBe(true);
+        expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+          expect.objectContaining({
+            method: "chat.inject",
+            params: expect.objectContaining({
+              sessionKey: "agent:main:main",
+              message: "first cron memory",
+            }),
+          }),
+        ]);
+
+        const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+          string,
+          { sessionId?: string }
+        >;
+        expect(typeof store["agent:main:main"]?.sessionId).toBe("string");
+      });
+    } finally {
+      if (previousFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousFast;
+      }
+    }
+  });
+
+  it("does not reuse hook scratch routes for shared implicit delivery", async () => {
+    await withTempCronHome(async (home) => {
+      const deps = createCliDeps();
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "-100111",
+          lastChannel: "telegram",
+        },
+        "agent:main:hook:webhook:42": {
+          sessionId: "hook-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "-100999",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "hook implicit delivery" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        runtimeSessionKey: "hook:webhook:42",
+        deliveryContract: "shared",
+        deliveryChannel: "last",
+        deliveryTo: null,
+      });
+
+      expect(deps.sendMessageTelegram).toHaveBeenCalledWith(
+        "-100111",
+        "hook implicit delivery",
+        expect.any(Object),
+      );
+      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "agent:main:main",
+            message: "hook implicit delivery",
+          }),
+        }),
+      ]);
+    });
+  });
+
+  it("uses a unique awareness idempotency key for repeated runs in a reused bound session", async () => {
+    vi.useFakeTimers();
+    try {
+      await withTempCronHome(async (home) => {
+        const firstRunAt = new Date("2026-03-22T10:00:00.000Z");
+        vi.setSystemTime(firstRunAt);
+        const storePath = await writeSessionStoreEntries(home, {
+          "agent:main:slack:channel:c123": {
+            sessionId: "reused-session",
+            updatedAt: firstRunAt.getTime(),
+            lastProvider: "telegram",
+            lastTo: "123",
+            lastChannel: "telegram",
+          },
+        });
+
+        mockAgentPayloads([{ text: "first bound delivery" }]);
+        await runAnnounceTurn({
+          home,
+          storePath,
+          runtimeSessionKey: "agent:main:slack:channel:c123",
+          sessionTarget: "session:agent:main:slack:channel:c123",
+        });
+
+        const firstInjectCall = vi
+          .mocked(callGateway)
+          .mock.calls.find(([call]) => call.method === "chat.inject");
+        const firstInjectParams = firstInjectCall?.[0].params as
+          | { idempotencyKey?: string }
+          | undefined;
+        const firstIdempotencyKey = firstInjectParams?.idempotencyKey;
+
+        vi.mocked(callGateway).mockClear();
+        vi.setSystemTime(new Date(firstRunAt.getTime() + 60_000));
+
+        mockAgentPayloads([{ text: "second bound delivery" }]);
+        await runAnnounceTurn({
+          home,
+          storePath,
+          runtimeSessionKey: "agent:main:slack:channel:c123",
+          sessionTarget: "session:agent:main:slack:channel:c123",
+        });
+
+        const secondInjectCall = vi
+          .mocked(callGateway)
+          .mock.calls.find(([call]) => call.method === "chat.inject");
+        const secondInjectParams = secondInjectCall?.[0].params as
+          | { idempotencyKey?: string }
+          | undefined;
+        const secondIdempotencyKey = secondInjectParams?.idempotencyKey;
+
+        expect(typeof firstIdempotencyKey).toBe("string");
+        expect(typeof secondIdempotencyKey).toBe("string");
+        expect(secondIdempotencyKey).not.toBe(firstIdempotencyKey);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import "./isolated-agent.mocks.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import { createCliDeps, mockAgentPayloads } from "./isolated-agent.delivery.test-helpers.js";
 import { runCronIsolatedAgentTurn } from "./isolated-agent.js";
@@ -24,9 +26,10 @@ async function runAnnounceTurn(params: {
   deps?: CliDeps;
   deliveryChannel?: "telegram" | "last";
   deliveryTo?: string | null;
+  cfgOverrides?: Partial<OpenClawConfig>;
 }) {
   return await runCronIsolatedAgentTurn({
-    cfg: makeCfg(params.home, params.storePath),
+    cfg: makeCfg(params.home, params.storePath, params.cfgOverrides),
     deps: params.deps ?? createCliDeps(),
     job: {
       ...makeJob({ kind: "agentTurn", message: "do it" }),
@@ -43,6 +46,26 @@ async function runAnnounceTurn(params: {
     lane: "cron",
     deliveryContract: params.deliveryContract,
   });
+}
+
+async function writeAgentScopedSessionStoreEntries(params: {
+  home: string;
+  byAgent: Record<string, Record<string, Record<string, unknown>>>;
+}): Promise<string> {
+  const storeTemplate = path.join(
+    params.home,
+    ".openclaw",
+    "agents",
+    "{agentId}",
+    "sessions",
+    "sessions.json",
+  );
+  for (const [agentId, entries] of Object.entries(params.byAgent)) {
+    const storePath = storeTemplate.replace("{agentId}", agentId);
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify(entries, null, 2), "utf-8");
+  }
+  return storeTemplate;
 }
 
 describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
@@ -178,6 +201,88 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
     });
   });
 
+  it("routes main-session aliases to the configured canonical main key", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:work": {
+          sessionId: "work-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "custom main alias delivery" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        runtimeSessionKey: "main",
+        sessionTarget: "session:main",
+        deliveryContract: "shared",
+        deliveryChannel: "last",
+        deliveryTo: null,
+        cfgOverrides: {
+          session: { store: storePath, mainKey: "work" },
+        },
+      });
+
+      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "agent:main:work",
+            message: "custom main alias delivery",
+          }),
+        }),
+      ]);
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+      expect(store["agent:main:main"]).toBeUndefined();
+    });
+  });
+
+  it("uses the global transcript when session scope is global", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        global: {
+          sessionId: "global-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "123",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "global cron delivery" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        runtimeSessionKey: "main",
+        sessionTarget: "session:main",
+        deliveryContract: "shared",
+        deliveryChannel: "last",
+        deliveryTo: null,
+        cfgOverrides: {
+          session: { store: storePath, scope: "global" },
+        },
+      });
+
+      expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+        expect.objectContaining({
+          method: "chat.inject",
+          params: expect.objectContaining({
+            sessionKey: "global",
+            message: "global cron delivery",
+          }),
+        }),
+      ]);
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, unknown>;
+      expect(store["agent:main:main"]).toBeUndefined();
+    });
+  });
+
   it("creates the main awareness session when none exists yet", async () => {
     const previousFast = process.env.OPENCLAW_TEST_FAST;
     delete process.env.OPENCLAW_TEST_FAST;
@@ -213,6 +318,87 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
         process.env.OPENCLAW_TEST_FAST = previousFast;
       }
     }
+  });
+
+  it("creates a fresh bound awareness session instead of reusing the main transcript", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "-100111",
+          lastChannel: "telegram",
+        },
+      });
+      mockAgentPayloads([{ text: "thread awareness" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        runtimeSessionKey: "agent:main:main:thread:42",
+        sessionTarget: "session:agent:main:main:thread:42",
+        deliveryChannel: "last",
+        deliveryTo: null,
+      });
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        {
+          sessionId?: string;
+          lastChannel?: string;
+          lastTo?: string;
+        }
+      >;
+      const threadEntry = store["agent:main:main:thread:42"];
+
+      expect(typeof threadEntry?.sessionId).toBe("string");
+      expect(threadEntry?.sessionId).not.toBe("main-session");
+      expect(threadEntry?.lastChannel).toBe("telegram");
+      expect(threadEntry?.lastTo).toBe("-100111");
+    });
+  });
+
+  it("backfills delivery context for bound awareness sessions that already have a transcript", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStoreEntries(home, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastTo: "-100111",
+          lastChannel: "telegram",
+        },
+        "agent:main:main:thread:42": {
+          sessionId: "thread-session",
+          updatedAt: Date.now(),
+        },
+      });
+      mockAgentPayloads([{ text: "route-less thread awareness" }]);
+
+      await runAnnounceTurn({
+        home,
+        storePath,
+        runtimeSessionKey: "agent:main:main:thread:42",
+        sessionTarget: "session:agent:main:main:thread:42",
+        deliveryChannel: "last",
+        deliveryTo: null,
+      });
+
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        {
+          sessionId?: string;
+          lastChannel?: string;
+          lastTo?: string;
+        }
+      >;
+      const threadEntry = store["agent:main:main:thread:42"];
+
+      expect(threadEntry?.sessionId).toBe("thread-session");
+      expect(threadEntry?.lastChannel).toBe("telegram");
+      expect(threadEntry?.lastTo).toBe("-100111");
+    });
   });
 
   it("does not reuse hook scratch routes for shared implicit delivery", async () => {
@@ -261,6 +447,63 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
         }),
       ]);
     });
+  });
+
+  it("writes cross-agent awareness session entries into the target agent store", async () => {
+    const previousFast = process.env.OPENCLAW_TEST_FAST;
+    delete process.env.OPENCLAW_TEST_FAST;
+    try {
+      await withTempCronHome(async (home) => {
+        const storeTemplate = await writeAgentScopedSessionStoreEntries({
+          home,
+          byAgent: {
+            main: {
+              "agent:main:main": {
+                sessionId: "main-session",
+                updatedAt: Date.now(),
+                lastProvider: "telegram",
+                lastTo: "123",
+                lastChannel: "telegram",
+              },
+            },
+            ops: {},
+          },
+        });
+        mockAgentPayloads([{ text: "cross agent awareness" }]);
+
+        await runAnnounceTurn({
+          home,
+          storePath: storeTemplate,
+          runtimeSessionKey: "agent:ops:main",
+          sessionTarget: "session:agent:ops:main",
+          cfgOverrides: {
+            session: { store: storeTemplate, mainKey: "main" },
+          },
+        });
+
+        expect(vi.mocked(callGateway).mock.calls).toContainEqual([
+          expect.objectContaining({
+            method: "chat.inject",
+            params: expect.objectContaining({
+              sessionKey: "agent:ops:main",
+              message: "cross agent awareness",
+            }),
+          }),
+        ]);
+
+        const opsStore = JSON.parse(
+          await fs.readFile(storeTemplate.replace("{agentId}", "ops"), "utf-8"),
+        ) as Record<string, { sessionId?: string }>;
+
+        expect(typeof opsStore["agent:ops:main"]?.sessionId).toBe("string");
+      });
+    } finally {
+      if (previousFast === undefined) {
+        delete process.env.OPENCLAW_TEST_FAST;
+      } else {
+        process.env.OPENCLAW_TEST_FAST = previousFast;
+      }
+    }
   });
 
   it("uses a unique awareness idempotency key for repeated runs in a reused bound session", async () => {

--- a/src/cron/isolated-agent.delivery-target-thread-session.test.ts
+++ b/src/cron/isolated-agent.delivery-target-thread-session.test.ts
@@ -100,6 +100,32 @@ describe("resolveDeliveryTarget thread session lookup", () => {
     expect(result.channel).toBe("telegram");
   });
 
+  it("normalizes unscoped session keys before looking up routed session state", async () => {
+    mockStore["/mock/store.json"] = {
+      "agent:main:main": {
+        sessionId: "s1",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-100222",
+      },
+      "agent:main:slack:channel:c123": {
+        sessionId: "s2",
+        updatedAt: 2,
+        lastChannel: "telegram",
+        lastTo: "-100777",
+      },
+    };
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "last",
+      sessionKey: "slack:channel:c123",
+    });
+
+    expect(result.to).toBe("-100777");
+    expect(result.threadId).toBeUndefined();
+    expect(result.channel).toBe("telegram");
+  });
+
   it("falls back to main session when no sessionKey is provided", async () => {
     mockStore["/mock/store.json"] = {
       "agent:main:main": {

--- a/src/cron/isolated-agent.delivery-target-thread-session.test.ts
+++ b/src/cron/isolated-agent.delivery-target-thread-session.test.ts
@@ -10,11 +10,27 @@ let resolveDeliveryTarget: DeliveryTargetModule["resolveDeliveryTarget"];
 
 beforeAll(async () => {
   vi.doMock("../config/sessions.js", () => ({
+    canonicalizeMainSessionAlias: vi.fn(
+      (params: {
+        cfg?: { session?: { mainKey?: string } };
+        agentId: string;
+        sessionKey: string;
+      }) => {
+        const raw = params.sessionKey.trim();
+        const mainKey = params.cfg?.session?.mainKey?.trim().toLowerCase() || "main";
+        const canonical = `agent:${params.agentId}:${mainKey}`;
+        return raw === "main" || raw === canonical || raw === `agent:${params.agentId}:main`
+          ? canonical
+          : raw;
+      },
+    ),
     loadSessionStore: vi.fn((storePath: string) => mockStore[storePath] ?? {}),
     resolveAgentMainSessionKey: vi.fn(
       ({ agentId }: { agentId: string }) => `agent:${agentId}:main`,
     ),
-    resolveStorePath: vi.fn((_store: unknown, _opts: unknown) => "/mock/store.json"),
+    resolveStorePath: vi.fn(
+      (_store: unknown, opts?: { agentId?: string }) => `/mock/${opts?.agentId ?? "main"}.json`,
+    ),
   }));
   vi.doMock("../infra/outbound/channel-selection.js", () => ({
     resolveMessageChannelSelection: vi.fn(async () => ({ channel: "telegram" })),
@@ -54,7 +70,7 @@ describe("resolveDeliveryTarget thread session lookup", () => {
   const cfg: OpenClawConfig = {};
 
   it("uses thread session entry when sessionKey is provided and entry exists", async () => {
-    mockStore["/mock/store.json"] = {
+    mockStore["/mock/main.json"] = {
       "agent:main:main": {
         sessionId: "s1",
         updatedAt: 1,
@@ -81,7 +97,7 @@ describe("resolveDeliveryTarget thread session lookup", () => {
   });
 
   it("falls back to main session when sessionKey entry does not exist", async () => {
-    mockStore["/mock/store.json"] = {
+    mockStore["/mock/main.json"] = {
       "agent:main:main": {
         sessionId: "s1",
         updatedAt: 1,
@@ -100,8 +116,32 @@ describe("resolveDeliveryTarget thread session lookup", () => {
     expect(result.channel).toBe("telegram");
   });
 
+  it("falls back to main session when the routed entry has no delivery context", async () => {
+    mockStore["/mock/main.json"] = {
+      "agent:main:main": {
+        sessionId: "s1",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-100444",
+      },
+      "agent:main:main:thread:empty": {
+        sessionId: "s2",
+        updatedAt: 2,
+      },
+    };
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "last",
+      sessionKey: "agent:main:main:thread:empty",
+    });
+
+    expect(result.to).toBe("-100444");
+    expect(result.threadId).toBeUndefined();
+    expect(result.channel).toBe("telegram");
+  });
+
   it("normalizes unscoped session keys before looking up routed session state", async () => {
-    mockStore["/mock/store.json"] = {
+    mockStore["/mock/main.json"] = {
       "agent:main:main": {
         sessionId: "s1",
         updatedAt: 1,
@@ -126,8 +166,78 @@ describe("resolveDeliveryTarget thread session lookup", () => {
     expect(result.channel).toBe("telegram");
   });
 
+  it("loads routed delivery context from the bound session's agent store", async () => {
+    mockStore["/mock/main.json"] = {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-100222",
+      },
+    };
+    mockStore["/mock/ops.json"] = {
+      "agent:ops:main": {
+        sessionId: "ops-session",
+        updatedAt: 2,
+        lastChannel: "telegram",
+        lastTo: "-100777",
+      },
+    };
+
+    const result = await resolveDeliveryTarget(cfg, "main", {
+      channel: "last",
+      sessionKey: "agent:ops:main",
+    });
+
+    expect(result.to).toBe("-100777");
+    expect(result.threadId).toBeUndefined();
+    expect(result.channel).toBe("telegram");
+  });
+
+  it("uses the routed session agent's bound account when lastAccountId is missing", async () => {
+    mockStore["/mock/main.json"] = {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-100222",
+      },
+    };
+    mockStore["/mock/ops.json"] = {
+      "agent:ops:main": {
+        sessionId: "ops-session",
+        updatedAt: 2,
+        lastChannel: "telegram",
+        lastTo: "-100777",
+      },
+    };
+
+    const result = await resolveDeliveryTarget(
+      {
+        bindings: [
+          {
+            agentId: "main",
+            match: { channel: "telegram", accountId: "main-account" },
+          },
+          {
+            agentId: "ops",
+            match: { channel: "telegram", accountId: "ops-account" },
+          },
+        ],
+      },
+      "main",
+      {
+        channel: "last",
+        sessionKey: "agent:ops:main",
+      },
+    );
+
+    expect(result.to).toBe("-100777");
+    expect(result.accountId).toBe("ops-account");
+  });
+
   it("falls back to main session when no sessionKey is provided", async () => {
-    mockStore["/mock/store.json"] = {
+    mockStore["/mock/main.json"] = {
       "agent:main:main": {
         sessionId: "s1",
         updatedAt: 1,
@@ -145,7 +255,7 @@ describe("resolveDeliveryTarget thread session lookup", () => {
   });
 
   it("preserves threadId from :topic: in delivery.to on first run (no session history)", async () => {
-    mockStore["/mock/store.json"] = {};
+    mockStore["/mock/main.json"] = {};
 
     const result = await resolveDeliveryTarget(cfg, "main", {
       channel: "telegram",
@@ -158,7 +268,7 @@ describe("resolveDeliveryTarget thread session lookup", () => {
   });
 
   it("explicit accountId overrides session lastAccountId", async () => {
-    mockStore["/mock/store.json"] = {
+    mockStore["/mock/main.json"] = {
       "agent:main:main": {
         sessionId: "s1",
         updatedAt: 1,
@@ -179,7 +289,7 @@ describe("resolveDeliveryTarget thread session lookup", () => {
   });
 
   it("preserves threadId from :topic: when lastTo differs", async () => {
-    mockStore["/mock/store.json"] = {
+    mockStore["/mock/main.json"] = {
       "agent:main:main": {
         sessionId: "s1",
         updatedAt: 1,

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -34,7 +34,12 @@ vi.mock("../../cli/outbound-send-deps.js", () => ({
   createOutboundSendDeps: vi.fn().mockReturnValue({}),
 }));
 
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
 vi.mock("../../logger.js", () => ({
+  logDebug: vi.fn(),
   logWarn: vi.fn(),
 }));
 
@@ -105,6 +110,7 @@ function makeBaseParams(overrides: {
       payload: { kind: "agentTurn", message: "hello" },
     } as never,
     agentId: "main",
+    sessionKey: "agent:main:main",
     agentSessionKey: "agent:main",
     runSessionId: overrides.runSessionId ?? "run-123",
     runStartedAt: Date.now(),

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from "node:crypto";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  canonicalizeMainSessionAlias,
   loadSessionStore,
+  resolveMainSessionKey,
   resolveAgentMainSessionKey,
   resolveStorePath,
   updateSessionStore,
@@ -19,7 +22,8 @@ import {
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { logWarn } from "../../logger.js";
-import { isCronSessionKey } from "../../routing/session-key.js";
+import { isCronSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickSummaryFromOutput } from "./helpers.js";
@@ -255,17 +259,28 @@ function resolveCronAwarenessSessionKey(params: {
   if (!agentId) {
     return undefined;
   }
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
-  const store = loadSessionStore(storePath);
   const requestedSessionKey = params.sessionKey?.trim();
-  const canonicalRequestedSessionKey = requestedSessionKey
+  const requestedSessionStoreKey = requestedSessionKey
     ? resolveCronAgentSessionKey({ sessionKey: requestedSessionKey, agentId })
     : undefined;
+  const canonicalRequestedSessionKey = requestedSessionStoreKey
+    ? canonicalizeMainSessionAlias({
+        cfg: params.cfg,
+        agentId: resolveAgentIdFromSessionKey(requestedSessionStoreKey),
+        sessionKey: requestedSessionStoreKey,
+      })
+    : undefined;
+  const requestedStorePath = canonicalRequestedSessionKey
+    ? resolveStorePath(params.cfg.session?.store, {
+        agentId: resolveAgentIdFromSessionKey(canonicalRequestedSessionKey),
+      })
+    : undefined;
+  const requestedStore = requestedStorePath ? loadSessionStore(requestedStorePath) : undefined;
   const requestedIsCronScratch =
     Boolean(requestedSessionKey && requestedSessionKey.toLowerCase().startsWith("cron:")) ||
     Boolean(canonicalRequestedSessionKey && isCronSessionKey(canonicalRequestedSessionKey));
   const requestedEntry = canonicalRequestedSessionKey
-    ? store[canonicalRequestedSessionKey]
+    ? requestedStore?.[canonicalRequestedSessionKey]
     : undefined;
   if (
     !requestedIsCronScratch &&
@@ -275,7 +290,10 @@ function resolveCronAwarenessSessionKey(params: {
   ) {
     return canonicalRequestedSessionKey;
   }
-  const mainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
+  const mainSessionKey =
+    params.cfg.session?.scope === "global"
+      ? resolveMainSessionKey(params.cfg)
+      : resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
   if (!requestedIsCronScratch && canonicalRequestedSessionKey) {
     return canonicalRequestedSessionKey;
   }
@@ -284,17 +302,38 @@ function resolveCronAwarenessSessionKey(params: {
 
 async function ensureCronAwarenessSessionEntry(params: {
   cfg: OpenClawConfig;
-  agentId: string;
   sessionKey: string;
 }): Promise<void> {
-  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+  const normalizedSessionKey = params.sessionKey.trim().toLowerCase();
+  const storeAgentId =
+    normalizedSessionKey === "global" || normalizedSessionKey === "unknown"
+      ? resolveDefaultAgentId(params.cfg)
+      : resolveAgentIdFromSessionKey(params.sessionKey);
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: storeAgentId });
+  const mainSessionKey =
+    normalizedSessionKey === "global"
+      ? resolveMainSessionKey(params.cfg)
+      : resolveAgentMainSessionKey({ cfg: params.cfg, agentId: storeAgentId });
   const now = Date.now();
   await updateSessionStore(storePath, (store) => {
     const existing = store[params.sessionKey];
+    const mainEntry = store[mainSessionKey];
+    const seededDeliveryContext = deliveryContextFromSession(mainEntry);
+    const existingDeliveryContext = deliveryContextFromSession(existing);
     if (typeof existing?.sessionId === "string" && existing.sessionId.trim()) {
-      if ((existing.updatedAt ?? 0) < now) {
+      const needsDeliverySeed = !existingDeliveryContext && Boolean(seededDeliveryContext);
+      if (needsDeliverySeed || (existing.updatedAt ?? 0) < now) {
         store[params.sessionKey] = {
           ...existing,
+          ...(needsDeliverySeed
+            ? {
+                lastChannel: existing.lastChannel ?? seededDeliveryContext?.channel,
+                lastTo: existing.lastTo ?? seededDeliveryContext?.to,
+                lastAccountId: existing.lastAccountId ?? seededDeliveryContext?.accountId,
+                lastThreadId: existing.lastThreadId ?? seededDeliveryContext?.threadId,
+                deliveryContext: existing.deliveryContext ?? seededDeliveryContext,
+              }
+            : {}),
           updatedAt: now,
         };
       }
@@ -302,8 +341,15 @@ async function ensureCronAwarenessSessionEntry(params: {
     }
     store[params.sessionKey] = {
       ...existing,
+      // Seed routing from the main session without aliasing its transcript.
       sessionId: existing?.sessionId?.trim() || randomUUID(),
+      sessionFile: existing?.sessionId?.trim() ? existing.sessionFile : undefined,
       updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+      lastChannel: existing?.lastChannel ?? seededDeliveryContext?.channel,
+      lastTo: existing?.lastTo ?? seededDeliveryContext?.to,
+      lastAccountId: existing?.lastAccountId ?? seededDeliveryContext?.accountId,
+      lastThreadId: existing?.lastThreadId ?? seededDeliveryContext?.threadId,
+      deliveryContext: existing?.deliveryContext ?? seededDeliveryContext,
     };
   });
 }
@@ -335,7 +381,6 @@ async function injectCronDeliveryAwareness(params: {
   try {
     await ensureCronAwarenessSessionEntry({
       cfg: params.cfg,
-      agentId: params.agentId,
       sessionKey: awarenessSessionKey,
     });
     await callGateway({

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -3,6 +3,11 @@ import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  loadSessionStore,
+  resolveAgentMainSessionKey,
+  resolveStorePath,
+} from "../../config/sessions.js";
 import { callGateway } from "../../gateway/call.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import {
@@ -228,6 +233,83 @@ function buildDirectCronDeliveryIdempotencyKey(params: {
   return `cron-direct-delivery:v1:${params.runSessionId}:${params.delivery.channel}:${accountId}:${normalizedTo}:${threadId}`;
 }
 
+function buildCronAwarenessIdempotencyKey(params: {
+  runSessionId: string;
+  sessionKey: string;
+}): string {
+  return `cron-awareness:v1:${params.runSessionId}:${params.sessionKey}`;
+}
+
+function resolveCronAwarenessSessionKey(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+}): string | undefined {
+  const agentId = params.agentId.trim();
+  if (!agentId) {
+    return undefined;
+  }
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
+  const store = loadSessionStore(storePath);
+  const requestedSessionKey = params.sessionKey?.trim();
+  const requestedEntry = requestedSessionKey ? store[requestedSessionKey] : undefined;
+  if (
+    requestedSessionKey &&
+    typeof requestedEntry?.sessionId === "string" &&
+    requestedEntry.sessionId.trim()
+  ) {
+    return requestedSessionKey;
+  }
+  const mainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
+  const mainEntry = store[mainSessionKey];
+  if (typeof mainEntry?.sessionId === "string" && mainEntry.sessionId.trim()) {
+    return mainSessionKey;
+  }
+  return undefined;
+}
+
+async function injectCronDeliveryAwareness(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+  message?: string;
+  runSessionId: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (params.signal?.aborted) {
+    return;
+  }
+  const message = params.message?.trim();
+  if (!message) {
+    return;
+  }
+  const awarenessSessionKey = resolveCronAwarenessSessionKey({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  if (!awarenessSessionKey) {
+    return;
+  }
+  try {
+    await callGateway({
+      method: "chat.inject",
+      params: {
+        sessionKey: awarenessSessionKey,
+        message,
+        label: "Cron delivery",
+        idempotencyKey: buildCronAwarenessIdempotencyKey({
+          runSessionId: params.runSessionId,
+          sessionKey: awarenessSessionKey,
+        }),
+      },
+      timeoutMs: 10_000,
+    });
+  } catch {
+    // Best-effort; the outbound delivery already succeeded.
+  }
+}
+
 export function resetCompletedDirectCronDeliveriesForTests() {
   COMPLETED_DIRECT_CRON_DELIVERIES.clear();
 }
@@ -419,6 +501,14 @@ export async function dispatchCronDelivery(
       delivered = deliveryResults.length > 0;
       if (delivered) {
         rememberCompletedDirectCronDelivery(deliveryIdempotencyKey, deliveryResults);
+        await injectCronDeliveryAwareness({
+          cfg: params.cfg,
+          agentId: params.agentId,
+          sessionKey: params.job.sessionKey,
+          message: outputText?.trim() ? outputText : synthesizedText,
+          runSessionId: params.runSessionId,
+          signal: params.abortSignal,
+        });
       }
       return null;
     } catch (err) {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -261,7 +261,9 @@ function resolveCronAwarenessSessionKey(params: {
   }
   const requestedSessionKey = params.sessionKey?.trim();
   const requestedSessionStoreKey = requestedSessionKey
-    ? resolveCronAgentSessionKey({ sessionKey: requestedSessionKey, agentId })
+    ? requestedSessionKey.toLowerCase() === "global"
+      ? requestedSessionKey
+      : resolveCronAgentSessionKey({ sessionKey: requestedSessionKey, agentId })
     : undefined;
   const canonicalRequestedSessionKey = requestedSessionStoreKey
     ? canonicalizeMainSessionAlias({

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
@@ -7,6 +8,7 @@ import {
   loadSessionStore,
   resolveAgentMainSessionKey,
   resolveStorePath,
+  updateSessionStore,
 } from "../../config/sessions.js";
 import { callGateway } from "../../gateway/call.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
@@ -17,10 +19,12 @@ import {
 import { resolveAgentOutboundIdentity } from "../../infra/outbound/identity.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { logWarn } from "../../logger.js";
+import { isCronSessionKey } from "../../routing/session-key.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickSummaryFromOutput } from "./helpers.js";
 import type { RunCronAgentTurnResult } from "./run.js";
+import { resolveCronAgentSessionKey } from "./session-key.js";
 import {
   expectsSubagentFollowup,
   isLikelyInterimCronMessage,
@@ -83,6 +87,7 @@ type DispatchCronDeliveryParams = {
   deps: CliDeps;
   job: CronJob;
   agentId: string;
+  sessionKey?: string;
   agentSessionKey: string;
   runSessionId: string;
   runStartedAt: number;
@@ -235,9 +240,10 @@ function buildDirectCronDeliveryIdempotencyKey(params: {
 
 function buildCronAwarenessIdempotencyKey(params: {
   runSessionId: string;
+  runStartedAt: number;
   sessionKey: string;
 }): string {
-  return `cron-awareness:v1:${params.runSessionId}:${params.sessionKey}`;
+  return `cron-awareness:v2:${params.runSessionId}:${params.runStartedAt}:${params.sessionKey}`;
 }
 
 function resolveCronAwarenessSessionKey(params: {
@@ -252,20 +258,54 @@ function resolveCronAwarenessSessionKey(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
   const store = loadSessionStore(storePath);
   const requestedSessionKey = params.sessionKey?.trim();
-  const requestedEntry = requestedSessionKey ? store[requestedSessionKey] : undefined;
+  const canonicalRequestedSessionKey = requestedSessionKey
+    ? resolveCronAgentSessionKey({ sessionKey: requestedSessionKey, agentId })
+    : undefined;
+  const requestedIsCronScratch =
+    Boolean(requestedSessionKey && requestedSessionKey.toLowerCase().startsWith("cron:")) ||
+    Boolean(canonicalRequestedSessionKey && isCronSessionKey(canonicalRequestedSessionKey));
+  const requestedEntry = canonicalRequestedSessionKey
+    ? store[canonicalRequestedSessionKey]
+    : undefined;
   if (
-    requestedSessionKey &&
+    !requestedIsCronScratch &&
+    canonicalRequestedSessionKey &&
     typeof requestedEntry?.sessionId === "string" &&
     requestedEntry.sessionId.trim()
   ) {
-    return requestedSessionKey;
+    return canonicalRequestedSessionKey;
   }
   const mainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
-  const mainEntry = store[mainSessionKey];
-  if (typeof mainEntry?.sessionId === "string" && mainEntry.sessionId.trim()) {
-    return mainSessionKey;
+  if (!requestedIsCronScratch && canonicalRequestedSessionKey) {
+    return canonicalRequestedSessionKey;
   }
-  return undefined;
+  return mainSessionKey;
+}
+
+async function ensureCronAwarenessSessionEntry(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): Promise<void> {
+  const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+  const now = Date.now();
+  await updateSessionStore(storePath, (store) => {
+    const existing = store[params.sessionKey];
+    if (typeof existing?.sessionId === "string" && existing.sessionId.trim()) {
+      if ((existing.updatedAt ?? 0) < now) {
+        store[params.sessionKey] = {
+          ...existing,
+          updatedAt: now,
+        };
+      }
+      return;
+    }
+    store[params.sessionKey] = {
+      ...existing,
+      sessionId: existing?.sessionId?.trim() || randomUUID(),
+      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+    };
+  });
 }
 
 async function injectCronDeliveryAwareness(params: {
@@ -274,6 +314,7 @@ async function injectCronDeliveryAwareness(params: {
   sessionKey?: string;
   message?: string;
   runSessionId: string;
+  runStartedAt: number;
   signal?: AbortSignal;
 }): Promise<void> {
   if (params.signal?.aborted) {
@@ -292,6 +333,11 @@ async function injectCronDeliveryAwareness(params: {
     return;
   }
   try {
+    await ensureCronAwarenessSessionEntry({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      sessionKey: awarenessSessionKey,
+    });
     await callGateway({
       method: "chat.inject",
       params: {
@@ -300,6 +346,7 @@ async function injectCronDeliveryAwareness(params: {
         label: "Cron delivery",
         idempotencyKey: buildCronAwarenessIdempotencyKey({
           runSessionId: params.runSessionId,
+          runStartedAt: params.runStartedAt,
           sessionKey: awarenessSessionKey,
         }),
       },
@@ -504,9 +551,10 @@ export async function dispatchCronDelivery(
         await injectCronDeliveryAwareness({
           cfg: params.cfg,
           agentId: params.agentId,
-          sessionKey: params.job.sessionKey,
+          sessionKey: params.sessionKey,
           message: outputText?.trim() ? outputText : synthesizedText,
           runSessionId: params.runSessionId,
+          runStartedAt: params.runStartedAt,
           signal: params.abortSignal,
         });
       }

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 
 vi.mock("../../config/sessions.js", () => ({
+  canonicalizeMainSessionAlias: vi.fn(
+    (params: { cfg?: { session?: { mainKey?: string } }; agentId: string; sessionKey: string }) => {
+      const raw = params.sessionKey.trim();
+      const mainKey = params.cfg?.session?.mainKey?.trim().toLowerCase() || "main";
+      const canonical = `agent:${params.agentId}:${mainKey}`;
+      return raw === "main" || raw === canonical || raw === `agent:${params.agentId}:main`
+        ? canonical
+        : raw;
+    },
+  ),
   loadSessionStore: vi.fn().mockReturnValue({}),
   resolveAgentMainSessionKey: vi.fn().mockReturnValue("agent:test:main"),
   resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -17,6 +17,7 @@ import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAccountId, normalizeAgentId } from "../../routing/session-key.js";
 import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
+import { resolveCronAgentSessionKey } from "./session-key.js";
 
 export type DeliveryTargetResolution =
   | {
@@ -59,7 +60,10 @@ export async function resolveDeliveryTarget(
 
   // Look up thread-specific session first (e.g. agent:main:main:thread:1234),
   // then fall back to the main session entry.
-  const threadSessionKey = jobPayload.sessionKey?.trim();
+  const threadSessionKeyRaw = jobPayload.sessionKey?.trim();
+  const threadSessionKey = threadSessionKeyRaw
+    ? resolveCronAgentSessionKey({ sessionKey: threadSessionKeyRaw, agentId })
+    : undefined;
   const threadEntry = threadSessionKey ? store[threadSessionKey] : undefined;
   const main = threadEntry ?? store[mainSessionKey];
 

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -62,7 +62,9 @@ export async function resolveDeliveryTarget(
   const sessionCfg = cfg.session;
   const threadSessionKeyRaw = jobPayload.sessionKey?.trim();
   const requestedSessionStoreKey = threadSessionKeyRaw
-    ? resolveCronAgentSessionKey({ sessionKey: threadSessionKeyRaw, agentId })
+    ? threadSessionKeyRaw.toLowerCase() === "global"
+      ? threadSessionKeyRaw
+      : resolveCronAgentSessionKey({ sessionKey: threadSessionKeyRaw, agentId })
     : undefined;
   const threadSessionKey = requestedSessionStoreKey
     ? canonicalizeMainSessionAlias({
@@ -75,7 +77,13 @@ export async function resolveDeliveryTarget(
   // store before looking up "last" delivery context so session-bound crons
   // follow the actual target transcript instead of the current agent's store.
   const storeAgentId = threadSessionKey ? resolveAgentIdFromSessionKey(threadSessionKey) : agentId;
-  const bindingAgentId = normalizeAgentId(storeAgentId);
+  // For global-scope sessions the key is bare "global" with no embedded agent,
+  // so resolveAgentIdFromSessionKey falls back to "main". Use the runner's
+  // agentId for binding resolution in that case to keep the correct account.
+  const bindingAgentId =
+    threadSessionKey?.toLowerCase() === "global"
+      ? normalizeAgentId(agentId)
+      : normalizeAgentId(storeAgentId);
   const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId: storeAgentId });
   const storePath = resolveStorePath(sessionCfg?.store, { agentId: storeAgentId });
   const store = loadSessionStore(storePath);

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -2,6 +2,7 @@ import { resolveWhatsAppAccount } from "../../../extensions/whatsapp/api.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  canonicalizeMainSessionAlias,
   loadSessionStore,
   resolveAgentMainSessionKey,
   resolveStorePath,
@@ -15,7 +16,12 @@ import {
 } from "../../infra/outbound/targets.js";
 import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
-import { normalizeAccountId, normalizeAgentId } from "../../routing/session-key.js";
+import {
+  normalizeAccountId,
+  normalizeAgentId,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
+import { deliveryContextFromSession } from "../../utils/delivery-context.js";
 import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 
@@ -54,18 +60,35 @@ export async function resolveDeliveryTarget(
   const allowMismatchedLastTo = requestedChannel === "last";
 
   const sessionCfg = cfg.session;
-  const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId });
-  const storePath = resolveStorePath(sessionCfg?.store, { agentId });
+  const threadSessionKeyRaw = jobPayload.sessionKey?.trim();
+  const requestedSessionStoreKey = threadSessionKeyRaw
+    ? resolveCronAgentSessionKey({ sessionKey: threadSessionKeyRaw, agentId })
+    : undefined;
+  const threadSessionKey = requestedSessionStoreKey
+    ? canonicalizeMainSessionAlias({
+        cfg,
+        agentId: resolveAgentIdFromSessionKey(requestedSessionStoreKey),
+        sessionKey: requestedSessionStoreKey,
+      })
+    : undefined;
+  // Bound session keys may belong to another agent store. Resolve the routed
+  // store before looking up "last" delivery context so session-bound crons
+  // follow the actual target transcript instead of the current agent's store.
+  const storeAgentId = threadSessionKey ? resolveAgentIdFromSessionKey(threadSessionKey) : agentId;
+  const bindingAgentId = normalizeAgentId(storeAgentId);
+  const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId: storeAgentId });
+  const storePath = resolveStorePath(sessionCfg?.store, { agentId: storeAgentId });
   const store = loadSessionStore(storePath);
 
   // Look up thread-specific session first (e.g. agent:main:main:thread:1234),
   // then fall back to the main session entry.
-  const threadSessionKeyRaw = jobPayload.sessionKey?.trim();
-  const threadSessionKey = threadSessionKeyRaw
-    ? resolveCronAgentSessionKey({ sessionKey: threadSessionKeyRaw, agentId })
-    : undefined;
   const threadEntry = threadSessionKey ? store[threadSessionKey] : undefined;
-  const main = threadEntry ?? store[mainSessionKey];
+  const main =
+    (deliveryContextFromSession(threadEntry as Parameters<typeof deliveryContextFromSession>[0])
+      ? threadEntry
+      : undefined) ??
+    store[mainSessionKey] ??
+    threadEntry;
 
   const preliminary = resolveSessionDeliveryTarget({
     entry: main,
@@ -118,7 +141,7 @@ export async function resolveDeliveryTarget(
   if (!accountId && channel) {
     const bindings = buildChannelAccountBindings(cfg);
     const byAgent = bindings.get(channel);
-    const boundAccounts = byAgent?.get(normalizeAgentId(agentId));
+    const boundAccounts = byAgent?.get(bindingAgentId);
     if (boundAccounts && boundAccounts.length > 0) {
       accountId = boundAccounts[0];
     }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -39,7 +39,11 @@ import {
 } from "../../config/sessions.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
+import {
+  isCronSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
 import {
   buildSafeExternalPrompt,
   detectSuspiciousPatterns,
@@ -111,10 +115,53 @@ function resolveCronToolPolicy(params: {
   };
 }
 
+function isCronScratchSessionKey(params: { sessionKey?: string; agentId: string }): boolean {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return false;
+  }
+  if (sessionKey.toLowerCase().startsWith("cron:")) {
+    return true;
+  }
+  return isCronSessionKey(
+    resolveCronAgentSessionKey({
+      sessionKey,
+      agentId: params.agentId,
+    }),
+  );
+}
+
+function resolveCronDeliverySessionKey(params: {
+  runtimeSessionKey?: string;
+  jobSessionKey?: string;
+  agentId: string;
+}): string | undefined {
+  const runtimeSessionKey = params.runtimeSessionKey?.trim();
+  const runtimeSessionRest = runtimeSessionKey
+    ? parseAgentSessionKey(
+        resolveCronAgentSessionKey({ sessionKey: runtimeSessionKey, agentId: params.agentId }),
+      )?.rest
+    : undefined;
+  if (
+    runtimeSessionKey &&
+    !isExternalHookSession(runtimeSessionKey) &&
+    !(runtimeSessionRest && isExternalHookSession(runtimeSessionRest)) &&
+    !isCronScratchSessionKey({
+      sessionKey: runtimeSessionKey,
+      agentId: params.agentId,
+    })
+  ) {
+    return runtimeSessionKey;
+  }
+  const jobSessionKey = params.jobSessionKey?.trim();
+  return jobSessionKey || undefined;
+}
+
 async function resolveCronDeliveryContext(params: {
   cfg: OpenClawConfig;
   job: CronJob;
   agentId: string;
+  sessionKey: string;
   deliveryContract: IsolatedDeliveryContract;
 }) {
   const deliveryPlan = resolveCronDeliveryPlan(params.job);
@@ -139,11 +186,16 @@ async function resolveCronDeliveryContext(params: {
       }),
     };
   }
+  const deliverySessionKey = resolveCronDeliverySessionKey({
+    runtimeSessionKey: params.sessionKey,
+    jobSessionKey: params.job.sessionKey,
+    agentId: params.agentId,
+  });
   const resolvedDelivery = await resolveDeliveryTarget(params.cfg, params.agentId, {
     channel: deliveryPlan.channel ?? "last",
     to: deliveryPlan.to,
     accountId: deliveryPlan.accountId,
-    sessionKey: params.job.sessionKey,
+    sessionKey: deliverySessionKey,
   });
   return {
     deliveryPlan,
@@ -328,6 +380,7 @@ export async function runCronIsolatedAgentTurn(params: {
     cfg: cfgWithAgentDefaults,
     job: params.job,
     agentId,
+    sessionKey: baseSessionKey,
     deliveryContract,
   });
 
@@ -734,6 +787,11 @@ export async function runCronIsolatedAgentTurn(params: {
     deps: params.deps,
     job: params.job,
     agentId,
+    sessionKey: resolveCronDeliverySessionKey({
+      runtimeSessionKey: baseSessionKey,
+      jobSessionKey: params.job.sessionKey,
+      agentId,
+    }),
     agentSessionKey,
     runSessionId,
     runStartedAt,

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -59,6 +59,7 @@ export const ChatInjectParamsSchema = Type.Object(
     sessionKey: NonEmptyString,
     message: NonEmptyString,
     label: Type.Optional(Type.String({ maxLength: 100 })),
+    idempotencyKey: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1703,6 +1703,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey: string;
       message: string;
       label?: string;
+      idempotencyKey?: string;
     };
 
     // Load session to find transcript file
@@ -1717,6 +1718,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const appended = appendAssistantTranscriptMessage({
       message: p.message,
       label: p.label,
+      idempotencyKey: p.idempotencyKey,
       sessionId,
       storePath,
       sessionFile: entry?.sessionFile,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1725,6 +1725,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
       createIfMissing: true,
     });
+    if (appended.ok && !appended.messageId) {
+      // Idempotency dedup: key already present in transcript, nothing to write.
+      respond(true, { deduplicated: true });
+      return;
+    }
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(
         false,


### PR DESCRIPTION
## Summary

### **tldr:** - Cron job outputs delivered to channels were never saved in the agent's session history, so the agent couldn't recall what it sent. This fix writes delivered cron output back into the correct transcript with proper routing and deduplication.

  - **Problem:** When an isolated cron job delivers a message to a channel (e.g. Telegram/Discord), the main agent has no record of it. Users can ask:
    - "what did you send this morning?" and the agent has no idea — it forwarded the content but never wrote it to its own transcript.
  - **Why it matters:** The agent acts as a blind pipe — receive, forward, forget. Users expect the agent to recall its own deliveries, especially when asking follow-up questions about content it just sent.
- **What changed:**
    - **Bug fix:** After a successful direct isolated cron announce delivery, OpenClaw now makes a best-effort `chat.inject` write into the routed main or thread transcript using a stable idempotency key, so the agent can recall what it already sent. New session entries are seeded with delivery context from the main session to avoid creating routing-empty store entries. The `chat.inject` handler now returns success for idempotent dedup replays instead of a spurious error.

    - **Refactor:** Session key routing was unified so awareness injection, delivery target resolution, and store writes all use the runtime session key consistently instead of pulling from different sources (`job.sessionKey` vs the runtime param):
      - `resolveCronDeliveryContext` (`run.ts`) — changed from `params.job.sessionKey` to `params.sessionKey` so delivery target resolution uses the correct session context for hook dispatches and shared-contract runs.
      - `dispatchCronDelivery` params (`delivery-dispatch.ts`) — added a required `sessionKey` field to `DispatchCronDeliveryParams` so the runtime session key flows through the delivery dispatch path.
      - `resolveDeliveryTarget` (`delivery-target.ts`) — changed to resolve the session store from the session key's agent ID instead of always using the runner's `agentId`, and added `canonicalizeMainSessionAlias` so thread/routed keys are properly canonicalized before store lookup.



  - **Scope boundary:** This does not resend cron output to users, does not switch cron over to the subagent announce flow, and does not change the existing no-fallback-main-summary behavior.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [x] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [ ] Integrations
  - [x] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Fixes #52136

  ## User-visible / Behavior Changes

  Successful direct isolated cron announce deliveries now attempt to append a labeled `Cron delivery` assistant entry into the routed main or thread transcript so later follow-up turns can recall what cron already sent externally.

  ## Security Impact (required)

  - New permissions/capabilities? `No`
  - Secrets/tokens handling changed? `No`
  - New/changed network calls? `No`
  - Command/tool execution surface changed? `No`
  - Data access scope changed? `No`

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local repo checkout on `main` plus the fix branch
  - Model/provider: N/A
  - Integration/channel: isolated cron direct announce delivery with routed main or thread transcript awareness
  - Relevant config: test harness session store with `agent:main:main` and optional thread session entries

  ### Steps

  1. Configure an isolated cron `agentTurn` job with `delivery.mode="announce"`.
  2. Let the isolated run produce a normal text response and deliver it through the direct outbound path.
  3. Inspect the routed main or thread transcript after delivery.

  ### Expected

  - After a successful direct delivery, OpenClaw writes a `Cron delivery` transcript entry into the routed session.
  - Replayed `chat.inject` writes for the same run/session combination are deduped by idempotency key.

  ### Actual Before This Change

  - Direct delivery completed, but the routed transcript did not receive the delivered content.

  ## Evidence

  - [x] Failing test/log before plus passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers

  Regression coverage added for:
  - main-session awareness injection
  - thread-session awareness injection
  - idempotent transcript injection behavior through `chat.inject`
  - runtime session key routing for hook dispatch / shared-contract runs
  - cross-agent awareness store resolution
  - delivery context seeding on new awareness session entries

  ## Human Verification (required)

  - Verified scenarios:
    - direct isolated cron announce delivery appends a `Cron delivery` transcript entry to `agent:main:main`
    - thread-bound cron delivery appends to the routed thread session instead of the generic main session
    - runtime session key is used for awareness when `job.sessionKey` is absent (hook dispatch path)
    - cross-agent awareness entries are written to the correct agent store
    - new awareness session entries are seeded with delivery metadata so `resolveDeliveryTarget` doesn't lose `lastChannel`/`lastTo`
    - `chat.inject` dedup replays return `{ deduplicated: true }` instead of an error
    - existing outbound direct delivery still works
    - existing no-fallback-main-summary behavior still holds
  - Edge cases checked:
    - transcript injection uses a stable idempotency key per run/session
    - missing routed session safely skips awareness injection instead of failing the delivery
    - cross-agent `sessionTarget` resolves store path from the awareness session key's agent, not the runner's agent
    - awareness entries created for keys without prior store entries carry seeded delivery context
  - `pnpm test` passed
  - Not verified:

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? `Yes`
  - Config/env changes? `No`
  - Migration needed? `No`

  ## Failure Recovery (if this breaks)

  - Revert the transcript-awareness injection in `src/cron/isolated-agent/delivery-dispatch.ts`
  - Revert the optional `idempotencyKey` support added to `chat.inject`
  - Revert the delivery-target routing changes in `src/cron/isolated-agent/delivery-target.ts`

  ## Risks and Mitigations

  - Risk: duplicate transcript awareness entries on retries or replays
    - Mitigation: `chat.inject` now accepts an optional idempotency key and cron uses a stable per-run/session key

  - Risk: routed thread awareness could land on the wrong session
    - Mitigation: the awareness target prefers the explicit runtime session key and falls back to the agent main session only when that routed entry is
   absent

  - Risk: awareness creates a new store entry for a session key that didn't previously exist, which could affect `resolveDeliveryTarget` on future runs
    - Mitigation: new entries are seeded with `lastChannel`/`lastTo`/`lastAccountId`/`lastThreadId` from the main session's delivery context so target
  resolution behaves the same as the main-session fallback