### PR TITLE
fix(acp): time out stuck session lane tasks

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -57,6 +57,7 @@ import {
   resolveAcpSessionResolutionError,
   resolveMissingMetaError,
   resolveRuntimeIdleTtlMs,
+  resolveSessionLaneTaskTimeoutMs,
 } from "./manager.utils.js";
 import { CachedRuntimeState, RuntimeCache } from "./runtime-cache.js";
 import {
@@ -70,7 +71,7 @@ import {
   validateRuntimeModeInput,
   validateRuntimeOptionPatch,
 } from "./runtime-options.js";
-import { SessionActorQueue } from "./session-actor-queue.js";
+import { SessionActorQueue, SessionActorQueueTimeoutError } from "./session-actor-queue.js";
 
 const ACP_TURN_TIMEOUT_GRACE_MS = 1_000;
 const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
@@ -178,28 +179,32 @@ export class AcpSessionManager {
 
       checked += 1;
       try {
-        const becameResolved = await this.withSessionActor(session.sessionKey, async () => {
-          const resolution = this.resolveSession({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-          });
-          if (resolution.kind !== "ready") {
-            return false;
-          }
-          const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            meta: resolution.meta,
-          });
-          const reconciled = await this.reconcileRuntimeSessionIdentifiers({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            runtime,
-            handle,
-            meta,
-            failOnStatusError: false,
-          });
-          return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+        const becameResolved = await this.withSessionActor({
+          cfg: params.cfg,
+          sessionKey: session.sessionKey,
+          op: async () => {
+            const resolution = this.resolveSession({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+            });
+            if (resolution.kind !== "ready") {
+              return false;
+            }
+            const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              meta: resolution.meta,
+            });
+            const reconciled = await this.reconcileRuntimeSessionIdentifiers({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              runtime,
+              handle,
+              meta,
+              failOnStatusError: false,
+            });
+            return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+          },
         });
         if (becameResolved) {
           resolved += 1;
@@ -229,100 +234,105 @@ export class AcpSessionManager {
     }
     const agent = normalizeAgentId(input.agent);
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
-      const runtime = backend.runtime;
-      const initialRuntimeOptions = validateRuntimeOptionPatch({ cwd: input.cwd });
-      const requestedCwd = initialRuntimeOptions.cwd;
-      this.enforceConcurrentSessionLimit({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const handle = await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.ensureSession({
-            sessionKey,
-            agent,
-            mode: input.mode,
-            resumeSessionId: input.resumeSessionId,
-            cwd: requestedCwd,
-          }),
-        fallbackCode: "ACP_SESSION_INIT_FAILED",
-        fallbackMessage: "Could not initialize ACP session runtime.",
-      });
-      const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
-      const effectiveRuntimeOptions = normalizeRuntimeOptions({
-        ...initialRuntimeOptions,
-        ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
-      });
-
-      const identityNow = Date.now();
-      const initializedIdentity =
-        mergeSessionIdentity({
-          current: undefined,
-          incoming: createIdentityFromEnsure({
-            handle,
-            now: identityNow,
-          }),
-          now: identityNow,
-        }) ??
-        ({
-          state: "pending",
-          source: "ensure",
-          lastUpdatedAt: identityNow,
-        } as const);
-      const meta: SessionAcpMeta = {
-        backend: handle.backend || backend.id,
-        agent,
-        runtimeSessionName: handle.runtimeSessionName,
-        identity: initializedIdentity,
-        mode: input.mode,
-        ...(Object.keys(effectiveRuntimeOptions).length > 0
-          ? { runtimeOptions: effectiveRuntimeOptions }
-          : {}),
-        cwd: effectiveCwd,
-        state: "idle",
-        lastActivityAt: Date.now(),
-      };
-      try {
-        const persisted = await this.writeSessionMeta({
+    return await this.withSessionActor({
+      cfg: input.cfg,
+      sessionKey,
+      timeoutCode: "ACP_SESSION_INIT_FAILED",
+      op: async () => {
+        const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
+        const runtime = backend.runtime;
+        const initialRuntimeOptions = validateRuntimeOptionPatch({ cwd: input.cwd });
+        const requestedCwd = initialRuntimeOptions.cwd;
+        this.enforceConcurrentSessionLimit({
           cfg: input.cfg,
           sessionKey,
-          mutate: () => meta,
-          failOnError: true,
         });
-        if (!persisted?.acp) {
-          throw new AcpRuntimeError(
-            "ACP_SESSION_INIT_FAILED",
-            `Could not persist ACP metadata for ${sessionKey}.`,
-          );
-        }
-      } catch (error) {
-        await runtime
-          .close({
-            handle,
-            reason: "init-meta-failed",
-          })
-          .catch((closeError) => {
-            logVerbose(
-              `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
-            );
+        const handle = await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.ensureSession({
+              sessionKey,
+              agent,
+              mode: input.mode,
+              resumeSessionId: input.resumeSessionId,
+              cwd: requestedCwd,
+            }),
+          fallbackCode: "ACP_SESSION_INIT_FAILED",
+          fallbackMessage: "Could not initialize ACP session runtime.",
+        });
+        const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
+        const effectiveRuntimeOptions = normalizeRuntimeOptions({
+          ...initialRuntimeOptions,
+          ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+        });
+
+        const identityNow = Date.now();
+        const initializedIdentity =
+          mergeSessionIdentity({
+            current: undefined,
+            incoming: createIdentityFromEnsure({
+              handle,
+              now: identityNow,
+            }),
+            now: identityNow,
+          }) ??
+          ({
+            state: "pending",
+            source: "ensure",
+            lastUpdatedAt: identityNow,
+          } as const);
+        const meta: SessionAcpMeta = {
+          backend: handle.backend || backend.id,
+          agent,
+          runtimeSessionName: handle.runtimeSessionName,
+          identity: initializedIdentity,
+          mode: input.mode,
+          ...(Object.keys(effectiveRuntimeOptions).length > 0
+            ? { runtimeOptions: effectiveRuntimeOptions }
+            : {}),
+          cwd: effectiveCwd,
+          state: "idle",
+          lastActivityAt: Date.now(),
+        };
+        try {
+          const persisted = await this.writeSessionMeta({
+            cfg: input.cfg,
+            sessionKey,
+            mutate: () => meta,
+            failOnError: true,
           });
-        throw error;
-      }
-      this.setCachedRuntimeState(sessionKey, {
-        runtime,
-        handle,
-        backend: handle.backend || backend.id,
-        agent,
-        mode: input.mode,
-        cwd: effectiveCwd,
-      });
-      return {
-        runtime,
-        handle,
-        meta,
-      };
+          if (!persisted?.acp) {
+            throw new AcpRuntimeError(
+              "ACP_SESSION_INIT_FAILED",
+              `Could not persist ACP metadata for ${sessionKey}.`,
+            );
+          }
+        } catch (error) {
+          await runtime
+            .close({
+              handle,
+              reason: "init-meta-failed",
+            })
+            .catch((closeError) => {
+              logVerbose(
+                `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
+              );
+            });
+          throw error;
+        }
+        this.setCachedRuntimeState(sessionKey, {
+          runtime,
+          handle,
+          backend: handle.backend || backend.id,
+          agent,
+          mode: input.mode,
+          cwd: effectiveCwd,
+        });
+        return {
+          runtime,
+          handle,
+          meta,
+        };
+      },
     });
   }
 
@@ -337,9 +347,11 @@ export class AcpSessionManager {
     }
     this.throwIfAborted(params.signal);
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(
+    return await this.withSessionActor({
+      cfg: params.cfg,
       sessionKey,
-      async () => {
+      signal: params.signal,
+      op: async () => {
         this.throwIfAborted(params.signal);
         const resolution = this.resolveSession({
           cfg: params.cfg,
@@ -398,8 +410,7 @@ export class AcpSessionManager {
           lastError: meta.lastError,
         };
       },
-      params.signal,
-    );
+    });
   }
 
   async setSessionRuntimeMode(params: {
@@ -414,45 +425,49 @@ export class AcpSessionManager {
     const runtimeMode = validateRuntimeModeInput(params.runtimeMode);
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
-      if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
-        throw createUnsupportedControlError({
-          backend: handle.backend || meta.backend,
-          control: "session/set_mode",
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
         });
-      }
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
+        if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
+          throw createUnsupportedControlError({
+            backend: handle.backend || meta.backend,
+            control: "session/set_mode",
+          });
+        }
 
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.setMode!({
-            handle,
-            mode: runtimeMode,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime mode.",
-      });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.setMode!({
+              handle,
+              mode: runtimeMode,
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not update ACP runtime mode.",
+        });
 
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(meta),
-        patch: { runtimeMode },
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(meta),
+          patch: { runtimeMode },
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -471,62 +486,66 @@ export class AcpSessionManager {
     const value = normalizedOption.value;
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
-      const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
-      if (
-        !capabilities.controls.includes("session/set_config_option") ||
-        !runtime.setConfigOption
-      ) {
-        throw createUnsupportedControlError({
-          backend: handle.backend || meta.backend,
-          control: "session/set_config_option",
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
         });
-      }
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
+        const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
+        if (
+          !capabilities.controls.includes("session/set_config_option") ||
+          !runtime.setConfigOption
+        ) {
+          throw createUnsupportedControlError({
+            backend: handle.backend || meta.backend,
+            control: "session/set_config_option",
+          });
+        }
 
-      const advertisedKeys = new Set(
-        (capabilities.configOptionKeys ?? [])
-          .map((entry) => normalizeText(entry))
-          .filter(Boolean) as string[],
-      );
-      if (advertisedKeys.size > 0 && !advertisedKeys.has(key)) {
-        throw new AcpRuntimeError(
-          "ACP_BACKEND_UNSUPPORTED_CONTROL",
-          `ACP backend "${handle.backend || meta.backend}" does not accept config key "${key}".`,
+        const advertisedKeys = new Set(
+          (capabilities.configOptionKeys ?? [])
+            .map((entry) => normalizeText(entry))
+            .filter(Boolean) as string[],
         );
-      }
+        if (advertisedKeys.size > 0 && !advertisedKeys.has(key)) {
+          throw new AcpRuntimeError(
+            "ACP_BACKEND_UNSUPPORTED_CONTROL",
+            `ACP backend "${handle.backend || meta.backend}" does not accept config key "${key}".`,
+          );
+        }
 
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.setConfigOption!({
-            handle,
-            key,
-            value,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime config option.",
-      });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.setConfigOption!({
+              handle,
+              key,
+              value,
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not update ACP runtime config option.",
+        });
 
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(meta),
-        patch: inferredPatch,
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(meta),
+          patch: inferredPatch,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -542,22 +561,26 @@ export class AcpSessionManager {
     }
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(resolvedMeta),
-        patch: validatedPatch,
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
+        });
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(resolvedMeta),
+          patch: validatedPatch,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -570,33 +593,37 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.close({
-            handle,
-            reason: "reset-runtime-options",
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not reset ACP runtime options.",
-      });
-      this.clearCachedRuntimeState(sessionKey);
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: {},
-      });
-      return {};
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
+        });
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.close({
+              handle,
+              reason: "reset-runtime-options",
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not reset ACP runtime options.",
+        });
+        this.clearCachedRuntimeState(sessionKey);
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: {},
+        });
+        return {};
+      },
     });
   }
 
