### PR TITLE
fix(slack): add HEARTBEAT_OK safety-net stripping to Slack delivery paths

### DIFF
--- a/src/channels/plugins/outbound/slack.test.ts
+++ b/src/channels/plugins/outbound/slack.test.ts
@@ -169,3 +169,45 @@ describe("slack outbound hook wiring", () => {
     expect(sendMessageSlack).toHaveBeenCalled();
   });
 });
+
+describe("slack outbound HEARTBEAT_OK safety-net", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getGlobalHookRunner).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips messages that are exactly 'HEARTBEAT_OK'", async () => {
+    const result = await sendSlackTextWithDefaults({ text: "HEARTBEAT_OK" });
+    expect(sendMessageSlack).not.toHaveBeenCalled();
+    expect(result.channel).toBe("slack");
+  });
+
+  it("strips messages that are 'HEARTBEAT_OK' with surrounding whitespace", async () => {
+    const result = await sendSlackTextWithDefaults({ text: "  HEARTBEAT_OK  " });
+    expect(sendMessageSlack).not.toHaveBeenCalled();
+    expect(result.channel).toBe("slack");
+  });
+
+  it("strips HEARTBEAT_OK from messages with surrounding content", async () => {
+    await sendSlackTextWithDefaults({ text: "HEARTBEAT_OK Here is some other text" });
+    expect(sendMessageSlack).toHaveBeenCalledWith(
+      "C123",
+      expect.not.stringContaining("HEARTBEAT_OK"),
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages containing the word 'heartbeat'", async () => {
+    await sendSlackTextWithDefaults({ text: "The heartbeat check passed successfully" });
+    expectSlackSendCalledWith("The heartbeat check passed successfully");
+  });
+
+  it("does NOT strip normal messages", async () => {
+    await sendSlackTextWithDefaults({ text: "Hello, how can I help?" });
+    expectSlackSendCalledWith("Hello, how can I help?");
+  });
+});

--- a/src/channels/plugins/outbound/slack.ts
+++ b/src/channels/plugins/outbound/slack.ts
@@ -1,3 +1,5 @@
+import { stripHeartbeatToken } from "../../../auto-reply/heartbeat.js";
+import { HEARTBEAT_TOKEN } from "../../../auto-reply/tokens.js";
 import type { OutboundIdentity } from "../../../infra/outbound/identity.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../../../slack/send.js";
@@ -77,8 +79,23 @@ async function sendSlackOutboundMessage(params: {
     };
   }
 
+  // Safety-net: strip stray HEARTBEAT_OK tokens that escaped upstream normalization.
+  let finalText = hookResult.text;
+  if (finalText.includes(HEARTBEAT_TOKEN)) {
+    const stripped = stripHeartbeatToken(finalText, { mode: "message" });
+    if (stripped.shouldSkip && !params.mediaUrl) {
+      return {
+        channel: "slack" as const,
+        messageId: "heartbeat-stripped",
+        channelId: params.to,
+        meta: { heartbeatStripped: true },
+      };
+    }
+    finalText = stripped.text;
+  }
+
   const slackIdentity = resolveSlackSendIdentity(params.identity);
