### PR TITLE
fix(gateway): defer restarts while ACP turns are active [AI-assisted]

### DIFF
--- a/src/gateway/restart-deferral.test.ts
+++ b/src/gateway/restart-deferral.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const hoisted = vi.hoisted(() => {
+  const getActiveEmbeddedRunCountMock = vi.fn(() => 0);
+  const getTotalPendingRepliesMock = vi.fn(() => 0);
+  const getTotalQueueSizeMock = vi.fn(() => 0);
+  const getObservabilitySnapshotMock = vi.fn(() => ({
+    turns: { active: 0, queueDepth: 0 },
+  }));
+
+  return {
+    getActiveEmbeddedRunCountMock,
+    getTotalPendingRepliesMock,
+    getTotalQueueSizeMock,
+    getObservabilitySnapshotMock,
+  };
+});
+
+vi.mock("../agents/pi-embedded-runner/runs.js", () => ({
+  getActiveEmbeddedRunCount: hoisted.getActiveEmbeddedRunCountMock,
+}));
+
+vi.mock("../auto-reply/reply/dispatcher-registry.js", () => ({
+  getTotalPendingReplies: hoisted.getTotalPendingRepliesMock,
+}));
+
+vi.mock("../process/command-queue.js", () => ({
+  getTotalQueueSize: hoisted.getTotalQueueSizeMock,
+}));
+
+vi.mock("../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    getObservabilitySnapshot: hoisted.getObservabilitySnapshotMock,
+  }),
+}));
+
+const { formatGatewayRestartDeferralDetails, getGatewayRestartDeferralCounts } =
+  await import("./restart-deferral.js");
+
+describe("gateway restart deferral counts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getActiveEmbeddedRunCountMock.mockReturnValue(0);
+    hoisted.getTotalPendingRepliesMock.mockReturnValue(0);
+    hoisted.getTotalQueueSizeMock.mockReturnValue(0);
+    hoisted.getObservabilitySnapshotMock.mockReturnValue({
+      turns: { active: 0, queueDepth: 0 },
+    });
+  });
+
+  it("includes ACP turns without double-counting active vs queue depth", () => {
+    hoisted.getTotalQueueSizeMock.mockReturnValue(5);
+    hoisted.getTotalPendingRepliesMock.mockReturnValue(4);
+    hoisted.getActiveEmbeddedRunCountMock.mockReturnValue(3);
+    hoisted.getObservabilitySnapshotMock.mockReturnValue({
+      turns: { active: 1, queueDepth: 2 },
+    });
+
+    const counts = getGatewayRestartDeferralCounts({} as OpenClawConfig);
+
+    expect(counts).toMatchObject({
+      queueSize: 5,
+      pendingReplies: 4,
+      embeddedRuns: 3,
+      acpActiveTurns: 1,
+      acpQueueDepth: 2,
+      acpTurns: 2,
+      totalActive: 14,
+    });
+    expect(formatGatewayRestartDeferralDetails(counts)).toEqual([
+      "5 operation(s)",
+      "4 reply(ies)",
+      "3 embedded run(s)",
+      "2 ACP turn(s)",
+    ]);
+  });
+});

