### PR TITLE
feat: materialize explicit workspace authority links in sandbox

### DIFF
--- a/src/agents/sandbox.workspace.test.ts
+++ b/src/agents/sandbox.workspace.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ensureSandboxWorkspace } from "./sandbox/workspace.js";
+
+describe("ensureSandboxWorkspace", () => {
+  it("materializes explicit top-level symlinked workspace authorities into the sandbox", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-workspace-"));
+    const sourceWorkspace = path.join(tmpRoot, "workspace");
+    const sandboxWorkspace = path.join(tmpRoot, "sandbox");
+    const authorityRoot = path.join(tmpRoot, "authority");
+    const authorityDocs = path.join(authorityRoot, "docs");
+    const authorityRepoDocs = path.join(authorityRoot, "voro-docs");
+
+    await fs.mkdir(sourceWorkspace, { recursive: true });
+    await fs.mkdir(authorityDocs, { recursive: true });
+    await fs.mkdir(authorityRepoDocs, { recursive: true });
+    await fs.writeFile(path.join(sourceWorkspace, "AGENTS.md"), "# Agent\n", "utf-8");
+    await fs.writeFile(path.join(authorityRoot, "README.md"), "repo readme\n", "utf-8");
+    await fs.writeFile(path.join(authorityRoot, "CLAUDE.md"), "repo claude\n", "utf-8");
+    await fs.writeFile(path.join(authorityDocs, "CODEBASE_MAP.md"), "map\n", "utf-8");
+    await fs.writeFile(path.join(authorityRepoDocs, "PLAN.md"), "plan\n", "utf-8");
+
+    await fs.symlink(path.join(authorityRoot, "README.md"), path.join(sourceWorkspace, "README.md"));
+    await fs.symlink(path.join(authorityRoot, "CLAUDE.md"), path.join(sourceWorkspace, "CLAUDE.md"));
+    await fs.symlink(authorityDocs, path.join(sourceWorkspace, "docs"));
+    await fs.symlink(authorityRepoDocs, path.join(sourceWorkspace, "voro-docs"));
+
+    await ensureSandboxWorkspace(sandboxWorkspace, sourceWorkspace, true);
+
+    await expect(fs.readFile(path.join(sandboxWorkspace, "README.md"), "utf-8")).resolves.toBe(
+      "repo readme\n",
+    );
+    await expect(fs.readFile(path.join(sandboxWorkspace, "CLAUDE.md"), "utf-8")).resolves.toBe(
+      "repo claude\n",
+    );
+    await expect(
+      fs.readFile(path.join(sandboxWorkspace, "docs", "CODEBASE_MAP.md"), "utf-8"),
+    ).resolves.toBe("map\n");
+    await expect(
+      fs.readFile(path.join(sandboxWorkspace, "voro-docs", "PLAN.md"), "utf-8"),
+    ).resolves.toBe("plan\n");
+
+    await expect(fs.lstat(path.join(sandboxWorkspace, "README.md"))).resolves.toMatchObject({
+      isSymbolicLink: expect.any(Function),
+    });
+    expect((await fs.lstat(path.join(sandboxWorkspace, "README.md"))).isSymbolicLink()).toBe(false);
+    expect((await fs.lstat(path.join(sandboxWorkspace, "docs"))).isSymbolicLink()).toBe(false);
+  });
+
+  it("does not mirror non-symlink top-level workspace entries", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-workspace-"));
+    const sourceWorkspace = path.join(tmpRoot, "workspace");
+    const sandboxWorkspace = path.join(tmpRoot, "sandbox");
+
+    await fs.mkdir(sourceWorkspace, { recursive: true });
+    await fs.writeFile(path.join(sourceWorkspace, "AGENTS.md"), "# Agent\n", "utf-8");
+    await fs.writeFile(path.join(sourceWorkspace, "README.md"), "plain file\n", "utf-8");
+    await fs.mkdir(path.join(sourceWorkspace, "docs"), { recursive: true });
+    await fs.writeFile(path.join(sourceWorkspace, "docs", "CODEBASE_MAP.md"), "plain dir\n", "utf-8");
+
+    await ensureSandboxWorkspace(sandboxWorkspace, sourceWorkspace, true);
+
+    await expect(fs.stat(path.join(sandboxWorkspace, "AGENTS.md"))).resolves.toBeTruthy();
+    await expect(fs.stat(path.join(sandboxWorkspace, "README.md"))).rejects.toBeTruthy();
+    await expect(fs.stat(path.join(sandboxWorkspace, "docs"))).rejects.toBeTruthy();
+  });
+});