-  const result = await send(params.to, hookResult.text, {
+  const result = await send(params.to, finalText, {
     threadTs,
     accountId: params.accountId ?? undefined,
     ...(params.mediaUrl

--- a/src/slack/monitor/replies.heartbeat.test.ts
+++ b/src/slack/monitor/replies.heartbeat.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../auto-reply/chunk.js", () => ({
+  chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+}));
+
+vi.mock("../format.js", () => ({
+  markdownToSlackMrkdwnChunks: vi.fn((text: string) => [text]),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSlack: vi.fn().mockResolvedValue({ messageId: "1234.5678", channelId: "C123" }),
+}));
+
+import { sendMessageSlack } from "../send.js";
+import { deliverReplies } from "./replies.js";
+
+const baseParams = {
+  target: "C123",
+  token: "xoxb-test",
+  runtime: { log: vi.fn() } as never,
+  textLimit: 4000,
+  replyToMode: "off" as const,
+};
+
+describe("deliverReplies HEARTBEAT_OK safety-net", () => {
+  it("strips messages that are exactly 'HEARTBEAT_OK'", async () => {
+    await deliverReplies({
+      ...baseParams,
+      replies: [{ text: "HEARTBEAT_OK" }],
+    });
+    expect(sendMessageSlack).not.toHaveBeenCalled();
+  });
+
+  it("strips messages that are 'HEARTBEAT_OK' with surrounding whitespace", async () => {
+    await deliverReplies({
+      ...baseParams,
+      replies: [{ text: "  HEARTBEAT_OK  " }],
+    });
+    expect(sendMessageSlack).not.toHaveBeenCalled();
+  });
+
+  it("strips HEARTBEAT_OK from messages with surrounding content", async () => {
+    await deliverReplies({
+      ...baseParams,
+      replies: [{ text: "HEARTBEAT_OK Here is some other text" }],
+    });
+    expect(sendMessageSlack).toHaveBeenCalledWith(
+      "C123",
+      expect.not.stringContaining("HEARTBEAT_OK"),
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages containing the word 'heartbeat'", async () => {
+    await deliverReplies({
+      ...baseParams,
+      replies: [{ text: "The heartbeat check passed successfully" }],
+    });
+    expect(sendMessageSlack).toHaveBeenCalledWith(
+      "C123",
+      "The heartbeat check passed successfully",
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages", async () => {
+    await deliverReplies({
+      ...baseParams,
+      replies: [{ text: "Hello, how can I help?" }],
+    });
+    expect(sendMessageSlack).toHaveBeenCalledWith(
+      "C123",
+      "Hello, how can I help?",
+      expect.any(Object),
+    );
+  });
+
+  it("still delivers media when HEARTBEAT_OK text is stripped", async () => {
+    await deliverReplies({
+      ...baseParams,
+      replies: [{ text: "HEARTBEAT_OK", mediaUrl: "https://example.com/image.png" }],
+    });
+    expect(sendMessageSlack).toHaveBeenCalled();
+  });
+});

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -1,7 +1,8 @@
 import type { ChunkMode } from "../../auto-reply/chunk.js";
 import { chunkMarkdownTextWithMode } from "../../auto-reply/chunk.js";
+import { stripHeartbeatToken } from "../../auto-reply/heartbeat.js";
 import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-reference.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -24,7 +25,17 @@ export async function deliverReplies(params: {
     const inlineReplyToId = params.replyToMode === "off" ? undefined : payload.replyToId;
     const threadTs = inlineReplyToId ?? params.replyThreadTs;
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
-    const text = payload.text ?? "";
+    let text = payload.text ?? "";
+
+    // Safety-net: strip stray HEARTBEAT_OK tokens that escaped upstream normalization.
+    if (text.includes(HEARTBEAT_TOKEN)) {
+      const stripped = stripHeartbeatToken(text, { mode: "message" });
+      if (stripped.shouldSkip && mediaList.length === 0) {
+        continue;
+      }
+      text = stripped.text;
+    }
+
     if (!text && mediaList.length === 0) {
       continue;
     }


### PR DESCRIPTION
## Bug
HEARTBEAT_OK messages leak through to Slack channels as visible user messages. The web channel module has safety-net stripping for HEARTBEAT_OK but the Slack channel module does not. When a heartbeat fires concurrently with an active conversation, the health module may not flag it as a heartbeat run, and Slack lets the raw HEARTBEAT_OK through.

## Fix
Added the same HEARTBEAT_OK stripping logic from the web channel to the Slack channel module, ensuring consistent behavior across both channels.

## Testing
- Written with TDD: failing tests first, then implementation
- Unit tests cover: exact match stripping, whitespace handling, normal message passthrough
- pnpm check passes

Fixes #52370

## Notes
This PR was authored with AI assistance (Claude via OpenClaw).