### PR TITLE
fix(fs): route FreeBSD writes through legacy fallback

### DIFF
--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -551,7 +551,7 @@ export async function writeFileWithinRoot(params: {
   encoding?: BufferEncoding;
   mkdir?: boolean;
 }): Promise<void> {
-  if (process.platform === "win32") {
+  if (process.platform === "win32" || process.platform === "freebsd") {
     await writeFileWithinRootLegacy(params);
     return;
   }
@@ -608,7 +608,7 @@ export async function copyFileWithinRoot(params: {
   }
 
   try {
-    if (process.platform === "win32") {
+    if (process.platform === "win32" || process.platform === "freebsd") {
       await copyFileWithinRootLegacy(params, source);
       return;
     }


### PR DESCRIPTION
## Summary

- **Problem:** On FreeBSD, file write/copy operations can fail during post-write verification when they go through the Python-helper-based pinned-write path.
- **Why it matters:** This can trigger `SafeOpenError: path mismatch` and break real workflows such as `openclaw plugins install` in affected FreeBSD environments.
- **What changed:** On FreeBSD, route `writeFileWithinRoot` and `copyFileWithinRoot` through the existing legacy fallback path, matching the existing Windows behavior.
- **Why this approach:** This reuses an existing code path already present in the codebase and keeps the workaround scoped to the affected platform/path instead of changing shared file identity verification semantics.
- **What did NOT change (scope boundary):** This does not change `sameFileIdentity`, does not introduce a broader `BigInt` / 64-bit stat refactor, and does not alter file verification behavior on other platforms.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`None` directly. This is an underlying compatibility fix; users on affected FreeBSD environments should stop seeing unexpected `SafeOpenError: path mismatch` failures during file operations such as plugin installation.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

Note: This change reuses an existing legacy fallback path on FreeBSD rather than changing shared file identity verification semantics.

## Repro + Verification

### Environment

- OS: FreeBSD 15.0-RELEASE-p4
- Runtime/container: ZFS Jail
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Node.js runtime

### Steps

1. Install OpenClaw inside a FreeBSD ZFS jail environment.
2. Trigger a workflow that performs file writes/copies followed by post-write verification (for example, `openclaw plugins install`).
3. Observe whether execution fails with filesystem verification errors.

### Expected

- File operations complete successfully without `SafeOpenError: path mismatch`.

### Actual

- Before this fix, the Python-helper-based path could fail with:

```
16:03:57 [security] fs-safe write boundary warning (post-copy verification failed: SafeOpenError: path changed during write)
failed to extract archive: SafeOpenError: path changed during write
Failed to install plugin from npm.
Error: Command failed: openclaw plugins install ...
```

### Evidence

Attach at least one:
* Trace/log snippets

The failure reproduces on the Python-helper-based write/copy path in our FreeBSD/ZFS jail environment and disappears when routing through the existing legacy fallback path instead.

<details>
<summary>Additional diagnostic context</summary>

```python
>>> import os
>>> os.stat("/etc/passwd")
os.stat_result(st_mode=33188, st_ino=296605, st_dev=-6692299710746245206, st_nlink=1, st_uid=0, st_gid=0, st_size=2229, st_atime=1773319168, st_mtime=1773319168, st_ctime=1773319168)
```
</details>