### PR TITLE
[codex] fix(gateway): wait for agents.create readiness before success

### DIFF
--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -5,37 +5,125 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 /* Mocks                                                              */
 /* ------------------------------------------------------------------ */
 
-const mocks = vi.hoisted(() => ({
-  loadConfigReturn: {} as Record<string, unknown>,
-  listAgentEntries: vi.fn(() => [] as Array<{ agentId: string }>),
-  findAgentEntryIndex: vi.fn(() => -1),
-  applyAgentConfig: vi.fn((_cfg: unknown, _opts: unknown) => ({})),
-  pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
-  writeConfigFile: vi.fn(async () => {}),
-  ensureAgentWorkspace: vi.fn(async () => {}),
-  resolveAgentDir: vi.fn(() => "/agents/test-agent"),
-  resolveAgentWorkspaceDir: vi.fn(() => "/workspace/test-agent"),
-  resolveSessionTranscriptsDirForAgent: vi.fn(() => "/transcripts/test-agent"),
-  listAgentsForGateway: vi.fn(() => ({
-    defaultId: "main",
-    mainKey: "agent:main:main",
-    scope: "global",
-    agents: [],
-  })),
-  movePathToTrash: vi.fn(async () => "/trashed"),
-  fsAccess: vi.fn(async () => {}),
-  fsMkdir: vi.fn(async () => undefined),
-  fsAppendFile: vi.fn(async () => {}),
-  fsReadFile: vi.fn(async () => ""),
-  fsStat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
-  fsLstat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
-  fsRealpath: vi.fn(async (p: string) => p),
-  fsOpen: vi.fn(async () => ({}) as unknown),
-  writeFileWithinRoot: vi.fn(async () => {}),
-}));
+const mocks = vi.hoisted(() => {
+  const state = {
+    writtenConfig: null as Record<string, unknown> | null,
+    runtimeSnapshotActive: true,
+    runtimeConfig: null as Record<string, unknown> | null,
+  };
+  return {
+    state,
+    loadConfigReturn: {} as Record<string, unknown>,
+    clearConfigCache: vi.fn(),
+    listAgentEntries: vi.fn((cfg?: Record<string, unknown>) => {
+      const raw = (cfg as { __agentIds?: unknown } | undefined)?.__agentIds;
+      const ids =
+        Array.isArray(raw) && raw.length > 0
+          ? raw.filter((value): value is string => typeof value === "string")
+          : [];
+      return ids.map((agentId) => ({ agentId }));
+    }),
+    findAgentEntryIndex: vi.fn((entries: Array<{ agentId: string }>, agentId: string) =>
+      entries.findIndex((entry) => entry.agentId === agentId),
+    ),
+    applyAgentConfig: vi.fn((cfg: unknown, opts: unknown) => {
+      const next =
+        cfg && typeof cfg === "object"
+          ? ({ ...(cfg as Record<string, unknown>) } as Record<string, unknown>)
+          : ({} as Record<string, unknown>);
+      const existingRaw = next.__agentIds;
+      const existing =
+        Array.isArray(existingRaw) && existingRaw.length > 0
+          ? existingRaw.filter((value): value is string => typeof value === "string")
+          : [];
+      const candidateAgentId =
+        opts && typeof opts === "object" ? (opts as { agentId?: unknown }).agentId : undefined;
+      if (typeof candidateAgentId === "string" && candidateAgentId.trim()) {
+        const normalized = candidateAgentId.trim();
+        next.__agentIds = existing.includes(normalized) ? existing : [...existing, normalized];
+      } else {
+        next.__agentIds = existing;
+      }
+      return next;
+    }),
+    pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
+    writeConfigFile: vi.fn(async (cfg: unknown) => {
+      if (cfg && typeof cfg === "object") {
+        state.writtenConfig = { ...(cfg as Record<string, unknown>) };
+        return;
+      }
+      state.writtenConfig = {};
+    }),
+    ensureAgentWorkspace: vi.fn(async () => {}),
+    resolveAgentDir: vi.fn(() => "/agents/test-agent"),
+    resolveAgentWorkspaceDir: vi.fn(() => "/workspace/test-agent"),
+    resolveSessionTranscriptsDirForAgent: vi.fn(() => "/transcripts/test-agent"),
+    listAgentsForGateway: vi.fn(() => ({
+      defaultId: "main",
+      mainKey: "agent:main:main",
+      scope: "global",
+      agents: [],
+    })),
+    movePathToTrash: vi.fn(async () => "/trashed"),
+    fsAccess: vi.fn(async () => {}),
+    fsMkdir: vi.fn(async () => undefined),
+    fsAppendFile: vi.fn(async () => {}),
+    fsReadFile: vi.fn(async () => ""),
+    fsStat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
+    fsLstat: vi.fn(async (..._args: unknown[]) => null as import("node:fs").Stats | null),
+    fsRealpath: vi.fn(async (p: string) => p),
+    fsOpen: vi.fn(async () => ({}) as unknown),
+    getActiveSecretsRuntimeSnapshot: vi.fn(() =>
+      state.runtimeSnapshotActive
+        ? {
+            sourceConfig: {},
+            config: {},
+            authStores: [],
+            warnings: [],
+          }
+        : null,
+    ),
+    prepareSecretsRuntimeSnapshot: vi.fn(
+      async ({ config }: { config: Record<string, unknown> }) => ({
+        sourceConfig: config,
+        config,
+        authStores: [],
+        warnings: [],
+      }),
+    ),
+    activateSecretsRuntimeSnapshot: vi.fn((snapshot: { config: Record<string, unknown> }) => {
+      state.runtimeSnapshotActive = true;
+      state.runtimeConfig = snapshot.config;
+    }),
+    writeFileWithinRoot: vi.fn(async () => {}),
+    refreshRuntimeConfigFromDisk: vi.fn(async () => {
+      if (!state.runtimeSnapshotActive) {
+        return;
+      }
+      state.runtimeConfig = state.writtenConfig ? { ...state.writtenConfig } : state.runtimeConfig;
+    }),
+  };
+});
 
 vi.mock("../../config/config.js", () => ({
-  loadConfig: () => mocks.loadConfigReturn,
+  clearConfigCache: mocks.clearConfigCache,
+  loadConfig: () => mocks.state.runtimeConfig ?? mocks.loadConfigReturn,
+  projectConfigOntoRuntimeSourceSnapshot: <T>(cfg: T) => cfg,
+  readConfigFileSnapshot: async () => {
+    const config = mocks.state.writtenConfig ?? mocks.loadConfigReturn;
+    return {
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: config,
+      resolved: config,
+      valid: true,
+      config,
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    };
+  },
   writeConfigFile: mocks.writeConfigFile,
 }));
 
