### PR TITLE
fix(security): add form-action CSP directive and cross-domain policy header

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -15,4 +15,9 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("https://fonts.googleapis.com");
     expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
+
+  it("restricts form submissions to same origin", () => {
+    const csp = buildControlUiCspHeader();
+    expect(csp).toContain("form-action 'self'");
+  });
 });

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -13,5 +13,6 @@ export function buildControlUiCspHeader(): string {
     "img-src 'self' data: https:",
     "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
+    "form-action 'self'",
   ].join("; ");
 }

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -46,4 +46,10 @@ describe("setDefaultSecurityHeaders", () => {
     setDefaultSecurityHeaders(res, { strictTransportSecurity: "" });
     expect(setHeader).not.toHaveBeenCalledWith("Strict-Transport-Security", expect.anything());
   });
+
+  it("sets X-Permitted-Cross-Domain-Policies to none", () => {
+    const { res, setHeader } = makeMockHttpResponse();
+    setDefaultSecurityHeaders(res);
+    expect(setHeader).toHaveBeenCalledWith("X-Permitted-Cross-Domain-Policies", "none");
+  });
 });

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -15,6 +15,9 @@ export function setDefaultSecurityHeaders(
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("Referrer-Policy", "no-referrer");
   res.setHeader("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+  // Prevent Adobe Flash/Acrobat from loading cross-domain policy files that
+  // could grant read access to response data from this origin.
+  res.setHeader("X-Permitted-Cross-Domain-Policies", "none");
   const strictTransportSecurity = opts?.strictTransportSecurity;
   if (typeof strictTransportSecurity === "string" && strictTransportSecurity.length > 0) {
     res.setHeader("Strict-Transport-Security", strictTransportSecurity);


### PR DESCRIPTION
## Problem

The Control UI's Content-Security-Policy was missing a `form-action` directive, and the gateway's baseline security headers did not include `X-Permitted-Cross-Domain-Policies`. Both are recommended by OWASP for defense-in-depth.

### Missing `form-action` CSP directive

Without `form-action`, the CSP falls back to `default-src` for form submissions. While the current UI doesn't use HTML forms, a content-injection vulnerability (e.g. via a future XSS or markup injection) could craft a form that submits sensitive data to an external origin. Adding `form-action 'self'` closes this vector explicitly.

### Missing `X-Permitted-Cross-Domain-Policies`

Adobe Flash Player and Acrobat can request cross-domain policy files (`crossdomain.xml`) to determine whether they may load data from a given origin. Setting `X-Permitted-Cross-Domain-Policies: none` instructs these clients that no such policy file should be honored, preventing legacy plugin-based cross-origin data access.

## Changes

- **`src/gateway/control-ui-csp.ts`**: Add `form-action 'self'` to the CSP header
- **`src/gateway/http-common.ts`**: Add `X-Permitted-Cross-Domain-Policies: none` to baseline security headers
- **Tests**: Added corresponding test coverage for both headers

## Testing

```
pnpm vitest run src/gateway/control-ui-csp.test.ts src/gateway/http-common.test.ts
# 10 tests pass (3 + 7)
```