### PR TITLE
fix(exec): return plain-text tool result on failure instead of raw JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - Mattermost/threading: honor `replyToMode: "off"` for already-threaded inbound posts so threaded follow-ups can fall back to top-level replies when configured. (#52543) Thanks @RichardCao.
 - Telegram/replies: set `allow_sending_without_reply` on reply-targeted sends and media-error notices so deleted parent messages no longer drop otherwise valid replies. (#52524) Thanks @moltbot886.
 - Gateway/status: resolve env-backed `gateway.auth.*` SecretRefs before read-only probe auth checks so status no longer reports false probe failures when auth is configured through SecretRef. (#52513) Thanks @CodeForgeNet.
+- Agents/exec: return plain-text failed tool output for timeouts and other non-success exec outcomes so models no longer parrot raw JSON error payloads back to users. (#52508) Thanks @martingarramon.
 - CLI/startup: lazy-load channel add and root help startup paths to trim avoidable RSS and help latency on constrained hosts. (#46784) Thanks @vincentkoc.
 - CLI/onboarding: import static provider definitions directly for onboarding model/config helpers so those paths no longer pull provider discovery just for built-in defaults. (#47467) Thanks @vincentkoc.
 - CLI/configure: clarify fresh-setup memory-search warnings so they say semantic recall needs at least one embedding provider, and scope the initial model allowlist picker to the provider selected in configure. Thanks @vincentkoc.

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -598,7 +598,22 @@ export function createExecTool(
               return;
             }
             if (outcome.status === "failed") {
-              reject(new Error(outcome.reason ?? "Command failed."));
+              const failText = outcome.reason ?? "Command failed.";
+              resolve({
+                content: [
+                  {
+                    type: "text",
+                    text: `${getWarningText()}${failText}`,
+                  },
+                ],
+                details: {
+                  status: "failed",
+                  exitCode: outcome.exitCode ?? null,
+                  durationMs: outcome.durationMs,
+                  aggregated: outcome.aggregated,
+                  cwd: run.session.cwd,
+                },
+              });
               return;
             }
             resolve({

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -462,11 +462,21 @@ describe("exec tool backgrounding", () => {
       allowBackground: false,
     });
     const result = await executeExecCommand(customBash, longDelayCmd);
-    const text = (result as { content: { text: string }[] }).content[0].text;
+    const text = readTextContent(result.content);
     expect(text).toMatch(/timed out/i);
     expect(text).toMatch(/re-run with a higher timeout/i);
-    const details = (result as { details: { status: string } }).details;
-    expect(details.status).toBe("failed");
+    const details = result.details as {
+      status?: string;
+      exitCode?: number | null;
+      durationMs?: number;
+      aggregated?: string;
+    };
+    expect(details).toMatchObject({
+      status: "failed",
+      exitCode: null,
+      aggregated: "",
+    });
+    expect(details.durationMs).toEqual(expect.any(Number));
   });
 
   it.each<DisallowedElevationCase>(DISALLOWED_ELEVATION_CASES)(

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -461,10 +461,12 @@ describe("exec tool backgrounding", () => {
       backgroundMs: 10,
       allowBackground: false,
     });
-    await expect(executeExecCommand(customBash, longDelayCmd)).rejects.toThrow(/timed out/i);
-    await expect(executeExecCommand(customBash, longDelayCmd)).rejects.toThrow(
-      /re-run with a higher timeout/i,
-    );
+    const result = await executeExecCommand(customBash, longDelayCmd);
+    const text = (result as { content: { text: string }[] }).content[0].text;
+    expect(text).toMatch(/timed out/i);
+    expect(text).toMatch(/re-run with a higher timeout/i);
+    const details = (result as { details: { status: string } }).details;
+    expect(details.status).toBe("failed");
   });
 
   it.each<DisallowedElevationCase>(DISALLOWED_ELEVATION_CASES)(


### PR DESCRIPTION
## Problem

When a direct subagent handoff times out via `exec`, the main agent can surface the raw timeout JSON to the user instead of a natural-language response:

```json
{
  "status": "error",
  "tool": "exec",
  "error": "Command timed out after 90 seconds..."
}
```

This happens because the exec tool rejects with an `Error` on failure. The tool adapter in `pi-tool-definition-adapter.ts` catches that rejection and wraps it in a `jsonResult({ status, tool, error })` — which the model receives as structured JSON text and can parrot verbatim.

## Fix

Instead of rejecting on exec failure, resolve with a proper `AgentToolResult` containing the error as plain text in `content[]`, matching the same structure used for successful results. The model now sees human-readable text it can naturally incorporate into its reply.

The `details` object still carries `status: "failed"` so callers that inspect details can distinguish success from failure.

## Testing

Updated the existing timeout test in `bash-tools.test.ts` to verify the new resolved-result shape instead of expecting a rejection. All 27 existing tests pass (`bash-tools.test.ts` + `bash-tools.exec-runtime.test.ts`).

Also fixes a pre-existing `oxfmt` issue in `update-cli.test.ts`.

Fixes #52484


🤖 Generated with [Claude Code](https://claude.com/claude-code)