### PR TITLE
fix(mattermost): persist threadId in delivery context for all session types

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1380,7 +1380,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       ...mediaPayload,
     });
 
-    if (kind === "direct") {
+    {
+      // Persist delivery context for all session types (including threads).
+      // Without threadId here, cron/heartbeat wakeups into a thread-scoped session
+      // lose thread context and deliver to channel root (issue #45082 case 2).
       const sessionCfg = cfg.session;
       const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
         agentId: route.agentId,
@@ -1392,6 +1395,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           channel: "mattermost",
           to,
           accountId: route.accountId,
+          threadId: effectiveReplyToId,
         },
       });
     }


### PR DESCRIPTION
## Problem

When a cron job or heartbeat wakes a thread-scoped Mattermost session, the reply lands at the channel root instead of in the thread.

## Root Cause

`updateLastRoute` in `monitor.ts` was guarded by `if (kind === "direct")`, so delivery context (including `threadId`) was only persisted for DM sessions. For group/channel sessions with threads, `deliveryContext.threadId` was never stored in the session store.

When a cron fires into a thread-scoped session, `dispatch-from-config.ts` recovers the thread ID via `parseSessionThreadInfo(runSessionKey)` — which correctly extracts the thread ID from the session key string. However, without `threadId` stored in `deliveryContext`, the delivery has no thread context when looking up the session entry.

## Fix

Remove the `kind === "direct"` guard from `updateLastRoute` so delivery context is persisted for all session types. This ensures `threadId` is stored whenever an inbound message is processed in a thread-scoped session.

## How to test

1. Configure Mattermost with `replyToMode: "all"`
2. Start a conversation in a channel thread — this creates a thread-scoped session
3. Have the agent set a cron job targeting the thread session key using `--session main --session-key <thread-session-key>`
4. Before: reply lands at channel root
5. After: reply should land in the thread

Related: #45082 (case 2), companion to #52120 (case 1 — message tool)

Closes #45082