@@ -609,9 +636,11 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    await this.withSessionActor(
+    await this.withSessionActor({
+      cfg: input.cfg,
       sessionKey,
-      async () => {
+      signal: input.signal,
+      op: async () => {
         const turnStartedAt = Date.now();
         const actorKey = normalizeActorKey(sessionKey);
         for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -820,8 +849,7 @@ export class AcpSessionManager {
           }
         }
       },
-      input.signal,
-    );
+    });
   }
 
   private resolveTurnTimeoutMs(params: { cfg: OpenClawConfig; meta: SessionAcpMeta }): number {
@@ -1037,47 +1065,51 @@ export class AcpSessionManager {
       return;
     }
 
-    await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      try {
-        await withAcpRuntimeErrorBoundary({
-          run: async () =>
-            await runtime.cancel({
-              handle,
-              reason: params.reason,
-            }),
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP cancel failed before completion.",
-        });
-        await this.setSessionState({
+    await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
-          state: "idle",
-          clearLastError: true,
         });
-      } catch (error) {
-        const acpError = toAcpRuntimeError({
-          error,
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP cancel failed before completion.",
-        });
-        await this.setSessionState({
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle } = await this.ensureRuntimeHandle({
           cfg: params.cfg,
           sessionKey,
-          state: "error",
-          lastError: acpError.message,
+          meta: resolvedMeta,
         });
-        throw acpError;
-      }
+        try {
+          await withAcpRuntimeErrorBoundary({
+            run: async () =>
+              await runtime.cancel({
+                handle,
+                reason: params.reason,
+              }),
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP cancel failed before completion.",
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "idle",
+            clearLastError: true,
+          });
+        } catch (error) {
+          const acpError = toAcpRuntimeError({
+            error,
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP cancel failed before completion.",
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "error",
+            lastError: acpError.message,
+          });
+          throw acpError;
+        }
+      },
     });
   }
 
