### PR TITLE
Plugins: add agent_error hook to replace provider errors before broadcast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3132,6 +3132,7 @@ Docs: https://docs.openclaw.ai
 - Browser/existing-session: support `browser.profiles.<name>.userDataDir` so Chrome DevTools MCP can attach to Brave, Edge, and other Chromium-based browsers through their own user data directories. (#48170) Thanks @velvet-shark.
 - Plugins/bundles: make enabled bundle MCP servers expose runnable tools in embedded Pi, and default relative bundle MCP launches to the bundle root so marketplace bundles like Context7 work through Pi instead of stopping at config import.
 - Plugins/providers: move OpenRouter, GitHub Copilot, and OpenAI Codex provider/runtime logic into bundled plugins, including dynamic model fallback, runtime auth exchange, stream wrappers, capability hints, and cache-TTL policy.
+- Plugins/hooks: add `agent_error` hook fired before an agent-error message is broadcast to the user, allowing plugins to replace raw provider errors (e.g. billing limit exhaustion) with friendly localised messages.
 - Models/Anthropic Vertex: add core `anthropic-vertex` provider support for Claude via Google Vertex AI, including GCP auth/discovery and main run-path routing. (#43356) Thanks @sallyom and @yossiovadia.
 - Plugins/Chutes: add a bundled Chutes provider with plugin-owned OAuth/API-key auth, dynamic model discovery, and default-on extension wiring. (#41416) Thanks @Veightor.
 - Web tools/Exa: add Exa as a bundled web-search plugin with Exa-native date filters, search-mode selection, and optional content extraction under `plugins.entries.exa.config.webSearch.*`. Thanks @V-Gutierrez and @vincentkoc.

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -678,5 +678,42 @@ describe("handleAgentEnd", () => {
         }),
       );
     });
+
+    it("broadcasts original error when hook hangs past the timeout", async () => {
+      vi.useFakeTimers();
+      try {
+        const onAgentEvent = vi.fn();
+        const ctx = createContext(
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "connection refused",
+            content: [{ type: "text", text: "" }],
+          },
+          {
+            onAgentEvent,
+            hookRunner: {
+              hasHooks: vi.fn(() => true),
+              runAgentError: vi.fn(() => new Promise(() => {})),
+            } as unknown as EmbeddedPiSubscribeContext["hookRunner"],
+          },
+        );
+
+        const endPromise = handleAgentEnd(ctx);
+        await vi.advanceTimersByTimeAsync(2000);
+        await endPromise;
+
+        expect(onAgentEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              phase: "error",
+              error: expect.stringContaining("connection refused"),
+            }),
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { handleAgentEnd } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -591,6 +591,10 @@ describe("handleAgentEnd", () => {
   });
 
   describe("agent_error hook", () => {
+    afterEach(() => {
+      _globalHookRunner = null;
+    });
+
     it("broadcasts hook replacement message instead of raw error", async () => {
       const onAgentEvent = vi.fn();
       _globalHookRunner = {
@@ -616,7 +620,6 @@ describe("handleAgentEnd", () => {
           error: "⚠️ Me he quedado sin tokens",
         },
       });
-      _globalHookRunner = null;
     });
 
     it("broadcasts original error when hook returns no message", async () => {
@@ -645,7 +648,6 @@ describe("handleAgentEnd", () => {
           }),
         }),
       );
-      _globalHookRunner = null;
     });
 
     it("broadcasts original error when hook throws", async () => {
@@ -676,7 +678,6 @@ describe("handleAgentEnd", () => {
           }),
         }),
       );
-      _globalHookRunner = null;
     });
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -579,7 +579,7 @@ describe("handleAgentEnd", () => {
       throw new Error("flush exploded");
     });
 
-    expect(() => handleAgentEnd(ctx)).toThrow("flush exploded");
+    await expect(handleAgentEnd(ctx)).rejects.toThrow("flush exploded");
 
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -7,6 +7,15 @@ vi.mock("../infra/agent-events.js", () => ({
   emitAgentEvent: vi.fn(),
 }));
 
