### PR TITLE
ACP: revert acpx-plugin package naming

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -510,7 +510,7 @@ See [Configuration Reference](/gateway/configuration-reference).
 Install and enable plugin:
 
 ```bash
-openclaw plugins install @openclaw/acpx-plugin
+openclaw plugins install acpx
 openclaw config set plugins.entries.acpx.enabled true
 ```
 
@@ -528,7 +528,7 @@ Then verify backend health:
 
 ### acpx command and version configuration
 
-By default, the acpx backend plugin package (`@openclaw/acpx-plugin`) uses the plugin-local pinned binary:
+By default, the bundled acpx backend plugin (`acpx`) uses the plugin-local pinned binary:
 
 1. Command defaults to `extensions/acpx/node_modules/.bin/acpx`.
 2. Expected version defaults to the extension pin.

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openclaw/acpx-plugin",
+  "name": "@openclaw/acpx",
   "version": "2026.3.22",
   "description": "OpenClaw ACP runtime backend via acpx",
   "type": "module",

--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -109,7 +109,7 @@ Do not default to subagent runtime for these requests.
 
 ## ACPX install and version policy (direct acpx path)
 
-For this repo, direct `acpx` calls must follow the same pinned policy as the `@openclaw/acpx-plugin` extension package.
+For this repo, direct `acpx` calls must follow the same pinned policy as the `@openclaw/acpx` extension package.
 
 1. Prefer plugin-local binary, not global PATH:
    - `./extensions/acpx/node_modules/.bin/acpx`

--- a/src/auto-reply/reply/commands-acp/install-hints.test.ts
+++ b/src/auto-reply/reply/commands-acp/install-hints.test.ts
@@ -21,11 +21,9 @@ afterEach(() => {
 describe("ACP install hints", () => {
   it("prefers explicit runtime install command", () => {
     const cfg = withAcpConfig({
-      runtime: { installCommand: "pnpm openclaw plugins install @openclaw/acpx-plugin" },
+      runtime: { installCommand: "pnpm openclaw plugins install acpx" },
     });
-    expect(resolveAcpInstallCommandHint(cfg)).toBe(
-      "pnpm openclaw plugins install @openclaw/acpx-plugin",
-    );
+    expect(resolveAcpInstallCommandHint(cfg)).toBe("pnpm openclaw plugins install acpx");
   });
 
   it("uses local acpx extension path when present", () => {
@@ -46,9 +44,7 @@ describe("ACP install hints", () => {
     vi.spyOn(process, "cwd").mockReturnValue(tempRoot);
 
     const cfg = withAcpConfig({ backend: "acpx" });
-    expect(resolveAcpInstallCommandHint(cfg)).toBe(
-      "openclaw plugins install @openclaw/acpx-plugin",
-    );
+    expect(resolveAcpInstallCommandHint(cfg)).toBe("openclaw plugins install acpx");
   });
 
   it("returns generic plugin hint for non-acpx backend", () => {

--- a/src/auto-reply/reply/commands-acp/install-hints.ts
+++ b/src/auto-reply/reply/commands-acp/install-hints.ts
@@ -17,7 +17,7 @@ export function resolveAcpInstallCommandHint(cfg: OpenClawConfig): string {
     if (existsSync(localPath)) {
       return `openclaw plugins install ${localPath}`;
     }
-    return "openclaw plugins install @openclaw/acpx-plugin";
+    return "openclaw plugins install acpx";
   }
   return `Install and enable the plugin that provides ACP backend "${backendId}".`;
 }

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -51,7 +51,7 @@ describe("copyBundledPluginMetadata", () => {
       skills: ["./skills"],
     });
     writeJson(path.join(pluginDir, "package.json"), {
-      name: "@openclaw/acpx-plugin",
+      name: "@openclaw/acpx",
       openclaw: { extensions: ["./index.ts"] },
     });
 


### PR DESCRIPTION
## Summary

- Problem: the bundled ACP runtime plugin package was renamed to `@openclaw/acpx-plugin`, which reintroduced the naming split we had decided not to carry forward.
- Why it matters: docs, install hints, and bundled metadata started telling users to install `@openclaw/acpx-plugin` even though the stable plugin/backend identity remains `acpx`.
- What changed: reverted the bundled package name to `@openclaw/acpx`, switched ACP install hints back to `openclaw plugins install acpx`, and updated the bundled metadata/doc references to match.
- What did NOT change (scope boundary): plugin id/backend id/config keys remain `acpx`; no ACP runtime behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- ACP install guidance now points back to `openclaw plugins install acpx`.
- Bundled plugin metadata names the package as `@openclaw/acpx` again.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: N/A
- Integration/channel (if any): ACP install hints / bundled plugin metadata
- Relevant config (redacted): default local checkout

### Steps

1. Search the repo for `@openclaw/acpx-plugin` / `acpx-plugin` references in the bundled ACP plugin surface.
2. Revert the bundled package name and install/doc hint strings back to `acpx`.
3. Run focused ACP install-hint and bundled-metadata tests.

### Expected

- Bundled ACP package metadata, docs, and install hints all consistently use `acpx` again.

### Actual

- Verified locally after the revert.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/auto-reply/reply/commands-acp/install-hints.test.ts src/plugins/copy-bundled-plugin-metadata.test.ts`
- Edge cases checked: local `extensions/acpx` hint path and generic install-command override path still pass.
- What you did **not** verify: full end-to-end plugin install from a release build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR; it is string/metadata-only.
- Files/config to restore: `extensions/acpx/package.json`, `src/auto-reply/reply/commands-acp/install-hints.ts`, `docs/tools/acp-agents.md`
- Known bad symptoms reviewers should watch for: docs or hints still mentioning `@openclaw/acpx-plugin`.

## Risks and Mitigations

- Risk: a remaining repo reference still points to `acpx-plugin` and creates mixed guidance.
  - Mitigation: repo search after the patch only left an unrelated temp-dir test string; focused ACP hint/metadata tests passed.
