### PR TITLE
fix(telegram): validate photo dimensions before sendPhoto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/outbound errors: preserve actionable 403 membership/block/kick details and treat `bot not a member` as a permanent delivery failure so Telegram sends stop retrying doomed chats. (#53635) Thanks @w-sss.
 - Telegram/pairing: render pairing codes and approval commands as Telegram-only code blocks while keeping shared pairing replies plain text for other channels. (#52784) Thanks @sumukhj1219.
 - Telegram/native commands: run native slash-command execution against the resolved runtime snapshot so DM commands still reply when fresh config reads surface unresolved SecretRefs. (#53179) Thanks @nimbleenigma.
+- Telegram/photos: preflight Telegram photo dimension and aspect-ratio rules, and fall back to document sends when image metadata is invalid or unavailable so photo uploads stop failing with `PHOTO_INVALID_DIMENSIONS`. (#52545) Thanks @hnshah.
 - Feishu/groups: when `groupPolicy` is `open`, stop implicitly requiring @mentions for unset `requireMention`, so image, file, audio, and other non-text group messages reach the bot unless operators explicitly keep mention gating on. (#54058) Thanks @byungsker.
 
 ## 2026.3.23

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -7,8 +7,7 @@
   "dependencies": {
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
-    "grammy": "^1.41.1",
-    "sharp": "^0.34.5"
+    "grammy": "^1.41.1"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@grammyjs/runner": "^2.0.3",
     "@grammyjs/transformer-throttler": "^1.2.1",
-    "grammy": "^1.41.1"
+    "grammy": "^1.41.1",
+    "sharp": "^0.34.5"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -28,14 +28,11 @@ const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
 
-const { sharp, sharpMetadata } = vi.hoisted(() => ({
-  sharpMetadata: {
+const { imageMetadata } = vi.hoisted(() => ({
+  imageMetadata: {
     width: undefined as number | undefined,
     height: undefined as number | undefined,
   },
-  sharp: vi.fn(() => ({
-    metadata: vi.fn(async () => ({ ...sharpMetadata })),
-  })),
 }));
 
 const { loadConfig } = vi.hoisted(() => ({
@@ -81,17 +78,20 @@ type TelegramSendTestMocks = {
   loadConfig: MockFn;
   loadWebMedia: MockFn;
   maybePersistResolvedTelegramTarget: MockFn;
-  sharp: MockFn;
-  sharpMetadata: { width: number | undefined; height: number | undefined };
+  imageMetadata: { width: number | undefined; height: number | undefined };
 };
 
 vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMedia,
 }));
 
-vi.mock("sharp", () => ({
-  default: sharp,
-}));
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
+  return {
+    ...actual,
+    getImageMetadata: vi.fn(async () => ({ ...imageMetadata })),
+  };
+});
 
 vi.mock("grammy", () => ({
   API_CONSTANTS: {
@@ -151,8 +151,7 @@ export function getTelegramSendTestMocks(): TelegramSendTestMocks {
     loadConfig,
     loadWebMedia,
     maybePersistResolvedTelegramTarget,
-    sharp,
-    sharpMetadata,
+    imageMetadata,
   };
 }
 
@@ -160,9 +159,8 @@ export function installTelegramSendTestHooks() {
   beforeEach(() => {
     loadConfig.mockReturnValue({});
     loadWebMedia.mockReset();
-    sharp.mockClear();
-    sharpMetadata.width = undefined;
-    sharpMetadata.height = undefined;
+    imageMetadata.width = undefined;
+    imageMetadata.height = undefined;
     maybePersistResolvedTelegramTarget.mockReset();
     maybePersistResolvedTelegramTarget.mockResolvedValue(undefined);
     undiciFetch.mockReset();

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -28,6 +28,16 @@ const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
 }));
 
+const { sharp, sharpMetadata } = vi.hoisted(() => ({
+  sharpMetadata: {
+    width: undefined as number | undefined,
+    height: undefined as number | undefined,
+  },
+  sharp: vi.fn(() => ({
+    metadata: vi.fn(async () => ({ ...sharpMetadata })),
+  })),
+}));
+
 const { loadConfig } = vi.hoisted(() => ({
   loadConfig: vi.fn(() => ({})),
 }));
@@ -71,10 +81,16 @@ type TelegramSendTestMocks = {
   loadConfig: MockFn;
   loadWebMedia: MockFn;
   maybePersistResolvedTelegramTarget: MockFn;
+  sharp: MockFn;
+  sharpMetadata: { width: number | undefined; height: number | undefined };
 };
 
 vi.mock("openclaw/plugin-sdk/web-media", () => ({
   loadWebMedia,
+}));
+
+vi.mock("sharp", () => ({
+  default: sharp,
 }));
 
 vi.mock("grammy", () => ({
@@ -129,13 +145,24 @@ vi.mock("./target-writeback.js", () => ({
 }));
 
 export function getTelegramSendTestMocks(): TelegramSendTestMocks {
-  return { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegramTarget };
+  return {
+    botApi,
+    botCtorSpy,
+    loadConfig,
+    loadWebMedia,
+    maybePersistResolvedTelegramTarget,
+    sharp,
+    sharpMetadata,
+  };
 }
 
 export function installTelegramSendTestHooks() {
   beforeEach(() => {
     loadConfig.mockReturnValue({});
     loadWebMedia.mockReset();
+    sharp.mockClear();
+    sharpMetadata.width = undefined;
+    sharpMetadata.height = undefined;
     maybePersistResolvedTelegramTarget.mockReset();
     maybePersistResolvedTelegramTarget.mockResolvedValue(undefined);
     undiciFetch.mockReset();

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -30,8 +30,8 @@ const { loadWebMedia } = vi.hoisted(() => ({
 
 const { imageMetadata } = vi.hoisted(() => ({
   imageMetadata: {
-    width: undefined as number | undefined,
-    height: undefined as number | undefined,
+    width: 1200 as number | undefined,
+    height: 800 as number | undefined,
   },
 }));
 
@@ -159,8 +159,8 @@ export function installTelegramSendTestHooks() {
   beforeEach(() => {
     loadConfig.mockReturnValue({});
     loadWebMedia.mockReset();
-    imageMetadata.width = undefined;
-    imageMetadata.height = undefined;
+    imageMetadata.width = 1200;
+    imageMetadata.height = 800;
     maybePersistResolvedTelegramTarget.mockReset();
     maybePersistResolvedTelegramTarget.mockResolvedValue(undefined);
     undiciFetch.mockReset();

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1094,6 +1094,40 @@ describe("sendMessageTelegram", () => {
     expect(res.messageId).toBe("10");
   });
 
+  it("sends images as documents when metadata dimensions are unavailable", async () => {
+    const chatId = "123";
+    const sendDocument = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: chatId },
+    });
+    const sendPhoto = vi.fn();
+    const api = { sendDocument, sendPhoto } as unknown as {
+      sendDocument: typeof sendDocument;
+      sendPhoto: typeof sendPhoto;
+    };
+
+    imageMetadata.width = undefined;
+    imageMetadata.height = undefined;
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/png",
+      fileName: "photo.png",
+    });
+
+    const res = await sendMessageTelegram(chatId, "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.png",
+    });
+
+    expect(sendDocument).toHaveBeenCalledWith(chatId, expect.anything(), {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(sendPhoto).not.toHaveBeenCalled();
+    expect(res.messageId).toBe("10");
+  });
+
   it("keeps regular document sends on the default Telegram params", async () => {
     const chatId = "123";
     const sendDocument = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -10,8 +10,14 @@ import { clearSentMessageCache, recordSentMessage, wasSentByBot } from "./sent-m
 
 installTelegramSendTestHooks();
 
-const { botApi, botCtorSpy, loadConfig, loadWebMedia, maybePersistResolvedTelegramTarget } =
-  getTelegramSendTestMocks();
+const {
+  botApi,
+  botCtorSpy,
+  loadConfig,
+  loadWebMedia,
+  maybePersistResolvedTelegramTarget,
+  sharpMetadata,
+} = getTelegramSendTestMocks();
 const {
   buildInlineKeyboard,
   createForumTopicTelegram,
@@ -1048,6 +1054,43 @@ describe("sendMessageTelegram", () => {
     });
     expect(sendPhoto, testCase.name).not.toHaveBeenCalled();
     expect(sendAnimation, testCase.name).not.toHaveBeenCalled();
+    expect(res.messageId).toBe("10");
+  });
+
+  it.each([
+    { name: "oversized dimensions", width: 6000, height: 5001 },
+    { name: "oversized aspect ratio", width: 4000, height: 100 },
+  ])("sends images as documents when Telegram rejects $name", async ({ width, height }) => {
+    const chatId = "123";
+    const sendDocument = vi.fn().mockResolvedValue({
+      message_id: 10,
+      chat: { id: chatId },
+    });
+    const sendPhoto = vi.fn();
+    const api = { sendDocument, sendPhoto } as unknown as {
+      sendDocument: typeof sendDocument;
+      sendPhoto: typeof sendPhoto;
+    };
+
+    sharpMetadata.width = width;
+    sharpMetadata.height = height;
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/png",
+      fileName: "photo.png",
+    });
+
+    const res = await sendMessageTelegram(chatId, "caption", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.png",
+    });
+
+    expect(sendDocument).toHaveBeenCalledWith(chatId, expect.anything(), {
+      caption: "caption",
+      parse_mode: "HTML",
+    });
+    expect(sendPhoto).not.toHaveBeenCalled();
     expect(res.messageId).toBe("10");
   });
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -13,10 +13,10 @@ installTelegramSendTestHooks();
 const {
   botApi,
   botCtorSpy,
+  imageMetadata,
   loadConfig,
   loadWebMedia,
   maybePersistResolvedTelegramTarget,
-  sharpMetadata,
 } = getTelegramSendTestMocks();
 const {
   buildInlineKeyboard,
@@ -1072,8 +1072,8 @@ describe("sendMessageTelegram", () => {
       sendPhoto: typeof sendPhoto;
     };
 
-    sharpMetadata.width = width;
-    sharpMetadata.height = height;
+    imageMetadata.width = width;
+    imageMetadata.height = height;
     mockLoadedMedia({
       buffer: Buffer.from("fake-image"),
       contentType: "image/png",

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -15,6 +15,7 @@ import { createTelegramRetryRunner } from "openclaw/plugin-sdk/infra-runtime";
 import type { RetryConfig } from "openclaw/plugin-sdk/infra-runtime";
 import type { MediaKind } from "openclaw/plugin-sdk/media-runtime";
 import { buildOutboundMediaLoadOptions } from "openclaw/plugin-sdk/media-runtime";
+import { getImageMetadata } from "openclaw/plugin-sdk/media-runtime";
 import { isGifMedia, kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/media-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -43,7 +44,6 @@ import {
 } from "./targets.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
 
-type Sharp = typeof import("sharp");
 type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 const InputFileCtor: typeof grammy.InputFile =
@@ -793,11 +793,9 @@ export async function sendMessageTelegram(
 
   async function shouldSendTelegramImageAsPhoto(buffer: Buffer): Promise<boolean> {
     try {
-      const mod = (await import("sharp")) as unknown as { default?: Sharp };
-      const sharp = mod.default ?? (mod as unknown as Sharp);
-      const metadata = await sharp(buffer).metadata();
-      const width = metadata.width;
-      const height = metadata.height;
+      const metadata = await getImageMetadata(buffer);
+      const width = metadata?.width;
+      const height = metadata?.height;
 
       if (typeof width !== "number" || typeof height !== "number") {
         return true;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -43,6 +43,7 @@ import {
 } from "./targets.js";
 import { resolveTelegramVoiceSend } from "./voice.js";
 
+type Sharp = typeof import("sharp");
 type TelegramApi = Bot["api"];
 export type TelegramApiOverride = Partial<TelegramApi>;
 const InputFileCtor: typeof grammy.InputFile =
@@ -788,6 +789,45 @@ export async function sendMessageTelegram(
   const sendChunkedText = async (rawText: string, context: string) =>
     await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
 
+  /**
+   * Validates photo dimensions against Telegram Bot API requirements.
+   * Falls back to sending as document if dimensions are invalid.
+   * 
+   * Telegram photo requirements (as of 2026-03):
+   * - Sum of width + height must not exceed 10,000px
+   * - Both dimensions must be at least 1px (practically minimum ~10x10)
+   * 
+   * @param buffer - Image buffer to validate
+   * @param verbose - Whether to log validation warnings
+   * @returns true if valid for sendPhoto, false if should use sendDocument instead
+   */
+  async function validatePhotoDimensions(
+    buffer: Buffer,
+    verbose?: boolean,
+  ): Promise<boolean> {
+    try {
+      // Dynamic import for sharp (CommonJS module in ESM context)
+      const mod = (await import("sharp")) as unknown as { default?: Sharp };
+      const sharp = mod.default ?? (mod as unknown as Sharp);
+      const instance = sharp(buffer);
+      const metadata = await instance.metadata();
+      const width = metadata.width ?? 0;
+      const height = metadata.height ?? 0;
+
+      if (width + height > 10000) {
+        sendLogger.warn(
+          `Photo dimensions (${width}x${height}) exceed Telegram limit (sum > 10,000px). Sending as document instead.`,
+        );
+        return false;
+      }
+      return true;
+    } catch (err) {
+      // If we can't read dimensions, let Telegram handle it (backward compatible)
+      logVerbose(`Failed to validate photo dimensions: ${formatErrorMessage(err)}`);
+      return true;
+    }
+  }
+
   if (mediaUrl) {
     const media = await loadWebMedia(
       mediaUrl,
@@ -802,6 +842,15 @@ export async function sendMessageTelegram(
       contentType: media.contentType,
       fileName: media.fileName,
     });
+    
+    // Validate photo dimensions before attempting sendPhoto
+    let forceDocumentDueToInvalidDimensions = false;
+    if (kind === "image" && !isGif && !opts.forceDocument) {
+      const isValidPhoto = await validatePhotoDimensions(media.buffer, opts.verbose);
+      if (!isValidPhoto) {
+        forceDocumentDueToInvalidDimensions = true;
+      }
+    }
     const isVideoNote = kind === "video" && opts.asVideoNote === true;
     const fileName =
       media.fileName ?? (isGif ? "animation.gif" : inferFilename(kind ?? "document")) ?? "file";
@@ -858,7 +907,7 @@ export async function sendMessageTelegram(
             ) as Promise<TelegramMessageLike>,
         };
       }
-      if (kind === "image" && !opts.forceDocument) {
+      if (kind === "image" && !opts.forceDocument && !forceDocumentDueToInvalidDimensions) {
         return {
           label: "photo",
           sender: (effectiveParams: Record<string, unknown> | undefined) =>

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -798,7 +798,8 @@ export async function sendMessageTelegram(
       const height = metadata?.height;
 
       if (typeof width !== "number" || typeof height !== "number") {
-        return true;
+        sendLogger.warn("Photo dimensions are unavailable. Sending as document instead.");
+        return false;
       }
 
       const shorterSide = Math.min(width, height);
@@ -816,8 +817,10 @@ export async function sendMessageTelegram(
       }
       return true;
     } catch (err) {
-      logVerbose(`Failed to validate photo dimensions: ${formatErrorMessage(err)}`);
-      return true;
+      sendLogger.warn(
+        `Failed to validate photo dimensions: ${formatErrorMessage(err)}. Sending as document instead.`,
+      );
+      return false;
     }
   }
 

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -55,6 +55,8 @@ const InputFileCtor: typeof grammy.InputFile =
           public readonly fileName?: string,
         ) {}
       } as unknown as typeof grammy.InputFile);
+const MAX_TELEGRAM_PHOTO_DIMENSION_SUM = 10_000;
+const MAX_TELEGRAM_PHOTO_ASPECT_RATIO = 20;
 
 type TelegramSendOpts = {
   cfg?: ReturnType<typeof loadConfig>;
@@ -789,40 +791,33 @@ export async function sendMessageTelegram(
   const sendChunkedText = async (rawText: string, context: string) =>
     await sendTelegramTextChunks(buildChunkedTextPlan(rawText, context), context);
 
-  /**
-   * Validates photo dimensions against Telegram Bot API requirements.
-   * Falls back to sending as document if dimensions are invalid.
-   * 
-   * Telegram photo requirements (as of 2026-03):
-   * - Sum of width + height must not exceed 10,000px
-   * - Both dimensions must be at least 1px (practically minimum ~10x10)
-   * 
-   * @param buffer - Image buffer to validate
-   * @param verbose - Whether to log validation warnings
-   * @returns true if valid for sendPhoto, false if should use sendDocument instead
-   */
-  async function validatePhotoDimensions(
-    buffer: Buffer,
-    verbose?: boolean,
-  ): Promise<boolean> {
+  async function shouldSendTelegramImageAsPhoto(buffer: Buffer): Promise<boolean> {
     try {
-      // Dynamic import for sharp (CommonJS module in ESM context)
       const mod = (await import("sharp")) as unknown as { default?: Sharp };
       const sharp = mod.default ?? (mod as unknown as Sharp);
-      const instance = sharp(buffer);
-      const metadata = await instance.metadata();
-      const width = metadata.width ?? 0;
-      const height = metadata.height ?? 0;
+      const metadata = await sharp(buffer).metadata();
+      const width = metadata.width;
+      const height = metadata.height;
 
-      if (width + height > 10000) {
+      if (typeof width !== "number" || typeof height !== "number") {
+        return true;
+      }
+
+      const shorterSide = Math.min(width, height);
+      const longerSide = Math.max(width, height);
+      const isValidPhoto =
+        width + height <= MAX_TELEGRAM_PHOTO_DIMENSION_SUM &&
+        shorterSide > 0 &&
+        longerSide <= shorterSide * MAX_TELEGRAM_PHOTO_ASPECT_RATIO;
+
+      if (!isValidPhoto) {
         sendLogger.warn(
-          `Photo dimensions (${width}x${height}) exceed Telegram limit (sum > 10,000px). Sending as document instead.`,
+          `Photo dimensions (${width}x${height}) are not valid for Telegram photos. Sending as document instead.`,
         );
         return false;
       }
       return true;
     } catch (err) {
-      // If we can't read dimensions, let Telegram handle it (backward compatible)
       logVerbose(`Failed to validate photo dimensions: ${formatErrorMessage(err)}`);
       return true;
     }
@@ -842,14 +837,11 @@ export async function sendMessageTelegram(
       contentType: media.contentType,
       fileName: media.fileName,
     });
-    
+
     // Validate photo dimensions before attempting sendPhoto
-    let forceDocumentDueToInvalidDimensions = false;
+    let sendImageAsPhoto = true;
     if (kind === "image" && !isGif && !opts.forceDocument) {
-      const isValidPhoto = await validatePhotoDimensions(media.buffer, opts.verbose);
-      if (!isValidPhoto) {
-        forceDocumentDueToInvalidDimensions = true;
-      }
+      sendImageAsPhoto = await shouldSendTelegramImageAsPhoto(media.buffer);
     }
     const isVideoNote = kind === "video" && opts.asVideoNote === true;
     const fileName =
@@ -907,7 +899,7 @@ export async function sendMessageTelegram(
             ) as Promise<TelegramMessageLike>,
         };
       }
-      if (kind === "image" && !opts.forceDocument && !forceDocumentDueToInvalidDimensions) {
+      if (kind === "image" && !opts.forceDocument && sendImageAsPhoto) {
         return {
           label: "photo",
           sender: (effectiveParams: Record<string, unknown> | undefined) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       grammy:
         specifier: ^1.41.1
         version: 1.41.1
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
 
   extensions/tlon:
     dependencies:
@@ -1176,8 +1179,8 @@ packages:
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -7755,7 +7758,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.8.1':
+  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7992,7 +7995,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.9.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -8701,7 +8704,7 @@ snapshots:
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.8.1
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.9.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,9 +589,6 @@ importers:
       grammy:
         specifier: ^1.41.1
         version: 1.41.1
-      sharp:
-        specifier: ^0.34.5
-        version: 0.34.5
 
   extensions/tlon:
     dependencies:


### PR DESCRIPTION
## Problem

Telegram Bot API rejects photos that exceed dimension limits with `PHOTO_INVALID_DIMENSIONS` error (400 Bad Request). This causes message sends to fail completely.

**Real error from production** (OpenClaw 2026.3.13):
```
2026-03-21T18:27:49.960-07:00 [telegram] tool reply failed: 
  GrammyError: Call to 'sendPhoto' failed! 
  (400: Bad Request: PHOTO_INVALID_DIMENSIONS)
```

## Solution

Validate image dimensions **before** calling `sendPhoto`. If dimensions exceed Telegram's limits (width + height > 10,000px), automatically fall back to sending as document instead.

### Changes
- Added dimension validation using existing `sharp` dependency
- Checks image metadata before `sendPhoto` call
- Falls back to `sendDocument` if invalid (preserves image without compression)
- Gracefully degrades if validation fails (backward compatible)

### Technical Details

**Telegram Bot API photo requirements:**
- Sum of width + height must not exceed 10,000 pixels
- Both dimensions must be at least 1px

**Implementation:**
```typescript
async function validatePhotoDimensions(buffer: Buffer): Promise<boolean> {
  const metadata = await sharp(buffer).metadata();
  const width = metadata.width ?? 0;
  const height = metadata.height ?? 0;
  return width + height <= 10000;
}
```

If validation fails → `forceDocumentDueToInvalidDimensions = true` → sends via `sendDocument` instead of crashing.

## Testing

- ✅ Hit this bug in production on OpenClaw 2026.3.13
- ✅ Fix prevents the crash by validating dimensions first
- ✅ Graceful fallback: invalid photos send as documents (no message loss)
- ✅ Uses existing `sharp` dependency (no new deps)

## Impact

**Before:** Invalid photo dimensions → crash → message not sent  
**After:** Invalid photo dimensions → automatic fallback to document → message sent successfully

This is a **dogfooding contribution** - we hit this bug ourselves in daily OpenClaw usage and fixed it with real production data. 🐕