### PR TITLE
[codex] fix(embedded): recover orphaned turns without dropping repeats

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { appendBootstrapPromptWarning } from "../../bootstrap-budget.js";
@@ -8,6 +9,7 @@ import {
   composeSystemPromptWithHookContext,
   isOllamaCompatProvider,
   prependSystemPromptAddition,
+  recoverOrphanedUserMessagesForPrompt,
   resolveAttemptFsWorkspaceOnly,
   resolveOllamaCompatNumCtxEnabled,
   resolvePromptBuildHookResult,
@@ -217,6 +219,297 @@ describe("resolvePromptModeForSession", () => {
     expect(resolvePromptModeForSession(undefined)).toBe("full");
     expect(resolvePromptModeForSession("agent:main")).toBe("full");
     expect(resolvePromptModeForSession("agent:main:thread:abc")).toBe("full");
+  });
+});
+
+describe("recoverOrphanedUserMessagesForPrompt", () => {
+  type LeafEntry = {
+    id: string;
+    type: "message" | "custom";
+    parentId?: string | null;
+    message?: AgentMessage;
+  };
+
+  function agentMessage(value: Record<string, unknown>): AgentMessage {
+    return value as unknown as AgentMessage;
+  }
+
+  function createSessionManager(entries: LeafEntry[], leafId: string | null) {
+    const byId = new Map(entries.map((entry) => [entry.id, entry]));
+    let currentLeafId = leafId;
+
+    return {
+      getLeafEntry: () => (currentLeafId ? byId.get(currentLeafId) : undefined),
+      branch: (parentId: string) => {
+        currentLeafId = parentId;
+      },
+      resetLeaf: () => {
+        currentLeafId = null;
+      },
+      buildSessionContext: () => {
+        const messages: AgentMessage[] = [];
+        const seen = new Set<string>();
+        let cursor = currentLeafId;
+        while (cursor && !seen.has(cursor)) {
+          seen.add(cursor);
+          const entry = byId.get(cursor);
+          if (!entry) {
+            break;
+          }
+          if (entry.type === "message" && entry.message) {
+            messages.push(entry.message);
+          }
+          cursor = entry.parentId ?? null;
+        }
+        messages.reverse();
+        return { messages };
+      },
+    };
+  }
+
+  it("merges trailing orphaned users into the current prompt in order", () => {
+    const sessionManager = createSessionManager(
+      [
+        {
+          id: "assistant",
+          type: "message",
+          message: agentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "seed assistant" }],
+          }),
+        },
+        {
+          id: "u1",
+          type: "message",
+          parentId: "assistant",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "text", text: "first orphaned message" }],
+          }),
+        },
+        {
+          id: "u2",
+          type: "message",
+          parentId: "u1",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "text", text: "second orphaned message" }],
+          }),
+        },
+      ],
+      "u2",
+    );
+
+    const replaceMessages = vi.fn();
+    const result = recoverOrphanedUserMessagesForPrompt({
+      sessionManager,
+      prompt: "hello",
+      replaceMessages,
+    });
+
+    expect(result.recoveredCount).toBe(2);
+    expect(result.mergedCount).toBe(2);
+    expect(result.prompt).toContain("first orphaned message");
+    expect(result.prompt).toContain("second orphaned message");
+    expect(result.prompt.indexOf("first orphaned message")).toBeLessThan(
+      result.prompt.indexOf("second orphaned message"),
+    );
+    expect(result.prompt.indexOf("second orphaned message")).toBeLessThan(
+      result.prompt.indexOf("hello"),
+    );
+    expect(replaceMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds a placeholder for orphaned image-only user content", () => {
+    const sessionManager = createSessionManager(
+      [
+        {
+          id: "assistant",
+          type: "message",
+          message: agentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "seed assistant" }],
+          }),
+        },
+        {
+          id: "u1",
+          type: "message",
+          parentId: "assistant",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "image", data: "abc", mimeType: "image/png" }],
+          }),
+        },
+      ],
+      "u1",
+    );
+
+    const replaceMessages = vi.fn();
+    const result = recoverOrphanedUserMessagesForPrompt({
+      sessionManager,
+      prompt: "hello",
+      replaceMessages,
+    });
+
+    expect(result.recoveredCount).toBe(1);
+    expect(result.mergedCount).toBe(1);
+    expect(result.prompt).toContain("[user attached an image]");
+    expect(replaceMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns prompt unchanged when no orphaned user leaf exists", () => {
+    const sessionManager = createSessionManager(
+      [
+        {
+          id: "assistant",
+          type: "message",
+          message: agentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "seed assistant" }],
+          }),
+        },
+      ],
+      "assistant",
+    );
+
+    const replaceMessages = vi.fn();
+    const result = recoverOrphanedUserMessagesForPrompt({
+      sessionManager,
+      prompt: "hello",
+      replaceMessages,
+    });
+
+    expect(result).toEqual({
+      prompt: "hello",
+      recoveredCount: 0,
+      mergedCount: 0,
+    });
+    expect(replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate prompt when orphaned carry-forward matches current prompt", () => {
+    const sessionManager = createSessionManager(
+      [
+        {
+          id: "assistant",
+          type: "message",
+          message: agentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "seed assistant" }],
+          }),
+        },
+        {
+          id: "u1",
+          type: "message",
+          parentId: "assistant",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "text", text: "retry me" }],
+          }),
+        },
+      ],
+      "u1",
+    );
+
+    const replaceMessages = vi.fn();
+    const result = recoverOrphanedUserMessagesForPrompt({
+      sessionManager,
+      prompt: "retry me",
+      replaceMessages,
+    });
+
+    expect(result).toEqual({
+      prompt: "retry me",
+      recoveredCount: 1,
+      mergedCount: 0,
+    });
+    expect(replaceMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves repeated orphaned turns when multiple entries match current prompt", () => {
+    const sessionManager = createSessionManager(
+      [
+        {
+          id: "assistant",
+          type: "message",
+          message: agentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "seed assistant" }],
+          }),
+        },
+        {
+          id: "u1",
+          type: "message",
+          parentId: "assistant",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "text", text: "retry me" }],
+          }),
+        },
+        {
+          id: "u2",
+          type: "message",
+          parentId: "u1",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "text", text: "retry me" }],
+          }),
+        },
+      ],
+      "u2",
+    );
+
+    const replaceMessages = vi.fn();
+    const result = recoverOrphanedUserMessagesForPrompt({
+      sessionManager,
+      prompt: "retry me",
+      replaceMessages,
+    });
+
+    expect(result.recoveredCount).toBe(2);
+    expect(result.mergedCount).toBe(1);
+    expect(result.prompt).toBe("retry me\n\nretry me");
+    expect(replaceMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes prompt echo against raw prompt when hooks prepend context", () => {
+    const sessionManager = createSessionManager(
+      [
+        {
+          id: "assistant",
+          type: "message",
+          message: agentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "seed assistant" }],
+          }),
+        },
+        {
+          id: "u1",
+          type: "message",
+          parentId: "assistant",
+          message: agentMessage({
+            role: "user",
+            content: [{ type: "text", text: "retry me" }],
+          }),
+        },
+      ],
+      "u1",
+    );
+
+    const replaceMessages = vi.fn();
+    const result = recoverOrphanedUserMessagesForPrompt({
+      sessionManager,
+      prompt: "[context from before_prompt_build]\n\nretry me",
+      rawPrompt: "retry me",
+      replaceMessages,
+    });
+
+    expect(result).toEqual({
+      prompt: "[context from before_prompt_build]\n\nretry me",
+      recoveredCount: 1,
+      mergedCount: 0,
+    });
+    expect(replaceMessages).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1624,6 +1624,122 @@ function summarizeSessionContext(messages: AgentMessage[]): {
   };
 }
 