--- a/src/agents/sandbox.workspace.test.ts
+++ b/src/agents/sandbox.workspace.test.ts
@@ -22,8 +22,14 @@ describe("ensureSandboxWorkspace", () => {
     await fs.writeFile(path.join(authorityDocs, "CODEBASE_MAP.md"), "map\n", "utf-8");
     await fs.writeFile(path.join(authorityRepoDocs, "PLAN.md"), "plan\n", "utf-8");
 
-    await fs.symlink(path.join(authorityRoot, "README.md"), path.join(sourceWorkspace, "README.md"));
-    await fs.symlink(path.join(authorityRoot, "CLAUDE.md"), path.join(sourceWorkspace, "CLAUDE.md"));
+    await fs.symlink(
+      path.join(authorityRoot, "README.md"),
+      path.join(sourceWorkspace, "README.md"),
+    );
+    await fs.symlink(
+      path.join(authorityRoot, "CLAUDE.md"),
+      path.join(sourceWorkspace, "CLAUDE.md"),
+    );
     await fs.symlink(authorityDocs, path.join(sourceWorkspace, "docs"));
     await fs.symlink(authorityRepoDocs, path.join(sourceWorkspace, "voro-docs"));
 
@@ -58,7 +64,11 @@ describe("ensureSandboxWorkspace", () => {
     await fs.writeFile(path.join(sourceWorkspace, "AGENTS.md"), "# Agent\n", "utf-8");
     await fs.writeFile(path.join(sourceWorkspace, "README.md"), "plain file\n", "utf-8");
     await fs.mkdir(path.join(sourceWorkspace, "docs"), { recursive: true });
-    await fs.writeFile(path.join(sourceWorkspace, "docs", "CODEBASE_MAP.md"), "plain dir\n", "utf-8");
+    await fs.writeFile(
+      path.join(sourceWorkspace, "docs", "CODEBASE_MAP.md"),
+      "plain dir\n",
+      "utf-8",
+    );
 
     await ensureSandboxWorkspace(sandboxWorkspace, sourceWorkspace, true);
 

--- a/src/agents/sandbox.workspace.test.ts
+++ b/src/agents/sandbox.workspace.test.ts
@@ -76,4 +76,56 @@ describe("ensureSandboxWorkspace", () => {
     await expect(fs.stat(path.join(sandboxWorkspace, "README.md"))).rejects.toBeTruthy();
     await expect(fs.stat(path.join(sandboxWorkspace, "docs"))).rejects.toBeTruthy();
   });
+
+  it("materializes only approved top-level authority link names", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-workspace-"));
+    const sourceWorkspace = path.join(tmpRoot, "workspace");
+    const sandboxWorkspace = path.join(tmpRoot, "sandbox");
+    const authorityRoot = path.join(tmpRoot, "authority");
+    const privateDir = path.join(authorityRoot, "private-notes");
+
+    await fs.mkdir(sourceWorkspace, { recursive: true });
+    await fs.mkdir(privateDir, { recursive: true });
+    await fs.writeFile(path.join(sourceWorkspace, "AGENTS.md"), "# Agent\n", "utf-8");
+    await fs.writeFile(path.join(authorityRoot, "README.md"), "repo readme\n", "utf-8");
+    await fs.writeFile(path.join(privateDir, "note.md"), "secret\n", "utf-8");
+
+    await fs.symlink(
+      path.join(authorityRoot, "README.md"),
+      path.join(sourceWorkspace, "README.md"),
+    );
+    await fs.symlink(privateDir, path.join(sourceWorkspace, "private-notes"));
+
+    await ensureSandboxWorkspace(sandboxWorkspace, sourceWorkspace, true);
+
+    await expect(fs.readFile(path.join(sandboxWorkspace, "README.md"), "utf-8")).resolves.toBe(
+      "repo readme\n",
+    );
+    await expect(fs.stat(path.join(sandboxWorkspace, "private-notes"))).rejects.toBeTruthy();
+  });
+
+  it("does not dereference nested symlinks inside allowed authority directories", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-workspace-"));
+    const sourceWorkspace = path.join(tmpRoot, "workspace");
+    const sandboxWorkspace = path.join(tmpRoot, "sandbox");
+    const authorityRoot = path.join(tmpRoot, "authority");
+    const authorityDocs = path.join(authorityRoot, "docs");
+    const externalRoot = path.join(tmpRoot, "external");
+
+    await fs.mkdir(sourceWorkspace, { recursive: true });
+    await fs.mkdir(authorityDocs, { recursive: true });
+    await fs.mkdir(externalRoot, { recursive: true });
+    await fs.writeFile(path.join(sourceWorkspace, "AGENTS.md"), "# Agent\n", "utf-8");
+    await fs.writeFile(path.join(authorityDocs, "CODEBASE_MAP.md"), "map\n", "utf-8");
+    await fs.writeFile(path.join(externalRoot, "secret.txt"), "top secret\n", "utf-8");
+    await fs.symlink(path.join(externalRoot, "secret.txt"), path.join(authorityDocs, "secret.txt"));
+    await fs.symlink(authorityDocs, path.join(sourceWorkspace, "docs"));
+
+    await ensureSandboxWorkspace(sandboxWorkspace, sourceWorkspace, true);
+
+    await expect(
+      fs.readFile(path.join(sandboxWorkspace, "docs", "CODEBASE_MAP.md"), "utf-8"),
+    ).resolves.toBe("map\n");
+    await expect(fs.stat(path.join(sandboxWorkspace, "docs", "secret.txt"))).rejects.toBeTruthy();
+  });
 });

