### PR TITLE
fix(test): reduce startup-heavy hotspot retention

### DIFF
--- a/extensions/feishu/index.test.ts
+++ b/extensions/feishu/index.test.ts
@@ -7,8 +7,13 @@ const registerFeishuWikiToolsMock = vi.hoisted(() => vi.fn());
 const registerFeishuDriveToolsMock = vi.hoisted(() => vi.fn());
 const registerFeishuPermToolsMock = vi.hoisted(() => vi.fn());
 const registerFeishuBitableToolsMock = vi.hoisted(() => vi.fn());
+const feishuPluginMock = vi.hoisted(() => ({ id: "feishu-test-plugin" }));
 const setFeishuRuntimeMock = vi.hoisted(() => vi.fn());
 const registerFeishuSubagentHooksMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./src/channel.js", () => ({
+  feishuPlugin: feishuPluginMock,
+}));
 
 vi.mock("./src/docx.js", () => ({
   registerFeishuDocTools: registerFeishuDocToolsMock,
@@ -58,6 +63,7 @@ describe("feishu plugin register", () => {
 
     expect(setFeishuRuntimeMock).toHaveBeenCalledWith(api.runtime);
     expect(registerChannel).toHaveBeenCalledTimes(1);
+    expect(registerChannel).toHaveBeenCalledWith({ plugin: feishuPluginMock });
     expect(registerFeishuSubagentHooksMock).toHaveBeenCalledWith(api);
     expect(registerFeishuDocToolsMock).toHaveBeenCalledWith(api);
     expect(registerFeishuChatToolsMock).toHaveBeenCalledWith(api);

--- a/extensions/msteams/src/monitor.test.ts
+++ b/extensions/msteams/src/monitor.test.ts
@@ -3,7 +3,7 @@ import type { Server } from "node:http";
 import { createConnection, type AddressInfo } from "node:net";
 import express from "express";
 import { describe, expect, it } from "vitest";
-import { applyMSTeamsWebhookTimeouts } from "./monitor.js";
+import { applyMSTeamsWebhookTimeouts } from "./webhook-timeouts.js";
 
 async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve) => {

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -1,4 +1,3 @@
-import type { Server } from "node:http";
 import type { Request, Response } from "express";
 import {
   DEFAULT_WEBHOOK_MAX_BODY_BYTES,
@@ -21,6 +20,10 @@ import {
 import { getMSTeamsRuntime } from "./runtime.js";
 import { createMSTeamsAdapter, loadMSTeamsSdkWithAuth } from "./sdk.js";
 import { resolveMSTeamsCredentials } from "./token.js";
+import {
+  applyMSTeamsWebhookTimeouts,
+  type ApplyMSTeamsWebhookTimeoutsOpts,
+} from "./webhook-timeouts.js";
 
 export type MonitorMSTeamsOpts = {
   cfg: OpenClawConfig;
@@ -36,32 +39,6 @@ export type MonitorMSTeamsResult = {
 };
 
 const MSTEAMS_WEBHOOK_MAX_BODY_BYTES = DEFAULT_WEBHOOK_MAX_BODY_BYTES;
-const MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS = 30_000;
-const MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS = 30_000;
-const MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS = 15_000;
-
-export type ApplyMSTeamsWebhookTimeoutsOpts = {
-  inactivityTimeoutMs?: number;
-  requestTimeoutMs?: number;
-  headersTimeoutMs?: number;
-};
-
-export function applyMSTeamsWebhookTimeouts(
-  httpServer: Server,
-  opts?: ApplyMSTeamsWebhookTimeoutsOpts,
-): void {
-  const inactivityTimeoutMs = opts?.inactivityTimeoutMs ?? MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS;
-  const requestTimeoutMs = opts?.requestTimeoutMs ?? MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS;
-  const headersTimeoutMs = Math.min(
-    opts?.headersTimeoutMs ?? MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS,
-    requestTimeoutMs,
-  );
-
-  httpServer.setTimeout(inactivityTimeoutMs);
-  httpServer.requestTimeout = requestTimeoutMs;
-  httpServer.headersTimeout = headersTimeoutMs;
-}
-
 export async function monitorMSTeamsProvider(
   opts: MonitorMSTeamsOpts,
 ): Promise<MonitorMSTeamsResult> {

--- a/extensions/msteams/src/webhook-timeouts.ts
+++ b/extensions/msteams/src/webhook-timeouts.ts
@@ -1,0 +1,27 @@
+import type { Server } from "node:http";
+
+const MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS = 30_000;
+const MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS = 15_000;
+
+export type ApplyMSTeamsWebhookTimeoutsOpts = {
+  inactivityTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  headersTimeoutMs?: number;
+};
+
+export function applyMSTeamsWebhookTimeouts(
+  httpServer: Server,
+  opts?: ApplyMSTeamsWebhookTimeoutsOpts,
+): void {
+  const inactivityTimeoutMs = opts?.inactivityTimeoutMs ?? MSTEAMS_WEBHOOK_INACTIVITY_TIMEOUT_MS;
+  const requestTimeoutMs = opts?.requestTimeoutMs ?? MSTEAMS_WEBHOOK_REQUEST_TIMEOUT_MS;
+  const headersTimeoutMs = Math.min(
+    opts?.headersTimeoutMs ?? MSTEAMS_WEBHOOK_HEADERS_TIMEOUT_MS,
+    requestTimeoutMs,
+  );
+
+  httpServer.setTimeout(inactivityTimeoutMs);
+  httpServer.requestTimeout = requestTimeoutMs;
+  httpServer.headersTimeout = headersTimeoutMs;
+}

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -54,6 +54,9 @@ const unitBehaviorIsolatedFiles = existingUnitConfigFiles(behaviorManifest.unit.
 const unitSingletonIsolatedFiles = existingUnitConfigFiles(behaviorManifest.unit.singletonIsolated);
 const unitThreadSingletonFiles = existingUnitConfigFiles(behaviorManifest.unit.threadSingleton);
 const unitVmForkSingletonFiles = existingUnitConfigFiles(behaviorManifest.unit.vmForkSingleton);
+const extensionSingletonIsolatedFiles = existingFiles(
+  behaviorManifest.extensions.singletonIsolated,
+);
 const unitBehaviorOverrideSet = new Set([
   ...unitBehaviorIsolatedFiles,
   ...unitSingletonIsolatedFiles,
@@ -424,6 +427,10 @@ const unitFastExcludedFileSet = new Set(unitFastExcludedFiles);
 const unitFastCandidateFiles = allKnownUnitFiles.filter(
   (file) => !unitFastExcludedFileSet.has(file),
 );
+const extensionSingletonExcludedFileSet = new Set(extensionSingletonIsolatedFiles);
+const extensionSharedCandidateFiles = allKnownTestFiles.filter(
+  (file) => file.startsWith("extensions/") && !extensionSingletonExcludedFileSet.has(file),
+);
 const defaultUnitFastLaneCount = isCI && !isWindows ? 3 : 1;
 const unitFastLaneCount = Math.max(
   1,
@@ -500,6 +507,10 @@ const unitThreadEntries =
         },
       ]
     : [];
+const extensionSingletonEntries = extensionSingletonIsolatedFiles.map((file) => ({
+  name: `${path.basename(file, ".test.ts")}-extensions-isolated`,
+  args: ["vitest", "run", "--config", "vitest.extensions.config.ts", "--pool=forks", file],
+}));
 const baseRuns = [
   ...(shouldSplitUnitRuns
     ? [
@@ -567,6 +578,15 @@ const baseRuns = [
     ? [
         {
           name: "extensions",
+          env:
+            extensionSharedCandidateFiles.length > 0
+              ? {
+                  OPENCLAW_VITEST_INCLUDE_FILE: writeTempJsonArtifact(
+                    "vitest-extensions-include",
+                    extensionSharedCandidateFiles,
+                  ),
+                }
+              : undefined,
           args: [
             "vitest",
             "run",
@@ -575,6 +595,7 @@ const baseRuns = [
             ...(useVmForks ? ["--pool=vmForks"] : []),
           ],
         },
+        ...extensionSingletonEntries,
       ]
     : []),
   ...(includeGatewaySuite

--- a/scripts/test-runner-manifest.mjs
+++ b/scripts/test-runner-manifest.mjs
@@ -31,6 +31,7 @@ export function loadTestRunnerBehavior() {
   const raw = tryReadJsonFile(behaviorManifestPath, {});
   const unit = raw.unit ?? {};
   const base = raw.base ?? {};
+  const extensions = raw.extensions ?? {};
   return {
     base: {
       threadSingleton: normalizeManifestEntries(base.threadSingleton ?? []),
@@ -40,6 +41,9 @@ export function loadTestRunnerBehavior() {
       singletonIsolated: normalizeManifestEntries(unit.singletonIsolated ?? []),
       threadSingleton: normalizeManifestEntries(unit.threadSingleton ?? []),
       vmForkSingleton: normalizeManifestEntries(unit.vmForkSingleton ?? []),
+    },
+    extensions: {
+      singletonIsolated: normalizeManifestEntries(extensions.singletonIsolated ?? []),
     },
   };
 }

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -1,89 +1,38 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-const mocks = vi.hoisted(() => ({
-  executeSendAction: vi.fn(),
-  recordSessionMetaFromInbound: vi.fn(async () => ({ ok: true })),
-}));
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  prepareOutboundMirrorRoute,
+  resolveAndApplyOutboundThreadId,
+} from "./message-action-threading.js";
 
-vi.mock("./outbound-send-service.js", async () => {
-  const actual = await vi.importActual<typeof import("./outbound-send-service.js")>(
-    "./outbound-send-service.js",
-  );
-  return {
-    ...actual,
-    executeSendAction: mocks.executeSendAction,
-  };
-});
+const ensureOutboundSessionEntry = vi.fn(async () => undefined);
+const resolveOutboundSessionRoute = vi.fn();
 
-vi.mock("../../config/sessions.js", async () => {
-  const actual = await vi.importActual<typeof import("../../config/sessions.js")>(
-    "../../config/sessions.js",
-  );
-  return {
-    ...actual,
-    recordSessionMetaFromInbound: mocks.recordSessionMetaFromInbound,
-  };
-});
+const slackConfig = {
+  channels: {
+    slack: {
+      botToken: "xoxb-test",
+    },
+  },
+} as OpenClawConfig;
 
-type MessageActionRunnerModule = typeof import("./message-action-runner.js");
-type MessageActionRunnerTestHelpersModule =
-  typeof import("./message-action-runner.test-helpers.js");
-
-let runMessageAction: MessageActionRunnerModule["runMessageAction"];
-let installMessageActionRunnerTestRegistry: MessageActionRunnerTestHelpersModule["installMessageActionRunnerTestRegistry"];
-let resetMessageActionRunnerTestRegistry: MessageActionRunnerTestHelpersModule["resetMessageActionRunnerTestRegistry"];
-let slackConfig: MessageActionRunnerTestHelpersModule["slackConfig"];
-let telegramConfig: MessageActionRunnerTestHelpersModule["telegramConfig"];
-
-async function runThreadingAction(params: {
-  cfg: MessageActionRunnerTestHelpersModule["slackConfig"];
-  actionParams: Record<string, unknown>;
-  toolContext?: Record<string, unknown>;
-}) {
-  await runMessageAction({
-    cfg: params.cfg,
-    action: "send",
-    params: params.actionParams as never,
-    toolContext: params.toolContext as never,
-    agentId: "main",
-  });
-  return mocks.executeSendAction.mock.calls[0]?.[0] as {
-    threadId?: string;
-    replyToId?: string;
-    ctx?: { agentId?: string; mirror?: { sessionKey?: string }; params?: Record<string, unknown> };
-  };
-}
-
-function mockHandledSendAction() {
-  mocks.executeSendAction.mockResolvedValue({
-    handledBy: "plugin",
-    payload: {},
-  });
-}
+const telegramConfig = {
+  channels: {
+    telegram: {
+      botToken: "telegram-test",
+    },
+  },
+} as OpenClawConfig;
 
 const defaultTelegramToolContext = {
   currentChannelId: "telegram:123",
   currentThreadTs: "42",
 } as const;
 
-describe("runMessageAction threading auto-injection", () => {
-  beforeAll(async () => {
-    ({ runMessageAction } = await import("./message-action-runner.js"));
-    ({
-      installMessageActionRunnerTestRegistry,
-      resetMessageActionRunnerTestRegistry,
-      slackConfig,
-      telegramConfig,
-    } = await import("./message-action-runner.test-helpers.js"));
-  });
-
+describe("message action threading helpers", () => {
   beforeEach(() => {
-    installMessageActionRunnerTestRegistry();
-  });
-
-  afterEach(() => {
-    resetMessageActionRunnerTestRegistry?.();
-    mocks.executeSendAction.mockClear();
-    mocks.recordSessionMetaFromInbound.mockClear();
+    ensureOutboundSessionEntry.mockClear();
+    resolveOutboundSessionRoute.mockReset();
   });
 
   it.each([
@@ -99,25 +48,42 @@ describe("runMessageAction threading auto-injection", () => {
       threadTs: "333.444",
       expectedSessionKey: "agent:main:slack:channel:c123:thread:333.444",
     },
-  ] as const)("auto-threads slack using $name", async (testCase) => {
-    mockHandledSendAction();
+  ] as const)("prepares outbound routes for slack using $name", async (testCase) => {
+    const actionParams: Record<string, unknown> = {
+      channel: "slack",
+      target: testCase.target,
+      message: "hi",
+    };
+    resolveOutboundSessionRoute.mockResolvedValue({
+      sessionKey: testCase.expectedSessionKey,
+      baseSessionKey: "base",
+      peer: { id: "peer", kind: "channel" },
+      chatType: "channel",
+      from: "from",
+      to: testCase.target,
+      threadId: testCase.threadTs,
+    });
 
-    const call = await runThreadingAction({
+    const result = await prepareOutboundMirrorRoute({
       cfg: slackConfig,
-      actionParams: {
-        channel: "slack",
-        target: testCase.target,
-        message: "hi",
-      },
+      channel: "slack",
+      to: testCase.target,
+      actionParams,
       toolContext: {
         currentChannelId: "C123",
         currentThreadTs: testCase.threadTs,
         replyToMode: "all",
       },
+      agentId: "main",
+      resolveAutoThreadId: ({ toolContext }) => toolContext?.currentThreadTs,
+      resolveOutboundSessionRoute,
+      ensureOutboundSessionEntry,
     });
 
-    expect(call?.ctx?.agentId).toBe("main");
-    expect(call?.ctx?.mirror?.sessionKey).toBe(testCase.expectedSessionKey);
+    expect(result.outboundRoute?.sessionKey).toBe(testCase.expectedSessionKey);
+    expect(actionParams.__sessionKey).toBe(testCase.expectedSessionKey);
+    expect(actionParams.__agentId).toBe("main");
+    expect(ensureOutboundSessionEntry).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -136,58 +102,66 @@ describe("runMessageAction threading auto-injection", () => {
       target: "telegram:999",
       expectedThreadId: undefined,
     },
-  ] as const)("telegram auto-threading: $name", async (testCase) => {
-    mockHandledSendAction();
+  ] as const)("telegram auto-threading: $name", (testCase) => {
+    const actionParams: Record<string, unknown> = {
+      channel: "telegram",
+      target: testCase.target,
+      message: "hi",
+    };
 
-    const call = await runThreadingAction({
+    const resolved = resolveAndApplyOutboundThreadId(actionParams, {
       cfg: telegramConfig,
-      actionParams: {
-        channel: "telegram",
-        target: testCase.target,
-        message: "hi",
-      },
+      to: testCase.target,
       toolContext: defaultTelegramToolContext,
+      resolveAutoThreadId: ({ to, toolContext }) =>
+        to.includes("123") ? toolContext?.currentThreadTs : undefined,
     });
 
-    expect(call?.ctx?.params?.threadId).toBe(testCase.expectedThreadId);
-    if (testCase.expectedThreadId !== undefined) {
-      expect(call?.threadId).toBe(testCase.expectedThreadId);
-    }
+    expect(actionParams.threadId).toBe(testCase.expectedThreadId);
+    expect(resolved).toBe(testCase.expectedThreadId);
   });
 
-  it("uses explicit telegram threadId when provided", async () => {
-    mockHandledSendAction();
+  it("uses explicit telegram threadId when provided", () => {
+    const actionParams: Record<string, unknown> = {
+      channel: "telegram",
+      target: "telegram:123",
+      message: "hi",
+      threadId: "999",
+    };
 
-    const call = await runThreadingAction({
+    const resolved = resolveAndApplyOutboundThreadId(actionParams, {
       cfg: telegramConfig,
-      actionParams: {
-        channel: "telegram",
-        target: "telegram:123",
-        message: "hi",
-        threadId: "999",
-      },
+      to: "telegram:123",
       toolContext: defaultTelegramToolContext,
+      resolveAutoThreadId: () => "42",
     });
 
-    expect(call?.threadId).toBe("999");
-    expect(call?.ctx?.params?.threadId).toBe("999");
+    expect(actionParams.threadId).toBe("999");
+    expect(resolved).toBe("999");
   });
 
-  it("threads explicit replyTo through executeSendAction", async () => {
-    mockHandledSendAction();
+  it("passes explicit replyTo into auto-thread resolution", () => {
+    const resolveAutoThreadId = vi.fn(() => "thread-777");
+    const actionParams: Record<string, unknown> = {
+      channel: "telegram",
+      target: "telegram:123",
+      message: "hi",
+      replyTo: "777",
+    };
 
-    const call = await runThreadingAction({
+    const resolved = resolveAndApplyOutboundThreadId(actionParams, {
       cfg: telegramConfig,
-      actionParams: {
-        channel: "telegram",
-        target: "telegram:123",
-        message: "hi",
-        replyTo: "777",
-      },
+      to: "telegram:123",
       toolContext: defaultTelegramToolContext,
+      resolveAutoThreadId,
     });
 
-    expect(call?.replyToId).toBe("777");
-    expect(call?.ctx?.params?.replyTo).toBe("777");
+    expect(resolveAutoThreadId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToId: "777",
+      }),
+    );
+    expect(resolved).toBe("thread-777");
+    expect(actionParams.threadId).toBe("thread-777");
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -40,6 +40,10 @@ import {
   readBooleanParam,
   resolveAttachmentMediaPolicy,
 } from "./message-action-params.js";
+import {
+  prepareOutboundMirrorRoute,
+  resolveAndApplyOutboundThreadId,
+} from "./message-action-threading.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
@@ -61,34 +65,6 @@ export type MessageActionRunnerGateway = {
   clientDisplayName?: string;
   mode: GatewayClientMode;
 };
-
-function resolveAndApplyOutboundThreadId(
-  params: Record<string, unknown>,
-  ctx: {
-    cfg: OpenClawConfig;
-    channel: ChannelId;
-    to: string;
-    accountId?: string | null;
-    toolContext?: ChannelThreadingToolContext;
-  },
-): string | undefined {
-  const threadId = readStringParam(params, "threadId");
-  const resolved =
-    threadId ??
-    getChannelPlugin(ctx.channel)?.threading?.resolveAutoThreadId?.({
-      cfg: ctx.cfg,
-      accountId: ctx.accountId,
-      to: ctx.to,
-      toolContext: ctx.toolContext,
-      replyToId: readStringParam(params, "replyTo"),
-    });
-  // Write auto-resolved threadId back into params so downstream dispatch
-  // (plugin `readStringParam(params, "threadId")`) picks it up.
-  if (resolved && !params.threadId) {
-    params.threadId = resolved;
-  }
-  return resolved ?? undefined;
-}
 
 export type RunMessageActionParams = {
   cfg: OpenClawConfig;
@@ -501,41 +477,20 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   const silent = readBooleanParam(params, "silent");
 
   const replyToId = readStringParam(params, "replyTo");
-  const resolvedThreadId = resolveAndApplyOutboundThreadId(params, {
+  const { resolvedThreadId, outboundRoute } = await prepareOutboundMirrorRoute({
     cfg,
     channel,
     to,
+    actionParams: params,
     accountId,
     toolContext: input.toolContext,
+    agentId,
+    dryRun,
+    resolvedTarget,
+    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
+    resolveOutboundSessionRoute,
+    ensureOutboundSessionEntry,
   });
-  const outboundRoute =
-    agentId && !dryRun
-      ? await resolveOutboundSessionRoute({
-          cfg,
-          channel,
-          agentId,
-          accountId,
-          target: to,
-          resolvedTarget,
-          replyToId,
-          threadId: resolvedThreadId,
-        })
-      : null;
-  if (outboundRoute && agentId && !dryRun) {
-    await ensureOutboundSessionEntry({
-      cfg,
-      agentId,
-      channel,
-      accountId,
-      route: outboundRoute,
-    });
-  }
-  if (outboundRoute && !dryRun) {
-    params.__sessionKey = outboundRoute.sessionKey;
-  }
-  if (agentId) {
-    params.__agentId = agentId;
-  }
   const mirrorMediaUrls =
     mergedMediaUrls.length > 0 ? mergedMediaUrls : mediaUrl ? [mediaUrl] : undefined;
   throwIfAborted(abortSignal);
@@ -595,10 +550,10 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
 
   const resolvedThreadId = resolveAndApplyOutboundThreadId(params, {
     cfg,
-    channel,
     to,
     accountId,
     toolContext: input.toolContext,
+    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
   });
 
   const base = typeof params.message === "string" ? params.message : "";

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -1,0 +1,107 @@
+import { readStringParam } from "../../agents/tools/common.js";
+import type {
+  ChannelId,
+  ChannelThreadingAdapter,
+  ChannelThreadingToolContext,
+} from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type {
+  OutboundSessionRoute,
+  ResolveOutboundSessionRouteParams,
+} from "./outbound-session.js";
+import type { ResolvedMessagingTarget } from "./target-resolver.js";
+
+type ResolveAutoThreadId = NonNullable<ChannelThreadingAdapter["resolveAutoThreadId"]>;
+
+export function resolveAndApplyOutboundThreadId(
+  actionParams: Record<string, unknown>,
+  context: {
+    cfg: OpenClawConfig;
+    to: string;
+    accountId?: string | null;
+    toolContext?: ChannelThreadingToolContext;
+    resolveAutoThreadId?: ResolveAutoThreadId;
+  },
+): string | undefined {
+  const threadId = readStringParam(actionParams, "threadId");
+  const resolved =
+    threadId ??
+    context.resolveAutoThreadId?.({
+      cfg: context.cfg,
+      accountId: context.accountId,
+      to: context.to,
+      toolContext: context.toolContext,
+      replyToId: readStringParam(actionParams, "replyTo"),
+    });
+  if (resolved && !actionParams.threadId) {
+    actionParams.threadId = resolved;
+  }
+  return resolved ?? undefined;
+}
+
+export async function prepareOutboundMirrorRoute(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  to: string;
+  actionParams: Record<string, unknown>;
+  accountId?: string | null;
+  toolContext?: ChannelThreadingToolContext;
+  agentId?: string;
+  dryRun?: boolean;
+  resolvedTarget?: ResolvedMessagingTarget;
+  resolveAutoThreadId?: ResolveAutoThreadId;
+  resolveOutboundSessionRoute: (
+    params: ResolveOutboundSessionRouteParams,
+  ) => Promise<OutboundSessionRoute | null>;
+  ensureOutboundSessionEntry: (params: {
+    cfg: OpenClawConfig;
+    agentId: string;
+    channel: ChannelId;
+    accountId?: string | null;
+    route: OutboundSessionRoute;
+  }) => Promise<void>;
+}): Promise<{
+  resolvedThreadId?: string;
+  outboundRoute: OutboundSessionRoute | null;
+}> {
+  const replyToId = readStringParam(params.actionParams, "replyTo");
+  const resolvedThreadId = resolveAndApplyOutboundThreadId(params.actionParams, {
+    cfg: params.cfg,
+    to: params.to,
+    accountId: params.accountId,
+    toolContext: params.toolContext,
+    resolveAutoThreadId: params.resolveAutoThreadId,
+  });
+  const outboundRoute =
+    params.agentId && !params.dryRun
+      ? await params.resolveOutboundSessionRoute({
+          cfg: params.cfg,
+          channel: params.channel,
+          agentId: params.agentId,
+          accountId: params.accountId,
+          target: params.to,
+          resolvedTarget: params.resolvedTarget,
+          replyToId,
+          threadId: resolvedThreadId,
+        })
+      : null;
+  if (outboundRoute && params.agentId && !params.dryRun) {
+    await params.ensureOutboundSessionEntry({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      channel: params.channel,
+      accountId: params.accountId,
+      route: outboundRoute,
+    });
+  }
+  if (outboundRoute && !params.dryRun) {
+    params.actionParams.__sessionKey = outboundRoute.sessionKey;
+  }
+  if (params.agentId) {
+    params.actionParams.__agentId = params.agentId;
+  }
+  return {
+    resolvedThreadId,
+    outboundRoute,
+  };
+}

--- a/test/fixtures/test-parallel.behavior.json
+++ b/test/fixtures/test-parallel.behavior.json
@@ -248,6 +248,10 @@
         "reason": "Clean in isolation, but can hang after sharing the broad lane."
       },
       {
+        "file": "src/plugins/provider-wizard.test.ts",
+        "reason": "Retained ~318 MiB in an isolated memory trace and is safer outside the shared unit-fast lane."
+      },
+      {
         "file": "src/config/doc-baseline.integration.test.ts",
         "reason": "Builds the full bundled config schema graph and is safer outside the shared unit-fast heap."
       },
@@ -982,6 +986,22 @@
       {
         "file": "src/channels/plugins/contracts/inbound.telegram.contract.test.ts",
         "reason": "Needs the vmForks lane when targeted."
+      }
+    ]
+  },
+  "extensions": {
+    "singletonIsolated": [
+      {
+        "file": "extensions/bluebubbles/src/setup-surface.test.ts",
+        "reason": "Loads the setup-wizard/plugin-sdk graph and retained ~576 MiB in an isolated memory trace."
+      },
+      {
+        "file": "extensions/feishu/index.test.ts",
+        "reason": "Plugin entry registration coverage loads a broad channel graph and is safer outside the shared extensions lane."
+      },
+      {
+        "file": "extensions/msteams/src/monitor.test.ts",
+        "reason": "Webhook timeout coverage is startup-heavy but showed no material retained heap growth across repeated snapshots."
       }
     ]
   }

--- a/test/vitest-extensions-config.test.ts
+++ b/test/vitest-extensions-config.test.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadIncludePatternsFromEnv } from "../vitest.extensions.config.ts";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+const writePatternFile = (basename: string, value: unknown) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-vitest-extensions-config-"));
+  tempDirs.add(dir);
+  const filePath = path.join(dir, basename);
+  fs.writeFileSync(filePath, `${JSON.stringify(value)}\n`, "utf8");
+  return filePath;
+};
+
+describe("extensions vitest include patterns", () => {
+  it("returns null when no include file is configured", () => {
+    expect(loadIncludePatternsFromEnv({})).toBeNull();
+  });
+
+  it("loads include patterns from a JSON file", () => {
+    const filePath = writePatternFile("include.json", [
+      "extensions/feishu/index.test.ts",
+      42,
+      "",
+      "extensions/msteams/src/monitor.test.ts",
+    ]);
+
+    expect(
+      loadIncludePatternsFromEnv({
+        OPENCLAW_VITEST_INCLUDE_FILE: filePath,
+      }),
+    ).toEqual(["extensions/feishu/index.test.ts", "extensions/msteams/src/monitor.test.ts"]);
+  });
+
+  it("throws when the configured file is not a JSON array", () => {
+    const filePath = writePatternFile("include.json", {
+      include: ["extensions/feishu/index.test.ts"],
+    });
+
+    expect(() =>
+      loadIncludePatternsFromEnv({
+        OPENCLAW_VITEST_INCLUDE_FILE: filePath,
+      }),
+    ).toThrow(/JSON array/u);
+  });
+});

--- a/vitest.extensions.config.ts
+++ b/vitest.extensions.config.ts
@@ -1,9 +1,31 @@
+import fs from "node:fs";
 import { channelTestExclude } from "./vitest.channel-paths.mjs";
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
-export default createScopedVitestConfig(["extensions/**/*.test.ts"], {
-  // Channel implementations live under extensions/ but are tested by
-  // vitest.channels.config.ts (pnpm test:channels) which provides
-  // the heavier mock scaffolding they need.
-  exclude: channelTestExclude.filter((pattern) => pattern.startsWith("extensions/")),
-});
+function loadPatternListFile(filePath: string, label: string): string[] {
+  const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(`${label} must point to a JSON array: ${filePath}`);
+  }
+  return parsed.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+export function loadIncludePatternsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): string[] | null {
+  const includeFile = env.OPENCLAW_VITEST_INCLUDE_FILE?.trim();
+  if (!includeFile) {
+    return null;
+  }
+  return loadPatternListFile(includeFile, "OPENCLAW_VITEST_INCLUDE_FILE");
+}
+
+export default createScopedVitestConfig(
+  loadIncludePatternsFromEnv() ?? ["extensions/**/*.test.ts"],
+  {
+    // Channel implementations live under extensions/ but are tested by
+    // vitest.channels.config.ts (pnpm test:channels) which provides
+    // the heavier mock scaffolding they need.
+    exclude: channelTestExclude.filter((pattern) => pattern.startsWith("extensions/")),
+  },
+);


### PR DESCRIPTION
## Summary

- Problem: several small hotspot tests were paying very high startup/import costs and inflating shared worker RSS, especially `src/infra/outbound/message-action-runner.threading.test.ts`, `extensions/msteams/src/monitor.test.ts`, `extensions/feishu/index.test.ts`, `extensions/bluebubbles/src/setup-surface.test.ts`, and `src/plugins/provider-wizard.test.ts`.
- Why it matters: these files distort shared-lane memory, make traces look leakier than they are, and slow targeted/local verification.
- What changed: split two heavy test seams into lighter helpers, trimmed one plugin-entry test import graph, and added extension `singletonIsolated` scheduler support so startup-heavy extension tests can be peeled out of the shared lane.
- What did NOT change (scope boundary): no product behavior changes; this only adjusts test/runtime seams and test scheduling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu, MS Teams, BlueBubbles test surfaces
- Relevant config (redacted): default local test env

### Steps

1. Run the hotspot tests with `OPENCLAW_TEST_MEMORY_TRACE=1 OPENCLAW_TEST_WORKERS=1 pnpm test -- <file>`.
2. Compare startup time / peak RSS before and after the seam split or scheduler change.
3. Re-run targeted tests, `pnpm build`, and `pnpm check`.

### Expected

- Startup-heavy tests use lighter seams where possible.
- Remaining import-heavy extension tests are isolated out of the shared extensions worker lane.
- No product behavior regressions.

### Actual

- `src/infra/outbound/message-action-runner.threading.test.ts`: `22.88s` / `518.6 MiB` -> `2.39s` / `222.4 MiB`
- `extensions/msteams/src/monitor.test.ts`: `19.56s` / `584.8 MiB` -> `1.20s` / `250.2 MiB`
- `src/plugins/provider-wizard.test.ts`: `317.8 MiB` -> `237.0 MiB`, and now isolated from shared `unit-fast`
- `extensions/feishu/index.test.ts` and `extensions/bluebubbles/src/setup-surface.test.ts` remain startup-heavy, but are now isolated from the shared extensions lane
- Heap snapshots for `extensions/msteams/src/monitor.test.ts` showed no meaningful retained growth, so that case was startup/import cost rather than a real leak

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - targeted memory-traced reruns for the hotspot files
  - targeted tests for the new seams and the extension include-file config
  - `pnpm build`
  - `pnpm check`
- Edge cases checked:
  - explicit thread id still wins over auto-threading
  - replyTo still flows into thread resolution
  - extension include-file config rejects malformed JSON shape
  - MS Teams timeout helper behavior unchanged
- What you did **not** verify:
  - full `pnpm test`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `4d7706e64c`
- Files/config to restore: test runner manifest/scheduler files and the two extracted helper modules
- Known bad symptoms reviewers should watch for: missing extension tests in the shared lane, or threading helper tests no longer covering route/session-key injection

## Risks and Mitigations

- Risk: extension singleton scheduling could accidentally exclude tests from the shared lane without rerunning them elsewhere.
  - Mitigation: `scripts/test-parallel.mjs` now creates explicit isolated extension entries, and `test/vitest-extensions-config.test.ts` covers the include-file behavior.
- Risk: splitting helpers could weaken coverage if tests stop exercising important paths.
  - Mitigation: the threading test still verifies route/session-key injection semantics, and the MS Teams timeout test still validates the real exported helper behavior.
