### PR TITLE
CLI: use lightweight probe for daemon status

### DIFF
--- a/src/cli/daemon-cli.coverage.test.ts
+++ b/src/cli/daemon-cli.coverage.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { createCliRuntimeCapture } from "./test-runtime-capture.js";
 
-const callGateway = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
+const probeGatewayStatus = vi.fn(async (..._args: unknown[]) => ({ ok: true }));
 const resolveGatewayProgramArguments = vi.fn(async (_opts?: unknown) => ({
   programArguments: ["/bin/node", "cli", "gateway", "--port", "18789"],
 }));
@@ -35,8 +35,8 @@ const buildGatewayInstallPlan = vi.fn(
 
 const { runtimeLogs, defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
 
-vi.mock("../gateway/call.js", () => ({
-  callGateway: (opts: unknown) => callGateway(opts),
+vi.mock("./daemon-cli/probe.js", () => ({
+  probeGatewayStatus: (opts: unknown) => probeGatewayStatus(opts),
 }));
 
 vi.mock("../gateway/probe-auth.js", () => ({
@@ -143,19 +143,21 @@ describe("daemon-cli coverage", () => {
 
   it("probes gateway status by default", async () => {
     resetRuntimeCapture();
-    callGateway.mockClear();
+    probeGatewayStatus.mockClear();
 
     await runDaemonCommand(["daemon", "status"]);
 
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(callGateway).toHaveBeenCalledWith(expect.objectContaining({ method: "status" }));
+    expect(probeGatewayStatus).toHaveBeenCalledTimes(1);
+    expect(probeGatewayStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "ws://127.0.0.1:18789" }),
+    );
     expect(findExtraGatewayServices).toHaveBeenCalled();
     expect(inspectPortUsage).toHaveBeenCalled();
   });
 
   it("derives probe URL from service args + env (json)", async () => {
     resetRuntimeCapture();
-    callGateway.mockClear();
+    probeGatewayStatus.mockClear();
     inspectPortUsage.mockClear();
 
     serviceReadCommand.mockResolvedValueOnce({
@@ -171,10 +173,9 @@ describe("daemon-cli coverage", () => {
 
     await runDaemonCommand(["daemon", "status", "--json"]);
 
-    expect(callGateway).toHaveBeenCalledWith(
+    expect(probeGatewayStatus).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "ws://127.0.0.1:19001",
-        method: "status",
       }),
     );
     expect(inspectPortUsage).toHaveBeenCalledWith(19001);

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+const probeGatewayMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../gateway/probe.js", () => ({
+  probeGateway: (...args: unknown[]) => probeGatewayMock(...args),
+}));
+
+vi.mock("../progress.js", () => ({
+  withProgress: async (_opts: unknown, fn: () => Promise<unknown>) => await fn(),
+}));
+
+const { probeGatewayStatus } = await import("./probe.js");
+
+describe("probeGatewayStatus", () => {
+  it("uses lightweight token-only probing for daemon status", async () => {
+    probeGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      token: "temp-token",
+      tlsFingerprint: "abc123",
+      timeoutMs: 5_000,
+      json: true,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(probeGatewayMock).toHaveBeenCalledWith({
+      url: "ws://127.0.0.1:19191",
+      auth: {
+        token: "temp-token",
+        password: undefined,
+      },
+      tlsFingerprint: "abc123",
+      timeoutMs: 5_000,
+      includeDetails: false,
+    });
+  });
+
+  it("surfaces probe close details when the handshake fails", async () => {
+    probeGatewayMock.mockResolvedValueOnce({
+      ok: false,
+      error: null,
+      close: { code: 1008, reason: "pairing required" },
+    });
+
+    const result = await probeGatewayStatus({
+      url: "ws://127.0.0.1:19191",
+      timeoutMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "gateway closed (1008): pairing required",
+    });
+  });
+});

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -1,5 +1,4 @@
-import { callGateway } from "../../gateway/call.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
+import { probeGateway } from "../../gateway/probe.js";
 import { withProgress } from "../progress.js";
 
 export async function probeGatewayStatus(opts: {
@@ -12,26 +11,34 @@ export async function probeGatewayStatus(opts: {
   configPath?: string;
 }) {
   try {
-    await withProgress(
+    const result = await withProgress(
       {
         label: "Checking gateway status...",
         indeterminate: true,
         enabled: opts.json !== true,
       },
       async () =>
-        await callGateway({
+        await probeGateway({
           url: opts.url,
-          token: opts.token,
-          password: opts.password,
+          auth: {
+            token: opts.token,
+            password: opts.password,
+          },
           tlsFingerprint: opts.tlsFingerprint,
-          method: "status",
           timeoutMs: opts.timeoutMs,
-          clientName: GATEWAY_CLIENT_NAMES.CLI,
-          mode: GATEWAY_CLIENT_MODES.CLI,
-          ...(opts.configPath ? { configPath: opts.configPath } : {}),
+          includeDetails: false,
         }),
     );
-    return { ok: true } as const;
+    if (result.ok) {
+      return { ok: true } as const;
+    }
+    const closeHint = result.close
+      ? `gateway closed (${result.close.code}): ${result.close.reason}`
+      : null;
+    return {
+      ok: false,
+      error: result.error ?? closeHint ?? "gateway probe failed",
+    } as const;
   } catch (err) {
     return {
       ok: false,

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -81,4 +81,16 @@ describe("probeGateway", () => {
     expect(result.ok).toBe(true);
     expect(gatewayClientState.requests).toEqual([]);
   });
+
+  it("passes through tls fingerprints for secure daemon probes", async () => {
+    await probeGateway({
+      url: "wss://gateway.example/ws",
+      auth: { token: "secret" },
+      tlsFingerprint: "sha256:abc",
+      timeoutMs: 1_000,
+      includeDetails: false,
+    });
+
+    expect(gatewayClientState.options?.tlsFingerprint).toBe("sha256:abc");
+  });
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -34,6 +34,7 @@ export async function probeGateway(opts: {
   auth?: GatewayProbeAuth;
   timeoutMs: number;
   includeDetails?: boolean;
+  tlsFingerprint?: string;
 }): Promise<GatewayProbeResult> {
   const startedAt = Date.now();
   const instanceId = randomUUID();
@@ -65,6 +66,7 @@ export async function probeGateway(opts: {
       url: opts.url,
       token: opts.auth?.token,
       password: opts.auth?.password,
+      tlsFingerprint: opts.tlsFingerprint,
       scopes: [READ_SCOPE],
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       clientVersion: "dev",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw daemon status` was using a full gateway call path for its RPC check instead of the lightweight probe path.
- Why it matters: that could turn a simple daemon-status reachability check into the wrong auth flow and produce misleading handshake failures.
- What changed: daemon status now calls `probeGateway(...)` directly with `includeDetails: false`, and the probe path now accepts a TLS fingerprint so secure daemon probes keep working.
- What did NOT change (scope boundary): this PR does not touch the broader loopback device-identity behavior for generic gateway calls; that overlaps with other open work, especially #51087.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #48360
- Related #48414
- Related #52333
- Related #51087

## User-visible / Behavior Changes

- `openclaw daemon status` now uses the lightweight probe path for its RPC health check instead of a full gateway call.
- Secure daemon probes keep their TLS fingerprint on that path.
- Handshake failures from daemon status now surface probe close details instead of going through the wrong request path.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 on `mb-air`
- Runtime/container: Node 22
- Model/provider: n/a
- Integration/channel (if any): local daemon CLI status path
- Relevant config (redacted): local loopback and TLS-capable daemon probe flows

### Steps

1. Run `openclaw daemon status` against a local daemon-managed gateway.
2. Ensure the status path performs a reachability probe without taking the full gateway call path.
3. For secure targets, ensure the TLS fingerprint is preserved on the probe path.

### Expected

- Daemon status uses the lightweight probe path and reports probe failures accurately.

### Actual

- Verified by targeted regression tests covering the new daemon-status probe helper and TLS-fingerprint passthrough.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - daemon status now calls `probeGateway(...)` with `includeDetails: false`
  - daemon-status probe close details are surfaced cleanly
  - secure daemon probes preserve `tlsFingerprint`
- Edge cases checked:
  - lightweight probe path still skips detail RPCs
  - daemon status test harness now asserts probe URL rather than a full `status` RPC call
- What you did **not** verify:
  - full host-level rollout on prod/dev services in this PR branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR
- Files/config to restore:
  - `src/cli/daemon-cli/probe.ts`
  - `src/gateway/probe.ts`
- Known bad symptoms reviewers should watch for:
  - `daemon status` losing TLS-fingerprint support on secure probes
  - daemon status accidentally reverting to a full gateway request path

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: this only fixes the daemon-status probe surface, not the broader loopback call/probe auth inconsistencies.
  - Mitigation: scope is explicit; related broader fixes stay in separate/open work such as #51087.
