### PR TITLE
fix(openrouter): resolve thinking/reasoning defaults for dynamic models

### DIFF
--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -7,6 +7,7 @@ import {
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
 import { applyXaiModelCompat, DEFAULT_CONTEXT_TOKENS } from "openclaw/plugin-sdk/provider-models";
 import {
+  getAllCachedOpenRouterModels,
   getOpenRouterModelCapabilities,
   loadOpenRouterModelCapabilities,
   createOpenRouterSystemCacheWrapper,
@@ -135,6 +136,46 @@ export default definePluginEntry({
       },
       normalizeResolvedModel: ({ modelId, model }) =>
         isXaiOpenRouterModel(modelId) ? applyXaiModelCompat(model) : undefined,
+      augmentModelCatalog: (ctx) => {
+        // Surface cached OpenRouter model capabilities in the catalog so that
+        // reasoning/thinking defaults resolve correctly for dynamic models
+        // (e.g. kimi-k2.5) that aren't in the static models.json.
+        const existing = new Set(
+          ctx.entries.filter((e) => e.provider === PROVIDER_ID).map((e) => e.id),
+        );
+        const cached = getAllCachedOpenRouterModels();
+        const supplemental: Array<{
+          id: string;
+          name: string;
+          provider: string;
+          reasoning: boolean;
+          input: Array<"text" | "image">;
+          contextWindow: number;
+        }> = [];
+        for (const [id, caps] of cached) {
+          if (!existing.has(id)) {
+            supplemental.push({
+              id,
+              name: caps.name,
+              provider: PROVIDER_ID,
+              reasoning: caps.reasoning,
+              input: caps.input,
+              contextWindow: caps.contextWindow,
+            });
+          }
+        }
+        return supplemental;
+      },
+      resolveDefaultThinkingLevel: (ctx) => {
+        // Use catalog hint when available.
+        if (ctx.reasoning != null) {
+          return ctx.reasoning ? "low" : undefined;
+        }
+        // Fallback: check the OpenRouter capability cache for dynamic models
+        // that are not yet in the static catalog.
+        const caps = getOpenRouterModelCapabilities(ctx.modelId);
+        return caps?.reasoning ? "low" : undefined;
+      },
       isModernModelRef: () => true,
       wrapStreamFn: (ctx) => {
         let streamFn = ctx.streamFn;

--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -299,3 +299,12 @@ export function getOpenRouterModelCapabilities(
 
   return result;
 }
+
+/**
+ * Return all cached model capabilities (in-memory or disk).
+ * Returns an empty map if no cache is available yet.
+ */
+export function getAllCachedOpenRouterModels(): ReadonlyMap<string, OpenRouterModelCapabilities> {
+  ensureOpenRouterModelCache();
+  return cache ?? new Map();
+}

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -35,16 +35,17 @@ const resolveGatewayPort = vi.fn(() => 18789);
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -27,6 +27,7 @@ export {
   createZaiToolStreamWrapper,
 } from "../agents/pi-embedded-runner/zai-stream-wrappers.js";
 export {
+  getAllCachedOpenRouterModels,
   getOpenRouterModelCapabilities,
   loadOpenRouterModelCapabilities,
 } from "../agents/pi-embedded-runner/openrouter-model-capabilities.js";


### PR DESCRIPTION
## Summary

- OpenRouter models not in the static catalog (e.g. `moonshotai/kimi-k2.5`) have both thinking and reasoning defaults fall to `"off"`, hiding reasoning output in the TUI even when the model returns `reasoning_content`
- Add `augmentModelCatalog` hook to surface cached OpenRouter model capabilities in the catalog, so `resolveReasoningDefault` can find dynamic models with `reasoning: true`
- Add `resolveDefaultThinkingLevel` hook with fallback to the capability cache for models not yet in the static catalog
- Export `getAllCachedOpenRouterModels` from `openclaw/plugin-sdk/provider-stream`

## Problem

When using an OpenRouter reasoning model that isn't in the static `models.json` catalog (any model resolved dynamically via `resolveDynamicModel`), the thinking/reasoning default resolution chain finds no catalog entry:

1. `resolveThinkingDefault` checks per-model config → global config → provider `resolveDefaultThinkingLevel` (not implemented) → catalog (model not found) → falls to `"off"`
2. `resolveReasoningDefault` checks catalog only (no provider hook) → model not found → falls to `"off"`

With both defaults at `"off"`, `reasoningMode` is `"off"`, so `streamReasoning=false` and `includeReasoning=false`. The pi-ai library correctly parses `reasoning_content` from the OpenRouter response into thinking blocks, but the subscribe handler silently drops them.

The user sees only the brief `content` field (or nothing if `content` is null), making it appear the model returned an empty response.

## Fix

The OpenRouter capability cache already has the `reasoning: boolean` flag for every model in the OpenRouter catalog (fetched at startup). This PR wires that data into the two default-resolution paths:

1. **`augmentModelCatalog`** — injects supplemental catalog rows from the capability cache, so `resolveReasoningDefault`'s catalog lookup succeeds for dynamic models
2. **`resolveDefaultThinkingLevel`** — returns `"low"` for reasoning-capable models, with fallback to the capability cache when the catalog entry doesn't have a `reasoning` hint yet

## Test plan

- [x] `pnpm test -- src/agents/pi-embedded-runner/openrouter-model-capabilities.test.ts` passes (2 tests)
- [x] `pnpm tsgo` — no new errors (all errors are pre-existing on `main`)
- [x] `pnpm format` — clean
- [x] Manual verification: with kimi-k2.5 via OpenRouter, reasoning blocks now display in the TUI instead of being silently dropped

---

> [!NOTE]
> **AI-assisted:** Built with Claude Code (claude.ai/code). Code reviewed and tested by the author. Full understanding of the thinking/reasoning default resolution chain and how the capability cache integrates with the catalog.