@@ -47,7 +135,14 @@ vi.mock("../../commands/agents.config.js", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  listAgentIds: () => ["main"],
+  listAgentIds: (cfg?: Record<string, unknown>) => {
+    const raw = (cfg as { __agentIds?: unknown } | undefined)?.__agentIds;
+    const ids =
+      Array.isArray(raw) && raw.length > 0
+        ? raw.filter((value): value is string => typeof value === "string")
+        : [];
+    return ["main", ...ids.filter((agentId) => agentId !== "main")];
+  },
   resolveAgentDir: mocks.resolveAgentDir,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
 }));
@@ -78,6 +173,11 @@ vi.mock("../session-utils.js", () => ({
   listAgentsForGateway: mocks.listAgentsForGateway,
 }));
 
+vi.mock("../../secrets/runtime.js", () => ({
+  getActiveSecretsRuntimeSnapshot: mocks.getActiveSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot: mocks.prepareSecretsRuntimeSnapshot,
+  activateSecretsRuntimeSnapshot: mocks.activateSecretsRuntimeSnapshot,
+}));
 vi.mock("../../infra/fs-safe.js", async () => {
   const actual =
     await vi.importActual<typeof import("../../infra/fs-safe.js")>("../../infra/fs-safe.js");
@@ -122,7 +222,9 @@ function makeCall(method: keyof typeof agentsHandlers, params: Record<string, un
   const promise = handler({
     params,
     respond,
-    context: {} as never,
+    context: {
+      refreshRuntimeConfigFromDisk: mocks.refreshRuntimeConfigFromDisk,
+    } as never,
     req: { type: "req" as const, id: "1", method },
     client: null,
     isWebchatConnect: () => false,
@@ -226,6 +328,22 @@ async function expectUnsafeWorkspaceFile(method: "agents.files.get" | "agents.fi
 }
 
 beforeEach(() => {
+  mocks.state.writtenConfig = null;
+  mocks.state.runtimeSnapshotActive = true;
+  mocks.state.runtimeConfig = null;
+  mocks.refreshRuntimeConfigFromDisk.mockImplementation(async () => {
+    if (!mocks.state.runtimeSnapshotActive) {
+      return;
+    }
+    mocks.state.runtimeConfig = mocks.state.writtenConfig ? { ...mocks.state.writtenConfig } : null;
+  });
+  mocks.writeConfigFile.mockImplementation(async (cfg: unknown) => {
+    if (cfg && typeof cfg === "object") {
+      mocks.state.writtenConfig = { ...(cfg as Record<string, unknown>) };
+      return;
+    }
+    mocks.state.writtenConfig = {};
+  });
   mocks.fsReadFile.mockImplementation(async () => {
     throw createEnoentError();
   });
@@ -256,8 +374,10 @@ describe("agents.create", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.loadConfigReturn = {};
-    mocks.findAgentEntryIndex.mockReturnValue(-1);
-    mocks.applyAgentConfig.mockImplementation((_cfg, _opts) => ({}));
+    mocks.findAgentEntryIndex.mockImplementation(
+      (entries: Array<{ agentId: string }>, agentId: string) =>
+        entries.findIndex((entry) => entry.agentId === agentId),
+    );
   });
 
   it("creates a new agent successfully", async () => {
@@ -280,13 +400,143 @@ describe("agents.create", () => {
     expect(mocks.writeConfigFile).toHaveBeenCalled();
   });
 
+  it("refreshes runtime snapshot so follow-up RPCs can resolve the new agent", async () => {
+    mocks.loadConfigReturn = { gateway: { reload: { mode: "off" } } };
+    const { respond, promise } = makeCall("agents.create", {
+      name: "Ready Agent",
+      workspace: "/home/user/agents/ready",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        agentId: "ready-agent",
+      }),
+      undefined,
+    );
+    expect(mocks.refreshRuntimeConfigFromDisk).toHaveBeenCalledTimes(1);
+    expect(mocks.refreshRuntimeConfigFromDisk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __agentIds: expect.arrayContaining(["ready-agent"]),
+      }),
+    );
+
+    const { respond: filesRespond, promise: filesPromise } = makeCall("agents.files.list", {
+      agentId: "ready-agent",
+    });
+    await filesPromise;
+    expect(filesRespond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ agentId: "ready-agent" }),
+      undefined,
+    );
+  });
+
+  it("retries runtime refresh during readiness polling after transient failures", async () => {
+    const previousTimeout = process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS;
+    const previousPoll = process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS;
+    process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS = "250";
+    process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS = "10";
+    mocks.state.runtimeConfig = null;
+    let refreshAttempts = 0;
+    mocks.refreshRuntimeConfigFromDisk.mockImplementation(async () => {
+      refreshAttempts += 1;
+      if (refreshAttempts === 1) {
+        throw new Error("temporary refresh failure");
+      }
+      mocks.state.runtimeConfig = mocks.state.writtenConfig
+        ? { ...mocks.state.writtenConfig }
+        : null;
+    });
+    try {
+      const { respond, promise } = makeCall("agents.create", {
+        name: "Retry Agent",
+        workspace: "/home/user/agents/retry",
+      });
+      await promise;
+
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          ok: true,
+          agentId: "retry-agent",
+        }),
+        undefined,
+      );
+      expect(refreshAttempts).toBeGreaterThan(1);
+    } finally {
+      mocks.refreshRuntimeConfigFromDisk.mockImplementation(async () => {
+        if (!mocks.state.runtimeSnapshotActive) {
+          return;
+        }
+        mocks.state.runtimeConfig = mocks.state.writtenConfig
+          ? { ...mocks.state.writtenConfig }
+          : mocks.state.runtimeConfig;
+      });
+      if (previousTimeout === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS = previousTimeout;
+      }
+      if (previousPoll === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS;
+      } else {
+        process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS = previousPoll;
+      }
+    }
+  });
+
+  it("keeps readiness refresh scoped to the created config payload", async () => {
+    mocks.state.runtimeConfig = null;
+    let refreshAttempts = 0;
+    const refreshPayloads: Array<Record<string, unknown> | undefined> = [];
+    mocks.refreshRuntimeConfigFromDisk.mockImplementation(async (cfg?: Record<string, unknown>) => {
+      refreshAttempts += 1;
+      refreshPayloads.push(cfg ? { ...cfg } : undefined);
+      if (refreshAttempts === 1) {
+        // Simulate a concurrent config write landing after agents.create wrote its initial config.
+        mocks.state.writtenConfig = {
+          ...mocks.state.writtenConfig,
+          __agentIds: ["stale-safe-agent", "newer-agent"],
+        };
+        return;
+      }
+      mocks.state.runtimeConfig = cfg ? { ...cfg } : null;
+    });
+
+    const { respond, promise } = makeCall("agents.create", {
+      name: "Stale Safe Agent",
+      workspace: "/home/user/agents/stale-safe",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        agentId: "stale-safe-agent",
+      }),
+      undefined,
+    );
+    expect(refreshAttempts).toBeGreaterThan(1);
+    const lastRefresh = refreshPayloads.at(-1);
+    expect(lastRefresh?.__agentIds).toEqual(expect.arrayContaining(["stale-safe-agent"]));
+    const refreshedAgentIds = Array.isArray(lastRefresh?.__agentIds) ? lastRefresh.__agentIds : [];
+    expect(refreshedAgentIds).not.toContain("newer-agent");
+  });
+
   it("ensures workspace is set up before writing config", async () => {
     const callOrder: string[] = [];
     mocks.ensureAgentWorkspace.mockImplementation(async () => {
       callOrder.push("ensureAgentWorkspace");
     });
-    mocks.writeConfigFile.mockImplementation(async () => {
+    mocks.writeConfigFile.mockImplementation(async (cfg: unknown) => {
       callOrder.push("writeConfigFile");
+      if (cfg && typeof cfg === "object") {
+        mocks.state.writtenConfig = { ...(cfg as Record<string, unknown>) };
+      }
     });
 
     const { promise } = makeCall("agents.create", {
@@ -373,6 +623,41 @@ describe("agents.create", () => {
       "utf-8",
     );
   });
+
+  it("fails readiness when runtime config never includes the newly written agent", async () => {
+    const previousTimeout = process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS;
+    const previousPoll = process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS;
+    process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS = "25";
+    process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS = "5";
+    mocks.state.runtimeSnapshotActive = false;
+    try {
+      const { respond, promise } = makeCall("agents.create", {
+        name: "Never Visible Agent",
+        workspace: "/tmp/ws",
+      });
+      await promise;
+
+      expect(mocks.refreshRuntimeConfigFromDisk).toHaveBeenCalledTimes(1);
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          message: expect.stringContaining("created but not yet resolvable"),
+        }),
+      );
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS = previousTimeout;
+      }
+      if (previousPoll === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS;
+      } else {
+        process.env.OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS = previousPoll;
+      }
+    }
+  });
 });
 
 describe("agents.update", () => {
@@ -380,7 +665,6 @@ describe("agents.update", () => {
     vi.clearAllMocks();
     mocks.loadConfigReturn = {};
     mocks.findAgentEntryIndex.mockReturnValue(0);
-    mocks.applyAgentConfig.mockImplementation((_cfg, _opts) => ({}));
   });
 
   it("updates an existing agent successfully", async () => {
@@ -543,19 +827,22 @@ describe("agents.files.get/set symlink safety", () => {
 
   function mockWorkspaceEscapeSymlink() {
     const workspace = "/workspace/test-agent";
-    const candidate = path.resolve(workspace, "AGENTS.md");
+    const workspaceReal = path.resolve(workspace);
+    const candidate = path.resolve(workspaceReal, "AGENTS.md");
+    const outside = path.resolve("/outside/secret.txt");
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
-        return workspace;
+      const resolved = path.resolve(p);
+      if (resolved === workspaceReal) {
+        return workspaceReal;
       }
-      if (p === candidate) {
-        return "/outside/secret.txt";
+      if (resolved === candidate) {
+        return outside;
       }
-      return p;
+      return resolved;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === candidate) {
+      if (path.resolve(p) === candidate) {
         return makeSymlinkStat();
       }
       throw createEnoentError();
@@ -578,32 +865,34 @@ describe("agents.files.get/set symlink safety", () => {
 
   it("allows in-workspace symlink reads and writes through symlink aliases", async () => {
     const workspace = "/workspace/test-agent";
-    const candidate = path.resolve(workspace, "AGENTS.md");
-    const target = path.resolve(workspace, "policies", "AGENTS.md");
+    const workspaceReal = path.resolve(workspace);
+    const candidate = path.resolve(workspaceReal, "AGENTS.md");
+    const target = path.resolve(workspaceReal, "policies", "AGENTS.md");
     const targetStat = makeFileStat({ size: 7, mtimeMs: 1700, dev: 9, ino: 42 });
 
     mocks.fsRealpath.mockImplementation(async (p: string) => {
-      if (p === workspace) {
-        return workspace;
+      const resolved = path.resolve(p);
+      if (resolved === workspaceReal) {
+        return workspaceReal;
       }
-      if (p === candidate) {
+      if (resolved === candidate) {
         return target;
       }
-      return p;
+      return resolved;
     });
     mocks.fsLstat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === candidate) {
+      if (path.resolve(p) === candidate) {
         return makeSymlinkStat({ dev: 9, ino: 41 });
       }
-      if (p === target) {
+      if (path.resolve(p) === target) {
         return targetStat;
       }
       throw createEnoentError();
     });
     mocks.fsStat.mockImplementation(async (...args: unknown[]) => {
       const p = typeof args[0] === "string" ? args[0] : "";
-      if (p === target) {
+      if (path.resolve(p) === target) {
         return targetStat;
       }
       throw createEnoentError();
@@ -638,12 +927,16 @@ describe("agents.files.get/set symlink safety", () => {
     expect(setCall.respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({
-        file: expect.objectContaining({
-          missing: false,
-          content: "updated\n",
-        }),
+        ok: true,
+        file: expect.objectContaining({ missing: false, content: "updated\n" }),
       }),
       undefined,
+    );
+    expect(mocks.writeFileWithinRoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootDir: workspaceReal,
+        relativePath: path.join("policies", "AGENTS.md"),
+      }),
     );
   });
 

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -25,7 +25,12 @@ import {
   listAgentEntries,
   pruneAgentConfig,
 } from "../../commands/agents.config.js";
-import { loadConfig, writeConfigFile } from "../../config/config.js";
+import {
+  clearConfigCache,
+  loadConfig,
+  projectConfigOntoRuntimeSourceSnapshot,
+  writeConfigFile,
+} from "../../config/config.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
 import { sameFileIdentity } from "../../infra/file-identity.js";
 import { SafeOpenError, readLocalFileSafely, writeFileWithinRoot } from "../../infra/fs-safe.js";
@@ -64,6 +69,96 @@ const BOOTSTRAP_FILE_NAMES_POST_ONBOARDING = BOOTSTRAP_FILE_NAMES.filter(
 const MEMORY_FILE_NAMES = [DEFAULT_MEMORY_FILENAME, DEFAULT_MEMORY_ALT_FILENAME] as const;
 
 const ALLOWED_FILE_NAMES = new Set<string>([...BOOTSTRAP_FILE_NAMES, ...MEMORY_FILE_NAMES]);
+
+const DEFAULT_AGENT_CREATE_READY_TIMEOUT_MS = 3000;
+const DEFAULT_AGENT_CREATE_READY_POLL_MS = 25;
+
+function resolvePositiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function resolveAgentCreateReadyTimeoutMs(): number {
+  return resolvePositiveIntFromEnv(
+    "OPENCLAW_GATEWAY_AGENT_CREATE_READY_TIMEOUT_MS",
+    DEFAULT_AGENT_CREATE_READY_TIMEOUT_MS,
+  );
+}
+
+function resolveAgentCreateReadyPollMs(): number {
+  return resolvePositiveIntFromEnv(
+    "OPENCLAW_GATEWAY_AGENT_CREATE_READY_POLL_MS",
+    DEFAULT_AGENT_CREATE_READY_POLL_MS,
+  );
+}
+
+function delayMs(durationMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}
+
+const AGENT_READY_TIMEOUT = Symbol("agent-ready-timeout");
+
+async function waitForAgentReady(params: {
+  agentId: string;
+  refreshRuntimeConfigFromDisk?: () => Promise<void>;
+}): Promise<{ ok: true } | { ok: false }> {
+  const timeoutMs = resolveAgentCreateReadyTimeoutMs();
+  const pollMs = resolveAgentCreateReadyPollMs();
+  const refreshIntervalMs = Math.max(50, pollMs);
+  const deadline = Date.now() + timeoutMs;
+  let lastRefreshAtMs = 0;
+
+  for (;;) {
+    const now = Date.now();
+    const remainingMsBeforeRefresh = deadline - now;
+    if (remainingMsBeforeRefresh <= 0) {
+      return { ok: false };
+    }
+    if (
+      now - lastRefreshAtMs >= refreshIntervalMs &&
+      typeof params.refreshRuntimeConfigFromDisk === "function"
+    ) {
+      lastRefreshAtMs = now;
+      try {
+        await Promise.race([
+          params.refreshRuntimeConfigFromDisk(),
+          delayMs(remainingMsBeforeRefresh).then(() => {
+            throw AGENT_READY_TIMEOUT;
+          }),
+        ]);
+      } catch (error) {
+        if (error === AGENT_READY_TIMEOUT) {
+          return { ok: false };
+        }
+        // Best-effort: transient refresh failures should not prevent retries.
+      }
+    }
+    clearConfigCache();
+    // Readiness must reflect runtime visibility because follow-up RPCs resolve
+    // agent IDs from loadConfig().
+    const cfg = loadConfig();
+    const foundInEntries = findAgentEntryIndex(listAgentEntries(cfg), params.agentId) >= 0;
+    const resolvableForFiles = resolveAgentIdOrError(params.agentId, cfg) === params.agentId;
+    if (foundInEntries && resolvableForFiles) {
+      return { ok: true };
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return { ok: false };
+    }
+    await delayMs(Math.min(pollMs, remainingMs));
+  }
+}
 
 function resolveAgentWorkspaceFileOrRespondError(
   params: Record<string, unknown>,
@@ -473,7 +568,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const result = listAgentsForGateway(cfg);
     respond(true, result, undefined);
   },
-  "agents.create": async ({ params, respond }) => {
+  "agents.create": async ({ params, respond, context }) => {
     if (!validateAgentsCreateParams(params)) {
       respond(
         false,
@@ -542,6 +637,32 @@ export const agentsHandlers: GatewayRequestHandlers = {
       "",
     ];
     await fs.appendFile(identityPath, lines.join("\n"), "utf-8");
+
+    const sourceConfigForCreate = projectConfigOntoRuntimeSourceSnapshot(nextConfig);
+    const refreshRuntimeConfigForCreate =
+      typeof context.refreshRuntimeConfigFromDisk === "function"
+        ? async () => {
+            // Refresh runtime from the source-shaped config we just persisted
+            // for this mutation so secrets refs remain intact and unrelated
+            // disk edits are not imported during readiness polling.
+            await context.refreshRuntimeConfigFromDisk?.(sourceConfigForCreate);
+          }
+        : undefined;
+    const ready = await waitForAgentReady({
+      agentId,
+      refreshRuntimeConfigFromDisk: refreshRuntimeConfigForCreate,
+    });
+    if (!ready.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.AGENT_TIMEOUT,
+          `agent "${agentId}" created but not yet resolvable after ${resolveAgentCreateReadyTimeoutMs()}ms`,
+        ),
+      );
+      return;
+    }
 
     respond(true, { ok: true, agentId, name: rawName, workspace: workspaceDir }, undefined);
   },

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -1,6 +1,7 @@
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { createDefaultDeps } from "../../cli/deps.js";
 import type { HealthSummary } from "../../commands/health.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import type { CronService } from "../../cron/service.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { WizardSession } from "../../wizard/session.js";
@@ -98,6 +99,7 @@ export type GatewayRequestContext = {
     prompter: import("../../wizard/prompts.js").WizardPrompter,
   ) => Promise<void>;
   broadcastVoiceWakeChanged: (triggers: string[]) => void;
+  refreshRuntimeConfigFromDisk?: (configOverride?: OpenClawConfig) => Promise<void>;
 };
 
 export type GatewayRequestOptions = {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -74,7 +74,7 @@ import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
-import { startGatewayConfigReloader } from "./config-reload.js";
+import { resolveGatewayReloadSettings, startGatewayConfigReloader } from "./config-reload.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
@@ -434,6 +434,7 @@ export async function startGatewayServer(
     });
   };
   let secretsActivationTail: Promise<void> = Promise.resolve();
+  let runtimeSecretsActivationSerial = 0;
   const runWithSecretsActivationLock = async <T>(operation: () => Promise<T>): Promise<T> => {
     const run = secretsActivationTail.then(operation, operation);
     secretsActivationTail = run.then(
@@ -451,6 +452,7 @@ export async function startGatewayServer(
         const prepared = await prepareSecretsRuntimeSnapshot({ config });
         if (params.activate) {
           activateSecretsRuntimeSnapshot(prepared);
+          runtimeSecretsActivationSerial += 1;
           logGatewayAuthSurfaceDiagnostics(prepared);
         }
         for (const warning of prepared.warnings) {
@@ -487,7 +489,6 @@ export async function startGatewayServer(
         throw err;
       }
     });
-
   let cfgAtStart: OpenClawConfig;
   const startupRuntimeConfig = applyConfigOverrides(configSnapshot.config);
   const authBootstrap = await prepareGatewayStartupConfig({
@@ -1149,7 +1150,27 @@ export async function startGatewayServer(
       ...secretsHandlers,
     },
     broadcast,
-    context: gatewayRequestContext,
+    context: {
+      ...gatewayRequestContext,
+      refreshRuntimeConfigFromDisk: async (configOverride) => {
+        if (!getActiveSecretsRuntimeSnapshot()) {
+          return;
+        }
+        if (configOverride) {
+          await activateRuntimeSecrets(configOverride, { reason: "reload", activate: true });
+          return;
+        }
+        const reloadMode = resolveGatewayReloadSettings(loadConfig()).mode;
+        if (reloadMode === "off" || reloadMode === "restart") {
+          return;
+        }
+        const snapshot = await readConfigFileSnapshot();
+        if (!snapshot.exists || !snapshot.valid) {
+          return;
+        }
+        await activateRuntimeSecrets(snapshot.config, { reason: "reload", activate: true });
+      },
+    },
   });
   logGatewayStartup({
     cfg: cfgAtStart,
@@ -1273,14 +1294,23 @@ export async function startGatewayServer(
               reason: "reload",
               activate: true,
             });
+            const preparedActivationSerial = runtimeSecretsActivationSerial;
             try {
               await applyHotReload(plan, prepared.config);
             } catch (err) {
-              if (previousSnapshot) {
-                activateSecretsRuntimeSnapshot(previousSnapshot);
-              } else {
-                clearSecretsRuntimeSnapshot();
-              }
+              await runWithSecretsActivationLock(async () => {
+                if (runtimeSecretsActivationSerial !== preparedActivationSerial) {
+                  logReload.warn(
+                    "gateway: skipping hot-reload snapshot rollback because runtime snapshot advanced",
+                  );
+                  return;
+                }
+                if (previousSnapshot) {
+                  activateSecretsRuntimeSnapshot(previousSnapshot);
+                } else {
+                  clearSecretsRuntimeSnapshot();
+                }
+              });
               throw err;
             }
           },


### PR DESCRIPTION
## Summary
This refreshes the old `agents.create` readiness work as a clean branch off current `origin/main`.

The replacement keeps the core behavior from the original PR:
- `agents.create` waits until the new agent is visible through runtime config before returning success
- readiness polling can refresh runtime visibility so immediate follow-up RPCs (`agents.files.*`, `agents.update`) stop racing stale runtime snapshots
- tests cover success, retry, scoped refresh, and timeout behavior

It also folds in the live review feedback that was still unresolved on the old branch:
- readiness refresh now uses `projectConfigOntoRuntimeSourceSnapshot(...)` so secrets-runtime refreshes preserve source refs instead of activating a resolved runtime object as the source snapshot
- refresh attempts are now bounded by the overall create timeout instead of being able to block past it
- hot-reload rollback now keys off a runtime activation serial, which prevents a later same-config activation from being rolled back as if it were the earlier one

## Validation
- `npx vitest run src/gateway/server-methods/agents-mutate.test.ts -t "refreshes runtime snapshot so follow-up RPCs can resolve the new agent|retries runtime refresh during readiness polling after transient failures|keeps readiness refresh scoped to the created config payload|fails readiness when runtime config never includes the newly written agent"`
- commit-time `pnpm check` / lint hooks passed during `git commit`

## Notes
A broader `src/gateway/server.reload.test.ts -t "gateway hot reload"` run still reports an unrelated failing traversal-segment startup test in the current tree; I did not use that as the validation gate for this focused readiness branch.
