### PR TITLE
fix(daemon): prefer Volta shim path over version-pinned image path

### DIFF
--- a/src/infra/stable-node-path.test.ts
+++ b/src/infra/stable-node-path.test.ts
@@ -25,6 +25,42 @@ describe("resolveStableNodePath", () => {
     await expect(resolveStableNodePath(versionedNode)).resolves.toBe(optVersioned);
   });
 
+  it("resolves Volta tools/image path to the stable Volta shim", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-volta-"));
+    const voltaImageNode = path.join(
+      home,
+      ".volta",
+      "tools",
+      "image",
+      "node",
+      "24.14.0",
+      "bin",
+      "node",
+    );
+    const voltaShim = path.join(home, ".volta", "bin", "node");
+
+    await fs.mkdir(path.dirname(voltaShim), { recursive: true });
+    await fs.writeFile(voltaShim, "", "utf8");
+
+    await expect(resolveStableNodePath(voltaImageNode)).resolves.toBe(voltaShim);
+  });
+
+  it("returns Volta tools/image path unchanged when shim is not accessible", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-volta-"));
+    const voltaImageNode = path.join(
+      home,
+      ".volta",
+      "tools",
+      "image",
+      "node",
+      "24.14.0",
+      "bin",
+      "node",
+    );
+    // No shim created — shim directory doesn't exist.
+    await expect(resolveStableNodePath(voltaImageNode)).resolves.toBe(voltaImageNode);
+  });
+
   it("falls back to the bin symlink for the default formula, otherwise original path", async () => {
     const prefix = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stable-node-"));
     const defaultNode = path.join(prefix, "Cellar", "node", "25.7.0", "bin", "node");

--- a/src/infra/stable-node-path.ts
+++ b/src/infra/stable-node-path.ts
@@ -7,8 +7,30 @@ import path from "node:path";
  * Resolve these to a stable Homebrew-managed path that survives upgrades:
  *   - Default formula "node":  <prefix>/opt/node/bin/node  or  <prefix>/bin/node
  *   - Versioned formula "node@22":  <prefix>/opt/node@22/bin/node  (keg-only)
+ *
+ * Volta tools/image paths (e.g. ~/.volta/tools/image/node/24.14.0/bin/node)
+ * become stale when Volta pins a different version. Resolve these to the
+ * stable Volta shim at ~/.volta/bin/node which always delegates to the
+ * currently-pinned version.
  */
 export async function resolveStableNodePath(nodePath: string): Promise<string> {
+  // Volta: ~/.volta/tools/image/node/<version>/bin/node[.exe]
+  const voltaImageMatch = nodePath.match(
+    /^(.+?)[/\\]\.volta[/\\]tools[/\\]image[/\\]node[/\\][^/\\]+[/\\]bin[/\\]node(?:\.exe)?$/,
+  );
+  if (voltaImageMatch) {
+    const home = voltaImageMatch[1];
+    const pathModule = nodePath.includes("\\") ? path.win32 : path.posix;
+    const ext = nodePath.endsWith(".exe") ? ".exe" : "";
+    const shimPath = pathModule.join(home, ".volta", "bin", `node${ext}`);
+    try {
+      await fs.access(shimPath);
+      return shimPath;
+    } catch {
+      // Volta shim not accessible; fall through and return original path.
+    }
+  }
+
   const cellarMatch = nodePath.match(
     /^(.+?)[\\/]Cellar[\\/]([^\\/]+)[\\/][^\\/]+[\\/]bin[\\/]node$/,
   );


### PR DESCRIPTION
## Summary

Fixes #52184.

When `resolveStableNodePath` encounters a Volta tools/image path such as
`~/.volta/tools/image/node/24.14.0/bin/node`, it now resolves to the
stable Volta shim at `~/.volta/bin/node` instead.  If the shim is not
accessible the original path is returned unchanged.

## Root Cause

`resolveStableNodePath` already handles Homebrew Cellar paths
(`/opt/homebrew/Cellar/node/VERSION/bin/node → /opt/homebrew/opt/node/bin/node`)
following #32185, but had no equivalent handling for Volta.  Volta's
tools/image directory stores one concrete directory per pinned version; the
version-specific path becomes stale when the pin changes, leaving the
LaunchAgent / systemd unit pointing at an old binary.

The stable Volta shim (`~/.volta/bin/node`) delegates to whichever version is
currently active and survives version upgrades without needing the service to
be reinstalled.

## Changes

- `src/infra/stable-node-path.ts` — detect `~/.volta/tools/image/node/<v>/bin/node[.exe]`
  and resolve to `~/.volta/bin/node[.exe]` when accessible
- `src/infra/stable-node-path.test.ts` — two new tests:
  1. shim accessible → resolved to shim
  2. shim not accessible → original path returned

## Testing


[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/byungskersmacbook/Documents/GitHub/openclaw-contributing[39m

 [32m✓[39m src/infra/stable-node-path.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 7[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m5 passed[39m[22m[90m (5)[39m
[2m   Start at [22m 21:51:08
[2m   Duration [22m 146ms[2m (transform 38ms, setup 44ms, import 10ms, tests 7ms, environment 0ms)[22m


[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/byungskersmacbook/Documents/GitHub/openclaw-contributing[39m

 [32m✓[39m src/daemon/runtime-paths.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 7[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m17 passed[39m[22m[90m (17)[39m
[2m   Start at [22m 21:51:09
[2m   Duration [22m 166ms[2m (transform 55ms, setup 43ms, import 32ms, tests 7ms, environment 0ms)[22m

Pre-existing `pnpm check` errors (`@mariozechner/pi-agent-core`, `zod`,
`@sinclair/typebox`) are unrelated to this change.