### PR TITLE
fix: Discord retry policy only covers 429 — misses 502/503/timeout/connection errors (AI-authored)

### DIFF
--- a/extensions/discord/src/retry.ts
+++ b/extensions/discord/src/retry.ts
@@ -1,9 +1,15 @@
 import { RateLimitError } from "@buape/carbon";
 import {
   createRateLimitRetryRunner,
+  formatErrorMessage,
   type RetryConfig,
   type RetryRunner,
 } from "openclaw/plugin-sdk/infra-runtime";
+
+// Matches transient HTTP and network errors that are safe to retry.
+// Mirrors the pattern used by the Telegram retry policy.
+const DISCORD_TRANSIENT_RE =
+  /429|502|503|timeout|connect|reset|closed|unavailable|temporarily|fetch.failed/i;
 
 export const DISCORD_RETRY_DEFAULTS = {
   attempts: 3,
@@ -21,7 +27,8 @@ export function createDiscordRetryRunner(params: {
     ...params,
     defaults: DISCORD_RETRY_DEFAULTS,
     logLabel: "discord",
-    shouldRetry: (err) => err instanceof RateLimitError,
+    shouldRetry: (err) =>
+      err instanceof RateLimitError || DISCORD_TRANSIENT_RE.test(formatErrorMessage(err)),
     retryAfterMs: (err) => (err instanceof RateLimitError ? err.retryAfter * 1000 : undefined),
   });
 }


### PR DESCRIPTION
## Summary

Widens the Discord outbound message retry predicate to cover transient HTTP and network errors beyond just HTTP 429.

### Changes

- Adds `DISCORD_TRANSIENT_RE` regex pattern matching `429|502|503|timeout|connect|reset|closed|unavailable|temporarily|fetch.failed` (mirrors Telegram's retry policy)
- Imports `formatErrorMessage` from `openclaw/plugin-sdk/infra-runtime` (already used elsewhere in the discord extension)
- `shouldRetry` now retries on `RateLimitError` OR any error whose message matches the transient pattern
- `retryAfterMs` is unchanged — `RateLimitError` still gets Discord-specific backoff; other errors use `DISCORD_RETRY_DEFAULTS`

### Why this is safe

- 502/503 from Discord are always transient; retrying is correct behavior
- Connection errors (`reset`, `closed`, `fetch failed`) are network-level and should be retried
- The existing `channels.discord.retry` config (attempts, delays, backoff) applies unchanged — only the eligibility predicate is widened

Fixes https://github.com/openclaw/openclaw/issues/52396

---

This PR was created by an AI agent.