### PR TITLE
fix: suppress reminder guard for sweep-backed reminders

### DIFF
--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -1,4 +1,5 @@
 import { loadCronStore, resolveCronStorePath } from "../../cron/store.js";
+import type { CronJob } from "../../cron/types.js";
 import type { ReplyPayload } from "../types.js";
 
 export const UNSCHEDULED_REMINDER_NOTE =
@@ -20,10 +21,28 @@ export function hasUnbackedReminderCommitment(text: string): boolean {
   return REMINDER_COMMITMENT_PATTERNS.some((pattern) => pattern.test(text));
 }
 
+function isReminderSweepLikeCronJob(job: CronJob): boolean {
+  if (!job.enabled || job.payload.kind !== "agentTurn") {
+    return false;
+  }
+  const haystack = [job.name, job.payload.message]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join("\n")
+    .toLowerCase();
+  if (!haystack) {
+    return false;
+  }
+  return /(remind(?:er)?|sweep|due reminders?|check reminders?)/i.test(haystack);
+}
+
 /**
- * Returns true when the cron store has at least one enabled job that shares the
- * current session key. Used to suppress the "no reminder scheduled" guard note
- * when an existing cron (created in a prior turn) already covers the commitment.
+ * Returns true when the cron store has an enabled job that likely backs a
+ * reminder promise made in the current turn.
+ *
+ * We suppress the guard note in two cases:
+ * 1. a cron job shares the current session key (existing behavior), or
+ * 2. an enabled isolated agent cron already looks like a reminder sweep job,
+ *    which covers agent-persisted reminder architectures (#52528).
  */
 export async function hasSessionRelatedCronJobs(params: {
   cronStorePath?: string;
@@ -35,10 +54,13 @@ export async function hasSessionRelatedCronJobs(params: {
     if (store.jobs.length === 0) {
       return false;
     }
-    if (params.sessionKey) {
-      return store.jobs.some((job) => job.enabled && job.sessionKey === params.sessionKey);
+    if (
+      params.sessionKey &&
+      store.jobs.some((job) => job.enabled && job.sessionKey === params.sessionKey)
+    ) {
+      return true;
     }
-    return false;
+    return store.jobs.some((job) => isReminderSweepLikeCronJob(job));
   } catch {
     // If we cannot read the cron store, do not suppress the note.
     return false;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1485,6 +1485,37 @@ describe("runReplyAgent reminder commitment guard", () => {
     });
   });
 
+  it("suppresses guard note when an enabled reminder sweep cron exists for another session", async () => {
+    loadCronStoreMock.mockResolvedValueOnce({
+      version: 1,
+      jobs: [
+        {
+          id: "reminder-sweep",
+          name: "family-reminder sweep",
+          enabled: true,
+          sessionTarget: "isolated",
+          payload: { kind: "agentTurn", message: "check due reminders and deliver them" },
+          delivery: { mode: "announce" },
+          sessionKey: "other-session",
+          createdAtMs: Date.now() - 60_000,
+          updatedAtMs: Date.now() - 60_000,
+          state: {},
+        },
+      ],
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "I'll remind you tomorrow morning." }],
+      meta: {},
+      successfulCronAdds: 0,
+    });
+
+    const result = await createRun();
+    expect(result).toMatchObject({
+      text: "I'll remind you tomorrow morning.",
+    });
+  });
+
   it("still appends guard note when cron jobs for session exist but are disabled", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,


### PR DESCRIPTION
## Summary
- suppress the unscheduled reminder disclaimer when an enabled isolated cron already looks like a reminder sweep
- keep the existing session-key suppression behavior unchanged
- add a regression test covering agent-persisted reminders handled by a separate sweep job

Fixes #52528

## Notes
This targets reminder architectures where reminders are persisted to agent-owned storage and later delivered by an existing recurring cron job, rather than by calling `cron.add` for each reminder.
