### PR TITLE
docs: add missing plugin author guides

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -312,6 +312,10 @@
     "target": "插件 SDK 设置"
   },
   {
+    "source": "Plugin Setup and Config",
+    "target": "插件设置与配置"
+  },
+  {
     "source": "Setup and Config",
     "target": "设置和配置"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -252,6 +252,14 @@
     "target": "SDK 概览"
   },
   {
+    "source": "Plugins",
+    "target": "插件"
+  },
+  {
+    "source": "plugins CLI",
+    "target": "plugins CLI"
+  },
+  {
     "source": "Install and use plugins",
     "target": "安装和使用插件"
   },
@@ -288,6 +296,10 @@
     "target": "运行时辅助工具"
   },
   {
+    "source": "Plugin Runtime Helpers",
+    "target": "插件运行时辅助工具"
+  },
+  {
     "source": "Plugin Setup",
     "target": "插件设置"
   },
@@ -302,6 +314,10 @@
   {
     "source": "Setup and Config",
     "target": "设置和配置"
+  },
+  {
+    "source": "Migrate to SDK",
+    "target": "迁移到 SDK"
   },
   {
     "source": "Building Plugins",
@@ -320,6 +336,14 @@
     "target": "渠道插件"
   },
   {
+    "source": "Channel Plugin Interface",
+    "target": "渠道插件接口"
+  },
+  {
+    "source": "Channel Interface",
+    "target": "渠道接口"
+  },
+  {
     "source": "SDK Channel Plugins",
     "target": "SDK 渠道插件"
   },
