### PR TITLE
feat(docker): add optional uv installation for skills and extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,18 +195,16 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 
 # Optionally install uv (Python package manager) for skills or extensions.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_UV=1 ...
-# Installs uv to /usr/local/bin so it is accessible to all users (including non-root node user).
-# Docker build args are not persisted in the final image layer, so uv survives container restarts.
+# Installs uv and uvx to /usr/local/bin so they are accessible to all users.
 ARG OPENCLAW_INSTALL_UV=""
 RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
-    if [ -n "$OPENCLAW_INSTALL_UV" ]; then \
-      apt-get update && \
-      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl && \
-      curl -LsSf https://astral.sh/uv/install.sh | sh && \
-      mv /root/.local/bin/uv /usr/local/bin/uv && \
-      chmod 755 /usr/local/bin/uv; \
-    fi
+--mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+if [ -n "$OPENCLAW_INSTALL_UV" ]; then \
+curl -LsSf https://astral.sh/uv/install.sh | sh && \
+mv /root/.local/bin/uv /usr/local/bin/uv && \
+mv /root/.local/bin/uvx /usr/local/bin/uvx && \
+chmod 755 /usr/local/bin/uv /usr/local/bin/uvx; \
+fi
 
 # Optionally install Docker CLI for sandbox container management.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_DOCKER_CLI=1 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,21 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       chown -R node:node /home/node/.cache/ms-playwright; \
     fi
 
+# Optionally install uv (Python package manager) for skills or extensions.
+# Build with: docker build --build-arg OPENCLAW_INSTALL_UV=1 ...
+# Installs uv to /usr/local/bin so it is accessible to all users (including non-root node user).
+# Docker build args are not persisted in the final image layer, so uv survives container restarts.
+ARG OPENCLAW_INSTALL_UV=""
+RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+    if [ -n "$OPENCLAW_INSTALL_UV" ]; then \
+      apt-get update && \
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl && \
+      curl -LsSf https://astral.sh/uv/install.sh | sh && \
+      mv /root/.local/bin/uv /usr/local/bin/uv && \
+      chmod 755 /usr/local/bin/uv; \
+    fi
+
 # Optionally install Docker CLI for sandbox container management.
 # Build with: docker build --build-arg OPENCLAW_INSTALL_DOCKER_CLI=1 ...
 # Adds ~50MB. Only the CLI is installed — no Docker daemon.


### PR DESCRIPTION
## Summary
Add `OPENCLAW_INSTALL_UV` build arg to the Dockerfile to optionally install [uv](https://astral.sh/uv), a fast Python package manager, during image build.
## Motivation
Several OpenClaw workspace skills (e.g. `stock-analysis`) require uv for managing Python dependencies. In Docker deployments, manually installing uv inside a running container causes it to be lost on restart. This change allows uv to be baked into the image at build time, making it persistent across container restarts.
## Implementation
- New `ARG OPENCLAW_INSTALL_UV=""` build flag (default: off)
- When enabled, installs uv to `/usr/local/bin` so it is accessible to the non-root `node` user
- Uses the officialAstral install script: `curl -LsSf https://astral.sh/uv/install.sh | sh`
## Build example
```bash
docker build --build-arg OPENCLAW_INSTALL_UV=1 -t openclaw:uv .