### PR TITLE
fix(usage): attribute per-channel stats by origin provider, not delivery channel

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -224,11 +224,6 @@ describe("sessions.usage", () => {
 
     try {
       await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
-        const mainSessionsDir = path.join(stateDir, "agents", "main", "sessions");
-        fs.mkdirSync(mainSessionsDir, { recursive: true });
-        fs.writeFileSync(path.join(mainSessionsDir, "s-webchat.jsonl"), "", "utf-8");
-        fs.writeFileSync(path.join(mainSessionsDir, "s-telegram.jsonl"), "", "utf-8");
-
         // Two sessions: webchat origin delivered into a telegram group, and
         // a telegram origin delivered into a webchat group. storeEntry.channel
         // is the delivery target; origin.provider is the originating channel.

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -219,6 +219,91 @@ describe("sessions.usage", () => {
     expect(vi.mocked(loadSessionLogs).mock.calls[0]?.[0]?.agentId).toBe("opus");
   });
 
+  it("attributes per-channel usage by origin.provider, not delivery channel (#52436)", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-channel-"));
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        const mainSessionsDir = path.join(stateDir, "agents", "main", "sessions");
+        fs.mkdirSync(mainSessionsDir, { recursive: true });
+        fs.writeFileSync(path.join(mainSessionsDir, "s-webchat.jsonl"), "", "utf-8");
+        fs.writeFileSync(path.join(mainSessionsDir, "s-telegram.jsonl"), "", "utf-8");
+
+        // Two sessions: webchat origin delivered into a telegram group, and
+        // a telegram origin delivered into a webchat group. storeEntry.channel
+        // is the delivery target; origin.provider is the originating channel.
+        //
+        // discoverAllSessions returns s-main and s-opus (from the top-level mock).
+        // We match those sessionIds in the store so the merge path picks up storeEntry.
+        vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+          storePath: "(multiple)",
+          store: {
+            "webchat-origin-session": {
+              sessionId: "s-main",
+              sessionFile: "s-main.jsonl",
+              updatedAt: 300,
+              channel: "telegram", // delivery channel (wrong for attribution)
+              chatType: "group",
+              origin: { provider: "webchat", chatType: "direct" }, // originating channel
+            },
+            "telegram-origin-session": {
+              sessionId: "s-opus",
+              sessionFile: "s-opus.jsonl",
+              updatedAt: 200,
+              channel: "webchat", // delivery channel (wrong for attribution)
+              chatType: "group",
+              origin: { provider: "telegram", chatType: "direct" }, // originating channel
+            },
+          },
+        });
+
+        vi.mocked(loadSessionCostSummary).mockImplementation(async (params) => {
+          const tokens = params?.sessionId === "s-main" ? 1000 : 500;
+          return {
+            input: tokens,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: tokens,
+            totalCost: tokens * 0.001,
+            inputCost: tokens * 0.001,
+            outputCost: 0,
+            cacheReadCost: 0,
+            cacheWriteCost: 0,
+            missingCostEntries: 0,
+          } as Awaited<ReturnType<typeof loadSessionCostSummary>>;
+        });
+
+        const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+        expect(respond).toHaveBeenCalledTimes(1);
+        expect(respond.mock.calls[0]?.[0]).toBe(true);
+
+        const result = respond.mock.calls[0]?.[1] as {
+          sessions: Array<{ key: string; channel: string; chatType: string }>;
+          aggregates: {
+            byChannel: Array<{ channel: string; totals: { totalTokens: number } }>;
+          };
+        };
+
+        // Per-session channel should reflect origin, not delivery target.
+        const webchatSession = result.sessions.find((s) => s.key === "webchat-origin-session");
+        const telegramSession = result.sessions.find((s) => s.key === "telegram-origin-session");
+        expect(webchatSession?.channel).toBe("webchat");
+        expect(webchatSession?.chatType).toBe("direct");
+        expect(telegramSession?.channel).toBe("telegram");
+        expect(telegramSession?.chatType).toBe("direct");
+
+        // Per-channel aggregate should bucket by origin provider.
+        const webchatBucket = result.aggregates.byChannel.find((c) => c.channel === "webchat");
+        const telegramBucket = result.aggregates.byChannel.find((c) => c.channel === "telegram");
+        expect(webchatBucket?.totals.totalTokens).toBe(1000);
+        expect(telegramBucket?.totals.totalTokens).toBe(500);
+      });
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects traversal-style keys in timeseries/log lookups", async () => {
     const timeseriesRespond = await runSessionsUsageTimeseries({
       key: "agent:opus:../../etc/passwd",

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -615,8 +615,11 @@ export const usageHandlers: GatewayRequestHandlers = {
         aggregateTotals.missingCostEntries += usage.missingCostEntries;
       }
 
-      const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
-      const chatType = merged.storeEntry?.chatType ?? merged.storeEntry?.origin?.chatType;
+      // Origin provider is the channel that *originated* the message; storeEntry.channel
+      // is the delivery/group channel set by deriveGroupSessionPatch. For usage attribution
+      // the originating channel is the correct bucket key (#52436).
+      const channel = merged.storeEntry?.origin?.provider ?? merged.storeEntry?.channel;
+      const chatType = merged.storeEntry?.origin?.chatType ?? merged.storeEntry?.chatType;
 
       if (usage) {
         if (usage.messageCounts) {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,6 +1157,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "google-gemini-cli-auth",
+    idHint: "google-gemini-cli-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/google-gemini-cli-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "google-gemini-cli-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["google-gemini-cli"],
+    },
+  },
+  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1859,6 +1882,29 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
+    },
+  },
+  {
+    dirName: "minimax-portal-auth",
+    idHint: "minimax-portal-auth",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/minimax-portal-auth",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "minimax-portal-auth",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["minimax-portal"],
     },
   },
   {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1157,29 +1157,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
-    dirName: "google-gemini-cli-auth",
-    idHint: "google-gemini-cli-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/google-gemini-cli-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw Gemini CLI OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "google-gemini-cli-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["google-gemini-cli"],
-    },
-  },
-  {
     dirName: "googlechat",
     idHint: "googlechat",
     source: {
@@ -1882,29 +1859,6 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "MiniMax API key",
         },
       ],
