### PR TITLE
fix(plugins): distinguish missing entry file from path-escape security violation

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -476,8 +476,17 @@ function resolvePackageEntrySource(params: {
     rejectHardlinks: params.rejectHardlinks ?? true,
   });
   if (!opened.ok) {
-    if (opened.reason !== "validation") {
-      // File missing (ENOENT) or I/O error — skip silently, not a security violation.
+    if (opened.reason === "path") {
+      // File missing (ENOENT) — skip, not a security violation.
+      return null;
+    }
+    if (opened.reason === "io") {
+      // Filesystem error (EACCES, EMFILE, etc.) — warn but don't abort.
+      params.diagnostics.push({
+        level: "warn",
+        message: `extension entry unreadable (I/O error): ${params.entryPath}`,
+        source: params.sourceLabel,
+      });
       return null;
     }
     params.diagnostics.push({

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -476,6 +476,10 @@ function resolvePackageEntrySource(params: {
     rejectHardlinks: params.rejectHardlinks ?? true,
   });
   if (!opened.ok) {
+    if (opened.reason !== "validation") {
+      // File missing (ENOENT) or I/O error — skip silently, not a security violation.
+      return null;
+    }
     params.diagnostics.push({
       level: "error",
       message: `extension entry escapes package directory: ${params.entryPath}`,


### PR DESCRIPTION
lobster-biscuit

Closes #52445

## Problem

Gateway enters a fatal crash loop during startup when any extension entry point file is missing. The error message says "extension entry escapes package directory" but the file is simply not found (ENOENT) — not a security violation.

This affects AUR/Arch Linux builds and any environment where built-in extensions may be partially installed.

## Root cause

`src/plugins/discovery.ts:478` — `resolvePackageEntrySource()` checks `!opened.ok` but never inspects `opened.reason`. `openBoundaryFileSync` returns `SafeOpenSyncResult` with `reason: "path"` for ENOENT and `reason: "validation"` for actual path-escape violations (`safe-open-sync.ts:4`).

All failures were treated as security violations, aborting the gateway.

## User impact

Gateway cannot start at all. Crash loop on every startup attempt. No workaround except manually creating missing entry files.

## Fix

Only emit the security diagnostic when `opened.reason === "validation"`. For `"path"` (ENOENT) or `"io"` errors, return `null` to skip the entry silently.

1 file, +4 lines.

## How to verify

1. Remove or rename an extension entry point file (e.g. `extensions/acpx/index.js`)
2. Start gateway
3. Before: crash loop with "escapes package directory". After: extension skipped, gateway starts.

## Tests

The `SafeOpenSyncResult` type and `openBoundaryFileSync` are covered by existing tests in `safe-open-sync.test.ts`. This change is a call-site guard — the function behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)