+let _globalHookRunner: {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runAgentError: ReturnType<typeof vi.fn>;
+} | null = null;
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => _globalHookRunner,
+}));
+
 function createContext(
   lastAssistant: unknown,
   overrides?: {
@@ -578,6 +587,96 @@ describe("handleAgentEnd", () => {
     expect(onAgentEvent).toHaveBeenCalledWith({
       stream: "lifecycle",
       data: { phase: "end" },
+    });
+  });
+
+  describe("agent_error hook", () => {
+    it("broadcasts hook replacement message instead of raw error", async () => {
+      const onAgentEvent = vi.fn();
+      _globalHookRunner = {
+        hasHooks: vi.fn(() => true),
+        runAgentError: vi.fn(async () => ({ message: "⚠️ Me he quedado sin tokens" })),
+      };
+      const ctx = createContext(
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "403: Key limit exceeded",
+          content: [{ type: "text", text: "" }],
+        },
+        { onAgentEvent },
+      );
+
+      await handleAgentEnd(ctx);
+
+      expect(onAgentEvent).toHaveBeenCalledWith({
+        stream: "lifecycle",
+        data: {
+          phase: "error",
+          error: "⚠️ Me he quedado sin tokens",
+        },
+      });
+      _globalHookRunner = null;
+    });
+
+    it("broadcasts original error when hook returns no message", async () => {
+      const onAgentEvent = vi.fn();
+      _globalHookRunner = {
+        hasHooks: vi.fn(() => true),
+        runAgentError: vi.fn(async () => undefined),
+      };
+      const ctx = createContext(
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "connection refused",
+          content: [{ type: "text", text: "" }],
+        },
+        { onAgentEvent },
+      );
+
+      await handleAgentEnd(ctx);
+
+      expect(onAgentEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            error: expect.stringContaining("connection refused"),
+          }),
+        }),
+      );
+      _globalHookRunner = null;
+    });
+
+    it("broadcasts original error when hook throws", async () => {
+      const onAgentEvent = vi.fn();
+      _globalHookRunner = {
+        hasHooks: vi.fn(() => true),
+        runAgentError: vi.fn(async () => {
+          throw new Error("hook failure");
+        }),
+      };
+      const ctx = createContext(
+        {
+          role: "assistant",
+          stopReason: "error",
+          errorMessage: "connection refused",
+          content: [{ type: "text", text: "" }],
+        },
+        { onAgentEvent },
+      );
+
+      await handleAgentEnd(ctx);
+
+      expect(onAgentEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "error",
+            error: expect.stringContaining("connection refused"),
+          }),
+        }),
+      );
+      _globalHookRunner = null;
     });
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { handleAgentEnd } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -7,13 +7,8 @@ vi.mock("../infra/agent-events.js", () => ({
   emitAgentEvent: vi.fn(),
 }));
 