@@ -1090,84 +1122,88 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const resolutionError = resolveAcpSessionResolutionError(resolution);
-      if (resolutionError) {
-        if (input.requireAcpSession ?? true) {
-          throw resolutionError;
-        }
-        return {
-          runtimeClosed: false,
-          metaCleared: false,
-        };
-      }
-      const meta = requireReadySessionMeta(resolution);
-
-      let runtimeClosed = false;
-      let runtimeNotice: string | undefined;
-      try {
-        const { runtime, handle } = await this.ensureRuntimeHandle({
+    return await this.withSessionActor({
+      cfg: input.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
           cfg: input.cfg,
           sessionKey,
-          meta,
         });
-        await withAcpRuntimeErrorBoundary({
-          run: async () =>
-            await runtime.close({
-              handle,
-              reason: input.reason,
-            }),
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP close failed before completion.",
-        });
-        runtimeClosed = true;
-        this.clearCachedRuntimeState(sessionKey);
-      } catch (error) {
-        const acpError = toAcpRuntimeError({
-          error,
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP close failed before completion.",
-        });
-        if (
-          input.allowBackendUnavailable &&
-          (acpError.code === "ACP_BACKEND_MISSING" ||
-            acpError.code === "ACP_BACKEND_UNAVAILABLE" ||
-            this.isRecoverableAcpxExitError(acpError.message))
-        ) {
-          // Treat unavailable backends as terminal for this cached handle so it
-          // cannot continue counting against maxConcurrentSessions.
+        const resolutionError = resolveAcpSessionResolutionError(resolution);
+        if (resolutionError) {
+          if (input.requireAcpSession ?? true) {
+            throw resolutionError;
+          }
+          return {
+            runtimeClosed: false,
+            metaCleared: false,
+          };
+        }
+        const meta = requireReadySessionMeta(resolution);
+
+        let runtimeClosed = false;
+        let runtimeNotice: string | undefined;
+        try {
+          const { runtime, handle } = await this.ensureRuntimeHandle({
+            cfg: input.cfg,
+            sessionKey,
+            meta,
+          });
+          await withAcpRuntimeErrorBoundary({
+            run: async () =>
+              await runtime.close({
+                handle,
+                reason: input.reason,
+              }),
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP close failed before completion.",
+          });
+          runtimeClosed = true;
           this.clearCachedRuntimeState(sessionKey);
-          runtimeNotice = acpError.message;
-        } else {
-          throw acpError;
+        } catch (error) {
+          const acpError = toAcpRuntimeError({
+            error,
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP close failed before completion.",
+          });
+          if (
+            input.allowBackendUnavailable &&
+            (acpError.code === "ACP_BACKEND_MISSING" ||
+              acpError.code === "ACP_BACKEND_UNAVAILABLE" ||
+              this.isRecoverableAcpxExitError(acpError.message))
+          ) {
+            // Treat unavailable backends as terminal for this cached handle so it
+            // cannot continue counting against maxConcurrentSessions.
+            this.clearCachedRuntimeState(sessionKey);
+            runtimeNotice = acpError.message;
+          } else {
+            throw acpError;
+          }
         }
-      }
 
-      let metaCleared = false;
-      if (input.clearMeta) {
-        await this.writeSessionMeta({
-          cfg: input.cfg,
-          sessionKey,
-          mutate: (_current, entry) => {
-            if (!entry) {
+        let metaCleared = false;
+        if (input.clearMeta) {
+          await this.writeSessionMeta({
+            cfg: input.cfg,
+            sessionKey,
+            mutate: (_current, entry) => {
+              if (!entry) {
+                return null;
+              }
               return null;
-            }
-            return null;
-          },
-          failOnError: true,
-        });
-        metaCleared = true;
-      }
+            },
+            failOnError: true,
+          });
+          metaCleared = true;
+        }
 
-      return {
-        runtimeClosed,
-        runtimeNotice,
-        metaCleared,
-      };
+        return {
+          runtimeClosed,
+          runtimeNotice,
+          metaCleared,
+        };
+      },
     });
   }
 