+function stringifyUserMessageContentForPrompt(message: AgentMessage): string {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const chunks: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; text?: unknown };
+    if (typeof typedBlock.text === "string") {
+      const trimmed = typedBlock.text.trim();
+      if (trimmed.length > 0) {
+        chunks.push(trimmed);
+      }
+      continue;
+    }
+    if (typedBlock.type === "image") {
+      chunks.push("[user attached an image]");
+    }
+  }
+
+  return chunks.join("\n").trim();
+}
+
+type SessionLeafEntryLike = {
+  type?: unknown;
+  parentId?: string | null;
+  message?: AgentMessage;
+};
+
+type OrphanRecoverySessionManager = {
+  getLeafEntry: () => SessionLeafEntryLike | undefined;
+  branch: (parentId: string) => void;
+  resetLeaf: () => void;
+  buildSessionContext: () => { messages: AgentMessage[] };
+};
+
+export function recoverOrphanedUserMessagesForPrompt(params: {
+  sessionManager: OrphanRecoverySessionManager;
+  prompt: string;
+  rawPrompt?: string;
+  replaceMessages: (messages: AgentMessage[]) => void;
+}): { prompt: string; recoveredCount: number; mergedCount: number } {
+  const orphanedUserCarryForward: string[] = [];
+  let orphanedUserCount = 0;
+  let leafEntry = params.sessionManager.getLeafEntry();
+  while (leafEntry?.type === "message" && leafEntry.message?.role === "user") {
+    orphanedUserCount++;
+    const carryForwardText = stringifyUserMessageContentForPrompt(leafEntry.message);
+    if (carryForwardText.length > 0) {
+      orphanedUserCarryForward.push(carryForwardText);
+    }
+    if (leafEntry.parentId) {
+      params.sessionManager.branch(leafEntry.parentId);
+    } else {
+      params.sessionManager.resetLeaf();
+    }
+    leafEntry = params.sessionManager.getLeafEntry();
+  }
+  if (orphanedUserCount === 0) {
+    return { prompt: params.prompt, recoveredCount: 0, mergedCount: 0 };
+  }
+
+  const sessionContext = params.sessionManager.buildSessionContext();
+  params.replaceMessages(sessionContext.messages);
+  if (orphanedUserCarryForward.length === 0) {
+    return {
+      prompt: params.prompt,
+      recoveredCount: orphanedUserCount,
+      mergedCount: 0,
+    };
+  }
+
+  const normalizedPromptCandidates = new Set<string>();
+  const normalizedPrompt = params.prompt.trim();
+  if (normalizedPrompt) {
+    normalizedPromptCandidates.add(normalizedPrompt);
+  }
+  const normalizedRawPrompt = params.rawPrompt?.trim();
+  if (normalizedRawPrompt) {
+    normalizedPromptCandidates.add(normalizedRawPrompt);
+  }
+  const carryForwardEntries = orphanedUserCarryForward
+    .toReversed()
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (normalizedPromptCandidates.size > 0) {
+    // Drop only one prompt-echo entry so repeated identical user turns still survive recovery.
+    const promptEchoIndex = carryForwardEntries.findLastIndex((entry) =>
+      normalizedPromptCandidates.has(entry),
+    );
+    if (promptEchoIndex >= 0) {
+      carryForwardEntries.splice(promptEchoIndex, 1);
+    }
+  }
+  if (carryForwardEntries.length === 0) {
+    return {
+      prompt: params.prompt,
+      recoveredCount: orphanedUserCount,
+      mergedCount: 0,
+    };
+  }
+  const carryForwardPrompt = carryForwardEntries.join("\n\n");
+  return {
+    prompt: `${carryForwardPrompt}\n\n${params.prompt}`,
+    recoveredCount: orphanedUserCount,
+    mergedCount: carryForwardEntries.length,
+  };
+}
+
 export async function runEmbeddedAttempt(
   params: EmbeddedRunAttemptParams,
 ): Promise<EmbeddedRunAttemptResult> {
@@ -2733,19 +2849,19 @@ export async function runEmbeddedAttempt(
           messages: activeSession.messages,
         });
 
