### PR TITLE
fix: clean up seqByRun entry in clearAgentRunContext()

### DIFF
--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
+import type { AgentEventPayload } from "./agent-events.js";
 import {
   clearAgentRunContext,
   emitAgentEvent,
@@ -189,5 +190,27 @@ describe("agent-events sequencing", () => {
     ]);
 
     first.resetAgentEventsForTest();
+  });
+
+  it("clearAgentRunContext also removes seqByRun entry", () => {
+    // Emit an event to create a seqByRun entry
+    emitAgentEvent({ runId: "run-seq-cleanup", stream: "lifecycle", data: {} });
+    // Verify it was tracked
+    emitAgentEvent({ runId: "run-seq-cleanup", stream: "lifecycle", data: {} });
+    const events: AgentEventPayload[] = [];
+    const unsub = onAgentEvent((e) => events.push(e));
+    emitAgentEvent({ runId: "run-seq-cleanup", stream: "lifecycle", data: {} });
+    expect(events[0].seq).toBe(3); // was incremented
+
+    // Clear the run context — should also clear seqByRun
+    clearAgentRunContext("run-seq-cleanup");
+
+    // Next emit for same runId should start from seq 1 again
+    emitAgentEvent({ runId: "run-seq-cleanup", stream: "lifecycle", data: {} });
+    expect(events[1].seq).toBe(1); // reset after cleanup
+    unsub();
+
+    // Clean up the re-created seqByRun entry so it doesn't leak across tests
+    clearAgentRunContext("run-seq-cleanup");
   });
 });

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -64,6 +64,7 @@ export function getAgentRunContext(runId: string) {
 
 export function clearAgentRunContext(runId: string) {
   state.runContextById.delete(runId);
+  state.seqByRun.delete(runId);
 }
 
 export function resetAgentRunContextForTest() {


### PR DESCRIPTION
## Summary

The `seqByRun` Map in `agent-events.ts` stores one entry per `runId` but `clearAgentRunContext()` only deletes from `runContextById`, leaving `seqByRun` entries to accumulate indefinitely. Over hundreds of runs per day this contributes to heap growth on long-running gateways.

## Fix

Add `seqByRun.delete(runId)` in `clearAgentRunContext()` alongside the existing `runContextById` cleanup.

## Changes

- `src/infra/agent-events.ts` — 1 line: delete seqByRun entry in clearAgentRunContext()
- `src/infra/agent-events.test.ts` — add test verifying seq counter resets after context clear

## Testing

- 9 tests pass (`vitest run src/infra/agent-events.test`)
- Full pre-commit suite passes (tsgo, oxlint, oxfmt, all boundary lints)
- New test emits events to build up seq counter, calls clearAgentRunContext(), then verifies seq resets to 1

Closes #51819

🤖 AI-assisted (Claude), fully tested, author understands the change.