### PR TITLE
test(plugin-sdk): keep subpath smoke tests working without prebuilt dist

### DIFF
--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -58,8 +58,30 @@ const representativeRuntimeSmokeSubpaths = [
   "webhook-ingress",
 ] as const;
 
-const importResolvedPluginSdkSubpath = async (specifier: string) =>
-  import(pathToFileURL(requireFromHere.resolve(specifier)).href);
+function resolvePluginSdkSourceSpecifier(specifier: string): string {
+  const entry =
+    specifier === "openclaw/plugin-sdk"
+      ? "index"
+      : specifier.replace(/^openclaw\/plugin-sdk\//u, "");
+  return pathToFileURL(resolve(PLUGIN_SDK_DIR, `${entry}.ts`)).href;
+}
+
+async function importResolvedPluginSdkSubpath(specifier: string) {
+  let resolved: string;
+  try {
+    resolved = requireFromHere.resolve(specifier);
+  } catch (error) {
+    if (specifier.startsWith("openclaw/plugin-sdk")) {
+      return import(resolvePluginSdkSourceSpecifier(specifier));
+    }
+    throw error;
+  }
+  if (!existsSync(resolved) && resolved.includes("/dist/plugin-sdk/")) {
+    // Source-tree unit tests do not always prebuild dist/plugin-sdk/* artifacts.
+    return import(resolvePluginSdkSourceSpecifier(specifier));
+  }
+  return import(pathToFileURL(resolved).href);
+}
 
 function readPluginSdkSource(subpath: string): string {
   const file = resolve(PLUGIN_SDK_DIR, `${subpath}.ts`);


### PR DESCRIPTION
This fixes the current shared CI red in `src/plugin-sdk/subpaths.test.ts` when the source-tree test job runs before any `dist/plugin-sdk/*` artifacts exist.

Instead of assuming package-exported `dist` entrypoints are already present, the smoke-test helper now resolves through the public `openclaw/plugin-sdk/*` specifier first and falls back to the matching `src/plugin-sdk/*.ts` entrypoint only when the source-tree checkout has not built that `dist` file yet. That keeps the package-export path covered when artifacts exist, while making the unit test self-contained in the normal `pnpm test` lane.

Testing:
- `pnpm exec vitest run src/plugin-sdk/subpaths.test.ts`
- `./scripts/committer "test(plugin-sdk): fall back to source entrypoints in subpath smoke test" src/plugin-sdk/subpaths.test.ts`