### PR TITLE
Agents: add missing tool parameter aliases

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts
@@ -39,6 +39,71 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("accepts file alias for read/write and exposes it in their schemas", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-file-alias-"));
+    try {
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { readTool, writeTool } = expectReadWriteEditTools(tools);
+
+      const readParameters = readTool?.parameters as
+        | { properties?: Record<string, unknown> }
+        | undefined;
+      const writeParameters = writeTool?.parameters as
+        | { properties?: Record<string, unknown> }
+        | undefined;
+      expect(readParameters?.properties?.file).toBeDefined();
+      expect(writeParameters?.properties?.file).toBeDefined();
+
+      const filePath = "file-alias.txt";
+      await writeTool?.execute("tool-file-alias-write", {
+        file: filePath,
+        content: "hello file alias",
+      });
+
+      const result = await readTool?.execute("tool-file-alias-read", {
+        file: filePath,
+      });
+
+      const textBlocks = result?.content?.filter((block) => block.type === "text") as
+        | Array<{ text?: string }>
+        | undefined;
+      const combinedText = textBlocks?.map((block) => block.text ?? "").join("\n");
+      expect(combinedText).toContain("hello file alias");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts file, old_text, and new_text aliases for edit and exposes them in the schema", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-edit-alias-"));
+    try {
+      const filePath = path.join(tmpDir, "edit-alias.txt");
+      await fs.writeFile(filePath, "hello world\n", "utf8");
+
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+
+      const parameters = editTool?.parameters as
+        | { properties?: Record<string, unknown> }
+        | undefined;
+      expect(parameters?.properties).toBeDefined();
+      expect(parameters?.properties?.file).toBeDefined();
+      expect(parameters?.properties?.old_text).toBeDefined();
+      expect(parameters?.properties?.new_text).toBeDefined();
+
+      await editTool?.execute("tool-edit-alias", {
+        file: "edit-alias.txt",
+        old_text: "world",
+        new_text: "friend",
+      });
+
+      const edited = await fs.readFile(filePath, "utf8");
+      expect(edited).toBe("hello friend\n");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("coerces structured content blocks for write", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-structured-write-"));
     try {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -13,20 +13,20 @@ function parameterValidationError(message: string): Error {
 }
 
 export const CLAUDE_PARAM_GROUPS = {
-  read: [{ keys: ["path", "file_path"], label: "path (path or file_path)" }],
+  read: [{ keys: ["path", "file_path", "file"], label: "path (path, file_path, or file)" }],
   write: [
-    { keys: ["path", "file_path"], label: "path (path or file_path)" },
+    { keys: ["path", "file_path", "file"], label: "path (path, file_path, or file)" },
     { keys: ["content"], label: "content" },
   ],
   edit: [
-    { keys: ["path", "file_path"], label: "path (path or file_path)" },
+    { keys: ["path", "file_path", "file"], label: "path (path, file_path, or file)" },
     {
-      keys: ["oldText", "old_string"],
-      label: "oldText (oldText or old_string)",
+      keys: ["oldText", "old_string", "old_text"],
+      label: "oldText (oldText, old_string, or old_text)",
     },
     {
-      keys: ["newText", "new_string"],
-      label: "newText (newText or new_string)",
+      keys: ["newText", "new_string", "new_text"],
+      label: "newText (newText, new_string, or new_text)",
       allowEmpty: true,
     },
   ],
@@ -82,8 +82,26 @@ function normalizeTextLikeParam(record: Record<string, unknown>, key: string) {
   }
 }
 
-// Normalize tool parameters from Claude Code conventions to pi-coding-agent conventions.
-// Claude Code uses file_path/old_string/new_string while pi-coding-agent uses path/oldText/newText.
+function normalizeAliasKey(
+  record: Record<string, unknown>,
+  canonicalKey: string,
+  aliasKeys: readonly string[],
+) {
+  if (canonicalKey in record) {
+    return;
+  }
+  for (const aliasKey of aliasKeys) {
+    if (!(aliasKey in record)) {
+      continue;
+    }
+    record[canonicalKey] = record[aliasKey];
+    delete record[aliasKey];
+    return;
+  }
+}
+
+// Normalize tool parameters from Claude-style aliases to pi-coding-agent conventions.
+// Some models emit file/file_path and old_text/old_string/new_text/new_string variants.
 // This prevents models trained on Claude Code from getting stuck in tool-call loops.
 export function normalizeToolParams(params: unknown): Record<string, unknown> | undefined {
   if (!params || typeof params !== "object") {
@@ -91,21 +109,9 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   }
   const record = params as Record<string, unknown>;
   const normalized = { ...record };
-  // file_path → path (read, write, edit)
-  if ("file_path" in normalized && !("path" in normalized)) {
-    normalized.path = normalized.file_path;
-    delete normalized.file_path;
-  }
-  // old_string → oldText (edit)
-  if ("old_string" in normalized && !("oldText" in normalized)) {
-    normalized.oldText = normalized.old_string;
-    delete normalized.old_string;
-  }
-  // new_string → newText (edit)
-  if ("new_string" in normalized && !("newText" in normalized)) {
-    normalized.newText = normalized.new_string;
-    delete normalized.new_string;
-  }
+  normalizeAliasKey(normalized, "path", ["file_path", "file"]);
+  normalizeAliasKey(normalized, "oldText", ["old_string", "old_text"]);
+  normalizeAliasKey(normalized, "newText", ["new_string", "new_text"]);
   // Some providers/models emit text payloads as structured blocks instead of raw strings.
   // Normalize these for write/edit so content matching and writes stay deterministic.
   normalizeTextLikeParam(normalized, "content");
@@ -132,8 +138,11 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
 
   const aliasPairs: Array<{ original: string; alias: string }> = [
     { original: "path", alias: "file_path" },
+    { original: "path", alias: "file" },
     { original: "oldText", alias: "old_string" },
+    { original: "oldText", alias: "old_text" },
     { original: "newText", alias: "new_string" },
+    { original: "newText", alias: "new_text" },
   ];
 
   for (const { original, alias } of aliasPairs) {


### PR DESCRIPTION
## Summary

- Problem: the edit tool compatibility layer exposed `file_path`, `old_string`, and `new_string`, but not the common `file`, `old_text`, and `new_text` aliases.
- Why it matters: Claude-style tool calls and schema-driven help could omit or reject those spellings, which makes the edit tool less reliable and less discoverable.
- What changed: added the missing aliases to the file-tool parameter groups, normalized them to the canonical `path` / `oldText` / `newText` fields, exposed them in the wrapped tool schemas, and added targeted regression coverage.
- What did NOT change (scope boundary): no broader tool-surface refactor, no behavior change outside the existing read/write/edit file-tool compatibility path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52164
- Related #52164

## User-visible / Behavior Changes

- Wrapped file tools now expose `file` as a path alias in their schema/help surface.
- Wrapped edit tools now expose and accept `old_text` / `new_text` in addition to the existing canonical and Claude-style aliases.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  Existing file tools now accept additional alias spellings for the same canonical parameters. The underlying capabilities and data scope are unchanged; the wrapper normalizes the aliases back to the existing `path` / `oldText` / `newText` fields, and the new regression tests cover both schema exposure and execution.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node v22.20.0 / pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): None

### Steps

1. Call the wrapped edit tool with `file`, `old_text`, and `new_text`, or inspect the wrapped tool schema for those alias properties.
2. Before this change, the edit compatibility path only exposed and normalized `file_path`, `old_string`, and `new_string`.
3. After this change, the schema exposes the missing aliases and the wrapper normalizes them to the canonical edit fields before execution.

### Expected

- The wrapped schema/help surface includes the missing aliases.
- The wrapped edit tool accepts `file` / `old_text` / `new_text` without validation failures.

### Actual

- Verified via regression tests after the patch; the new alias cases pass and the older alias cases still pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm build`, `pnpm check`, and `pnpm test -- src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts`.
- Edge cases checked: legacy `file_path` / `old_string` / `new_string` still pass; `file` works for wrapped read/write schema + execution; `file` / `old_text` / `new_text` work for wrapped edit schema + execution.
- What you did **not** verify: I did not capture an interactive CLI help screenshot; verification was done through the wrapped schema and regression tests that drive the same compatibility path.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `312ce17f90`.
- Files/config to restore: `src/agents/pi-tools.params.ts` and `src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-f.test.ts`.
- Known bad symptoms reviewers should watch for: wrapped file tools missing the `file` alias again, or edit calls with `old_text` / `new_text` failing validation.

## Risks and Mitigations

- Risk: expanding `file` alias coverage to wrapped read/write alongside edit could introduce an untested path mismatch.
- Mitigation: added regression coverage for wrapped read/write schema + execution with `file`, and kept normalization scoped to the existing file-tool wrapper path.