### PR TITLE
fix: non-interactive paste-token and PAT auth for github-copilot provider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -1,7 +1,9 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import {
+  COPILOT_EDITOR_HEADERS,
   DEFAULT_COPILOT_API_BASE_URL,
+  isGitHubPAT,
   resolveCopilotApiToken,
 } from "../providers/github-copilot-token.js";
 import { isRecord } from "../utils.js";
@@ -942,6 +944,8 @@ export async function resolveImplicitCopilotProvider(params: {
   }
 
   let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+  // PATs are sent directly to the enterprise endpoint with editor headers.
+  const needsEditorHeaders = selectedGithubToken ? isGitHubPAT(selectedGithubToken) : false;
   if (selectedGithubToken) {
     try {
       const token = await resolveCopilotApiToken({
@@ -963,6 +967,7 @@ export async function resolveImplicitCopilotProvider(params: {
   return {
     baseUrl,
     models: [],
+    ...(needsEditorHeaders ? { headers: { ...COPILOT_EDITOR_HEADERS } } : {}),
   } satisfies ProviderConfig;
 }
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -343,6 +343,10 @@ export function registerModelsCli(program: Command) {
     .command("paste-token")
     .description("Paste a token into auth-profiles.json and update config")
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
+    .option(
+      "--token <value>",
+      'Token value; use "--token -" to read from stdin. Also accepts OPENCLAW_PASTE_TOKEN env var.',
+    )
     .option("--profile-id <id>", "Auth profile id (default: <provider>:manual)")
     .option(
       "--expires-in <duration>",
@@ -353,6 +357,7 @@ export function registerModelsCli(program: Command) {
         await modelsAuthPasteTokenCommand(
           {
             provider: opts.provider as string | undefined,
+            token: opts.token as string | undefined,
             profileId: opts.profileId as string | undefined,
             expiresIn: opts.expiresIn as string | undefined,
           },

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -229,4 +229,123 @@ describe("modelsAuthLoginCommand", () => {
       exitSpy.mockRestore();
     }
   });
+
+  it("uses --token directly and skips interactive prompt", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthPasteTokenCommand(
+      { provider: "anthropic", token: "sk-ant-test-token-123" },
+      runtime,
+    );
+
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: "anthropic:manual",
+      credential: {
+        type: "token",
+        provider: "anthropic",
+        token: "sk-ant-test-token-123",
+      },
+    });
+    expect(mocks.updateConfig).toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith("Auth profile: anthropic:manual (anthropic/token)");
+  });
+
+  it("throws when no TTY and no --token provided", async () => {
+    const runtime = createRuntime();
+    const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
+    const savedDescriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+    Object.defineProperty(stdin, "isTTY", {
+      configurable: true,
+      enumerable: true,
+      get: () => false,
+    });
+    try {
+      await expect(modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime)).rejects.toThrow(
+        "paste-token requires --token",
+      );
+      expect(mocks.clackText).not.toHaveBeenCalled();
+      expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    } finally {
+      if (savedDescriptor) {
+        Object.defineProperty(stdin, "isTTY", savedDescriptor);
+      } else {
+        delete (stdin as { isTTY?: boolean }).isTTY;
+      }
+    }
+  });
+
+  it("reads token from OPENCLAW_PASTE_TOKEN env var", async () => {
+    const runtime = createRuntime();
+    const orig = process.env.OPENCLAW_PASTE_TOKEN;
+    try {
+      process.env.OPENCLAW_PASTE_TOKEN = "env-token-abc";
+      await modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime);
+
+      expect(mocks.clackText).not.toHaveBeenCalled();
+      expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+        profileId: "anthropic:manual",
+        credential: {
+          type: "token",
+          provider: "anthropic",
+          token: "env-token-abc",
+        },
+      });
+    } finally {
+      if (orig === undefined) {
+        delete process.env.OPENCLAW_PASTE_TOKEN;
+      } else {
+        process.env.OPENCLAW_PASTE_TOKEN = orig;
+      }
+    }
+  });
+
+  it("prefers --token over OPENCLAW_PASTE_TOKEN env var", async () => {
+    const runtime = createRuntime();
+    const orig = process.env.OPENCLAW_PASTE_TOKEN;
+    try {
+      process.env.OPENCLAW_PASTE_TOKEN = "env-token";
+      await modelsAuthPasteTokenCommand(
+        { provider: "anthropic", token: "flag-token" },
+        runtime,
+      );
+
+      expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+        profileId: "anthropic:manual",
+        credential: expect.objectContaining({ token: "flag-token" }),
+      });
+    } finally {
+      if (orig === undefined) {
+        delete process.env.OPENCLAW_PASTE_TOKEN;
+      } else {
+        process.env.OPENCLAW_PASTE_TOKEN = orig;
+      }
+    }
+  });
+
+  it("uses --token with custom --profile-id and --expires-in", async () => {
+    const runtime = createRuntime();
+
+    await modelsAuthPasteTokenCommand(
+      {
+        provider: "openai",
+        token: "sk-test-token",
+        profileId: "openai:ci",
+        expiresIn: "30d",
+      },
+      runtime,
+    );
+
+    expect(mocks.clackText).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: "openai:ci",
+      credential: expect.objectContaining({
+        type: "token",
+        provider: "openai",
+        token: "sk-test-token",
+        expires: expect.any(Number),
+      }),
+    });
+    expect(runtime.log).toHaveBeenCalledWith("Auth profile: openai:ci (openai/token)");
+  });
 });

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -91,6 +91,18 @@ function resolveDefaultTokenProfileId(provider: string): string {
   return `${normalizeProviderId(provider)}:manual`;
 }
 
