### PR TITLE
perf(ci): gate install smoke on changed-smoke

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -37,9 +37,42 @@ jobs:
         id: check
         uses: ./.github/actions/detect-docs-changes
 
-  install-smoke:
+  changed-smoke:
     needs: [docs-scope]
-    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.docs-scope.outputs.docs_only != 'true'
+    if: needs.docs-scope.outputs.docs_only != 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    outputs:
+      run_changed_smoke: ${{ steps.scope.outputs.run_changed_smoke }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+
+      - name: Ensure changed-smoke base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Detect changed smoke scope
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="${{ github.event.before }}"
+          else
+            BASE="${{ github.event.pull_request.base.sha }}"
+          fi
+
+          node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
+
+  install-smoke:
+    needs: [docs-scope, changed-smoke]
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-smoke.outputs.run_changed_smoke == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     env:
       DOCKER_BUILD_SUMMARY: "false"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -36,6 +36,7 @@ Jobs are ordered so cheap checks fail before expensive ones run:
 3. Pushes to `main`: `build-artifacts` + `release-check` + Bun compat + `compat-node22`
 
 Scope logic lives in `scripts/ci-changed-scope.mjs` and is covered by unit tests in `src/scripts/ci-changed-scope.test.ts`.
+The same shared scope module also drives the separate `install-smoke` workflow through a narrower `changed-smoke` gate, so Docker/install smoke only runs for install, packaging, and container-relevant changes.
 
 ## Runners
 

--- a/scripts/ci-changed-scope.d.mts
+++ b/scripts/ci-changed-scope.d.mts
@@ -2,6 +2,9 @@ export type ChangedScope = {
   runNode: boolean;
   runMacos: boolean;
   runAndroid: boolean;
+  runWindows: boolean;
+  runSkillsPython: boolean;
+  runChangedSmoke: boolean;
 };
 
 export function detectChangedScope(changedPaths: string[]): ChangedScope;

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -1,11 +1,12 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean; runWindows: boolean; runSkillsPython: boolean }} ChangedScope */
+/** @typedef {{ runNode: boolean; runMacos: boolean; runAndroid: boolean; runWindows: boolean; runSkillsPython: boolean; runChangedSmoke: boolean }} ChangedScope */
 
 const DOCS_PATH_RE = /^(docs\/|.*\.mdx?$)/;
 const SKILLS_PYTHON_SCOPE_RE = /^(skills\/|pyproject\.toml$)/;
 const CI_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/ci\.yml$/;
+const INSTALL_SMOKE_WORKFLOW_SCOPE_RE = /^\.github\/workflows\/install-smoke\.yml$/;
 const MACOS_PROTOCOL_GEN_RE =
   /^(apps\/macos\/Sources\/OpenClawProtocol\/|apps\/shared\/OpenClawKit\/Sources\/OpenClawProtocol\/)/;
 const MACOS_NATIVE_RE = /^(apps\/macos\/|apps\/ios\/|apps\/shared\/|Swabble\/)/;
