### PR TITLE
fix(discord): trim DM allowlist entries

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -94,7 +94,11 @@ const resolveDiscordDmPolicy = createScopedDmSecurityResolver<ResolvedDiscordAcc
   resolvePolicy: (account) => account.config.dm?.policy,
   resolveAllowFrom: (account) => account.config.dm?.allowFrom,
   allowFromPathSuffix: "dm.",
-  normalizeEntry: (raw) => raw.replace(/^(discord|user):/i, "").replace(/^<@!?(\d+)>$/, "$1"),
+  normalizeEntry: (raw) =>
+    raw
+      .trim()
+      .replace(/^(discord|user):/i, "")
+      .replace(/^<@!?(\d+)>$/, "$1"),
 });
 
 function formatDiscordIntents(intents?: {


### PR DESCRIPTION
## Summary
- trim Discord DM allowlist entries before prefix and mention normalization
- add a regression test for prefixed mention allowlist entries with surrounding whitespace

## Testing
- pnpm test -- extensions/discord/src/channel.test.ts
- pnpm build
