### PR TITLE
fix(feishu): treat OpenChat (oc_) topic groups as group chats

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -134,7 +134,7 @@ describe("handleFeishuMessage ACP routing", () => {
     });
     mockSendMessageFeishu
       .mockReset()
-      .mockResolvedValue({ messageId: "reply-msg", chatId: "oc_dm" });
+      .mockResolvedValue({ messageId: "reply-msg", chatId: "p2p_user_abc" });
     mockCreateFeishuReplyDispatcher.mockReset().mockReturnValue({
       dispatcher: {
         sendToolResult: vi.fn(),
@@ -266,7 +266,7 @@ describe("handleFeishuMessage ACP routing", () => {
         sender: { sender_id: { open_id: "ou_sender_1" } },
         message: {
           message_id: "msg-1",
-          chat_id: "oc_dm",
+          chat_id: "p2p_user_abc",
           chat_type: "p2p",
           message_type: "text",
           content: JSON.stringify({ text: "hello" }),
@@ -355,7 +355,7 @@ describe("handleFeishuMessage ACP routing", () => {
         sender: { sender_id: { open_id: "ou_sender_1" } },
         message: {
           message_id: "msg-2",
-          chat_id: "oc_dm",
+          chat_id: "p2p_user_abc",
           chat_type: "p2p",
           message_type: "text",
           content: JSON.stringify({ text: "hello" }),
@@ -365,7 +365,7 @@ describe("handleFeishuMessage ACP routing", () => {
 
     expect(mockSendMessageFeishu).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "chat:oc_dm",
+        to: "chat:p2p_user_abc",
         text: expect.stringContaining("runtime unavailable"),
       }),
     );
@@ -821,7 +821,7 @@ describe("handleFeishuMessage command authorization", () => {
       },
       message: {
         message_id: "msg-pairing-chat-reply",
-        chat_id: "oc_dm_chat_1",
+        chat_id: "p2p_dm_chat_1",
         chat_type: "p2p",
         message_type: "text",
         content: JSON.stringify({ text: "hello" }),
@@ -835,7 +835,7 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockSendMessageFeishu).toHaveBeenCalledWith(
       expect.objectContaining({
-        to: "chat:oc_dm_chat_1",
+        to: "chat:p2p_dm_chat_1",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -32,6 +32,7 @@ import {
   toMessageResourceType,
 } from "./bot-content.js";
 import { type FeishuPermissionError, resolveFeishuSenderName } from "./bot-sender-name.js";
+import { isFeishuGroupChat } from "./chat-type.js";
 import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
@@ -260,7 +261,7 @@ export async function handleFeishuMessage(params: {
   }
 
   let ctx = parseFeishuMessageEvent(event, botOpenId, botName);
-  const isGroup = ctx.chatType === "group";
+  const isGroup = isFeishuGroupChat(ctx.chatType, ctx.chatId);
   const isDirect = !isGroup;
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;
 

--- a/extensions/feishu/src/chat-type.test.ts
+++ b/extensions/feishu/src/chat-type.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isFeishuGroupChat } from "./chat-type.js";
+
+describe("isFeishuGroupChat", () => {
+  it("returns true for chat_type='group' regardless of chat_id prefix", () => {
+    expect(isFeishuGroupChat("group", "oc_abc123")).toBe(true);
+    expect(isFeishuGroupChat("group", "g_abc123")).toBe(true);
+    expect(isFeishuGroupChat("group", "p2p_abc123")).toBe(true);
+  });
+
+  it("returns false for chat_type='p2p' with a non-oc_ chat_id (real DM)", () => {
+    expect(isFeishuGroupChat("p2p", "p2p_abc123")).toBe(false);
+    expect(isFeishuGroupChat("p2p", "")).toBe(false);
+    expect(isFeishuGroupChat("p2p", "ou_abc123")).toBe(false);
+  });
+
+  it("returns true for chat_type='p2p' with an oc_ chat_id (Feishu OpenChat / topic group)", () => {
+    // Reproduces: https://github.com/openclaw/openclaw/issues/52238
+    // Real-world log: "received message from ou_... in oc_ceaacf99d602be4842fe4505a77a4e70 (p2p)"
+    expect(isFeishuGroupChat("p2p", "oc_ceaacf99d602be4842fe4505a77a4e70")).toBe(true);
+    expect(isFeishuGroupChat("p2p", "oc_abc123")).toBe(true);
+  });
+
+  it("returns false for chat_type='private'", () => {
+    expect(isFeishuGroupChat("private", "oc_abc123")).toBe(false);
+    expect(isFeishuGroupChat("private", "p2p_abc123")).toBe(false);
+  });
+});

--- a/extensions/feishu/src/chat-type.ts
+++ b/extensions/feishu/src/chat-type.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns true when a Feishu message event should be treated as a group chat.
+ *
+ * Feishu OpenChat entities (topic groups / 话题群) have a `chat_id` starting
+ * with `"oc_"` but report `chat_type` as `"p2p"` in bot-receive events.
+ * Routing logic must treat these as group chats so messages are dispatched to
+ * the configured channel session rather than the main agent session.
+ *
+ * @param chatType The raw `chat_type` value from the Feishu event.
+ * @param chatId   The raw `chat_id` value from the Feishu event.
+ */
+export function isFeishuGroupChat(chatType: string, chatId: string): boolean {
+  return chatType === "group" || (chatType === "p2p" && chatId.startsWith("oc_"));
+}

--- a/extensions/feishu/src/chat-type.ts
+++ b/extensions/feishu/src/chat-type.ts
@@ -9,6 +9,8 @@
  * @param chatType The raw `chat_type` value from the Feishu event.
  * @param chatId   The raw `chat_id` value from the Feishu event.
  */
-export function isFeishuGroupChat(chatType: string, chatId: string): boolean {
-  return chatType === "group" || (chatType === "p2p" && chatId.startsWith("oc_"));
+export function isFeishuGroupChat(chatType: unknown, chatId: unknown): boolean {
+  if (chatType === "group") return true;
+  if (chatType !== "p2p") return false;
+  return typeof chatId === "string" && chatId.startsWith("oc_");
 }

--- a/extensions/feishu/src/mention.ts
+++ b/extensions/feishu/src/mention.ts
@@ -1,4 +1,5 @@
 import type { FeishuMessageEvent } from "./bot.js";
+import { isFeishuGroupChat } from "./chat-type.js";
 
 /**
  * Escape regex metacharacters so user-controlled mention fields are treated literally.
@@ -53,7 +54,7 @@ export function isMentionForwardRequest(event: FeishuMessageEvent, botOpenId?: s
     return false;
   }
 
-  const isDirectMessage = event.message.chat_type !== "group";
+  const isDirectMessage = !isFeishuGroupChat(event.message.chat_type, event.message.chat_id);
   const hasOtherMention = mentions.some((m) => m.id.open_id !== botOpenId);
 
   if (isDirectMessage) {


### PR DESCRIPTION
## Summary

Feishu 话题群 (OpenChat / topic groups) bot-receive events carry `chat_type: "p2p"` even though the `chat_id` starts with `oc_` — Feishu's OpenChat/topic-group prefix. The existing `isGroup` guard in `bot.ts`:

```ts
const isGroup = ctx.chatType === 'group';
```

therefore classified every topic-group message as a DM, routing it to the main agent session instead of the configured channel session. Replies never appeared inside the 话题群. (Reported log: `received message from ou_... in oc_ceaacf99d602be4842fe4505a77a4e70 (p2p)`)

The same misclassification also affected `isMentionForwardRequest` in `mention.ts`.

## Changes

- **`extensions/feishu/src/chat-type.ts`** (new) — `isFeishuGroupChat(chatType, chatId)` helper extracted into its own module to avoid circular imports (`bot.ts` already imports from `mention.ts` and vice-versa).
  - Returns `true` when `chat_type === 'group'` OR when `chat_type === 'p2p'` and `chat_id.startsWith('oc_')`.
- **`extensions/feishu/src/bot.ts`** — `isGroup` now uses `isFeishuGroupChat`.
- **`extensions/feishu/src/mention.ts`** — `isDirectMessage` now uses `isFeishuGroupChat`.
- **`extensions/feishu/src/chat-type.test.ts`** (new) — 4 unit tests covering: normal group, real DM (`p2p_` prefix), OpenChat topic group (`oc_` prefix), and `private` chat type.

## Test

```
pnpm vitest run extensions/feishu/src/chat-type.test.ts
✓ extensions/feishu/src/chat-type.test.ts (4 tests) 3ms
Test Files: 1 passed (1)
     Tests: 4 passed (4)
```

Closes #52238