-        // Repair orphaned trailing user messages so new prompts don't violate role ordering.
-        const leafEntry = sessionManager.getLeafEntry();
-        if (leafEntry?.type === "message" && leafEntry.message.role === "user") {
-          if (leafEntry.parentId) {
-            sessionManager.branch(leafEntry.parentId);
-          } else {
-            sessionManager.resetLeaf();
-          }
-          const sessionContext = sessionManager.buildSessionContext();
-          activeSession.agent.replaceMessages(sessionContext.messages);
+        // Preserve orphaned trailing user content by carrying it into the next prompt.
+        const orphanRecovery = recoverOrphanedUserMessagesForPrompt({
+          sessionManager,
+          prompt: effectivePrompt,
+          rawPrompt: params.prompt,
+          replaceMessages: (messages) => activeSession.agent.replaceMessages(messages),
+        });
+        effectivePrompt = orphanRecovery.prompt;
+        if (orphanRecovery.recoveredCount > 0) {
           log.warn(
-            `Removed orphaned user message to prevent consecutive user turns. ` +
-              `runId=${params.runId} sessionId=${params.sessionId}`,
+            `Recovered orphaned user message(s) by carrying context forward. ` +
+              `runId=${params.runId} sessionId=${params.sessionId} ` +
+              `recovered=${orphanRecovery.recoveredCount} merged=${orphanRecovery.mergedCount}`,
           );
         }
         const transcriptLeafId =


### PR DESCRIPTION
## Summary
- extract the orphaned-turn recovery work from old #28926 into a narrow PR
- carry orphaned trailing user turns into the next prompt instead of dropping them
- keep review-followup dedupe behavior so prompt retries do not duplicate the same text while repeated real user turns still survive recovery

## Review feedback folded in
- avoid prompt echo duplication when the orphaned leaf matches the current prompt
- preserve distinct repeated orphaned turns with identical text instead of collapsing them all
- dedupe against the raw prompt as well when hooks prepend context before prompt build

## Validation
- `npx vitest run src/agents/pi-embedded-runner/run/attempt.test.ts`