+async function readStdinToken(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+  const value = Buffer.concat(chunks).toString("utf-8").trim();
+  if (!value) {
+    throw new Error("No token received from stdin.");
+  }
+  return value;
+}
+
 export async function modelsAuthSetupTokenCommand(
   opts: { provider?: string; yes?: boolean },
   runtime: RuntimeEnv,
@@ -145,6 +157,7 @@ export async function modelsAuthSetupTokenCommand(
 export async function modelsAuthPasteTokenCommand(
   opts: {
     provider?: string;
+    token?: string;
     profileId?: string;
     expiresIn?: string;
   },
@@ -157,11 +170,27 @@ export async function modelsAuthPasteTokenCommand(
   const provider = normalizeProviderId(rawProvider);
   const profileId = opts.profileId?.trim() || resolveDefaultTokenProfileId(provider);
 
-  const tokenInput = await text({
-    message: `Paste token for ${provider}`,
-    validate: (value) => (value?.trim() ? undefined : "Required"),
-  });
-  const token = String(tokenInput ?? "").trim();
+  let token: string;
+  const envToken = process.env.OPENCLAW_PASTE_TOKEN?.trim();
+  if (opts.token === "-") {
+    // Read token from stdin (e.g. `echo $TOKEN | openclaw models auth paste-token --provider anthropic --token -`)
+    token = await readStdinToken();
+  } else if (opts.token?.trim()) {
+    token = opts.token.trim();
+  } else if (envToken) {
+    token = envToken;
+  } else {
+    if (!process.stdin.isTTY) {
+      throw new Error(
+        "paste-token requires --token <value>, --token - (stdin), or OPENCLAW_PASTE_TOKEN env var in non-interactive environments.",
+      );
+    }
+    const tokenInput = await text({
+      message: `Paste token for ${provider}`,
+      validate: (value) => (value?.trim() ? undefined : "Required"),
+    });
+    token = String(tokenInput ?? "").trim();
+  }
 
   const expires =
     opts.expiresIn?.trim() && opts.expiresIn.trim().length > 0

--- a/src/providers/github-copilot-token.test.ts
+++ b/src/providers/github-copilot-token.test.ts
@@ -72,4 +72,76 @@ describe("github-copilot token", () => {
     expect(res.baseUrl).toBe("https://api.contoso.test");
     expect(saveJsonFile).toHaveBeenCalledTimes(1);
   });
+
+  it("uses Bearer prefix for OAuth tokens (ghu_)", async () => {
+    loadJsonFile.mockReturnValue(undefined);
+
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: "result-token",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    await resolveCopilotApiToken({
+      githubToken: "ghu_abc123",
+      cachePath,
+      loadJsonFileImpl: loadJsonFile,
+      saveJsonFileImpl: saveJsonFile,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const headers = fetchImpl.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe("Bearer ghu_abc123");
+  });
+
+  it("uses token prefix for PATs (github_pat_)", async () => {
+    loadJsonFile.mockReturnValue(undefined);
+
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: "result-token",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    await resolveCopilotApiToken({
+      githubToken: "github_pat_abc123",
+      cachePath,
+      loadJsonFileImpl: loadJsonFile,
+      saveJsonFileImpl: saveJsonFile,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const headers = fetchImpl.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe("token github_pat_abc123");
+  });
+
+  it("uses token prefix for classic PATs (ghp_)", async () => {
+    loadJsonFile.mockReturnValue(undefined);
+
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        token: "result-token",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    await resolveCopilotApiToken({
+      githubToken: "ghp_abc123",
+      cachePath,
+      loadJsonFileImpl: loadJsonFile,
+      saveJsonFileImpl: saveJsonFile,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const headers = fetchImpl.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe("token ghp_abc123");
+  });
 });

--- a/src/providers/github-copilot-token.test.ts
+++ b/src/providers/github-copilot-token.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ENTERPRISE_COPILOT_API_BASE_URL,
   deriveCopilotApiBaseUrlFromToken,
+  isGitHubPAT,
   resolveCopilotApiToken,
 } from "./github-copilot-token.js";
 
@@ -97,19 +99,10 @@ describe("github-copilot token", () => {
     expect(headers.Authorization).toBe("Bearer ghu_abc123");
   });
 
-  it("uses token prefix for PATs (github_pat_)", async () => {
-    loadJsonFile.mockReturnValue(undefined);
+  it("skips token exchange for PATs (github_pat_) and returns direct token", async () => {
+    const fetchImpl = vi.fn();
 
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        token: "result-token",
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
-      }),
-    });
-
-    await resolveCopilotApiToken({
+    const res = await resolveCopilotApiToken({
       githubToken: "github_pat_abc123",
       cachePath,
       loadJsonFileImpl: loadJsonFile,
@@ -117,23 +110,16 @@ describe("github-copilot token", () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    const headers = fetchImpl.mock.calls[0][1].headers;
-    expect(headers.Authorization).toBe("token github_pat_abc123");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(res.token).toBe("github_pat_abc123");
+    expect(res.baseUrl).toBe(ENTERPRISE_COPILOT_API_BASE_URL);
+    expect(res.source).toBe("pat:direct");
   });
 
-  it("uses token prefix for classic PATs (ghp_)", async () => {
-    loadJsonFile.mockReturnValue(undefined);
+  it("skips token exchange for classic PATs (ghp_) and returns direct token", async () => {
+    const fetchImpl = vi.fn();
 
-    const fetchImpl = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        token: "result-token",
-        expires_at: Math.floor(Date.now() / 1000) + 3600,
-      }),
-    });
-
-    await resolveCopilotApiToken({
+    const res = await resolveCopilotApiToken({
       githubToken: "ghp_abc123",
       cachePath,
       loadJsonFileImpl: loadJsonFile,
@@ -141,7 +127,16 @@ describe("github-copilot token", () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    const headers = fetchImpl.mock.calls[0][1].headers;
-    expect(headers.Authorization).toBe("token ghp_abc123");
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(res.token).toBe("ghp_abc123");
+    expect(res.baseUrl).toBe(ENTERPRISE_COPILOT_API_BASE_URL);
+  });
+
+  it("isGitHubPAT detects token types correctly", () => {
+    expect(isGitHubPAT("github_pat_abc")).toBe(true);
+    expect(isGitHubPAT("ghp_abc")).toBe(true);
+    expect(isGitHubPAT("ghu_abc")).toBe(false);
+    expect(isGitHubPAT("gho_abc")).toBe(false);
+    expect(isGitHubPAT("some-random-token")).toBe(false);
   });
 });

--- a/src/providers/github-copilot-token.ts
+++ b/src/providers/github-copilot-token.ts
@@ -54,6 +54,22 @@ function parseCopilotTokenResponse(value: unknown): {
 
 export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com";
 
+/** Enterprise endpoint supports the full model catalogue (Claude, GPT, Gemini). */
+export const ENTERPRISE_COPILOT_API_BASE_URL = "https://api.enterprise.githubcopilot.com";
+
+/** Editor-identification headers required when sending PATs directly to the Copilot API. */
+export const COPILOT_EDITOR_HEADERS = {
+  "User-Agent": "copilot/0.0.410",
+  "Copilot-Integration-Id": "copilot-developer-cli",
+  "Editor-Version": "copilot/0.0.410",
+  "Editor-Plugin-Version": "copilot/0.0.410",
+} as const;
+
+/** Returns true for GitHub PATs (github_pat_ or ghp_) which skip token exchange. */
+export function isGitHubPAT(token: string): boolean {
+  return token.startsWith("github_pat_") || token.startsWith("ghp_");
+}
+
 export function deriveCopilotApiBaseUrlFromToken(token: string): string | null {
   const trimmed = token.trim();
   if (!trimmed) {
@@ -95,6 +111,19 @@ export async function resolveCopilotApiToken(params: {
   const cachePath = params.cachePath?.trim() || resolveCopilotTokenCachePath(env);
   const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;
   const saveJsonFileFn = params.saveJsonFileImpl ?? saveJsonFile;
+
+  // PATs (github_pat_, ghp_) are sent directly to the Copilot API with editor
+  // headers — no /v2/token exchange needed. Use the enterprise endpoint which
+  // exposes the full model catalogue (Claude, GPT, Gemini).
+  if (isGitHubPAT(params.githubToken)) {
+    return {
+      token: params.githubToken,
+      expiresAt: Number.MAX_SAFE_INTEGER,
+      source: "pat:direct",
+      baseUrl: ENTERPRISE_COPILOT_API_BASE_URL,
+    };
+  }
+
   const cached = loadJsonFileFn(cachePath) as CachedCopilotToken | undefined;
   if (cached && typeof cached.token === "string" && typeof cached.expiresAt === "number") {
     if (isTokenUsable(cached)) {
@@ -108,13 +137,11 @@ export async function resolveCopilotApiToken(params: {
   }
 
   const fetchImpl = params.fetchImpl ?? fetch;
-  // PATs (github_pat_, ghp_) use "token" prefix; OAuth tokens (ghu_) use "Bearer".
-  const authPrefix = params.githubToken.startsWith("ghu_") ? "Bearer" : "token";
   const res = await fetchImpl(COPILOT_TOKEN_URL, {
     method: "GET",
     headers: {
       Accept: "application/json",
-      Authorization: `${authPrefix} ${params.githubToken}`,
+      Authorization: `Bearer ${params.githubToken}`,
     },
   });
 

--- a/src/providers/github-copilot-token.ts
+++ b/src/providers/github-copilot-token.ts
@@ -108,11 +108,13 @@ export async function resolveCopilotApiToken(params: {
   }
 
   const fetchImpl = params.fetchImpl ?? fetch;
+  // PATs (github_pat_, ghp_) use "token" prefix; OAuth tokens (ghu_) use "Bearer".
+  const authPrefix = params.githubToken.startsWith("ghu_") ? "Bearer" : "token";
   const res = await fetchImpl(COPILOT_TOKEN_URL, {
     method: "GET",
     headers: {
       Accept: "application/json",
-      Authorization: `Bearer ${params.githubToken}`,
+      Authorization: `${authPrefix} ${params.githubToken}`,
     },
   });
 


### PR DESCRIPTION
## Problem

OpenClaw cannot be deployed in fully automated environments (Terraform, CI/CD, Docker, NVIDIA OpenShell sandboxes) because two critical auth paths require an interactive TTY:

1. **`paste-token` has no `--token` flag** — the command always prompts interactively via `@clack/prompts text()`, with no way to pass the token value non-interactively. The only workaround is manually writing `auth-profiles.json`, but the schema is undocumented and fragile.

2. **`github-copilot` provider rejects PATs with 403** — the token exchange endpoint (`/copilot_internal/v2/token`) only accepts OAuth tokens (`ghu_`). When a PAT (`github_pat_`, `ghp_`) is passed with `Authorization: Bearer ...`, the endpoint returns HTTP 403. The only working path is the interactive device flow (`login-github-copilot`), which requires a browser.

Combined, there is **zero non-interactive path** to configure the Copilot provider — blocking fully automated deployments.

## Context

These issues were discovered while building [Terraform IaC for automated OpenClaw deployment](https://github.com/htekdev/openclaw-repo-management) inside NVIDIA OpenShell sandboxes. The entire stack (EC2/Azure VM → Docker → OpenShell → sandbox → OpenClaw → Telegram) can be automated via `terraform apply` — except Copilot auth, which required manually SSH-ing in.

After 20+ hours of debugging (documented in [session-report.md](https://github.com/htekdev/openclaw-repo-management/blob/main/docs/session-report.md)), we found that:

- PATs **can** call the Copilot API directly — they don't need the `/v2/token` JWT exchange at all
- The [Azure/az-prototype Copilot provider](https://github.com/Azure/az-prototype/blob/main/azext_prototype/ai/copilot_provider.py) confirms this: it sends raw tokens directly to `api.enterprise.githubcopilot.com` with editor-identification headers, no exchange step
- The enterprise endpoint exposes the full model catalogue (Claude, GPT, Gemini) vs the individual endpoint

## Changes

### Fix 1: `paste-token --token` flag (#52321)

**`src/cli/models-cli.ts`** — Added `--token <value>` option to the CLI command

**`src/commands/models/auth.ts`** — Three non-interactive token sources (in priority order):
1. `--token <value>` — direct flag
2. `--token -` — read from stdin (pipe-friendly, token not in process args)
3. `OPENCLAW_PASTE_TOKEN` env var (not visible in `ps`)
4. Falls back to interactive prompt when TTY is available

**`src/commands/models/auth.test.ts`** — 6 new test cases

### Fix 2: PAT auth for github-copilot (#52322)

**`src/providers/github-copilot-token.ts`**:
- `isGitHubPAT()` — detect `github_pat_` / `ghp_` prefixes
- `resolveCopilotApiToken()` — when PAT detected, skip `/v2/token` exchange entirely and return the raw token with the enterprise base URL
- Export `COPILOT_EDITOR_HEADERS` (Copilot-Integration-Id, Editor-Version, Editor-Plugin-Version) — required for PAT auth
- Export `ENTERPRISE_COPILOT_API_BASE_URL` (`api.enterprise.githubcopilot.com`)
- OAuth tokens (`ghu_`) are unchanged — still go through `/v2/token` exchange

**`src/agents/models-config.providers.ts`** — When a PAT is detected, inject `COPILOT_EDITOR_HEADERS` into the provider config so they're sent with every API request

**`src/providers/github-copilot-token.test.ts`** — 4 new test cases

## Usage

```bash
# Automated deployment (Terraform user-data, CI/CD, Docker, OpenShell sandbox)
openclaw models auth paste-token --provider github-copilot --token "$COPILOT_GITHUB_TOKEN"

# Stdin (pipe from secret manager)
vault kv get -field=token secret/copilot | openclaw models auth paste-token --provider github-copilot --token -

# Env var
export OPENCLAW_PASTE_TOKEN="github_pat_..."
openclaw models auth paste-token --provider github-copilot

# Interactive (unchanged)
openclaw models auth paste-token --provider github-copilot
```

## Base

Branched from stable `v2026.3.13-1` — the latest published npm release.

Fixes #52321, fixes #52322