### PR TITLE
fix(plugins): reuse active registry during tool resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/websocket auth: refresh auth on new websocket connects after secrets reload so rotated gateway tokens take effect immediately without requiring a restart. (#60323) Thanks @mappel-nv.
 - Agents/workspace: respect `agents.defaults.workspace` for non-default agents by resolving them under the configured base path instead of falling back to `workspace-<id>`. (#59858) Thanks @joelnishanth.
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the snapshot during redaction. (#28214) thanks @solodmd.
+- Plugins/runtime: honor explicit capability allowlists during fallback speech, media-understanding, and image-generation provider loading so bundled capability plugins do not bypass restrictive `plugins.allow` config. (#52262) Thanks @PerfectPan.
 
 ## 2026.4.2
 

--- a/src/image-generation/provider-registry.allowlist.test.ts
+++ b/src/image-generation/provider-registry.allowlist.test.ts
@@ -1,0 +1,76 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveRuntimePluginRegistry: vi.fn<
+    (params?: unknown) => ReturnType<typeof createEmptyPluginRegistry> | undefined
+  >(() => undefined),
+  loadPluginManifestRegistry: vi.fn(() => ({ plugins: [], diagnostics: [] })),
+  withBundledPluginEnablementCompat: vi.fn(({ config }) => config),
+  withBundledPluginVitestCompat: vi.fn(({ config }) => config),
+}));
+
+vi.mock("../plugins/loader.js", () => ({
+  resolveRuntimePluginRegistry: mocks.resolveRuntimePluginRegistry,
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
+}));
+
+vi.mock("../plugins/bundled-compat.js", () => ({
+  withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
+  withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
+}));
+
+let getImageGenerationProvider: typeof import("./provider-registry.js").getImageGenerationProvider;
+let listImageGenerationProviders: typeof import("./provider-registry.js").listImageGenerationProviders;
+
+describe("image-generation provider registry allowlist fallback", () => {
+  beforeAll(async () => {
+    ({ getImageGenerationProvider, listImageGenerationProviders } =
+      await import("./provider-registry.js"));
+  });
+
+  beforeEach(() => {
+    mocks.resolveRuntimePluginRegistry.mockReset();
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(undefined);
+    mocks.loadPluginManifestRegistry.mockReset();
+    mocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });
+    mocks.withBundledPluginEnablementCompat.mockReset();
+    mocks.withBundledPluginEnablementCompat.mockImplementation(({ config }) => config);
+    mocks.withBundledPluginVitestCompat.mockReset();
+    mocks.withBundledPluginVitestCompat.mockImplementation(({ config }) => config);
+  });
+
+  it("honors explicit allowlists when fallback loading bundled providers", () => {
+    const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
+    const compatConfig = {
+      plugins: {
+        allow: ["custom-plugin"],
+        entries: { openai: { enabled: true } },
+      },
+    };
+
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { imageGenerationProviders: ["openai"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(compatConfig);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(compatConfig);
+    mocks.resolveRuntimePluginRegistry.mockImplementation(() => createEmptyPluginRegistry());
+
+    expect(listImageGenerationProviders(cfg)).toEqual([]);
+    expect(getImageGenerationProvider("openai", cfg)).toBeUndefined();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      config: compatConfig,
+    });
+  });
+});

