### PR TITLE
fix(supervisor): always spawn exec children in own process group on POSIX

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -29,6 +29,9 @@ const abortEmbeddedPiRun = vi.fn(
 );
 const getActiveEmbeddedRunCount = vi.fn(() => 0);
 const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
+const cancelAllSupervisorRuns = vi.fn((_reason?: string) => {});
+const getActiveProcessRunCount = vi.fn(() => 0);
+const waitForActiveProcessRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
 const gatewayLog = {
   info: vi.fn(),
@@ -64,6 +67,14 @@ vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
     abortEmbeddedPiRun(sessionId, opts),
   getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
   waitForActiveEmbeddedRuns: (timeoutMs: number) => waitForActiveEmbeddedRuns(timeoutMs),
+}));
+
+vi.mock("../../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({
+    cancelAll: (reason?: string) => cancelAllSupervisorRuns(reason),
+    getActiveRunCount: () => getActiveProcessRunCount(),
+    waitForActiveRuns: (timeoutMs: number) => waitForActiveProcessRuns(timeoutMs),
+  }),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -210,8 +221,10 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
       getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
+      getActiveProcessRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
       waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
+      waitForActiveProcessRuns.mockResolvedValueOnce({ drained: true });
 
       type StartServer = () => Promise<{
         close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
@@ -269,8 +282,10 @@ describe("runGatewayLoop", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "compacting" });
+      expect(cancelAllSupervisorRuns).toHaveBeenCalledWith("manual-cancel");
       expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(90_000);
