### PR TITLE
fix(cron): skip skills prompt in lightweight cron mode

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.skip-skills.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.skip-skills.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { shouldSkipSkillsPrompt } from "./skip-skills.js";
+
+describe("shouldSkipSkillsPrompt", () => {
+  it("returns true for lightweight cron mode", () => {
+    expect(shouldSkipSkillsPrompt({ contextMode: "lightweight", runKind: "cron" })).toBe(true);
+  });
+
+  it("returns false for full cron mode", () => {
+    expect(shouldSkipSkillsPrompt({ contextMode: "full", runKind: "cron" })).toBe(false);
+  });
+
+  it("returns false for lightweight heartbeat mode (heartbeat may need skills)", () => {
+    expect(shouldSkipSkillsPrompt({ contextMode: "lightweight", runKind: "heartbeat" })).toBe(
+      false,
+    );
+  });
+
+  it("returns false for lightweight default mode", () => {
+    expect(shouldSkipSkillsPrompt({ contextMode: "lightweight", runKind: "default" })).toBe(false);
+  });
+
+  it("returns false when contextMode is undefined", () => {
+    expect(shouldSkipSkillsPrompt({ runKind: "cron" })).toBe(false);
+  });
+
+  it("returns false when runKind is undefined", () => {
+    expect(shouldSkipSkillsPrompt({ contextMode: "lightweight" })).toBe(false);
+  });
+
+  it("returns false when both are undefined", () => {
+    expect(shouldSkipSkillsPrompt({})).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -130,6 +130,7 @@ import {
 } from "./compaction-timeout.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
+import { shouldSkipSkillsPrompt as shouldSkipSkillsPromptFn } from "./skip-skills.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 type PromptBuildHookRunner = {
@@ -788,12 +789,18 @@ export async function runEmbeddedAttempt(
           config: params.config,
         });
 
-    const skillsPrompt = resolveSkillsPromptForRun({
-      skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
-      config: params.config,
-      workspaceDir: effectiveWorkspace,
+    const skipSkillsPrompt = shouldSkipSkillsPromptFn({
+      contextMode: params.bootstrapContextMode,
+      runKind: params.bootstrapContextRunKind,
     });
+    const skillsPrompt = skipSkillsPrompt
+      ? ""
+      : resolveSkillsPromptForRun({
+          skillsSnapshot: params.skillsSnapshot,
+          entries: shouldLoadSkillEntries ? skillEntries : undefined,
+          config: params.config,
+          workspaceDir: effectiveWorkspace,
+        });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =

--- a/src/agents/pi-embedded-runner/run/skip-skills.ts
+++ b/src/agents/pi-embedded-runner/run/skip-skills.ts
@@ -1,0 +1,16 @@
+/**
+ * In lightweight cron mode the bootstrap files are already empty; extend
+ * the same principle to the skills prompt so that simple cron scripts only
+ * pay for the tools and system prompt they actually need.
+ *
+ * Heartbeat runs are excluded because heartbeat prompts commonly instruct
+ * the agent to check skills or perform tasks that require skill awareness.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/7957
+ */
+export function shouldSkipSkillsPrompt(params: {
+  contextMode?: "full" | "lightweight";
+  runKind?: "default" | "heartbeat" | "cron";
+}): boolean {
+  return params.contextMode === "lightweight" && params.runKind === "cron";
+}


### PR DESCRIPTION
## Problem

When `lightContext: true` is set for cron jobs, the bootstrap files (AGENTS.md, SOUL.md, etc.) are correctly stripped via `applyContextModeFilter`. However, the skills prompt—which can contribute thousands of tokens from skill descriptions—is still injected unconditionally.

For users with many installed skills, this means lightweight cron jobs still consume ~29K tokens per run, defeating the purpose of the optimization.

**Relates to #7957** — this implements the skills-prompt portion of the lightweight context request.

## Solution

Extract a `shouldSkipSkillsPrompt()` helper that returns `true` when both:
- `bootstrapContextMode === "lightweight"`
- `bootstrapContextRunKind === "cron"`

When true, the skills prompt is set to an empty string, skipping the `resolveSkillsPromptForRun` call entirely.

**Heartbeat runs are intentionally excluded** because heartbeat prompts commonly instruct the agent to check skills or perform tasks that require skill awareness.

## Changes

- `src/agents/pi-embedded-runner/run/skip-skills.ts` — new module with the `shouldSkipSkillsPrompt` function (zero-dependency, pure logic)
- `src/agents/pi-embedded-runner/run/attempt.ts` — import and use the helper to conditionally skip skills prompt
- `src/agents/pi-embedded-runner/run/attempt.skip-skills.test.ts` — 7 unit tests covering all mode combinations

## Impact

For a cron job with 50+ skills installed, this reduces token usage by several thousand tokens per run when `lightContext` is enabled. The exact savings depend on the number and size of installed skill descriptions.