### PR TITLE
fix(gateway): tolerate network interface discovery failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/polling: hard-timeout stuck `getUpdates` requests so wedged network paths fail over sooner instead of waiting for the polling stall watchdog. Thanks @vincentkoc.
 - Agents/models: cache `models.json` readiness by config and auth-file state so embedded runner turns stop paying repeated model-catalog startup work before replies. Thanks @vincentkoc.
 - Security/device pairing: harden `device.token.rotate` deny handling by keeping public failures generic while logging internal deny reasons and preserving approved-baseline enforcement. (`GHSA-7jrw-x62h-64p8`)
+- Gateway/status: tolerate network interface discovery failures in status, onboarding control-UI links, and self-presence display paths so those surfaces fall back cleanly instead of crashing. (#52195) Thanks @meng-clb.
 - Inbound policy hardening: tighten callback and webhook sender checks across Mattermost and Google Chat, match Nextcloud Talk rooms by stable room token, and treat explicit empty Twitch allowlists as deny-all. (#46787) Thanks @zpbrent, @ijxpwastaken and @vincentkoc.
 - Webhooks/runtime: move auth earlier and tighten pre-auth body limits and timeouts across bundled webhook handlers, including slow-body handling for Mattermost slash commands. (#46802) Thanks @vincentkoc.
 - Email/webhook wrapping: sanitize sender and subject metadata before external-content wrapping so metadata fields cannot break the wrapper structure. (#46816) Thanks @vincentkoc.

--- a/extensions/firecrawl/src/config.test.ts
+++ b/extensions/firecrawl/src/config.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_FIRECRAWL_BASE_URL,
   DEFAULT_FIRECRAWL_MAX_AGE_MS,

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -14,10 +14,7 @@ describe("kimi web search provider", () => {
   it("extracts unique citations from search results and tool call arguments", () => {
     expect(
       __testing.extractKimiCitations({
-        search_results: [
-          { url: "https://a.test" },
-          { url: "https://b.test" },
-        ],
+        search_results: [{ url: "https://a.test" }, { url: "https://b.test" }],
         choices: [
           {
             message: {

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -15,9 +15,9 @@ describe("perplexity web search provider", () => {
     expect(__testing.resolvePerplexityBaseUrl(undefined, "openrouter_env")).toBe(
       "https://openrouter.ai/api/v1",
     );
-    expect(__testing.resolvePerplexityRequestModel("https://api.perplexity.ai", "perplexity/sonar-pro")).toBe(
-      "sonar-pro",
-    );
+    expect(
+      __testing.resolvePerplexityRequestModel("https://api.perplexity.ai", "perplexity/sonar-pro"),
+    ).toBe("sonar-pro");
     expect(
       __testing.resolvePerplexityRequestModel(
         "https://openrouter.ai/api/v1",

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -215,6 +215,36 @@ describe("gatherDaemonStatus", () => {
     expect(status.rpc?.url).toBe("wss://override.example:18790");
   });
 
+  it("uses fallback network details when interface discovery throws during status inspection", async () => {
+    daemonLoadedConfig = {
+      gateway: {
+        bind: "tailnet",
+        tls: { enabled: true },
+        auth: { token: "daemon-token" },
+      },
+    };
+    resolveGatewayBindHost.mockImplementationOnce(async () => {
+      throw new Error("uv_interface_addresses failed");
+    });
+    pickPrimaryTailnetIPv4.mockImplementationOnce(() => {
+      throw new Error("uv_interface_addresses failed");
+    });
+
+    const status = await gatherDaemonStatus({
+      rpc: {},
+      probe: true,
+      deep: false,
+    });
+
+    expect(status.gateway).toMatchObject({
+      bindMode: "tailnet",
+      bindHost: "127.0.0.1",
+      probeUrl: "wss://127.0.0.1:19001",
+    });
+    expect(status.gateway?.probeNote).toContain("interface discovery failed");
+    expect(status.gateway?.probeNote).toContain("tailnet addresses");
+  });
+
   it("reuses command environment when reading runtime status", async () => {
     serviceReadCommand.mockResolvedValueOnce({
       programArguments: ["/bin/node", "cli", "gateway", "--port", "19001"],

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -74,6 +74,37 @@ type ResolvedGatewayStatus = {
   probeUrlOverride: string | null;
 };
 
+function summarizeDisplayNetworkError(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    if (message) {
+      return message;
+    }
+  }
+  return "network interface discovery failed";
+}
+
+function fallbackBindHostForStatus(bindMode: GatewayBindMode, customBindHost?: string): string {
+  if (bindMode === "lan") {
+    return "0.0.0.0";
+  }
+  if (bindMode === "custom") {
+    return customBindHost?.trim() || "0.0.0.0";
+  }
+  return "127.0.0.1";
+}
+
+function appendProbeNote(
+  existing: string | undefined,
+  extra: string | undefined,
+): string | undefined {
+  const values = [existing, extra].filter((value): value is string => Boolean(value?.trim()));
+  if (values.length === 0) {
+    return undefined;
+  }
+  return [...new Set(values)].join(" ");
+}
+
 export type DaemonStatus = {
   service: {
     label: string;
@@ -201,18 +232,34 @@ async function resolveGatewayStatusSummary(params: {
     : "env/config";
   const bindMode: GatewayBindMode = params.daemonCfg.gateway?.bind ?? "loopback";
   const customBindHost = params.daemonCfg.gateway?.customBindHost;
-  const bindHost = await resolveGatewayBindHost(bindMode, customBindHost);
-  const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  let bindHost: string;
+  let networkWarning: string | undefined;
+  try {
+    bindHost = await resolveGatewayBindHost(bindMode, customBindHost);
+  } catch (error) {
+    bindHost = fallbackBindHostForStatus(bindMode, customBindHost);
+    networkWarning = `Status is using fallback network details because interface discovery failed: ${summarizeDisplayNetworkError(error)}.`;
+  }
+  let tailnetIPv4: string | undefined;
+  try {
+    tailnetIPv4 = pickPrimaryTailnetIPv4();
+  } catch (error) {
+    networkWarning = appendProbeNote(
+      networkWarning,
+      `Status could not inspect tailnet addresses: ${summarizeDisplayNetworkError(error)}.`,
+    );
+  }
   const probeHost = pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost);
   const probeUrlOverride = trimToUndefined(params.rpcUrlOverride) ?? null;
   const scheme = params.daemonCfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   const probeUrl = probeUrlOverride ?? `${scheme}://${probeHost}:${daemonPort}`;
-  const probeNote =
+  let probeNote =
     !probeUrlOverride && bindMode === "lan"
       ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`
       : !probeUrlOverride && bindMode === "loopback"
         ? "Loopback-only gateway; only local clients can connect."
         : undefined;
+  probeNote = appendProbeNote(probeNote, networkWarning);
 
   return {
     gateway: {

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -220,6 +220,24 @@ describe("gateway-status command", () => {
     expect(targets[0]?.summary).toBeTruthy();
   });
 
+  it("keeps status output working when tailnet discovery throws", async () => {
+    const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
+    pickPrimaryTailnetIPv4.mockImplementationOnce(() => {
+      throw new Error("uv_interface_addresses failed");
+    });
+
+    await runGatewayStatus(runtime, { timeout: "1000", json: true });
+
+    expect(runtimeErrors).toHaveLength(0);
+    const parsed = JSON.parse(runtimeLogs.join("\n")) as {
+      network?: { tailnetIPv4?: string | null; localTailnetUrl?: string | null };
+    };
+    expect(parsed.network).toMatchObject({
+      tailnetIPv4: null,
+      localTailnetUrl: null,
+    });
+  });
+
   it("treats missing-scope RPC probe failures as degraded but reachable", async () => {
     const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
     readBestEffortConfig.mockResolvedValueOnce({

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -81,6 +81,14 @@ function normalizeWsUrl(value: string): string | null {
   return trimmed;
 }
 
+function pickPrimaryTailnetIPv4ForStatus(): string | undefined {
+  try {
+    return pickPrimaryTailnetIPv4();
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): GatewayStatusTarget[] {
   const targets: GatewayStatusTarget[] = [];
   const add = (t: GatewayStatusTarget) => {
@@ -310,7 +318,7 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
 }
 
 export function buildNetworkHints(cfg: OpenClawConfig) {
-  const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  const tailnetIPv4 = pickPrimaryTailnetIPv4ForStatus();
   const port = resolveGatewayPort(cfg);
   return {
     localLoopbackUrl: `ws://127.0.0.1:${port}`,

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeGatewayTokenInput,
@@ -108,6 +109,30 @@ describe("resolveControlUiLinks", () => {
     const links = resolveControlUiLinks({
       port: 18789,
       bind: "auto",
+    });
+    expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
+    expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
+  });
+
+  it("falls back to loopback when tailnet discovery throws", () => {
+    mocks.pickPrimaryTailnetIPv4.mockImplementationOnce(() => {
+      throw new Error("uv_interface_addresses failed");
+    });
+    const links = resolveControlUiLinks({
+      port: 18789,
+      bind: "tailnet",
+    });
+    expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
+    expect(links.wsUrl).toBe("ws://127.0.0.1:18789");
+  });
+
+  it("falls back to loopback when LAN discovery throws", () => {
+    vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+      throw new Error("uv_interface_addresses failed");
+    });
+    const links = resolveControlUiLinks({
+      port: 18789,
+      bind: "lan",
     });
     expect(links.httpUrl).toBe("http://127.0.0.1:18789/");
     expect(links.wsUrl).toBe("ws://127.0.0.1:18789");

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -456,6 +456,22 @@ function summarizeError(err: unknown): string {
 
 export const DEFAULT_WORKSPACE = DEFAULT_AGENT_WORKSPACE_DIR;
 
+function pickPrimaryTailnetIPv4ForDisplay(): string | undefined {
+  try {
+    return pickPrimaryTailnetIPv4();
+  } catch {
+    return undefined;
+  }
+}
+
+function pickPrimaryLanIPv4ForDisplay(): string | undefined {
+  try {
+    return pickPrimaryLanIPv4();
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveControlUiLinks(params: {
   port: number;
   bind?: "auto" | "lan" | "loopback" | "custom" | "tailnet";
@@ -465,7 +481,7 @@ export function resolveControlUiLinks(params: {
   const port = params.port;
   const bind = params.bind ?? "loopback";
   const customBindHost = params.customBindHost?.trim();
-  const tailnetIPv4 = pickPrimaryTailnetIPv4();
+  const tailnetIPv4 = pickPrimaryTailnetIPv4ForDisplay();
   const host = (() => {
     if (bind === "custom" && customBindHost && isValidIPv4(customBindHost)) {
       return customBindHost;
@@ -474,7 +490,7 @@ export function resolveControlUiLinks(params: {
       return tailnetIPv4 ?? "127.0.0.1";
     }
     if (bind === "lan") {
-      return pickPrimaryLanIPv4() ?? "127.0.0.1";
+      return pickPrimaryLanIPv4ForDisplay() ?? "127.0.0.1";
     }
     return "127.0.0.1";
   })();

--- a/src/infra/system-presence.ts
+++ b/src/infra/system-presence.ts
@@ -45,7 +45,12 @@ function normalizePresenceKey(key: string | undefined): string | undefined {
 }
 
 function resolvePrimaryIPv4(): string | undefined {
-  return pickPrimaryLanIPv4() ?? os.hostname();
+  const host = os.hostname();
+  try {
+    return pickPrimaryLanIPv4() ?? host;
+  } catch {
+    return host;
+  }
 }
 
 function initSelfPresence() {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import os from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 
 async function withPresenceModule<T>(
@@ -13,6 +14,10 @@ async function withPresenceModule<T>(
 }
 
 describe("system-presence version fallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   async function expectSelfVersion(
     env: Record<string, string | undefined>,
     expectedVersion: string | (() => Promise<string>),
@@ -77,5 +82,19 @@ describe("system-presence version fallback", () => {
       },
       async () => (await import("../version.js")).VERSION,
     );
+  });
+
+  it("falls back to hostname when self-presence LAN discovery throws", async () => {
+    await withEnvAsync({}, async () => {
+      vi.spyOn(os, "hostname").mockReturnValue("test-host");
+      vi.spyOn(os, "networkInterfaces").mockImplementation(() => {
+        throw new Error("uv_interface_addresses failed");
+      });
+      vi.resetModules();
+      const module = await import("./system-presence.js");
+      const selfEntry = module.listSystemPresence().find((entry) => entry.reason === "self");
+      expect(selfEntry?.host).toBe("test-host");
+      expect(selfEntry?.ip).toBe("test-host");
+    });
   });
 });

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -35,10 +35,6 @@ function createEmptyPluginRegistry(): PluginRegistry {
   };
 }
 
-function createPluginRegistryStub(): PluginRegistry {
-  return createEmptyPluginRegistry();
-}
-
 const sessionBindingState = vi.hoisted(() => {
   const records = new Map<string, SessionBindingRecord>();
   let nextId = 1;


### PR DESCRIPTION
 ## Summary

  Guard `os.networkInterfaces()` when resolving:
  - the primary LAN IPv4 used by gateway status/self presence
  - tailnet addresses used by infra runtime

  This makes gateway status and related probes degrade cleanly instead of crashing on hosts where interface discovery fails.

  ## Changes

  - return `undefined` from `pickPrimaryLanIPv4()` if `os.networkInterfaces()` throws
  - return empty tailnet address lists if `os.networkInterfaces()` throws
  - add regression tests for both paths

  ## Validation

  - `./node_modules/.bin/vitest run --config vitest.config.ts src/gateway/net.test.ts src/infra/infra-runtime.test.ts src/infra/tailnet.test.ts`
  - local repo checks passed during commit hook