### PR TITLE
feat(telegram): add asDocument param to message tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Docs: https://docs.openclaw.ai
 - Docs/plugins: add the community DingTalk plugin listing to the docs catalog. (#29913) Thanks @sliverp.
 - Docs/plugins: add the community QQbot plugin listing to the docs catalog. (#29898) Thanks @sliverp.
 - Docs/plugins: add the community wecom plugin listing to the docs catalog. (#29905) Thanks @sliverp.
+- Telegram/message tool: add `asDocument` as a user-facing alias for `forceDocument` on image and GIF sends, while preserving explicit `forceDocument` precedence when both flags are present. (#52461) Thanks @bakhtiersizhaev.
 
 ### Fixes
 

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -354,7 +354,9 @@ export async function handleTelegramAction(
       quoteText: quoteText ?? undefined,
       asVoice: readBooleanParam(params, "asVoice"),
       silent: readBooleanParam(params, "silent"),
-      forceDocument: readBooleanParam(params, "forceDocument") ?? false,
+      forceDocument:
+        (readBooleanParam(params, "forceDocument") || readBooleanParam(params, "asDocument")) ??
+        false,
     });
     return jsonResult({
       ok: true,

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -355,7 +355,8 @@ export async function handleTelegramAction(
       asVoice: readBooleanParam(params, "asVoice"),
       silent: readBooleanParam(params, "silent"),
       forceDocument:
-        (readBooleanParam(params, "forceDocument") || readBooleanParam(params, "asDocument")) ??
+        readBooleanParam(params, "forceDocument") ??
+        readBooleanParam(params, "asDocument") ??
         false,
     });
     return jsonResult({

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -1,156 +1,334 @@
 import { Type } from "@sinclair/typebox";
 import {
+  readNumberParam,
+  readStringArrayParam,
+  readStringOrNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/agent-runtime";
+import { handleTelegramAction } from "openclaw/plugin-sdk/agent-runtime";
+import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
+import { resolveReactionMessageId } from "openclaw/plugin-sdk/channel-runtime";
+import {
   createUnionActionGate,
   listTokenSourcedAccounts,
-  resolveReactionMessageId,
-} from "openclaw/plugin-sdk/channel-actions";
-import { createMessageToolButtonsSchema } from "openclaw/plugin-sdk/channel-actions";
+} from "openclaw/plugin-sdk/channel-runtime";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
-  ChannelMessageToolDiscovery,
-  ChannelMessageToolSchemaContribution,
-} from "openclaw/plugin-sdk/channel-contract";
+} from "openclaw/plugin-sdk/channel-runtime";
 import type { TelegramActionConfig } from "openclaw/plugin-sdk/config-runtime";
+import { resolveTelegramPollVisibility } from "openclaw/plugin-sdk/telegram";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
   resolveTelegramPollActionGateState,
 } from "./accounts.js";
-import { handleTelegramAction } from "./action-runtime.js";
+import { resolveTelegramInlineButtons } from "./button-types.js";
 import { isTelegramInlineButtonsEnabled } from "./inline-buttons.js";
-import { createTelegramPollExtraToolSchemas } from "./message-tool-schema.js";
 
-export const telegramMessageActionRuntime = {
-  handleTelegramAction,
-};
+const providerId = "telegram";
 
-const TELEGRAM_MESSAGE_ACTION_MAP = {
-  delete: "deleteMessage",
-  edit: "editMessage",
-  poll: "poll",
-  react: "react",
-  send: "sendMessage",
-  sticker: "sendSticker",
-  "sticker-search": "searchSticker",
-  "topic-create": "createForumTopic",
-  "topic-edit": "editForumTopic",
-} as const satisfies Partial<Record<ChannelMessageActionName, string>>;
-
-function resolveTelegramMessageActionName(action: ChannelMessageActionName) {
-  return TELEGRAM_MESSAGE_ACTION_MAP[action as keyof typeof TELEGRAM_MESSAGE_ACTION_MAP];
-}
-
-function resolveTelegramActionDiscovery(cfg: Parameters<typeof listEnabledTelegramAccounts>[0]) {
-  const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
-  if (accounts.length === 0) {
-    return null;
-  }
-  const unionGate = createUnionActionGate(accounts, (account) =>
-    createTelegramActionGate({
-      cfg,
-      accountId: account.accountId,
-    }),
-  );
-  const pollEnabled = accounts.some((account) => {
-    const accountGate = createTelegramActionGate({
-      cfg,
-      accountId: account.accountId,
-    });
-    return resolveTelegramPollActionGateState(accountGate).enabled;
+function readTelegramSendParams(params: Record<string, unknown>) {
+  const to = readStringParam(params, "to", { required: true });
+  const mediaUrl = readStringParam(params, "media", { trim: false });
+  const buttons = resolveTelegramInlineButtons({
+    buttons: params.buttons as ReturnType<typeof resolveTelegramInlineButtons>,
+    interactive: params.interactive,
   });
-  const buttonsEnabled = accounts.some((account) =>
-    isTelegramInlineButtonsEnabled({ cfg, accountId: account.accountId }),
-  );
+  const hasButtons = Array.isArray(buttons) && buttons.length > 0;
+  const message = readStringParam(params, "message", {
+    required: !mediaUrl && !hasButtons,
+    allowEmpty: true,
+  });
+  const caption = readStringParam(params, "caption", { allowEmpty: true });
+  const content = message || caption || "";
+  const replyTo = readStringParam(params, "replyTo");
+  const threadId = readStringParam(params, "threadId");
+  const asVoice = readBooleanParam(params, "asVoice");
+  const silent = readBooleanParam(params, "silent");
+  const forceDocument = readBooleanParam(params, "forceDocument");
+  const asDocument = readBooleanParam(params, "asDocument");
+  const quoteText = readStringParam(params, "quoteText");
   return {
-    isEnabled: (key: keyof TelegramActionConfig, defaultValue = true) =>
-      unionGate(key, defaultValue),
-    pollEnabled,
-    buttonsEnabled,
+    to,
+    content,
+    mediaUrl: mediaUrl ?? undefined,
+    replyToMessageId: replyTo ?? undefined,
+    messageThreadId: threadId ?? undefined,
+    buttons,
+    asVoice,
+    silent,
+    forceDocument,
+    asDocument,
+    quoteText: quoteText ?? undefined,
   };
 }
 
-function describeTelegramMessageTool({
-  cfg,
-}: Parameters<
-  NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>
->[0]): ChannelMessageToolDiscovery {
-  const discovery = resolveTelegramActionDiscovery(cfg);
-  if (!discovery) {
-    return {
-      actions: [],
-      capabilities: [],
-      schema: null,
-    };
+function readTelegramChatIdParam(params: Record<string, unknown>): string | number {
+  return (
+    readStringOrNumberParam(params, "chatId") ??
+    readStringOrNumberParam(params, "channelId") ??
+    readStringParam(params, "to", { required: true })
+  );
+}
+
+function readTelegramMessageIdParam(params: Record<string, unknown>): number {
+  const messageId = readNumberParam(params, "messageId", {
+    required: true,
+    integer: true,
+  });
+  if (typeof messageId !== "number") {
+    throw new Error("messageId is required.");
   }
-  const actions = new Set<ChannelMessageActionName>(["send"]);
-  if (discovery.pollEnabled) {
-    actions.add("poll");
-  }
-  if (discovery.isEnabled("reactions")) {
-    actions.add("react");
-  }
-  if (discovery.isEnabled("deleteMessage")) {
-    actions.add("delete");
-  }
-  if (discovery.isEnabled("editMessage")) {
-    actions.add("edit");
-  }
-  if (discovery.isEnabled("sticker", false)) {
-    actions.add("sticker");
-    actions.add("sticker-search");
-  }
-  if (discovery.isEnabled("createForumTopic")) {
-    actions.add("topic-create");
-  }
-  if (discovery.isEnabled("editForumTopic")) {
-    actions.add("topic-edit");
-  }
-  const schema: ChannelMessageToolSchemaContribution[] = [];
-  if (discovery.buttonsEnabled) {
-    schema.push({
-      properties: {
-        buttons: Type.Optional(createMessageToolButtonsSchema()),
-      },
-    });
-  }
-  if (discovery.pollEnabled) {
-    schema.push({
-      properties: createTelegramPollExtraToolSchemas(),
-      visibility: "all-configured",
-    });
-  }
-  return {
-    actions: Array.from(actions),
-    capabilities: discovery.buttonsEnabled ? ["interactive", "buttons"] : [],
-    schema,
-  };
+  return messageId;
 }
 
 export const telegramMessageActions: ChannelMessageActionAdapter = {
-  describeMessageTool: describeTelegramMessageTool,
+  listActions: ({ cfg }) => {
+    const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
+    if (accounts.length === 0) {
+      return [];
+    }
+    // Union of all accounts' action gates (any account enabling an action makes it available)
+    const gate = createUnionActionGate(accounts, (account) =>
+      createTelegramActionGate({
+        cfg,
+        accountId: account.accountId,
+      }),
+    );
+    const isEnabled = (key: keyof TelegramActionConfig, defaultValue = true) =>
+      gate(key, defaultValue);
+    const actions = new Set<ChannelMessageActionName>(["send"]);
+    const pollEnabledForAnyAccount = accounts.some((account) => {
+      const accountGate = createTelegramActionGate({
+        cfg,
+        accountId: account.accountId,
+      });
+      return resolveTelegramPollActionGateState(accountGate).enabled;
+    });
+    if (pollEnabledForAnyAccount) {
+      actions.add("poll");
+    }
+    if (isEnabled("reactions")) {
+      actions.add("react");
+    }
+    if (isEnabled("deleteMessage")) {
+      actions.add("delete");
+    }
+    if (isEnabled("editMessage")) {
+      actions.add("edit");
+    }
+    if (isEnabled("sticker", false)) {
+      actions.add("sticker");
+      actions.add("sticker-search");
+    }
+    if (isEnabled("createForumTopic")) {
+      actions.add("topic-create");
+    }
+    if (isEnabled("editForumTopic")) {
+      actions.add("topic-edit");
+    }
+    return Array.from(actions);
+  },
+  getCapabilities: ({ cfg }) => {
+    const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
+    if (accounts.length === 0) {
+      return [];
+    }
+    const buttonsEnabled = accounts.some((account) =>
+      isTelegramInlineButtonsEnabled({ cfg, accountId: account.accountId }),
+    );
+    return buttonsEnabled ? (["interactive", "buttons"] as const) : [];
+  },
   extractToolSend: ({ args }) => {
     return extractToolSend(args, "sendMessage");
   },
   handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots, toolContext }) => {
-    const telegramAction = resolveTelegramMessageActionName(action);
-    if (!telegramAction) {
-      throw new Error(`Unsupported Telegram action: ${action}`);
+    if (action === "send") {
+      const sendParams = readTelegramSendParams(params);
+      return await handleTelegramAction(
+        {
+          action: "sendMessage",
+          ...sendParams,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
     }
-    return await telegramMessageActionRuntime.handleTelegramAction(
-      {
-        ...params,
-        action: telegramAction,
-        accountId: accountId ?? undefined,
-        ...(action === "react"
-          ? {
-              messageId: resolveReactionMessageId({ args: params, toolContext }),
-            }
-          : {}),
-      },
-      cfg,
-      { mediaLocalRoots },
-    );
+
+    if (action === "react") {
+      const messageId = resolveReactionMessageId({ args: params, toolContext });
+      const emoji = readStringParam(params, "emoji", { allowEmpty: true });
+      const remove = readBooleanParam(params, "remove");
+      return await handleTelegramAction(
+        {
+          action: "react",
+          chatId: readTelegramChatIdParam(params),
+          messageId,
+          emoji,
+          remove,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "poll") {
+      const to = readStringParam(params, "to", { required: true });
+      const question = readStringParam(params, "pollQuestion", { required: true });
+      const answers = readStringArrayParam(params, "pollOption", { required: true });
+      const durationHours = readNumberParam(params, "pollDurationHours", {
+        integer: true,
+        strict: true,
+      });
+      const durationSeconds = readNumberParam(params, "pollDurationSeconds", {
+        integer: true,
+        strict: true,
+      });
+      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      const allowMultiselect = readBooleanParam(params, "pollMulti");
+      const pollAnonymous = readBooleanParam(params, "pollAnonymous");
+      const pollPublic = readBooleanParam(params, "pollPublic");
+      const isAnonymous = resolveTelegramPollVisibility({ pollAnonymous, pollPublic });
+      const silent = readBooleanParam(params, "silent");
+      return await handleTelegramAction(
+        {
+          action: "poll",
+          to,
+          question,
+          answers,
+          allowMultiselect,
+          durationHours: durationHours ?? undefined,
+          durationSeconds: durationSeconds ?? undefined,
+          replyToMessageId: replyToMessageId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
+          isAnonymous,
+          silent,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "delete") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageId = readTelegramMessageIdParam(params);
+      return await handleTelegramAction(
+        {
+          action: "deleteMessage",
+          chatId,
+          messageId,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "edit") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageId = readTelegramMessageIdParam(params);
+      const message = readStringParam(params, "message", { required: true, allowEmpty: false });
+      const buttons = params.buttons;
+      return await handleTelegramAction(
+        {
+          action: "editMessage",
+          chatId,
+          messageId,
+          content: message,
+          buttons,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "sticker") {
+      const to =
+        readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
+      // Accept stickerId (array from shared schema) and use first element as fileId
+      const stickerIds = readStringArrayParam(params, "stickerId");
+      const fileId = stickerIds?.[0] ?? readStringParam(params, "fileId", { required: true });
+      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
+      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
+      return await handleTelegramAction(
+        {
+          action: "sendSticker",
+          to,
+          fileId,
+          replyToMessageId: replyToMessageId ?? undefined,
+          messageThreadId: messageThreadId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "sticker-search") {
+      const query = readStringParam(params, "query", { required: true });
+      const limit = readNumberParam(params, "limit", { integer: true });
+      return await handleTelegramAction(
+        {
+          action: "searchSticker",
+          query,
+          limit: limit ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "topic-create") {
+      const chatId = readTelegramChatIdParam(params);
+      const name = readStringParam(params, "name", { required: true });
+      const iconColor = readNumberParam(params, "iconColor", { integer: true });
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "createForumTopic",
+          chatId,
+          name,
+          iconColor: iconColor ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "topic-edit") {
+      const chatId = readTelegramChatIdParam(params);
+      const messageThreadId =
+        readNumberParam(params, "messageThreadId", { integer: true }) ??
+        readNumberParam(params, "threadId", { integer: true });
+      if (typeof messageThreadId !== "number") {
+        throw new Error("messageThreadId or threadId is required.");
+      }
+      const name = readStringParam(params, "name");
+      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
+      return await handleTelegramAction(
+        {
+          action: "editForumTopic",
+          chatId,
+          messageThreadId,
+          name: name ?? undefined,
+          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
   },
 };

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -1,334 +1,156 @@
 import { Type } from "@sinclair/typebox";
 import {
-  readNumberParam,
-  readStringArrayParam,
-  readStringOrNumberParam,
-  readStringParam,
-} from "openclaw/plugin-sdk/agent-runtime";
-import { handleTelegramAction } from "openclaw/plugin-sdk/agent-runtime";
-import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
-import { resolveReactionMessageId } from "openclaw/plugin-sdk/channel-runtime";
-import {
   createUnionActionGate,
   listTokenSourcedAccounts,
-} from "openclaw/plugin-sdk/channel-runtime";
+  resolveReactionMessageId,
+} from "openclaw/plugin-sdk/channel-actions";
+import { createMessageToolButtonsSchema } from "openclaw/plugin-sdk/channel-actions";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
-} from "openclaw/plugin-sdk/channel-runtime";
+  ChannelMessageToolDiscovery,
+  ChannelMessageToolSchemaContribution,
+} from "openclaw/plugin-sdk/channel-contract";
 import type { TelegramActionConfig } from "openclaw/plugin-sdk/config-runtime";
-import { resolveTelegramPollVisibility } from "openclaw/plugin-sdk/telegram";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import {
   createTelegramActionGate,
   listEnabledTelegramAccounts,
   resolveTelegramPollActionGateState,
 } from "./accounts.js";
-import { resolveTelegramInlineButtons } from "./button-types.js";
+import { handleTelegramAction } from "./action-runtime.js";
 import { isTelegramInlineButtonsEnabled } from "./inline-buttons.js";
+import { createTelegramPollExtraToolSchemas } from "./message-tool-schema.js";
 
-const providerId = "telegram";
+export const telegramMessageActionRuntime = {
+  handleTelegramAction,
+};
 
-function readTelegramSendParams(params: Record<string, unknown>) {
-  const to = readStringParam(params, "to", { required: true });
-  const mediaUrl = readStringParam(params, "media", { trim: false });
-  const buttons = resolveTelegramInlineButtons({
-    buttons: params.buttons as ReturnType<typeof resolveTelegramInlineButtons>,
-    interactive: params.interactive,
+const TELEGRAM_MESSAGE_ACTION_MAP = {
+  delete: "deleteMessage",
+  edit: "editMessage",
+  poll: "poll",
+  react: "react",
+  send: "sendMessage",
+  sticker: "sendSticker",
+  "sticker-search": "searchSticker",
+  "topic-create": "createForumTopic",
+  "topic-edit": "editForumTopic",
+} as const satisfies Partial<Record<ChannelMessageActionName, string>>;
+
+function resolveTelegramMessageActionName(action: ChannelMessageActionName) {
+  return TELEGRAM_MESSAGE_ACTION_MAP[action as keyof typeof TELEGRAM_MESSAGE_ACTION_MAP];
+}
+
+function resolveTelegramActionDiscovery(cfg: Parameters<typeof listEnabledTelegramAccounts>[0]) {
+  const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
+  if (accounts.length === 0) {
+    return null;
+  }
+  const unionGate = createUnionActionGate(accounts, (account) =>
+    createTelegramActionGate({
+      cfg,
+      accountId: account.accountId,
+    }),
+  );
+  const pollEnabled = accounts.some((account) => {
+    const accountGate = createTelegramActionGate({
+      cfg,
+      accountId: account.accountId,
+    });
+    return resolveTelegramPollActionGateState(accountGate).enabled;
   });
-  const hasButtons = Array.isArray(buttons) && buttons.length > 0;
-  const message = readStringParam(params, "message", {
-    required: !mediaUrl && !hasButtons,
-    allowEmpty: true,
-  });
-  const caption = readStringParam(params, "caption", { allowEmpty: true });
-  const content = message || caption || "";
-  const replyTo = readStringParam(params, "replyTo");
-  const threadId = readStringParam(params, "threadId");
-  const asVoice = readBooleanParam(params, "asVoice");
-  const silent = readBooleanParam(params, "silent");
-  const forceDocument = readBooleanParam(params, "forceDocument");
-  const asDocument = readBooleanParam(params, "asDocument");
-  const quoteText = readStringParam(params, "quoteText");
+  const buttonsEnabled = accounts.some((account) =>
+    isTelegramInlineButtonsEnabled({ cfg, accountId: account.accountId }),
+  );
   return {
-    to,
-    content,
-    mediaUrl: mediaUrl ?? undefined,
-    replyToMessageId: replyTo ?? undefined,
-    messageThreadId: threadId ?? undefined,
-    buttons,
-    asVoice,
-    silent,
-    forceDocument,
-    asDocument,
-    quoteText: quoteText ?? undefined,
+    isEnabled: (key: keyof TelegramActionConfig, defaultValue = true) =>
+      unionGate(key, defaultValue),
+    pollEnabled,
+    buttonsEnabled,
   };
 }
 
-function readTelegramChatIdParam(params: Record<string, unknown>): string | number {
-  return (
-    readStringOrNumberParam(params, "chatId") ??
-    readStringOrNumberParam(params, "channelId") ??
-    readStringParam(params, "to", { required: true })
-  );
-}
-
-function readTelegramMessageIdParam(params: Record<string, unknown>): number {
-  const messageId = readNumberParam(params, "messageId", {
-    required: true,
-    integer: true,
-  });
-  if (typeof messageId !== "number") {
-    throw new Error("messageId is required.");
+function describeTelegramMessageTool({
+  cfg,
+}: Parameters<
+  NonNullable<ChannelMessageActionAdapter["describeMessageTool"]>
+>[0]): ChannelMessageToolDiscovery {
+  const discovery = resolveTelegramActionDiscovery(cfg);
+  if (!discovery) {
+    return {
+      actions: [],
+      capabilities: [],
+      schema: null,
+    };
   }
-  return messageId;
+  const actions = new Set<ChannelMessageActionName>(["send"]);
+  if (discovery.pollEnabled) {
+    actions.add("poll");
+  }
+  if (discovery.isEnabled("reactions")) {
+    actions.add("react");
+  }
+  if (discovery.isEnabled("deleteMessage")) {
+    actions.add("delete");
+  }
+  if (discovery.isEnabled("editMessage")) {
+    actions.add("edit");
+  }
+  if (discovery.isEnabled("sticker", false)) {
+    actions.add("sticker");
+    actions.add("sticker-search");
+  }
+  if (discovery.isEnabled("createForumTopic")) {
+    actions.add("topic-create");
+  }
+  if (discovery.isEnabled("editForumTopic")) {
+    actions.add("topic-edit");
+  }
+  const schema: ChannelMessageToolSchemaContribution[] = [];
+  if (discovery.buttonsEnabled) {
+    schema.push({
+      properties: {
+        buttons: createMessageToolButtonsSchema(),
+      },
+    });
+  }
+  if (discovery.pollEnabled) {
+    schema.push({
+      properties: createTelegramPollExtraToolSchemas(),
+      visibility: "all-configured",
+    });
+  }
+  return {
+    actions: Array.from(actions),
+    capabilities: discovery.buttonsEnabled ? ["interactive", "buttons"] : [],
+    schema,
+  };
 }
 
 export const telegramMessageActions: ChannelMessageActionAdapter = {
-  listActions: ({ cfg }) => {
-    const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
-    if (accounts.length === 0) {
-      return [];
-    }
-    // Union of all accounts' action gates (any account enabling an action makes it available)
-    const gate = createUnionActionGate(accounts, (account) =>
-      createTelegramActionGate({
-        cfg,
-        accountId: account.accountId,
-      }),
-    );
-    const isEnabled = (key: keyof TelegramActionConfig, defaultValue = true) =>
-      gate(key, defaultValue);
-    const actions = new Set<ChannelMessageActionName>(["send"]);
-    const pollEnabledForAnyAccount = accounts.some((account) => {
-      const accountGate = createTelegramActionGate({
-        cfg,
-        accountId: account.accountId,
-      });
-      return resolveTelegramPollActionGateState(accountGate).enabled;
-    });
-    if (pollEnabledForAnyAccount) {
-      actions.add("poll");
-    }
-    if (isEnabled("reactions")) {
-      actions.add("react");
-    }
-    if (isEnabled("deleteMessage")) {
-      actions.add("delete");
-    }
-    if (isEnabled("editMessage")) {
-      actions.add("edit");
-    }
-    if (isEnabled("sticker", false)) {
-      actions.add("sticker");
-      actions.add("sticker-search");
-    }
-    if (isEnabled("createForumTopic")) {
-      actions.add("topic-create");
-    }
-    if (isEnabled("editForumTopic")) {
-      actions.add("topic-edit");
-    }
-    return Array.from(actions);
-  },
-  getCapabilities: ({ cfg }) => {
-    const accounts = listTokenSourcedAccounts(listEnabledTelegramAccounts(cfg));
-    if (accounts.length === 0) {
-      return [];
-    }
-    const buttonsEnabled = accounts.some((account) =>
-      isTelegramInlineButtonsEnabled({ cfg, accountId: account.accountId }),
-    );
-    return buttonsEnabled ? (["interactive", "buttons"] as const) : [];
-  },
+  describeMessageTool: describeTelegramMessageTool,
   extractToolSend: ({ args }) => {
     return extractToolSend(args, "sendMessage");
   },
   handleAction: async ({ action, params, cfg, accountId, mediaLocalRoots, toolContext }) => {
-    if (action === "send") {
-      const sendParams = readTelegramSendParams(params);
-      return await handleTelegramAction(
-        {
-          action: "sendMessage",
-          ...sendParams,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
+    const telegramAction = resolveTelegramMessageActionName(action);
+    if (!telegramAction) {
+      throw new Error(`Unsupported Telegram action: ${action}`);
     }
-
-    if (action === "react") {
-      const messageId = resolveReactionMessageId({ args: params, toolContext });
-      const emoji = readStringParam(params, "emoji", { allowEmpty: true });
-      const remove = readBooleanParam(params, "remove");
-      return await handleTelegramAction(
-        {
-          action: "react",
-          chatId: readTelegramChatIdParam(params),
-          messageId,
-          emoji,
-          remove,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "poll") {
-      const to = readStringParam(params, "to", { required: true });
-      const question = readStringParam(params, "pollQuestion", { required: true });
-      const answers = readStringArrayParam(params, "pollOption", { required: true });
-      const durationHours = readNumberParam(params, "pollDurationHours", {
-        integer: true,
-        strict: true,
-      });
-      const durationSeconds = readNumberParam(params, "pollDurationSeconds", {
-        integer: true,
-        strict: true,
-      });
-      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
-      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
-      const allowMultiselect = readBooleanParam(params, "pollMulti");
-      const pollAnonymous = readBooleanParam(params, "pollAnonymous");
-      const pollPublic = readBooleanParam(params, "pollPublic");
-      const isAnonymous = resolveTelegramPollVisibility({ pollAnonymous, pollPublic });
-      const silent = readBooleanParam(params, "silent");
-      return await handleTelegramAction(
-        {
-          action: "poll",
-          to,
-          question,
-          answers,
-          allowMultiselect,
-          durationHours: durationHours ?? undefined,
-          durationSeconds: durationSeconds ?? undefined,
-          replyToMessageId: replyToMessageId ?? undefined,
-          messageThreadId: messageThreadId ?? undefined,
-          isAnonymous,
-          silent,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "delete") {
-      const chatId = readTelegramChatIdParam(params);
-      const messageId = readTelegramMessageIdParam(params);
-      return await handleTelegramAction(
-        {
-          action: "deleteMessage",
-          chatId,
-          messageId,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "edit") {
-      const chatId = readTelegramChatIdParam(params);
-      const messageId = readTelegramMessageIdParam(params);
-      const message = readStringParam(params, "message", { required: true, allowEmpty: false });
-      const buttons = params.buttons;
-      return await handleTelegramAction(
-        {
-          action: "editMessage",
-          chatId,
-          messageId,
-          content: message,
-          buttons,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "sticker") {
-      const to =
-        readStringParam(params, "to") ?? readStringParam(params, "target", { required: true });
-      // Accept stickerId (array from shared schema) and use first element as fileId
-      const stickerIds = readStringArrayParam(params, "stickerId");
-      const fileId = stickerIds?.[0] ?? readStringParam(params, "fileId", { required: true });
-      const replyToMessageId = readNumberParam(params, "replyTo", { integer: true });
-      const messageThreadId = readNumberParam(params, "threadId", { integer: true });
-      return await handleTelegramAction(
-        {
-          action: "sendSticker",
-          to,
-          fileId,
-          replyToMessageId: replyToMessageId ?? undefined,
-          messageThreadId: messageThreadId ?? undefined,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "sticker-search") {
-      const query = readStringParam(params, "query", { required: true });
-      const limit = readNumberParam(params, "limit", { integer: true });
-      return await handleTelegramAction(
-        {
-          action: "searchSticker",
-          query,
-          limit: limit ?? undefined,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "topic-create") {
-      const chatId = readTelegramChatIdParam(params);
-      const name = readStringParam(params, "name", { required: true });
-      const iconColor = readNumberParam(params, "iconColor", { integer: true });
-      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
-      return await handleTelegramAction(
-        {
-          action: "createForumTopic",
-          chatId,
-          name,
-          iconColor: iconColor ?? undefined,
-          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    if (action === "topic-edit") {
-      const chatId = readTelegramChatIdParam(params);
-      const messageThreadId =
-        readNumberParam(params, "messageThreadId", { integer: true }) ??
-        readNumberParam(params, "threadId", { integer: true });
-      if (typeof messageThreadId !== "number") {
-        throw new Error("messageThreadId or threadId is required.");
-      }
-      const name = readStringParam(params, "name");
-      const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
-      return await handleTelegramAction(
-        {
-          action: "editForumTopic",
-          chatId,
-          messageThreadId,
-          name: name ?? undefined,
-          iconCustomEmojiId: iconCustomEmojiId ?? undefined,
-          accountId: accountId ?? undefined,
-        },
-        cfg,
-        { mediaLocalRoots },
-      );
-    }
-
-    throw new Error(`Action ${action} is not supported for provider ${providerId}.`);
+    return await telegramMessageActionRuntime.handleTelegramAction(
+      {
+        ...params,
+        action: telegramAction,
+        accountId: accountId ?? undefined,
+        ...(action === "react"
+          ? {
+              messageId: resolveReactionMessageId({ args: params, toolContext }),
+            }
+          : {}),
+      },
+      cfg,
+      { mediaLocalRoots },
+    );
   },
 };

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -122,6 +122,12 @@ function buildSendSchema(options: { includeInteractive: boolean }) {
         description: "Send image/GIF as document to avoid Telegram compression (Telegram only).",
       }),
     ),
+    asDocument: Type.Optional(
+      Type.Boolean({
+        description:
+          "Send files (images, videos, GIFs, etc.) as documents to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+      }),
+    ),
     interactive: Type.Optional(interactiveMessageSchema),
   };
   if (!options.includeInteractive) {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -125,7 +125,7 @@ function buildSendSchema(options: { includeInteractive: boolean }) {
     asDocument: Type.Optional(
       Type.Boolean({
         description:
-          "Send files (images, videos, GIFs, etc.) as documents to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+          "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
       }),
     ),
     interactive: Type.Optional(interactiveMessageSchema),

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -738,6 +738,22 @@ describe("telegramMessageActions", () => {
         }),
       },
       {
+        name: "media-only send preserves asDocument",
+        action: "send" as const,
+        params: {
+          to: "123",
+          media: "https://example.com/photo.jpg",
+          asDocument: true,
+        },
+        expectedPayload: expect.objectContaining({
+          action: "sendMessage",
+          to: "123",
+          content: "",
+          mediaUrl: "https://example.com/photo.jpg",
+          asDocument: true,
+        }),
+      },
+      {
         name: "silent send forwards silent flag",
         action: "send" as const,
         params: {

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -753,6 +753,22 @@ describe("telegramMessageActions", () => {
         }),
       },
       {
+        name: "explicit forceDocument false beats asDocument alias",
+        action: "send" as const,
+        params: {
+          to: "123",
+          media: "https://example.com/photo.jpg",
+          forceDocument: false,
+          asDocument: true,
+        },
+        expectedPayload: expect.objectContaining({
+          action: "sendMessage",
+          to: "123",
+          media: "https://example.com/photo.jpg",
+          forceDocument: false,
+        }),
+      },
+      {
         name: "silent send forwards silent flag",
         action: "send" as const,
         params: {

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -748,8 +748,7 @@ describe("telegramMessageActions", () => {
         expectedPayload: expect.objectContaining({
           action: "sendMessage",
           to: "123",
-          content: "",
-          mediaUrl: "https://example.com/photo.jpg",
+          media: "https://example.com/photo.jpg",
           asDocument: true,
         }),
       },

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -472,7 +472,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   }
   params.message = message;
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
-  const forceDocument = readBooleanParam(params, "forceDocument") ?? false;
+  const forceDocument =
+    (readBooleanParam(params, "forceDocument") || readBooleanParam(params, "asDocument")) ?? false;
   const bestEffort = readBooleanParam(params, "bestEffort");
   const silent = readBooleanParam(params, "silent");
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -473,7 +473,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   params.message = message;
   const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
   const forceDocument =
-    (readBooleanParam(params, "forceDocument") || readBooleanParam(params, "asDocument")) ?? false;
+    readBooleanParam(params, "forceDocument") ?? readBooleanParam(params, "asDocument") ?? false;
   const bestEffort = readBooleanParam(params, "bestEffort");
   const silent = readBooleanParam(params, "silent");
 


### PR DESCRIPTION
## Summary

Adds `asDocument` as a user-facing alias for the existing `forceDocument` parameter in the message tool.

When set to `true`, media files (images, videos, GIFs) are sent via `sendDocument` instead of `sendPhoto`/`sendVideo`/`sendAnimation`, preserving the original file quality without Telegram compression.

## Motivation

When agents generate high-resolution images (e.g. via nano-banana-pro) or need to deliver uncompressed files to users, Telegram's automatic compression degrades quality. The existing `forceDocument` parameter handles this but isn't discoverable — `asDocument` provides a more intuitive name consistent with the existing `asVoice` pattern.

## Changes

- `src/agents/tools/message-tool.ts`: add `asDocument` to send schema with description
- `src/agents/tools/telegram-actions.ts`: OR `asDocument` into `forceDocument` 
- `src/infra/outbound/message-action-runner.ts`: same OR logic for outbound path
- `extensions/telegram/src/channel-actions.ts`: read and forward `asDocument`
- `src/channels/plugins/actions/actions.test.ts`: add test case

## Notes

- `asDocument` is an alias — `forceDocument` continues to work unchanged
- Follows the same naming pattern as `asVoice`
- Telegram-only parameter, ignored on other channels