### PR TITLE
feat(web-search): add Exa as bundled web search plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - Agents: add per-agent thinking/reasoning/fast defaults and auto-revert disallowed model overrides to the agent's default selection. Thanks @xuanmingguo and @vincentkoc.
 - Control UI/usage: drop the empty session-detail placeholder card so the usage view stays single-column until a real session detail panel is selected. (#52013) Thanks @BunsDev.
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
+- Web tools/Exa: add Exa as a bundled web-search plugin with Exa-native date filters, search-mode selection, and optional content extraction under `plugins.entries.exa.config.webSearch.*`. Thanks @V-Gutierrez and @vincentkoc.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
 
 ### Fixes

--- a/extensions/exa/index.test.ts
+++ b/extensions/exa/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+describe("exa plugin", () => {
+  it("registers the web search provider", () => {
+    const registrations: { webSearchProviders: unknown[] } = { webSearchProviders: [] };
+
+    const mockApi = {
+      registerWebSearchProvider(provider: unknown) {
+        registrations.webSearchProviders.push(provider);
+      },
+      config: {},
+    };
+
+    plugin.register(mockApi as never);
+
+    expect(plugin.id).toBe("exa");
+    expect(plugin.name).toBe("Exa Plugin");
+    expect(registrations.webSearchProviders).toHaveLength(1);
+
+    const provider = registrations.webSearchProviders[0] as Record<string, unknown>;
+    expect(provider.id).toBe("exa");
+    expect(provider.autoDetectOrder).toBe(65);
+    expect(provider.envVars).toEqual(["EXA_API_KEY"]);
+  });
+});

--- a/extensions/exa/index.ts
+++ b/extensions/exa/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createExaWebSearchProvider } from "./src/exa-web-search-provider.js";
+
+export default definePluginEntry({
+  id: "exa",
+  name: "Exa Plugin",
+  description: "Bundled Exa web search plugin",
+  register(api) {
+    api.registerWebSearchProvider(createExaWebSearchProvider());
+  },
+});

