### PR TITLE
fix: handle missing brew in Docker; fix Gemini CLI OAuth 400 on loadCodeAssist

### DIFF
--- a/extensions/google/oauth.project.ts
+++ b/extensions/google/oauth.project.ts
@@ -99,7 +99,9 @@ async function discoverProject(accessToken: string): Promise<string> {
   const envProject = process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_CLOUD_PROJECT_ID;
   const platform = resolvePlatform();
   const metadata = {
-    ideType: "ANTIGRAVITY",
+    // IDE_UNSPECIFIED is the correct enum value accepted by the Cloud Code Assist API.
+    // Using any other string (e.g. "ANTIGRAVITY") causes a 400 Bad Request.
+    ideType: "IDE_UNSPECIFIED",
     platform,
     pluginType: "GEMINI",
   };

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -388,7 +388,7 @@ describe("loginGeminiCliOAuth", () => {
     const clientMetadata = getHeaderValue(firstHeaders, "Client-Metadata");
     expect(clientMetadata).toBeDefined();
     expect(JSON.parse(clientMetadata as string)).toEqual({
-      ideType: "ANTIGRAVITY",
+      ideType: "IDE_UNSPECIFIED",
       platform: getExpectedPlatform(),
       pluginType: "GEMINI",
     });
@@ -396,11 +396,54 @@ describe("loginGeminiCliOAuth", () => {
     const body = JSON.parse(String(loadRequests[0]?.init?.body));
     expect(body).toEqual({
       metadata: {
-        ideType: "ANTIGRAVITY",
+        ideType: "IDE_UNSPECIFIED",
         platform: getExpectedPlatform(),
         pluginType: "GEMINI",
       },
     });
+  });
+
+  it("sends IDE_UNSPECIFIED as ideType in loadCodeAssist body and Client-Metadata header", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = getRequestUrl(input);
+      requests.push({ url, init });
+
+      if (url === TOKEN_URL) {
+        return responseJson({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        });
+      }
+      if (url === USERINFO_URL) {
+        return responseJson({ email: "lobster@openclaw.ai" });
+      }
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    await runRemoteLoginExpectingProjectId(loginGeminiCliOAuth, "prod-project");
+
+    const loadRequest = requests.find((r) => r.url.includes("v1internal:loadCodeAssist"));
+    expect(loadRequest).toBeDefined();
+
+    // Verify Client-Metadata header uses IDE_UNSPECIFIED (not ANTIGRAVITY)
+    const clientMetadata = getHeaderValue(loadRequest?.init?.headers, "Client-Metadata");
+    expect(clientMetadata).toBeDefined();
+    const parsedMeta = JSON.parse(clientMetadata as string);
+    expect(parsedMeta.ideType).toBe("IDE_UNSPECIFIED");
+
+    // Verify request body uses IDE_UNSPECIFIED
+    const body = JSON.parse(String(loadRequest?.init?.body));
+    expect(body.metadata.ideType).toBe("IDE_UNSPECIFIED");
   });
 
   it("falls back to GOOGLE_CLOUD_PROJECT when all loadCodeAssist endpoints fail", async () => {

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -18,9 +18,13 @@ vi.mock("./onboard-helpers.js", () => ({
     { value: "bun", label: "bun" },
   ]),
 }));
+vi.mock("../infra/docker-env.js", () => ({
+  isRunningInDocker: vi.fn(() => false),
+}));
 
 import { installSkill } from "../agents/skills-install.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
+import { isRunningInDocker } from "../infra/docker-env.js";
 import { detectBinary } from "./onboard-helpers.js";
 import { setupSkills } from "./onboard-skills.js";
 
@@ -181,5 +185,36 @@ describe("setupSkills", () => {
 
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeDefined();
+  });
+
+  it("shows Docker-specific note instead of Homebrew install when running in Docker", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    vi.mocked(isRunningInDocker).mockReturnValue(true);
+
+    mockMissingBrewStatus([
+      createBundledSkill({
+        name: "video-frames",
+        description: "ffmpeg",
+        bins: ["ffmpeg"],
+        installLabel: "Install ffmpeg (brew)",
+      }),
+    ]);
+
+    const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+    await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+    // Should show Docker-specific note, not the generic Homebrew one
+    const dockerNote = notes.find((n) => n.title === "Homebrew unavailable in Docker");
+    expect(dockerNote).toBeDefined();
+    expect(dockerNote?.message).toContain("Docker container");
+
+    const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+    expect(brewNote).toBeUndefined();
+
+    // Restore mock to default
+    vi.mocked(isRunningInDocker).mockReturnValue(false);
   });
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -2,6 +2,7 @@ import { installSkill } from "../agents/skills-install.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { isRunningInDocker } from "../infra/docker-env.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -114,25 +115,38 @@ export async function setupSkills(
       !(await detectBinary("brew"));
 
     if (needsBrewPrompt) {
-      await prompter.note(
-        [
-          "Many skill dependencies are shipped via Homebrew.",
-          "Without brew, you'll need to build from source or download releases manually.",
-        ].join("\n"),
-        "Homebrew recommended",
-      );
-      const showBrewInstall = await prompter.confirm({
-        message: "Show Homebrew install command?",
-        initialValue: true,
-      });
-      if (showBrewInstall) {
+      if (isRunningInDocker()) {
+        // In Docker containers Homebrew is not available and cannot be easily
+        // installed. Guide the user toward system package managers instead.
         await prompter.note(
           [
-            "Run:",
-            '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+            "Running inside a Docker container — Homebrew is not available here.",
+            "Install brew-backed skill dependencies via your system package manager",
+            "(e.g. apt-get, dnf, pacman) or use a custom image that includes them.",
           ].join("\n"),
-          "Homebrew install",
+          "Homebrew unavailable in Docker",
         );
+      } else {
+        await prompter.note(
+          [
+            "Many skill dependencies are shipped via Homebrew.",
+            "Without brew, you'll need to build from source or download releases manually.",
+          ].join("\n"),
+          "Homebrew recommended",
+        );
+        const showBrewInstall = await prompter.confirm({
+          message: "Show Homebrew install command?",
+          initialValue: true,
+        });
+        if (showBrewInstall) {
+          await prompter.note(
+            [
+              "Run:",
+              '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"',
+            ].join("\n"),
+            "Homebrew install",
+          );
+        }
       }
     }
 

--- a/src/infra/docker-env.test.ts
+++ b/src/infra/docker-env.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { isRunningInDocker } from "./docker-env.js";
+
+describe("isRunningInDocker", () => {
+  const noDockerEnv: NodeJS.ProcessEnv = {};
+  const noDockerFile = (_path: string) => false;
+
+  it("returns false when no Docker signals are present", () => {
+    expect(isRunningInDocker({ env: noDockerEnv, fsExistsSync: noDockerFile })).toBe(false);
+  });
+
+  it("returns true when DOCKER_CONTAINER=true is set", () => {
+    expect(
+      isRunningInDocker({
+        env: { DOCKER_CONTAINER: "true" },
+        fsExistsSync: noDockerFile,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when DOCKER_CONTAINER is set to a non-true value", () => {
+    expect(
+      isRunningInDocker({
+        env: { DOCKER_CONTAINER: "1" },
+        fsExistsSync: noDockerFile,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when container=docker is set", () => {
+    expect(
+      isRunningInDocker({
+        env: { container: "docker" },
+        fsExistsSync: noDockerFile,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when container env var is a different value", () => {
+    expect(
+      isRunningInDocker({
+        env: { container: "podman" },
+        fsExistsSync: noDockerFile,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when /.dockerenv file exists", () => {
+    expect(
+      isRunningInDocker({
+        env: noDockerEnv,
+        fsExistsSync: (p: string) => p === "/.dockerenv",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when /.dockerenv does not exist", () => {
+    expect(
+      isRunningInDocker({
+        env: noDockerEnv,
+        fsExistsSync: (p: string) => p !== "/.dockerenv",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when fsExistsSync throws", () => {
+    expect(
+      isRunningInDocker({
+        env: noDockerEnv,
+        fsExistsSync: () => {
+          throw new Error("permission denied");
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("DOCKER_CONTAINER=true takes priority over other signals", () => {
+    // Even if /.dockerenv is absent, the env var wins
+    expect(
+      isRunningInDocker({
+        env: { DOCKER_CONTAINER: "true", container: "podman" },
+        fsExistsSync: noDockerFile,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/infra/docker-env.ts
+++ b/src/infra/docker-env.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+
+/**
+ * Detects whether the current process is running inside a Docker container.
+ *
+ * Checks several signals in priority order:
+ *   1. `DOCKER_CONTAINER=true` environment variable (explicit override, useful in tests)
+ *   2. `/.dockerenv` file — created by the Docker runtime in every container
+ *   3. `container=docker` env var — set by some container runtimes (e.g. podman with Docker compat)
+ */
+export function isRunningInDocker(opts?: {
+  env?: NodeJS.ProcessEnv;
+  fsExistsSync?: (path: string) => boolean;
+}): boolean {
+  const env = opts?.env ?? process.env;
+  const existsSync = opts?.fsExistsSync ?? ((p: string) => fs.existsSync(p));
+
+  if (env.DOCKER_CONTAINER === "true") {
+    return true;
+  }
+
+  if (env.container === "docker") {
+    return true;
+  }
+
+  try {
+    if (existsSync("/.dockerenv")) {
+      return true;
+    }
+  } catch {
+    // Ignore access errors; treat as not in Docker
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Fixes #14593 and #29539.

**#14593 — Docker image has no Homebrew**
- `onboard-skills` showed the generic Homebrew install command even inside Docker containers where Homebrew cannot be installed
- Added `src/infra/docker-env.ts` utility (`isRunningInDocker`) that checks `/.dockerenv`, `DOCKER_CONTAINER=true`, and `container=docker` environment signals
- When a brew-backed skill install is selected and we are in Docker, show a Docker-specific note directing users to their system package manager (apt-get, dnf, pacman) instead of prompting to install Homebrew

**#29539 — Gemini CLI OAuth 400 error on `loadCodeAssist`**
- Root cause: `extensions/google/oauth.project.ts` used `ideType: "ANTIGRAVITY"` in the `loadCodeAssist` request body and `Client-Metadata` header
- The Cloud Code Assist API validates `ideType` against a proto enum; `ANTIGRAVITY` is not a valid value and the API returns HTTP 400
- The real `@google/gemini-cli-core` uses `ideType: "IDE_UNSPECIFIED"` (confirmed from installed package source)
- Fixed by changing `ideType` to `"IDE_UNSPECIFIED"` in `oauth.project.ts`

## Test plan
- [x] `src/infra/docker-env.test.ts` — 9 tests covering all Docker detection paths
- [x] `src/commands/onboard-skills.test.ts` — added test: Docker-specific note shown instead of Homebrew install command
- [x] `extensions/google/oauth.test.ts` — updated existing tests to assert `IDE_UNSPECIFIED`; added dedicated regression test for `ideType` field
- [x] `pnpm check` passes (lint, format, type-check, all custom boundary checks)
- [x] All scoped tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)