### PR TITLE
fix: keep unknown /status usage unknown

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -223,6 +223,31 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Context: 1.0k/66k");
   });
 
+  it("keeps context usage unknown when totalTokens is missing", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 32_000,
+      },
+      sessionEntry: {
+        sessionId: "unknown-usage",
+        updatedAt: 0,
+        inputTokens: 1_200,
+        outputTokens: 800,
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Tokens: 1.2k in / 800 out");
+    expect(normalized).toContain("Context: ?/32k");
+    expect(normalized).not.toContain("Context: 2.0k/32k");
+  });
+
   it("uses per-agent sandbox config when config and session key are provided", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -17,6 +17,7 @@ import {
   resolveMainSessionKey,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  resolveFreshSessionTotalTokens,
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
@@ -460,7 +461,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  let totalTokens = resolveFreshSessionTotalTokens(entry);
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).


### PR DESCRIPTION
## Summary
- keep chat  context usage unknown when session  is missing
- stop synthesizing a misleading known context total from 
- add a regression test for the missing-totalTokens case

## Validation
- attempted:  ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND  No package.json (or package.yaml, or package.json5) was found in "/root/.openclaw/workspace".
- blocked because  is missing in this worktree
- attempted:  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /root/.openclaw/workspace
- blocked by DNS/registry failure: 

Closes #52595