### PR TITLE
Fix swapped webchat/telegram usage statistics (#52436)

### DIFF
--- a/.ship/tasks/fix-usage-stats-swap/plan.md
+++ b/.ship/tasks/fix-usage-stats-swap/plan.md
@@ -1,0 +1,64 @@
+# Implementation Plan: Fix Usage Stats Channel Swap
+
+## Story 1: Reproduce the swap with a failing test
+
+**Files:** `src/gateway/server-methods/usage.test.ts` (or new test file)
+
+Write a unit test that:
+
+- Creates two mock session store entries: one with webchat origin, one with telegram origin
+- Simulates the channel resolution logic from `usage.ts:610`
+- Asserts that `byChannel` aggregation attributes usage to the correct originating channel
+- The test should FAIL with the current code, confirming the swap
+
+## Story 2: Fix channel resolution in usage aggregation
+
+**Files:** `src/gateway/server-methods/usage.ts`
+
+Fix the channel resolution at line 610. The fix should prefer `origin.provider` (the originating channel) over `storeEntry.channel` (the delivery/group channel) for usage attribution. Candidate fix:
+
+```typescript
+const channel = merged.storeEntry?.origin?.provider ?? merged.storeEntry?.channel;
+```
+
+Or use a dedicated helper that resolves the "usage channel" correctly:
+
+- For group sessions: use `storeEntry.channel` (the group's channel is the correct attribution)
+- For DM sessions: use `origin.provider`
+- Fallback: use `storeEntry.lastChannel`
+
+Ensure the same corrected value flows to both:
+
+- `byChannelMap` aggregation (line 688)
+- Per-session `channel` field in the response (line 734)
+
+## Story 3: Verify client-side aggregation consistency
+
+**Files:** `ui/src/ui/views/usage-metrics.ts`
+
+Since the client recalculates aggregates from session data (`buildAggregatesFromSessions`), the fix in Story 2 (correcting `session.channel`) automatically fixes the client side. Verify:
+
+- `channelMap` at line 427-430 uses `session.channel` (which is now correct from the server)
+- No additional client-side changes needed unless there's a separate mapping
+
+## Story 4: Add regression tests
+
+**Files:** `src/gateway/server-methods/usage.test.ts`
+
+Add test cases covering:
+
+- DM webchat session → attributed to "webchat"
+- DM telegram session → attributed to "telegram"
+- Group telegram session → attributed to "telegram"
+- Cross-channel session (webchat origin, telegram delivery) → attributed to originating channel
+- Session with `storeEntry.channel` set but different from `origin.provider`
+
+## Story 5: Validate end-to-end
+
+Run full test suite and type checks:
+
+- `pnpm test -- src/gateway/server-methods/usage`
+- `pnpm tsgo`
+- `pnpm check`
+
+Verify the channel breakdown renders correctly in the dashboard UI.

--- a/.ship/tasks/fix-usage-stats-swap/review.md
+++ b/.ship/tasks/fix-usage-stats-swap/review.md
@@ -1,0 +1,29 @@
+# Code Review: Fix Usage Stats Channel Swap
+
+## Summary
+
+The fix is a single-line change in `src/gateway/server-methods/usage.ts:610` that swaps the nullish coalescing operand order from `storeEntry.channel ?? origin.provider` to `origin.provider ?? storeEntry.channel`. This directly addresses the root cause identified in the spec. Tests are well-structured and cover the key scenarios.
+
+## Findings
+
+### 1. [info] `chatType` resolution has the same precedence issue
+
+At `src/gateway/server-methods/usage.ts:611`, the `chatType` resolution still reads:
+
+```typescript
+const chatType = merged.storeEntry?.chatType ?? merged.storeEntry?.origin?.chatType;
+```
+
+This mirrors the old (buggy) pattern — preferring the top-level field over `origin`. If `chatType` can diverge from `origin.chatType` in the same way `channel` diverges from `origin.provider`, this line has the same class of bug. Worth investigating whether this matters for any aggregation or display logic.
+
+### 2. [info] Spec acceptance criterion #7 (CSV export) not covered by tests
+
+The spec lists "CSV export includes the correct channel value per session" as an acceptance criterion. No test in this diff exercises the CSV export path. The fix likely covers it implicitly (same `channel` value flows through), but there's no explicit verification.
+
+### 3. [info] Test helper `buildSessionUsage` sets `output: 0` for all cases
+
+The helper always creates input-only usage. This is fine for channel attribution testing, but a single test case with nonzero `output`/`cacheRead` would increase confidence that the aggregation pipeline handles all cost fields correctly under the new resolution order. Minor — not blocking.
+
+## Verdict
+
+The core fix is correct and minimal. The test coverage for channel attribution is thorough — parameterized cases cover DM, group, cross-channel, and legacy fallback scenarios. The swapped-delivery test directly reproduces the reported bug. No critical or normal issues found.

--- a/.ship/tasks/fix-usage-stats-swap/spec.md
+++ b/.ship/tasks/fix-usage-stats-swap/spec.md
@@ -1,0 +1,62 @@
+# Fix Usage Stats Channel Swap (Issue #52436)
+
+## Goal
+
+Fix the /usage dashboard so that per-channel breakdown correctly attributes usage to the originating channel. Currently, webchat and telegram usage statistics appear swapped — webchat shows telegram's numbers and vice versa — while total usage remains correct.
+
+## Root Cause Analysis
+
+The channel resolution in the usage aggregation pipeline at `src/gateway/server-methods/usage.ts:610` uses:
+
+```typescript
+const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
+```
+
+`storeEntry.channel` is set by `deriveGroupSessionPatch` (in `src/config/sessions/metadata.ts:122-126`) and reflects the **delivery/group channel** rather than the **originating channel**. For sessions that cross channel boundaries (e.g., a webchat-originated session that delivers to telegram, or a main session with `lastChannel` set differently from origin), `storeEntry.channel` can be the wrong value for usage attribution. The `origin.provider` field correctly tracks the originating channel but is only used as a fallback.
+
+The same channel value is used both for:
+
+- Server-side aggregation (`byChannelMap` at line 688-692)
+- Per-session `channel` field sent to the client (line 734)
+- Client-side recalculation in `ui/src/ui/views/usage-metrics.ts:427-430`
+
+Since the total is correct (all sessions' usage sums up regardless of channel label), but per-channel buckets are inverted, the issue is strictly in channel label assignment.
+
+## Affected Files
+
+### Backend (primary)
+
+- `src/gateway/server-methods/usage.ts` — channel resolution at line 610
+- `src/config/sessions/metadata.ts` — `deriveSessionOrigin`, `deriveGroupSessionPatch`
+
+### Frontend (display)
+
+- `ui/src/ui/views/usage-metrics.ts` — client-side channel aggregation (line 427-430)
+- `ui/src/ui/views/usage-render-overview.ts` — "Top Channels" rendering (line 443-447)
+- `ui/src/ui/views/usage-render-details.ts` — session detail badges (line 69-70)
+
+### Types
+
+- `src/shared/usage-types.ts` — `SessionUsageEntry.channel` type definition
+- `src/config/sessions/types.ts` — `SessionEntry.channel`, `SessionEntry.origin`
+
+## Acceptance Criteria
+
+1. Per-channel usage breakdown on `/usage` correctly attributes sessions to their originating channel.
+2. Webchat sessions show under "webchat" in the Top Channels insight list.
+3. Telegram sessions show under "telegram" in the Top Channels insight list.
+4. Total usage numbers remain unchanged.
+5. Group sessions still correctly display their channel.
+6. Session detail view shows the correct channel badge.
+7. CSV export includes the correct channel value per session.
+8. Existing tests pass; new tests cover the channel resolution logic.
+
+## Definition of Done
+
+- [ ] Root cause confirmed via test case reproducing the swap
+- [ ] Fix applied to channel resolution in usage aggregation
+- [ ] Unit test added covering webchat vs telegram channel attribution
+- [ ] Existing usage tests pass (`pnpm test -- src/gateway/server-methods/usage`)
+- [ ] Type check passes (`pnpm tsgo`)
+- [ ] Lint/format passes (`pnpm check`)
+- [ ] Manual verification: channel breakdown matches expected attribution

--- a/.ship/tasks/fix-usage-stats-swap/task_state.json
+++ b/.ship/tasks/fix-usage-stats-swap/task_state.json
@@ -1,14 +1,14 @@
 {
   "task_id": "fix-usage-stats-swap",
   "title": "Fix swapped webchat/telegram usage statistics on /usage dashboard",
-  "stage": "implementing",
+  "stage": "handoff",
   "status": "active",
   "stories": [
-    { "id": "s1", "title": "Reproduce the swap with a failing test", "status": "active" },
-    { "id": "s2", "title": "Fix channel resolution in usage aggregation", "status": "pending" },
-    { "id": "s3", "title": "Verify client-side aggregation consistency", "status": "pending" },
-    { "id": "s4", "title": "Add regression tests", "status": "pending" },
-    { "id": "s5", "title": "Validate end-to-end", "status": "pending" }
+    { "id": "s1", "title": "Reproduce the swap with a failing test", "status": "done" },
+    { "id": "s2", "title": "Fix channel resolution in usage aggregation", "status": "done" },
+    { "id": "s3", "title": "Verify client-side aggregation consistency", "status": "done" },
+    { "id": "s4", "title": "Add regression tests", "status": "done" },
+    { "id": "s5", "title": "Validate end-to-end", "status": "done" }
   ],
   "issues": []
 }

--- a/.ship/tasks/fix-usage-stats-swap/task_state.json
+++ b/.ship/tasks/fix-usage-stats-swap/task_state.json
@@ -1,0 +1,14 @@
+{
+  "task_id": "fix-usage-stats-swap",
+  "title": "Fix swapped webchat/telegram usage statistics on /usage dashboard",
+  "stage": "implementing",
+  "status": "active",
+  "stories": [
+    { "id": "s1", "title": "Reproduce the swap with a failing test", "status": "active" },
+    { "id": "s2", "title": "Fix channel resolution in usage aggregation", "status": "pending" },
+    { "id": "s3", "title": "Verify client-side aggregation consistency", "status": "pending" },
+    { "id": "s4", "title": "Add regression tests", "status": "pending" },
+    { "id": "s5", "title": "Validate end-to-end", "status": "pending" }
+  ],
+  "issues": []
+}

--- a/.ship/tasks/fix-usage-stats-swap/verify-frontend.md
+++ b/.ship/tasks/fix-usage-stats-swap/verify-frontend.md
@@ -1,0 +1,15 @@
+# Frontend Verification
+
+## Result: No frontend changes required
+
+The client-side code in `ui/src/ui/views/usage-metrics.ts`, `usage-render-overview.ts`, and `usage-render-details.ts` reads `session.channel` directly from the server response. The server-side fix in `src/gateway/server-methods/usage.ts:610` corrects the channel value at the source, so the frontend displays the correct channel without any code changes.
+
+Verified paths:
+
+- `usage-metrics.ts:427-430` -- `channelMap` aggregates from `session.channel`
+- `usage-render-overview.ts:443-447` -- Top Channels displays `entry.channel`
+- `usage-render-details.ts:69-70` -- detail badges display `session.channel`
+- `usage-query.ts:62,155` -- filters on `session.channel`, no remapping
+- `usage-helpers.ts:158-160` -- reads `session.channel`, no substitution
+
+No client-side mapping or override exists that would re-introduce the swap.

--- a/.ship/tasks/fix-usage-stats-swap/verify.md
+++ b/.ship/tasks/fix-usage-stats-swap/verify.md
@@ -1,0 +1,53 @@
+# Verification Results
+
+## 1
+
+Command run: `pnpm test -- src/gateway/server-methods/usage`
+Pass/fail: PASS
+HEAD sha: `8ad157ff0d101b5462f11d276b5789c14c129578`
+Error output: None
+
+## 2
+
+Command run: `pnpm tsgo`
+Pass/fail: PASS
+HEAD sha: `8ad157ff0d101b5462f11d276b5789c14c129578`
+Error output: None
+
+## 3
+
+Command run: `pnpm check`
+Pass/fail: PASS
+HEAD sha: `8ad157ff0d101b5462f11d276b5789c14c129578`
+Error output: None
+
+## Spec Verification (acceptance criteria)
+
+HEAD sha: `8ad157ff0d101b5462f11d276b5789c14c129578`
+
+| #   | Criterion                                                                  | Status | Evidence                                                                                                                                                                                                          |
+| --- | -------------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Per-channel breakdown correctly attributes sessions to originating channel | PASS   | Fix at `usage.ts:610` swaps priority to `origin.provider ?? channel`. Test "attributes byChannel usage to the originating channel when delivery channels are swapped" validates this with cross-channel sessions. |
+| 2   | Webchat sessions show under "webchat"                                      | PASS   | Parameterized test case "attributes DM webchat sessions to webchat when only origin.provider is set" asserts `channel === "webchat"` in both session and byChannel aggregate.                                     |
+| 3   | Telegram sessions show under "telegram"                                    | PASS   | Parameterized test cases cover DM telegram and group telegram; both assert `channel === "telegram"`.                                                                                                              |
+| 4   | Total usage numbers remain unchanged                                       | PASS   | Fix only changes channel label resolution order; aggregation of `aggregateTotals` at line 604-608 is unchanged and sums all sessions regardless of channel label.                                                 |
+| 5   | Group sessions still correctly display their channel                       | PASS   | Test case "attributes group telegram sessions to telegram" uses `storeEntry.channel = "telegram"` with matching `origin.provider = "telegram"`, confirming group sessions resolve correctly.                      |
+| 6   | Session detail view shows correct channel badge                            | PASS   | Per-session `channel` field at `usage.ts:734` uses the same corrected `channel` variable; client renders from this field.                                                                                         |
+| 7   | CSV export includes correct channel value per session                      | PASS   | `buildSessionsCsv` in `usage-query.ts:32` reads `session.channel` from the server response — same corrected field. No separate CSV channel resolution exists.                                                     |
+| 8   | Existing tests pass; new tests cover channel resolution logic              | PASS   | Mechanical verification (section 1 above) confirms `pnpm test` passes. New tests: 1 swap-reproduction test + 5 parameterized channel-attribution cases added to `usage.sessions-usage.test.ts`.                   |
+
+### Definition of Done
+
+| Item                                                             | Status       | Evidence                                                            |
+| ---------------------------------------------------------------- | ------------ | ------------------------------------------------------------------- |
+| Root cause confirmed via test case reproducing the swap          | DONE         | Commit `b94551b5f7` adds reproduction test that fails with old code |
+| Fix applied to channel resolution in usage aggregation           | DONE         | Commit `91d2beaa2b` swaps `origin.provider` to preferred position   |
+| Unit test added covering webchat vs telegram channel attribution | DONE         | Commit `8ad157ff0d` adds 5 parameterized regression tests           |
+| Existing usage tests pass                                        | DONE         | Section 1 above                                                     |
+| Type check passes                                                | DONE         | Section 2 above                                                     |
+| Lint/format passes                                               | DONE         | Section 3 above                                                     |
+| Manual verification                                              | NOT VERIFIED | No live environment tested; covered by unit tests only              |
+
+### Verdict
+
+All acceptance criteria are satisfied by the code changes and test coverage. The only gap is manual verification against a live dashboard, which is expected to be covered during PR review or staging.

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -115,6 +115,22 @@ const BASE_USAGE_RANGE = {
   limit: 10,
 } as const;
 
+function buildSessionUsage(totalTokens: number) {
+  return {
+    input: totalTokens,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens,
+    totalCost: 0,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+  };
+}
+
 function expectSuccessfulSessionsUsage(
   respond: ReturnType<typeof vi.fn>,
 ): Array<{ key: string; agentId: string }> {
@@ -187,6 +203,58 @@ describe("sessions.usage", () => {
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
+  });
+
+  it("attributes byChannel usage to the originating channel when delivery channels are swapped", async () => {
+    vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+      storePath: "(multiple)",
+      store: {
+        "named:webchat-origin": {
+          sessionId: "s-main",
+          label: "Webchat origin",
+          updatedAt: 300,
+          channel: "telegram",
+          origin: {
+            provider: "webchat",
+            chatType: "direct",
+          },
+        },
+        "named:telegram-origin": {
+          sessionId: "s-opus",
+          label: "Telegram origin",
+          updatedAt: 200,
+          channel: "webchat",
+          origin: {
+            provider: "telegram",
+            chatType: "direct",
+          },
+        },
+      },
+    });
+    vi.mocked(loadSessionCostSummary).mockImplementation(async (params) => {
+      if (params?.sessionId === "s-main") {
+        return buildSessionUsage(111);
+      }
+      if (params?.sessionId === "s-opus") {
+        return buildSessionUsage(222);
+      }
+      return buildSessionUsage(0);
+    });
+
+    const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+    const result = respond.mock.calls[0]?.[1] as {
+      aggregates: {
+        byChannel: Array<{ channel: string; totals: { totalTokens: number } }>;
+      };
+    };
+    const totalsByChannel = new Map(
+      result.aggregates.byChannel.map((entry) => [entry.channel, entry.totals.totalTokens]),
+    );
+
+    // Current bug: usage.ts prefers storeEntry.channel (delivery/group channel), which swaps
+    // webchat and telegram attribution for sessions whose origin.provider differs.
+    expect(totalsByChannel.get("webchat")).toBe(111);
+    expect(totalsByChannel.get("telegram")).toBe(222);
   });
 
   it("rejects traversal-style keys in specific session usage lookups", async () => {

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 
 vi.mock("../../config/config.js", () => {
@@ -142,6 +143,77 @@ function expectSuccessfulSessionsUsage(
   return result.sessions;
 }
 
+const CHANNEL_ATTRIBUTION_CASES = [
+  {
+    name: "attributes DM webchat sessions to webchat when only origin.provider is set",
+    storeEntry: {
+      sessionId: "s-main",
+      label: "Webchat DM",
+      updatedAt: 300,
+      origin: {
+        provider: "webchat",
+        chatType: "direct",
+      },
+    },
+    expectedChannel: "webchat",
+  },
+  {
+    name: "attributes DM telegram sessions to telegram when only origin.provider is set",
+    storeEntry: {
+      sessionId: "s-main",
+      label: "Telegram DM",
+      updatedAt: 300,
+      origin: {
+        provider: "telegram",
+        chatType: "direct",
+      },
+    },
+    expectedChannel: "telegram",
+  },
+  {
+    name: "attributes group telegram sessions to telegram",
+    storeEntry: {
+      sessionId: "s-main",
+      label: "Telegram Group",
+      updatedAt: 300,
+      channel: "telegram",
+      origin: {
+        provider: "telegram",
+        chatType: "group",
+      },
+    },
+    expectedChannel: "telegram",
+  },
+  {
+    name: "prefers origin.provider over storeEntry.channel when they differ",
+    storeEntry: {
+      sessionId: "s-main",
+      label: "Telegram origin via webchat delivery",
+      updatedAt: 300,
+      channel: "webchat",
+      origin: {
+        provider: "telegram",
+        chatType: "direct",
+      },
+    },
+    expectedChannel: "telegram",
+  },
+  {
+    name: "falls back to storeEntry.channel when origin is missing",
+    storeEntry: {
+      sessionId: "s-main",
+      label: "Legacy channel fallback",
+      updatedAt: 300,
+      channel: "slack",
+    },
+    expectedChannel: "slack",
+  },
+] satisfies Array<{
+  name: string;
+  storeEntry: SessionEntry;
+  expectedChannel: string;
+}>;
+
 describe("sessions.usage", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -255,6 +327,43 @@ describe("sessions.usage", () => {
     // webchat and telegram attribution for sessions whose origin.provider differs.
     expect(totalsByChannel.get("webchat")).toBe(111);
     expect(totalsByChannel.get("telegram")).toBe(222);
+  });
+
+  it.each(CHANNEL_ATTRIBUTION_CASES)("$name", async ({ storeEntry, expectedChannel }) => {
+    const attributedTokens = 321;
+    vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+      storePath: "(multiple)",
+      store: {
+        "named:channel-attribution": storeEntry,
+      },
+    });
+    vi.mocked(loadSessionCostSummary).mockImplementation(async (params) => {
+      if (params?.sessionId === storeEntry.sessionId) {
+        return buildSessionUsage(attributedTokens);
+      }
+      return buildSessionUsage(0);
+    });
+
+    const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    const result = respond.mock.calls[0]?.[1] as {
+      sessions: Array<{ key: string; channel?: string }>;
+      aggregates: {
+        byChannel: Array<{ channel: string; totals: { totalTokens: number } }>;
+      };
+    };
+
+    const attributedSession = result.sessions.find(
+      (session) => session.key === "named:channel-attribution",
+    );
+    expect(attributedSession?.channel).toBe(expectedChannel);
+
+    const totalsByChannel = new Map(
+      result.aggregates.byChannel.map((entry) => [entry.channel, entry.totals.totalTokens]),
+    );
+    expect(totalsByChannel.get(expectedChannel)).toBe(attributedTokens);
+    expect(totalsByChannel.size).toBe(1);
   });
 
   it("rejects traversal-style keys in specific session usage lookups", async () => {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -607,7 +607,7 @@ export const usageHandlers: GatewayRequestHandlers = {
         aggregateTotals.missingCostEntries += usage.missingCostEntries;
       }
 
-      const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
+      const channel = merged.storeEntry?.origin?.provider ?? merged.storeEntry?.channel;
       const chatType = merged.storeEntry?.chatType ?? merged.storeEntry?.origin?.chatType;
 
       if (usage) {


### PR DESCRIPTION
# Fix Usage Stats Channel Swap (Issue #52436)

## Goal

Fix the /usage dashboard so that per-channel breakdown correctly attributes usage to the originating channel. Currently, webchat and telegram usage statistics appear swapped — webchat shows telegram's numbers and vice versa — while total usage remains correct.

## Root Cause Analysis

The channel resolution in the usage aggregation pipeline at `src/gateway/server-methods/usage.ts:610` uses:

```typescript
const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
```

`storeEntry.channel` is set by `deriveGroupSessionPatch` (in `src/config/sessions/metadata.ts:122-126`) and reflects the **delivery/group channel** rather than the **originating channel**. For sessions that cross channel boundaries (e.g., a webchat-originated session that delivers to telegram, or a main session with `lastChannel` set differently from origin), `storeEntry.channel` can be the wrong value for usage attribution. The `origin.provider` field correctly tracks the originating channel but is only used as a fallback.

The same channel value is used both for:

- Server-side aggregation (`byChannelMap` at line 688-692)
- Per-session `channel` field sent to the client (line 734)
- Client-side recalculation in `ui/src/ui/views/usage-metrics.ts:427-430`

Since the total is correct (all sessions' usage sums up regardless of channel label), but per-channel buckets are inverted, the issue is strictly in channel label assignment.

## Affected Files

### Backend (primary)

- `src/gateway/server-methods/usage.ts` — channel resolution at line 610
- `src/config/sessions/metadata.ts` — `deriveSessionOrigin`, `deriveGroupSessionPatch`

### Frontend (display)

- `ui/src/ui/views/usage-metrics.ts` — client-side channel aggregation (line 427-430)
- `ui/src/ui/views/usage-render-overview.ts` — "Top Channels" rendering (line 443-447)
- `ui/src/ui/views/usage-render-details.ts` — session detail badges (line 69-70)

### Types

- `src/shared/usage-types.ts` — `SessionUsageEntry.channel` type definition
- `src/config/sessions/types.ts` — `SessionEntry.channel`, `SessionEntry.origin`

## Acceptance Criteria

1. Per-channel usage breakdown on `/usage` correctly attributes sessions to their originating channel.
2. Webchat sessions show under "webchat" in the Top Channels insight list.
3. Telegram sessions show under "telegram" in the Top Channels insight list.
4. Total usage numbers remain unchanged.
5. Group sessions still correctly display their channel.
6. Session detail view shows the correct channel badge.
7. CSV export includes the correct channel value per session.
8. Existing tests pass; new tests cover the channel resolution logic.

## Definition of Done

- [ ] Root cause confirmed via test case reproducing the swap
- [ ] Fix applied to channel resolution in usage aggregation
- [ ] Unit test added covering webchat vs telegram channel attribution
- [ ] Existing usage tests pass (`pnpm test -- src/gateway/server-methods/usage`)
- [ ] Type check passes (`pnpm tsgo`)
- [ ] Lint/format passes (`pnpm check`)
- [ ] Manual verification: channel breakdown matches expected attribution
