### PR TITLE
fix(podman): relax image tar directory permissions for WSL

### DIFF
--- a/scripts/podman/setup.sh
+++ b/scripts/podman/setup.sh
@@ -249,7 +249,7 @@ mkdir_user_dirs_as_openclaw
 IMAGE_TMP_BASE="$(resolve_image_tmp_dir)"
 echo "Using temp base for image export: $IMAGE_TMP_BASE"
 IMAGE_TAR_DIR="$(mktemp -d "${IMAGE_TMP_BASE%/}/openclaw-podman-image.XXXXXX")"
-chmod 700 "$IMAGE_TAR_DIR"
+chmod 755 "$IMAGE_TAR_DIR"
 IMAGE_TAR="$IMAGE_TAR_DIR/openclaw-image.tar"
 cleanup_image_tar() {
   rm -rf "$IMAGE_TAR_DIR"


### PR DESCRIPTION
  ## What

  `scripts/podman/setup.sh` creates the image tar temp directory with `chmod 700`, which blocks the openclaw user from reading the tar file during `podman image load` on Windows WSL.
  Fixes #52180

  ## How

  `chmod 700` → `chmod 755`. The directory is temporary (cleaned up on EXIT trap) and only holds a build artifact, so world-readable is fine here.

  ## Testing

  Verified the permission change is consistent with how other temp directories are handled in the script. The directory is short-lived and removed by the cleanup trap at line 256.

  ---
  AI-assisted (Claude Code), reviewed by author.