--- a/src/media-understanding/provider-registry.allowlist.test.ts
+++ b/src/media-understanding/provider-registry.allowlist.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveRuntimePluginRegistry: vi.fn<
+    (params?: unknown) => ReturnType<typeof createEmptyPluginRegistry> | undefined
+  >(() => undefined),
+  loadPluginManifestRegistry: vi.fn(() => ({ plugins: [], diagnostics: [] })),
+  withBundledPluginEnablementCompat: vi.fn(({ config }) => config),
+  withBundledPluginVitestCompat: vi.fn(({ config }) => config),
+}));
+
+vi.mock("../plugins/loader.js", () => ({
+  resolveRuntimePluginRegistry: mocks.resolveRuntimePluginRegistry,
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
+}));
+
+vi.mock("../plugins/bundled-compat.js", () => ({
+  withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
+  withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
+}));
+
+let buildMediaUnderstandingRegistry: typeof import("./provider-registry.js").buildMediaUnderstandingRegistry;
+let getMediaUnderstandingProvider: typeof import("./provider-registry.js").getMediaUnderstandingProvider;
+
+describe("media-understanding provider registry allowlist fallback", () => {
+  beforeAll(async () => {
+    ({ buildMediaUnderstandingRegistry, getMediaUnderstandingProvider } =
+      await import("./provider-registry.js"));
+  });
+
+  beforeEach(() => {
+    mocks.resolveRuntimePluginRegistry.mockReset();
+    mocks.resolveRuntimePluginRegistry.mockReturnValue(undefined);
+    mocks.loadPluginManifestRegistry.mockReset();
+    mocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });
+    mocks.withBundledPluginEnablementCompat.mockReset();
+    mocks.withBundledPluginEnablementCompat.mockImplementation(({ config }) => config);
+    mocks.withBundledPluginVitestCompat.mockReset();
+    mocks.withBundledPluginVitestCompat.mockImplementation(({ config }) => config);
+  });
+
+  it("honors explicit allowlists when fallback loading bundled providers", () => {
+    const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
+    const compatConfig = {
+      plugins: {
+        allow: ["custom-plugin"],
+        entries: { openai: { enabled: true } },
+      },
+    };
+
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openai",
+          origin: "bundled",
+          contracts: { mediaUnderstandingProviders: ["openai"] },
+        },
+      ] as never,
+      diagnostics: [],
+    });
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(compatConfig);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(compatConfig);
+    mocks.resolveRuntimePluginRegistry.mockImplementation(() => createEmptyPluginRegistry());
+
+    const registry = buildMediaUnderstandingRegistry(undefined, cfg);
+
+    expect(getMediaUnderstandingProvider("openai", registry)).toBeUndefined();
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      config: compatConfig,
+    });
+  });
+});

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -18,7 +18,6 @@ const mocks = vi.hoisted(() => ({
   loadPluginManifestRegistry: vi.fn<() => MockManifestRegistry>(() =>
     createEmptyMockManifestRegistry(),
   ),
-  withBundledPluginAllowlistCompat: vi.fn(({ config }) => config),
   withBundledPluginEnablementCompat: vi.fn(({ config }) => config),
   withBundledPluginVitestCompat: vi.fn(({ config }) => config),
 }));
@@ -32,7 +31,6 @@ vi.mock("./manifest-registry.js", () => ({
 }));
 
 vi.mock("./bundled-compat.js", () => ({
-  withBundledPluginAllowlistCompat: mocks.withBundledPluginAllowlistCompat,
   withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
   withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
 }));
