### PR TITLE
fix(discord): trim dm allowlist entries after prefix removal

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -97,6 +97,7 @@ const resolveDiscordDmPolicy = createScopedDmSecurityResolver<ResolvedDiscordAcc
     raw
       .trim()
       .replace(/^(discord|user):/i, "")
+      .trim()
       .replace(/^<@!?(\d+)>$/, "$1"),
 });
 


### PR DESCRIPTION
## Summary
- restore Discord DM allowlist normalization for prefixed mention entries like `discord:<@!123>`
- trim again after removing the `discord:` / `user:` prefix so the mention matcher still sees a clean token
- fix the shared `extensions/discord/src/channel.test.ts` regression that was turning unrelated PRs red in `pnpm test:channels`

## Testing
- `./node_modules/.bin/vitest run --config vitest.channels.config.ts extensions/discord/src/channel.test.ts`
