### PR TITLE
feat: add --token flag to paste-token for non-interactive use

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -342,7 +342,10 @@ export function registerModelsCli(program: Command) {
     .command("paste-token")
     .description("Paste a token into auth-profiles.json and update config")
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
-    .option("--token <value>", "Token value (skips interactive prompt; required for non-TTY)")
+    .option(
+      "--token <value>",
+      'Token value; use "--token -" to read from stdin. Also accepts OPENCLAW_PASTE_TOKEN env var.',
+    )
     .option("--profile-id <id>", "Auth profile id (default: <provider>:manual)")
     .option(
       "--expires-in <duration>",

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -342,6 +342,7 @@ export function registerModelsCli(program: Command) {
     .command("paste-token")
     .description("Paste a token into auth-profiles.json and update config")
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
+    .option("--token <value>", "Token value (skips interactive prompt; required for non-TTY)")
     .option("--profile-id <id>", "Auth profile id (default: <provider>:manual)")
     .option(
       "--expires-in <duration>",
@@ -352,6 +353,7 @@ export function registerModelsCli(program: Command) {
         await modelsAuthPasteTokenCommand(
           {
             provider: opts.provider as string | undefined,
+            token: opts.token as string | undefined,
             profileId: opts.profileId as string | undefined,
             expiresIn: opts.expiresIn as string | undefined,
           },

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -347,7 +347,7 @@ describe("modelsAuthLoginCommand", () => {
     });
     try {
       await expect(modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
-        "paste-token requires --token <value> when running in a non-interactive",
+        "paste-token requires --token",
       );
       expect(mocks.clackText).not.toHaveBeenCalled();
       expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
@@ -356,6 +356,51 @@ describe("modelsAuthLoginCommand", () => {
         Object.defineProperty(stdin, "isTTY", savedDescriptor);
       } else {
         delete (stdin as { isTTY?: boolean }).isTTY;
+      }
+    }
+  });
+
+  it("reads token from OPENCLAW_PASTE_TOKEN env var", async () => {
+    const runtime = createRuntime();
+    const orig = process.env.OPENCLAW_PASTE_TOKEN;
+    try {
+      process.env.OPENCLAW_PASTE_TOKEN = "env-token-abc";
+      await modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime);
+
+      expect(mocks.clackText).not.toHaveBeenCalled();
+      expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+        profileId: "anthropic:manual",
+        credential: {
+          type: "token",
+          provider: "anthropic",
+          token: "env-token-abc",
+        },
+      });
+    } finally {
+      if (orig === undefined) {
+        delete process.env.OPENCLAW_PASTE_TOKEN;
+      } else {
+        process.env.OPENCLAW_PASTE_TOKEN = orig;
+      }
+    }
+  });
+
+  it("prefers --token over OPENCLAW_PASTE_TOKEN env var", async () => {
+    const runtime = createRuntime();
+    const orig = process.env.OPENCLAW_PASTE_TOKEN;
+    try {
+      process.env.OPENCLAW_PASTE_TOKEN = "env-token";
+      await modelsAuthPasteTokenCommand({ provider: "anthropic", token: "flag-token" }, runtime);
+
+      expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+        profileId: "anthropic:manual",
+        credential: expect.objectContaining({ token: "flag-token" }),
+      });
+    } finally {
+      if (orig === undefined) {
+        delete process.env.OPENCLAW_PASTE_TOKEN;
+      } else {
+        process.env.OPENCLAW_PASTE_TOKEN = orig;
       }
     }
   });

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -315,6 +315,77 @@ describe("modelsAuthLoginCommand", () => {
     }
   });
 
