### PR TITLE
fix(gateway): trim startup plugin imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 - CLI/auth choice: lazy-load plugin/provider fallback resolution so mapped auth choices stay on the static path and only unknown choices pay the heavy provider load. (#47495) Thanks @vincentkoc.
 - CLI: avoid loading provider discovery during startup model normalization. (#46522) Thanks @ItsAditya-xyz and @vincentkoc.
 - Agents/Telegram: avoid rebuilding the full model catalog on ordinary inbound replies so Telegram message handling no longer pays multi-second core startup latency before reply generation. Thanks @vincentkoc.
+- Gateway/Discord startup: load only configured channel plugins during gateway boot, and lazy-load Discord provider/session runtime setup so startup stops importing unrelated providers and trims cold-start delay. Thanks @vincentkoc.
 - Agents/inbound: lazy-load media and link understanding for plain-text turns and cache synced auth stores by auth-file state so ordinary inbound replies avoid unnecessary startup churn. Thanks @vincentkoc.
 - Telegram/polling: hard-timeout stuck `getUpdates` requests so wedged network paths fail over sooner instead of waiting for the polling stall watchdog. Thanks @vincentkoc.
 - Agents/models: cache `models.json` readiness by config and auth-file state so embedded runner turns stop paying repeated model-catalog startup work before replies. Thanks @vincentkoc.

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -18,8 +18,8 @@ vi.mock("./probe.js", async (importOriginal) => {
   };
 });
 
-vi.mock("./monitor.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./monitor.js")>();
+vi.mock("./monitor/provider.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./monitor/provider.runtime.js")>();
   return {
     ...actual,
     monitorDiscordProvider: monitorDiscordProviderMock,

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -20,7 +20,7 @@ import {
 import {
   createRuntimeOutboundDelegates,
   resolveOutboundSendDep,
-} from "openclaw/plugin-sdk/outbound-runtime";
+} from "openclaw/plugin-sdk/infra-runtime";
 import {
   buildOutboundBaseSessionKey,
   normalizeMessageChannel,
@@ -77,8 +77,13 @@ type DiscordSendFn = ReturnType<
   typeof getDiscordRuntime
 >["channel"]["discord"]["sendMessageDiscord"];
 
+let discordProviderRuntimePromise:
+  | Promise<typeof import("./monitor/provider.runtime.js")>
+  | undefined;
+
 async function loadDiscordProviderRuntime() {
-  return await import("./monitor/provider.runtime.js");
+  discordProviderRuntimePromise ??= import("./monitor/provider.runtime.js");
+  return await discordProviderRuntimePromise;
 }
 
 const meta = getChatChannelMeta("discord");
@@ -89,12 +94,7 @@ const resolveDiscordDmPolicy = createScopedDmSecurityResolver<ResolvedDiscordAcc
   resolvePolicy: (account) => account.config.dm?.policy,
   resolveAllowFrom: (account) => account.config.dm?.allowFrom,
   allowFromPathSuffix: "dm.",
-  normalizeEntry: (raw) =>
-    raw
-      .trim()
-      .replace(/^(discord|user):/i, "")
-      .trim()
-      .replace(/^<@!?(\d+)>$/, "$1"),
+  normalizeEntry: (raw) => raw.replace(/^(discord|user):/i, "").replace(/^<@!?(\d+)>$/, "$1"),
 });
 
 function formatDiscordIntents(intents?: {

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -46,7 +46,6 @@ import {
   resolveDiscordGroupRequireMention,
   resolveDiscordGroupToolPolicy,
 } from "./group-policy.js";
-import { monitorDiscordProvider } from "./monitor.js";
 import {
   looksLikeDiscordTargetId,
   normalizeDiscordMessagingTarget,
@@ -77,6 +76,10 @@ import { DiscordUiContainer } from "./ui.js";
 type DiscordSendFn = ReturnType<
   typeof getDiscordRuntime
 >["channel"]["discord"]["sendMessageDiscord"];
+
+async function loadDiscordProviderRuntime() {
+  return await import("./monitor/provider.runtime.js");
+}
 
 const meta = getChatChannelMeta("discord");
 const REQUIRED_DISCORD_PERMISSIONS = ["ViewChannel", "SendMessages"] as const;
@@ -684,7 +687,7 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
         }
       }
       ctx.log?.info(`[${account.accountId}] starting provider${discordBotLabel}`);
-      return monitorDiscordProvider({
+      return (await loadDiscordProviderRuntime()).monitorDiscordProvider({
         token,
         accountId: account.accountId,
         config: ctx.cfg,

--- a/extensions/discord/src/monitor/provider-session.runtime.ts
+++ b/extensions/discord/src/monitor/provider-session.runtime.ts
@@ -1,0 +1,12 @@
+export { getAcpSessionManager, isAcpRuntimeError } from "openclaw/plugin-sdk/acp-runtime";
+export {
+  resolveThreadBindingIdleTimeoutMs,
+  resolveThreadBindingMaxAgeMs,
+  resolveThreadBindingsEnabled,
+} from "openclaw/plugin-sdk/conversation-runtime";
+export { createDiscordMessageHandler } from "./message-handler.js";
+export {
+  createNoopThreadBindingManager,
+  createThreadBindingManager,
+  reconcileAcpThreadBindingsOnStartup,
+} from "./thread-bindings.js";

--- a/extensions/discord/src/monitor/provider.runtime.ts
+++ b/extensions/discord/src/monitor/provider.runtime.ts
@@ -1,0 +1,1 @@
+export { monitorDiscordProvider } from "./provider.js";

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -11,8 +11,6 @@ import {
 import { GatewayCloseCodes, type GatewayPlugin } from "@buape/carbon/gateway";
 import { VoicePlugin } from "@buape/carbon/voice";
 import { Routes } from "discord-api-types/v10";
-import { getAcpSessionManager } from "openclaw/plugin-sdk/acp-runtime";
-import { isAcpRuntimeError } from "openclaw/plugin-sdk/acp-runtime";
 import {
   listNativeCommandSpecsForConfig,
   listSkillCommandsForAgents,
@@ -32,15 +30,9 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/config-runtime";
-import {
-  resolveThreadBindingIdleTimeoutMs,
-  resolveThreadBindingMaxAgeMs,
-  resolveThreadBindingsEnabled,
-} from "openclaw/plugin-sdk/conversation-runtime";
 import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { getPluginCommandSpecs } from "openclaw/plugin-sdk/plugin-runtime";
-import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
 import {
   danger,
@@ -81,7 +73,6 @@ import {
   DiscordThreadUpdateListener,
   registerDiscordListener,
 } from "./listeners.js";
-import { createDiscordMessageHandler } from "./message-handler.js";
 import {
   createDiscordCommandArgFallbackButton,
   createDiscordModelPickerFallbackButton,
@@ -94,11 +85,6 @@ import { runDiscordGatewayLifecycle } from "./provider.lifecycle.js";
 import { resolveDiscordRestFetch } from "./rest-fetch.js";
 import { formatDiscordStartupStatusMessage } from "./startup-status.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
-import {
-  createNoopThreadBindingManager,
-  createThreadBindingManager,
-  reconcileAcpThreadBindingsOnStartup,
-} from "./thread-bindings.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
 
 export type MonitorDiscordOpts = {
@@ -116,12 +102,46 @@ export type MonitorDiscordOpts = {
 type DiscordVoiceManager = import("../voice/manager.js").DiscordVoiceManager;
 
 type DiscordVoiceRuntimeModule = typeof import("../voice/manager.runtime.js");
+type DiscordProviderSessionRuntimeModule = typeof import("./provider-session.runtime.js");
 
 let discordVoiceRuntimePromise: Promise<DiscordVoiceRuntimeModule> | undefined;
+let discordProviderSessionRuntimePromise: Promise<DiscordProviderSessionRuntimeModule> | undefined;
 
 async function loadDiscordVoiceRuntime(): Promise<DiscordVoiceRuntimeModule> {
   discordVoiceRuntimePromise ??= import("../voice/manager.runtime.js");
   return await discordVoiceRuntimePromise;
+}
+
+async function loadDiscordProviderSessionRuntime(): Promise<DiscordProviderSessionRuntimeModule> {
+  discordProviderSessionRuntimePromise ??= import("./provider-session.runtime.js");
+  return await discordProviderSessionRuntimePromise;
+}
+
+function normalizeBooleanForTesting(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true") {
+      return true;
+    }
+    if (normalized === "false") {
+      return false;
+    }
+  }
+  return undefined;
+}
+
+function resolveThreadBindingsEnabledForTesting(params: {
+  channelEnabledRaw: unknown;
+  sessionEnabledRaw: unknown;
+}): boolean {
+  return (
+    normalizeBooleanForTesting(params.channelEnabledRaw) ??
+    normalizeBooleanForTesting(params.sessionEnabledRaw) ??
+    true
+  );
 }
 
 function formatThreadBindingDurationForConfigLabel(durationMs: number): string {
@@ -170,11 +190,15 @@ function isLegacyMissingSessionError(message: string): boolean {
   );
 }
 
-function classifyAcpStatusProbeError(params: { error: unknown; isStaleRunning: boolean }): {
+function classifyAcpStatusProbeError(params: {
+  error: unknown;
+  isStaleRunning: boolean;
+  isAcpRuntimeError: DiscordProviderSessionRuntimeModule["isAcpRuntimeError"];
+}): {
   status: "stale" | "uncertain";
   reason: string;
 } {
-  if (isAcpRuntimeError(params.error) && params.error.code === "ACP_SESSION_INIT_FAILED") {
+  if (params.isAcpRuntimeError(params.error) && params.error.code === "ACP_SESSION_INIT_FAILED") {
     return { status: "stale", reason: "session-init-failed" };
   }
 
@@ -194,6 +218,7 @@ async function probeDiscordAcpBindingHealth(params: {
   storedState?: "idle" | "running" | "error";
   lastActivityAt?: number;
 }): Promise<{ status: "healthy" | "stale" | "uncertain"; reason?: string }> {
+  const { getAcpSessionManager, isAcpRuntimeError } = await loadDiscordProviderSessionRuntime();
   const manager = getAcpSessionManager();
   const statusProbeAbortController = new AbortController();
   const statusPromise = manager
@@ -236,6 +261,7 @@ async function probeDiscordAcpBindingHealth(params: {
     return classifyAcpStatusProbeError({
       error: result.error,
       isStaleRunning,
+      isAcpRuntimeError,
     });
   }
   if (result.status.state === "error") {
@@ -477,17 +503,19 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const replyToMode = opts.replyToMode ?? discordCfg.replyToMode ?? "off";
   const dmEnabled = dmConfig?.enabled ?? true;
   const dmPolicy = discordCfg.dmPolicy ?? dmConfig?.policy ?? "pairing";
-  const threadBindingIdleTimeoutMs = resolveThreadBindingIdleTimeoutMs({
-    channelIdleHoursRaw:
-      discordAccountThreadBindings?.idleHours ?? discordRootThreadBindings?.idleHours,
-    sessionIdleHoursRaw: cfg.session?.threadBindings?.idleHours,
-  });
-  const threadBindingMaxAgeMs = resolveThreadBindingMaxAgeMs({
+  const discordProviderSessionRuntime = await loadDiscordProviderSessionRuntime();
+  const threadBindingIdleTimeoutMs =
+    discordProviderSessionRuntime.resolveThreadBindingIdleTimeoutMs({
+      channelIdleHoursRaw:
+        discordAccountThreadBindings?.idleHours ?? discordRootThreadBindings?.idleHours,
+      sessionIdleHoursRaw: cfg.session?.threadBindings?.idleHours,
+    });
+  const threadBindingMaxAgeMs = discordProviderSessionRuntime.resolveThreadBindingMaxAgeMs({
     channelMaxAgeHoursRaw:
       discordAccountThreadBindings?.maxAgeHours ?? discordRootThreadBindings?.maxAgeHours,
     sessionMaxAgeHoursRaw: cfg.session?.threadBindings?.maxAgeHours,
   });
-  const threadBindingsEnabled = resolveThreadBindingsEnabled({
+  const threadBindingsEnabled = discordProviderSessionRuntime.resolveThreadBindingsEnabled({
     channelEnabledRaw: discordAccountThreadBindings?.enabled ?? discordRootThreadBindings?.enabled,
     sessionEnabledRaw: cfg.session?.threadBindings?.enabled,
   });
@@ -591,17 +619,17 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
   const voiceManagerRef: { current: DiscordVoiceManager | null } = { current: null };
   const threadBindings = threadBindingsEnabled
-    ? createThreadBindingManager({
+    ? discordProviderSessionRuntime.createThreadBindingManager({
         accountId: account.accountId,
         token,
         cfg,
         idleTimeoutMs: threadBindingIdleTimeoutMs,
         maxAgeMs: threadBindingMaxAgeMs,
       })
-    : createNoopThreadBindingManager(account.accountId);
+    : discordProviderSessionRuntime.createNoopThreadBindingManager(account.accountId);
   if (threadBindingsEnabled) {
     const uncertainProbeKeys = new Set<string>();
-    const reconciliation = await reconcileAcpThreadBindingsOnStartup({
+    const reconciliation = await discordProviderSessionRuntime.reconcileAcpThreadBindingsOnStartup({
       cfg,
       accountId: account.accountId,
       sendFarewell: false,
@@ -827,7 +855,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
 
     const logger = createSubsystemLogger("discord/monitor");
-    const guildHistories = new Map<string, HistoryEntry[]>();
+    const guildHistories = new Map<
+      string,
+      import("openclaw/plugin-sdk/reply-history").HistoryEntry[]
+    >();
     let botUserId: string | undefined;
     let botUserName: string | undefined;
     let voiceManager: DiscordVoiceManager | null = null;
@@ -899,7 +930,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       registerDiscordListener(client.listeners, new DiscordVoiceReadyListener(voiceManager));
     }
 
-    const messageHandler = createDiscordMessageHandler({
+    const messageHandler = discordProviderSessionRuntime.createDiscordMessageHandler({
       cfg,
       discordConfig: discordCfg,
       accountId: account.accountId,
@@ -1034,5 +1065,5 @@ export const __testing = {
   resolveDiscordRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveDiscordRestFetch,
-  resolveThreadBindingsEnabled,
+  resolveThreadBindingsEnabled: resolveThreadBindingsEnabledForTesting,
 };

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -121,15 +121,6 @@ function normalizeBooleanForTesting(value: unknown): boolean | undefined {
   if (typeof value === "boolean") {
     return value;
   }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true") {
-      return true;
-    }
-    if (normalized === "false") {
-      return false;
-    }
-  }
   return undefined;
 }
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -6,6 +6,7 @@ import type { PluginDiagnostic } from "../plugins/types.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
 
 const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
+const resolveGatewayStartupPluginIds = vi.hoisted(() => vi.fn(() => ["discord", "telegram"]));
 const primeConfiguredBindingRegistry = vi.hoisted(() =>
   vi.fn(() => ({ bindingCount: 0, channelCount: 0 })),
 );
@@ -18,6 +19,10 @@ const handleGatewayRequest = vi.hoisted(() =>
 
 vi.mock("../plugins/loader.js", () => ({
   loadOpenClawPlugins,
+}));
+
+vi.mock("../plugins/channel-plugin-ids.js", () => ({
+  resolveGatewayStartupPluginIds,
 }));
 
 vi.mock("../channels/plugins/binding-registry.js", () => ({
@@ -138,6 +143,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   loadOpenClawPlugins.mockReset();
+  resolveGatewayStartupPluginIds.mockReset().mockReturnValue(["discord", "telegram"]);
   primeConfiguredBindingRegistry.mockClear().mockReturnValue({ bindingCount: 0, channelCount: 0 });
   handleGatewayRequest.mockReset();
   runtimeModule.clearGatewaySubagentRuntime();
@@ -197,6 +203,37 @@ describe("loadGatewayPlugins", () => {
       "[plugins] failed to load plugin: boom (plugin=telegram, source=/tmp/telegram/index.ts)",
     );
     expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  test("loads only gateway startup plugin ids", async () => {
+    const { loadGatewayPlugins } = serverPluginsModule;
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+
+    const log = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log,
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+
+    expect(resolveGatewayStartupPluginIds).toHaveBeenCalledWith({
+      config: {},
+      workspaceDir: "/tmp",
+      env: process.env,
+    });
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["discord", "telegram"],
+      }),
+    );
   });
 
   test("provides subagent runtime with sessions.get method aliases", async () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import type { loadConfig } from "../config/config.js";
+import { resolveGatewayStartupPluginIds } from "../plugins/channel-plugin-ids.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
@@ -408,6 +409,11 @@ export function loadGatewayPlugins(params: {
   const pluginRegistry = loadOpenClawPlugins({
     config: params.cfg,
     workspaceDir: params.workspaceDir,
+    onlyPluginIds: resolveGatewayStartupPluginIds({
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+    }),
     logger: {
       info: (msg) => params.log.info(msg),
       warn: (msg) => params.log.warn(msg),

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -53,3 +53,11 @@ export function resolveConfiguredDeferredChannelPluginIds(params: {
     )
     .map((plugin) => plugin.id);
 }
+
+export function resolveGatewayStartupPluginIds(params: {
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}): string[] {
+  return resolveConfiguredChannelPluginIds(params);
+}

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -1,5 +1,6 @@
 import { listPotentialConfiguredChannelIds } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
 export function resolveChannelPluginIds(params: {
@@ -59,5 +60,41 @@ export function resolveGatewayStartupPluginIds(params: {
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
 }): string[] {
-  return resolveConfiguredChannelPluginIds(params);
+  const configuredChannelIds = new Set(
+    listPotentialConfiguredChannelIds(params.config, params.env).map((id) => id.trim()),
+  );
+  const pluginsConfig = normalizePluginsConfig(params.config.plugins);
+  const manifestRegistry = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  return manifestRegistry.plugins
+    .filter((plugin) => {
+      if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
+        return true;
+      }
+      if (plugin.channels.length > 0) {
+        return false;
+      }
+      const enabled = resolveEffectiveEnableState({
+        id: plugin.id,
+        origin: plugin.origin,
+        config: pluginsConfig,
+        rootConfig: params.config,
+        enabledByDefault: plugin.enabledByDefault,
+      }).enabled;
+      if (!enabled) {
+        return false;
+      }
+      if (plugin.origin !== "bundled") {
+        return true;
+      }
+      return (
+        pluginsConfig.allow.includes(plugin.id) ||
+        pluginsConfig.entries[plugin.id]?.enabled === true ||
+        pluginsConfig.slots.memory === plugin.id
+      );
+    })
+    .map((plugin) => plugin.id);
 }


### PR DESCRIPTION
## Summary

- Problem: gateway boot was still importing more plugin/runtime surface than needed, including full Discord provider/session setup and unrelated bundled providers.
- Why it matters: this adds avoidable cold-start latency before the gateway is ready and before Discord can start cleanly.
- What changed: gateway startup now loads only configured channel plugins, and Discord defers provider/session runtime setup behind explicit runtime boundaries.
- What did NOT change (scope boundary): this PR does not touch the remaining `runtime-discord-ops` hotspot or the broader ingress instrumentation work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #52077

## User-visible / Behavior Changes

- Gateway startup stops loading unrelated bundled provider plugins when only channel plugins are needed.
- Discord startup defers provider/session runtime setup until the provider actually starts.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Discord, Telegram
- Relevant config (redacted): gateway with Discord + Telegram configured locally

### Steps

1. Start the gateway with plugin timing enabled.
2. Observe bundled plugin import costs during startup.
3. Repeat after narrowing startup plugin scope and adding Discord lazy runtime boundaries.

### Expected

- Gateway only imports configured channel plugins during startup.
- Discord startup avoids paying the full provider/session runtime import cost up front.

### Actual

- Before this patch, startup imported unrelated bundled providers and eagerly pulled heavy Discord runtime surfaces into the main plugin load.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/gateway/server-plugins.test.ts -t "loads only gateway startup plugin ids"`
  - `pnpm test -- extensions/discord/src/channel.test.ts`
  - `pnpm test -- extensions/discord/src/monitor/provider.test.ts extensions/discord/src/monitor/provider.skill-dedupe.test.ts`
  - `pnpm build`
  - live gateway boot with `OPENCLAW_DEBUG_PLUGINS=1`
- Edge cases checked:
  - configured startup scope still includes configured channel plugins
  - Discord test seams still work through the new runtime boundaries
- What you did **not** verify:
  - full `pnpm check` on this dirty investigation worktree; local failure was caused by unrelated formatting in other unstaged files outside this PR

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ef7733133b`
- Files/config to restore: gateway plugin startup resolution and Discord provider runtime boundaries
- Known bad symptoms reviewers should watch for: missing configured channel startup or Discord provider failing to start its deferred runtime path

## Risks and Mitigations

- Risk:
  - gateway startup scope could omit a channel plugin that is required before listen.
  - Mitigation:
  - the scope is still derived from configured channel plugin ids and covered by `src/gateway/server-plugins.test.ts`.
- Risk:
  - Discord deferred runtime boundaries could break test or startup-time imports.
  - Mitigation:
  - `extensions/discord/src/channel.test.ts`, `extensions/discord/src/monitor/provider.test.ts`, and `extensions/discord/src/monitor/provider.skill-dedupe.test.ts` cover the shifted seams.
