### PR TITLE
feat(extensions): add openbrain-native MCP plugin extension

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -221,6 +221,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/open-prose/**"
+"extensions: openbrain-native":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/openbrain-native/**"
 "extensions: qwen-portal-auth":
   - changed-files:
       - any-glob-to-any-file:

--- a/extensions/openbrain-native/README.md
+++ b/extensions/openbrain-native/README.md
@@ -1,0 +1,77 @@
+# openbrain-native
+
+Native OpenBrain MCP bridge for OpenClaw.
+
+## Tools exposed
+
+- `openbrain_search`
+- `openbrain_capture`
+- `openbrain_list_recent`
+
+All tools are registered as optional plugin tools.
+
+## Canonical config example
+
+```json5
+plugins: {
+  entries: {
+    "openbrain-native": {
+      enabled: true,
+      config: {
+        // Option A: URL already contains key/query auth
+        url: "https://<supabase>/functions/v1/open-brain-mcp?key=<...>",
+
+        // Option B: bearer token auth
+        // apiKey: "<token>",
+
+        envelopeMode: true,
+        defaultLimit: 8,
+        timeoutMs: 25000
+      }
+    }
+  },
+  allow: ["openbrain-native", "telegram"]
+}
+
+// Profile-safe optional tool enablement
+tools: {
+  profile: "coding",
+  alsoAllow: [
+    "openbrain-native",
+    "openbrain_search",
+    "openbrain_capture",
+    "openbrain_list_recent"
+  ]
+}
+
+agents: {
+  list: [
+    {
+      id: "main",
+      tools: {
+        alsoAllow: [
+          "openbrain-native",
+          "openbrain_search",
+          "openbrain_capture",
+          "openbrain_list_recent"
+        ]
+      }
+    }
+  ]
+}
+```
+
+## Metadata behavior
+
+OpenBrain MCP deployments that only accept `capture_thought({ content })` can still keep category/tag semantics via envelope mode:
+
+```text
+[OBMETA v1]
+category: Decisions
+tags: platform:azure, intent:preflight
+source: openclaw-main
+---
+Complete read-only preflight before any Azure write operation.
+```
+
+Disable with `envelopeMode: false` if your server supports structured metadata directly.

--- a/extensions/openbrain-native/index.ts
+++ b/extensions/openbrain-native/index.ts
@@ -81,22 +81,37 @@ function parseMcpPayload(raw: string): unknown {
     return JSON.parse(trimmed);
   }
 
-  const dataLines = trimmed
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.replace(/^data:\s?/, "").trim())
-    .filter(Boolean)
-    .filter((line) => line !== "[DONE]");
+  const eventBlocks = trimmed
+    .split(/\r?\n\r?\n/)
+    .map((b) => b.trim())
+    .filter(Boolean);
 
-  for (let i = dataLines.length - 1; i >= 0; i -= 1) {
-    const chunk = dataLines[i];
-    if (!chunk.startsWith("{")) continue;
+  const candidates: unknown[] = [];
+  for (const block of eventBlocks) {
+    const dataParts = block
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.replace(/^data:\s?/, ""));
+    if (dataParts.length === 0) continue;
+
+    const dataCombined = dataParts.join("\n").trim();
+    if (!dataCombined || dataCombined === "[DONE]") continue;
+    if (!dataCombined.startsWith("{")) continue;
+
     try {
-      return JSON.parse(chunk);
+      candidates.push(JSON.parse(dataCombined));
     } catch {
-      // keep trying older frames
+      // keep scanning other events
     }
   }
+
+  for (let i = candidates.length - 1; i >= 0; i -= 1) {
+    const c = candidates[i] as { result?: unknown; error?: unknown };
+    if (c && (c.result !== undefined || c.error !== undefined)) {
+      return c;
+    }
+  }
+  if (candidates.length > 0) return candidates[candidates.length - 1];
 
   throw new Error(`OpenBrain MCP returned non-JSON payload: ${trimmed.slice(0, 400)}`);
 }

--- a/extensions/openbrain-native/index.ts
+++ b/extensions/openbrain-native/index.ts
@@ -1,0 +1,334 @@
+// @ts-nocheck
+
+function normalizeTags(raw: unknown): string[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) {
+    return raw
+      .map((v) => (typeof v === "string" ? v.trim() : ""))
+      .filter(Boolean);
+  }
+  if (typeof raw === "string") {
+    return raw
+      .split(",")
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function wrapContentWithEnvelope(content: string, metadata: { category?: string; tags?: string[]; source?: string }) {
+  const lines = ["[OBMETA v1]"];
+  if (metadata.category) lines.push(`category: ${metadata.category}`);
+  if (metadata.tags && metadata.tags.length > 0) lines.push(`tags: ${metadata.tags.join(", ")}`);
+  if (metadata.source) lines.push(`source: ${metadata.source}`);
+  lines.push("---");
+  lines.push(content);
+  return lines.join("\n");
+}
+
+function extractTextFromMcpResult(payload: any): string {
+  const result = payload?.result;
+  if (!result) {
+    return JSON.stringify(payload);
+  }
+  const content = Array.isArray(result.content) ? result.content : [];
+  const textBlocks = content
+    .map((item: any) => {
+      if (!item || typeof item !== "object") return "";
+      if (typeof item.text === "string") return item.text;
+      return "";
+    })
+    .filter(Boolean);
+  if (textBlocks.length > 0) {
+    return textBlocks.join("\n\n");
+  }
+  return JSON.stringify(result, null, 2);
+}
+
+function parseMcpPayload(raw: string): any {
+  const trimmed = (raw || "").trim();
+  if (!trimmed) {
+    throw new Error("OpenBrain MCP returned empty payload");
+  }
+
+  if (trimmed.startsWith("{")) {
+    return JSON.parse(trimmed);
+  }
+
+  const dataLines = trimmed
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.replace(/^data:\s?/, "").trim())
+    .filter(Boolean)
+    .filter((line) => line !== "[DONE]");
+
+  for (let i = dataLines.length - 1; i >= 0; i -= 1) {
+    const chunk = dataLines[i];
+    if (!chunk.startsWith("{")) continue;
+    try {
+      return JSON.parse(chunk);
+    } catch {
+      // continue
+    }
+  }
+
+  throw new Error(`OpenBrain MCP returned non-JSON payload: ${trimmed.slice(0, 400)}`);
+}
+
+async function callMcpTool({
+  url,
+  apiKey,
+  headers,
+  timeoutMs,
+  toolName,
+  args,
+}: {
+  url: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  timeoutMs: number;
+  toolName: string;
+  args: Record<string, unknown>;
+}) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const reqHeaders: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...(headers || {}),
+    };
+
+    if (apiKey && !reqHeaders.Authorization && !reqHeaders.authorization) {
+      reqHeaders.Authorization = `Bearer ${apiKey}`;
+    }
+
+    const body = {
+      jsonrpc: "2.0",
+      id: Date.now(),
+      method: "tools/call",
+      params: {
+        name: toolName,
+        arguments: args,
+      },
+    };
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: reqHeaders,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const raw = await response.text();
+    if (!response.ok) {
+      throw new Error(`OpenBrain MCP HTTP ${response.status}: ${raw.slice(0, 400)}`);
+    }
+
+    let payload: any;
+    try {
+      payload = parseMcpPayload(raw);
+    } catch (e: any) {
+      throw new Error(e?.message || `OpenBrain MCP parse failure: ${raw.slice(0, 400)}`);
+    }
+
+    if (payload?.error) {
+      throw new Error(`OpenBrain MCP tool error: ${JSON.stringify(payload.error)}`);
+    }
+
+    return payload;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const plugin = {
+  id: "openbrain-native",
+  name: "OpenBrain Native",
+  description: "Direct OpenBrain MCP tools without shell wrappers",
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      url: { type: "string" },
+      apiKey: { type: "string" },
+      headers: { type: "object", additionalProperties: { type: "string" } },
+      searchToolName: { type: "string", default: "search_thoughts" },
+      captureToolName: { type: "string", default: "capture_thought" },
+      listToolName: { type: "string", default: "list_thoughts" },
+      defaultLimit: { type: "number", default: 8 },
+      timeoutMs: { type: "number", default: 25000 },
+      envelopeMode: { type: "boolean", default: true },
+    },
+    required: ["url"],
+  },
+
+  register(api: any) {
+    const cfg = {
+      searchToolName: "search_thoughts",
+      captureToolName: "capture_thought",
+      listToolName: "list_thoughts",
+      defaultLimit: 8,
+      timeoutMs: 25000,
+      envelopeMode: true,
+      ...(api.pluginConfig || {}),
+    };
+
+    api.logger.info?.("openbrain-native: registering tools");
+
+    api.registerTool(
+      {
+        name: "openbrain_search",
+        label: "OpenBrain Search",
+        description: "Search OpenBrain semantic memory directly via MCP.",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search query" },
+            limit: { type: "number", description: "Max results" },
+            threshold: { type: "number", description: "Similarity threshold" },
+          },
+          required: ["query"],
+        },
+        async execute(_toolCallId: string, params: any) {
+          const query = String(params?.query || "").trim();
+          if (!query) {
+            return { content: [{ type: "text", text: "query is required" }] };
+          }
+
+          const args: Record<string, unknown> = {
+            query,
+            limit: Number.isFinite(params?.limit) ? Number(params.limit) : cfg.defaultLimit,
+          };
+          if (Number.isFinite(params?.threshold)) {
+            args.threshold = Number(params.threshold);
+          }
+
+          try {
+            const payload = await callMcpTool({
+              url: cfg.url,
+              apiKey: cfg.apiKey,
+              headers: cfg.headers,
+              timeoutMs: Number(cfg.timeoutMs),
+              toolName: String(cfg.searchToolName),
+              args,
+            });
+
+            return {
+              content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
+              details: payload?.result ?? null,
+            };
+          } catch (err: any) {
+            return { content: [{ type: "text", text: `openbrain_search failed: ${err?.message || String(err)}` }] };
+          }
+        },
+      },
+      { optional: true },
+    );
+
+    api.registerTool(
+      {
+        name: "openbrain_capture",
+        label: "OpenBrain Capture",
+        description: "Capture a thought into OpenBrain via MCP.",
+        parameters: {
+          type: "object",
+          properties: {
+            content: { type: "string", description: "Thought content to capture" },
+            category: { type: "string", description: "Optional category label" },
+            tags: {
+              anyOf: [
+                { type: "string", description: "Comma-separated tags" },
+                { type: "array", items: { type: "string" }, description: "Tag array" },
+              ],
+            },
+            source: { type: "string", description: "Optional source label" },
+          },
+          required: ["content"],
+        },
+        async execute(_toolCallId: string, params: any) {
+          const base = String(params?.content || "").trim();
+          if (!base) {
+            return { content: [{ type: "text", text: "content is required" }] };
+          }
+
+          const category = typeof params?.category === "string" ? params.category.trim() : "";
+          const tags = normalizeTags(params?.tags);
+          const source = typeof params?.source === "string" ? params.source.trim() : "";
+
+          const finalContent =
+            cfg.envelopeMode && (category || tags.length > 0 || source)
+              ? wrapContentWithEnvelope(base, { category, tags, source })
+              : base;
+
+          try {
+            const payload = await callMcpTool({
+              url: cfg.url,
+              apiKey: cfg.apiKey,
+              headers: cfg.headers,
+              timeoutMs: Number(cfg.timeoutMs),
+              toolName: String(cfg.captureToolName),
+              args: { content: finalContent },
+            });
+
+            return {
+              content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
+              details: payload?.result ?? null,
+            };
+          } catch (err: any) {
+            return { content: [{ type: "text", text: `openbrain_capture failed: ${err?.message || String(err)}` }] };
+          }
+        },
+      },
+      { optional: true },
+    );
+
+    api.registerTool(
+      {
+        name: "openbrain_list_recent",
+        label: "OpenBrain List Recent",
+        description: "List recent thoughts from OpenBrain.",
+        parameters: {
+          type: "object",
+          properties: {
+            limit: { type: "number" },
+            type: { type: "string" },
+            topic: { type: "string" },
+            person: { type: "string" },
+            days: { type: "number" },
+          },
+        },
+        async execute(_toolCallId: string, params: any) {
+          const args: Record<string, unknown> = {};
+          for (const key of ["limit", "type", "topic", "person", "days"]) {
+            if (params && params[key] !== undefined && params[key] !== null && params[key] !== "") {
+              args[key] = params[key];
+            }
+          }
+          if (args.limit === undefined) args.limit = cfg.defaultLimit;
+
+          try {
+            const payload = await callMcpTool({
+              url: cfg.url,
+              apiKey: cfg.apiKey,
+              headers: cfg.headers,
+              timeoutMs: Number(cfg.timeoutMs),
+              toolName: String(cfg.listToolName),
+              args,
+            });
+
+            return {
+              content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
+              details: payload?.result ?? null,
+            };
+          } catch (err: any) {
+            return { content: [{ type: "text", text: `openbrain_list_recent failed: ${err?.message || String(err)}` }] };
+          }
+        },
+      },
+      { optional: true },
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/openbrain-native/index.ts
+++ b/extensions/openbrain-native/index.ts
@@ -1,4 +1,38 @@
-import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+
+type CaptureParams = {
+  content?: unknown;
+  category?: unknown;
+  tags?: unknown;
+  source?: unknown;
+};
+
+type SearchParams = {
+  query?: unknown;
+  limit?: unknown;
+  threshold?: unknown;
+};
+
+type ListParams = {
+  limit?: unknown;
+  type?: unknown;
+  topic?: unknown;
+  person?: unknown;
+  days?: unknown;
+};
+
+type PluginConfig = {
+  url: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  searchToolName: string;
+  captureToolName: string;
+  listToolName: string;
+  defaultLimit: number;
+  timeoutMs: number;
+  envelopeMode: boolean;
+};
 
 function normalizeTags(raw: unknown): string[] {
   if (!raw) return [];
@@ -26,45 +60,22 @@ function wrapContentWithEnvelope(content: string, metadata: { category?: string;
   return lines.join("\n");
 }
 
-function toErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return String(err);
-}
-
 function extractTextFromMcpResult(payload: unknown): string {
-  if (!payload || typeof payload !== "object") {
+  const result = (payload as { result?: { content?: Array<{ text?: string }> } })?.result;
+  if (!result) {
     return JSON.stringify(payload);
   }
-
-  const result = (payload as { result?: unknown }).result;
-  if (!result || typeof result !== "object") {
-    return JSON.stringify(payload);
-  }
-
-  const content = Array.isArray((result as { content?: unknown }).content)
-    ? ((result as { content?: unknown[] }).content ?? [])
-    : [];
-
+  const content = Array.isArray(result.content) ? result.content : [];
   const textBlocks = content
-    .map((item) => {
-      if (!item || typeof item !== "object") return "";
-      const text = (item as { text?: unknown }).text;
-      return typeof text === "string" ? text : "";
-    })
+    .map((item) => (typeof item?.text === "string" ? item.text : ""))
     .filter(Boolean);
-
-  if (textBlocks.length > 0) {
-    return textBlocks.join("\n\n");
-  }
-
+  if (textBlocks.length > 0) return textBlocks.join("\n\n");
   return JSON.stringify(result, null, 2);
 }
 
 function parseMcpPayload(raw: string): unknown {
-  const trimmed = (raw || "").trim();
-  if (!trimmed) {
-    throw new Error("OpenBrain MCP returned empty payload");
-  }
+  const trimmed = raw.trim();
+  if (!trimmed) throw new Error("OpenBrain MCP returned empty payload");
 
   if (trimmed.startsWith("{")) {
     return JSON.parse(trimmed);
@@ -83,17 +94,12 @@ function parseMcpPayload(raw: string): unknown {
     try {
       return JSON.parse(chunk);
     } catch {
-      // continue
+      // keep trying older frames
     }
   }
 
   throw new Error(`OpenBrain MCP returned non-JSON payload: ${trimmed.slice(0, 400)}`);
 }
-
-type McpPayload = {
-  result?: unknown;
-  error?: unknown;
-};
 
 async function callMcpTool({
   url,
@@ -109,7 +115,7 @@ async function callMcpTool({
   timeoutMs: number;
   toolName: string;
   args: Record<string, unknown>;
-}): Promise<McpPayload> {
+}): Promise<unknown> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -145,20 +151,30 @@ async function callMcpTool({
       throw new Error(`OpenBrain MCP HTTP ${response.status}: ${raw.slice(0, 400)}`);
     }
 
-    const payload = parseMcpPayload(raw);
-    if (!payload || typeof payload !== "object") {
-      throw new Error(`OpenBrain MCP parse failure: ${raw.slice(0, 400)}`);
+    const payload = parseMcpPayload(raw) as { error?: unknown; result?: unknown };
+    if (payload?.error) {
+      throw new Error(`OpenBrain MCP tool error: ${JSON.stringify(payload.error)}`);
     }
 
-    const typedPayload = payload as McpPayload;
-    if (typedPayload.error) {
-      throw new Error(`OpenBrain MCP tool error: ${JSON.stringify(typedPayload.error)}`);
-    }
-
-    return typedPayload;
+    return payload;
   } finally {
     clearTimeout(timer);
   }
+}
+
+function parseConfig(api: OpenClawPluginApi): PluginConfig {
+  const raw = (api.pluginConfig || {}) as Partial<PluginConfig>;
+  return {
+    url: String(raw.url || ""),
+    apiKey: typeof raw.apiKey === "string" ? raw.apiKey : undefined,
+    headers: raw.headers && typeof raw.headers === "object" ? raw.headers : undefined,
+    searchToolName: String(raw.searchToolName || "search_thoughts"),
+    captureToolName: String(raw.captureToolName || "capture_thought"),
+    listToolName: String(raw.listToolName || "list_thoughts"),
+    defaultLimit: Number.isFinite(raw.defaultLimit) ? Number(raw.defaultLimit) : 8,
+    timeoutMs: Number.isFinite(raw.timeoutMs) ? Number(raw.timeoutMs) : 25000,
+    envelopeMode: raw.envelopeMode !== false,
+  };
 }
 
 export default definePluginEntry({
@@ -181,18 +197,8 @@ export default definePluginEntry({
     },
     required: ["url"],
   },
-
   register(api) {
-    const cfg = {
-      searchToolName: "search_thoughts",
-      captureToolName: "capture_thought",
-      listToolName: "list_thoughts",
-      defaultLimit: 8,
-      timeoutMs: 25000,
-      envelopeMode: true,
-      ...(api.pluginConfig || {}),
-    };
-
+    const cfg = parseConfig(api);
     api.logger.info?.("openbrain-native: registering tools");
 
     api.registerTool(
@@ -209,39 +215,31 @@ export default definePluginEntry({
           },
           required: ["query"],
         },
-        async execute(_toolCallId: string, params: Record<string, unknown>) {
+        async execute(_toolCallId: string, params: SearchParams) {
           const query = String(params?.query || "").trim();
-          if (!query) {
-            return { content: [{ type: "text", text: "query is required" }] };
-          }
+          if (!query) return { content: [{ type: "text", text: "query is required" }] };
 
           const args: Record<string, unknown> = {
             query,
-            limit: Number.isFinite(params?.limit) ? Number(params.limit) : cfg.defaultLimit,
+            limit: Number.isFinite(params?.limit as number) ? Number(params?.limit) : cfg.defaultLimit,
           };
-          if (Number.isFinite(params?.threshold)) {
-            args.threshold = Number(params.threshold);
-          }
+          if (Number.isFinite(params?.threshold as number)) args.threshold = Number(params?.threshold);
 
           try {
             const payload = await callMcpTool({
               url: cfg.url,
               apiKey: cfg.apiKey,
               headers: cfg.headers,
-              timeoutMs: Number(cfg.timeoutMs),
-              toolName: String(cfg.searchToolName),
+              timeoutMs: cfg.timeoutMs,
+              toolName: cfg.searchToolName,
               args,
             });
-
-            return {
-              content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
-              details: payload.result ?? null,
-            };
-          } catch (err: unknown) {
-            return { content: [{ type: "text", text: `openbrain_search failed: ${toErrorMessage(err)}` }] };
+            return { content: [{ type: "text", text: extractTextFromMcpResult(payload) }], details: (payload as { result?: unknown })?.result ?? null };
+          } catch (err) {
+            return { content: [{ type: "text", text: `openbrain_search failed: ${err instanceof Error ? err.message : String(err)}` }] };
           }
         },
-      },
+      } as AnyAgentTool,
       { optional: true },
     );
 
@@ -255,48 +253,43 @@ export default definePluginEntry({
           properties: {
             content: { type: "string", description: "Thought content to capture" },
             category: { type: "string", description: "Optional category label" },
-            tags: {
-              type: "string",
-              description: "Comma-separated tags",
-            },
+            tags: { type: "array", items: { type: "string" }, description: "Tag array" },
             source: { type: "string", description: "Optional source label" },
           },
           required: ["content"],
         },
-        async execute(_toolCallId: string, params: Record<string, unknown>) {
+        async execute(_toolCallId: string, params: CaptureParams) {
           const base = String(params?.content || "").trim();
-          if (!base) {
-            return { content: [{ type: "text", text: "content is required" }] };
-          }
+          if (!base) return { content: [{ type: "text", text: "content is required" }] };
 
           const category = typeof params?.category === "string" ? params.category.trim() : "";
           const tags = normalizeTags(params?.tags);
           const source = typeof params?.source === "string" ? params.source.trim() : "";
 
-          const finalContent =
-            cfg.envelopeMode && (category || tags.length > 0 || source)
-              ? wrapContentWithEnvelope(base, { category, tags, source })
-              : base;
+          const args: Record<string, unknown> = cfg.envelopeMode
+            ? { content: wrapContentWithEnvelope(base, { category, tags, source }) }
+            : {
+                content: base,
+                ...(category ? { category } : {}),
+                ...(tags.length > 0 ? { tags } : {}),
+                ...(source ? { source } : {}),
+              };
 
           try {
             const payload = await callMcpTool({
               url: cfg.url,
               apiKey: cfg.apiKey,
               headers: cfg.headers,
-              timeoutMs: Number(cfg.timeoutMs),
-              toolName: String(cfg.captureToolName),
-              args: { content: finalContent },
+              timeoutMs: cfg.timeoutMs,
+              toolName: cfg.captureToolName,
+              args,
             });
-
-            return {
-              content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
-              details: payload.result ?? null,
-            };
-          } catch (err: unknown) {
-            return { content: [{ type: "text", text: `openbrain_capture failed: ${toErrorMessage(err)}` }] };
+            return { content: [{ type: "text", text: extractTextFromMcpResult(payload) }], details: (payload as { result?: unknown })?.result ?? null };
+          } catch (err) {
+            return { content: [{ type: "text", text: `openbrain_capture failed: ${err instanceof Error ? err.message : String(err)}` }] };
           }
         },
-      },
+      } as AnyAgentTool,
       { optional: true },
     );
 
@@ -315,12 +308,11 @@ export default definePluginEntry({
             days: { type: "number" },
           },
         },
-        async execute(_toolCallId: string, params: Record<string, unknown>) {
+        async execute(_toolCallId: string, params: ListParams) {
           const args: Record<string, unknown> = {};
-          for (const key of ["limit", "type", "topic", "person", "days"]) {
-            if (params && params[key] !== undefined && params[key] !== null && params[key] !== "") {
-              args[key] = params[key];
-            }
+          for (const key of ["limit", "type", "topic", "person", "days"] as const) {
+            const value = params?.[key];
+            if (value !== undefined && value !== null && value !== "") args[key] = value;
           }
           if (args.limit === undefined) args.limit = cfg.defaultLimit;
 
@@ -329,20 +321,16 @@ export default definePluginEntry({
               url: cfg.url,
               apiKey: cfg.apiKey,
               headers: cfg.headers,
-              timeoutMs: Number(cfg.timeoutMs),
-              toolName: String(cfg.listToolName),
+              timeoutMs: cfg.timeoutMs,
+              toolName: cfg.listToolName,
               args,
             });
-
-            return {
-              content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
-              details: payload.result ?? null,
-            };
-          } catch (err: unknown) {
-            return { content: [{ type: "text", text: `openbrain_list_recent failed: ${toErrorMessage(err)}` }] };
+            return { content: [{ type: "text", text: extractTextFromMcpResult(payload) }], details: (payload as { result?: unknown })?.result ?? null };
+          } catch (err) {
+            return { content: [{ type: "text", text: `openbrain_list_recent failed: ${err instanceof Error ? err.message : String(err)}` }] };
           }
         },
-      },
+      } as AnyAgentTool,
       { optional: true },
     );
   },

--- a/extensions/openbrain-native/index.ts
+++ b/extensions/openbrain-native/index.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 
 function normalizeTags(raw: unknown): string[] {
   if (!raw) return [];
@@ -26,26 +26,41 @@ function wrapContentWithEnvelope(content: string, metadata: { category?: string;
   return lines.join("\n");
 }
 
-function extractTextFromMcpResult(payload: any): string {
-  const result = payload?.result;
-  if (!result) {
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function extractTextFromMcpResult(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
     return JSON.stringify(payload);
   }
-  const content = Array.isArray(result.content) ? result.content : [];
+
+  const result = (payload as { result?: unknown }).result;
+  if (!result || typeof result !== "object") {
+    return JSON.stringify(payload);
+  }
+
+  const content = Array.isArray((result as { content?: unknown }).content)
+    ? ((result as { content?: unknown[] }).content ?? [])
+    : [];
+
   const textBlocks = content
-    .map((item: any) => {
+    .map((item) => {
       if (!item || typeof item !== "object") return "";
-      if (typeof item.text === "string") return item.text;
-      return "";
+      const text = (item as { text?: unknown }).text;
+      return typeof text === "string" ? text : "";
     })
     .filter(Boolean);
+
   if (textBlocks.length > 0) {
     return textBlocks.join("\n\n");
   }
+
   return JSON.stringify(result, null, 2);
 }
 
-function parseMcpPayload(raw: string): any {
+function parseMcpPayload(raw: string): unknown {
   const trimmed = (raw || "").trim();
   if (!trimmed) {
     throw new Error("OpenBrain MCP returned empty payload");
@@ -75,6 +90,11 @@ function parseMcpPayload(raw: string): any {
   throw new Error(`OpenBrain MCP returned non-JSON payload: ${trimmed.slice(0, 400)}`);
 }
 
+type McpPayload = {
+  result?: unknown;
+  error?: unknown;
+};
+
 async function callMcpTool({
   url,
   apiKey,
@@ -89,7 +109,7 @@ async function callMcpTool({
   timeoutMs: number;
   toolName: string;
   args: Record<string, unknown>;
-}) {
+}): Promise<McpPayload> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -125,24 +145,23 @@ async function callMcpTool({
       throw new Error(`OpenBrain MCP HTTP ${response.status}: ${raw.slice(0, 400)}`);
     }
 
-    let payload: any;
-    try {
-      payload = parseMcpPayload(raw);
-    } catch (e: any) {
-      throw new Error(e?.message || `OpenBrain MCP parse failure: ${raw.slice(0, 400)}`);
+    const payload = parseMcpPayload(raw);
+    if (!payload || typeof payload !== "object") {
+      throw new Error(`OpenBrain MCP parse failure: ${raw.slice(0, 400)}`);
     }
 
-    if (payload?.error) {
-      throw new Error(`OpenBrain MCP tool error: ${JSON.stringify(payload.error)}`);
+    const typedPayload = payload as McpPayload;
+    if (typedPayload.error) {
+      throw new Error(`OpenBrain MCP tool error: ${JSON.stringify(typedPayload.error)}`);
     }
 
-    return payload;
+    return typedPayload;
   } finally {
     clearTimeout(timer);
   }
 }
 
-const plugin = {
+export default definePluginEntry({
   id: "openbrain-native",
   name: "OpenBrain Native",
   description: "Direct OpenBrain MCP tools without shell wrappers",
@@ -163,7 +182,7 @@ const plugin = {
     required: ["url"],
   },
 
-  register(api: any) {
+  register(api) {
     const cfg = {
       searchToolName: "search_thoughts",
       captureToolName: "capture_thought",
@@ -190,7 +209,7 @@ const plugin = {
           },
           required: ["query"],
         },
-        async execute(_toolCallId: string, params: any) {
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
           const query = String(params?.query || "").trim();
           if (!query) {
             return { content: [{ type: "text", text: "query is required" }] };
@@ -216,10 +235,10 @@ const plugin = {
 
             return {
               content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
-              details: payload?.result ?? null,
+              details: payload.result ?? null,
             };
-          } catch (err: any) {
-            return { content: [{ type: "text", text: `openbrain_search failed: ${err?.message || String(err)}` }] };
+          } catch (err: unknown) {
+            return { content: [{ type: "text", text: `openbrain_search failed: ${toErrorMessage(err)}` }] };
           }
         },
       },
@@ -237,16 +256,14 @@ const plugin = {
             content: { type: "string", description: "Thought content to capture" },
             category: { type: "string", description: "Optional category label" },
             tags: {
-              anyOf: [
-                { type: "string", description: "Comma-separated tags" },
-                { type: "array", items: { type: "string" }, description: "Tag array" },
-              ],
+              type: "string",
+              description: "Comma-separated tags",
             },
             source: { type: "string", description: "Optional source label" },
           },
           required: ["content"],
         },
-        async execute(_toolCallId: string, params: any) {
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
           const base = String(params?.content || "").trim();
           if (!base) {
             return { content: [{ type: "text", text: "content is required" }] };
@@ -273,10 +290,10 @@ const plugin = {
 
             return {
               content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
-              details: payload?.result ?? null,
+              details: payload.result ?? null,
             };
-          } catch (err: any) {
-            return { content: [{ type: "text", text: `openbrain_capture failed: ${err?.message || String(err)}` }] };
+          } catch (err: unknown) {
+            return { content: [{ type: "text", text: `openbrain_capture failed: ${toErrorMessage(err)}` }] };
           }
         },
       },
@@ -298,7 +315,7 @@ const plugin = {
             days: { type: "number" },
           },
         },
-        async execute(_toolCallId: string, params: any) {
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
           const args: Record<string, unknown> = {};
           for (const key of ["limit", "type", "topic", "person", "days"]) {
             if (params && params[key] !== undefined && params[key] !== null && params[key] !== "") {
@@ -319,16 +336,14 @@ const plugin = {
 
             return {
               content: [{ type: "text", text: extractTextFromMcpResult(payload) }],
-              details: payload?.result ?? null,
+              details: payload.result ?? null,
             };
-          } catch (err: any) {
-            return { content: [{ type: "text", text: `openbrain_list_recent failed: ${err?.message || String(err)}` }] };
+          } catch (err: unknown) {
+            return { content: [{ type: "text", text: `openbrain_list_recent failed: ${toErrorMessage(err)}` }] };
           }
         },
       },
       { optional: true },
     );
   },
-};
-
-export default plugin;
+});

--- a/extensions/openbrain-native/openclaw.plugin.json
+++ b/extensions/openbrain-native/openclaw.plugin.json
@@ -1,0 +1,73 @@
+{
+  "id": "openbrain-native",
+  "name": "OpenBrain Native",
+  "description": "First-class OpenBrain MCP tools without shell wrappers",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "url": {
+        "type": "string",
+        "description": "OpenBrain MCP HTTP endpoint URL"
+      },
+      "apiKey": {
+        "type": "string",
+        "description": "Optional bearer token if endpoint expects Authorization header"
+      },
+      "headers": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "searchToolName": {
+        "type": "string",
+        "default": "search_thoughts"
+      },
+      "captureToolName": {
+        "type": "string",
+        "default": "capture_thought"
+      },
+      "listToolName": {
+        "type": "string",
+        "default": "list_thoughts"
+      },
+      "defaultLimit": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 100,
+        "default": 8
+      },
+      "timeoutMs": {
+        "type": "number",
+        "minimum": 1000,
+        "maximum": 120000,
+        "default": 25000
+      },
+      "envelopeMode": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true, embeds category/tags/source metadata in a stable OBMETA v1 text envelope for MCP servers that only accept content"
+      }
+    },
+    "required": [
+      "url"
+    ]
+  },
+  "uiHints": {
+    "url": {
+      "label": "OpenBrain MCP URL",
+      "help": "HTTP MCP endpoint for OpenBrain (can include ?key=... if your deployment uses URL keys)",
+      "placeholder": "https://.../open-brain-mcp?key=..."
+    },
+    "apiKey": {
+      "label": "API Key",
+      "sensitive": true,
+      "help": "Optional bearer token for Authorization header"
+    },
+    "envelopeMode": {
+      "label": "Metadata envelope mode",
+      "help": "Enable OBMETA v1 text envelope fallback for servers without structured capture metadata"
+    }
+  }
+}

--- a/extensions/openbrain-native/openclaw.plugin.json
+++ b/extensions/openbrain-native/openclaw.plugin.json
@@ -57,6 +57,7 @@
   "uiHints": {
     "url": {
       "label": "OpenBrain MCP URL",
+      "sensitive": true,
       "help": "HTTP MCP endpoint for OpenBrain (can include ?key=... if your deployment uses URL keys)",
       "placeholder": "https://.../open-brain-mcp?key=..."
     },

--- a/extensions/openbrain-native/package.json
+++ b/extensions/openbrain-native/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Native OpenBrain MCP bridge tools for OpenClaw",
+  "private": true,
   "type": "module",
   "openclaw": {
     "extensions": [

--- a/extensions/openbrain-native/package.json
+++ b/extensions/openbrain-native/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "description": "Native OpenBrain MCP bridge tools for OpenClaw",
-  "private": true,
   "type": "module",
   "openclaw": {
     "extensions": [

--- a/extensions/openbrain-native/package.json
+++ b/extensions/openbrain-native/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@openclaw/openbrain-native",
   "version": "1.0.0",
+  "private": true,
   "description": "Native OpenBrain MCP bridge tools for OpenClaw",
   "type": "module",
   "openclaw": {

--- a/extensions/openbrain-native/package.json
+++ b/extensions/openbrain-native/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@openclaw/openbrain-native",
+  "version": "1.0.0",
+  "description": "Native OpenBrain MCP bridge tools for OpenClaw",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds a new first-class extension at `extensions/openbrain-native/` that exposes OpenBrain memory operations as native OpenClaw tools.

Included:
- `openbrain_search`
- `openbrain_capture`
- `openbrain_list_recent`

This extension calls OpenBrain MCP directly over HTTP JSON-RPC and supports both plain JSON and SSE-framed responses.

## Why
This removes wrapper-chain overhead for in-session usage and provides a cleaner, lower-latency native tool path.

## What was added
- `extensions/openbrain-native/index.ts`
- `extensions/openbrain-native/openclaw.plugin.json`
- `extensions/openbrain-native/package.json`
- `extensions/openbrain-native/README.md`

## Validation
Tested against a live OpenBrain MCP endpoint with:
- tool registration and discovery
- capture/search/list flows
- SSE response parsing behavior