+  it("uses --token directly and skips interactive prompt", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthPasteTokenCommand(
+      { provider: "anthropic", token: "sk-ant-test-token-123" },
+      runtime,
+    );
+
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: "anthropic:manual",
+      credential: {
+        type: "token",
+        provider: "anthropic",
+        token: "sk-ant-test-token-123",
+      },
+    });
+    expect(mocks.updateConfig).toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("Auth profile: anthropic:manual (anthropic/token)");
+  });
+
+  it("throws when no TTY and no --token provided", async () => {
+    const runtime = createRuntime();
+    const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+    const savedDescriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+    Object.defineProperty(stdin, "isTTY", {
+      configurable: true,
+      enumerable: true,
+      get: () => false,
+    });
+    try {
+      await expect(modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
+        "paste-token requires --token <value> when running in a non-interactive",
+      );
+      expect(mocks.clackText).not.toHaveBeenCalled();
+      expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    } finally {
+      if (savedDescriptor) {
+        Object.defineProperty(stdin, "isTTY", savedDescriptor);
+      } else {
+        delete (stdin as { isTTY?: boolean }).isTTY;
+      }
+    }
+  });
+
+  it("uses --token with custom --profile-id and --expires-in", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthPasteTokenCommand(
+      {
+        provider: "openai",
+        token: "sk-test-token",
+        profileId: "openai:ci",
+        expiresIn: "30d",
+      },
+      runtime,
+    );
+
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: "openai:ci",
+      credential: expect.objectContaining({
+        type: "token",
+        provider: "openai",
+        token: "sk-test-token",
+        expires: expect.any(Number),
+      }),
+    });
+    expect(runtime.log).toHaveBeenCalledWith("Auth profile: openai:ci (openai/token)");
+  });
+
   it("runs token auth for any token-capable provider plugin", async () => {
     const runtime = createRuntime();
     const runTokenAuth = vi.fn().mockResolvedValue({

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -5,14 +5,6 @@ import {
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
-import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
-import type { OpenClawConfig } from "../../config/config.js";
-import type {
-  ProviderAuthMethod,
-  ProviderAuthResult,
-  ProviderPlugin,
-} from "../../plugins/types.js";
-import type { RuntimeEnv } from "../../runtime.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -24,13 +16,21 @@ import {
   loadAuthProfileStoreForRuntime,
   upsertAuthProfile,
 } from "../../agents/auth-profiles.js";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { applyAuthProfileConfig } from "../../plugins/provider-auth-helpers.js";
 import { resolvePluginProviders } from "../../plugins/providers.js";
+import type {
+  ProviderAuthMethod,
+  ProviderAuthResult,
+  ProviderPlugin,
+} from "../../plugins/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { isRemoteEnvironment } from "../oauth-env.js";

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -5,6 +5,14 @@ import {
   select as clackSelect,
   text as clackText,
 } from "@clack/prompts";
+import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type {
+  ProviderAuthMethod,
+  ProviderAuthResult,
+  ProviderPlugin,
+} from "../../plugins/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -16,21 +24,13 @@ import {
   loadAuthProfileStoreForRuntime,
   upsertAuthProfile,
 } from "../../agents/auth-profiles.js";
-import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { parseDurationMs } from "../../cli/parse-duration.js";
-import type { OpenClawConfig } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { applyAuthProfileConfig } from "../../plugins/provider-auth-helpers.js";
 import { resolvePluginProviders } from "../../plugins/providers.js";
-import type {
-  ProviderAuthMethod,
-  ProviderAuthResult,
-  ProviderPlugin,
-} from "../../plugins/types.js";
-import type { RuntimeEnv } from "../../runtime.js";
 import { stylePromptHint, stylePromptMessage } from "../../terminal/prompt-style.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
@@ -354,6 +354,7 @@ export async function modelsAuthSetupTokenCommand(
 export async function modelsAuthPasteTokenCommand(
   opts: {
     provider?: string;
+    token?: string;
     profileId?: string;
     expiresIn?: string;
   },
@@ -366,11 +367,21 @@ export async function modelsAuthPasteTokenCommand(
   const provider = normalizeProviderId(rawProvider);
   const profileId = opts.profileId?.trim() || resolveDefaultTokenProfileId(provider);
 
-  const tokenInput = await text({
-    message: `Paste token for ${provider}`,
-    validate: (value) => (value?.trim() ? undefined : "Required"),
-  });
-  const token = String(tokenInput ?? "").trim();
+  let token: string;
+  if (opts.token?.trim()) {
+    token = opts.token.trim();
+  } else {
+    if (!process.stdin.isTTY) {
+      throw new Error(
+        "paste-token requires --token <value> when running in a non-interactive environment (no TTY).",
+      );
+    }
+    const tokenInput = await text({
+      message: `Paste token for ${provider}`,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    });
+    token = String(tokenInput ?? "").trim();
+  }
 
   const expires =
     opts.expiresIn?.trim() && opts.expiresIn.trim().length > 0

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -81,6 +81,18 @@ function resolveDefaultTokenProfileId(provider: string): string {
   return `${normalizeProviderId(provider)}:manual`;
 }
 
+async function readStdinToken(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+  const value = Buffer.concat(chunks).toString("utf-8").trim();
+  if (!value) {
+    throw new Error("No token received from stdin.");
+  }
+  return value;
+}
+
 type ResolvedModelsAuthContext = {
   config: OpenClawConfig;
   agentDir: string;
@@ -368,12 +380,18 @@ export async function modelsAuthPasteTokenCommand(
   const profileId = opts.profileId?.trim() || resolveDefaultTokenProfileId(provider);
 
   let token: string;
-  if (opts.token?.trim()) {
+  const envToken = process.env.OPENCLAW_PASTE_TOKEN?.trim();
+  if (opts.token === "-") {
+    // Read token from stdin (e.g. `echo $TOKEN | openclaw models auth paste-token --provider anthropic --token -`)
+    token = await readStdinToken();
+  } else if (opts.token?.trim()) {
     token = opts.token.trim();
+  } else if (envToken) {
+    token = envToken;
   } else {
     if (!process.stdin.isTTY) {
       throw new Error(
-        "paste-token requires --token <value> when running in a non-interactive environment (no TTY).",
+        "paste-token requires --token <value>, --token - (stdin), or OPENCLAW_PASTE_TOKEN env var in non-interactive environments.",
       );
     }
     const tokenInput = await text({


### PR DESCRIPTION
## Summary

The `paste-token` command currently requires an interactive TTY because it always calls `@clack/prompts text()` to collect the token value. This makes it unusable in CI/CD pipelines, Docker containers, and scripted environments.

## Changes

- **`src/cli/models-cli.ts`** — Added `--token <value>` option to the `paste-token` CLI command definition
- **`src/commands/models/auth.ts`** — Updated `modelsAuthPasteTokenCommand` to support three non-interactive token sources:
  1. `--token <value>` — direct flag (highest priority)
  2. `--token -` — read from stdin (pipe-friendly, avoids process arg exposure)
  3. `OPENCLAW_PASTE_TOKEN` env var — not visible in `ps`/`/proc`
  4. Falls back to interactive `@clack/prompts text()` when TTY is available
  - Throws a clear error when no TTY and no token source provided
- **`src/commands/models/auth.test.ts`** — Added 5 test cases:
  - `--token` skips the interactive prompt and persists correctly
  - Missing `--token` in non-TTY throws a descriptive error
  - `--token` works with `--profile-id` and `--expires-in`
  - `OPENCLAW_PASTE_TOKEN` env var is used when no `--token` flag
  - `--token` flag takes precedence over `OPENCLAW_PASTE_TOKEN`

## Usage

```bash
# Non-interactive: direct flag
openclaw models auth paste-token --provider anthropic --token sk-ant-xxx

# Non-interactive: stdin (safer — token not in process args)
echo "$TOKEN" | openclaw models auth paste-token --provider anthropic --token -

# Non-interactive: env var (safest — not in process args or shell history)
export OPENCLAW_PASTE_TOKEN=sk-ant-xxx
openclaw models auth paste-token --provider anthropic

# With optional flags
openclaw models auth paste-token --provider openai --token sk-xxx --profile-id openai:ci --expires-in 30d

# Interactive (unchanged behavior when TTY is available)
openclaw models auth paste-token --provider anthropic
```

Fixes #52321