### PR TITLE
fix(windows): detect stale gateway PIDs via netstat

### DIFF
--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -183,16 +183,26 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(result).toEqual([stalePid]); // deduped — not [pid, pid]
     });
 
-    it("returns [] and skips lsof on win32", () => {
+    it("returns [] when no listeners on win32", () => {
       // The entire describe block is skipped on Windows (isWindows guard at top),
-      // so this test only runs on Linux/macOS. It mocks platform to win32 for the
-      // single assertion without needing to restore — the suite-level skipIf means
-      // this will never run on an actual Windows runner where the mock could leak.
+      // so this test only runs on Linux/macOS. It mocks platform to win32 so
+      // findGatewayPidsOnPortSync takes the Windows netstat path.
       const origDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       try {
+        // netstat returns successfully but no LISTENING entries on our port
+        mockSpawnSync.mockReturnValue({
+          error: null,
+          status: 0,
+          stdout: "\r\nActive Connections\r\n\r\n  Proto  Local Address          Foreign Address        State           PID\r\n  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1024\r\n",
+          stderr: "",
+        });
         expect(findGatewayPidsOnPortSync(18789)).toEqual([]);
-        expect(mockSpawnSync).not.toHaveBeenCalled();
+        expect(mockSpawnSync).toHaveBeenCalledWith(
+          "netstat",
+          expect.arrayContaining(["-ano"]),
+          expect.any(Object),
+        );
       } finally {
         if (origDescriptor) {
           Object.defineProperty(process, "platform", origDescriptor);

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -82,12 +82,106 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
  * Find PIDs of gateway processes listening on the given port using synchronous lsof.
  * Returns only PIDs that belong to openclaw gateway processes (not the current process).
  */
+/**
+ * Parse gateway PIDs from `netstat -ano` output on Windows.
+ * Looks for LISTENING entries on the given port and returns PIDs of openclaw
+ * processes (excluding the current process).
+ *
+ * netstat -ano output format:
+ *   TCP    0.0.0.0:18789          0.0.0.0:0              LISTENING       12345
+ *   TCP    [::]:18789             [::]:0                  LISTENING       12345
+ */
+function findGatewayPidsOnPortWindows(
+  port: number,
+  spawnTimeoutMs: number,
+): number[] {
+  const res = spawnSync("netstat", ["-ano", "-p", "TCP"], {
+    encoding: "utf8",
+    timeout: spawnTimeoutMs,
+    windowsHide: true,
+  });
+  if (res.error || res.status !== 0) {
+    restartLog.warn(
+      `netstat failed during stale-pid scan for port ${port}: ${res.error ? String(res.error) : `exit ${res.status}`}`,
+    );
+    return [];
+  }
+  const pids = new Set<number>();
+  const portSuffix = `:${port}`;
+  for (const line of res.stdout.split(/\r?\n/)) {
+    // Match lines like: TCP  0.0.0.0:18789  0.0.0.0:0  LISTENING  12345
+    if (!line.includes("LISTENING")) continue;
+    const parts = line.trim().split(/\s+/);
+    // parts: [proto, local_addr, foreign_addr, state, pid]
+    if (parts.length < 5) continue;
+    const localAddr = parts[1];
+    if (!localAddr || !localAddr.endsWith(portSuffix)) continue;
+    const pid = Number.parseInt(parts[4], 10);
+    if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) {
+      pids.add(pid);
+    }
+  }
+  if (pids.size === 0) return [];
+  // Verify each PID is actually an openclaw/node process via tasklist
+  const confirmed: number[] = [];
+  for (const pid of pids) {
+    try {
+      const tl = spawnSync("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"], {
+        encoding: "utf8",
+        timeout: spawnTimeoutMs,
+        windowsHide: true,
+      });
+      if (tl.stdout && tl.stdout.toLowerCase().includes("node")) {
+        confirmed.push(pid);
+      }
+    } catch {
+      // If tasklist fails, include the PID anyway — better to kill a stale
+      // process than leave a port occupied.
+      confirmed.push(pid);
+    }
+  }
+  return confirmed;
+}
+
+/**
+ * Poll whether the given port is free on Windows using netstat.
+ */
+function pollPortOnceWindows(port: number): PollResult {
+  try {
+    const res = spawnSync("netstat", ["-ano", "-p", "TCP"], {
+      encoding: "utf8",
+      timeout: POLL_SPAWN_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    if (res.error) {
+      const code = (res.error as NodeJS.ErrnoException).code;
+      const permanent = code === "ENOENT" || code === "EACCES" || code === "EPERM";
+      return { free: null, permanent };
+    }
+    if (res.status !== 0) {
+      return { free: null, permanent: false };
+    }
+    const portSuffix = `:${port}`;
+    for (const line of res.stdout.split(/\r?\n/)) {
+      if (line.includes("LISTENING") && line.includes(portSuffix)) {
+        const parts = line.trim().split(/\s+/);
+        if (parts[1]?.endsWith(portSuffix)) {
+          return { free: false };
+        }
+      }
+    }
+    return { free: true };
+  } catch {
+    return { free: null, permanent: false };
+  }
+}
+
 export function findGatewayPidsOnPortSync(
   port: number,
   spawnTimeoutMs = SPAWN_TIMEOUT_MS,
 ): number[] {
   if (process.platform === "win32") {
-    return [];
+    return findGatewayPidsOnPortWindows(port, spawnTimeoutMs);
   }
   const lsof = resolveLsofCommandSync();
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
@@ -139,6 +233,9 @@ export function findGatewayPidsOnPortSync(
 type PollResult = { free: true } | { free: false } | { free: null; permanent: boolean };
 
 function pollPortOnce(port: number): PollResult {
+  if (process.platform === "win32") {
+    return pollPortOnceWindows(port);
+  }
   try {
     const lsof = resolveLsofCommandSync();
     const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -79,10 +79,6 @@ function parsePidsFromLsofOutput(stdout: string): number[] {
 }
 
 /**
- * Find PIDs of gateway processes listening on the given port using synchronous lsof.
- * Returns only PIDs that belong to openclaw gateway processes (not the current process).
- */
-/**
  * Parse gateway PIDs from `netstat -ano` output on Windows.
  * Looks for LISTENING entries on the given port and returns PIDs of openclaw
  * processes (excluding the current process).
@@ -125,18 +121,18 @@ function findGatewayPidsOnPortWindows(
   // Verify each PID is actually an openclaw/node process via tasklist
   const confirmed: number[] = [];
   for (const pid of pids) {
-    try {
-      const tl = spawnSync("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"], {
-        encoding: "utf8",
-        timeout: spawnTimeoutMs,
-        windowsHide: true,
-      });
-      if (tl.stdout && tl.stdout.toLowerCase().includes("node")) {
-        confirmed.push(pid);
-      }
-    } catch {
+    const tl = spawnSync("tasklist", ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"], {
+      encoding: "utf8",
+      timeout: spawnTimeoutMs,
+      windowsHide: true,
+    });
+    if (tl.error || tl.status !== 0) {
       // If tasklist fails, include the PID anyway — better to kill a stale
       // process than leave a port occupied.
+      confirmed.push(pid);
+      continue;
+    }
+    if (tl.stdout && tl.stdout.toLowerCase().includes("node")) {
       confirmed.push(pid);
     }
   }
@@ -176,6 +172,10 @@ function pollPortOnceWindows(port: number): PollResult {
   }
 }
 
+/**
+ * Find PIDs of gateway processes listening on the given port using synchronous lsof.
+ * Returns only PIDs that belong to openclaw gateway processes (not the current process).
+ */
 export function findGatewayPidsOnPortSync(
   port: number,
   spawnTimeoutMs = SPAWN_TIMEOUT_MS,


### PR DESCRIPTION
## Problem

\indGatewayPidsOnPortSync()\ returns \[]\ on Windows (line 89: early return). This means \openclaw gateway stop\ cannot detect or kill stale \
ode.exe\ processes holding the gateway port, causing EADDRINUSE on restart.

## Fix

- Add \indGatewayPidsOnPortWindows()\ — uses \
etstat -ano\ to find PIDs listening on the gateway port, verified via \	asklist\ to confirm they are node.exe processes
- Add \pollPortOnceWindows()\ — polls port availability after termination using netstat
- Route both through Windows implementations when \process.platform === 'win32'\

No changes to \	erminateStaleProcessesSync()\ — Node.js \process.kill(pid, 'SIGTERM')\ already works on Windows.

## Testing

Tested on Windows 10 (build 26200) with 3 scenarios:
1. Normal stop+start — stale node.exe detected and killed, clean restart
2. Port conflict — netstat correctly identifies PID holding port 18789
3. Clean state — returns empty array when no stale processes exist

Fixes #52049