### PR TITLE
fix(fs): avoid file identity verification failures on FreeBSD

### DIFF
--- a/src/infra/file-identity.test.ts
+++ b/src/infra/file-identity.test.ts
@@ -63,6 +63,20 @@ describe("sameFileIdentity", () => {
       platform: "win32" as const,
       expected: true,
     },
+    {
+      name: "ignores device id on freebsd when inode matches",
+      left: stat(0, 11),
+      right: stat(1, 11),
+      platform: "freebsd" as const,
+      expected: true,
+    },
+    {
+      name: "rejects inode mismatch on freebsd",
+      left: stat(1, 11),
+      right: stat(1, 12),
+      platform: "freebsd" as const,
+      expected: false,
+    },
   ])("$name", ({ left, right, platform, expected }) => {
     expect(sameFileIdentity(left, right, platform)).toBe(expected);
   });

--- a/src/infra/file-identity.ts
+++ b/src/infra/file-identity.ts
@@ -16,6 +16,12 @@ export function sameFileIdentity(
     return false;
   }
 
+  // FreeBSD: treat inode match as sufficient.
+  // Ignore st_dev here as a compatibility workaround.
+  if (platform === "freebsd") {
+    return true;
+  }
+
   // On Windows, path-based stat calls can report dev=0 while fd-based stat
   // reports a real volume serial; treat either-side dev=0 as "unknown device".
   if (left.dev === right.dev) {

--- a/src/infra/fs-pinned-write-helper.ts
+++ b/src/infra/fs-pinned-write-helper.ts
@@ -87,7 +87,7 @@ const LOCAL_PINNED_WRITE_PYTHON = [
   "    temp_name = None",
   "    os.fsync(parent_fd)",
   "    result_stat = os.stat(basename, dir_fd=parent_fd, follow_symlinks=False)",
-  "    print(f'{result_stat.st_dev}|{result_stat.st_ino}')",
+  "    print(f'{result_stat.st_dev & 0xffffffffffffffff}|{result_stat.st_ino & 0xffffffffffffffff}')",
   "finally:",
   "    if temp_fd is not None:",
   "        os.close(temp_fd)",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** On FreeBSD, especially in our ZFS jail setup, file identity checks can fail due to `st_dev` mismatches during path-based vs fd-based verification.
- **Why it matters:** This can trigger `SafeOpenError: path mismatch` during file operations and cause commands such as `openclaw plugins install` to fail in affected environments.
- **What changed:** Updated `sameFileIdentity` to treat inode matches as sufficient on FreeBSD by ignoring `st_dev` on that platform. Also normalized the Python helper’s `stat` output to unsigned 64-bit strings to avoid signed `st_dev` ambiguity.
- **What did NOT change (scope boundary):** Avoided a broader `BigInt` refactor across the file verification stack. Existing stat call sites and surrounding filesystem verification flow remain unchanged outside this targeted FreeBSD workaround.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # 
- Related # 

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
`None` directly. This is an underlying compatibility/stability fix; users on affected FreeBSD environments should simply stop seeing unexpected file verification failures during file operations such as plugin installation.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: FreeBSD 15.0-RELEASE-p4
- Runtime/container: ZFS Jail
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Node.js runtime

### Steps

1. Install OpenClaw inside FreeBSD ZFS Jail environment.
2. Trigger a task that involves file writes and identity validation (e.g., running `openclaw plugins install`).
3. Observe whether the execution is interrupted by filesystem validation errors.

### Expected

- File writes and post-write verification complete successfully without `SafeOpenError`.

### Actual

- Before this fix, the process could fail with:

```text
16:03:57 [security] fs-safe write boundary warning (post-copy verification failed: SafeOpenError: path changed during write)
failed to extract archive: SafeOpenError: path changed during write
Failed to install plugin from npm.
Error: Command failed: openclaw plugins install ...
```

## Evidence

Attach at least one:
- [x] Trace/log snippets (see diagnostic below)

The affected environment exposes `st_dev` as a signed 64-bit value in Python, which is one of the factors contributing to the mismatch behavior in the current verification path:

<details>
<summary>Diagnostic</summary>

```python
>>> import os                                                                                                                                                                                                                
>>> os.stat("/etc/passwd")                                                                                                                                                                                                   
os.stat_result(st_mode=33188, st_ino=296605, st_dev=-6692299710746245206, st_nlink=1, st_uid=0, st_gid=0, st_size=2229, st_atime=1773319168, st_mtime=1773319168, st_ctime=1773319168)
```