### PR TITLE
[codex] fix(outbound): preserve delivery queue recovery metadata

### DIFF
--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -7,6 +7,7 @@ import {
   computeBackoffMs,
   type DeliverFn,
   enqueueDelivery,
+  ensureQueueDir,
   failDelivery,
   isEntryEligibleForRecoveryRetry,
   isPermanentDeliveryError,
@@ -150,6 +151,37 @@ describe("delivery-queue", () => {
       expect(entry.lastAttemptAt).toBeGreaterThan(0);
       expect(entry.lastError).toBe("connection refused");
     });
+
+    it("normalizes legacy entries before incrementing retry metadata", async () => {
+      const id = "legacy-fail-entry";
+      await ensureQueueDir(tmpDir);
+      fs.writeFileSync(
+        path.join(tmpDir, "delivery-queue", `${id}.json`),
+        JSON.stringify(
+          {
+            id,
+            channel: "telegram",
+            to: "12345",
+            payload: { text: "legacy" },
+            attempt: 0,
+            createdAt: new Date("2026-03-22T12:00:00.000Z").toISOString(),
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      await failDelivery(id, "boom", tmpDir);
+
+      const entry = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, "delivery-queue", `${id}.json`), "utf-8"),
+      );
+      expect(entry.retryCount).toBe(1);
+      expect(entry.lastError).toBe("boom");
+      expect(Array.isArray(entry.payloads)).toBe(true);
+      expect(entry.payloads[0]?.text).toBe("legacy");
+    });
   });
 
   describe("moveToFailed", () => {
@@ -228,6 +260,44 @@ describe("delivery-queue", () => {
 
       const persisted = JSON.parse(fs.readFileSync(filePath, "utf-8"));
       expect(persisted.lastAttemptAt).toBe(persisted.enqueuedAt);
+    });
+
+    it("preserves mirror idempotency keys and forceDocument when normalizing legacy entries", async () => {
+      const id = "legacy-normalized-entry";
+      const filePath = path.join(tmpDir, "delivery-queue", `${id}.json`);
+      await ensureQueueDir(tmpDir);
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify(
+          {
+            id,
+            channel: "telegram",
+            to: "12345",
+            payload: { text: "legacy" },
+            attempt: 0,
+            createdAt: new Date("2026-03-22T12:00:00.000Z").toISOString(),
+            forceDocument: true,
+            mirror: {
+              sessionKey: "agent:main:main",
+              idempotencyKey: "idem-legacy-1",
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const entries = await loadPendingDeliveries(tmpDir);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]?.forceDocument).toBe(true);
+      expect(entries[0]?.mirror?.idempotencyKey).toBe("idem-legacy-1");
+
+      const persisted = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      expect(persisted.forceDocument).toBe(true);
+      expect(persisted.mirror?.idempotencyKey).toBe("idem-legacy-1");
+      expect(Array.isArray(persisted.payloads)).toBe(true);
+      expect(persisted.retryCount).toBe(0);
     });
   });
 

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -46,6 +46,13 @@ export interface QueuedDelivery extends QueuedDeliveryPayload {
   lastError?: string;
 }
 
+type LegacyQueuedDelivery = Partial<QueuedDelivery> & {
+  target?: unknown;
+  attempt?: unknown;
+  payload?: unknown;
+  createdAt?: unknown;
+};
+
 export type RecoverySummary = {
   recovered: number;
   failed: number;
@@ -163,8 +170,13 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
-  entry.retryCount += 1;
+  const parsedRaw = JSON.parse(raw);
+  const normalized = normalizeQueuedDelivery(parsedRaw, id);
+  if (!normalized) {
+    throw new Error(`Invalid queued delivery entry: ${id}`);
+  }
+  const { entry } = normalizeLegacyQueuedDeliveryEntry(normalized);
+  entry.retryCount = asRetryCount(entry.retryCount) + 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;
   const tmp = `${filePath}.${process.pid}.tmp`;
@@ -209,9 +221,13 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
         continue;
       }
       const raw = await fs.promises.readFile(filePath, "utf-8");
-      const parsed = JSON.parse(raw) as QueuedDelivery;
+      const parsedRaw = JSON.parse(raw);
+      const parsed = normalizeQueuedDelivery(parsedRaw, file.slice(0, -".json".length));
+      if (!parsed) {
+        continue;
+      }
       const { entry, migrated } = normalizeLegacyQueuedDeliveryEntry(parsed);
-      if (migrated) {
+      if (migrated || shouldPersistNormalizedQueuedDeliveryEntry(parsedRaw)) {
         const tmp = `${filePath}.${process.pid}.tmp`;
         await fs.promises.writeFile(tmp, JSON.stringify(entry, null, 2), {
           encoding: "utf-8",
@@ -225,6 +241,141 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
     }
   }
   return entries;
+}
+
+function asTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function asEpochMs(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function asRetryCount(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return Math.floor(value);
+  }
+  return 0;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asReplyPayloads(value: unknown): ReplyPayload[] {
+  if (Array.isArray(value)) {
+    return value.filter(
+      (payload): payload is ReplyPayload => !!payload && typeof payload === "object",
+    );
+  }
+  return [];
+}
+
+function shouldPersistNormalizedQueuedDeliveryEntry(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return true;
+  }
+  const record = raw as Record<string, unknown>;
+  if ("target" in record || "attempt" in record || "payload" in record || "createdAt" in record) {
+    return true;
+  }
+  if (!asTrimmedString(record.channel) || !asTrimmedString(record.to)) {
+    return true;
+  }
+  if (!Array.isArray(record.payloads)) {
+    return true;
+  }
+  if (
+    typeof record.retryCount !== "number" ||
+    !Number.isFinite(record.retryCount) ||
+    record.retryCount < 0 ||
+    Math.floor(record.retryCount) !== record.retryCount
+  ) {
+    return true;
+  }
+  if (asEpochMs(record.enqueuedAt) === null) {
+    return true;
+  }
+  if (
+    "lastAttemptAt" in record &&
+    record.lastAttemptAt !== undefined &&
+    asEpochMs(record.lastAttemptAt) === null
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function normalizeQueuedDelivery(raw: unknown, fallbackId: string): QueuedDelivery | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const record = raw as LegacyQueuedDelivery;
+
+  const id = asTrimmedString(record.id) ?? fallbackId;
+  const channel = asTrimmedString(record.channel);
+  const to = asTrimmedString(record.to) ?? asTrimmedString(record.target);
+  const payloads =
+    asReplyPayloads(record.payloads).length > 0
+      ? asReplyPayloads(record.payloads)
+      : record.payload && typeof record.payload === "object"
+        ? ([record.payload] as ReplyPayload[])
+        : [];
+
+  if (!channel || channel === "none" || !to || payloads.length === 0) {
+    return null;
+  }
+
+  const mirrorRecord =
+    record.mirror && typeof record.mirror === "object"
+      ? (record.mirror as Partial<OutboundMirror>)
+      : null;
+  const mirrorSessionKey = asTrimmedString(mirrorRecord?.sessionKey);
+  const mirror =
+    mirrorSessionKey !== null
+      ? {
+          sessionKey: mirrorSessionKey,
+          agentId: asTrimmedString(mirrorRecord?.agentId) ?? undefined,
+          text: typeof mirrorRecord?.text === "string" ? mirrorRecord.text : undefined,
+          mediaUrls: Array.isArray(mirrorRecord?.mediaUrls)
+            ? mirrorRecord.mediaUrls.filter(
+                (url: unknown): url is string => typeof url === "string",
+              )
+            : undefined,
+          idempotencyKey: asTrimmedString(mirrorRecord?.idempotencyKey) ?? undefined,
+        }
+      : undefined;
+
+  return {
+    id,
+    enqueuedAt: asEpochMs(record.enqueuedAt) ?? asEpochMs(record.createdAt) ?? Date.now(),
+    channel: channel as Exclude<OutboundChannel, "none">,
+    to,
+    accountId: asTrimmedString(record.accountId) ?? undefined,
+    payloads,
+    threadId:
+      typeof record.threadId === "string" || typeof record.threadId === "number"
+        ? record.threadId
+        : undefined,
+    replyToId: asTrimmedString(record.replyToId) ?? undefined,
+    bestEffort: asBoolean(record.bestEffort),
+    gifPlayback: asBoolean(record.gifPlayback),
+    forceDocument: asBoolean(record.forceDocument),
+    silent: asBoolean(record.silent),
+    mirror,
+    retryCount: asRetryCount(record.retryCount ?? record.attempt),
+    lastAttemptAt: asEpochMs(record.lastAttemptAt) ?? undefined,
+    lastError: typeof record.lastError === "string" ? record.lastError : undefined,
+  };
 }
 
 /** Move a queue entry to the failed/ subdirectory. */


### PR DESCRIPTION
## Summary
This replacement extracts a clean queue-recovery fix from the old mixed outbound reliability PR.

The new branch focuses on one upstream-safe piece of value from that work: preserving delivery metadata when legacy queue entries are normalized and replayed on recovery.

What it fixes:
- legacy queue entries are normalized into canonical replayable records before recovery and before failure retry bookkeeping
- normalized mirror metadata now keeps `idempotencyKey`, so crash-replayed mirrored sends do not duplicate transcript writes
- normalized queue entries now keep `forceDocument`, so recovered media sends preserve the original document-vs-media intent

This directly addresses the still-live review feedback on the old PR without reopening the entire transport stack diff.

## Validation
- `npx vitest run src/infra/outbound/delivery-queue.test.ts -t "legacy entries before incrementing retry metadata|mirror idempotency keys and forceDocument|backfills lastAttemptAt for legacy retry entries during load|increments retryCount, records attempt time, and sets lastError"`
- commit-time `pnpm check` / lint hooks passed during `git commit`