+      expect(waitForActiveProcessRuns).toHaveBeenCalledWith(90_000);
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
@@ -322,6 +337,38 @@ describe("runGatewayLoop", () => {
       expect(close).not.toHaveBeenCalled();
       expect(start).toHaveBeenCalledTimes(1);
       expect(markGatewaySigusr1RestartHandled).not.toHaveBeenCalled();
+    });
+  });
+
+  it("cancels active exec runs during graceful stop", async () => {
+    vi.clearAllMocks();
+    getActiveProcessRunCount.mockReturnValueOnce(2);
+    let resolveWait: (() => void) | null = null;
+    waitForActiveProcessRuns.mockImplementationOnce(
+      () =>
+        new Promise<{ drained: boolean }>((resolve) => {
+          resolveWait = () => resolve({ drained: true });
+        }),
+    );
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime, exited } = await createSignaledLoopHarness();
+      const sigterm = captureSignal("SIGTERM");
+
+      sigterm();
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
+
+      resolveWait?.();
+
+      await expect(exited).resolves.toBe(0);
+      expect(cancelAllSupervisorRuns).toHaveBeenCalledWith("manual-cancel");
+      expect(waitForActiveProcessRuns).toHaveBeenCalledWith(5_000);
+      expect(runtime.exit).toHaveBeenCalledWith(0);
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -19,6 +19,7 @@ import {
   resetAllLanes,
   waitForActiveTasks,
 } from "../../process/command-queue.js";
+import { getProcessSupervisor } from "../../process/supervisor/index.js";
 import { createRestartIterationHook } from "../../process/restart-recovery.js";
 import type { defaultRuntime } from "../../runtime.js";
 
@@ -128,34 +129,59 @@ export async function runGatewayLoop(params: {
           markGatewayDraining();
           const activeTasks = getActiveTaskCount();
           const activeRuns = getActiveEmbeddedRunCount();
+          const processSupervisor = getProcessSupervisor();
+          const activeProcessRuns = processSupervisor.getActiveRunCount();
 
           // Best-effort abort for compacting runs so long compaction operations
           // don't hold session write locks across restart boundaries.
           if (activeRuns > 0) {
             abortEmbeddedPiRun(undefined, { mode: "compacting" });
           }
+          if (activeProcessRuns > 0) {
+            processSupervisor.cancelAll("manual-cancel");
+          }
 
-          if (activeTasks > 0 || activeRuns > 0) {
+          if (activeTasks > 0 || activeRuns > 0 || activeProcessRuns > 0) {
             gatewayLog.info(
-              `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
+              `draining ${activeTasks} active task(s), ${activeRuns} active embedded run(s), and ${activeProcessRuns} active exec run(s) before restart (timeout ${DRAIN_TIMEOUT_MS}ms)`,
             );
-            const [tasksDrain, runsDrain] = await Promise.all([
+            const [tasksDrain, runsDrain, processRunsDrain] = await Promise.all([
               activeTasks > 0
                 ? waitForActiveTasks(DRAIN_TIMEOUT_MS)
                 : Promise.resolve({ drained: true }),
               activeRuns > 0
                 ? waitForActiveEmbeddedRuns(DRAIN_TIMEOUT_MS)
                 : Promise.resolve({ drained: true }),
+              activeProcessRuns > 0
+                ? processSupervisor.waitForActiveRuns(DRAIN_TIMEOUT_MS)
+                : Promise.resolve({ drained: true }),
             ]);
-            if (tasksDrain.drained && runsDrain.drained) {
+            if (tasksDrain.drained && runsDrain.drained && processRunsDrain.drained) {
               gatewayLog.info("all active work drained");
             } else {
               gatewayLog.warn("drain timeout reached; proceeding with restart");
               // Final best-effort abort to avoid carrying active runs into the
               // next lifecycle when drain time budget is exhausted.
               abortEmbeddedPiRun(undefined, { mode: "all" });
+              processSupervisor.cancelAll("manual-cancel");
             }
           }
+        } else {
+          const processSupervisor = getProcessSupervisor();
+          const closePromise = server?.close({
+            reason: isRestart ? "gateway restarting" : "gateway stopping",
+            restartExpectedMs: isRestart ? 1500 : null,
+          });
+          if (processSupervisor.getActiveRunCount() > 0) {
+            processSupervisor.cancelAll("manual-cancel");
+            await Promise.all([
+              closePromise,
+              processSupervisor.waitForActiveRuns(SHUTDOWN_TIMEOUT_MS),
+            ]);
+          } else {
+            await closePromise;
+          }
+          return;
         }
 
         await server?.close({

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { spawnWithFallbackMock, killProcessTreeMock } = vi.hoisted(() => ({
   spawnWithFallbackMock: vi.fn(),
@@ -49,22 +49,11 @@ async function createAdapterHarness(params?: {
 }
 
 describe("createChildAdapter", () => {
-  const originalServiceMarker = process.env.OPENCLAW_SERVICE_MARKER;
-
   beforeEach(async () => {
     vi.resetModules();
     ({ createChildAdapter } = await import("./child.js"));
     spawnWithFallbackMock.mockClear();
     killProcessTreeMock.mockClear();
-    delete process.env.OPENCLAW_SERVICE_MARKER;
-  });
-
-  afterAll(() => {
-    if (originalServiceMarker === undefined) {
-      delete process.env.OPENCLAW_SERVICE_MARKER;
-    } else {
-      process.env.OPENCLAW_SERVICE_MARKER = originalServiceMarker;
-    }
   });
 
   it("uses process-tree kill for default SIGKILL", async () => {
@@ -99,17 +88,29 @@ describe("createChildAdapter", () => {
     expect(killMock).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("disables detached mode in service-managed runtime", async () => {
+  it("uses detached mode even in service-managed runtime for PGID isolation", async () => {
+    const origMarker = process.env.OPENCLAW_SERVICE_MARKER;
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    try {
+      await createAdapterHarness({ pid: 7777 });
 
-    await createAdapterHarness({ pid: 7777 });
-
-    const spawnArgs = spawnWithFallbackMock.mock.calls[0]?.[0] as {
-      options?: { detached?: boolean };
-      fallbacks?: Array<{ options?: { detached?: boolean } }>;
-    };
-    expect(spawnArgs.options?.detached).toBe(false);
-    expect(spawnArgs.fallbacks ?? []).toEqual([]);
+      const spawnArgs = spawnWithFallbackMock.mock.calls[0]?.[0] as {
+        options?: { detached?: boolean };
+        fallbacks?: Array<{ options?: { detached?: boolean } }>;
+      };
+      if (process.platform === "win32") {
+        expect(spawnArgs.options?.detached).toBe(false);
+      } else {
+        expect(spawnArgs.options?.detached).toBe(true);
+        expect(spawnArgs.fallbacks?.[0]?.options?.detached).toBe(false);
+      }
+    } finally {
+      if (origMarker === undefined) {
+        delete process.env.OPENCLAW_SERVICE_MARKER;
+      } else {
+        process.env.OPENCLAW_SERVICE_MARKER = origMarker;
+      }
+    }
   });
 
   it("keeps inherited env when no override env is provided", async () => {

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -14,10 +14,6 @@ function resolveCommand(command: string): string {
 
 export type ChildAdapter = SpawnProcessAdapter<NodeJS.Signals | null>;
 
-function isServiceManagedRuntime(): boolean {
-  return Boolean(process.env.OPENCLAW_SERVICE_MARKER?.trim());
-}
-
 export async function createChildAdapter(params: {
   argv: string[];
   cwd?: string;
@@ -31,10 +27,16 @@ export async function createChildAdapter(params: {
 
   const stdinMode = params.stdinMode ?? (params.input !== undefined ? "pipe-closed" : "inherit");
 
-  // In service-managed mode keep children attached so systemd/launchd can
-  // stop the full process tree reliably. Outside service mode preserve the
-  // existing POSIX detached behavior.
-  const useDetached = process.platform !== "win32" && !isServiceManagedRuntime();
+  // Always spawn in a new process group on POSIX so that:
+  //  1. killProcessTree(-pid) can reach the full child tree (without a
+  //     dedicated PGID, -pid gets ESRCH and grandchildren survive), and
+  //  2. exec children cannot accidentally signal the gateway (`kill 0`).
+  // systemd KillMode=control-group is cgroup-based and unaffected by PGID.
+  // macOS launchd signals the job's own PGID; the gateway shutdown handler
+  // (abortEmbeddedPiRun) kills active runs before exit covers that path.
+  // On Windows, detached: true breaks stdio pipes under headless Scheduled
+  // Tasks, so it stays false there.
+  const useDetached = process.platform !== "win32";
 
   const options: SpawnOptions = {
     cwd: params.cwd,

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -106,4 +106,33 @@ describe("process supervisor", () => {
     expect(streamed).toBe("streamed");
     expect(exit.stdout).toBe("");
   });
+
+  it("tracks active runs and drains after cancelAll", async () => {
+    const supervisor = createProcessSupervisor();
+    const first = await spawnChild(supervisor, {
+      sessionId: "s-drain-1",
+      argv: [process.execPath, "-e", "setTimeout(() => {}, 1_000)"],
+      timeoutMs: 2_000,
+      stdinMode: "pipe-open",
+    });
+    const second = await spawnChild(supervisor, {
+      sessionId: "s-drain-2",
+      argv: [process.execPath, "-e", "setTimeout(() => {}, 1_000)"],
+      timeoutMs: 2_000,
+      stdinMode: "pipe-open",
+    });
+
+    expect(supervisor.getActiveRunCount()).toBe(2);
+
+    supervisor.cancelAll("manual-cancel");
+    await expect(supervisor.waitForActiveRuns(1_000, { pollMs: 10 })).resolves.toEqual({
+      drained: true,
+    });
+
+    const firstExit = await first.wait();
+    const secondExit = await second.wait();
+    expect(firstExit.reason === "manual-cancel" || firstExit.reason === "signal").toBe(true);
+    expect(secondExit.reason === "manual-cancel" || secondExit.reason === "signal").toBe(true);
+    expect(supervisor.getActiveRunCount()).toBe(0);
+  });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -46,6 +46,12 @@ export function createProcessSupervisor(): ProcessSupervisor {
     current.run.cancel(reason);
   };
 
+  const cancelAll = (reason: TerminationReason = "manual-cancel") => {
+    for (const runId of [...active.keys()]) {
+      cancel(runId, reason);
+    }
+  };
+
   const cancelScope = (scopeKey: string, reason: TerminationReason = "manual-cancel") => {
     if (!scopeKey.trim()) {
       return;
@@ -55,6 +61,28 @@ export function createProcessSupervisor(): ProcessSupervisor {
         continue;
       }
       cancel(runId, reason);
+    }
+  };
+
+  const getActiveRunCount = () => active.size;
+
+  const waitForActiveRuns = async (
+    timeoutMs = 15_000,
+    opts?: { pollMs?: number },
+  ): Promise<{ drained: boolean }> => {
+    const pollMsRaw = opts?.pollMs ?? 250;
+    const pollMs = Math.max(10, Math.floor(pollMsRaw));
+    const maxWaitMs = Math.max(pollMs, Math.floor(timeoutMs));
+    const startedAt = Date.now();
+
+    while (true) {
+      if (active.size === 0) {
+        return { drained: true };
+      }
+      if (Date.now() - startedAt >= maxWaitMs) {
+        return { drained: false };
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, pollMs));
     }
   };
 
@@ -272,7 +300,10 @@ export function createProcessSupervisor(): ProcessSupervisor {
   return {
     spawn,
     cancel,
+    cancelAll,
     cancelScope,
+    getActiveRunCount,
+    waitForActiveRuns,
     reconcileOrphans: async () => {
       // Deliberate no-op: this supervisor uses in-memory ownership only.
       // Active runs are not recovered after process restart in the current model.

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -100,7 +100,13 @@ export type SpawnInput = SpawnChildInput | SpawnPtyInput;
 export interface ProcessSupervisor {
   spawn(input: SpawnInput): Promise<ManagedRun>;
   cancel(runId: string, reason?: TerminationReason): void;
+  cancelAll(reason?: TerminationReason): void;
   cancelScope(scopeKey: string, reason?: TerminationReason): void;
+  getActiveRunCount(): number;
+  waitForActiveRuns(
+    timeoutMs?: number,
+    opts?: { pollMs?: number },
+  ): Promise<{ drained: boolean }>;
   reconcileOrphans(): Promise<void>;
   getRecord(runId: string): RunRecord | undefined;
 }


### PR DESCRIPTION
## Summary

- **Problem:** When `OPENCLAW_SERVICE_MARKER` is set (systemd/launchd service installs), `createChildAdapter` spawns exec children with `detached: false`. The child inherits the gateway's PGID, which breaks `killProcessTree`: `process.kill(-childPid)` gets `ESRCH` because no process group with ID `childPid` exists. Only the direct shell is killed; grandchild processes survive, hold stdio pipes open, and `child.on('close')` never fires — the exec tool hangs.
- **Why it matters:** Any exec command that forks grandchildren (`npm run`, `python -m http.server`, pipes, background jobs) can permanently stall an agent session and leave orphaned descendants behind.
- **What changed:** Exec children now always spawn in their own process group on POSIX (`detached: true`), so `killProcessTree(-pid)` correctly targets the full child tree. In addition, the gateway now explicitly cancels and drains active process-supervisor exec runs during graceful `stop` and `restart`, so macOS launchd no longer relies on process-group cleanup for those children.
- **What did NOT change:** Windows behavior remains unchanged (`detached: false`). Hard-kill scenarios (`SIGKILL`, OOM, host crash/power loss) still cannot guarantee cleanup.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #44790
- Related #41198
- Partially reverts the `detached: false` portion of #38463

## User-visible / Behavior Changes

Exec tool child processes now always spawn in their own process group on POSIX, even when running as a systemd/launchd service. This means:

- `killProcessTree` correctly terminates the full exec child tree
- commands like `kill 0` inside exec no longer signal the gateway process group
- systemd cleanup remains unaffected (`KillMode=control-group` is cgroup-based)
- on macOS launchd, graceful gateway `stop` / `restart` now explicitly cancels and drains active exec runs before exit instead of relying on launchd PG cleanup

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes` — exec children are process-group-isolated from the gateway, which prevents accidental gateway termination from inside exec
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 LTS for live repro of the original bug
- Runtime/container: Node.js v24, systemd user service with `OPENCLAW_SERVICE_MARKER=openclaw`

### Original repro

1. Run OpenClaw as a service (`OPENCLAW_SERVICE_MARKER` set)
2. Execute a command via exec that forks a grandchild: `bash -c "sleep 999 & echo done"`
3. Cancel or timeout the exec session

### Before

- `process.kill(-childPid, "SIGTERM")` -> `ESRCH`
- only the direct shell dies
- grandchild keeps pipes open
- `close` never fires
- agent hangs

### After

- exec child gets its own PGID
- `killProcessTree(-pid)` reaches the full child tree
- `close` fires normally
- agent resumes

## Evidence

- [x] Failing test/log before + passing after

Targeted tests passing:

- `pnpm test -- src/process/supervisor/supervisor.test.ts`
- `pnpm test -- src/cli/gateway-cli/run-loop.test.ts`

These cover:

- supervisor active-run tracking / cancel-all / drain behavior
- gateway restart draining active exec runs
- gateway graceful stop starting close immediately while canceling/draining active exec runs

## Human Verification (required)

- Verified scenarios:
  - live Linux/systemd PGID repro for the original hang
  - targeted unit tests for process supervisor cleanup
  - targeted unit tests for gateway graceful stop/restart cleanup
- Edge cases checked:
  - Windows unchanged
  - graceful macOS launchd stop/restart path now handled explicitly in gateway shutdown flow
- Not verified end-to-end:
  - real macOS launchd runtime on a Mac host
  - Windows Scheduled Task behavior beyond existing unchanged logic

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/process/supervisor/adapters/child.ts`, `src/process/supervisor/supervisor.ts`, `src/cli/gateway-cli/run-loop.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected exec-run shutdown behavior during graceful stop/restart
  - platform-specific spawn regressions on macOS/Windows

## Risks and Mitigations

- **Risk:** Hard-kill scenarios (`SIGKILL`, OOM, host crash`) can still orphan detached children on POSIX
  - **Mitigation:** graceful `stop` / `restart` now explicitly cancels and drains active exec runs before exit
- **Risk:** macOS launchd was previously depending on shared PG cleanup when service-managed exec children used `detached: false`
  - **Mitigation:** this PR now handles graceful cleanup in OpenClaw itself instead of relying on launchd's process-group behavior

---

*This PR was AI-assisted. The current revision includes the original PGID isolation fix plus explicit graceful shutdown cleanup for active process-supervisor exec runs on stop/restart.*
