### PR TITLE
ci: hydrate dist before plugin-sdk test lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
           path: dist/
 
       - name: Build dist
-        if: github.event_name != 'push' && matrix.task == 'test'
+        if: github.event_name != 'push' && matrix.task == 'test' && matrix.runtime == 'node'
         run: pnpm build
 
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,8 @@ jobs:
         run: pnpm release:check
 
   checks:
-    needs: [docs-scope, changed-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true'
+    needs: [docs-scope, changed-scope, build-artifacts]
+    if: always() && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_node == 'true' && (github.event_name != 'push' || needs.build-artifacts.result == 'success')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     strategy:
       fail-fast: false
@@ -262,6 +262,17 @@ jobs:
             echo "OPENCLAW_TEST_SHARDS=$SHARD_COUNT" >> "$GITHUB_ENV"
             echo "OPENCLAW_TEST_SHARD_INDEX=$SHARD_INDEX" >> "$GITHUB_ENV"
           fi
+
+      - name: Download dist artifact
+        if: github.event_name == 'push' && matrix.task == 'test'
+        uses: actions/download-artifact@v8
+        with:
+          name: dist-build
+          path: dist/
+
+      - name: Build dist
+        if: github.event_name != 'push' && matrix.task == 'test'
+        run: pnpm build
 
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         if: github.event_name != 'pull_request' || (matrix.runtime != 'bun' && matrix.task != 'compat-node22')
@@ -570,8 +581,8 @@ jobs:
         run: pre-commit run --all-files pnpm-audit-prod
 
   checks-windows:
-    needs: [docs-scope, changed-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true'
+    needs: [docs-scope, changed-scope, build-artifacts]
+    if: always() && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_windows == 'true' && (github.event_name != 'push' || needs.build-artifacts.result == 'success')
     runs-on: blacksmith-32vcpu-windows-2025
     timeout-minutes: 45
     env:
@@ -690,6 +701,17 @@ jobs:
       - name: Build A2UI bundle (Windows)
         if: matrix.task == 'test'
         run: pnpm canvas:a2ui:bundle
+
+      - name: Download dist artifact
+        if: github.event_name == 'push' && matrix.task == 'test'
+        uses: actions/download-artifact@v8
+        with:
+          name: dist-build
+          path: dist/
+
+      - name: Build dist (Windows)
+        if: github.event_name != 'push' && matrix.task == 'test'
+        run: pnpm build
 
       - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
         run: ${{ matrix.command }}


### PR DESCRIPTION
## Summary
- make Linux and Bun test lanes depend on the shared dist artifact on push
- build dist locally for test lanes on pull requests where the shared artifact is not produced
- hydrate the Windows test shards the same way so plugin-sdk subpath tests resolve package exports consistently

## Verification
- reproduced the current main failure from a clean origin/main worktree with 
> openclaw@2026.3.14 test /Users/thoffman/openclaw/.worktrees/fix-main-ci-plugin-sdk
> node scripts/test-parallel.mjs -- src/plugin-sdk/subpaths.test.ts

[test-parallel] start unit-threads workers=1 filters=1

 RUN  v4.1.0 /Users/thoffman/openclaw/.worktrees/fix-main-ci-plugin-sdk


 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  08:40:03
   Duration  766ms (transform 865ms, setup 28ms, import 12ms, tests 675ms, environment 0ms)

[test-parallel] done unit-threads code=0 elapsed=1.3s and no 
- confirmed the same test passes once  exists
-  hook checks passed for the workflow change