--- a/src/agents/sandbox/workspace.ts
+++ b/src/agents/sandbox/workspace.ts
@@ -34,7 +34,9 @@ const SANDBOX_NON_BOOTSTRAP_SKIP = new Set([
   "memory",
 ]);
 
-async function copyIfMissing(src: string, dest: string) {
+const SANDBOX_ALLOWED_AUTHORITY_LINKS = new Set(["README.md", "CLAUDE.md", "docs", "voro-docs"]);
+
+async function copyAuthorityTreeIfMissing(src: string, dest: string) {
   try {
     await fs.access(dest);
     return;
@@ -42,8 +44,12 @@ async function copyIfMissing(src: string, dest: string) {
     // missing; continue
   }
 
-  const stat = await fs.stat(src).catch(() => null);
+  const stat = await fs.lstat(src).catch(() => null);
   if (!stat) {
+    return;
+  }
+
+  if (stat.isSymbolicLink()) {
     return;
   }
 
@@ -53,19 +59,25 @@ async function copyIfMissing(src: string, dest: string) {
   }
 
   if (stat.isDirectory()) {
-    await fs.cp(src, dest, {
-      recursive: true,
-      force: false,
-      errorOnExist: true,
-      dereference: true,
-    });
+    await fs.mkdir(dest, { recursive: false });
+    const entries = await fs.readdir(src, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+      await copyAuthorityTreeIfMissing(path.join(src, entry.name), path.join(dest, entry.name));
+    }
   }
 }
 
 async function materializeExplicitWorkspaceLinks(workspaceDir: string, seedFrom: string) {
   const entries = await fs.readdir(seedFrom, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
-    if (!entry.isSymbolicLink() || SANDBOX_NON_BOOTSTRAP_SKIP.has(entry.name)) {
+    if (
+      !entry.isSymbolicLink() ||
+      SANDBOX_NON_BOOTSTRAP_SKIP.has(entry.name) ||
+      !SANDBOX_ALLOWED_AUTHORITY_LINKS.has(entry.name)
+    ) {
       continue;
     }
 
@@ -76,7 +88,7 @@ async function materializeExplicitWorkspaceLinks(workspaceDir: string, seedFrom:
       continue;
     }
 
-    await copyIfMissing(resolved, dest).catch(() => {
+    await copyAuthorityTreeIfMissing(resolved, dest).catch(() => {
       // Ignore invalid or unreadable explicit links; sandbox seeding should stay best-effort.
     });
   }

--- a/src/agents/sandbox/workspace.ts
+++ b/src/agents/sandbox/workspace.ts
@@ -14,6 +14,74 @@ import {
   ensureAgentWorkspace,
 } from "../workspace.js";
 
+const SANDBOX_BOOTSTRAP_FILES = [
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_HEARTBEAT_FILENAME,
+] as const;
+
+const SANDBOX_NON_BOOTSTRAP_SKIP = new Set([
+  ...SANDBOX_BOOTSTRAP_FILES,
+  ".git",
+  ".openclaw",
+  "skills",
+  "MEMORY.md",
+  "memory.md",
+  "memory",
+]);
+
+async function copyIfMissing(src: string, dest: string) {
+  try {
+    await fs.access(dest);
+    return;
+  } catch {
+    // missing; continue
+  }
+
+  const stat = await fs.stat(src).catch(() => null);
+  if (!stat) {
+    return;
+  }
+
+  if (stat.isFile()) {
+    await fs.copyFile(src, dest);
+    return;
+  }
+
+  if (stat.isDirectory()) {
+    await fs.cp(src, dest, {
+      recursive: true,
+      force: false,
+      errorOnExist: true,
+      dereference: true,
+    });
+  }
+}
+
+async function materializeExplicitWorkspaceLinks(workspaceDir: string, seedFrom: string) {
+  const entries = await fs.readdir(seedFrom, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (!entry.isSymbolicLink() || SANDBOX_NON_BOOTSTRAP_SKIP.has(entry.name)) {
+      continue;
+    }
+
+    const src = path.join(seedFrom, entry.name);
+    const dest = path.join(workspaceDir, entry.name);
+    const resolved = await fs.realpath(src).catch(() => null);
+    if (!resolved) {
+      continue;
+    }
+
+    await copyIfMissing(resolved, dest).catch(() => {
+      // Ignore invalid or unreadable explicit links; sandbox seeding should stay best-effort.
+    });
+  }
+}
+
 export async function ensureSandboxWorkspace(
   workspaceDir: string,
   seedFrom?: string,
@@ -22,16 +90,7 @@ export async function ensureSandboxWorkspace(
   await fs.mkdir(workspaceDir, { recursive: true });
   if (seedFrom) {
     const seed = resolveUserPath(seedFrom);
-    const files = [
-      DEFAULT_AGENTS_FILENAME,
-      DEFAULT_SOUL_FILENAME,
-      DEFAULT_TOOLS_FILENAME,
-      DEFAULT_IDENTITY_FILENAME,
-      DEFAULT_USER_FILENAME,
-      DEFAULT_BOOTSTRAP_FILENAME,
-      DEFAULT_HEARTBEAT_FILENAME,
-    ];
-    for (const name of files) {
+    for (const name of SANDBOX_BOOTSTRAP_FILES) {
       const src = path.join(seed, name);
       const dest = path.join(workspaceDir, name);
       try {
@@ -57,6 +116,7 @@ export async function ensureSandboxWorkspace(
         }
       }
     }
+    await materializeExplicitWorkspaceLinks(workspaceDir, seed);
   }
   await ensureAgentWorkspace({
     dir: workspaceDir,


### PR DESCRIPTION
## Summary

- Materialize explicit top-level workspace authority links (symlinks to `README.md`, `CLAUDE.md`, `docs/`, etc.) into sandbox workspaces as real files/directories
- Preserve existing bootstrap file seeding behavior (`AGENTS.md`, `SOUL.md`, etc.)
- Add `materializeExplicitWorkspaceLinks` helper that walks the seed workspace for symlinks, skipping bootstrap files and internal directories (`.git`, `.openclaw`, `skills`, `memory`)
- Add unit test coverage for hydrated authority links and non-symlink exclusion

## Motivation

Sandbox workspaces only copied bootstrap files but ignored symlinked authority paths that the host workspace uses for local-first context. Agents running in sandboxed mode had no access to repo-level authority docs (`README.md`, `CLAUDE.md`, `docs/CODEBASE_MAP.md`), breaking local-first research workflows.

## Validation

```
corepack pnpm vitest run src/agents/sandbox.workspace.test.ts src/agents/sandbox-skills.test.ts --config vitest.unit.config.ts
```

- Runtime tests passed
- Hydrated sandbox contains: `README.md`, `CLAUDE.md`, `docs/`, `voro-docs/`
- Existing bootstrap file behavior unchanged

## Test plan

- [x] Symlinked authority files/dirs are materialized as real copies (not symlinks)
- [x] Non-symlink workspace entries are NOT copied
- [x] Bootstrap files (`AGENTS.md`, `SOUL.md`, etc.) still seeded via existing path
- [x] Existing `sandbox-skills.test.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)