### PR TITLE
fix: ensure env proxy dispatcher before MiniMax and OpenAI Codex OAuth flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/OpenAI Codex OAuth and Plugins/MiniMax OAuth: ensure env-configured HTTP/HTTPS proxy dispatchers are initialized before OAuth preflight and token exchange requests so proxy-required environments can complete MiniMax and OpenAI Codex sign-in flows again. (#52228; fixes #51619, #51569) Thanks @openperf.
 - Plugins/DeepSeek: refactor the bundled DeepSeek provider onto the shared single-provider plugin entry, move its coverage into the extension test lane, and keep bundled auth env-var metadata on the generated manifest path. (#48762) Thanks @07akioni.
 - Web tools/search provider lists: keep onboarding, configure, and docs provider lists alphabetical while preserving the separate runtime auto-detect precedence used for credential-based provider selection.
 - Media/Windows security: block remote-host `file://` media URLs and UNC/network paths before local filesystem resolution in core media loading and adjacent prompt/sandbox attachment seams, so the next release no longer allows structured local-media inputs to trigger outbound SMB credential handshakes on Windows. Thanks @RacerZ-fighting for reporting.

--- a/extensions/minimax/oauth.ts
+++ b/extensions/minimax/oauth.ts
@@ -1,4 +1,5 @@
 import { randomBytes, randomUUID } from "node:crypto";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/infra-runtime";
 import { generatePkceVerifierChallenge, toFormUrlEncoded } from "openclaw/plugin-sdk/provider-auth";
 
 export type MiniMaxRegion = "cn" | "global";
@@ -184,6 +185,9 @@ export async function loginMiniMaxPortalOAuth(params: {
   progress: { update: (message: string) => void; stop: (message?: string) => void };
   region?: MiniMaxRegion;
 }): Promise<MiniMaxOAuthToken> {
+  // Ensure env-based proxy dispatcher is active before any outbound fetch calls.
+  // Without this, HTTP_PROXY/HTTPS_PROXY env vars are silently ignored (#51619).
+  ensureGlobalUndiciEnvProxyDispatcher();
   const region = params.region ?? "global";
   const { verifier, challenge, state } = generatePkce();
   const oauth = await requestOAuthCode({ challenge, state, region });

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,3 +1,4 @@
+import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 
@@ -72,6 +73,10 @@ export async function minimaxUnderstandImage(params: {
     modelBaseUrl: params.modelBaseUrl,
   });
   const url = new URL("/v1/coding_plan/vlm", host).toString();
+
+  // Ensure env-based proxy dispatcher is active before the outbound fetch call.
+  // Without this, HTTP_PROXY/HTTPS_PROXY env vars are silently ignored (#51619).
+  ensureGlobalUndiciEnvProxyDispatcher();
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -26,6 +26,7 @@ export * from "../infra/net/hostname.ts";
 export * from "../infra/net/fetch-guard.js";
 export * from "../infra/net/proxy-env.js";
 export * from "../infra/net/proxy-fetch.js";
+export * from "../infra/net/undici-global-dispatcher.js";
 export * from "../infra/net/ssrf.js";
 export * from "../infra/outbound/identity.js";
 export * from "../infra/outbound/send-deps.js";

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -18,6 +18,11 @@ export async function loginOpenAICodexOAuth(params: {
   localBrowserMessage?: string;
 }): Promise<OAuthCredentials | null> {
   const { prompter, runtime, isRemote, openUrl, localBrowserMessage } = params;
+
+  // Ensure env-based proxy dispatcher is active before any outbound fetch calls,
+  // including the TLS preflight check.
+  ensureGlobalUndiciEnvProxyDispatcher();
+
   const preflight = await runOpenAIOAuthTlsPreflight();
   if (!preflight.ok && preflight.kind === "tls-cert") {
     const hint = formatOpenAIOAuthTlsPreflightFix(preflight);
@@ -52,12 +57,6 @@ export async function loginOpenAICodexOAuth(params: {
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
       manualPromptMessage: manualInputPromptMessage,
     });
-
-    // Ensure env-based proxy dispatcher is active before the OAuth token exchange.
-    // The move from @mariozechner/pi-ai to @mariozechner/pi-ai/oauth dropped the
-    // implicit http-proxy.js side-effect import that previously initialized the
-    // global undici dispatcher (#51569, #51619).
-    ensureGlobalUndiciEnvProxyDispatcher();
 
     const creds = await loginOpenAICodex({
       onAuth: baseOnAuth,

--- a/src/plugins/provider-openai-codex-oauth.ts
+++ b/src/plugins/provider-openai-codex-oauth.ts
@@ -1,4 +1,5 @@
 import { loginOpenAICodex, type OAuthCredentials } from "@mariozechner/pi-ai/oauth";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global-dispatcher.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
@@ -51,6 +52,12 @@ export async function loginOpenAICodexOAuth(params: {
       localBrowserMessage: localBrowserMessage ?? "Complete sign-in in browser…",
       manualPromptMessage: manualInputPromptMessage,
     });
+
+    // Ensure env-based proxy dispatcher is active before the OAuth token exchange.
+    // The move from @mariozechner/pi-ai to @mariozechner/pi-ai/oauth dropped the
+    // implicit http-proxy.js side-effect import that previously initialized the
+    // global undici dispatcher (#51569, #51619).
+    ensureGlobalUndiciEnvProxyDispatcher();
 
     const creds = await loginOpenAICodex({
       onAuth: baseOnAuth,


### PR DESCRIPTION
### Summary

This PR fixes a regression where the environment-based proxy (`HTTP_PROXY`/`HTTPS_PROXY`) is ignored during the MiniMax and OpenAI Codex OAuth flows, causing them to fail in environments that require a proxy (e.g., mitmproxy debugging or corporate networks).

This addresses both #51619 and #51569.

### Root Cause

The root cause was identified in #51569: The import path change from `@mariozechner/pi-ai` to `@mariozechner/pi-ai/oauth` dropped the implicit `http-proxy.js` side-effect import that previously called `setGlobalDispatcher(new EnvHttpProxyAgent( ))`. 

Since `loginMiniMaxPortalOAuth` and `loginOpenAICodex` execute outside the `runEmbeddedAttempt` lifecycle (which handles proxy initialization for normal LLM requests), the global `fetch` falls back to the default dispatcher, ignoring proxy environment variables.

### Changes

1. **`src/plugin-sdk/infra-runtime.ts`**: Exported `undici-global-dispatcher.js` so extension plugins can access it.
2. **`extensions/minimax/oauth.ts`**: Added `ensureGlobalUndiciEnvProxyDispatcher()` before `loginMiniMaxPortalOAuth` makes any outbound fetch calls.
3. **`src/plugins/provider-openai-codex-oauth.ts`**: Added the same initialization before `loginOpenAICodex`.
4. **`src/agents/minimax-vlm.ts`**: Added defensive proxy initialization before the VLM fetch call.

*Note: While investigating #51619, I also noticed that the MiniMax plugin currently lacks a `refreshOAuth` implementation (unlike OpenAI Codex). When a MiniMax token expires, the refresh silently fails, which might also manifest as an "LLM ERROR" to the user. I've kept this PR strictly focused on the proxy initialization regression, but the missing refresh hook should probably be addressed in a follow-up PR.*

### Fixes

Fixes #51619
Fixes #51569