--- a/src/gateway/restart-deferral.ts
+++ b/src/gateway/restart-deferral.ts
@@ -1,0 +1,56 @@
+import { getAcpSessionManager } from "../acp/control-plane/manager.js";
+import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
+import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { getTotalQueueSize } from "../process/command-queue.js";
+
+export type GatewayRestartDeferralCounts = {
+  queueSize: number;
+  pendingReplies: number;
+  embeddedRuns: number;
+  acpActiveTurns: number;
+  acpQueueDepth: number;
+  acpTurns: number;
+  totalActive: number;
+};
+
+export function getGatewayRestartDeferralCounts(cfg: OpenClawConfig): GatewayRestartDeferralCounts {
+  const queueSize = getTotalQueueSize();
+  const pendingReplies = getTotalPendingReplies();
+  const embeddedRuns = getActiveEmbeddedRunCount();
+  const acpSnapshot = getAcpSessionManager().getObservabilitySnapshot(cfg);
+  const acpActiveTurns = acpSnapshot.turns.active;
+  const acpQueueDepth = acpSnapshot.turns.queueDepth;
+  // ACP queueDepth can already include the active turn, so use the higher watermark
+  // instead of double-counting active + queued work.
+  const acpTurns = Math.max(acpActiveTurns, acpQueueDepth);
+
+  return {
+    queueSize,
+    pendingReplies,
+    embeddedRuns,
+    acpActiveTurns,
+    acpQueueDepth,
+    acpTurns,
+    totalActive: queueSize + pendingReplies + embeddedRuns + acpTurns,
+  };
+}
+
+export function formatGatewayRestartDeferralDetails(
+  counts: GatewayRestartDeferralCounts,
+): string[] {
+  const details: string[] = [];
+  if (counts.queueSize > 0) {
+    details.push(`${counts.queueSize} operation(s)`);
+  }
+  if (counts.pendingReplies > 0) {
+    details.push(`${counts.pendingReplies} reply(ies)`);
+  }
+  if (counts.embeddedRuns > 0) {
+    details.push(`${counts.embeddedRuns} embedded run(s)`);
+  }
+  if (counts.acpTurns > 0) {
+    details.push(`${counts.acpTurns} ACP turn(s)`);
+  }
+  return details;
+}

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -47,10 +47,7 @@ vi.mock("./restart-deferral.js", () => ({
 
 const { createGatewayReloadHandlers } = await import("./server-reload-handlers.js");
 
-function createHandlers(logReload: {
-  info: ReturnType<typeof vi.fn>;
-  warn: ReturnType<typeof vi.fn>;
-}) {
+function createHandlers(logReload: Parameters<typeof createGatewayReloadHandlers>[0]["logReload"]) {
   return createGatewayReloadHandlers({
     deps: {} as never,
     broadcast: () => {},
@@ -123,6 +120,7 @@ describe("gateway reload restart deferral", () => {
         restartBrowserControl: false,
         restartCron: false,
         restartHeartbeat: false,
+        restartHealthMonitor: false,
         restartChannels: new Set(),
         noopPaths: [],
       },

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing as restartTesting } from "../infra/restart.js";
+
+const hoisted = vi.hoisted(() => {
+  const countsState = {
+    current: {
+      queueSize: 0,
+      pendingReplies: 0,
+      embeddedRuns: 0,
+      acpActiveTurns: 0,
+      acpQueueDepth: 0,
+      acpTurns: 0,
+      totalActive: 0,
+    },
+  };
+
+  const formatDetails = (counts: typeof countsState.current) => {
+    const details: string[] = [];
+    if (counts.queueSize > 0) {
+      details.push(`${counts.queueSize} operation(s)`);
+    }
+    if (counts.pendingReplies > 0) {
+      details.push(`${counts.pendingReplies} reply(ies)`);
+    }
+    if (counts.embeddedRuns > 0) {
+      details.push(`${counts.embeddedRuns} embedded run(s)`);
+    }
+    if (counts.acpTurns > 0) {
+      details.push(`${counts.acpTurns} ACP turn(s)`);
+    }
+    return details;
+  };
+
+  return {
+    countsState,
+    getGatewayRestartDeferralCountsMock: vi.fn(() => countsState.current),
+    formatGatewayRestartDeferralDetailsMock: vi.fn((counts: typeof countsState.current) =>
+      formatDetails(counts),
+    ),
+  };
+});
+
+vi.mock("./restart-deferral.js", () => ({
+  getGatewayRestartDeferralCounts: hoisted.getGatewayRestartDeferralCountsMock,
+  formatGatewayRestartDeferralDetails: hoisted.formatGatewayRestartDeferralDetailsMock,
+}));
+
+const { createGatewayReloadHandlers } = await import("./server-reload-handlers.js");
+
+function createHandlers(logReload: {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+}) {
+  return createGatewayReloadHandlers({
+    deps: {} as never,
+    broadcast: () => {},
+    getState: () =>
+      ({
+        hooksConfig: {},
+        hookClientIpConfig: {},
+        heartbeatRunner: { updateConfig: () => {} },
+        cronState: { cron: { stop: () => {} } },
+        browserControl: null,
+        channelHealthMonitor: null,
+      }) as never,
+    setState: () => {},
+    startChannel: async () => {},
+    stopChannel: async () => {},
+    logHooks: { info: () => {}, warn: () => {}, error: () => {} },
+    logBrowser: { error: () => {} },
+    logChannels: { info: () => {}, error: () => {} },
+    logCron: { error: () => {} },
+    logReload,
+    createHealthMonitor: () => null as never,
+  });
+}
+
+describe("gateway reload restart deferral", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    restartTesting.resetSigusr1State();
+    hoisted.countsState.current = {
+      queueSize: 0,
+      pendingReplies: 0,
+      embeddedRuns: 0,
+      acpActiveTurns: 0,
+      acpQueueDepth: 0,
+      acpTurns: 0,
+      totalActive: 0,
+    };
+  });
+
+  afterEach(() => {
+    restartTesting.resetSigusr1State();
+    vi.useRealTimers();
+  });
+
+  it("defers config-triggered restart while ACP turns are still active", async () => {
+    hoisted.countsState.current = {
+      queueSize: 0,
+      pendingReplies: 0,
+      embeddedRuns: 0,
+      acpActiveTurns: 1,
+      acpQueueDepth: 1,
+      acpTurns: 1,
+      totalActive: 1,
+    };
+    const logReload = { info: vi.fn(), warn: vi.fn() };
+    const handlers = createHandlers(logReload);
+    const signalSpy = vi.fn();
+    const handler = () => signalSpy();
+    process.once("SIGUSR1", handler);
+
+    handlers.requestGatewayRestart(
+      {
+        changedPaths: ["gateway.port"],
+        restartGateway: true,
+        restartReasons: ["gateway.port"],
+        hotReasons: [],
+        reloadHooks: false,
+        restartGmailWatcher: false,
+        restartBrowserControl: false,
+        restartCron: false,
+        restartHeartbeat: false,
+        restartChannels: new Set(),
+        noopPaths: [],
+      },
+      {},
+    );
+
+    expect(signalSpy).not.toHaveBeenCalled();
+    expect(logReload.warn).toHaveBeenCalledWith(
+      expect.stringContaining("deferring until 1 ACP turn(s) complete"),
+    );
+
+    hoisted.countsState.current = {
+      queueSize: 0,
+      pendingReplies: 0,
+      embeddedRuns: 0,
+      acpActiveTurns: 0,
+      acpQueueDepth: 0,
+      acpTurns: 0,
+      totalActive: 0,
+    };
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(signalSpy).toHaveBeenCalledTimes(1);
+    expect(logReload.info).toHaveBeenCalledWith(
+      "all active work completed; restarting gateway now",
+    );
+  });
+});

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,5 +1,3 @@
-import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
-import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveAgentMaxConcurrent, resolveSubagentMaxConcurrent } from "../config/agent-limits.js";
 import { isRestartEnabled } from "../config/commands.js";
@@ -14,12 +12,16 @@ import {
   emitGatewayRestart,
   setGatewaySigusr1RestartPolicy,
 } from "../infra/restart.js";
-import { setCommandLaneConcurrency, getTotalQueueSize } from "../process/command-queue.js";
+import { setCommandLaneConcurrency } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
 import type { ChannelKind } from "./config-reload-plan.js";
 import type { GatewayReloadPlan } from "./config-reload.js";
 import { resolveHooksConfig } from "./hooks.js";
+import {
+  formatGatewayRestartDeferralDetails,
+  getGatewayRestartDeferralCounts,
+} from "./restart-deferral.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { buildGatewayCronService, type GatewayCronState } from "./server-cron.js";
 import type { HookClientIpConfig } from "./server-http.js";
@@ -177,30 +179,7 @@ export function createGatewayReloadHandlers(params: {
       return;
     }
 
-    const getActiveCounts = () => {
-      const queueSize = getTotalQueueSize();
-      const pendingReplies = getTotalPendingReplies();
-      const embeddedRuns = getActiveEmbeddedRunCount();
-      return {
-        queueSize,
-        pendingReplies,
-        embeddedRuns,
-        totalActive: queueSize + pendingReplies + embeddedRuns,
-      };
-    };
-    const formatActiveDetails = (counts: ReturnType<typeof getActiveCounts>) => {
-      const details = [];
-      if (counts.queueSize > 0) {
-        details.push(`${counts.queueSize} operation(s)`);
-      }
-      if (counts.pendingReplies > 0) {
-        details.push(`${counts.pendingReplies} reply(ies)`);
-      }
-      if (counts.embeddedRuns > 0) {
-        details.push(`${counts.embeddedRuns} embedded run(s)`);
-      }
-      return details;
-    };
+    const getActiveCounts = () => getGatewayRestartDeferralCounts(nextConfig);
     const active = getActiveCounts();
 
     if (active.totalActive > 0) {
@@ -212,7 +191,7 @@ export function createGatewayReloadHandlers(params: {
         return;
       }
       restartPending = true;
-      const initialDetails = formatActiveDetails(active);
+      const initialDetails = formatGatewayRestartDeferralDetails(active);
       params.logReload.warn(
         `config change requires gateway restart (${reasons}) — deferring until ${initialDetails.join(", ")} complete`,
       );
@@ -223,10 +202,10 @@ export function createGatewayReloadHandlers(params: {
         hooks: {
           onReady: () => {
             restartPending = false;
-            params.logReload.info("all operations and replies completed; restarting gateway now");
+            params.logReload.info("all active work completed; restarting gateway now");
           },
           onTimeout: (_pending, elapsedMs) => {
-            const remaining = formatActiveDetails(getActiveCounts());
+            const remaining = formatGatewayRestartDeferralDetails(getActiveCounts());
             restartPending = false;
             params.logReload.warn(
               `restart timeout after ${elapsedMs}ms with ${remaining.join(", ")} still active; restarting anyway`,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,9 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
-import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -55,7 +53,6 @@ import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
-import { getTotalQueueSize } from "../process/command-queue.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { CommandSecretAssignment } from "../secrets/command-config.js";
 import {
@@ -83,6 +80,7 @@ import {
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { startGatewayModelPricingRefresh } from "./model-pricing-cache.js";
 import { NodeRegistry } from "./node-registry.js";
+import { getGatewayRestartDeferralCounts } from "./restart-deferral.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import {
@@ -513,10 +511,9 @@ export async function startGatewayServer(
   if (diagnosticsEnabled) {
     startDiagnosticHeartbeat();
   }
+  let activeConfig = cfgAtStart;
   setGatewaySigusr1RestartPolicy({ allowExternal: isRestartEnabled(cfgAtStart) });
-  setPreRestartDeferralCheck(
-    () => getTotalQueueSize() + getTotalPendingReplies() + getActiveEmbeddedRunCount(),
-  );
+  setPreRestartDeferralCheck(() => getGatewayRestartDeferralCounts(activeConfig).totalActive);
   // Unconditional startup migration: seed gateway.controlUi.allowedOrigins for existing
   // non-loopback installs that upgraded to v2026.2.26+ without required origins.
   cfgAtStart = await maybeSeedControlUiAllowedOriginsAtStartup({
@@ -1278,6 +1275,7 @@ export async function startGatewayServer(
             });
             try {
               await applyHotReload(plan, prepared.config);
+              activeConfig = prepared.config;
             } catch (err) {
               if (previousSnapshot) {
                 activateSecretsRuntimeSnapshot(previousSnapshot);


### PR DESCRIPTION
## Summary
- include ACP turns in gateway restart deferral counts so config-triggered reloads wait for active ACP work
- reuse a shared restart-deferral counter/formatter in both the config watcher and direct SIGUSR1 deferral path
- add focused regression coverage for ACP-aware deferral and count formatting
## Testing
- F:\openclaw\node_modules\.bin\vitest.cmd run --config vitest.gateway.config.ts src/gateway/restart-deferral.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-restart-deferral.test.ts
## Notes
- AI-assisted: Codex
- lightly tested
Fixes #52440