### PR TITLE
feat(web-fetch): add ssrfPolicy config option

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -458,6 +458,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  ssrfPolicy?: SsrFPolicy;
 };
 
 function toFirecrawlContentParams(
@@ -539,6 +540,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      policy: params.ssrfPolicy,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -795,6 +797,7 @@ export function createWebFetchTool(options?: {
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
         firecrawlTimeoutSeconds,
+        ssrfPolicy: fetch?.ssrfPolicy,
       });
       return jsonResult(result);
     },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -505,6 +505,19 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** SSRF policy for web fetch tool. */
+      ssrfPolicy?: {
+        /** Allow private network addresses. */
+        allowPrivateNetwork?: boolean;
+        /** Dangerously allow private network addresses (legacy alias). */
+        dangerouslyAllowPrivateNetwork?: boolean;
+        /** Allow RFC 2544 benchmark range (198.18.x.x) used by TUN-mode DNS hijacking. */
+        allowRfc2544BenchmarkRange?: boolean;
+        /** Explicitly allowed hostnames. */
+        allowedHostnames?: string[];
+        /** Hostname allowlist patterns. */
+        hostnameAllowlist?: string[];
+      };
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -322,6 +322,17 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+const SsrFPolicySchema = z
+  .object({
+    allowPrivateNetwork: z.boolean().optional(),
+    dangerouslyAllowPrivateNetwork: z.boolean().optional(),
+    allowRfc2544BenchmarkRange: z.boolean().optional(),
+    allowedHostnames: z.array(z.string()).optional(),
+    hostnameAllowlist: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -332,6 +343,7 @@ export const ToolsWebFetchSchema = z
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
     readability: z.boolean().optional(),
+    ssrfPolicy: SsrFPolicySchema,
     firecrawl: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
**Problem:**
- web_fetch tool blocks requests when DNS is hijacked by proxy tools (Shadowrocket, Clash, etc.)
- These tools use TUN mode with fake DNS that returns 198.18.x.x (RFC 2544 benchmark range)
- The SSRF protection blocks these IPs as "private/internal/special-use"
- browser.ssrfPolicy config only affects browser operations, not web_fetch

**Solution:**
- Add ssrfPolicy field to tools.web.fetch config
- Pass the policy to fetchWithWebToolsNetworkGuard
- Users can now configure:

```json
{
  "tools": {
    "web": {
      "fetch": {
        "ssrfPolicy": {
          "allowRfc2544BenchmarkRange": true
        }
      }
    }
  }
}
```

**Changes:**
- src/agents/tools/web-fetch.ts: Import SsrFPolicy type, add to params, pass to guard
- src/config/types.tools.ts: Add ssrfPolicy type definition
- src/config/zod-schema.agent-runtime.ts: Add SsrFPolicySchema and ssrfPolicy field

**Note:**
- `config-docs-drift` check will fail until baseline is regenerated
- Maintainer: please run `pnpm build` to regenerate `docs/.generated/config-baseline.*`

**Testing:**
- Manually tested with Shadowrocket TUN mode DNS hijacking
- xhslink.com (and other short links) now work with allowRfc2544BenchmarkRange: true