### PR TITLE
Android: fix MediaPlayer double-release race in TalkModeManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,7 @@ Docs: https://docs.openclaw.ai
 - Android/theme: switch status bar icon contrast with the active system theme so Android light mode no longer leaves unreadable light icons over the app header. (#51098) Thanks @goweii.
 - Discord/ACP: forward worker abort signals into ACP turns so timed-out Discord jobs cancel the running turn instead of silently leaving the bound ACP session working in the background.
 - Gateway/openresponses: preserve assistant commentary and session continuity across hosted-tool `/v1/responses` turns, and emit streamed tool-call payloads before finalization so client tool loops stay resumable. (#52171) Thanks @CharZhou.
+- Android/Talk: serialize `TalkModeManager` player teardown so rapid interrupt/restart cycles stop double-releasing or overlapping TTS playback. (#52310) Thanks @Kaneki-x.
 
 ### Breaking
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -23,7 +23,6 @@ import ai.openclaw.app.isCanonicalMainSessionKey
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -105,7 +104,8 @@ class TalkModeManager(
   private val playbackGeneration = AtomicLong(0L)
 
   private var ttsJob: Job? = null
-  private val player = AtomicReference<MediaPlayer?>(null)
+  private val playerLock = Any()
+  private var player: MediaPlayer? = null
   @Volatile private var finalizeInFlight = false
   private var listenWatchdogJob: Job? = null
 
@@ -764,7 +764,9 @@ class TalkModeManager(
     try {
       withContext(Dispatchers.IO) { tempFile.writeBytes(audioBytes) }
       val player = MediaPlayer()
-      this.player.set(player)
+      synchronized(playerLock) {
+        this.player = player
+      }
       val finished = CompletableDeferred<Unit>()
       player.setAudioAttributes(
         AudioAttributes.Builder()
@@ -785,7 +787,7 @@ class TalkModeManager(
       ensurePlaybackActive(playbackToken)
     } finally {
       try {
-        cleanupPlayer()
+        cleanupPlayer(player)
       } catch (_: Throwable) {}
       tempFile.delete()
     }
@@ -822,9 +824,11 @@ class TalkModeManager(
       return
     }
     if (resetInterrupt) {
-      val currentMs = try {
-        player.get()?.currentPosition?.toDouble() ?: 0.0
-      } catch (_: IllegalStateException) { 0.0 }
+      val currentMs = synchronized(playerLock) {
+        try {
+          player?.currentPosition?.toDouble() ?: 0.0
+        } catch (_: IllegalStateException) { 0.0 }
+      }
       lastInterruptedAtSeconds = currentMs / 1000.0
     }
     cleanupPlayer()
@@ -867,13 +871,16 @@ class TalkModeManager(
     audioFocusRequest = null
   }
 
-  private fun cleanupPlayer() {
-    // Atomically take ownership so concurrent callers don't double-release
-    val p = player.getAndSet(null) ?: return
-    try {
-      p.stop()
-    } catch (_: IllegalStateException) {}
-    p.release()
+  private fun cleanupPlayer(expectedPlayer: MediaPlayer? = null) {
+    synchronized(playerLock) {
+      val p = player ?: return
+      if (expectedPlayer != null && p !== expectedPlayer) return
+      player = null
+      try {
+        p.stop()
+      } catch (_: IllegalStateException) {}
+      p.release()
+    }
   }
 
   private fun shouldInterrupt(transcript: String): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -23,6 +23,7 @@ import ai.openclaw.app.isCanonicalMainSessionKey
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -104,7 +105,7 @@ class TalkModeManager(
   private val playbackGeneration = AtomicLong(0L)
 
   private var ttsJob: Job? = null
-  private var player: MediaPlayer? = null
+  private val player = AtomicReference<MediaPlayer?>(null)
   @Volatile private var finalizeInFlight = false
   private var listenWatchdogJob: Job? = null
 
@@ -763,7 +764,7 @@ class TalkModeManager(
     try {
       withContext(Dispatchers.IO) { tempFile.writeBytes(audioBytes) }
       val player = MediaPlayer()
-      this.player = player
+      this.player.set(player)
       val finished = CompletableDeferred<Unit>()
       player.setAudioAttributes(
         AudioAttributes.Builder()
@@ -821,7 +822,7 @@ class TalkModeManager(
       return
     }
     if (resetInterrupt) {
-      val currentMs = player?.currentPosition?.toDouble() ?: 0.0
+      val currentMs = player.get()?.currentPosition?.toDouble() ?: 0.0
       lastInterruptedAtSeconds = currentMs / 1000.0
     }
     cleanupPlayer()
@@ -865,9 +866,12 @@ class TalkModeManager(
   }
 
   private fun cleanupPlayer() {
-    player?.stop()
-    player?.release()
-    player = null
+    // Atomically take ownership so concurrent callers don't double-release
+    val p = player.getAndSet(null) ?: return
+    try {
+      p.stop()
+    } catch (_: IllegalStateException) {}
+    p.release()
   }
 
   private fun shouldInterrupt(transcript: String): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -822,7 +822,9 @@ class TalkModeManager(
       return
     }
     if (resetInterrupt) {
-      val currentMs = player.get()?.currentPosition?.toDouble() ?: 0.0
+      val currentMs = try {
+        player.get()?.currentPosition?.toDouble() ?: 0.0
+      } catch (_: IllegalStateException) { 0.0 }
       lastInterruptedAtSeconds = currentMs / 1000.0
     }
     cleanupPlayer()


### PR DESCRIPTION
## Summary

Fixes a race condition in `TalkModeManager.cleanupPlayer()` where concurrent callers (coroutine teardown in `playGatewaySpeech` finally block, `stopSpeaking` from UI/audio focus loss, etc.) could both attempt to stop/release the same `MediaPlayer` instance.

- Promotes `player` from a plain nullable `var` to `AtomicReference<MediaPlayer?>` so `getAndSet(null)` atomically transfers ownership — only one cleanup path ever holds the player reference.
- Adds `IllegalStateException` guard around `stop()` since the player may already be in an error/end state.
- Reads `currentPosition` via `player.get()?.currentPosition` to safely handle concurrent release.

This is the same class of bug fixed in the now-deleted `ElevenLabsStreamingTts` (see #45815) — the race carried over to the replacement `TalkModeManager` gateway playback path. Also supersedes #41904 (backward seek crash in `StreamingMediaDataSource`, which was deleted along with the legacy stack and is no longer applicable).

## Test plan

- [ ] Start TTS playback on Android, rapidly interrupt with voice/tap to exercise concurrent cleanup paths
- [ ] Verify no `IllegalStateException` crashes in logcat during rapid stop/start cycles
- [ ] Verify normal playback completion still works (no premature release)