--- a/extensions/exa/openclaw.plugin.json
+++ b/extensions/exa/openclaw.plugin.json
@@ -1,0 +1,29 @@
+{
+  "id": "exa",
+  "providerAuthEnvVars": {
+    "exa": ["EXA_API_KEY"]
+  },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Exa API Key",
+      "help": "Exa Search API key (fallback: EXA_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "exa-..."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/exa-plugin",
+  "version": "2026.3.22",
+  "private": true,
+  "description": "OpenClaw Exa plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { __testing, createExaWebSearchProvider } from "./exa-web-search-provider.js";
+
+describe("exa web search provider", () => {
+  it("exposes the expected metadata and selection wiring", () => {
+    const provider = createExaWebSearchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.id).toBe("exa");
+    expect(provider.credentialPath).toBe("plugins.entries.exa.config.webSearch.apiKey");
+    expect(applied.plugins?.entries?.exa?.enabled).toBe(true);
+  });
+
+  it("prefers scoped configured api keys over environment fallbacks", () => {
+    expect(__testing.resolveExaApiKey({ apiKey: "exa-secret" })).toBe("exa-secret");
+  });
+
+  it("normalizes Exa result descriptions from highlights before text", () => {
+    expect(
+      __testing.resolveExaDescription({
+        highlights: ["first", "", "second"],
+        text: "full text",
+      }),
+    ).toBe("first\nsecond");
+    expect(__testing.resolveExaDescription({ text: "full text" })).toBe("full text");
+  });
+
+  it("handles month freshness without date overflow", () => {
+    const iso = __testing.resolveFreshnessStartDate("month");
+    expect(Number.isNaN(Date.parse(iso))).toBe(false);
+  });
+
+  it("returns validation errors for conflicting time filters", async () => {
+    const provider = createExaWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: { exa: { apiKey: "exa-secret" } },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    const result = await tool.execute({
+      query: "latest gpu news",
+      freshness: "day",
+      date_after: "2026-03-01",
+    });
+
+    expect(result).toMatchObject({
+      error: "conflicting_time_filters",
+    });
+  });
+});

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -1,0 +1,420 @@
+import { Type } from "@sinclair/typebox";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  enablePluginInConfig,
+  getScopedCredentialValue,
+  MAX_SEARCH_COUNT,
+  mergeScopedSearchConfig,
+  normalizeFreshness,
+  normalizeToIsoDate,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  setProviderWebSearchPluginConfigValue,
+  setScopedCredentialValue,
+  type SearchConfigRecord,
+  type WebSearchProviderPlugin,
+  type WebSearchProviderToolDefinition,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+const EXA_SEARCH_ENDPOINT = "https://api.exa.ai/search";
+const EXA_SEARCH_TYPES = ["auto", "keyword", "neural"] as const;
+const EXA_FRESHNESS_VALUES = ["day", "week", "month", "year"] as const;
+
+type ExaConfig = {
+  apiKey?: string;
+};
+
+type ExaSearchType = (typeof EXA_SEARCH_TYPES)[number];
+
+type ExaContentsArgs = {
+  highlights?: boolean;
+  text?: boolean;
+};
+
+type ExaSearchResult = {
+  title?: unknown;
+  url?: unknown;
+  publishedDate?: unknown;
+  highlights?: unknown;
+  text?: unknown;
+};
+
+type ExaSearchResponse = {
+  results?: unknown;
+};
+
+function optionalStringEnum<T extends readonly string[]>(values: T, description: string) {
+  return Type.Optional(
+    Type.Unsafe<T[number]>({
+      type: "string",
+      enum: [...values],
+      description,
+    }),
+  );
+}
+
+function resolveExaConfig(searchConfig?: SearchConfigRecord): ExaConfig {
+  const exa = searchConfig?.exa;
+  return exa && typeof exa === "object" && !Array.isArray(exa) ? (exa as ExaConfig) : {};
+}
+
+function resolveExaApiKey(exa?: ExaConfig): string | undefined {
+  return (
+    readConfiguredSecretString(exa?.apiKey, "tools.web.search.exa.apiKey") ??
+    readProviderEnvValue(["EXA_API_KEY"])
+  );
+}
+
+function resolveExaDescription(result: ExaSearchResult): string {
+  const highlights = result.highlights;
+  if (Array.isArray(highlights)) {
+    const highlightText = highlights
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter(Boolean)
+      .join("\n");
+    if (highlightText) {
+      return highlightText;
+    }
+  }
+  return typeof result.text === "string" ? result.text.trim() : "";
+}
+
+function normalizeExaResults(payload: unknown): ExaSearchResult[] {
+  if (!payload || typeof payload !== "object") {
+    return [];
+  }
+  const results = (payload as ExaSearchResponse).results;
+  if (!Array.isArray(results)) {
+    return [];
+  }
+  return results.filter((entry): entry is ExaSearchResult =>
+    Boolean(entry && typeof entry === "object" && !Array.isArray(entry)),
+  );
+}
+
+function resolveFreshnessStartDate(freshness: (typeof EXA_FRESHNESS_VALUES)[number]): string {
+  const now = new Date();
+  if (freshness === "day") {
+    now.setUTCDate(now.getUTCDate() - 1);
+    return now.toISOString();
+  }
+  if (freshness === "week") {
+    now.setUTCDate(now.getUTCDate() - 7);
+    return now.toISOString();
+  }
+  if (freshness === "month") {
+    const currentDay = now.getUTCDate();
+    now.setUTCDate(1);
+    now.setUTCMonth(now.getUTCMonth() - 1);
+    const lastDayOfTargetMonth = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0),
+    ).getUTCDate();
+    now.setUTCDate(Math.min(currentDay, lastDayOfTargetMonth));
+    return now.toISOString();
+  }
+  now.setUTCFullYear(now.getUTCFullYear() - 1);
+  return now.toISOString();
+}
+
+async function runExaSearch(params: {
+  apiKey: string;
+  query: string;
+  count: number;
+  freshness?: (typeof EXA_FRESHNESS_VALUES)[number];
+  dateAfter?: string;
+  dateBefore?: string;
+  type: ExaSearchType;
+  contents?: ExaContentsArgs;
+  timeoutSeconds: number;
+}): Promise<ExaSearchResult[]> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    numResults: params.count,
+    type: params.type,
+    contents: params.contents ?? { highlights: true },
+  };
+
+  if (params.dateAfter) {
+    body.startPublishedDate = params.dateAfter;
+  } else if (params.freshness) {
+    body.startPublishedDate = resolveFreshnessStartDate(params.freshness);
+  }
+  if (params.dateBefore) {
+    body.endPublishedDate = params.dateBefore;
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: EXA_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "x-api-key": params.apiKey,
+          "x-exa-integration": "openclaw",
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(`Exa API error (${res.status}): ${detail || res.statusText}`);
+      }
+      try {
+        return normalizeExaResults(await res.json());
+      } catch (error) {
+        throw new Error(`Exa API returned invalid JSON: ${String(error)}`, { cause: error });
+      }
+    },
+  );
+}
+
+function createExaSchema() {
+  return Type.Object(
+    {
+      query: Type.String({ description: "Search query string." }),
+      count: Type.Optional(
+        Type.Number({
+          description: "Number of results to return (1-10).",
+          minimum: 1,
+          maximum: MAX_SEARCH_COUNT,
+        }),
+      ),
+      freshness: optionalStringEnum(
+        EXA_FRESHNESS_VALUES,
+        'Filter by time: "day", "week", "month", or "year".',
+      ),
+      date_after: Type.Optional(
+        Type.String({
+          description: "Only results published after this date (YYYY-MM-DD).",
+        }),
+      ),
+      date_before: Type.Optional(
+        Type.String({
+          description: "Only results published before this date (YYYY-MM-DD).",
+        }),
+      ),
+      type: optionalStringEnum(
+        EXA_SEARCH_TYPES,
+        'Exa search mode: "auto", "keyword", or "neural".',
+      ),
+      contents: Type.Optional(
+        Type.Object(
+          {
+            highlights: Type.Optional(
+              Type.Boolean({ description: "Include Exa highlights in results." }),
+            ),
+            text: Type.Optional(Type.Boolean({ description: "Include full text in results." })),
+          },
+          { additionalProperties: false },
+        ),
+      ),
+    },
+    { additionalProperties: false },
+  );
+}
+
+function missingExaKeyPayload() {
+  return {
+    error: "missing_exa_api_key",
+    message:
+      "web_search (exa) needs an Exa API key. Set EXA_API_KEY in the Gateway environment, or configure tools.web.search.exa.apiKey.",
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
+}
+
+function createExaToolDefinition(
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  return {
+    description:
+      "Search the web using Exa AI. Supports neural or keyword search, publication date filters, and optional highlights or text extraction.",
+    parameters: createExaSchema(),
+    execute: async (args) => {
+      const params = args as Record<string, unknown>;
+      const exaConfig = resolveExaConfig(searchConfig);
+      const apiKey = resolveExaApiKey(exaConfig);
+      if (!apiKey) {
+        return missingExaKeyPayload();
+      }
+
+      const query = readStringParam(params, "query", { required: true });
+      const rawType = readStringParam(params, "type");
+      const type: ExaSearchType =
+        rawType === "keyword" || rawType === "neural" || rawType === "auto" ? rawType : "auto";
+      const count =
+        readNumberParam(params, "count", { integer: true }) ??
+        searchConfig?.maxResults ??
+        undefined;
+      const rawFreshness = readStringParam(params, "freshness");
+      const freshness = rawFreshness ? normalizeFreshness(rawFreshness, "exa") : undefined;
+      if (rawFreshness && !freshness) {
+        return {
+          error: "invalid_freshness",
+          message: 'freshness must be one of "day", "week", "month", or "year".',
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const rawDateAfter = readStringParam(params, "date_after");
+      const rawDateBefore = readStringParam(params, "date_before");
+      if (freshness && (rawDateAfter || rawDateBefore)) {
+        return {
+          error: "conflicting_time_filters",
+          message:
+            "freshness cannot be combined with date_after or date_before. Use one time-filter mode.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const dateAfter = rawDateAfter ? normalizeToIsoDate(rawDateAfter) : undefined;
+      if (rawDateAfter && !dateAfter) {
+        return {
+          error: "invalid_date",
+          message: "date_after must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const dateBefore = rawDateBefore ? normalizeToIsoDate(rawDateBefore) : undefined;
+      if (rawDateBefore && !dateBefore) {
+        return {
+          error: "invalid_date",
+          message: "date_before must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      if (dateAfter && dateBefore && dateAfter > dateBefore) {
+        return {
+          error: "invalid_date_range",
+          message: "date_after must be earlier than or equal to date_before.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const rawContents = params.contents;
+      const contents =
+        rawContents && typeof rawContents === "object" && !Array.isArray(rawContents)
+          ? (rawContents as ExaContentsArgs)
+          : undefined;
+
+      const cacheKey = buildSearchCacheKey([
+        "exa",
+        type,
+        query,
+        resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        freshness,
+        dateAfter,
+        dateBefore,
+        contents?.highlights,
+        contents?.text,
+      ]);
+      const cached = readCachedSearchPayload(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const start = Date.now();
+      const results = await runExaSearch({
+        apiKey,
+        query,
+        count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+        freshness,
+        dateAfter,
+        dateBefore,
+        type,
+        contents,
+        timeoutSeconds: resolveSearchTimeoutSeconds(searchConfig),
+      });
+
+      const payload = {
+        query,
+        provider: "exa",
+        count: results.length,
+        tookMs: Date.now() - start,
+        externalContent: {
+          untrusted: true,
+          source: "web_search",
+          provider: "exa",
+          wrapped: true,
+        },
+        results: results.map((entry) => {
+          const title = typeof entry.title === "string" ? entry.title : "";
+          const url = typeof entry.url === "string" ? entry.url : "";
+          const description = resolveExaDescription(entry);
+          const published =
+            typeof entry.publishedDate === "string" && entry.publishedDate
+              ? entry.publishedDate
+              : undefined;
+          return {
+            title: title ? wrapWebContent(title, "web_search") : "",
+            url,
+            description: description ? wrapWebContent(description, "web_search") : "",
+            published,
+            siteName: resolveSiteName(url) || undefined,
+          };
+        }),
+      };
+
+      writeCachedSearchPayload(cacheKey, payload, resolveSearchCacheTtlMs(searchConfig));
+      return payload;
+    },
+  };
+}
+
+export function createExaWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "exa",
+    label: "Exa Search",
+    hint: "Neural + keyword search with date filters and content extraction",
+    credentialLabel: "Exa API key",
+    envVars: ["EXA_API_KEY"],
+    placeholder: "exa-...",
+    signupUrl: "https://exa.ai/",
+    docsUrl: "https://docs.openclaw.ai/tools/web",
+    autoDetectOrder: 65,
+    credentialPath: "plugins.entries.exa.config.webSearch.apiKey",
+    inactiveSecretPaths: ["plugins.entries.exa.config.webSearch.apiKey"],
+    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "exa"),
+    setCredentialValue: (searchConfigTarget, value) =>
+      setScopedCredentialValue(searchConfigTarget, "exa", value),
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, "exa")?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, "exa", "apiKey", value);
+    },
+    applySelectionConfig: (config) => enablePluginInConfig(config, "exa").config,
+    createTool: (ctx) =>
+      createExaToolDefinition(
+        mergeScopedSearchConfig(
+          ctx.searchConfig as SearchConfigRecord | undefined,
+          "exa",
+          resolveProviderWebSearchPluginConfig(ctx.config, "exa"),
+        ) as SearchConfigRecord | undefined,
+      ),
+  };
+}
+
+export const __testing = {
+  normalizeExaResults,
+  resolveExaApiKey,
+  resolveExaConfig,
+  resolveExaDescription,
+  resolveFreshnessStartDate,
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,8 @@ importers:
 
   extensions/copilot-proxy: {}
 
+  extensions/deepgram: {}
+
   extensions/diagnostics-otel:
     dependencies:
       '@opentelemetry/api':
@@ -341,6 +343,8 @@ importers:
 
   extensions/elevenlabs: {}
 
+  extensions/exa: {}
+
   extensions/fal: {}
 
   extensions/feishu:
@@ -377,6 +381,8 @@ importers:
       openclaw:
         specifier: workspace:*
         version: link:../..
+
+  extensions/groq: {}
 
   extensions/huggingface: {}
 

--- a/src/bundled-web-search-registry.ts
+++ b/src/bundled-web-search-registry.ts
@@ -1,4 +1,5 @@
 import bravePlugin from "../extensions/brave/index.js";
+import exaPlugin from "../extensions/exa/index.js";
 import firecrawlPlugin from "../extensions/firecrawl/index.js";
 import googlePlugin from "../extensions/google/index.js";
 import moonshotPlugin from "../extensions/moonshot/index.js";
@@ -21,6 +22,12 @@ export const bundledWebSearchPluginRegistrations: ReadonlyArray<{
       return bravePlugin;
     },
     credentialValue: "BSA-test",
+  },
+  {
+    get plugin() {
+      return exaPlugin;
+    },
+    credentialValue: "exa-test",
   },
   {
     get plugin() {

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -775,6 +775,49 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "exa",
+    idHint: "exa-plugin",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/exa-plugin",
+    packageVersion: "2026.3.22",
+    packageDescription: "OpenClaw Exa plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "exa",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          webSearch: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              apiKey: {
+                type: ["string", "object"],
+              },
+            },
+          },
+        },
+      },
+      providerAuthEnvVars: {
+        exa: ["EXA_API_KEY"],
+      },
+      uiHints: {
+        "webSearch.apiKey": {
+          label: "Exa API Key",
+          help: "Exa Search API key (fallback: EXA_API_KEY env var).",
+          sensitive: true,
+          placeholder: "exa-...",
+        },
+      },
+    },
+  },
+  {
     dirName: "fal",
     idHint: "fal",
     source: {

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -6,6 +6,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   byteplus: ["BYTEPLUS_API_KEY"],
   chutes: ["CHUTES_API_KEY", "CHUTES_OAUTH_TOKEN"],
   "cloudflare-ai-gateway": ["CLOUDFLARE_AI_GATEWAY_API_KEY"],
+  exa: ["EXA_API_KEY"],
   fal: ["FAL_KEY"],
   firecrawl: ["FIRECRAWL_API_KEY"],
   "github-copilot": ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"],

--- a/src/plugins/bundled-web-search-ids.ts
+++ b/src/plugins/bundled-web-search-ids.ts
@@ -1,5 +1,6 @@
 export const BUNDLED_WEB_SEARCH_PLUGIN_IDS = [
   "brave",
+  "exa",
   "firecrawl",
   "google",
   "moonshot",

--- a/src/plugins/bundled-web-search.test.ts
+++ b/src/plugins/bundled-web-search.test.ts
@@ -69,6 +69,7 @@ describe("bundled web search metadata", () => {
   it("keeps bundled web search compat ids aligned with bundled manifests", () => {
     expect(resolveBundledWebSearchPluginIds({})).toEqual([
       "brave",
+      "exa",
       "firecrawl",
       "google",
       "moonshot",

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -142,6 +142,7 @@ describe("plugin contract registry", () => {
 
   it("keeps bundled web search ownership explicit", () => {
     expect(findWebSearchIdsForPlugin("brave")).toEqual(["brave"]);
+    expect(findWebSearchIdsForPlugin("exa")).toEqual(["exa"]);
     expect(findWebSearchIdsForPlugin("firecrawl")).toEqual(["firecrawl"]);
     expect(findWebSearchIdsForPlugin("google")).toEqual(["gemini"]);
     expect(findWebSearchIdsForPlugin("moonshot")).toEqual(["kimi"]);
@@ -176,6 +177,14 @@ describe("plugin contract registry", () => {
   });
 
   it("keeps bundled provider and web search tool ownership explicit", () => {
+    expect(findRegistrationForPlugin("exa")).toMatchObject({
+      providerIds: [],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+      webSearchProviderIds: ["exa"],
+      toolNames: [],
+    });
     expect(findRegistrationForPlugin("firecrawl")).toMatchObject({
       providerIds: [],
       speechProviderIds: [],

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -13,6 +13,7 @@ const BUNDLED_WEB_SEARCH_PROVIDERS = [
   { pluginId: "moonshot", id: "kimi", order: 40 },
   { pluginId: "perplexity", id: "perplexity", order: 50 },
   { pluginId: "firecrawl", id: "firecrawl", order: 60 },
+  { pluginId: "exa", id: "exa", order: 65 },
   { pluginId: "tavily", id: "tavily", order: 70 },
 ] as const;
 
@@ -89,6 +90,7 @@ describe("resolvePluginWebSearchProviders", () => {
       "moonshot:kimi",
       "perplexity:perplexity",
       "firecrawl:firecrawl",
+      "exa:exa",
       "tavily:tavily",
     ]);
     expect(loadOpenClawPluginsMock).toHaveBeenCalledTimes(1);

--- a/src/plugins/web-search-providers.test.ts
+++ b/src/plugins/web-search-providers.test.ts
@@ -12,6 +12,7 @@ describe("resolveBundledPluginWebSearchProviders", () => {
       "moonshot:kimi",
       "perplexity:perplexity",
       "firecrawl:firecrawl",
+      "exa:exa",
       "tavily:tavily",
     ]);
     expect(providers.map((provider) => provider.credentialPath)).toEqual([
@@ -21,6 +22,7 @@ describe("resolveBundledPluginWebSearchProviders", () => {
       "plugins.entries.moonshot.config.webSearch.apiKey",
       "plugins.entries.perplexity.config.webSearch.apiKey",
       "plugins.entries.firecrawl.config.webSearch.apiKey",
+      "plugins.entries.exa.config.webSearch.apiKey",
       "plugins.entries.tavily.config.webSearch.apiKey",
     ]);
     expect(providers.find((provider) => provider.id === "firecrawl")?.applySelectionConfig).toEqual(
@@ -48,6 +50,7 @@ describe("resolveBundledPluginWebSearchProviders", () => {
       "moonshot",
       "perplexity",
       "firecrawl",
+      "exa",
       "tavily",
     ]);
   });
@@ -102,6 +105,7 @@ describe("resolveBundledPluginWebSearchProviders", () => {
       "moonshot:kimi",
       "perplexity:perplexity",
       "firecrawl:firecrawl",
+      "exa:exa",
       "tavily:tavily",
     ]);
   });


### PR DESCRIPTION
## Summary

- Problem: OpenClaw still had multiple stale Exa PRs after the main rebase, but no clean bundled Exa web-search plugin aligned with the current plugin-owned provider pattern.
- Why it matters: Exa is useful specifically for date-sensitive agent search and content extraction; landing it as a bundled plugin removes the need for custom `exec` wrappers and resolves the duplicate PR cluster.
- What changed: Added a new bundled `extensions/exa` web-search plugin, wired it into the bundled web-search registry/contracts/generated metadata, and added the changelog credit line for the earlier implementation work.
- What did NOT change (scope boundary): I did not broaden scope into the unrelated current-main `src/plugins` Telegram import regression or the existing `src/line/*` build-entry failure.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20134
- Related #49319
- Related #50281
- Related #21628
- Related #31310
- Related #35062
- Related #34862

## User-visible / Behavior Changes

- New bundled `exa` web-search provider.
- Exa supports `type`, `freshness`, `date_after`, `date_before`, and optional `contents.{highlights,text}`.
- Exa uses bundled plugin config under `plugins.entries.exa.config.webSearch.apiKey` and `EXA_API_KEY` env fallback.
- Exa sits conservatively after Firecrawl in auto-detect order.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - Adds optional Exa API-key handling via the same bundled-plugin secret/config path used by other web-search providers.
  - Adds POST requests to `https://api.exa.ai/search` behind explicit key presence and the existing trusted web-search endpoint wrapper.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Exa web search
- Relevant config (redacted): `EXA_API_KEY=exa-***`

### Steps

1. Set `EXA_API_KEY` or configure `plugins.entries.exa.config.webSearch.apiKey`.
2. Select Exa in web-search config or let bundled provider auto-detect choose it.
3. Call `web_search` with Exa-specific filters like `freshness`, `date_after`, `date_before`, or `type`.

### Expected

- Exa is available as a bundled web-search provider and returns wrapped search results with Exa-native filters.

### Actual

- Verified with focused Exa extension tests and generated bundled-plugin metadata/env-var checks.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused checks run:

- `pnpm test -- extensions/exa/index.test.ts extensions/exa/src/exa-web-search-provider.test.ts`
- `pnpm check:bundled-plugin-metadata`
- `pnpm check:bundled-provider-auth-env-vars`

Blocked unrelated on current `origin/main`:

- Shared `src/plugins/*` tests import the Telegram sent-message cache and fail on `openclaw/plugin-sdk/text-runtime` export mismatch for `createScopedExpiringIdCache`.
- `pnpm build` fails on unresolved existing `src/line/accounts.ts`, `src/line/send.ts`, and `src/line/template-messages.ts` entries.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: clean `origin/main`-based branch diff, Exa plugin registration, Exa provider metadata, Exa-specific validation behavior, generated bundled metadata/env-var baselines.
- Edge cases checked: conflicting time filters, month freshness normalization, highlight-vs-text description fallback, plugin selection wiring.
- What you did **not** verify: live Exa API calls, full repo build/test gate because current `origin/main` is already red in unrelated surfaces.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: disable the `exa` plugin entry or remove it from the bundled web-search registry.
- Files/config to restore: `src/bundled-web-search-registry.ts`, `src/plugins/bundled-web-search-ids.ts`, `extensions/exa/*`
- Known bad symptoms reviewers should watch for: Exa incorrectly selected when another search provider should win, or bad handling of Exa date-filter params.

## Risks and Mitigations

- Risk: Exa search semantics drift from Exa API expectations.
  - Mitigation: scoped provider tests cover selection wiring, validation, and helper behavior; request path uses the same guarded wrapper and cached payload pattern as other bundled providers.

AI-assisted: yes.
