### PR TITLE
Android: make current-location callback cancellation-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Android/pairing: resolve portless secure setup URLs to `443` while preserving direct cleartext gateway defaults and explicit `:80` manual endpoints in onboarding. (#43540) Thanks @fmercurio.
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.
 - CLI/Ollama onboarding: keep the interactive model picker for explicit `openclaw onboard --auth-choice ollama` runs so setup still selects a default model without reintroducing pre-picker auto-pulls. (#49249) Thanks @BruceMacD.
+- Android/location: make current-location requests drop late callbacks after timeout instead of crashing with `Already resumed`. (#52318) Thanks @Kaneki-x.
 - Plugins/bundler TDZ: fix `RESERVED_COMMANDS` temporal dead zone error that prevented device-pair, phone-control, and talk-voice plugins from registering when the bundler placed the commands module after call sites in the same output chunk. Thanks @BunsDev.
 - Plugins/imports: fix stale googlechat runtime-api import paths and signal SDK circular re-exports broken by recent plugin-sdk refactors. Thanks @BunsDev.
 - Telegram/setup: seed fresh setups with `channels.telegram.groups["*"].requireMention=true` so new bots stay mention-gated in groups unless you explicitly open them up. Thanks @vincentkoc.

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationCaptureManager.kt
@@ -12,8 +12,6 @@ import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
 
 class LocationCaptureManager(private val context: Context) {
@@ -100,18 +98,15 @@ class LocationCaptureManager(private val context: Context) {
     val resolved =
       providers.firstOrNull { manager.isProviderEnabled(it) }
         ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no providers available")
-    return withTimeout(timeoutMs.coerceAtLeast(1)) {
-      suspendCancellableCoroutine { cont ->
+    val location = withTimeout(timeoutMs.coerceAtLeast(1)) {
+      suspendCancellableCoroutine<Location?> { cont ->
         val signal = CancellationSignal()
         cont.invokeOnCancellation { signal.cancel() }
         manager.getCurrentLocation(resolved, signal, context.mainExecutor) { location ->
-          if (location != null) {
-            cont.resume(location)
-          } else {
-            cont.resumeWithException(IllegalStateException("LOCATION_UNAVAILABLE: no fix"))
-          }
+          cont.resume(location) { _, _, _ -> }
         }
       }
     }
+    return location ?: throw IllegalStateException("LOCATION_UNAVAILABLE: no fix")
   }
 }


### PR DESCRIPTION
## Summary

Fixes a race condition in `LocationCaptureManager.requestCurrent()` where `getCurrentLocation()` could still invoke its callback after `withTimeout()` had already cancelled the continuation, crashing with `Already resumed`.

- Uses the cancellation-safe `cont.resume(location) { _, _, _ -> }` overload so delayed callbacks are safely dropped instead of crashing
- Moves the `null` location guard to after the suspension point, preserving the existing `LOCATION_UNAVAILABLE: no fix` behavior
- Removes unused `kotlin.coroutines.resume` / `resumeWithException` imports

Resubmission of #45821 (closed due to `r: too-many-prs`), with the indentation fix from Greptile's review applied.

## Test plan

- [ ] Verify location capture works normally on Android
- [ ] Trigger timeout scenario (e.g. indoors with GPS-only provider) to verify no `Already resumed` crash
- [ ] Verify `null` location still produces `LOCATION_UNAVAILABLE: no fix` error