### PR TITLE
Docs: align MiniMax examples with M2.7

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2148,12 +2148,11 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
 
   <Accordion title='Why do I see "Unknown model: minimax/MiniMax-M2.7"?'>
     This means the **provider isn't configured** (no MiniMax provider config or auth
-    profile was found), so the model can't be resolved. A fix for this detection is
-    in **2026.1.12** (unreleased at the time of writing).
+    profile was found), so the model can't be resolved.
 
     Fix checklist:
 
-    1. Upgrade to **2026.1.12** (or run from source `main`), then restart the gateway.
+    1. Upgrade to a current OpenClaw release (or run from source `main`), then restart the gateway.
     2. Make sure MiniMax is configured (wizard or JSON), or that a MiniMax API key
        exists in env/auth profiles so the provider can be injected.
     3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.7`,

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -283,7 +283,7 @@ Narrow, explicit allowlists are fastest and least flaky:
   - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Tool calling across several providers:
-  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3-flash-preview,zai/glm-4.7,minimax/minimax-m2.5" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+  - `OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,anthropic/claude-opus-4-6,google/gemini-3-flash-preview,zai/glm-4.7,minimax/MiniMax-M2.7" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 - Google focus (Gemini API key + Antigravity):
   - Gemini (API key): `OPENCLAW_LIVE_GATEWAY_MODELS="google/gemini-3-flash-preview" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
@@ -312,10 +312,10 @@ This is the “common models” run we expect to keep working:
 - Google (Gemini API): `google/gemini-3.1-pro-preview` and `google/gemini-3-flash-preview` (avoid older Gemini 2.x models)
 - Google (Antigravity): `google-antigravity/claude-opus-4-6-thinking` and `google-antigravity/gemini-3-flash`
 - Z.AI (GLM): `zai/glm-4.7`
-- MiniMax: `minimax/minimax-m2.5`
+- MiniMax: `minimax/MiniMax-M2.7`
 
 Run gateway smoke with tools + image:
-`OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.4,anthropic/claude-opus-4-6,google/gemini-3.1-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,zai/glm-4.7,minimax/minimax-m2.5" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
+`OPENCLAW_LIVE_GATEWAY_MODELS="openai/gpt-5.2,openai-codex/gpt-5.4,anthropic/claude-opus-4-6,google/gemini-3.1-pro-preview,google/gemini-3-flash-preview,google-antigravity/claude-opus-4-6-thinking,google-antigravity/gemini-3-flash,zai/glm-4.7,minimax/MiniMax-M2.7" pnpm test:live src/gateway/gateway-models.profiles.live.test.ts`
 
 ### Baseline: tool calling (Read + optional Exec)
 
@@ -325,7 +325,7 @@ Pick at least one per provider family:
 - Anthropic: `anthropic/claude-opus-4-6` (or `anthropic/claude-sonnet-4-6`)
 - Google: `google/gemini-3-flash-preview` (or `google/gemini-3.1-pro-preview`)
 - Z.AI (GLM): `zai/glm-4.7`
-- MiniMax: `minimax/minimax-m2.5`
+- MiniMax: `minimax/MiniMax-M2.7`
 
 Optional additional coverage (nice to have):
 


### PR DESCRIPTION
## Summary

- Problem: MiniMax live test examples in the docs still used `minimax/minimax-m2.5`, while the current built-in MiniMax provider docs and config use case-sensitive `minimax/MiniMax-M2.7`.
- Why it matters: users copying the old example can hit an unknown-model mismatch and get confused.
- What changed: updated MiniMax live test examples to `minimax/MiniMax-M2.7` and removed an outdated “unreleased at the time of writing” note from the FAQ.
- What did NOT change (scope boundary): no runtime code, provider logic, or model catalog behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Docs now point users to the current MiniMax hosted default model ID in live test examples and no longer mention an outdated unreleased version note.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local docs edit only
- Model/provider: MiniMax docs/examples
- Integration/channel (if any): None
- Relevant config (redacted): None

### Steps

1. Open `docs/help/testing.md`.
2. Open `docs/help/faq.md`.
3. Compare the MiniMax examples and FAQ wording with the current MiniMax provider docs/defaults.

### Expected

- MiniMax live test examples use a current supported case-sensitive model ID.
- FAQ wording does not mention an outdated unreleased fix.

### Actual

- Updated examples now use `minimax/MiniMax-M2.7`.
- Removed the outdated unreleased note and generalized the upgrade guidance.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked the updated docs against the current MiniMax provider defaults in the repo.
- Edge cases checked: confirmed the edited files no longer contain `minimax/minimax-m2.5` or the outdated unreleased note.
- What you did **not** verify: full docs site render/build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this docs-only commit.
- Files/config to restore: `docs/help/testing.md`, `docs/help/faq.md`
- Known bad symptoms reviewers should watch for: none beyond doc wording disagreements.

## Risks and Mitigations

- Risk: doc examples could still diverge later if MiniMax defaults change again.
  - Mitigation: examples now match the current provider docs and hosted default model.