@@ -49,10 +47,9 @@ function expectNoResolvedCapabilityProviders(providers: Array<{ id: string }>) {
 
 function expectBundledCompatLoadPath(params: {
   cfg: OpenClawConfig;
-  allowlistCompat: { plugins: { allow: string[] } };
   enablementCompat: {
     plugins: {
-      allow: string[];
+      allow?: string[];
       entries: { openai: { enabled: boolean } };
     };
   };
@@ -61,12 +58,8 @@ function expectBundledCompatLoadPath(params: {
     config: params.cfg,
     env: process.env,
   });
-  expect(mocks.withBundledPluginAllowlistCompat).toHaveBeenCalledWith({
-    config: params.cfg,
-    pluginIds: ["openai"],
-  });
   expect(mocks.withBundledPluginEnablementCompat).toHaveBeenCalledWith({
-    config: params.allowlistCompat,
+    config: params.cfg,
     pluginIds: ["openai"],
   });
   expect(mocks.withBundledPluginVitestCompat).toHaveBeenCalledWith({
@@ -81,14 +74,13 @@ function expectBundledCompatLoadPath(params: {
 
 function createCompatChainConfig() {
   const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
-  const allowlistCompat = { plugins: { allow: ["custom-plugin", "openai"] } };
   const enablementCompat = {
     plugins: {
-      allow: ["custom-plugin", "openai"],
+      allow: ["custom-plugin"],
       entries: { openai: { enabled: true } },
     },
   };
-  return { cfg, allowlistCompat, enablementCompat };
+  return { cfg, enablementCompat };
 }
 
 function setBundledCapabilityFixture(contractKey: string) {
@@ -113,16 +105,14 @@ function expectCompatChainApplied(params: {
   key: "speechProviders" | "mediaUnderstandingProviders" | "imageGenerationProviders";
   contractKey: string;
   cfg: OpenClawConfig;
-  allowlistCompat: { plugins: { allow: string[] } };
   enablementCompat: {
     plugins: {
-      allow: string[];
+      allow?: string[];
       entries: { openai: { enabled: boolean } };
     };
   };
 }) {
   setBundledCapabilityFixture(params.contractKey);
-  mocks.withBundledPluginAllowlistCompat.mockReturnValue(params.allowlistCompat);
   mocks.withBundledPluginEnablementCompat.mockReturnValue(params.enablementCompat);
   mocks.withBundledPluginVitestCompat.mockReturnValue(params.enablementCompat);
   expectNoResolvedCapabilityProviders(
@@ -141,8 +131,6 @@ describe("resolvePluginCapabilityProviders", () => {
     mocks.resolveRuntimePluginRegistry.mockReturnValue(undefined);
     mocks.loadPluginManifestRegistry.mockReset();
     mocks.loadPluginManifestRegistry.mockReturnValue(createEmptyMockManifestRegistry());
-    mocks.withBundledPluginAllowlistCompat.mockReset();
-    mocks.withBundledPluginAllowlistCompat.mockImplementation(({ config }) => config);
     mocks.withBundledPluginEnablementCompat.mockReset();
     mocks.withBundledPluginEnablementCompat.mockImplementation(({ config }) => config);
     mocks.withBundledPluginVitestCompat.mockReset();
@@ -216,13 +204,43 @@ describe("resolvePluginCapabilityProviders", () => {
     ["mediaUnderstandingProviders", "mediaUnderstandingProviders"],
     ["imageGenerationProviders", "imageGenerationProviders"],
   ] as const)("applies bundled compat before fallback loading for %s", (key, contractKey) => {
-    const { cfg, allowlistCompat, enablementCompat } = createCompatChainConfig();
+    const { cfg, enablementCompat } = createCompatChainConfig();
     expectCompatChainApplied({
       key,
       contractKey,
       cfg,
-      allowlistCompat,
       enablementCompat,
+    });
+  });
+
+  it("does not re-add bundled capability plugins excluded by an explicit allowlist", () => {
+    const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
+    const enablementCompat = {
+      plugins: {
+        allow: ["custom-plugin"],
+        entries: { openai: { enabled: true } },
+      },
+    };
+
+    setBundledCapabilityFixture("speechProviders");
+    mocks.withBundledPluginEnablementCompat.mockReturnValue(enablementCompat);
+    mocks.withBundledPluginVitestCompat.mockReturnValue(enablementCompat);
+
+    expectNoResolvedCapabilityProviders(
+      resolvePluginCapabilityProviders({ key: "speechProviders", cfg }),
+    );
+
+    expect(mocks.withBundledPluginEnablementCompat).toHaveBeenCalledWith({
+      config: cfg,
+      pluginIds: ["openai"],
+    });
+    expect(mocks.withBundledPluginVitestCompat).toHaveBeenCalledWith({
+      config: enablementCompat,
+      pluginIds: ["openai"],
+      env: process.env,
+    });
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
+      config: enablementCompat,
     });
   });
 

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -1,6 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  withBundledPluginAllowlistCompat,
   withBundledPluginEnablementCompat,
   withBundledPluginVitestCompat,
 } from "./bundled-compat.js";
@@ -48,12 +47,8 @@ function resolveCapabilityProviderConfig(params: {
   cfg?: OpenClawConfig;
 }) {
   const pluginIds = resolveBundledCapabilityCompatPluginIds(params);
-  const allowlistCompat = withBundledPluginAllowlistCompat({
-    config: params.cfg,
-    pluginIds,
-  });
   const enablementCompat = withBundledPluginEnablementCompat({
-    config: allowlistCompat,
+    config: params.cfg,
     pluginIds,
   });
   return withBundledPluginVitestCompat({


### PR DESCRIPTION
## Summary
- add `resolveEffectivePluginRegistry()` as the single place that decides whether to reuse the active registry or perform a fallback plugin load
- - make tool resolution and plugin-backed provider registries share that same effective-registry logic
- - reuse the active registry only after the runtime has explicitly loaded one, while preserving the existing fallback load behavior when startup has not done that yet
## Why

This fixes #52250.

In the broken path, a later tool-resolution step could reload plugins under a different state/workspace context and replace the process-global active plugin registry. After that, plugin-backed channels such as `feishu` could become unknown in subagent flows.

The earlier `activate: false, cache: false` approach avoided the overwrite, but it also rebuilt a second registry and could split stateful plugin runtime/service instances. This version fixes the same bug by converging all hot paths on a single effective-registry resolver instead.

## Verification
- `pnpm exec vitest run src/plugins/runtime.test.ts src/plugins/tools.optional.test.ts src/image-generation/provider-registry.test.ts src/tts/provider-registry.test.ts src/media-understanding/providers/index.loader.test.ts src/gateway/server-methods/tools-catalog.test.ts src/agents/openclaw-tools.plugin-context.test.ts`
- - validated against the standalone repro fixture at https://github.com/PerfectPan/openclaw-repro-plugin-registry-subagent
- - on the relative-state-dir repro path, the channel remained known after tool resolution (`before=true`, `after=true`)