### PR TITLE
feat: start typing indicator during tool-dispatched skill execution

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -241,6 +241,9 @@ export async function handleInlineActions(params: {
 
       const toolCallId = `cmd_${generateSecureToken(8)}`;
       try {
+        // Start typing indicator before tool execution so users see
+        // feedback while the skill is running (e.g. long API calls).
+        await typing.startTypingLoop();
         const result = await tool.execute(toolCallId, {
           command: rawArgs,
           commandName: skillInvocation.command.name,


### PR DESCRIPTION
## Summary
- When a skill uses `dispatch.kind === "tool"`, the typing indicator was never started before `tool.execute()`, so users saw no visual feedback (typing...) while the skill was running
- Added `typing.startTypingLoop()` before tool execution, matching the behavior of regular message replies
- `typing.cleanup()` is already called after execution completes, so no additional cleanup needed

## Test plan
- [ ] Send a tool-dispatched skill command in Telegram
- [ ] Verify "typing..." indicator appears while the skill is executing
- [ ] Verify typing stops after skill completes
- [ ] Verify prompt-rewrite skills still work as before (no change to that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)