-    },
-  },
-  {
-    dirName: "minimax-portal-auth",
-    idHint: "minimax-portal-auth",
-    source: {
-      source: "./index.ts",
-      built: "index.js",
-    },
-    packageName: "@openclaw/minimax-portal-auth",
-    packageVersion: "2026.3.14",
-    packageDescription: "OpenClaw MiniMax Portal OAuth provider plugin",
-    packageManifest: {
-      extensions: ["./index.ts"],
-    },
-    manifest: {
-      id: "minimax-portal-auth",
-      configSchema: {
-        type: "object",
-        additionalProperties: false,
-        properties: {},
-      },
-      providers: ["minimax-portal"],
     },
   },
   {


### PR DESCRIPTION
## Summary

Fixes #52436

The `/usage` dashboard incorrectly attributes per-channel token usage. When a session crosses channel boundaries (e.g., a webchat-originated message delivered into a Telegram group), the usage is bucketed under the **delivery channel** instead of the **originating channel**, causing webchat and Telegram stats to appear swapped.

**Root cause:** `src/gateway/server-methods/usage.ts:610-611` resolves the channel via:

```typescript
const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
```

`storeEntry.channel` is set by `deriveGroupSessionPatch()` and reflects the delivery/group channel. `origin.provider` reflects the originating channel. The nullish coalescing priority is inverted — `origin.provider` should take precedence for usage attribution.

**Fix:** Invert the priority on both `channel` (line 610) and `chatType` (line 611) so `origin.provider`/`origin.chatType` are preferred over `storeEntry.channel`/`storeEntry.chatType`. Total usage is unaffected; only per-channel bucketing changes.

## Changes

- `src/gateway/server-methods/usage.ts`: 2-line fix inverting the nullish coalescing order
- `src/gateway/server-methods/usage.sessions-usage.test.ts`: Regression test seeding two cross-channel sessions and verifying per-channel attribution uses the origin provider

## Test plan

- [x] New regression test: seeds two sessions with swapped `origin.provider` vs `storeEntry.channel`, verifies `aggregates.byChannel` and per-session `channel`/`chatType` reflect the origin
- [x] All existing usage tests pass (`usage.test.ts`, `usage.sessions-usage.test.ts`, `usage-aggregates.test.ts`)