@@ -1491,32 +1527,48 @@ export class AcpSessionManager {
     }
 
     for (const candidate of candidates) {
-      await this.actorQueue.run(candidate.actorKey, async () => {
-        if (this.activeTurnBySession.has(candidate.actorKey)) {
-          return;
-        }
-        const lastTouchedAt = this.runtimeCache.getLastTouchedAt(candidate.actorKey);
-        if (lastTouchedAt == null || now - lastTouchedAt < idleTtlMs) {
-          return;
-        }
-        const cached = this.runtimeCache.peek(candidate.actorKey);
-        if (!cached) {
-          return;
-        }
-        this.runtimeCache.clear(candidate.actorKey);
-        this.evictedRuntimeCount += 1;
-        this.lastEvictedAt = Date.now();
-        try {
-          await cached.runtime.close({
-            handle: cached.handle,
-            reason: "idle-evicted",
-          });
-        } catch (error) {
+      try {
+        await this.actorQueue.run(
+          candidate.actorKey,
+          async () => {
+            if (this.activeTurnBySession.has(candidate.actorKey)) {
+              return;
+            }
+            const lastTouchedAt = this.runtimeCache.getLastTouchedAt(candidate.actorKey);
+            if (lastTouchedAt == null || now - lastTouchedAt < idleTtlMs) {
+              return;
+            }
+            const cached = this.runtimeCache.peek(candidate.actorKey);
+            if (!cached) {
+              return;
+            }
+            this.runtimeCache.clear(candidate.actorKey);
+            this.evictedRuntimeCount += 1;
+            this.lastEvictedAt = Date.now();
+            try {
+              await cached.runtime.close({
+                handle: cached.handle,
+                reason: "idle-evicted",
+              });
+            } catch (error) {
+              logVerbose(
+                `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+              );
+            }
+          },
+          {
+            timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
+          },
+        );
+      } catch (error) {
+        if (error instanceof SessionActorQueueTimeoutError) {
           logVerbose(
-            `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+            `acp-manager: idle runtime eviction timed out for ${candidate.actorKey} after ${error.timeoutMs}ms`,
           );
+          continue;
         }
-      });
+        throw error;
+      }
     }
   }
 
@@ -1630,62 +1682,83 @@ export class AcpSessionManager {
     }
   }
 
-  private async withSessionActor<T>(
-    sessionKey: string,
-    op: () => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T> {
-    const actorKey = normalizeActorKey(sessionKey);
-    this.throwIfAborted(signal);
+  private async withSessionActor<T>(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    op: () => Promise<T>;
+    signal?: AbortSignal;
+    timeoutCode?: AcpRuntimeError["code"];
+  }): Promise<T> {
+    const actorKey = normalizeActorKey(params.sessionKey);
+    this.throwIfAborted(params.signal);
 
     let actorStarted = false;
-    const queued = this.actorQueue.run(actorKey, async () => {
-      actorStarted = true;
-      this.throwIfAborted(signal);
-      return await op();
-    });
-    if (!signal) {
-      return await queued;
-    }
+    const queued = this.actorQueue.run(
+      actorKey,
+      async () => {
+        actorStarted = true;
+        this.throwIfAborted(params.signal);
+        return await params.op();
+      },
+      {
+        timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
+      },
+    );
 
-    return await new Promise<T>((resolve, reject) => {
-      let settled = false;
-      const cleanup = () => {
-        signal.removeEventListener("abort", onAbort);
-      };
-      const settleValue = (value: T) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        resolve(value);
-      };
-      const settleError = (error: unknown) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        reject(error);
-      };
-      const onAbort = () => {
-        if (actorStarted) {
-          return;
-        }
-        try {
-          this.throwIfAborted(signal);
-        } catch (error) {
-          settleError(error);
-        }
-      };
-
-      signal.addEventListener("abort", onAbort, { once: true });
-      queued.then(settleValue, settleError);
-      if (signal.aborted) {
-        onAbort();
+    try {
+      if (!params.signal) {
+        return await queued;
       }
-    });
+
+      const signal = params.signal;
+      return await new Promise<T>((resolve, reject) => {
+        let settled = false;
+        const cleanup = () => {
+          signal.removeEventListener("abort", onAbort);
+        };
+        const settleValue = (value: T) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+        const settleError = (error: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+        const onAbort = () => {
+          if (actorStarted) {
+            return;
+          }
+          try {
+            this.throwIfAborted(signal);
+          } catch (error) {
+            settleError(error);
+          }
+        };
+
+        signal.addEventListener("abort", onAbort, { once: true });
+        queued.then(settleValue, settleError);
+        if (signal.aborted) {
+          onAbort();
+        }
+      });
+    } catch (error) {
+      if (error instanceof SessionActorQueueTimeoutError) {
+        throw new AcpRuntimeError(
+          params.timeoutCode ?? "ACP_TURN_FAILED",
+          `ACP session lane task timed out after ${error.timeoutMs}ms for ${params.sessionKey}.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
   }
 
   private throwIfAborted(signal?: AbortSignal): void {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -435,6 +435,100 @@ describe("AcpSessionManager", () => {
     }
   });
 
+  it("times out a hung initializeSession actor task and lets the next queued initialize run", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          sessionKey: string;
+          mutate: (
+            current: SessionAcpMeta | undefined,
+            entry: { acp?: SessionAcpMeta } | undefined,
+          ) => SessionAcpMeta | null | undefined;
+        };
+        const next = params.mutate(undefined, undefined);
+        return next
+          ? {
+              sessionKey: params.sessionKey,
+              storeSessionKey: params.sessionKey,
+              acp: next,
+            }
+          : null;
+      });
+
+      let firstEnsureStarted = false;
+      let ensureCalls = 0;
+      runtimeState.ensureSession.mockImplementation(
+        async (input: { sessionKey: string; agent: string; mode: "persistent" | "oneshot" }) => {
+          ensureCalls += 1;
+          if (ensureCalls === 1) {
+            firstEnsureStarted = true;
+            await new Promise(() => {});
+          }
+          return {
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime:${ensureCalls}`,
+          };
+        },
+      );
+
+      const manager = new AcpSessionManager();
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+
+      const first = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(firstEnsureStarted).toBe(true);
+      });
+
+      const second = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: "ACP session lane task timed out after 100ms for agent:codex:acp:session-1.",
+      });
+      await expect(second).resolves.toMatchObject({
+        handle: expect.objectContaining({
+          runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
+        }),
+        meta: expect.objectContaining({
+          state: "idle",
+        }),
+      });
+
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+      expect(manager.getObservabilitySnapshot(cfg).turns.queueDepth).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps timed-out runtime handles counted until timeout cleanup finishes", async () => {
     vi.useFakeTimers();
     try {

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -12,6 +12,8 @@ import {
 import { ACP_ERROR_CODES, AcpRuntimeError } from "../runtime/errors.js";
 import type { AcpSessionResolution } from "./manager.types.js";
 
+export const DEFAULT_ACP_SESSION_LANE_TASK_TIMEOUT_MS = 600_000;
+
 export function resolveAcpAgentFromSessionKey(sessionKey: string, fallback = "main"): string {
   const parsed = parseAgentSessionKey(sessionKey);
   return normalizeAgentId(parsed?.agentId ?? fallback);
@@ -110,6 +112,17 @@ export function resolveRuntimeIdleTtlMs(cfg: OpenClawConfig): number {
     return 0;
   }
   return Math.round(ttlMinutes * 60 * 1000);
+}
+
+export function resolveSessionLaneTaskTimeoutMs(cfg: OpenClawConfig): number {
+  const timeoutMs = cfg.acp?.sessionLane?.taskTimeoutMs;
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return DEFAULT_ACP_SESSION_LANE_TASK_TIMEOUT_MS;
+  }
+  if (timeoutMs <= 0) {
+    return 0;
+  }
+  return Math.round(timeoutMs);
 }
 
 export function hasLegacyAcpIdentityProjection(meta: SessionAcpMeta): boolean {

--- a/src/acp/control-plane/session-actor-queue.ts
+++ b/src/acp/control-plane/session-actor-queue.ts
@@ -1,5 +1,58 @@
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 
+export class SessionActorQueueTimeoutError extends Error {
+  readonly actorKey: string;
+  readonly timeoutMs: number;
+
+  constructor(actorKey: string, timeoutMs: number) {
+    super(`ACP session lane task timed out after ${timeoutMs}ms for ${actorKey}.`);
+    this.name = "SessionActorQueueTimeoutError";
+    this.actorKey = actorKey;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+function runWithTaskTimeout<T>(params: {
+  actorKey: string;
+  timeoutMs?: number;
+  op: () => Promise<T>;
+}): Promise<T> {
+  const timeoutMs = params.timeoutMs;
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return params.op();
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(new SessionActorQueueTimeoutError(params.actorKey, timeoutMs));
+    }, timeoutMs);
+
+    void params.op().then(
+      (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 export class SessionActorQueue {
   private readonly queue = new KeyedAsyncQueue();
   private readonly pendingBySession = new Map<string, number>();
@@ -20,19 +73,34 @@ export class SessionActorQueue {
     return this.pendingBySession.get(actorKey) ?? 0;
   }
 
-  async run<T>(actorKey: string, op: () => Promise<T>): Promise<T> {
-    return this.queue.enqueue(actorKey, op, {
-      onEnqueue: () => {
-        this.pendingBySession.set(actorKey, (this.pendingBySession.get(actorKey) ?? 0) + 1);
+  async run<T>(
+    actorKey: string,
+    op: () => Promise<T>,
+    options?: {
+      timeoutMs?: number;
+    },
+  ): Promise<T> {
+    return this.queue.enqueue(
+      actorKey,
+      () =>
+        runWithTaskTimeout({
+          actorKey,
+          timeoutMs: options?.timeoutMs,
+          op,
+        }),
+      {
+        onEnqueue: () => {
+          this.pendingBySession.set(actorKey, (this.pendingBySession.get(actorKey) ?? 0) + 1);
+        },
+        onSettle: () => {
+          const pending = (this.pendingBySession.get(actorKey) ?? 1) - 1;
+          if (pending <= 0) {
+            this.pendingBySession.delete(actorKey);
+          } else {
+            this.pendingBySession.set(actorKey, pending);
+          }
+        },
       },
-      onSettle: () => {
-        const pending = (this.pendingBySession.get(actorKey) ?? 1) - 1;
-        if (pending <= 0) {
-          this.pendingBySession.delete(actorKey);
-        } else {
-          this.pendingBySession.set(actorKey, pending);
-        }
-      },
-    });
+    );
   }
 }

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -824,6 +824,17 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
             exclusiveMinimum: 0,
             maximum: 9007199254740991,
           },
+          sessionLane: {
+            type: "object",
+            properties: {
+              taskTimeoutMs: {
+                type: "integer",
+                minimum: 0,
+                maximum: 9007199254740991,
+              },
+            },
+            additionalProperties: false,
+          },
           stream: {
             type: "object",
             properties: {
@@ -13773,6 +13784,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     "acp.maxConcurrentSessions": {
       label: "ACP Max Concurrent Sessions",
       help: "Maximum concurrently active ACP sessions across this gateway process.",
+      tags: ["performance", "storage"],
+    },
+    "acp.sessionLane": {
+      label: "ACP Session Lane",
+      help: "ACP per-session lane controls for serial actor tasks such as initialize, status, cancel, and close.",
+      tags: ["storage"],
+    },
+    "acp.sessionLane.taskTimeoutMs": {
+      label: "ACP Session Lane Task Timeout (ms)",
+      help: "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw releases it and lets the next queued task run. Default: 600000. Set 0 to disable.",
       tags: ["performance", "storage"],
     },
     "acp.stream": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -182,6 +182,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.",
   "acp.maxConcurrentSessions":
     "Maximum concurrently active ACP sessions across this gateway process.",
+  "acp.sessionLane":
+    "ACP per-session lane controls for serial actor tasks such as initialize, status, cancel, and close.",
+  "acp.sessionLane.taskTimeoutMs":
+    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw releases it and lets the next queued task run. Default: 600000. Set 0 to disable.",
   "acp.stream":
     "ACP streaming projection controls for chunk sizing, metadata visibility, and deduped delivery behavior.",
   "acp.stream.coalesceIdleMs":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -406,6 +406,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "acp.defaultAgent": "ACP Default Agent",
   "acp.allowedAgents": "ACP Allowed Agents",
   "acp.maxConcurrentSessions": "ACP Max Concurrent Sessions",
+  "acp.sessionLane": "ACP Session Lane",
+  "acp.sessionLane.taskTimeoutMs": "ACP Session Lane Task Timeout (ms)",
   "acp.stream": "ACP Stream",
   "acp.stream.coalesceIdleMs": "ACP Stream Coalesce Idle (ms)",
   "acp.stream.maxChunkChars": "ACP Stream Max Chunk Chars",

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -34,6 +34,11 @@ export type AcpRuntimeConfig = {
   installCommand?: string;
 };
 
+export type AcpSessionLaneConfig = {
+  /** Maximum time a single ACP session-lane task may hold the lane before release. */
+  taskTimeoutMs?: number;
+};
+
 export type AcpConfig = {
   /** Global ACP runtime gate. */
   enabled?: boolean;
@@ -43,6 +48,7 @@ export type AcpConfig = {
   defaultAgent?: string;
   allowedAgents?: string[];
   maxConcurrentSessions?: number;
+  sessionLane?: AcpSessionLaneConfig;
   stream?: AcpStreamConfig;
   runtime?: AcpRuntimeConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -461,6 +461,12 @@ export const OpenClawSchema = z
         defaultAgent: z.string().optional(),
         allowedAgents: z.array(z.string()).optional(),
         maxConcurrentSessions: z.number().int().positive().optional(),
+        sessionLane: z
+          .object({
+            taskTimeoutMs: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
         stream: z
           .object({
             coalesceIdleMs: z.number().int().nonnegative().optional(),


### PR DESCRIPTION
## Problem

When an ACP session gets stuck (e.g. Gemini CLI `session/load` fails), it holds the session lane forever, blocking all subsequent tasks from dequeuing and executing.

## Solution

Add a configurable `taskTimeoutMs` to the session lane. When a task exceeds this timeout:

1. The task is marked as failed with an `AcpRuntimeError`
2. The lane is released
3. The next queued task is automatically dequeued and executed

### Configuration

```yaml
acp:
  sessionLane:
    taskTimeoutMs: 600000  # default: 10 minutes
```

### Changes

- `src/acp/control-plane/manager.ts`: Add timeout timer on task start, clear on completion, auto-release lane on expiry
- `src/config/types.acp.ts`: Add `acp.sessionLane.taskTimeoutMs` config with schema validation
- `src/acp/control-plane/manager.test.ts`: Add regression test covering stuck-task-timeout → next-task-dequeue flow

### Testing

- All 37 existing + new tests pass
- `pnpm check:base-config-schema` passes
- Build failure is pre-existing on `upstream/main` (missing LINE provider files in `tsdown.config.ts`), unrelated to this change