@@ -16,6 +17,8 @@ const WINDOWS_SCOPE_RE =
   /^(src\/|test\/|extensions\/|packages\/|scripts\/|ui\/|openclaw\.mjs$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|tsconfig.*\.json$|vitest.*\.ts$|tsdown\.config\.ts$|\.github\/workflows\/ci\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
 const NATIVE_ONLY_RE =
   /^(apps\/android\/|apps\/ios\/|apps\/macos\/|apps\/shared\/|Swabble\/|appcast\.xml$)/;
+const CHANGED_SMOKE_SCOPE_RE =
+  /^(Dockerfile$|\.npmrc$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|scripts\/install\.sh$|scripts\/test-install-sh-docker\.sh$|scripts\/docker\/|extensions\/[^/]+\/package\.json$|\.github\/workflows\/install-smoke\.yml$|\.github\/actions\/setup-node-env\/action\.yml$)/;
 
 /**
  * @param {string[]} changedPaths
@@ -29,6 +32,7 @@ export function detectChangedScope(changedPaths) {
       runAndroid: true,
       runWindows: true,
       runSkillsPython: true,
+      runChangedSmoke: true,
     };
   }
 
@@ -37,6 +41,7 @@ export function detectChangedScope(changedPaths) {
   let runAndroid = false;
   let runWindows = false;
   let runSkillsPython = false;
+  let runChangedSmoke = false;
   let hasNonDocs = false;
   let hasNonNativeNonDocs = false;
 
@@ -62,6 +67,10 @@ export function detectChangedScope(changedPaths) {
       runSkillsPython = true;
     }
 
+    if (INSTALL_SMOKE_WORKFLOW_SCOPE_RE.test(path)) {
+      runChangedSmoke = true;
+    }
+
     if (!MACOS_PROTOCOL_GEN_RE.test(path) && MACOS_NATIVE_RE.test(path)) {
       runMacos = true;
     }
@@ -78,6 +87,10 @@ export function detectChangedScope(changedPaths) {
       runWindows = true;
     }
 
+    if (CHANGED_SMOKE_SCOPE_RE.test(path)) {
+      runChangedSmoke = true;
+    }
+
     if (!NATIVE_ONLY_RE.test(path)) {
       hasNonNativeNonDocs = true;
     }
@@ -87,7 +100,7 @@ export function detectChangedScope(changedPaths) {
     runNode = true;
   }
 
-  return { runNode, runMacos, runAndroid, runWindows, runSkillsPython };
+  return { runNode, runMacos, runAndroid, runWindows, runSkillsPython, runChangedSmoke };
 }
 
 /**
@@ -122,6 +135,7 @@ export function writeGitHubOutput(scope, outputPath = process.env.GITHUB_OUTPUT)
   appendFileSync(outputPath, `run_android=${scope.runAndroid}\n`, "utf8");
   appendFileSync(outputPath, `run_windows=${scope.runWindows}\n`, "utf8");
   appendFileSync(outputPath, `run_skills_python=${scope.runSkillsPython}\n`, "utf8");
+  appendFileSync(outputPath, `run_changed_smoke=${scope.runChangedSmoke}\n`, "utf8");
 }
 
 function isDirectRun() {
@@ -157,6 +171,7 @@ if (isDirectRun()) {
         runAndroid: true,
         runWindows: true,
         runSkillsPython: true,
+        runChangedSmoke: true,
       });
       process.exit(0);
     }
@@ -168,6 +183,7 @@ if (isDirectRun()) {
       runAndroid: true,
       runWindows: true,
       runSkillsPython: true,
+      runChangedSmoke: true,
     });
   }
 }

--- a/src/infra/scripts-modules.d.ts
+++ b/src/infra/scripts-modules.d.ts
@@ -18,5 +18,8 @@ declare module "../../scripts/ci-changed-scope.mjs" {
     runNode: boolean;
     runMacos: boolean;
     runAndroid: boolean;
+    runWindows: boolean;
+    runSkillsPython: boolean;
+    runChangedSmoke: boolean;
   };
 }

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -11,6 +11,7 @@ const { detectChangedScope, listChangedPaths } =
       runAndroid: boolean;
       runWindows: boolean;
       runSkillsPython: boolean;
+      runChangedSmoke: boolean;
     };
     listChangedPaths: (base: string, head?: string) => string[];
   };
@@ -34,6 +35,7 @@ describe("detectChangedScope", () => {
       runAndroid: true,
       runWindows: true,
       runSkillsPython: true,
+      runChangedSmoke: true,
     });
   });
 
@@ -44,6 +46,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
   });
 
@@ -54,6 +57,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: true,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
   });
 
@@ -64,6 +68,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
     expect(detectChangedScope(["apps/shared/OpenClawKit/Sources/Foo.swift"])).toEqual({
       runNode: false,
@@ -71,6 +76,7 @@ describe("detectChangedScope", () => {
       runAndroid: true,
       runWindows: false,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
   });
 
@@ -82,6 +88,7 @@ describe("detectChangedScope", () => {
         runAndroid: false,
         runWindows: false,
         runSkillsPython: false,
+        runChangedSmoke: false,
       },
     );
   });
@@ -93,6 +100,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
 
     expect(detectChangedScope(["assets/icon.png"])).toEqual({
@@ -101,6 +109,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
   });
 
@@ -111,6 +120,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: false,
+      runChangedSmoke: false,
     });
   });
 
@@ -121,6 +131,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: true,
+      runChangedSmoke: false,
     });
   });
 
@@ -131,6 +142,7 @@ describe("detectChangedScope", () => {
       runAndroid: false,
       runWindows: false,
       runSkillsPython: true,
+      runChangedSmoke: false,
     });
   });
 
@@ -141,6 +153,34 @@ describe("detectChangedScope", () => {
       runAndroid: true,
       runWindows: true,
       runSkillsPython: true,
+      runChangedSmoke: false,
+    });
+  });
+
+  it("runs changed-smoke for install and packaging surfaces", () => {
+    expect(detectChangedScope(["scripts/install.sh"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: true,
+      runSkillsPython: false,
+      runChangedSmoke: true,
+    });
+    expect(detectChangedScope(["extensions/matrix/package.json"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: true,
+      runSkillsPython: false,
+      runChangedSmoke: true,
+    });
+    expect(detectChangedScope([".github/workflows/install-smoke.yml"])).toEqual({
+      runNode: true,
+      runMacos: false,
+      runAndroid: false,
+      runWindows: false,
+      runSkillsPython: false,
+      runChangedSmoke: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- add a dedicated changed-smoke gate to the shared CI scope detector
- run install-smoke only for install, packaging, and container-relevant changes
- keep install-smoke separate from CI while reusing the same scope engine

## Testing
- pnpm exec vitest run src/scripts/ci-changed-scope.test.ts
- pnpm exec oxfmt --check .github/workflows/install-smoke.yml docs/ci.md scripts/ci-changed-scope.d.mts scripts/ci-changed-scope.mjs src/infra/scripts-modules.d.ts src/scripts/ci-changed-scope.test.ts