### PR TITLE
fix(feishu): prevent duplicate text send when sendMedia has no media URL

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -156,8 +156,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       threadId,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
-      // Send text first if provided
-      if (text?.trim()) {
+      // Send text as a companion message before media (only when media is present).
+      if (text?.trim() && mediaUrl) {
         await sendOutboundText({
           cfg,
           to,


### PR DESCRIPTION
## Summary

- In the Feishu `sendMedia` handler, text is sent unconditionally at line 160 before checking for `mediaUrl`
- When `sendMedia` is called with text but no media URL, the text-only fallback at line 196 sends the same text again
- This results in duplicate messages in Feishu chats

## Root cause

The `sendMedia` function has three code paths:

1. **Text + media**: sends text (line 161), then sends media (line 173) — correct
2. **Media only**: skips text (line 160), sends media (line 173) — correct
3. **Text only (no media)**: sends text (line 161), skips media (line 171), sends text AGAIN (line 196) — **bug**

The pre-media text send at line 160 was not guarded by a `mediaUrl` check, so it fires even when there is no media to follow.

## Fix

Add `&& mediaUrl` to the condition at line 160, so the companion text message is only sent when media follows it. The text-only fallback at line 196 handles the no-media case correctly on its own.

## Test plan

- [x] All 13 Feishu outbound tests pass (`pnpm test -- extensions/feishu/src/outbound`)
- [x] Code inspection confirms the three code paths now produce exactly one text send each

🤖 Generated with [Claude Code](https://claude.com/claude-code)