### PR TITLE
fix(cli): route plugin logs to stderr during --json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Docs: https://docs.openclaw.ai
 - CLI/configure: clarify fresh-setup memory-search warnings so they say semantic recall needs at least one embedding provider, and scope the initial model allowlist picker to the provider selected in configure. Thanks @vincentkoc.
 - CLI/auth choice: lazy-load plugin/provider fallback resolution so mapped auth choices stay on the static path and only unknown choices pay the heavy provider load. (#47495) Thanks @vincentkoc.
 - CLI: avoid loading provider discovery during startup model normalization. (#46522) Thanks @ItsAditya-xyz and @vincentkoc.
+- CLI/status: keep `status --json` stdout clean by skipping plugin compatibility scans that were not rendered in the JSON payload. (#52449) Thanks @cgdusek.
 - Agents/Telegram: avoid rebuilding the full model catalog on ordinary inbound replies so Telegram message handling no longer pays multi-second core startup latency before reply generation. Thanks @vincentkoc.
 - Gateway/Discord startup: load only configured channel plugins during gateway boot, and lazy-load Discord provider/session runtime setup so startup stops importing unrelated providers and trims cold-start delay. Thanks @vincentkoc.
 - Security/exec: harden macOS allowlist resolution against wrapper and `env` spoofing, require fresh approval for inline interpreter eval with `tools.exec.strictInlineEval`, wrap Discord guild message bodies as untrusted external content, and add audit findings for risky exec approval and open-channel combinations.

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -352,8 +352,8 @@ describe("registerPreActionHooks", () => {
     });
 
     await runPreAction({
-      parseArgv: ["agents"],
-      processArgv: ["node", "openclaw", "agents", "--json"],
+      parseArgv: ["agents", "list"],
+      processArgv: ["node", "openclaw", "agents", "list", "--json"],
     });
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
@@ -369,8 +369,8 @@ describe("registerPreActionHooks", () => {
     });
 
     await runPreAction({
-      parseArgv: ["agents"],
-      processArgv: ["node", "openclaw", "agents"],
+      parseArgv: ["agents", "list"],
+      processArgv: ["node", "openclaw", "agents", "list"],
     });
 
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { loggingState } from "../../logging/state.js";
 import { setCommandJsonMode } from "./json-mode.js";
 
 const setVerboseMock = vi.fn();
@@ -58,6 +59,7 @@ let originalProcessArgv: string[];
 let originalProcessTitle: string;
 let originalNodeNoWarnings: string | undefined;
 let originalHideBanner: string | undefined;
+let originalForceStderr: boolean;
 
 beforeAll(async () => {
   ({ registerPreActionHooks } = await import("./preaction.js"));
@@ -76,6 +78,8 @@ beforeEach(() => {
   originalProcessTitle = process.title;
   originalNodeNoWarnings = process.env.NODE_NO_WARNINGS;
   originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
+  originalForceStderr = loggingState.forceConsoleToStderr;
+  loggingState.forceConsoleToStderr = false;
   delete process.env.NODE_NO_WARNINGS;
   delete process.env.OPENCLAW_HIDE_BANNER;
 });
@@ -83,6 +87,7 @@ beforeEach(() => {
 afterEach(() => {
   process.argv = originalProcessArgv;
   process.title = originalProcessTitle;
+  loggingState.forceConsoleToStderr = originalForceStderr;
   if (originalNodeNoWarnings === undefined) {
     delete process.env.NODE_NO_WARNINGS;
   } else {
@@ -338,6 +343,39 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("routes logs to stderr during plugin loading in --json mode and restores after", async () => {
+    let stderrDuringPluginLoad = false;
+    ensurePluginRegistryLoadedMock.mockImplementation(() => {
+      stderrDuringPluginLoad = loggingState.forceConsoleToStderr;
+    });
+
+    await runPreAction({
+      parseArgv: ["agents"],
+      processArgv: ["node", "openclaw", "agents", "--json"],
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
+    expect(stderrDuringPluginLoad).toBe(true);
+    // Flag must be restored after plugin loading completes
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("does not route logs to stderr during plugin loading without --json", async () => {
+    let stderrDuringPluginLoad = false;
+    ensurePluginRegistryLoadedMock.mockImplementation(() => {
+      stderrDuringPluginLoad = loggingState.forceConsoleToStderr;
+    });
+
+    await runPreAction({
+      parseArgv: ["agents"],
+      processArgv: ["node", "openclaw", "agents"],
+    });
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
+    expect(stderrDuringPluginLoad).toBe(false);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
   beforeAll(() => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -3,6 +3,7 @@ import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import { routeLogsToStderr } from "../../logging/console.js";
 import type { LogLevel } from "../../logging/levels.js";
+import { loggingState } from "../../logging/state.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getCommandPathWithRootOptions, getVerboseFlag, hasHelpOrVersion } from "../argv.js";
 import { emitCliBanner } from "../banner.js";
@@ -138,10 +139,21 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       commandPath,
       ...(jsonOutputMode ? { suppressDoctorStdout: true } : {}),
     });
-    // Load plugins for commands that need channel access
+<<<<<<< HEAD
+    // Load plugins for commands that need channel access.
+    // When --json output is active, temporarily route logs to stderr so plugin
+    // registration messages don't corrupt the JSON payload on stdout.
     if (shouldLoadPluginsForCommand(commandPath, jsonOutputMode)) {
       const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
-      ensurePluginRegistryLoaded({ scope: resolvePluginRegistryScope(commandPath) });
+      const prev = loggingState.forceConsoleToStderr;
+      if (jsonOutputMode) {
+        loggingState.forceConsoleToStderr = true;
+      }
+      try {
+        ensurePluginRegistryLoaded({ scope: resolvePluginRegistryScope(commandPath) });
+      } finally {
+        loggingState.forceConsoleToStderr = prev;
+      }
     }
   });
 }

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -139,7 +139,6 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       commandPath,
       ...(jsonOutputMode ? { suppressDoctorStdout: true } : {}),
     });
-<<<<<<< HEAD
     // Load plugins for commands that need channel access.
     // When --json output is active, temporarily route logs to stderr so plugin
     // registration messages don't corrupt the JSON payload on stdout.

--- a/src/cli/route.test.ts
+++ b/src/cli/route.test.ts
@@ -34,7 +34,11 @@ vi.mock("../runtime.js", () => ({
 
 describe("tryRouteCli", () => {
   let tryRouteCli: typeof import("./route.js").tryRouteCli;
+  // After vi.resetModules(), reimported modules get fresh loggingState.
+  // Capture the same reference that route.js uses.
+  let loggingState: typeof import("../logging/state.js").loggingState;
   let originalDisableRouteFirst: string | undefined;
+  let originalForceStderr: boolean;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -42,6 +46,9 @@ describe("tryRouteCli", () => {
     delete process.env.OPENCLAW_DISABLE_ROUTE_FIRST;
     vi.resetModules();
     ({ tryRouteCli } = await import("./route.js"));
+    ({ loggingState } = await import("../logging/state.js"));
+    originalForceStderr = loggingState.forceConsoleToStderr;
+    loggingState.forceConsoleToStderr = false;
     findRoutedCommandMock.mockReturnValue({
       loadPlugins: (argv: string[]) => !argv.includes("--json"),
       run: runRouteMock,
@@ -49,6 +56,9 @@ describe("tryRouteCli", () => {
   });
 
   afterEach(() => {
+    if (loggingState) {
+      loggingState.forceConsoleToStderr = originalForceStderr;
+    }
     if (originalDisableRouteFirst === undefined) {
       delete process.env.OPENCLAW_DISABLE_ROUTE_FIRST;
     } else {
@@ -76,6 +86,44 @@ describe("tryRouteCli", () => {
       commandPath: ["status"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "channels" });
+  });
+
+  it("routes logs to stderr during plugin loading in --json mode and restores after", async () => {
+    findRoutedCommandMock.mockReturnValue({
+      loadPlugins: true,
+      run: runRouteMock,
+    });
+
+    // Capture the value inside the mock callback using the same loggingState
+    // reference that route.js sees (both imported after vi.resetModules()).
+    const captured: boolean[] = [];
+    ensurePluginRegistryLoadedMock.mockImplementation(() => {
+      captured.push(loggingState.forceConsoleToStderr);
+    });
+
+    await tryRouteCli(["node", "openclaw", "agents", "--json"]);
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
+    expect(captured[0]).toBe(true);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("does not route logs to stderr during plugin loading without --json", async () => {
+    findRoutedCommandMock.mockReturnValue({
+      loadPlugins: true,
+      run: runRouteMock,
+    });
+
+    const captured: boolean[] = [];
+    ensurePluginRegistryLoadedMock.mockImplementation(() => {
+      captured.push(loggingState.forceConsoleToStderr);
+    });
+
+    await tryRouteCli(["node", "openclaw", "agents"]);
+
+    expect(ensurePluginRegistryLoadedMock).toHaveBeenCalled();
+    expect(captured[0]).toBe(false);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
   it("routes status when root options precede the command", async () => {

--- a/src/cli/route.ts
+++ b/src/cli/route.ts
@@ -1,4 +1,5 @@
 import { isTruthyEnvValue } from "../infra/env.js";
+import { loggingState } from "../logging/state.js";
 import { defaultRuntime } from "../runtime.js";
 import { VERSION } from "../version.js";
 import { getCommandPathWithRootOptions, hasFlag, hasHelpOrVersion } from "./argv.js";
@@ -22,12 +23,20 @@ async function prepareRoutedCommand(params: {
     typeof params.loadPlugins === "function" ? params.loadPlugins(params.argv) : params.loadPlugins;
   if (shouldLoadPlugins) {
     const { ensurePluginRegistryLoaded } = await import("./plugin-registry.js");
-    ensurePluginRegistryLoaded({
-      scope:
-        params.commandPath[0] === "status" || params.commandPath[0] === "health"
-          ? "channels"
-          : "all",
-    });
+    const prev = loggingState.forceConsoleToStderr;
+    if (suppressDoctorStdout) {
+      loggingState.forceConsoleToStderr = true;
+    }
+    try {
+      ensurePluginRegistryLoaded({
+        scope:
+          params.commandPath[0] === "status" || params.commandPath[0] === "health"
+            ? "channels"
+            : "all",
+      });
+    } finally {
+      loggingState.forceConsoleToStderr = prev;
+    }
   }
 }
 

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loggingState } from "../logging/state.js";
 
 const mocks = vi.hoisted(() => ({
   resolveConfigPath: vi.fn(() => `/tmp/openclaw-status-fast-json-missing-${process.pid}.json`),
@@ -18,8 +19,12 @@ const mocks = vi.hoisted(() => ({
   buildPluginCompatibilityNotices: vi.fn(() => []),
 }));
 
+let originalForceStderr: boolean;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  originalForceStderr = loggingState.forceConsoleToStderr;
+  loggingState.forceConsoleToStderr = false;
   mocks.hasPotentialConfiguredChannels.mockReturnValue(false);
   mocks.readBestEffortConfig.mockResolvedValue({
     session: {},
@@ -170,7 +175,26 @@ vi.mock("../plugins/status.js", () => ({
 
 const { scanStatusJsonFast } = await import("./status.scan.fast-json.js");
 
+afterEach(() => {
+  loggingState.forceConsoleToStderr = originalForceStderr;
+});
+
 describe("scanStatusJsonFast", () => {
+  it("routes plugin logs to stderr during deferred plugin loading", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    let stderrDuringLoad = false;
+    mocks.ensurePluginRegistryLoaded.mockImplementation(() => {
+      stderrDuringLoad = loggingState.forceConsoleToStderr;
+    });
+
+    await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalled();
+    expect(stderrDuringLoad).toBe(true);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
   it("skips memory inspection for the lean status --json fast path", async () => {
     const result = await scanStatusJsonFast({}, {} as never);
 

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -195,6 +195,14 @@ describe("scanStatusJsonFast", () => {
     expect(loggingState.forceConsoleToStderr).toBe(false);
   });
 
+  it("skips plugin compatibility loading even when configured channels are present", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+
+    await scanStatusJsonFast({}, {} as never);
+
+    expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
+  });
+
   it("skips memory inspection for the lean status --json fast path", async () => {
     const result = await scanStatusJsonFast({}, {} as never);
 

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -5,6 +5,7 @@ import { hasPotentialConfiguredChannels } from "../channels/config-presence.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveOsSummary } from "../infra/os-summary.js";
+import { loggingState } from "../logging/state.js";
 import { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { getAgentLocalStatuses } from "./status.agent-local.js";
@@ -159,7 +160,14 @@ export async function scanStatusJsonFast(
   const hasConfiguredChannels = hasPotentialConfiguredChannels(cfg);
   if (hasConfiguredChannels) {
     const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
-    ensurePluginRegistryLoaded({ scope: "configured-channels" });
+    // Route plugin registration logs to stderr so they don't corrupt JSON on stdout.
+    const prev = loggingState.forceConsoleToStderr;
+    loggingState.forceConsoleToStderr = true;
+    try {
+      ensurePluginRegistryLoaded({ scope: "configured-channels" });
+    } finally {
+      loggingState.forceConsoleToStderr = prev;
+    }
   }
   const osSummary = resolveOsSummary();
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";

--- a/src/commands/status.scan.fast-json.ts
+++ b/src/commands/status.scan.fast-json.ts
@@ -23,7 +23,6 @@ import { getStatusSummary } from "./status.summary.js";
 import { getUpdateCheckResult } from "./status.update.js";
 
 let pluginRegistryModulePromise: Promise<typeof import("../cli/plugin-registry.js")> | undefined;
-let pluginStatusModulePromise: Promise<typeof import("../plugins/status.js")> | undefined;
 let configIoModulePromise: Promise<typeof import("../config/io.js")> | undefined;
 let commandSecretTargetsModulePromise:
   | Promise<typeof import("../cli/command-secret-targets.js")>
@@ -39,11 +38,6 @@ let statusScanDepsRuntimeModulePromise:
 function loadPluginRegistryModule() {
   pluginRegistryModulePromise ??= import("../cli/plugin-registry.js");
   return pluginRegistryModulePromise;
-}
-
-function loadPluginStatusModule() {
-  pluginStatusModulePromise ??= import("../plugins/status.js");
-  return pluginStatusModulePromise;
 }
 
 function loadConfigIoModule() {
@@ -89,13 +83,6 @@ function buildColdStartUpdateResult(): Awaited<ReturnType<typeof getUpdateCheckR
     installKind: "unknown",
     packageManager: "unknown",
   };
-}
-
-function shouldCollectPluginCompatibility(cfg: OpenClawConfig): boolean {
-  if (hasPotentialConfiguredChannels(cfg)) {
-    return true;
-  }
-  return existsSync(resolveConfigPath(process.env));
 }
 
 function resolveDefaultMemoryStorePath(agentId: string): string {
@@ -233,14 +220,9 @@ export async function scanStatusJsonFast(
   const memory = opts.all
     ? await resolveMemoryStatusSnapshot({ cfg, agentStatus, memoryPlugin })
     : null;
-  const pluginCompatibility = shouldCollectPluginCompatibility(cfg)
-    ? await loadPluginStatusModule().then(({ buildPluginCompatibilityNotices }) =>
-        // Keep plugin status loading off the empty-config `status --json` fast path.
-        // The plugin status module pulls in the full loader graph and materially bloats
-        // startup RSS even when plugin compatibility is never consulted.
-        buildPluginCompatibilityNotices({ config: cfg }),
-      )
-    : [];
+  // `status --json` does not serialize plugin compatibility notices, so keep the
+  // fast path off the full plugin status graph after the initial scoped preload.
+  const pluginCompatibility: StatusScanResult["pluginCompatibility"] = [];
 
   return {
     cfg,

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loggingState } from "../logging/state.js";
 
 const mocks = vi.hoisted(() => ({
   resolveConfigPath: vi.fn(() => `/tmp/openclaw-status-scan-missing-${process.pid}.json`),
@@ -18,9 +19,17 @@ const mocks = vi.hoisted(() => ({
   buildPluginCompatibilityNotices: vi.fn(() => []),
 }));
 
+let originalForceStderr: boolean;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  originalForceStderr = loggingState.forceConsoleToStderr;
+  loggingState.forceConsoleToStderr = false;
   mocks.hasPotentialConfiguredChannels.mockReturnValue(false);
+});
+
+afterEach(() => {
+  loggingState.forceConsoleToStderr = originalForceStderr;
 });
 
 vi.mock("../channels/config-presence.js", () => ({
@@ -503,6 +512,8 @@ describe("scanStatus", () => {
     expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith({
       scope: "configured-channels",
     });
+    // Verify plugin logs were routed to stderr during loading and restored after
+    expect(loggingState.forceConsoleToStderr).toBe(false);
     expect(mocks.probeGateway).toHaveBeenCalledWith(
       expect.objectContaining({ detailLevel: "presence" }),
     );

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -284,6 +284,59 @@ describe("scanStatus", () => {
     expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
   });
 
+  it("skips plugin compatibility loading for status --json even with configured channels", async () => {
+    mocks.hasPotentialConfiguredChannels.mockReturnValue(true);
+    mocks.readBestEffortConfig.mockResolvedValue({
+      session: {},
+      gateway: {},
+      channels: { discord: {} },
+    });
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig: {
+        session: {},
+        gateway: {},
+        channels: { discord: {} },
+      },
+      diagnostics: [],
+    });
+    mocks.getUpdateCheckResult.mockResolvedValue({
+      installKind: "git",
+      git: null,
+      registry: null,
+    });
+    mocks.getAgentLocalStatuses.mockResolvedValue({
+      defaultId: "main",
+      agents: [],
+    });
+    mocks.getStatusSummary.mockResolvedValue({
+      linkChannel: undefined,
+      sessions: { count: 0, paths: [], defaults: {}, recent: [] },
+    });
+    mocks.buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "default",
+    });
+    mocks.resolveGatewayProbeAuthResolution.mockResolvedValue({
+      auth: {},
+      warning: undefined,
+    });
+    mocks.probeGateway.mockResolvedValue({
+      ok: false,
+      url: "ws://127.0.0.1:18789",
+      connectLatencyMs: null,
+      error: "timeout",
+      close: null,
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    await scanStatus({ json: true }, {} as never);
+
+    expect(mocks.buildPluginCompatibilityNotices).not.toHaveBeenCalled();
+  });
+
   it("skips gateway and update probes on cold-start status paths", async () => {
     mocks.readBestEffortConfig.mockResolvedValue({
       session: {},

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -10,6 +10,7 @@ import { resolveConfigPath } from "../config/paths.js";
 import { callGateway } from "../gateway/call.js";
 import type { collectChannelStatusIssues as collectChannelStatusIssuesFn } from "../infra/channels-status-issues.js";
 import { resolveOsSummary } from "../infra/os-summary.js";
+import { loggingState } from "../logging/state.js";
 import {
   buildPluginCompatibilityNotices,
   type PluginCompatibilityNotice,
@@ -166,7 +167,14 @@ async function scanStatusJsonFast(opts: {
   const hasConfiguredChannels = hasPotentialConfiguredChannels(cfg);
   if (hasConfiguredChannels) {
     const { ensurePluginRegistryLoaded } = await loadPluginRegistryModule();
-    ensurePluginRegistryLoaded({ scope: "configured-channels" });
+    // Route plugin registration logs to stderr so they don't corrupt JSON on stdout.
+    const prev = loggingState.forceConsoleToStderr;
+    loggingState.forceConsoleToStderr = true;
+    try {
+      ensurePluginRegistryLoaded({ scope: "configured-channels" });
+    } finally {
+      loggingState.forceConsoleToStderr = prev;
+    }
   }
   const osSummary = resolveOsSummary();
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";

--- a/src/commands/status.scan.ts
+++ b/src/commands/status.scan.ts
@@ -69,13 +69,6 @@ function unwrapDeferredResult<T>(result: DeferredResult<T>): T {
   return result.value;
 }
 
-function shouldCollectPluginCompatibility(cfg: OpenClawConfig): boolean {
-  if (hasPotentialConfiguredChannels(cfg)) {
-    return true;
-  }
-  return existsSync(resolveConfigPath(process.env));
-}
-
 function isMissingConfigColdStart(): boolean {
   return !existsSync(resolveConfigPath(process.env));
 }
@@ -237,9 +230,9 @@ async function scanStatusJsonFast(opts: {
   const memoryPlugin = resolveMemoryPluginStatus(cfg);
   const memoryPromise = resolveMemoryStatusSnapshot({ cfg, agentStatus, memoryPlugin });
   const memory = await memoryPromise;
-  const pluginCompatibility = shouldCollectPluginCompatibility(cfg)
-    ? buildPluginCompatibilityNotices({ config: cfg })
-    : [];
+  // `status --json` never renders plugin compatibility notices, so skip the
+  // full compatibility scan and avoid a second plugin load on the JSON path.
+  const pluginCompatibility: StatusScanResult["pluginCompatibility"] = [];
 
   return {
     cfg,


### PR DESCRIPTION
## Summary

Fixes #52032.

Plugin registration logs (e.g. `[plugins] feishu: Registered ...`) were emitted to stdout during `ensurePluginRegistryLoaded()`, corrupting `--json` output and breaking `| jq` pipelines.

- Temporarily sets `loggingState.forceConsoleToStderr = true` around the `ensurePluginRegistryLoaded()` call when `--json` mode is active
- Uses a save/restore pattern (`const prev = ...` / `finally { ... = prev }`) so the flag is never unconditionally clobbered
- Applies the fix in both code paths: Commander preAction hook (`preaction.ts`) and fast-route (`route.ts`)
- After plugin loading completes, the flag is restored — the JSON payload emitted later via `runtime.log()` → `console.log()` stays on stdout as expected

### Why existing PRs are insufficient

| PR | Issue |
|---|---|
| #52063 | Routes **all** `console.log` to stderr globally — including the JSON payload itself → empty stdout |
| #52060 | Same global-redirect problem as #52063; bot review correctly flagged the P1 |
| #52102 | Closest approach (scoped try/finally), but: no tests, unconditional `false` restore (unsafe if outer code already set the flag), dynamic import in `finally` |
| #51641 | Checks `!process.stdout.isTTY` in subsystem logger — too broad, affects daemon/container/CI mode |
| #51086 | Only fixes `agent` command path, same global redirect problem |

## Test plan

- [x] `pnpm test -- src/cli/program/preaction.test.ts` — 11 tests pass (2 new)
- [x] `pnpm test -- src/cli/route.test.ts` — 7 tests pass (2 new)
- [x] `pnpm check` — lint/format clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>