### PR TITLE
fix(ui): remove --prod flag from build dependency install

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -186,7 +186,7 @@ export function main(argv = process.argv.slice(2)) {
   if (!depsInstalled(action === "test" ? "test" : "build")) {
     const installEnv =
       action === "build" ? { ...process.env, NODE_ENV: "production" } : process.env;
-    const installArgs = action === "build" ? ["install", "--prod"] : ["install"];
+    const installArgs = ["install"];
     runSync(runner.cmd, installArgs, installEnv);
   }
 


### PR DESCRIPTION
lobster-biscuit

Closes #52494

## Problem

`pnpm ui:build` fails on a fresh clone with `Cannot find module vite/bin/vite.js`. The build script (`scripts/ui.js:189`) runs `pnpm install --prod` which excludes devDependencies, but `vite` is declared in `devDependencies`.

## Root cause

`scripts/ui.js:189` — `--prod` flag on `pnpm install` for the build action. This was added to optimize install size, but the build command (`vite build`) requires vite as a build tool.

`NODE_ENV=production` (line 188) already optimizes the vite build output — the `--prod` install flag is unnecessary and harmful.

## User impact

Anyone building from source (AUR, Fedora, NixOS, CI) gets a broken build. The UI cannot be compiled at all.

## Fix

Remove `--prod` from the install args. Always run `pnpm install` so build tools are available. 1 file, 1 line.

## How to verify

1. Fresh clone
2. `pnpm install && pnpm ui:build`
3. Before: "Cannot find module vite". After: builds successfully.

## Tests

Build script — no unit test. Verified by running the build command locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)