### PR TITLE
fix(cli): route logs to stderr in --json mode

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -5,6 +5,7 @@ const setVerboseMock = vi.fn();
 const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
+const routeLogsToStderrMock = vi.fn();
 
 const runtimeMock = {
   log: vi.fn(),
@@ -22,6 +23,10 @@ vi.mock("../../runtime.js", () => ({
 
 vi.mock("../banner.js", () => ({
   emitCliBanner: emitCliBannerMock,
+}));
+
+vi.mock("../../logging/console.js", () => ({
+  routeLogsToStderr: routeLogsToStderrMock,
 }));
 
 vi.mock("../cli-name.js", () => ({
@@ -268,6 +273,35 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["config", "set"],
     });
+  });
+
+  it("routes logs to stderr in --json mode so stdout stays clean", async () => {
+    await runPreAction({
+      parseArgv: ["agents"],
+      processArgv: ["node", "openclaw", "agents", "--json"],
+    });
+
+    expect(routeLogsToStderrMock).toHaveBeenCalledOnce();
+
+    vi.clearAllMocks();
+
+    // config set --json is parse-only (not JSON output mode), should not route
+    await runPreAction({
+      parseArgv: ["config", "set", "gateway.auth.mode", "local", "--json"],
+      processArgv: ["node", "openclaw", "config", "set", "gateway.auth.mode", "local", "--json"],
+    });
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+
+    // non-json command should not route
+    await runPreAction({
+      parseArgv: ["agents"],
+      processArgv: ["node", "openclaw", "agents"],
+    });
+
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
   it("bypasses config guard for config validate", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { routeLogsToStderr } from "../../logging/console.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -123,6 +124,9 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const commandPath = getCommandPathWithRootOptions(argv, 2);
+    if (isJsonOutputMode(commandPath, argv)) {
+      routeLogsToStderr();
+    }
     const hideBanner =
       isTruthyEnvValue(process.env.OPENCLAW_HIDE_BANNER) ||
       commandPath[0] === "update" ||

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -288,8 +288,9 @@ export function enableConsoleCapture(): void {
       } catch {
         // never block console output on logging failures
       }
-      if (loggingState.forceConsoleToStderr) {
-        // in RPC/JSON mode, keep stdout clean
+      if (loggingState.forceConsoleToStderr && !isJsonPayload(trimmed)) {
+        // In --json mode, route diagnostic logs to stderr but let JSON
+        // payloads (the actual command output) through to stdout via orig().
         try {
           const line = timestamp ? `${timestamp} ${formatted}` : formatted;
           process.stderr.write(`${line}\n`);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,3 +1,5 @@
+import util from "node:util";
+import { loggingState } from "./logging/state.js";
 import { clearActiveProgressLine } from "./terminal/progress-line.js";
 import { restoreTerminalState } from "./terminal/restore.js";
 
@@ -25,6 +27,12 @@ function createRuntimeIo(): Pick<RuntimeEnv, "log" | "error"> {
         return;
       }
       clearActiveProgressLine();
+      // When console is captured and logs are routed to stderr (--json mode),
+      // write directly to stdout so the JSON payload is not redirected.
+      if (loggingState.forceConsoleToStderr && loggingState.consolePatched) {
+        process.stdout.write(`${util.format(...args)}\n`);
+        return;
+      }
       console.log(...args);
     },
     error: (...args: Parameters<typeof console.error>) => {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,5 +1,3 @@
-import util from "node:util";
-import { loggingState } from "./logging/state.js";
 import { clearActiveProgressLine } from "./terminal/progress-line.js";
 import { restoreTerminalState } from "./terminal/restore.js";
 
@@ -27,12 +25,6 @@ function createRuntimeIo(): Pick<RuntimeEnv, "log" | "error"> {
         return;
       }
       clearActiveProgressLine();
-      // When console is captured and logs are routed to stderr (--json mode),
-      // write directly to stdout so the JSON payload is not redirected.
-      if (loggingState.forceConsoleToStderr && loggingState.consolePatched) {
-        process.stdout.write(`${util.format(...args)}\n`);
-        return;
-      }
       console.log(...args);
     },
     error: (...args: Parameters<typeof console.error>) => {


### PR DESCRIPTION
## Summary

- Calls `routeLogsToStderr()` in the CLI preAction hook when `--json` output mode is detected, so plugin-loading logs and other diagnostic output go to stderr instead of corrupting the JSON on stdout.
- Modifies the console capture `forward()` function to keep JSON payloads on stdout even when `forceConsoleToStderr` is active — so the actual command output (emitted via `runtime.log()`) is not redirected.

Fixes #52032

## Root Cause

The preAction hook (`src/cli/program/preaction.ts`) already had `isJsonOutputMode()` and `routeLogsToStderr()` available but never connected them. When commands like `openclaw agents list --json` loaded plugins, their info-level logs went to stdout via `console.log()`, breaking `jq` / programmatic parsing.

The `status`/`health --json` commands happened to work because `shouldLoadPluginsForCommand` skips plugin loading entirely for those two commands — but all other `--json` commands (`agents`, `channels`, `message`, `configure`, `directory`) were affected.

## Approach

Two coordinated changes:

1. **`src/cli/program/preaction.ts`**: Call `routeLogsToStderr()` early in the preAction hook when `isJsonOutputMode()` is true — before banner, config-guard, or plugin loading can emit to stdout.

2. **`src/logging/console.ts`**: In the `forward()` function (the patched `console.log()`), when `forceConsoleToStderr` is true, check `isJsonPayload()` first. If the message is a valid JSON payload (the actual command output), let it through to stdout via the original `console.log()`. Only diagnostic/log messages get redirected to stderr.

This avoids touching `runtime.ts` (which is part of the plugin SDK API surface) and reuses the existing `isJsonPayload()` helper that was already used for timestamp-prefix suppression.

## Changes

- **`src/cli/program/preaction.ts`**: Import `routeLogsToStderr` and call it when `isJsonOutputMode()` is true.
- **`src/logging/console.ts`**: Add `!isJsonPayload(trimmed)` guard to the `forceConsoleToStderr` branch so JSON payloads stay on stdout.
- **`src/cli/program/preaction.test.ts`**: Add regression test verifying `routeLogsToStderr` is called for `agents --json`, is NOT called for `config set --json` (parse-only mode), and is NOT called without `--json`.

## Test plan

- [x] `pnpm test -- src/cli/program/preaction.test.ts` — 8/8 pass (including new test)
- [x] `pnpm test -- src/logging/` — all pass
- [x] `pnpm format:check` — clean
- [x] `pnpm plugin-sdk:api:check` — no API baseline drift
- [ ] CI passes (channels/whatsapp failures are pre-existing mock issues on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>