@@ -334,6 +358,14 @@
   {
     "source": "Provider Plugins",
     "target": "提供商插件"
+  },
+  {
+    "source": "Provider Plugin Interface",
+    "target": "提供商插件接口"
+  },
+  {
+    "source": "Provider Interface",
+    "target": "提供商接口"
   },
   {
     "source": "SDK Provider Plugins",
@@ -366,6 +398,10 @@
   {
     "source": "Plugin SDK Testing",
     "target": "插件 SDK 测试"
+  },
+  {
+    "source": "Plugin Testing",
+    "target": "插件测试"
   },
   {
     "source": "SDK Testing",

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -252,6 +252,10 @@
     "target": "SDK 概览"
   },
   {
+    "source": "Install and use plugins",
+    "target": "安装和使用插件"
+  },
+  {
     "source": "Plugin Entry Points",
     "target": "插件入口点"
   },
@@ -260,12 +264,28 @@
     "target": "入口点"
   },
   {
+    "source": "SDK Entry Points",
+    "target": "SDK 入口点"
+  },
+  {
     "source": "Plugin Runtime",
     "target": "插件运行时"
   },
   {
+    "source": "Plugin SDK Runtime",
+    "target": "插件 SDK 运行时"
+  },
+  {
     "source": "Runtime",
     "target": "运行时"
+  },
+  {
+    "source": "SDK Runtime",
+    "target": "SDK 运行时"
+  },
+  {
+    "source": "Runtime Helpers",
+    "target": "运行时辅助工具"
   },
   {
     "source": "Plugin Setup",
@@ -276,12 +296,36 @@
     "target": "设置"
   },
   {
+    "source": "Plugin SDK Setup",
+    "target": "插件 SDK 设置"
+  },
+  {
+    "source": "Setup and Config",
+    "target": "设置和配置"
+  },
+  {
+    "source": "Building Plugins",
+    "target": "构建插件"
+  },
+  {
+    "source": "Building Channel Plugins",
+    "target": "构建渠道插件"
+  },
+  {
     "source": "Channel Plugin SDK",
     "target": "渠道插件 SDK"
   },
   {
     "source": "Channel Plugins",
     "target": "渠道插件"
+  },
+  {
+    "source": "SDK Channel Plugins",
+    "target": "SDK 渠道插件"
+  },
+  {
+    "source": "Building Provider Plugins",
+    "target": "构建提供商插件"
   },
   {
     "source": "Provider Plugin SDK",
@@ -292,11 +336,55 @@
     "target": "提供商插件"
   },
   {
+    "source": "SDK Provider Plugins",
+    "target": "SDK 提供商插件"
+  },
+  {
+    "source": "Building Tool Plugins",
+    "target": "构建工具插件"
+  },
+  {
+    "source": "Tool Plugins",
+    "target": "工具插件"
+  },
+  {
+    "source": "Plugin Troubleshooting",
+    "target": "插件故障排除"
+  },
+  {
+    "source": "Troubleshooting",
+    "target": "故障排除"
+  },
+  {
+    "source": "Plugin SDK Subpaths",
+    "target": "插件 SDK 子路径"
+  },
+  {
+    "source": "SDK Subpaths",
+    "target": "SDK 子路径"
+  },
+  {
     "source": "Plugin SDK Testing",
     "target": "插件 SDK 测试"
   },
   {
+    "source": "SDK Testing",
+    "target": "SDK 测试"
+  },
+  {
     "source": "Testing",
     "target": "测试"
+  },
+  {
+    "source": "Plugin Manifest",
+    "target": "插件清单"
+  },
+  {
+    "source": "Plugin Internals",
+    "target": "插件内部机制"
+  },
+  {
+    "source": "SDK Migration",
+    "target": "SDK 迁移"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1043,15 +1043,18 @@
                     "group": "Building Plugins",
                     "pages": [
                       "plugins/building-plugins",
+                      "plugins/sdk-tool-plugins",
                       "plugins/sdk-channel-plugins",
                       "plugins/sdk-provider-plugins",
-                      "plugins/sdk-migration"
+                      "plugins/sdk-migration",
+                      "plugins/sdk-troubleshooting"
                     ]
                   },
                   {
                     "group": "SDK Reference",
                     "pages": [
                       "plugins/sdk-overview",
+                      "plugins/sdk-subpaths",
                       "plugins/sdk-entrypoints",
                       "plugins/sdk-runtime",
                       "plugins/sdk-setup",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1056,6 +1056,8 @@
                       "plugins/sdk-overview",
                       "plugins/sdk-subpaths",
                       "plugins/sdk-entrypoints",
+                      "plugins/sdk-channel-interface",
+                      "plugins/sdk-provider-interface",
                       "plugins/sdk-runtime",
                       "plugins/sdk-setup",
                       "plugins/sdk-testing",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1054,13 +1054,13 @@
                     "group": "SDK Reference",
                     "pages": [
                       "plugins/sdk-overview",
-                      "plugins/sdk-subpaths",
                       "plugins/sdk-entrypoints",
                       "plugins/sdk-channel-interface",
                       "plugins/sdk-provider-interface",
                       "plugins/sdk-runtime",
                       "plugins/sdk-setup",
                       "plugins/sdk-testing",
+                      "plugins/sdk-subpaths",
                       "plugins/manifest",
                       "plugins/architecture"
                     ]

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -18,6 +18,8 @@ sidebarTitle: "Internals"
   - [Tool Plugins](/plugins/sdk-tool-plugins) — build tools, hooks, and commands
   - [Channel Plugins](/plugins/sdk-channel-plugins) — build a messaging channel
   - [Provider Plugins](/plugins/sdk-provider-plugins) — build a model provider
+  - [Channel Plugin Interface](/plugins/sdk-channel-interface) — public channel shape
+  - [Provider Plugin Interface](/plugins/sdk-provider-interface) — public provider shape
   - [SDK Overview](/plugins/sdk-overview) — import map and registration API
 </Info>
 

--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -15,6 +15,7 @@ sidebarTitle: "Internals"
   This is the **deep architecture reference**. For practical guides, see:
   - [Install and use plugins](/tools/plugin) — user guide
   - [Getting Started](/plugins/building-plugins) — first plugin tutorial
+  - [Tool Plugins](/plugins/sdk-tool-plugins) — build tools, hooks, and commands
   - [Channel Plugins](/plugins/sdk-channel-plugins) — build a messaging channel
   - [Provider Plugins](/plugins/sdk-provider-plugins) — build a model provider
   - [SDK Overview](/plugins/sdk-overview) — import map and registration API

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -200,7 +200,7 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import { ... } from "openclaw/plugin-sdk";
 ```
 
-For the full subpath reference, see [SDK Subpaths](/plugins/sdk-subpaths).
+For import guidance, see [SDK Overview](/plugins/sdk-overview).
 
 Within your plugin, use local barrel files (`api.ts`, `runtime-api.ts`) for
 internal imports — never import your own plugin through its SDK path.
@@ -229,9 +229,6 @@ internal imports — never import your own plugin through its SDK path.
   </Card>
   <Card title="SDK Overview" icon="book-open" href="/plugins/sdk-overview">
     Import map and registration API reference
-  </Card>
-  <Card title="SDK Subpaths" icon="list" href="/plugins/sdk-subpaths">
-    Supported `openclaw/plugin-sdk/*` imports
   </Card>
   <Card title="Runtime Helpers" icon="settings" href="/plugins/sdk-runtime">
     TTS, search, subagent via api.runtime

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -200,7 +200,7 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import { ... } from "openclaw/plugin-sdk";
 ```
 
-For import guidance, see [SDK Overview](/plugins/sdk-overview).
+For subpath guidance, see [SDK Overview](/plugins/sdk-overview).
 
 Within your plugin, use local barrel files (`api.ts`, `runtime-api.ts`) for
 internal imports — never import your own plugin through its SDK path.

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -33,7 +33,7 @@ falls back to npm automatically.
   <Card title="Provider plugin" icon="cpu" href="/plugins/sdk-provider-plugins">
     Add a model provider (LLM, proxy, or custom endpoint)
   </Card>
-  <Card title="Tool / hook plugin" icon="wrench">
+  <Card title="Tool / hook plugin" icon="wrench" href="/plugins/sdk-tool-plugins">
     Register agent tools, event hooks, or services — continue below
   </Card>
 </CardGroup>
@@ -200,7 +200,7 @@ import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
 import { ... } from "openclaw/plugin-sdk";
 ```
 
-For the full subpath reference, see [SDK Overview](/plugins/sdk-overview).
+For the full subpath reference, see [SDK Subpaths](/plugins/sdk-subpaths).
 
 Within your plugin, use local barrel files (`api.ts`, `runtime-api.ts`) for
 internal imports — never import your own plugin through its SDK path.
@@ -218,6 +218,9 @@ internal imports — never import your own plugin through its SDK path.
 ## Next steps
 
 <CardGroup cols={2}>
+  <Card title="Tool Plugins" icon="wrench" href="/plugins/sdk-tool-plugins">
+    Build a tool, hook, or command plugin
+  </Card>
   <Card title="Channel Plugins" icon="messages-square" href="/plugins/sdk-channel-plugins">
     Build a messaging channel plugin
   </Card>
@@ -227,11 +230,17 @@ internal imports — never import your own plugin through its SDK path.
   <Card title="SDK Overview" icon="book-open" href="/plugins/sdk-overview">
     Import map and registration API reference
   </Card>
+  <Card title="SDK Subpaths" icon="list" href="/plugins/sdk-subpaths">
+    Supported `openclaw/plugin-sdk/*` imports
+  </Card>
   <Card title="Runtime Helpers" icon="settings" href="/plugins/sdk-runtime">
     TTS, search, subagent via api.runtime
   </Card>
   <Card title="Testing" icon="test-tubes" href="/plugins/sdk-testing">
     Test utilities and patterns
+  </Card>
+  <Card title="Troubleshooting" icon="triangle-alert" href="/plugins/sdk-troubleshooting">
+    Debug load, manifest, and config issues
   </Card>
   <Card title="Plugin Manifest" icon="file-json" href="/plugins/manifest">
     Full manifest schema reference

--- a/docs/plugins/sdk-channel-interface.md
+++ b/docs/plugins/sdk-channel-interface.md
@@ -30,6 +30,11 @@ Common supporting imports:
 - `openclaw/plugin-sdk/channel-config-helpers` for config adapters
 - `openclaw/plugin-sdk/channel-send-result` for outbound result helpers
 
+<Warning>
+  These supporting channel subpaths are expected to move under a channel
+  namespace very soon.
+</Warning>
+
 ## Required fields
 
 These fields are the public core of a `ChannelPlugin`:

--- a/docs/plugins/sdk-channel-interface.md
+++ b/docs/plugins/sdk-channel-interface.md
@@ -214,4 +214,4 @@ Practical rules:
 - [Plugin Entry Points](/plugins/sdk-entrypoints) — `defineChannelPluginEntry(...)`
 - [Plugin Setup and Config](/plugins/sdk-setup) — manifests, setup entries, config schemas
 - [Plugin Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and runtime storage
-- [SDK Subpaths](/plugins/sdk-subpaths) — public import paths
+- [SDK Subpaths](/plugins/sdk-subpaths) — public subpaths

--- a/docs/plugins/sdk-channel-interface.md
+++ b/docs/plugins/sdk-channel-interface.md
@@ -23,7 +23,7 @@ the interface itself.
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 ```
 
-Use focused subpaths for supporting types:
+Common supporting imports:
 
 - `openclaw/plugin-sdk/channel-contract` for shared channel contract types
 - `openclaw/plugin-sdk/channel-setup` for setup helpers
@@ -171,50 +171,22 @@ Common optional methods:
 | `setAccountEnabled` / `deleteAccount`  | Management flows               |
 | `resolveAllowFrom` / `formatAllowFrom` | Shared DM allowlist handling   |
 
-## Common optional adapters
+## Common additional sections
 
-Most channel plugins do not implement every adapter. These are the ones authors
-touch most often.
+Most channel plugins only need a few sections beyond `meta`, `capabilities`,
+and `config`.
 
-### Setup and security
+| Section                   | Use it for                               |
+| ------------------------- | ---------------------------------------- |
+| `setup`                   | Writing or validating account config     |
+| `configSchema`            | Channel config schema and setup UI hints |
+| `outbound`                | Sending text, media, and polls           |
+| `messaging` / `threading` | Message semantics and session routing    |
+| `status`                  | Probes, audits, and diagnostics          |
+| `pairing` / `security`    | DM approval, linking, and access policy  |
 
-| Field          | Use it for                                  |
-| -------------- | ------------------------------------------- |
-| `setupWizard`  | Guided setup UI and onboarding              |
-| `configSchema` | Channel config schema and UI hints          |
-| `setup`        | Writing or validating account config        |
-| `pairing`      | DM approval and linking flows               |
-| `security`     | DM policy, allowlists, and access checks    |
-| `auth`         | Channel-owned login/auth flows              |
-| `allowlist`    | Extra allowlist handling beyond base config |
-
-### Message flow
-
-| Field         | Use it for                                   |
-| ------------- | -------------------------------------------- |
-| `mentions`    | Mention stripping and mention detection      |
-| `outbound`    | Sending text, media, and polls               |
-| `messaging`   | Inbound/outbound message semantics           |
-| `threading`   | Reply threading and session routing          |
-| `actions`     | Channel-specific message actions and schemas |
-| `agentPrompt` | Channel-specific prompt shaping              |
-| `agentTools`  | Channel-owned tools such as login helpers    |
-
-### Runtime and operations
-
-| Field                 | Use it for                                |
-| --------------------- | ----------------------------------------- |
-| `status`              | Probes, audits, and status snapshots      |
-| `gateway`             | Long-running gateway connection lifecycle |
-| `lifecycle`           | Account start/stop lifecycle hooks        |
-| `streaming`           | Channel streaming behavior                |
-| `heartbeat`           | Health signals and connectivity hints     |
-| `directory`           | Directory and search integration          |
-| `resolver`            | Target/account resolution helpers         |
-| `bindings`            | Config-backed binding providers           |
-| `commands`            | Channel-native command behavior           |
-| `gatewayMethods`      | Plugin-owned gateway methods              |
-| `defaults` / `reload` | Small runtime defaults and reload rules   |
+The channel guide covers the full build path. This page stays focused on the
+main public shape authors usually implement directly.
 
 ## Interface expectations
 

--- a/docs/plugins/sdk-channel-interface.md
+++ b/docs/plugins/sdk-channel-interface.md
@@ -1,0 +1,245 @@
+---
+title: "Channel Plugin Interface"
+sidebarTitle: "Channel Interface"
+summary: "Reference for the public ChannelPlugin shape and its most important adapter surfaces"
+read_when:
+  - You want the public shape of `ChannelPlugin`
+  - You need to know which channel fields are required versus optional
+  - You are building a channel plugin and want a field-by-field reference
+---
+
+# Channel Plugin Interface
+
+This page describes the public `ChannelPlugin` interface used by native channel
+plugins.
+
+If you want a step-by-step walkthrough, start with
+[Channel Plugins](/plugins/sdk-channel-plugins). This page is the reference for
+the interface itself.
+
+## Import
+
+```typescript
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+```
+
+Use focused subpaths for supporting types:
+
+- `openclaw/plugin-sdk/channel-contract` for shared channel contract types
+- `openclaw/plugin-sdk/channel-setup` for setup helpers
+- `openclaw/plugin-sdk/channel-config-helpers` for config adapters
+- `openclaw/plugin-sdk/channel-send-result` for outbound result helpers
+
+## Required fields
+
+These fields are the public core of a `ChannelPlugin`:
+
+| Field          | What it does                                       |
+| -------------- | -------------------------------------------------- |
+| `id`           | Stable channel id                                  |
+| `meta`         | User-facing metadata for docs, pickers, and setup  |
+| `capabilities` | Static flags that describe what the channel can do |
+| `config`       | Account listing and account resolution             |
+
+In practice, most real channel plugins also define `setup`, because users need
+some way to write account config.
+
+## Minimal shape
+
+```typescript
+import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
+
+type ResolvedAccount = {
+  accountId: string | null;
+  token: string;
+};
+
+export const acmeChatPlugin: ChannelPlugin<ResolvedAccount> = {
+  id: "acme-chat",
+
+  meta: {
+    id: "acme-chat",
+    label: "Acme Chat",
+    selectionLabel: "Acme Chat",
+    docsPath: "/channels/acme-chat",
+    blurb: "Connect OpenClaw to Acme Chat.",
+  },
+
+  capabilities: {
+    chatTypes: ["direct", "group"],
+    reply: true,
+    media: true,
+  },
+
+  config: {
+    listAccountIds(cfg: OpenClawConfig) {
+      const section = (cfg.channels as Record<string, unknown>)?.["acme-chat"];
+      return section ? ["default"] : [];
+    },
+    resolveAccount(cfg: OpenClawConfig, accountId?: string | null) {
+      const section =
+        ((cfg.channels as Record<string, unknown>)?.["acme-chat"] as
+          | Record<string, unknown>
+          | undefined) ?? {};
+      const token = typeof section.token === "string" ? section.token : "";
+      if (!token) {
+        throw new Error("acme-chat: token is required");
+      }
+      return {
+        accountId: accountId ?? null,
+        token,
+      };
+    },
+  },
+
+  setup: {
+    applyAccountConfig({ cfg, input }) {
+      return {
+        ...cfg,
+        channels: {
+          ...(cfg.channels ?? {}),
+          "acme-chat": {
+            ...((cfg.channels as Record<string, unknown>)?.["acme-chat"] ?? {}),
+            token: input.token,
+          },
+        },
+      };
+    },
+  },
+};
+```
+
+## Core sections
+
+### `meta`
+
+`meta` is the user-facing description of the channel.
+
+The most important fields are:
+
+| Field            | Meaning                                              |
+| ---------------- | ---------------------------------------------------- |
+| `id`             | Channel id shown in metadata surfaces                |
+| `label`          | Human display name                                   |
+| `selectionLabel` | Label used in setup pickers                          |
+| `docsPath`       | Docs page for this channel                           |
+| `blurb`          | Short explanation shown in setup and selection flows |
+
+Other fields like `aliases`, `detailLabel`, `systemImage`, or `order` are
+display and UX refinements.
+
+### `capabilities`
+
+`capabilities` tells OpenClaw what the channel supports.
+
+Required:
+
+- `chatTypes`
+
+Common optional flags:
+
+- `media`
+- `reply`
+- `reactions`
+- `threads`
+- `polls`
+- `nativeCommands`
+- `blockStreaming`
+
+These flags shape shared behavior such as the message tool, reply formatting,
+and capability diagnostics.
+
+### `config`
+
+`config` is the most important adapter after `meta`.
+
+Required methods:
+
+| Method                            | Meaning                                                        |
+| --------------------------------- | -------------------------------------------------------------- |
+| `listAccountIds(cfg)`             | Return known account ids                                       |
+| `resolveAccount(cfg, accountId?)` | Return the resolved account object the rest of the plugin uses |
+
+Common optional methods:
+
+| Method                                 | Use it for                     |
+| -------------------------------------- | ------------------------------ |
+| `defaultAccountId`                     | Default account selection      |
+| `isEnabled` / `isConfigured`           | Channel status and setup flows |
+| `describeAccount`                      | Status snapshots               |
+| `setAccountEnabled` / `deleteAccount`  | Management flows               |
+| `resolveAllowFrom` / `formatAllowFrom` | Shared DM allowlist handling   |
+
+## Common optional adapters
+
+Most channel plugins do not implement every adapter. These are the ones authors
+touch most often.
+
+### Setup and security
+
+| Field          | Use it for                                  |
+| -------------- | ------------------------------------------- |
+| `setupWizard`  | Guided setup UI and onboarding              |
+| `configSchema` | Channel config schema and UI hints          |
+| `setup`        | Writing or validating account config        |
+| `pairing`      | DM approval and linking flows               |
+| `security`     | DM policy, allowlists, and access checks    |
+| `auth`         | Channel-owned login/auth flows              |
+| `allowlist`    | Extra allowlist handling beyond base config |
+
+### Message flow
+
+| Field         | Use it for                                   |
+| ------------- | -------------------------------------------- |
+| `mentions`    | Mention stripping and mention detection      |
+| `outbound`    | Sending text, media, and polls               |
+| `messaging`   | Inbound/outbound message semantics           |
+| `threading`   | Reply threading and session routing          |
+| `actions`     | Channel-specific message actions and schemas |
+| `agentPrompt` | Channel-specific prompt shaping              |
+| `agentTools`  | Channel-owned tools such as login helpers    |
+
+### Runtime and operations
+
+| Field                 | Use it for                                |
+| --------------------- | ----------------------------------------- |
+| `status`              | Probes, audits, and status snapshots      |
+| `gateway`             | Long-running gateway connection lifecycle |
+| `lifecycle`           | Account start/stop lifecycle hooks        |
+| `streaming`           | Channel streaming behavior                |
+| `heartbeat`           | Health signals and connectivity hints     |
+| `directory`           | Directory and search integration          |
+| `resolver`            | Target/account resolution helpers         |
+| `bindings`            | Config-backed binding providers           |
+| `commands`            | Channel-native command behavior           |
+| `gatewayMethods`      | Plugin-owned gateway methods              |
+| `defaults` / `reload` | Small runtime defaults and reload rules   |
+
+## Interface expectations
+
+Keep these ids aligned:
+
+- `openclaw.plugin.json` `id`
+- `package.json` `openclaw.channel.id`
+- `defineChannelPluginEntry({ id })`
+- `ChannelPlugin.id`
+
+Practical rules:
+
+- `config.resolveAccount(...)` should return a resolved account or throw a
+  clear config error.
+- Use `defineChannelPluginEntry(...)` for channel plugins instead of
+  `definePluginEntry(...)`.
+- Prefer `createChatChannelPlugin(...)` and `createChannelPluginBase(...)`
+  unless you need full manual control.
+- Keep channel-specific behavior inside the plugin adapters instead of pushing
+  it back into shared core.
+
+## Related
+
+- [Channel Plugins](/plugins/sdk-channel-plugins) — step-by-step channel walkthrough
+- [Plugin Entry Points](/plugins/sdk-entrypoints) — `defineChannelPluginEntry(...)`
+- [Plugin Setup and Config](/plugins/sdk-setup) — manifests, setup entries, config schemas
+- [Plugin Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and runtime storage
+- [SDK Subpaths](/plugins/sdk-subpaths) — public import paths

--- a/docs/plugins/sdk-channel-interface.md
+++ b/docs/plugins/sdk-channel-interface.md
@@ -23,16 +23,9 @@ the interface itself.
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 ```
 
-Common supporting imports:
-
-- `openclaw/plugin-sdk/channel-contract` for shared channel contract types
-- `openclaw/plugin-sdk/channel-setup` for setup helpers
-- `openclaw/plugin-sdk/channel-config-helpers` for config adapters
-- `openclaw/plugin-sdk/channel-send-result` for outbound result helpers
-
 <Warning>
-  These supporting channel subpaths are expected to move under a channel
-  namespace very soon.
+  Additional channel helper subpaths are intentionally not listed here because
+  they are expected to move under a channel namespace very soon.
 </Warning>
 
 ## Required fields

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -365,6 +365,6 @@ extensions/acme-chat/
 ## Next steps
 
 - [Provider Plugins](/plugins/sdk-provider-plugins) — if your plugin also provides models
-- [SDK Overview](/plugins/sdk-overview) — full subpath import reference
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported subpath import reference
 - [SDK Testing](/plugins/sdk-testing) — test utilities and contract tests
 - [Plugin Manifest](/plugins/manifest) — full manifest schema

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -366,6 +366,6 @@ extensions/acme-chat/
 
 - [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` field reference
 - [Provider Plugins](/plugins/sdk-provider-plugins) — if your plugin also provides models
-- [SDK Subpaths](/plugins/sdk-subpaths) — supported subpath import reference
+- [SDK Overview](/plugins/sdk-overview) — import guidance and registration API
 - [SDK Testing](/plugins/sdk-testing) — test utilities and contract tests
 - [Plugin Manifest](/plugins/manifest) — full manifest schema

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -364,6 +364,7 @@ extensions/acme-chat/
 
 ## Next steps
 
+- [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` field reference
 - [Provider Plugins](/plugins/sdk-provider-plugins) — if your plugin also provides models
 - [SDK Subpaths](/plugins/sdk-subpaths) — supported subpath import reference
 - [SDK Testing](/plugins/sdk-testing) — test utilities and contract tests

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -366,6 +366,6 @@ extensions/acme-chat/
 
 - [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` field reference
 - [Provider Plugins](/plugins/sdk-provider-plugins) — if your plugin also provides models
-- [SDK Overview](/plugins/sdk-overview) — import guidance and registration API
+- [SDK Overview](/plugins/sdk-overview) — subpath guidance and registration API
 - [SDK Testing](/plugins/sdk-testing) — test utilities and contract tests
 - [Plugin Manifest](/plugins/manifest) — full manifest schema

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -156,7 +156,6 @@ Use `openclaw plugins inspect <id>` to see a plugin's shape.
 ## Related
 
 - [SDK Overview](/plugins/sdk-overview) — registration API and subpath reference
-- [SDK Subpaths](/plugins/sdk-subpaths) — supported import paths
 - [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` shape
 - [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` shape
 - [Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and `createPluginRuntimeStore`

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -14,8 +14,9 @@ Every plugin exports a default entry object. The SDK provides three helpers for
 creating them.
 
 <Tip>
-  **Looking for a walkthrough?** See [Channel Plugins](/plugins/sdk-channel-plugins)
-  or [Provider Plugins](/plugins/sdk-provider-plugins) for step-by-step guides.
+  **Looking for a walkthrough?** See [Tool Plugins](/plugins/sdk-tool-plugins),
+  [Channel Plugins](/plugins/sdk-channel-plugins), or
+  [Provider Plugins](/plugins/sdk-provider-plugins) for step-by-step guides.
 </Tip>
 
 ## `definePluginEntry`
@@ -155,7 +156,9 @@ Use `openclaw plugins inspect <id>` to see a plugin's shape.
 ## Related
 
 - [SDK Overview](/plugins/sdk-overview) — registration API and subpath reference
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported import paths
 - [Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and `createPluginRuntimeStore`
 - [Setup and Config](/plugins/sdk-setup) — manifest, setup entry, deferred loading
+- [Tool Plugins](/plugins/sdk-tool-plugins) — building tool, hook, and command plugins
 - [Channel Plugins](/plugins/sdk-channel-plugins) — building the `ChannelPlugin` object
 - [Provider Plugins](/plugins/sdk-provider-plugins) — provider registration and hooks

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -157,6 +157,8 @@ Use `openclaw plugins inspect <id>` to see a plugin's shape.
 
 - [SDK Overview](/plugins/sdk-overview) — registration API and subpath reference
 - [SDK Subpaths](/plugins/sdk-subpaths) — supported import paths
+- [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` shape
+- [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` shape
 - [Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and `createPluginRuntimeStore`
 - [Setup and Config](/plugins/sdk-setup) — manifest, setup entry, deferred loading
 - [Tool Plugins](/plugins/sdk-tool-plugins) — building tool, hook, and command plugins

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -36,78 +36,19 @@ import { definePluginEntry } from "openclaw/plugin-sdk";
 Each subpath is a small, self-contained module. This keeps startup fast and
 prevents circular dependency issues.
 
-For the public import-path index, see [SDK Subpaths](/plugins/sdk-subpaths).
+For a short public import-path index, see [SDK Subpaths](/plugins/sdk-subpaths).
 
-## Common subpaths
+## Where imports usually start
 
-The most commonly used subpaths, grouped by purpose:
+| If you are building...          | Start here                         | Then read                                                                                                          |
+| ------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| a tool, hook, or command plugin | `openclaw/plugin-sdk/plugin-entry` | [Tool Plugins](/plugins/sdk-tool-plugins)                                                                          |
+| a channel plugin                | `openclaw/plugin-sdk/core`         | [Channel Plugins](/plugins/sdk-channel-plugins) and [Channel Plugin Interface](/plugins/sdk-channel-interface)     |
+| a provider plugin               | `openclaw/plugin-sdk/plugin-entry` | [Provider Plugins](/plugins/sdk-provider-plugins) and [Provider Plugin Interface](/plugins/sdk-provider-interface) |
+| setup/config surfaces           | `openclaw/plugin-sdk/core`         | [Plugin Setup and Config](/plugins/sdk-setup)                                                                      |
+| test helpers                    | `openclaw/plugin-sdk/testing`      | [Testing](/plugins/sdk-testing)                                                                                    |
 
-### Plugin entry
-
-| Subpath                   | Key exports                                                                                                                            |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `plugin-sdk/plugin-entry` | `definePluginEntry`                                                                                                                    |
-| `plugin-sdk/core`         | `defineChannelPluginEntry`, `createChatChannelPlugin`, `createChannelPluginBase`, `defineSetupPluginEntry`, `buildChannelConfigSchema` |
-
-<AccordionGroup>
-  <Accordion title="Channel subpaths">
-    | Subpath | Key exports |
-    | --- | --- |
-    | `plugin-sdk/channel-setup` | `createOptionalChannelSetupSurface` |
-    | `plugin-sdk/channel-pairing` | `createChannelPairingController` |
-    | `plugin-sdk/channel-reply-pipeline` | `createChannelReplyPipeline` |
-    | `plugin-sdk/channel-config-helpers` | `createHybridChannelConfigAdapter` |
-    | `plugin-sdk/channel-config-schema` | Channel config schema types |
-    | `plugin-sdk/channel-policy` | `resolveChannelGroupRequireMention` |
-    | `plugin-sdk/channel-lifecycle` | `createAccountStatusSink` |
-    | `plugin-sdk/channel-inbound` | Debounce, mention matching, envelope helpers |
-    | `plugin-sdk/channel-send-result` | Reply result types |
-    | `plugin-sdk/channel-actions` | `createMessageToolButtonsSchema`, `createMessageToolCardSchema` |
-    | `plugin-sdk/channel-targets` | Target parsing/matching helpers |
-    | `plugin-sdk/channel-contract` | Channel contract types |
-    | `plugin-sdk/channel-feedback` | Feedback/reaction wiring |
-  </Accordion>
-
-  <Accordion title="Provider subpaths">
-    | Subpath | Key exports |
-    | --- | --- |
-    | `plugin-sdk/provider-auth` | `createProviderApiKeyAuthMethod`, `ensureApiKeyFromOptionEnvOrPrompt`, `upsertAuthProfile` |
-    | `plugin-sdk/provider-models` | `normalizeModelCompat` |
-    | `plugin-sdk/provider-catalog` | Catalog type re-exports |
-    | `plugin-sdk/provider-usage` | `fetchClaudeUsage` and similar |
-    | `plugin-sdk/provider-stream` | Stream wrapper types |
-    | `plugin-sdk/provider-onboard` | Onboarding config patch helpers |
-  </Accordion>
-
-  <Accordion title="Auth and security subpaths">
-    | Subpath | Key exports |
-    | --- | --- |
-    | `plugin-sdk/command-auth` | `resolveControlCommandGate` |
-    | `plugin-sdk/allow-from` | `formatAllowFromLowercase` |
-    | `plugin-sdk/secret-input` | Secret input parsing helpers |
-    | `plugin-sdk/webhook-ingress` | Webhook request/target helpers |
-  </Accordion>
-
-  <Accordion title="Runtime and storage subpaths">
-    | Subpath | Key exports |
-    | --- | --- |
-    | `plugin-sdk/runtime-store` | `createPluginRuntimeStore` |
-    | `plugin-sdk/config-runtime` | Config load/write helpers |
-    | `plugin-sdk/infra-runtime` | System event/heartbeat helpers |
-    | `plugin-sdk/agent-runtime` | Agent dir/identity/workspace helpers |
-    | `plugin-sdk/directory-runtime` | Config-backed directory query/dedup |
-    | `plugin-sdk/keyed-async-queue` | `KeyedAsyncQueue` |
-  </Accordion>
-
-  <Accordion title="Capability and testing subpaths">
-    | Subpath | Key exports |
-    | --- | --- |
-    | `plugin-sdk/image-generation` | Image generation provider types |
-    | `plugin-sdk/media-understanding` | Media understanding provider types |
-    | `plugin-sdk/speech` | Speech provider types |
-    | `plugin-sdk/testing` | `installCommonResolveTargetErrorCases`, `shouldAckReaction` |
-  </Accordion>
-</AccordionGroup>
+Use the task-specific guides to choose the supporting imports for that job.
 
 ## Registration API
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Plugin SDK Overview"
 sidebarTitle: "SDK Overview"
-summary: "Import map, registration API reference, and SDK architecture"
+summary: "Registration API reference, import guidance, and SDK architecture"
 read_when:
   - You need to know which SDK subpath to import from
   - You want a reference for all registration methods on OpenClawPluginApi
@@ -16,6 +16,7 @@ reference for **what to import** and **what you can register**.
 <Tip>
   **Looking for a how-to guide?**
   - First plugin? Start with [Getting Started](/plugins/building-plugins)
+  - Tool plugin? See [Tool Plugins](/plugins/sdk-tool-plugins)
   - Channel plugin? See [Channel Plugins](/plugins/sdk-channel-plugins)
   - Provider plugin? See [Provider Plugins](/plugins/sdk-provider-plugins)
 </Tip>
@@ -35,10 +36,11 @@ import { definePluginEntry } from "openclaw/plugin-sdk";
 Each subpath is a small, self-contained module. This keeps startup fast and
 prevents circular dependency issues.
 
-## Subpath reference
+For the public import-path index, see [SDK Subpaths](/plugins/sdk-subpaths).
 
-The most commonly used subpaths, grouped by purpose. The full list of 100+
-subpaths is in `scripts/lib/plugin-sdk-entrypoints.json`.
+## Common subpaths
+
+The most commonly used subpaths, grouped by purpose:
 
 ### Plugin entry
 
@@ -188,9 +190,11 @@ my-plugin/
 
 ## Related
 
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported public import paths
 - [Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry` and `defineChannelPluginEntry` options
 - [Runtime Helpers](/plugins/sdk-runtime) — full `api.runtime` namespace reference
 - [Setup and Config](/plugins/sdk-setup) — packaging, manifests, config schemas
 - [Testing](/plugins/sdk-testing) — test utilities and lint rules
+- [Tool Plugins](/plugins/sdk-tool-plugins) — build tool, hook, and command plugins
 - [SDK Migration](/plugins/sdk-migration) — migrating from deprecated surfaces
 - [Plugin Internals](/plugins/architecture) — deep architecture and capability model

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -192,6 +192,8 @@ my-plugin/
 
 - [SDK Subpaths](/plugins/sdk-subpaths) — supported public import paths
 - [Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry` and `defineChannelPluginEntry` options
+- [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` shape
+- [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` shape
 - [Runtime Helpers](/plugins/sdk-runtime) — full `api.runtime` namespace reference
 - [Setup and Config](/plugins/sdk-setup) — packaging, manifests, config schemas
 - [Testing](/plugins/sdk-testing) — test utilities and lint rules

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -1,7 +1,7 @@
 ---
 title: "Plugin SDK Overview"
 sidebarTitle: "SDK Overview"
-summary: "Registration API reference, import guidance, and SDK architecture"
+summary: "Registration API reference, subpath guidance, and SDK architecture"
 read_when:
   - You need to know which SDK subpath to import from
   - You want a reference for all registration methods on OpenClawPluginApi
@@ -36,7 +36,7 @@ import { definePluginEntry } from "openclaw/plugin-sdk";
 Each subpath is a small, self-contained module. This keeps startup fast and
 prevents circular dependency issues.
 
-For a short public import-path index, see [SDK Subpaths](/plugins/sdk-subpaths).
+For a short public subpath index, see [SDK Subpaths](/plugins/sdk-subpaths).
 
 ## Where imports usually start
 
@@ -131,7 +131,7 @@ my-plugin/
 
 ## Related
 
-- [SDK Subpaths](/plugins/sdk-subpaths) — supported public import paths
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported public subpaths
 - [Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry` and `defineChannelPluginEntry` options
 - [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` shape
 - [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` shape

--- a/docs/plugins/sdk-provider-interface.md
+++ b/docs/plugins/sdk-provider-interface.md
@@ -19,20 +19,13 @@ for the interface itself.
 
 ## Import
 
-```typescript
-import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-models";
-```
-
-Common supporting imports:
-
-```typescript
-import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
-```
+Use the current provider-facing SDK surface shown in
+[Provider Plugins](/plugins/sdk-provider-plugins) and
+[Plugin Entry Points](/plugins/sdk-entrypoints).
 
 <Warning>
-  These supporting provider subpaths are expected to move under a provider
-  namespace very soon.
+  Additional provider helper subpaths are intentionally not listed here because
+  they are expected to move under a provider namespace very soon.
 </Warning>
 
 ## Required fields
@@ -51,9 +44,6 @@ In practice, most real providers also define `catalog` or
 ## Minimal shape
 
 ```typescript
-import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-models";
-import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
-
 export const acmeProvider: ProviderPlugin = {
   id: "acme-ai",
   label: "Acme AI",

--- a/docs/plugins/sdk-provider-interface.md
+++ b/docs/plugins/sdk-provider-interface.md
@@ -184,5 +184,5 @@ Practical rules:
 - [Provider Plugins](/plugins/sdk-provider-plugins) — step-by-step provider walkthrough
 - [Plugin Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry(...)`
 - [Plugin Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and subagent/runtime helpers
-- [SDK Subpaths](/plugins/sdk-subpaths) — public import paths
+- [SDK Subpaths](/plugins/sdk-subpaths) — public subpaths
 - [Plugin Internals](/plugins/architecture#provider-runtime-hooks) — provider runtime ownership and deeper architecture

--- a/docs/plugins/sdk-provider-interface.md
+++ b/docs/plugins/sdk-provider-interface.md
@@ -1,0 +1,203 @@
+---
+title: "Provider Plugin Interface"
+sidebarTitle: "Provider Interface"
+summary: "Reference for the public ProviderPlugin shape and the provider-owned hooks around auth, catalogs, and runtime behavior"
+read_when:
+  - You want the public shape of `ProviderPlugin`
+  - You need to know which provider fields are required versus optional
+  - You are building a provider plugin and want a field-by-field reference
+---
+
+# Provider Plugin Interface
+
+This page describes the public `ProviderPlugin` interface used by model
+provider plugins.
+
+If you want a step-by-step walkthrough, start with
+[Provider Plugins](/plugins/sdk-provider-plugins). This page is the reference
+for the interface itself.
+
+## Import
+
+```typescript
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-models";
+```
+
+Common supporting imports:
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+```
+
+## Required fields
+
+These fields are the public core of a `ProviderPlugin`:
+
+| Field   | What it does                                    |
+| ------- | ----------------------------------------------- |
+| `id`    | Stable provider id                              |
+| `label` | Human display name                              |
+| `auth`  | Auth methods used by onboarding and login flows |
+
+In practice, most real providers also define `catalog` or
+`resolveDynamicModel`, because OpenClaw needs some way to resolve models.
+
+## Minimal shape
+
+```typescript
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-models";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+
+export const acmeProvider: ProviderPlugin = {
+  id: "acme-ai",
+  label: "Acme AI",
+  docsPath: "/providers/acme-ai",
+  envVars: ["ACME_AI_API_KEY"],
+
+  auth: [
+    createProviderApiKeyAuthMethod({
+      providerId: "acme-ai",
+      methodId: "api-key",
+      label: "Acme AI API key",
+      optionKey: "acmeAiApiKey",
+      flagName: "--acme-ai-api-key",
+      envVar: "ACME_AI_API_KEY",
+      promptMessage: "Enter your Acme AI API key",
+      defaultModel: "acme-ai/acme-large",
+    }),
+  ],
+
+  catalog: {
+    order: "simple",
+    run: async (ctx) => {
+      const apiKey = ctx.resolveProviderApiKey("acme-ai").apiKey;
+      if (!apiKey) {
+        return null;
+      }
+
+      return {
+        provider: {
+          baseUrl: "https://api.acme-ai.com/v1",
+          apiKey,
+          api: "openai-completions",
+          models: [
+            {
+              id: "acme-large",
+              name: "Acme Large",
+              reasoning: true,
+              input: ["text", "image"],
+              cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+              contextWindow: 200000,
+              maxTokens: 32768,
+            },
+          ],
+        },
+      };
+    },
+  },
+};
+```
+
+## Core sections
+
+### Identity and discovery
+
+| Field      | Meaning                                         |
+| ---------- | ----------------------------------------------- |
+| `id`       | Provider id used in model refs and config       |
+| `label`    | User-facing provider name                       |
+| `docsPath` | Docs page for the provider                      |
+| `aliases`  | Alternate provider names                        |
+| `envVars`  | Relevant env vars shown in setup and help flows |
+| `wizard`   | Onboarding and model-picker metadata            |
+
+### Auth
+
+`auth` is required.
+
+Each entry is a `ProviderAuthMethod`, usually created with helpers such as
+`createProviderApiKeyAuthMethod(...)`.
+
+Related provider-owned auth hooks:
+
+| Field                     | Use it for                                                       |
+| ------------------------- | ---------------------------------------------------------------- |
+| `formatApiKey`            | Convert stored auth-profile data into the runtime API key string |
+| `refreshOAuth`            | Provider-owned OAuth refresh logic                               |
+| `buildAuthDoctorHint`     | Better repair guidance when auth breaks                          |
+| `buildMissingAuthMessage` | Better missing-auth message for this provider                    |
+| `deprecatedProfileIds`    | Retiring old provider profile ids                                |
+
+### Catalog and model resolution
+
+These hooks decide which models exist and how OpenClaw resolves them.
+
+| Field                    | Use it for                                                   |
+| ------------------------ | ------------------------------------------------------------ |
+| `catalog`                | Preferred model catalog hook                                 |
+| `discovery`              | Legacy alias for `catalog`                                   |
+| `resolveDynamicModel`    | Cheap sync fallback for model ids not in the local catalog   |
+| `prepareDynamicModel`    | Async prefetch before retrying `resolveDynamicModel`         |
+| `normalizeResolvedModel` | Final provider-specific model normalization                  |
+| `augmentModelCatalog`    | Append extra rows after base catalog merging                 |
+| `suppressBuiltInModel`   | Hide stale built-in rows or surface provider-specific errors |
+
+Prefer `catalog` for new code. `discovery` exists for compatibility.
+
+## Runtime hooks
+
+These hooks let the provider own runtime behavior without forking the generic
+runner.
+
+| Field                | Use it for                                                    |
+| -------------------- | ------------------------------------------------------------- |
+| `prepareExtraParams` | Provider-specific request params before stream wrapping       |
+| `wrapStreamFn`       | Custom headers or body rewrites around the stream call        |
+| `prepareRuntimeAuth` | Exchange a stored credential into a short-lived runtime token |
+| `resolveUsageAuth`   | Usage/billing auth resolution                                 |
+| `fetchUsageSnapshot` | Usage/quota snapshot fetching                                 |
+
+## Policy and capability hooks
+
+These hooks keep provider-specific policy out of core command logic.
+
+| Field                         | Use it for                                                   |
+| ----------------------------- | ------------------------------------------------------------ |
+| `capabilities`                | Static capability overrides for transcript and tooling logic |
+| `isCacheTtlEligible`          | Prompt-caching eligibility                                   |
+| `isBinaryThinking`            | Binary on/off reasoning support                              |
+| `supportsXHighThinking`       | `xhigh` reasoning support                                    |
+| `resolveDefaultThinkingLevel` | Provider-owned default reasoning level                       |
+| `isModernModelRef`            | Preferred modern-model matching                              |
+| `onModelSelected`             | Provider reaction after model selection                      |
+
+## Interface expectations
+
+Keep these ids aligned:
+
+- `openclaw.plugin.json` `id`
+- `package.json` `openclaw.providers`
+- `definePluginEntry({ id })`
+- `ProviderPlugin.id`
+
+Practical rules:
+
+- `auth` should describe at least one real auth path for the provider.
+- Prefer `catalog` over `discovery` for new code.
+- Keep `resolveDynamicModel(...)` cheap and deterministic.
+- If model resolution needs network I/O, do that in `prepareDynamicModel(...)`
+  and let OpenClaw retry `resolveDynamicModel(...)`.
+- Catalog and dynamic-model rows should return complete model definitions,
+  including `id`, `name`, `reasoning`, `input`, `cost`, `contextWindow`, and
+  `maxTokens`.
+- Keep provider-specific transport, auth, and policy behavior inside the
+  provider hooks instead of shared core.
+
+## Related
+
+- [Provider Plugins](/plugins/sdk-provider-plugins) — step-by-step provider walkthrough
+- [Plugin Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry(...)`
+- [Plugin Runtime Helpers](/plugins/sdk-runtime) — `api.runtime` and subagent/runtime helpers
+- [SDK Subpaths](/plugins/sdk-subpaths) — public import paths
+- [Plugin Internals](/plugins/architecture#provider-runtime-hooks) — provider runtime ownership and deeper architecture

--- a/docs/plugins/sdk-provider-interface.md
+++ b/docs/plugins/sdk-provider-interface.md
@@ -119,15 +119,11 @@ export const acmeProvider: ProviderPlugin = {
 Each entry is a `ProviderAuthMethod`, usually created with helpers such as
 `createProviderApiKeyAuthMethod(...)`.
 
-Related provider-owned auth hooks:
+Common supporting auth hooks:
 
-| Field                     | Use it for                                                       |
-| ------------------------- | ---------------------------------------------------------------- |
-| `formatApiKey`            | Convert stored auth-profile data into the runtime API key string |
-| `refreshOAuth`            | Provider-owned OAuth refresh logic                               |
-| `buildAuthDoctorHint`     | Better repair guidance when auth breaks                          |
-| `buildMissingAuthMessage` | Better missing-auth message for this provider                    |
-| `deprecatedProfileIds`    | Retiring old provider profile ids                                |
+- `formatApiKey` for runtime credential formatting
+- `refreshOAuth` for provider-owned OAuth refresh logic
+- `buildMissingAuthMessage` or `buildAuthDoctorHint` for better repair guidance
 
 ### Catalog and model resolution
 
@@ -145,32 +141,21 @@ These hooks decide which models exist and how OpenClaw resolves them.
 
 Prefer `catalog` for new code. `discovery` exists for compatibility.
 
-## Runtime hooks
+## Common additional hooks
 
-These hooks let the provider own runtime behavior without forking the generic
-runner.
+Most provider plugins only need a few extra hooks beyond `auth` and model
+resolution.
 
-| Field                | Use it for                                                    |
-| -------------------- | ------------------------------------------------------------- |
-| `prepareExtraParams` | Provider-specific request params before stream wrapping       |
-| `wrapStreamFn`       | Custom headers or body rewrites around the stream call        |
-| `prepareRuntimeAuth` | Exchange a stored credential into a short-lived runtime token |
-| `resolveUsageAuth`   | Usage/billing auth resolution                                 |
-| `fetchUsageSnapshot` | Usage/quota snapshot fetching                                 |
+| Hook                                      | Use it for                                                    |
+| ----------------------------------------- | ------------------------------------------------------------- |
+| `prepareRuntimeAuth`                      | Exchange a stored credential into a short-lived runtime token |
+| `prepareExtraParams` / `wrapStreamFn`     | Provider-specific request shaping around the stream call      |
+| `resolveUsageAuth` / `fetchUsageSnapshot` | Usage and billing snapshots                                   |
+| `capabilities`                            | Static capability overrides for transcript and tooling logic  |
+| `onModelSelected`                         | Provider reaction after model selection                       |
 
-## Policy and capability hooks
-
-These hooks keep provider-specific policy out of core command logic.
-
-| Field                         | Use it for                                                   |
-| ----------------------------- | ------------------------------------------------------------ |
-| `capabilities`                | Static capability overrides for transcript and tooling logic |
-| `isCacheTtlEligible`          | Prompt-caching eligibility                                   |
-| `isBinaryThinking`            | Binary on/off reasoning support                              |
-| `supportsXHighThinking`       | `xhigh` reasoning support                                    |
-| `resolveDefaultThinkingLevel` | Provider-owned default reasoning level                       |
-| `isModernModelRef`            | Preferred modern-model matching                              |
-| `onModelSelected`             | Provider reaction after model selection                      |
+The provider guide covers the larger workflow. This page stays focused on the
+main public hooks provider authors typically implement.
 
 ## Interface expectations
 

--- a/docs/plugins/sdk-provider-interface.md
+++ b/docs/plugins/sdk-provider-interface.md
@@ -30,6 +30,11 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
 ```
 
+<Warning>
+  These supporting provider subpaths are expected to move under a provider
+  namespace very soon.
+</Warning>
+
 ## Required fields
 
 These fields are the public core of a `ProviderPlugin`:

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -364,6 +364,7 @@ providers:
 
 ## Next steps
 
+- [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` field reference
 - [Channel Plugins](/plugins/sdk-channel-plugins) — if your plugin also provides a channel
 - [SDK Runtime](/plugins/sdk-runtime) — `api.runtime` helpers (TTS, search, subagent)
 - [SDK Subpaths](/plugins/sdk-subpaths) — supported subpath import reference

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -367,5 +367,5 @@ providers:
 - [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` field reference
 - [Channel Plugins](/plugins/sdk-channel-plugins) — if your plugin also provides a channel
 - [SDK Runtime](/plugins/sdk-runtime) — `api.runtime` helpers (TTS, search, subagent)
-- [SDK Overview](/plugins/sdk-overview) — import guidance and registration API
+- [SDK Overview](/plugins/sdk-overview) — subpath guidance and registration API
 - [Plugin Internals](/plugins/architecture#provider-runtime-hooks) — hook details and bundled examples

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -366,5 +366,5 @@ providers:
 
 - [Channel Plugins](/plugins/sdk-channel-plugins) — if your plugin also provides a channel
 - [SDK Runtime](/plugins/sdk-runtime) — `api.runtime` helpers (TTS, search, subagent)
-- [SDK Overview](/plugins/sdk-overview) — full subpath import reference
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported subpath import reference
 - [Plugin Internals](/plugins/architecture#provider-runtime-hooks) — hook details and bundled examples

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -367,5 +367,5 @@ providers:
 - [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` field reference
 - [Channel Plugins](/plugins/sdk-channel-plugins) — if your plugin also provides a channel
 - [SDK Runtime](/plugins/sdk-runtime) — `api.runtime` helpers (TTS, search, subagent)
-- [SDK Subpaths](/plugins/sdk-subpaths) — supported subpath import reference
+- [SDK Overview](/plugins/sdk-overview) — import guidance and registration API
 - [Plugin Internals](/plugins/architecture#provider-runtime-hooks) — hook details and bundled examples

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -1,17 +1,20 @@
 ---
 title: "Plugin SDK Subpaths"
 sidebarTitle: "SDK Subpaths"
-summary: "Supported public `openclaw/plugin-sdk/*` imports for plugin authors"
+summary: "Starting points and supporting public `openclaw/plugin-sdk/*` imports for plugin authors"
 read_when:
-  - You want to know which SDK import path to use
+  - You want to know where to start in the SDK
   - You are replacing old `openclaw/plugin-sdk` root-barrel imports
-  - You need a public import-path reference instead of internal repo files
+  - You need a short public import-path reference instead of internal repo files
 ---
 
 # Plugin SDK Subpaths
 
-This page lists the supported public `openclaw/plugin-sdk/*` imports for plugin
-authors.
+This page lists the public `openclaw/plugin-sdk/*` imports plugin authors
+should start from.
+
+It is intentionally short. Use the task-specific guides for the detailed
+channel, provider, runtime, and testing surfaces.
 
 Use these documented subpaths instead of:
 
@@ -31,66 +34,35 @@ Use these documented subpaths instead of:
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `openclaw/plugin-sdk/plugin-entry` | `definePluginEntry(...)` for provider, tool, and hook plugins                                    |
 | `openclaw/plugin-sdk/core`         | `defineChannelPluginEntry(...)`, `defineSetupPluginEntry(...)`, and shared plugin contract types |
+| `openclaw/plugin-sdk/testing`      | Public test helpers and fixtures                                                                 |
 
-## Channel building
+## Choose imports by task
 
-| Import path                                  | Use it for                                           |
-| -------------------------------------------- | ---------------------------------------------------- |
-| `openclaw/plugin-sdk/channel-setup`          | Setup surfaces and setup helpers                     |
-| `openclaw/plugin-sdk/channel-pairing`        | Pairing, approval, and account linking flows         |
-| `openclaw/plugin-sdk/channel-contract`       | Channel contract types                               |
-| `openclaw/plugin-sdk/channel-feedback`       | Feedback and reactions                               |
-| `openclaw/plugin-sdk/channel-inbound`        | Inbound envelope helpers, debounce, mention matching |
-| `openclaw/plugin-sdk/channel-lifecycle`      | Account status and lifecycle tracking                |
-| `openclaw/plugin-sdk/channel-reply-pipeline` | Reply and typing orchestration                       |
-| `openclaw/plugin-sdk/channel-config-schema`  | Channel config schema types                          |
-| `openclaw/plugin-sdk/channel-config-helpers` | Shared config adapter helpers                        |
-| `openclaw/plugin-sdk/channel-policy`         | Shared channel policy helpers                        |
-| `openclaw/plugin-sdk/channel-targets`        | Target parsing and matching                          |
-| `openclaw/plugin-sdk/channel-actions`        | Shared message-action and card helpers               |
-| `openclaw/plugin-sdk/channel-send-result`    | Send-result and reply result types                   |
+- Tool, hook, and command plugins usually start with
+  `openclaw/plugin-sdk/plugin-entry`. See [Tool Plugins](/plugins/sdk-tool-plugins).
+- Channel plugins start with `openclaw/plugin-sdk/core`, then pull focused
+  helpers as needed. See [Channel Plugins](/plugins/sdk-channel-plugins) and
+  [Channel Plugin Interface](/plugins/sdk-channel-interface).
+- Provider plugins usually start with `openclaw/plugin-sdk/plugin-entry`, plus
+  provider helpers when needed. See [Provider Plugins](/plugins/sdk-provider-plugins)
+  and [Provider Plugin Interface](/plugins/sdk-provider-interface).
+- Shared runtime helpers live in the runtime guide. See
+  [Plugin Runtime Helpers](/plugins/sdk-runtime).
+- Setup entrypoints, manifests, and config adapters live in the setup guide.
+  See [Plugin Setup and Config](/plugins/sdk-setup).
 
-## Provider building
+## Common supporting imports
 
-| Import path                               | Use it for                           |
-| ----------------------------------------- | ------------------------------------ |
-| `openclaw/plugin-sdk/provider-auth`       | API key auth and shared auth helpers |
-| `openclaw/plugin-sdk/provider-auth-login` | Interactive login flows              |
-| `openclaw/plugin-sdk/provider-catalog`    | Provider catalog types               |
-| `openclaw/plugin-sdk/provider-models`     | Model normalization helpers          |
-| `openclaw/plugin-sdk/provider-onboard`    | Onboarding config patches            |
-| `openclaw/plugin-sdk/provider-stream`     | Stream wrapper types                 |
-| `openclaw/plugin-sdk/provider-usage`      | Usage and billing helpers            |
-
-## Tool, auth, and webhook helpers
-
-| Import path                           | Use it for                                |
-| ------------------------------------- | ----------------------------------------- |
-| `openclaw/plugin-sdk/command-auth`    | Command-gating helpers                    |
-| `openclaw/plugin-sdk/secret-input`    | Secret parsing and prompt input helpers   |
-| `openclaw/plugin-sdk/allow-from`      | Allowlist formatting and normalization    |
-| `openclaw/plugin-sdk/webhook-ingress` | Shared webhook request and target helpers |
-| `openclaw/plugin-sdk/reply-payload`   | Shared reply-payload shaping              |
-
-## Runtime and storage helpers
-
-| Import path                             | Use it for                                                      |
-| --------------------------------------- | --------------------------------------------------------------- |
-| `openclaw/plugin-sdk/agent-runtime`     | Agent directories, identity, workspace, and embedded Pi helpers |
-| `openclaw/plugin-sdk/config-runtime`    | Config load and write helpers                                   |
-| `openclaw/plugin-sdk/infra-runtime`     | System events and heartbeat helpers                             |
-| `openclaw/plugin-sdk/directory-runtime` | Config-backed directories and dedup helpers                     |
-| `openclaw/plugin-sdk/runtime-store`     | Persistent plugin runtime storage                               |
-| `openclaw/plugin-sdk/keyed-async-queue` | Keyed async coordination helpers                                |
-
-## Capability type helpers
-
-| Import path                               | Use it for                            |
-| ----------------------------------------- | ------------------------------------- |
-| `openclaw/plugin-sdk/image-generation`    | Image generation provider types       |
-| `openclaw/plugin-sdk/media-understanding` | Media understanding provider types    |
-| `openclaw/plugin-sdk/speech`              | Speech provider types                 |
-| `openclaw/plugin-sdk/testing`             | Test helpers and fixtures for plugins |
+| Import path                            | Use it for                                |
+| -------------------------------------- | ----------------------------------------- |
+| `openclaw/plugin-sdk/channel-setup`    | Setup surfaces and setup helpers          |
+| `openclaw/plugin-sdk/channel-contract` | Shared channel contract types             |
+| `openclaw/plugin-sdk/provider-auth`    | API key auth and shared auth helpers      |
+| `openclaw/plugin-sdk/provider-models`  | Model normalization helpers               |
+| `openclaw/plugin-sdk/runtime-store`    | Persistent plugin runtime storage         |
+| `openclaw/plugin-sdk/command-auth`     | Command-gating helpers                    |
+| `openclaw/plugin-sdk/webhook-ingress`  | Shared webhook request and target helpers |
+| `openclaw/plugin-sdk/reply-payload`    | Shared reply-payload shaping              |
 
 ## Compatibility shims
 
@@ -120,5 +92,9 @@ cross-package contract.
 
 - [Plugin SDK Overview](/plugins/sdk-overview) — registration API and API object
 - [Plugin Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry` and channel entry helpers
+- [Tool Plugins](/plugins/sdk-tool-plugins) — build tool, hook, and command plugins
+- [Channel Plugin Interface](/plugins/sdk-channel-interface) — public `ChannelPlugin` shape
+- [Provider Plugin Interface](/plugins/sdk-provider-interface) — public `ProviderPlugin` shape
+- [Plugin Runtime Helpers](/plugins/sdk-runtime) — runtime-specific helpers
 - [Migrate to SDK](/plugins/sdk-migration) — replace deprecated import paths
 - [Building Plugins](/plugins/building-plugins) — first plugin walkthrough

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -1,0 +1,124 @@
+---
+title: "Plugin SDK Subpaths"
+sidebarTitle: "SDK Subpaths"
+summary: "Supported public `openclaw/plugin-sdk/*` imports for plugin authors"
+read_when:
+  - You want to know which SDK import path to use
+  - You are replacing old `openclaw/plugin-sdk` root-barrel imports
+  - You need a public import-path reference instead of internal repo files
+---
+
+# Plugin SDK Subpaths
+
+This page lists the supported public `openclaw/plugin-sdk/*` imports for plugin
+authors.
+
+Use these documented subpaths instead of:
+
+- the legacy root barrel `openclaw/plugin-sdk`
+- core `src/**` imports
+- `src/plugin-sdk-internal/**`
+- another plugin's private `src/**`
+
+<Info>
+  If the helper you need is not documented here, do not reach into internal
+  files. Open a request for a new public subpath instead.
+</Info>
+
+## Start here
+
+| Import path                        | Use it for                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `openclaw/plugin-sdk/plugin-entry` | `definePluginEntry(...)` for provider, tool, and hook plugins                                    |
+| `openclaw/plugin-sdk/core`         | `defineChannelPluginEntry(...)`, `defineSetupPluginEntry(...)`, and shared plugin contract types |
+
+## Channel building
+
+| Import path                                  | Use it for                                           |
+| -------------------------------------------- | ---------------------------------------------------- |
+| `openclaw/plugin-sdk/channel-setup`          | Setup surfaces and setup helpers                     |
+| `openclaw/plugin-sdk/channel-pairing`        | Pairing, approval, and account linking flows         |
+| `openclaw/plugin-sdk/channel-contract`       | Channel contract types                               |
+| `openclaw/plugin-sdk/channel-feedback`       | Feedback and reactions                               |
+| `openclaw/plugin-sdk/channel-inbound`        | Inbound envelope helpers, debounce, mention matching |
+| `openclaw/plugin-sdk/channel-lifecycle`      | Account status and lifecycle tracking                |
+| `openclaw/plugin-sdk/channel-reply-pipeline` | Reply and typing orchestration                       |
+| `openclaw/plugin-sdk/channel-config-schema`  | Channel config schema types                          |
+| `openclaw/plugin-sdk/channel-config-helpers` | Shared config adapter helpers                        |
+| `openclaw/plugin-sdk/channel-policy`         | Shared channel policy helpers                        |
+| `openclaw/plugin-sdk/channel-targets`        | Target parsing and matching                          |
+| `openclaw/plugin-sdk/channel-actions`        | Shared message-action and card helpers               |
+| `openclaw/plugin-sdk/channel-send-result`    | Send-result and reply result types                   |
+
+## Provider building
+
+| Import path                               | Use it for                           |
+| ----------------------------------------- | ------------------------------------ |
+| `openclaw/plugin-sdk/provider-auth`       | API key auth and shared auth helpers |
+| `openclaw/plugin-sdk/provider-auth-login` | Interactive login flows              |
+| `openclaw/plugin-sdk/provider-catalog`    | Provider catalog types               |
+| `openclaw/plugin-sdk/provider-models`     | Model normalization helpers          |
+| `openclaw/plugin-sdk/provider-onboard`    | Onboarding config patches            |
+| `openclaw/plugin-sdk/provider-stream`     | Stream wrapper types                 |
+| `openclaw/plugin-sdk/provider-usage`      | Usage and billing helpers            |
+
+## Tool, auth, and webhook helpers
+
+| Import path                           | Use it for                                |
+| ------------------------------------- | ----------------------------------------- |
+| `openclaw/plugin-sdk/command-auth`    | Command-gating helpers                    |
+| `openclaw/plugin-sdk/secret-input`    | Secret parsing and prompt input helpers   |
+| `openclaw/plugin-sdk/allow-from`      | Allowlist formatting and normalization    |
+| `openclaw/plugin-sdk/webhook-ingress` | Shared webhook request and target helpers |
+| `openclaw/plugin-sdk/reply-payload`   | Shared reply-payload shaping              |
+
+## Runtime and storage helpers
+
+| Import path                             | Use it for                                                      |
+| --------------------------------------- | --------------------------------------------------------------- |
+| `openclaw/plugin-sdk/agent-runtime`     | Agent directories, identity, workspace, and embedded Pi helpers |
+| `openclaw/plugin-sdk/config-runtime`    | Config load and write helpers                                   |
+| `openclaw/plugin-sdk/infra-runtime`     | System events and heartbeat helpers                             |
+| `openclaw/plugin-sdk/directory-runtime` | Config-backed directories and dedup helpers                     |
+| `openclaw/plugin-sdk/runtime-store`     | Persistent plugin runtime storage                               |
+| `openclaw/plugin-sdk/keyed-async-queue` | Keyed async coordination helpers                                |
+
+## Capability type helpers
+
+| Import path                               | Use it for                            |
+| ----------------------------------------- | ------------------------------------- |
+| `openclaw/plugin-sdk/image-generation`    | Image generation provider types       |
+| `openclaw/plugin-sdk/media-understanding` | Media understanding provider types    |
+| `openclaw/plugin-sdk/speech`              | Speech provider types                 |
+| `openclaw/plugin-sdk/testing`             | Test helpers and fixtures for plugins |
+
+## Compatibility shims
+
+| Import path                           | Status             | Notes                                                     |
+| ------------------------------------- | ------------------ | --------------------------------------------------------- |
+| `openclaw/plugin-sdk`                 | Deprecated         | Old root barrel. New code should use focused subpaths.    |
+| `openclaw/plugin-sdk/channel-runtime` | Compatibility only | Old channel shim. Prefer narrower channel subpaths above. |
+
+## What is not part of the public contract
+
+These are the common mistakes to avoid:
+
+- importing `src/**` from plugin code
+- importing `src/plugin-sdk-internal/**`
+- importing another plugin's `src/**`
+- using extension-specific helper barrels as if they were stable global SDK API
+
+Inside your own plugin package, prefer local barrels such as:
+
+- `./api.ts`
+- `./runtime-api.ts`
+
+Those are for your plugin's internal structure. `openclaw/plugin-sdk/*` is the
+cross-package contract.
+
+## Related
+
+- [Plugin SDK Overview](/plugins/sdk-overview) — registration API and API object
+- [Plugin Entry Points](/plugins/sdk-entrypoints) — `definePluginEntry` and channel entry helpers
+- [Migrate to SDK](/plugins/sdk-migration) — replace deprecated import paths
+- [Building Plugins](/plugins/building-plugins) — first plugin walkthrough

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -51,8 +51,8 @@ helpers as needed. See [Channel Plugins](/plugins/sdk-channel-plugins) and
 [Channel Plugin Interface](/plugins/sdk-channel-interface).
 
 <Warning>
-  Channel helper subpaths are expected to move under a channel namespace very
-  soon. Avoid spreading new channel-specific imports more broadly than needed.
+  Additional channel helper subpaths are intentionally omitted here because
+  they are expected to move under a channel namespace very soon.
 </Warning>
 
 ### Provider work
@@ -63,9 +63,8 @@ provider helpers when needed. See
 [Provider Plugin Interface](/plugins/sdk-provider-interface).
 
 <Warning>
-  Provider helper subpaths are expected to move under a provider namespace very
-  soon. Prefer the provider guides and interface docs over copying long import
-  lists.
+  Additional provider helper subpaths are intentionally omitted here because
+  they are expected to move under a provider namespace very soon.
 </Warning>
 
 ### Runtime and setup work
@@ -74,32 +73,26 @@ Shared runtime helpers live in the runtime guide. See
 [Plugin Runtime Helpers](/plugins/sdk-runtime).
 
 <Warning>
-  Runtime helper subpaths are expected to move under a runtime namespace very
-  soon. Keep new usages narrow and localized.
+  Additional runtime helper subpaths are intentionally omitted here because
+  they are expected to move under a runtime namespace very soon.
 </Warning>
 
 Setup entrypoints, manifests, and config adapters live in the setup guide. See
 [Plugin Setup and Config](/plugins/sdk-setup).
 
-## Common supporting imports
+## Supporting subpaths we still recommend listing
 
-| Subpath                                | Use it for                                |
-| -------------------------------------- | ----------------------------------------- |
-| `openclaw/plugin-sdk/channel-setup`    | Setup surfaces and setup helpers          |
-| `openclaw/plugin-sdk/channel-contract` | Shared channel contract types             |
-| `openclaw/plugin-sdk/provider-auth`    | API key auth and shared auth helpers      |
-| `openclaw/plugin-sdk/provider-models`  | Model normalization helpers               |
-| `openclaw/plugin-sdk/runtime-store`    | Persistent plugin runtime storage         |
-| `openclaw/plugin-sdk/command-auth`     | Command-gating helpers                    |
-| `openclaw/plugin-sdk/webhook-ingress`  | Shared webhook request and target helpers |
-| `openclaw/plugin-sdk/reply-payload`    | Shared reply-payload shaping              |
+| Subpath                               | Use it for                                |
+| ------------------------------------- | ----------------------------------------- |
+| `openclaw/plugin-sdk/command-auth`    | Command-gating helpers                    |
+| `openclaw/plugin-sdk/webhook-ingress` | Shared webhook request and target helpers |
+| `openclaw/plugin-sdk/reply-payload`   | Shared reply-payload shaping              |
 
 ## Compatibility shims
 
-| Import path                           | Status             | Notes                                                     |
-| ------------------------------------- | ------------------ | --------------------------------------------------------- |
-| `openclaw/plugin-sdk`                 | Deprecated         | Old root barrel. New code should use focused subpaths.    |
-| `openclaw/plugin-sdk/channel-runtime` | Compatibility only | Old channel shim. Prefer narrower channel subpaths above. |
+| Import path           | Status     | Notes                                                  |
+| --------------------- | ---------- | ------------------------------------------------------ |
+| `openclaw/plugin-sdk` | Deprecated | Old root barrel. New code should use focused subpaths. |
 
 ## What is not part of the public contract
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -38,18 +38,48 @@ Use these documented subpaths instead of:
 
 ## Choose subpaths by task
 
-- Tool, hook, and command plugins usually start with
-  `openclaw/plugin-sdk/plugin-entry`. See [Tool Plugins](/plugins/sdk-tool-plugins).
-- Channel plugins start with `openclaw/plugin-sdk/core`, then pull focused
-  helpers as needed. See [Channel Plugins](/plugins/sdk-channel-plugins) and
-  [Channel Plugin Interface](/plugins/sdk-channel-interface).
-- Provider plugins usually start with `openclaw/plugin-sdk/plugin-entry`, plus
-  provider helpers when needed. See [Provider Plugins](/plugins/sdk-provider-plugins)
-  and [Provider Plugin Interface](/plugins/sdk-provider-interface).
-- Shared runtime helpers live in the runtime guide. See
-  [Plugin Runtime Helpers](/plugins/sdk-runtime).
-- Setup entrypoints, manifests, and config adapters live in the setup guide.
-  See [Plugin Setup and Config](/plugins/sdk-setup).
+### Tool, hook, and command work
+
+Tool, hook, and command plugins usually start with
+`openclaw/plugin-sdk/plugin-entry`. See
+[Tool Plugins](/plugins/sdk-tool-plugins).
+
+### Channel work
+
+Channel plugins start with `openclaw/plugin-sdk/core`, then pull focused
+helpers as needed. See [Channel Plugins](/plugins/sdk-channel-plugins) and
+[Channel Plugin Interface](/plugins/sdk-channel-interface).
+
+<Warning>
+  Channel helper subpaths are expected to move under a channel namespace very
+  soon. Avoid spreading new channel-specific imports more broadly than needed.
+</Warning>
+
+### Provider work
+
+Provider plugins usually start with `openclaw/plugin-sdk/plugin-entry`, plus
+provider helpers when needed. See
+[Provider Plugins](/plugins/sdk-provider-plugins) and
+[Provider Plugin Interface](/plugins/sdk-provider-interface).
+
+<Warning>
+  Provider helper subpaths are expected to move under a provider namespace very
+  soon. Prefer the provider guides and interface docs over copying long import
+  lists.
+</Warning>
+
+### Runtime and setup work
+
+Shared runtime helpers live in the runtime guide. See
+[Plugin Runtime Helpers](/plugins/sdk-runtime).
+
+<Warning>
+  Runtime helper subpaths are expected to move under a runtime namespace very
+  soon. Keep new usages narrow and localized.
+</Warning>
+
+Setup entrypoints, manifests, and config adapters live in the setup guide. See
+[Plugin Setup and Config](/plugins/sdk-setup).
 
 ## Common supporting imports
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -1,16 +1,16 @@
 ---
 title: "Plugin SDK Subpaths"
 sidebarTitle: "SDK Subpaths"
-summary: "Starting points and supporting public `openclaw/plugin-sdk/*` imports for plugin authors"
+summary: "Starting points and supporting public `openclaw/plugin-sdk/*` subpaths for plugin authors"
 read_when:
   - You want to know where to start in the SDK
   - You are replacing old `openclaw/plugin-sdk` root-barrel imports
-  - You need a short public import-path reference instead of internal repo files
+  - You need a short public subpath reference instead of internal repo files
 ---
 
 # Plugin SDK Subpaths
 
-This page lists the public `openclaw/plugin-sdk/*` imports plugin authors
+This page lists the public `openclaw/plugin-sdk/*` subpaths plugin authors
 should start from.
 
 It is intentionally short. Use the task-specific guides for the detailed
@@ -30,13 +30,13 @@ Use these documented subpaths instead of:
 
 ## Start here
 
-| Import path                        | Use it for                                                                                       |
+| Subpath                            | Use it for                                                                                       |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `openclaw/plugin-sdk/plugin-entry` | `definePluginEntry(...)` for provider, tool, and hook plugins                                    |
 | `openclaw/plugin-sdk/core`         | `defineChannelPluginEntry(...)`, `defineSetupPluginEntry(...)`, and shared plugin contract types |
 | `openclaw/plugin-sdk/testing`      | Public test helpers and fixtures                                                                 |
 
-## Choose imports by task
+## Choose subpaths by task
 
 - Tool, hook, and command plugins usually start with
   `openclaw/plugin-sdk/plugin-entry`. See [Tool Plugins](/plugins/sdk-tool-plugins).
@@ -53,7 +53,7 @@ Use these documented subpaths instead of:
 
 ## Common supporting imports
 
-| Import path                            | Use it for                                |
+| Subpath                                | Use it for                                |
 | -------------------------------------- | ----------------------------------------- |
 | `openclaw/plugin-sdk/channel-setup`    | Setup surfaces and setup helpers          |
 | `openclaw/plugin-sdk/channel-contract` | Shared channel contract types             |

--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -258,7 +258,6 @@ OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test
 ## Related
 
 - [SDK Overview](/plugins/sdk-overview) -- import conventions
-- [SDK Subpaths](/plugins/sdk-subpaths) -- supported public import paths
 - [Channel Plugin Interface](/plugins/sdk-channel-interface) -- public `ChannelPlugin` shape
 - [Provider Plugin Interface](/plugins/sdk-provider-interface) -- public `ProviderPlugin` shape
 - [Tool Plugins](/plugins/sdk-tool-plugins) -- tool, hook, and command plugin guide

--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -259,6 +259,8 @@ OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test
 
 - [SDK Overview](/plugins/sdk-overview) -- import conventions
 - [SDK Subpaths](/plugins/sdk-subpaths) -- supported public import paths
+- [Channel Plugin Interface](/plugins/sdk-channel-interface) -- public `ChannelPlugin` shape
+- [Provider Plugin Interface](/plugins/sdk-provider-interface) -- public `ProviderPlugin` shape
 - [Tool Plugins](/plugins/sdk-tool-plugins) -- tool, hook, and command plugin guide
 - [SDK Channel Plugins](/plugins/sdk-channel-plugins) -- channel plugin interface
 - [SDK Provider Plugins](/plugins/sdk-provider-plugins) -- provider plugin hooks

--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -258,6 +258,8 @@ OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test
 ## Related
 
 - [SDK Overview](/plugins/sdk-overview) -- import conventions
+- [SDK Subpaths](/plugins/sdk-subpaths) -- supported public import paths
+- [Tool Plugins](/plugins/sdk-tool-plugins) -- tool, hook, and command plugin guide
 - [SDK Channel Plugins](/plugins/sdk-channel-plugins) -- channel plugin interface
 - [SDK Provider Plugins](/plugins/sdk-provider-plugins) -- provider plugin hooks
 - [Building Plugins](/plugins/building-plugins) -- getting started guide

--- a/docs/plugins/sdk-tool-plugins.md
+++ b/docs/plugins/sdk-tool-plugins.md
@@ -249,7 +249,6 @@ surfaces, target resolution, or send/receive behavior.
 ## Next steps
 
 - [Plugin SDK Overview](/plugins/sdk-overview) — registration methods and API object
-- [SDK Subpaths](/plugins/sdk-subpaths) — supported `openclaw/plugin-sdk/*` imports
 - [Plugin Runtime Helpers](/plugins/sdk-runtime) — `api.runtime`, logging, config, subagents
 - [Plugin Testing](/plugins/sdk-testing) — test utilities and patterns
 - [Plugin Troubleshooting](/plugins/sdk-troubleshooting) — common load and config failures

--- a/docs/plugins/sdk-tool-plugins.md
+++ b/docs/plugins/sdk-tool-plugins.md
@@ -1,0 +1,255 @@
+---
+title: "Building Tool Plugins"
+sidebarTitle: "Tool Plugins"
+summary: "Step-by-step guide to building a plugin that adds tools, hooks, and commands"
+read_when:
+  - You are building a plugin that adds agent tools
+  - You want a guide for non-channel, non-provider plugins
+  - You need examples for optional tools and runtime-aware tools
+---
+
+# Building Tool Plugins
+
+This guide walks through building a plugin that adds agent tools. Tool plugins
+can also register hooks, commands, HTTP routes, or services, but tools are
+usually the main entry point.
+
+<Info>
+  If you have not built any OpenClaw plugin before, read
+  [Getting Started](/plugins/building-plugins) first for the basic package
+  structure and manifest setup.
+</Info>
+
+## Walkthrough
+
+<Steps>
+  <Step title="Package and manifest">
+    <CodeGroup>
+    ```json package.json
+    {
+      "name": "@myorg/openclaw-acme-tools",
+      "version": "1.0.0",
+      "type": "module",
+      "openclaw": {
+        "extensions": ["./index.ts"]
+      }
+    }
+    ```
+
+    ```json openclaw.plugin.json
+    {
+      "id": "acme-tools",
+      "name": "Acme Tools",
+      "description": "Acme workflow tools for OpenClaw",
+      "configSchema": {
+        "type": "object",
+        "properties": {
+          "baseUrl": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+    ```
+    </CodeGroup>
+
+    Every native plugin needs `openclaw.plugin.json`, even if the config schema
+    is just an empty object. See [Plugin Manifest](/plugins/manifest) for the
+    full field reference.
+
+  </Step>
+
+  <Step title="Register a required tool">
+    Use `definePluginEntry(...)` for tool plugins:
+
+    ```typescript index.ts
+    import { Type } from "@sinclair/typebox";
+    import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+    export default definePluginEntry({
+      id: "acme-tools",
+      name: "Acme Tools",
+      description: "Acme workflow tools for OpenClaw",
+      register(api) {
+        api.registerTool({
+          name: "acme_echo",
+          description: "Echo text back to the agent",
+          parameters: Type.Object({
+            text: Type.String({ description: "Text to echo" }),
+          }),
+          async execute(_id, params) {
+            return {
+              content: [{ type: "text", text: params.text }],
+            };
+          },
+        });
+      },
+    });
+    ```
+
+    Required tools are available whenever the plugin is loaded.
+
+  </Step>
+
+  <Step title="Make side-effecting tools optional">
+    Use `optional: true` for tools that call outside systems, mutate state, or
+    depend on local binaries:
+
+    ```typescript
+    import { Type } from "@sinclair/typebox";
+
+    register(api) {
+      api.registerTool(
+        {
+          name: "acme_publish",
+          description: "Publish the current draft",
+          parameters: Type.Object({
+            documentId: Type.String(),
+          }),
+          async execute(_id, params) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Published ${params.documentId}`,
+                },
+              ],
+            };
+          },
+        },
+        { optional: true },
+      );
+    }
+    ```
+
+    Users must allow optional tools in config:
+
+    ```json5
+    {
+      tools: {
+        allow: ["acme_publish"],
+      },
+    }
+    ```
+
+    You can also allow every optional tool from one plugin by adding the plugin
+    id to `tools.allow`.
+
+  </Step>
+
+  <Step title="Use runtime-aware tool factories when needed">
+    If a tool should only exist in some environments, register a factory and
+    return `null` when the tool should be hidden:
+
+    ```typescript
+    import { Type } from "@sinclair/typebox";
+
+    register(api) {
+      api.registerTool(
+        (ctx) => {
+          if (ctx.sandboxed) {
+            return null;
+          }
+
+          return {
+            name: "acme_shell",
+            description: "Run a local shell command",
+            parameters: Type.Object({
+              command: Type.String(),
+            }),
+            async execute(_id, params) {
+              api.logger.info(`running ${params.command}`);
+              return {
+                content: [{ type: "text", text: `Ran ${params.command}` }],
+              };
+            },
+          };
+        },
+        { optional: true },
+      );
+    }
+    ```
+
+    This pattern is useful for sandbox-sensitive tools, tools that require
+    plugin config, or tools that should only appear for some channels.
+
+  </Step>
+
+  <Step title="Add hooks or routes around the tool">
+    Tool plugins are also a common place for lifecycle hooks or plugin-owned
+    HTTP routes:
+
+    ```typescript
+    register(api) {
+      api.on("before_prompt_build", async () => ({
+        prependSystemContext: "You can use acme_echo for literal echo tasks.",
+      }));
+
+      api.registerHttpRoute({
+        path: "/plugins/acme-tools/health",
+        auth: "plugin",
+        handler: async () => ({
+          ok: true,
+          body: { status: "ok" },
+        }),
+      });
+    }
+    ```
+
+    For the full registration surface, see
+    [Plugin SDK Overview](/plugins/sdk-overview#registration-api) and
+    [Plugin Entry Points](/plugins/sdk-entrypoints).
+
+  </Step>
+
+  <Step title="Test and inspect">
+    For in-repo plugins:
+
+    ```bash
+    pnpm test -- extensions/acme-tools/
+    ```
+
+    After install, confirm what OpenClaw sees:
+
+    ```bash
+    openclaw plugins inspect acme-tools
+    ```
+
+    The inspect output shows whether the plugin loaded, which tools it
+    registered, and any diagnostics.
+
+  </Step>
+</Steps>
+
+## File structure
+
+```text
+acme-tools/
+  package.json
+  openclaw.plugin.json
+  index.ts
+  src/
+    tools/
+    config.ts
+```
+
+- `index.ts` exports the plugin entry and registers tools.
+- `openclaw.plugin.json` is the manifest OpenClaw reads before loading code.
+- `src/` holds the actual tool logic and any config helpers.
+
+## When to use a tool plugin
+
+Use a tool plugin when your plugin mainly adds actions the agent can call.
+
+Use a provider plugin instead when you are adding models, auth, catalogs, or
+provider runtime hooks.
+
+Use a channel plugin instead when you are adding message transport, setup
+surfaces, target resolution, or send/receive behavior.
+
+## Next steps
+
+- [Plugin SDK Overview](/plugins/sdk-overview) — registration methods and API object
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported `openclaw/plugin-sdk/*` imports
+- [Plugin Runtime Helpers](/plugins/sdk-runtime) — `api.runtime`, logging, config, subagents
+- [Plugin Testing](/plugins/sdk-testing) — test utilities and patterns
+- [Plugin Troubleshooting](/plugins/sdk-troubleshooting) — common load and config failures

--- a/docs/plugins/sdk-troubleshooting.md
+++ b/docs/plugins/sdk-troubleshooting.md
@@ -1,0 +1,194 @@
+---
+title: "Plugin Troubleshooting"
+sidebarTitle: "Troubleshooting"
+summary: "Common plugin load, manifest, config, and registration problems and how to debug them"
+read_when:
+  - Your plugin is not loading or not showing up
+  - A plugin loads but some tools or capabilities are missing
+  - You need the shortest path to `inspect`, `doctor`, and the most common fixes
+---
+
+# Plugin Troubleshooting
+
+Use this page when a plugin is installed but does not behave the way you
+expect. Most problems show up quickly with `inspect`, `doctor`, and one check
+of the manifest and config.
+
+## Fast checks
+
+Run these first:
+
+```bash
+openclaw plugins list
+openclaw plugins inspect <id>
+openclaw plugins doctor
+openclaw gateway restart
+```
+
+What each one tells you:
+
+- `plugins list` tells you whether discovery found the plugin at all.
+- `plugins inspect <id>` shows load status, source, registrations, and diagnostics.
+- `plugins doctor` surfaces manifest, config, and install problems.
+- `gateway restart` applies config changes and reloads plugin code.
+
+## Common problems
+
+| Symptom                                     | Likely cause                              | What to check                                                           |
+| ------------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------- |
+| Plugin never appears in `plugins list`      | Discovery never found it                  | Install path, `plugins.load.paths`, archive contents, or package layout |
+| Plugin appears but is disabled              | Enablement rules turned it off            | `plugins.enabled`, `plugins.deny`, `plugins.entries.<id>.enabled`       |
+| Plugin shows diagnostics about the manifest | Missing or invalid `openclaw.plugin.json` | `id`, `configSchema`, JSON syntax, manifest location                    |
+| Plugin loads but some tools are missing     | Optional tool or setup-only load          | `tools.allow`, `api.registrationMode`, `inspect` output                 |
+| Wrong plugin wins                           | Duplicate plugin id shadowing             | `inspect`, `doctor`, and duplicate-id diagnostics                       |
+| Runtime warns about old imports             | Deprecated SDK surface                    | [Migrate to SDK](/plugins/sdk-migration)                                |
+
+## Plugin does not show up at all
+
+Check the package shape first:
+
+- Native plugins must ship `openclaw.plugin.json` at the plugin root.
+- `package.json` must point OpenClaw at the runtime entry via `openclaw.extensions`.
+- If you linked or loaded a local folder, the path must point at the plugin
+  root, not just a `src/` directory.
+
+If the plugin still does not appear, run:
+
+```bash
+openclaw plugins doctor
+```
+
+Doctor will surface broken or missing manifests and other discovery problems.
+
+## Plugin is found but not enabled
+
+The most common cause is config, not code.
+
+Check these in order:
+
+- `plugins.enabled` is still `true`
+- the plugin id is not in `plugins.deny`
+- `plugins.entries.<id>.enabled` is not `false`
+- workspace-origin plugins are explicitly enabled
+
+Then restart the gateway:
+
+```bash
+openclaw gateway restart
+```
+
+## Manifest errors
+
+For native plugins, these are hard requirements:
+
+- `openclaw.plugin.json` must be valid JSON
+- the manifest must include `id`
+- the manifest must include `configSchema`, even if empty
+
+Minimal safe schema:
+
+```json
+{
+  "id": "my-plugin",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false
+  }
+}
+```
+
+If the manifest is broken, OpenClaw treats the plugin as invalid and Doctor
+surfaces a warning.
+
+## Manifest id and entry id do not match
+
+The manifest and exported plugin definition must describe the same plugin id.
+
+If they differ, the loader reports a mismatch like:
+
+```text
+plugin id mismatch (config uses "my-plugin", export uses "other-id")
+```
+
+Keep the same id in:
+
+- `openclaw.plugin.json`
+- `definePluginEntry({ id: ... })` or `defineChannelPluginEntry({ id: ... })`
+- config keys under `plugins.entries.<id>`
+
+## Duplicate plugin ids
+
+If two discovered plugins use the same id, one shadows the other. This usually
+happens when you have both a bundled plugin and a local/dev copy with the same
+id.
+
+Look for duplicate-id diagnostics in:
+
+```bash
+openclaw plugins inspect <id>
+openclaw plugins doctor
+```
+
+If you are building a local replacement, that may be intentional. If not,
+rename the plugin id or remove the extra copy.
+
+## Optional tools are missing
+
+If you registered a tool with `{ optional: true }`, it does not appear by
+default.
+
+Allow it explicitly:
+
+```json5
+{
+  tools: {
+    allow: ["my_optional_tool"],
+  },
+}
+```
+
+Or allow the whole plugin by id:
+
+```json5
+{
+  tools: {
+    allow: ["my-plugin"],
+  },
+}
+```
+
+Then restart the gateway and run `openclaw plugins inspect <id>` again.
+
+## Channel plugin only partly loads
+
+Channel plugins can load in more than one registration mode:
+
+- `"full"` for normal startup
+- `"setup-only"` for disabled or unconfigured channels
+- `"setup-runtime"` for setup flows that still need runtime helpers
+
+If a channel plugin seems to register only setup behavior, inspect
+`api.registrationMode` and move heavy registrations behind the correct mode
+check. See [Plugin Entry Points](/plugins/sdk-entrypoints#registration-mode).
+
+## Deprecated import warnings
+
+If you see warnings about the old root barrel or extension-api bridge, move to
+focused SDK subpaths:
+
+- from `openclaw/plugin-sdk`
+- to `openclaw/plugin-sdk/<subpath>`
+
+Use:
+
+- [Migrate to SDK](/plugins/sdk-migration)
+- [SDK Subpaths](/plugins/sdk-subpaths)
+
+## When to inspect deeper
+
+If the quick fixes above do not explain the problem, the next pages are:
+
+- [Plugins](/tools/plugin) — discovery, precedence, enablement rules
+- [plugins CLI](/cli/plugins) — exact `inspect`, `install`, and `doctor` commands
+- [Plugin Manifest](/plugins/manifest) — manifest schema requirements
+- [Plugin Internals](/plugins/architecture) — load pipeline and registry behavior

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -248,8 +248,10 @@ Common registration methods:
 ## Related
 
 - [Building Plugins](/plugins/building-plugins) — create your own plugin
+- [Tool Plugins](/plugins/sdk-tool-plugins) — build a tool, hook, or command plugin
 - [Plugin Bundles](/plugins/bundles) — Codex/Claude/Cursor bundle compatibility
 - [Plugin Manifest](/plugins/manifest) — manifest schema
-- [Registering Tools](/plugins/building-plugins#registering-agent-tools) — add agent tools in a plugin
+- [SDK Subpaths](/plugins/sdk-subpaths) — supported public import paths
+- [Plugin Troubleshooting](/plugins/sdk-troubleshooting) — debug load and config issues
 - [Plugin Internals](/plugins/architecture) — capability model and load pipeline
 - [Community Plugins](/plugins/community) — third-party listings

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -251,7 +251,6 @@ Common registration methods:
 - [Tool Plugins](/plugins/sdk-tool-plugins) — build a tool, hook, or command plugin
 - [Plugin Bundles](/plugins/bundles) — Codex/Claude/Cursor bundle compatibility
 - [Plugin Manifest](/plugins/manifest) — manifest schema
-- [SDK Subpaths](/plugins/sdk-subpaths) — supported public import paths
 - [Plugin Troubleshooting](/plugins/sdk-troubleshooting) — debug load and config issues
 - [Plugin Internals](/plugins/architecture) — capability model and load pipeline
 - [Community Plugins](/plugins/community) — third-party listings


### PR DESCRIPTION
## Summary
- add a dedicated tool plugin guide for the missing third authoring path
- add a plugin troubleshooting page for discovery, manifest, config, and optional-tool issues
- add a public SDK subpath reference page and link the existing SDK docs to it instead of pointing readers at internal repo files

## Testing
- `pnpm check:docs`
- local Mint preview booted successfully via `cd docs && pnpm dlx mint dev` (the repo `pnpm docs:dev` script still depends on a globally installed `mint` binary in this environment)
