### PR TITLE
feat(plugins): add api.runtime.agent.abort for aborting agent runs

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -147,6 +147,7 @@ beforeEach(() => {
   primeConfiguredBindingRegistry.mockClear().mockReturnValue({ bindingCount: 0, channelCount: 0 });
   handleGatewayRequest.mockReset();
   runtimeModule.clearGatewaySubagentRuntime();
+  runtimeModule.clearGatewayAgentAbort();
   handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
     switch (opts.req.method) {
       case "agent":
@@ -169,6 +170,7 @@ beforeEach(() => {
 
 afterEach(() => {
   runtimeModule.clearGatewaySubagentRuntime();
+  runtimeModule.clearGatewayAgentAbort();
 });
 
 describe("loadGatewayPlugins", () => {
@@ -615,5 +617,93 @@ describe("loadGatewayPlugins", () => {
       | (GatewayRequestContext & { marker: string })
       | undefined;
     expect(dispatched?.marker).toBe("after-mutation");
+  });
+
+  test("runtime.agent.abort dispatches to gateway and returns the result", async () => {
+    const serverPlugins = serverPluginsModule;
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+
+    handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent.abort") {
+        opts.respond(true, { aborted: true });
+        return;
+      }
+      opts.respond(true, { runId: "run-1" });
+    });
+
+    serverPlugins.loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+    serverPlugins.setFallbackGatewayContext(createTestContext("agent-abort"));
+
+    const runtime = runtimeModule.createPluginRuntime({ allowGatewaySubagentBinding: true });
+    const result = await runtime.agent.abort({ runId: "run-42" });
+
+    expect(result).toEqual({ aborted: true });
+    const lastCall = handleGatewayRequest.mock.calls.at(-1)?.[0];
+    expect(lastCall?.req?.method).toBe("agent.abort");
+    expect(lastCall?.req?.params).toMatchObject({ runId: "run-42" });
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.admin"]);
+  });
+
+  test("runtime.agent.abort forwards sessionKey when provided", async () => {
+    const serverPlugins = serverPluginsModule;
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+
+    handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent.abort") {
+        opts.respond(true, { aborted: true });
+        return;
+      }
+      opts.respond(true, { runId: "run-1" });
+    });
+
+    serverPlugins.loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+    serverPlugins.setFallbackGatewayContext(createTestContext("agent-abort-session"));
+
+    const runtime = runtimeModule.createPluginRuntime({ allowGatewaySubagentBinding: true });
+    await runtime.agent.abort({ runId: "run-42", sessionKey: "sess-1" });
+
+    expect(getLastDispatchedParams()).toMatchObject({
+      runId: "run-42",
+      sessionKey: "sess-1",
+    });
+  });
+
+  test("runtime.agent.abort returns aborted=false when gateway reports it", async () => {
+    const serverPlugins = serverPluginsModule;
+    loadOpenClawPlugins.mockReturnValue(createRegistry([]));
+
+    handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
+      if (opts.req.method === "agent.abort") {
+        opts.respond(true, { aborted: false });
+        return;
+      }
+      opts.respond(true, { runId: "run-1" });
+    });
+
+    serverPlugins.loadGatewayPlugins({
+      cfg: {},
+      workspaceDir: "/tmp",
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      coreGatewayHandlers: {},
+      baseMethods: [],
+    });
+    serverPlugins.setFallbackGatewayContext(createTestContext("agent-abort-false"));
+
+    const runtime = runtimeModule.createPluginRuntime({ allowGatewaySubagentBinding: true });
+    const result = await runtime.agent.abort({ runId: "run-gone" });
+
+    expect(result).toEqual({ aborted: false });
   });
 });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -6,7 +6,7 @@ import { resolveGatewayStartupPluginIds } from "../plugins/channel-plugin-ids.js
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
-import { setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
+import { setGatewayAgentAbort, setGatewaySubagentRuntime } from "../plugins/runtime/index.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
@@ -293,6 +293,22 @@ async function dispatchGatewayMethod<T>(
   return result.payload as T;
 }
 
+function createGatewayAgentAbort(): PluginRuntime["agent"]["abort"] {
+  return async (params) => {
+    const payload = await dispatchGatewayMethod<{ aborted?: boolean }>(
+      "agent.abort",
+      {
+        runId: params.runId,
+        ...(params.sessionKey && { sessionKey: params.sessionKey }),
+      },
+      {
+        syntheticScopes: [ADMIN_SCOPE],
+      },
+    );
+    return { aborted: payload?.aborted === true };
+  };
+}
+
 function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
   const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
     const payload = await dispatchGatewayMethod<{ messages?: unknown[] }>("sessions.get", {
@@ -399,12 +415,13 @@ export function loadGatewayPlugins(params: {
   logDiagnostics?: boolean;
 }) {
   setPluginSubagentOverridePolicies(params.cfg);
-  // Set the process-global gateway subagent runtime BEFORE loading plugins.
+  // Set the process-global gateway runtimes BEFORE loading plugins.
   // Gateway-owned registries may already exist from schema loads, so the
   // gateway path opts those runtimes into late binding rather than changing
   // the default subagent behavior for every plugin runtime in the process.
   const gatewaySubagent = createGatewaySubagentRuntime();
   setGatewaySubagentRuntime(gatewaySubagent);
+  setGatewayAgentAbort(createGatewayAgentAbort());
 
   const pluginRegistry = loadOpenClawPlugins({
     config: params.cfg,

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -5,8 +5,10 @@ import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  clearGatewayAgentAbort,
   clearGatewaySubagentRuntime,
   createPluginRuntime,
+  setGatewayAgentAbort,
   setGatewaySubagentRuntime,
 } from "./index.js";
 
@@ -14,6 +16,7 @@ describe("plugin runtime command execution", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     clearGatewaySubagentRuntime();
+    clearGatewayAgentAbort();
   });
 
   it("exposes runtime.system.runCommandWithTimeout by default", async () => {
@@ -140,5 +143,38 @@ describe("plugin runtime command execution", () => {
       runId: "run-1",
     });
     expect(run).toHaveBeenCalledWith({ sessionKey: "s-2", message: "hello" });
+  });
+
+  it("agent.abort throws by default without gateway binding", () => {
+    const runtime = createPluginRuntime();
+    expect(() => runtime.agent.abort({ runId: "run-1" })).toThrow(
+      "Plugin runtime agent.abort is only available during a gateway request.",
+    );
+  });
+
+  it("agent.abort stays unavailable by default even after gateway initialization", () => {
+    const runtime = createPluginRuntime();
+    setGatewayAgentAbort(vi.fn().mockResolvedValue({ aborted: true }));
+    expect(() => runtime.agent.abort({ runId: "run-1" })).toThrow(
+      "Plugin runtime agent.abort is only available during a gateway request.",
+    );
+  });
+
+  it("agent.abort late-binds to the gateway agent abort when explicitly enabled", async () => {
+    const abort = vi.fn().mockResolvedValue({ aborted: true });
+    const runtime = createPluginRuntime({ allowGatewaySubagentBinding: true });
+    setGatewayAgentAbort(abort);
+
+    await expect(runtime.agent.abort({ runId: "run-42" })).resolves.toEqual({ aborted: true });
+    expect(abort).toHaveBeenCalledWith({ runId: "run-42" });
+  });
+
+  it("agent.abort forwards sessionKey when provided", async () => {
+    const abort = vi.fn().mockResolvedValue({ aborted: true });
+    const runtime = createPluginRuntime({ allowGatewaySubagentBinding: true });
+    setGatewayAgentAbort(abort);
+
+    await runtime.agent.abort({ runId: "run-42", sessionKey: "session-1" });
+    expect(abort).toHaveBeenCalledWith({ runId: "run-42", sessionKey: "session-1" });
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -103,6 +103,49 @@ export function clearGatewaySubagentRuntime(): void {
   gatewaySubagentState.subagent = undefined;
 }
 
+// ── Process-global gateway agent abort runtime ──────────────────────
+// Mirrors the subagent pattern: the gateway sets the real agent.abort
+// implementation at startup; plugin runtimes that opt in resolve it
+// dynamically via late binding.
+
+const GATEWAY_AGENT_ABORT_SYMBOL: unique symbol = Symbol.for(
+  "openclaw.plugin.gatewayAgentAbortRuntime",
+) as unknown as typeof GATEWAY_AGENT_ABORT_SYMBOL;
+
+type GatewayAgentAbortState = {
+  abort: PluginRuntime["agent"]["abort"] | undefined;
+};
+
+const gatewayAgentAbortState: GatewayAgentAbortState = (() => {
+  const g = globalThis as typeof globalThis & {
+    [GATEWAY_AGENT_ABORT_SYMBOL]?: GatewayAgentAbortState;
+  };
+  const existing = g[GATEWAY_AGENT_ABORT_SYMBOL];
+  if (existing) {
+    return existing;
+  }
+  const created: GatewayAgentAbortState = { abort: undefined };
+  g[GATEWAY_AGENT_ABORT_SYMBOL] = created;
+  return created;
+})();
+
+/**
+ * Set the process-global gateway agent abort runtime.
+ * Called during gateway startup so that gateway-bindable plugin runtimes can
+ * resolve agent.abort dynamically.
+ */
+export function setGatewayAgentAbort(abort: PluginRuntime["agent"]["abort"]): void {
+  gatewayAgentAbortState.abort = abort;
+}
+
+/**
+ * Reset the process-global gateway agent abort runtime.
+ * Used by tests to avoid leaking gateway state across module reloads.
+ */
+export function clearGatewayAgentAbort(): void {
+  gatewayAgentAbortState.abort = undefined;
+}
+
 /**
  * Create a late-binding subagent that resolves to:
  * 1. An explicitly provided subagent (from runtimeOptions), OR
@@ -136,10 +179,21 @@ export type CreatePluginRuntimeOptions = {
 };
 
 export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): PluginRuntime {
+  const baseAgent = createRuntimeAgent();
+  const agentWithAbort: PluginRuntime["agent"] = {
+    ...baseAgent,
+    abort:
+      _options.allowGatewaySubagentBinding === true
+        ? (params) => {
+            const resolved = gatewayAgentAbortState.abort ?? baseAgent.abort;
+            return resolved(params);
+          }
+        : baseAgent.abort,
+  };
   const runtime = {
     version: resolveVersion(),
     config: createRuntimeConfig(),
-    agent: createRuntimeAgent(),
+    agent: agentWithAbort,
     subagent: createLateBindingSubagent(
       _options.subagent,
       _options.allowGatewaySubagentBinding === true,

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -26,6 +26,9 @@ export function createRuntimeAgent(): PluginRuntime["agent"] {
     runEmbeddedPiAgent,
     resolveAgentTimeoutMs,
     ensureAgentWorkspace,
+    abort() {
+      throw new Error("Plugin runtime agent.abort is only available during a gateway request.");
+    },
     session: {
       resolveStorePath,
       loadSessionStore,

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -50,8 +50,22 @@ export type SubagentDeleteSessionParams = {
   deleteTranscript?: boolean;
 };
 
+// ── Agent runtime types ─────────────────────────────────────────────
+
+export type AgentAbortParams = {
+  runId: string;
+  sessionKey?: string;
+};
+
+export type AgentAbortResult = {
+  aborted: boolean;
+};
+
 /** Trusted in-process runtime surface injected into native plugins. */
 export type PluginRuntime = PluginRuntimeCore & {
+  agent: {
+    abort: (params: AgentAbortParams) => Promise<AgentAbortResult>;
+  };
   subagent: {
     run: (params: SubagentRunParams) => Promise<SubagentRunResult>;
     waitForRun: (params: SubagentWaitParams) => Promise<SubagentWaitResult>;


### PR DESCRIPTION
## Summary

- Problem: There is currently no way for plugins to programmatically cancel an in-progress agent run. Once an agent starts processing, it runs to completion regardless of whether the result is still needed.
- Why it matters: Multi-agent plugins need to cancel stale or redundant agent runs when new messages arrive or when a user requests silence.
- What changed: Added `api.runtime.agent.abort({ runId })` to the plugin runtime, dispatching to the gateway's existing abort controller registry with admin scope.
- What did NOT change: Agent runner behavior, abort controller internals.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52412
- Depends on #52413 (`runId` in agent hook context)

## User-visible / Behavior Changes

Plugins gain access to `api.runtime.agent.abort({ runId })`. No config changes. Existing plugins are unaffected.

## Security Impact (required)

- New permissions/capabilities? Yes — plugins can now abort any agent run by runId
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: The abort dispatches with admin scope internally. This is acceptable because plugins already have full runtime access. The runId is opaque and only available to the plugin that receives it via hook context.

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: Node.js 21.7
- Model/provider: Any
- Integration/channel: Discord

### Steps

1. Create a plugin that records `ctx.runId` in `before_agent_start`
2. On a new `message_received`, call `api.runtime.agent.abort({ runId: savedRunId })`
3. Observe the agent run is cancelled

### Expected

- `agent.abort` returns `{ aborted: true }` and the agent stops processing

### Actual

- Before this PR: `api.runtime.agent` does not exist

## Evidence

- Unit tests added in `server-plugins.test.ts` and `runtime/index.test.ts`
- Verified in production: multi-agent Discord setup with stale run cancellation

## Human Verification (required)

- Verified scenarios: abort cancels in-progress agent runs, abort on already-completed run returns gracefully
- Edge cases checked: abort with invalid runId, abort during agent startup
- What you did **not** verify: Concurrent abort from multiple plugins

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; agent namespace is additive
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Unexpected agent cancellations (would require a plugin to call abort)

## Risks and Mitigations

- Risk: A buggy plugin could abort agent runs it shouldn't
  - Mitigation: Abort requires a valid `runId` which is only available to plugins that receive it via hook context for their own managed agents.