### PR TITLE
fix(whatsapp): use sock.end() instead of sock.ws?.close() for proper cleanup

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -478,7 +478,15 @@ export async function monitorWebInbox(options: {
           ev.removeListener("messages.upsert", messagesUpsertHandler);
           ev.removeListener("connection.update", connectionUpdateHandler);
         }
-        sock.ws?.close();
+        // Use Baileys' full cleanup (clears keepalive, removes WS listeners,
+        // emits connection.update close event). Falls back to raw WS close
+        // if end() is unavailable for backward compatibility.
+        const sockWithEnd = sock as unknown as { end?: (err?: Error) => void };
+        if (typeof sockWithEnd.end === "function") {
+          sockWithEnd.end(new Error("OpenClaw listener close"));
+        } else {
+          sock.ws?.close();
+        }
       } catch (err) {
         logVerbose(`Socket close failed: ${String(err)}`);
       }


### PR DESCRIPTION
## Summary

- Replace `sock.ws?.close()` with `sock.end()` in the WhatsApp listener's `close()` function (`extensions/whatsapp/src/inbound/monitor.ts:481`)
- `sock.end()` is Baileys' proper cleanup that clears keepalive timer, removes all WS/ev listeners, and emits the connection.update close event
- `sock.ws?.close()` only closes the raw WebSocket, leaking everything else
- Falls back to `ws.close()` if `end()` is unavailable for backward compatibility

## Problem

Each reconnect cycle leaks:
- Keepalive interval (keeps pinging dead socket)
- `creds.update` event listener
- `connection.update` event listener (from session.ts)
- `ws.error` listener
- Baileys' internal `closed` flag stays `false`

This causes zombie sockets: report "connected" but cannot receive inbound messages. The health monitor detects "stale" → restarts → creates another zombie → infinite loop. In production: 14 restarts overnight, 5.5 hours zero message delivery.

## Test plan

- [ ] Verify `sock.end` exists on Baileys socket object (Socket/socket.js:858 — confirmed for v7.0.0-rc.9)
- [ ] Test reconnect cycle: disconnect WhatsApp → verify clean teardown → verify new socket receives messages
- [ ] Test rapid reconnect storm: kill connection 5x in 2 minutes → verify no listener accumulation
- [ ] Test health monitor restart: with `channelHealthCheckMinutes: 5`, verify restarted channels work

Fixes #52442

🤖 Generated with [Claude Code](https://claude.com/claude-code)