### PR TITLE
fix(memory): decay date-prefixed session-memory snapshots

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -512,8 +512,9 @@ With the default half-life of 30 days:
 - Non-dated files in `memory/` (e.g., `memory/projects.md`, `memory/network.md`)
 - These contain durable reference information that should always rank normally.
 
-**Dated daily files** (`memory/YYYY-MM-DD.md`) use the date extracted from the filename.
-Other sources (e.g., session transcripts) fall back to file modification time (`mtime`).
+**Date-prefixed memory files** (for example `memory/YYYY-MM-DD.md` and
+`memory/YYYY-MM-DD-slug.md`) use the date extracted from the filename. Other
+sources (e.g., session transcripts) fall back to file modification time (`mtime`).
 
 **Example -- query: "what's Rod's work schedule?"**
 

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -125,6 +125,26 @@ describe("temporal decay", () => {
     expect(merged[0]?.score ?? 0).toBeGreaterThan(merged[1]?.score ?? 0);
   });
 
+  it("applies decay to date-prefixed session-memory snapshots", async () => {
+    const merged = await mergeVectorResultsWithTemporalDecay([
+      createVectorMemoryEntry({
+        id: "old",
+        path: "memory/2025-01-01-old-passcode.md",
+        snippet: "old passcode",
+        vectorScore: 0.95,
+      }),
+      createVectorMemoryEntry({
+        id: "new",
+        path: "memory/2026-02-10-new-passcode.md",
+        snippet: "new passcode",
+        vectorScore: 0.8,
+      }),
+    ]);
+
+    expect(merged[0]?.path).toBe("memory/2026-02-10-new-passcode.md");
+    expect(merged[0]?.score ?? 0).toBeGreaterThan(merged[1]?.score ?? 0);
+  });
+
   it("handles future dates, zero age, and very old memories", async () => {
     const merged = await mergeVectorResultsWithTemporalDecay([
       createVectorMemoryEntry({
@@ -151,6 +171,25 @@ describe("temporal decay", () => {
     expect(byPath.get("memory/2099-01-01.md")?.score).toBeCloseTo(0.9);
     expect(byPath.get("memory/2026-02-10.md")?.score).toBeCloseTo(0.8);
     expect(byPath.get("memory/2000-01-01.md")?.score ?? 1).toBeLessThan(0.001);
+  });
+
+  it("does not treat non-date-prefixed memory files as dated snapshots", async () => {
+    const dir = await makeTempDir();
+    const topicPath = path.join(dir, "memory", "notes-2026-02-10.md");
+    await fs.mkdir(path.dirname(topicPath), { recursive: true });
+    await fs.writeFile(topicPath, "should stay evergreen");
+
+    const veryOld = new Date(Date.UTC(2010, 0, 1));
+    await fs.utimes(topicPath, veryOld, veryOld);
+
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [{ path: "memory/notes-2026-02-10.md", score: 0.75, source: "memory" }],
+      workspaceDir: dir,
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    expect(decayed[0]?.score).toBeCloseTo(0.75);
   });
 
   it("uses file mtime fallback for non-memory sources", async () => {

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -12,7 +12,7 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})(?:-[^/]+)?\.md$/;
 
 export function toDecayLambda(halfLifeDays: number): number {
   if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {


### PR DESCRIPTION
## Summary

- Problem: builtin temporal decay only recognized exact `memory/YYYY-MM-DD.md` files, while `session-memory` writes date-prefixed snapshots as `memory/YYYY-MM-DD-slug.md`.
- Why it matters: older session-memory snapshots were treated as evergreen memory and could outrank newer corrections in builtin hybrid search.
- What changed: widened the builtin dated-memory matcher so date-prefixed snapshot files also use filename-based temporal decay; added targeted tests and clarified docs.
- What did NOT change (scope boundary): no changes to `session-memory` write behavior, indexing scope, retention/archive behavior, or QMD retrieval behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Docs

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- When builtin temporal decay is enabled, `memory/YYYY-MM-DD-slug.md` files now decay by filename date like daily logs do.
- `MEMORY.md` and non-dated topic files under `memory/` remain evergreen.
- No default behavior changes when temporal decay is disabled.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): builtin memory search with temporal decay enabled

### Steps

1. Create dated memory files under `memory/`, including a session-memory style file like `memory/2025-01-01-old-passcode.md`.
2. Run builtin hybrid search with temporal decay enabled.
3. Compare ranking against a newer file like `memory/2026-02-10-new-passcode.md`.

### Expected

- Date-prefixed session-memory snapshots should decay by filename date, just like `memory/YYYY-MM-DD.md`.
- `MEMORY.md` and non-dated topic files should remain evergreen.

### Actual

- Before this change, only exact `memory/YYYY-MM-DD.md` matched the dated-memory rule.
- `memory/YYYY-MM-DD-slug.md` was treated as evergreen.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Automated:
- `npx pnpm test -- src/memory/temporal-decay.test.ts`

Relevant code paths:
- `src/hooks/bundled/session-memory/handler.ts` writes `memory/YYYY-MM-DD-slug.md`
- `src/memory/internal.ts` recursively indexes `memory/*.md`
- `src/memory/temporal-decay.ts` previously only matched exact `memory/YYYY-MM-DD.md`

## Human Verification (required)

- Verified scenarios: confirmed date-prefixed session-memory snapshots now match the dated-memory decay rule; confirmed targeted temporal decay tests pass.
- Edge cases checked: `MEMORY.md` and `memory/projects.md` remain evergreen; `memory/notes-2026-02-10.md` is not treated as a dated snapshot.
- What you did **not** verify: QMD-specific retrieval behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: disable builtin temporal decay or revert this commit.
- Files/config to restore: `src/memory/temporal-decay.ts`
- Known bad symptoms reviewers should watch for: non-dated memory topic files unexpectedly receiving recency decay.

## Risks and Mitigations

- Risk: broadening the dated-memory matcher could accidentally decay evergreen topic files that merely contain a date-like substring.
  - Mitigation: the matcher only applies to files whose basename starts with `YYYY-MM-DD`, and tests cover non-date-prefixed topic files.