-let _globalHookRunner: {
-  hasHooks: ReturnType<typeof vi.fn>;
-  runAgentError: ReturnType<typeof vi.fn>;
-} | null = null;
-
 vi.mock("../plugins/hook-runner-global.js", () => ({
-  getGlobalHookRunner: () => _globalHookRunner,
+  getGlobalHookRunner: () => null,
 }));
 
 function createContext(
@@ -23,6 +18,7 @@ function createContext(
     onBeforeLifecycleTerminal?: () => void | Promise<void>;
     onBlockReply?: ((payload: unknown) => void) | undefined;
     onBlockReplyFlush?: () => void | Promise<void>;
+    hookRunner?: EmbeddedPiSubscribeContext["hookRunner"];
   },
 ): EmbeddedPiSubscribeContext {
   const hasOnBlockReplyOverride = Boolean(overrides && "onBlockReply" in overrides);
@@ -38,6 +34,7 @@ function createContext(
       ...(onBlockReply ? { onBlockReply } : {}),
       onBlockReplyFlush: overrides?.onBlockReplyFlush,
     },
+    hookRunner: overrides?.hookRunner,
     state: {
       lastAssistant: lastAssistant as EmbeddedPiSubscribeContext["state"]["lastAssistant"],
       pendingCompactionRetry: 0,
@@ -591,16 +588,8 @@ describe("handleAgentEnd", () => {
   });
 
   describe("agent_error hook", () => {
-    afterEach(() => {
-      _globalHookRunner = null;
-    });
-
     it("broadcasts hook replacement message instead of raw error", async () => {
       const onAgentEvent = vi.fn();
-      _globalHookRunner = {
-        hasHooks: vi.fn(() => true),
-        runAgentError: vi.fn(async () => ({ message: "⚠️ Me he quedado sin tokens" })),
-      };
       const ctx = createContext(
         {
           role: "assistant",
@@ -608,7 +597,13 @@ describe("handleAgentEnd", () => {
           errorMessage: "403: Key limit exceeded",
           content: [{ type: "text", text: "" }],
         },
-        { onAgentEvent },
+        {
+          onAgentEvent,
+          hookRunner: {
+            hasHooks: vi.fn(() => true),
+            runAgentError: vi.fn(async () => ({ message: "⚠️ Me he quedado sin tokens" })),
+          } as unknown as EmbeddedPiSubscribeContext["hookRunner"],
+        },
       );
 
       await handleAgentEnd(ctx);
@@ -624,10 +619,6 @@ describe("handleAgentEnd", () => {
 
     it("broadcasts original error when hook returns no message", async () => {
       const onAgentEvent = vi.fn();
-      _globalHookRunner = {
-        hasHooks: vi.fn(() => true),
-        runAgentError: vi.fn(async () => undefined),
-      };
       const ctx = createContext(
         {
           role: "assistant",
@@ -635,7 +626,13 @@ describe("handleAgentEnd", () => {
           errorMessage: "connection refused",
           content: [{ type: "text", text: "" }],
         },
-        { onAgentEvent },
+        {
+          onAgentEvent,
+          hookRunner: {
+            hasHooks: vi.fn(() => true),
+            runAgentError: vi.fn(async () => undefined),
+          } as unknown as EmbeddedPiSubscribeContext["hookRunner"],
+        },
       );
 
       await handleAgentEnd(ctx);
@@ -652,12 +649,6 @@ describe("handleAgentEnd", () => {
 
     it("broadcasts original error when hook throws", async () => {
       const onAgentEvent = vi.fn();
-      _globalHookRunner = {
-        hasHooks: vi.fn(() => true),
-        runAgentError: vi.fn(async () => {
-          throw new Error("hook failure");
-        }),
-      };
       const ctx = createContext(
         {
           role: "assistant",
@@ -665,7 +656,15 @@ describe("handleAgentEnd", () => {
           errorMessage: "connection refused",
           content: [{ type: "text", text: "" }],
         },
-        { onAgentEvent },
+        {
+          onAgentEvent,
+          hookRunner: {
+            hasHooks: vi.fn(() => true),
+            runAgentError: vi.fn(async () => {
+              throw new Error("hook failure");
+            }),
+          } as unknown as EmbeddedPiSubscribeContext["hookRunner"],
+        },
       );
 
       await handleAgentEnd(ctx);

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -1,5 +1,6 @@
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import {
   buildApiErrorObservationFields,
   buildTextObservationFields,
@@ -36,7 +37,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   });
 }
 
-export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<void> {
+export async function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): Promise<void> {
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
   let lifecycleErrorText: string | undefined;
@@ -73,7 +74,25 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): void | Promise<
     const failoverReason = classifyFailoverReason(rawError ?? "", {
       provider: lastAssistant.provider,
     });
-    const errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
+    let errorText = (friendlyError || lastAssistant.errorMessage || "LLM request failed.").trim();
+
+    // Allow plugins to replace the error text before it is broadcast.
+    // This lets plugins swap raw provider errors for localised friendly messages.
+    const hookRunner = ctx.hookRunner ?? getGlobalHookRunner();
+    if (hookRunner?.hasHooks("agent_error")) {
+      try {
+        const hookResult = await hookRunner.runAgentError(
+          { error: errorText },
+          { sessionKey: ctx.params.sessionKey },
+        );
+        if (hookResult?.message != null) {
+          errorText = hookResult.message;
+        }
+      } catch {
+        // Don't block delivery on hook failure.
+      }
+    }
+
     const observedError = buildApiErrorObservationFields(rawError, {
       provider: lastAssistant.provider,
     });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -21,6 +21,13 @@ export {
   handleCompactionStart,
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 
+// Plugin agent_error hooks must not block lifecycle event emission or
+// compaction retry resolution. The fallback path in agent-command.ts emits a
+// synthetic phase: "end" if no lifecycle terminal event is observed in time,
+// so unbounded plugin latency could let clients see a false "end" before the
+// real "error". Two seconds is generous for a text-replacement hook.
+const AGENT_ERROR_HOOK_TIMEOUT_MS = 2000;
+
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
@@ -78,18 +85,27 @@ export async function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): Promise<v
 
     // Allow plugins to replace the error text before it is broadcast.
     // This lets plugins swap raw provider errors for localised friendly messages.
+    // Bounded by a timeout so a slow/hung hook can't delay lifecycle emission
+    // or compaction retry resolution beyond AGENT_ERROR_HOOK_TIMEOUT_MS.
     const hookRunner = ctx.hookRunner ?? getGlobalHookRunner();
     if (hookRunner?.hasHooks("agent_error")) {
+      let hookTimeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
-        const hookResult = await hookRunner.runAgentError(
-          { error: errorText },
-          { sessionKey: ctx.params.sessionKey },
-        );
+        const hookResult = await Promise.race([
+          hookRunner.runAgentError({ error: errorText }, { sessionKey: ctx.params.sessionKey }),
+          new Promise<undefined>((resolve) => {
+            hookTimeoutId = setTimeout(() => resolve(undefined), AGENT_ERROR_HOOK_TIMEOUT_MS);
+          }),
+        ]);
         if (typeof hookResult?.message === "string") {
           errorText = hookResult.message;
         }
       } catch {
         // Don't block delivery on hook failure.
+      } finally {
+        if (hookTimeoutId) {
+          clearTimeout(hookTimeoutId);
+        }
       }
     }
 

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -85,7 +85,7 @@ export async function handleAgentEnd(ctx: EmbeddedPiSubscribeContext): Promise<v
           { error: errorText },
           { sessionKey: ctx.params.sessionKey },
         );
-        if (hookResult?.message != null) {
+        if (typeof hookResult?.message === "string") {
           errorText = hookResult.message;
         }
       } catch {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -65,6 +65,7 @@ export type PluginHookName =
   | "llm_output"
   | "before_agent_finalize"
   | "agent_end"
+  | "agent_error"
   | "before_compaction"
   | "after_compaction"
   | "before_reset"
@@ -99,6 +100,7 @@ export const PLUGIN_HOOK_NAMES = [
   "llm_output",
   "before_agent_finalize",
   "agent_end",
+  "agent_error",
   "before_compaction",
   "after_compaction",
   "before_reset",
@@ -246,6 +248,19 @@ export type PluginHookLlmOutputEvent = {
     cacheWrite?: number;
     total?: number;
   };
+};
+
+// agent_error hook — fired when an agent run ends with an error, before the
+// error message is broadcast to the user. Allows plugins to replace the error
+// text with a friendlier, localised message.
+export type PluginHookAgentErrorEvent = {
+  /** The raw error message that would be sent to the user. */
+  error: string;
+};
+
+export type PluginHookAgentErrorResult = {
+  /** Replacement error message to broadcast instead. */
+  message?: string;
 };
 
 export type PluginHookAgentEndEvent = {
@@ -753,6 +768,10 @@ export type PluginHookHandlerMap = {
     | PluginHookBeforeAgentFinalizeResult
     | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  agent_error: (
+    event: PluginHookAgentErrorEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookAgentErrorResult | void> | PluginHookAgentErrorResult | void;
   before_compaction: (
     event: PluginHookBeforeCompactionEvent,
     ctx: PluginHookAgentContext,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -254,7 +254,7 @@ export type PluginHookLlmOutputEvent = {
 // error message is broadcast to the user. Allows plugins to replace the error
 // text with a friendlier, localised message.
 export type PluginHookAgentErrorEvent = {
-  /** The raw error message that would be sent to the user. */
+  /** The processed error message that would be sent to the user (after built-in friendly-error formatting). */
   error: string;
 };
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -14,6 +14,8 @@ import type {
   PluginHookAfterToolCallEvent,
   PluginHookAgentContext,
   PluginHookAgentEndEvent,
+  PluginHookAgentErrorEvent,
+  PluginHookAgentErrorResult,
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
   PluginHookBeforeAgentReplyEvent,
@@ -96,6 +98,8 @@ export type {
   PluginHookBeforeAgentFinalizeEvent,
   PluginHookBeforeAgentFinalizeResult,
   PluginHookAgentEndEvent,
+  PluginHookAgentErrorEvent,
+  PluginHookAgentErrorResult,
   PluginHookBeforeCompactionEvent,
   PluginHookBeforeResetEvent,
   PluginHookInboundClaimContext,
@@ -661,6 +665,26 @@ export function createHookRunner(
   }
 
   /**
+   * Run agent_error hook.
+   * Allows plugins to replace the error text broadcast to the user when an
+   * agent run ends with an error (e.g. billing limit → friendly message).
+   * Runs sequentially so each plugin sees the previous plugin's replacement.
+   */
+  async function runAgentError(
+    event: PluginHookAgentErrorEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookAgentErrorResult | undefined> {
+    return runModifyingHook<"agent_error", PluginHookAgentErrorResult>(
+      "agent_error",
+      event,
+      ctx,
+      (acc, next) => ({
+        message: next.message ?? acc?.message,
+      }),
+    );
+  }
+
+  /**
    * Run llm_input hook.
    * Allows plugins to observe the exact input payload sent to the LLM.
    * Runs in parallel (fire-and-forget).
@@ -1207,6 +1231,7 @@ export function createHookRunner(
     runLlmOutput,
     runBeforeAgentFinalize,
     runAgentEnd,
+    runAgentError,
     runBeforeCompaction,
     runAfterCompaction,
     runBeforeReset,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -674,14 +674,34 @@ export function createHookRunner(
     event: PluginHookAgentErrorEvent,
     ctx: PluginHookAgentContext,
   ): Promise<PluginHookAgentErrorResult | undefined> {
-    return runModifyingHook<"agent_error", PluginHookAgentErrorResult>(
-      "agent_error",
-      event,
-      ctx,
-      (acc, next) => ({
-        message: next.message ?? acc?.message,
-      }),
-    );
+    const hooks = getHooksForName(registry, "agent_error");
+    if (hooks.length === 0) {
+      return undefined;
+    }
+
+    logger?.debug?.(`[hooks] running agent_error (${hooks.length} handlers, sequential)`);
+
+    // Each handler receives the message produced by the previous one so that
+    // later plugins can build on an earlier plugin's replacement rather than
+    // seeing the original raw provider error.
+    let currentError = event.error;
+    for (const hook of hooks) {
+      try {
+        const handlerResult = await (
+          hook.handler as (
+            e: PluginHookAgentErrorEvent,
+            c: PluginHookAgentContext,
+          ) => Promise<PluginHookAgentErrorResult>
+        )({ error: currentError }, ctx);
+        if (typeof handlerResult?.message === "string") {
+          currentError = handlerResult.message;
+        }
+      } catch (err) {
+        handleHookError({ hookName: "agent_error", pluginId: hook.pluginId, error: err });
+      }
+    }
+
+    return currentError !== event.error ? { message: currentError } : undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds a new `agent_error` modifying hook that fires in `handleAgentEnd` when an agent run ends with an error, **before** the error message is broadcast to the user via the lifecycle WebSocket event.
- Plugins can return `{ message: string }` to replace the raw provider error (e.g. a billing-limit 403) with a friendly, localised message.
- If no plugin handles it (or the hook throws), the original error text is preserved — fully non-breaking.
- `handleAgentEnd` is made `async` and called fire-and-forget with `.catch()` from the dispatcher, consistent with the other async handlers in the same switch block.

## Why not `message_sending`?

`message_sending` fires when a reply is being delivered to a messaging channel (WhatsApp, Telegram, etc.). Agent lifecycle errors never go through that path — they are emitted directly as `{ stream: "lifecycle", data: { phase: "error", error } }` events. A dedicated `agent_error` hook is the correct seam for this.

## Changes

- `src/plugins/types.ts` — `PluginHookName`, `PLUGIN_HOOK_NAMES`, new `PluginHookAgentErrorEvent` / `PluginHookAgentErrorResult` types, and `agent_error` entry in `PluginHookHandlerMap`
- `src/plugins/hooks.ts` — `runAgentError` sequential modifying-hook runner (same pattern as `runMessageSending`), exported from the hook runner
- `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts` — `handleAgentEnd` made async; hook invoked via `getGlobalHookRunner()` fallback (matches existing pattern); `safeErrorText` derived from the possibly-replaced value
- `src/agents/pi-embedded-subscribe.handlers.ts` — `agent_end` case updated to `.catch()` the now-async handler
- `src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts` — existing tests updated to `await handleAgentEnd`; new `agent_error hook` describe block with 3 cases: replacement, no-op (undefined return), and hook throws

## Test plan

- [ ] `pnpm test -- src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts` — all 8 tests pass (5 existing + 3 new)
- [ ] `pnpm check` — lint, format, type-check, and all boundary checks pass
- [ ] Manual: install a plugin that registers `agent_error` and returns a custom message; trigger a billing/quota error on a live agent session; confirm the friendly message appears in the client instead of the raw provider error

## Failure recovery

Revert `handleAgentEnd` to `function` (sync), remove the hook call block, and revert the `.catch()` in the dispatcher — the hook is fully additive with no changes to existing error-path logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)