### PR TITLE
fix(telegram): use sendMessageDraft for DM answer streaming

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1612,13 +1612,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "auto",
       }),
     );
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "auto",
       }),
     );
   });
@@ -1643,7 +1643,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "auto",
       }),
     );
     expect(answerDraftStream.materialize).not.toHaveBeenCalled();

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -205,10 +205,10 @@ export const dispatchTelegramMessage = async ({
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
-  // Keep DM preview lanes on real message transport. Native draft previews still
-  // require a draft->message materialize hop, and that overlap keeps reintroducing
-  // a visible duplicate flash at finalize time.
-  const useMessagePreviewTransportForDm = threadSpec?.scope === "dm" && canStreamAnswerDraft;
+  // Use native sendMessageDraft for DM preview streaming (Bot API 9.5).
+  // sendMessageDraft provides smooth typing animation without notifications,
+  // "Edited" tags, or editMessageText rate-limiting.
+  const useMessagePreviewTransportForDm = false;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];


### PR DESCRIPTION
## Summary

- Problem: DM answer streaming uses `editMessageText` (chunky updates) instead of native `sendMessageDraft` (smooth typing animation), despite docs stating sendMessageDraft is the primary transport.
- Why it matters: Users see choppy message edits with "Edited" tags and push notifications before content is ready, instead of the smooth draft typing experience available since Bot API 9.5.
- What changed: Set `useMessagePreviewTransportForDm` to `false` so DM answer previews use `"auto"` transport, which resolves to `sendMessageDraft`.
- What did NOT change (scope boundary): No changes to group/topic streaming, reasoning stream, draft-stream.ts transport logic, or fallback behavior. editMessageText fallback still activates if sendMessageDraft is unavailable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32041
- Related #31061, #33531 (auto-closed, same fix), #32469

## User-visible / Behavior Changes

- Telegram DM answer streaming now uses native `sendMessageDraft` instead of `sendMessage + editMessageText`
- No more push notification before content is ready
- No more "Edited" tag on final message
- Smooth typing animation instead of chunky message edits

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — calls `sendMessageDraft` instead of `editMessageText` for DM previews
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: `sendMessageDraft` is a standard Bot API method available since 9.5. The existing fallback in `draft-stream.ts` automatically reverts to `editMessageText` if `sendMessageDraft` fails (e.g., on older Bot API servers).

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (Hetzner VPS)
- Runtime/container: Node.js 24.14.0, native install
- Model/provider: openai-codex/gpt-5.4
- Integration/channel: Telegram
- Relevant config: `channels.telegram.streaming: "partial"`

### Steps

1. Configure Telegram channel with `streaming: "partial"`
2. Send a DM to the bot
3. Observe how the response is delivered

### Expected

- Smooth typing animation via `sendMessageDraft` (native draft bubble)

### Actual

- Chunky `editMessageText` updates with "Edited" tag

## Evidence

- [x] Verified by patching the built dist file on a live VPS and confirming smooth sendMessageDraft streaming in Telegram DMs
- [x] The docs at docs.openclaw.ai/channels/telegram already describe sendMessageDraft as the primary transport with editMessageText as fallback, confirming this is the intended behavior

## Human Verification (required)

- Verified scenarios: Telegram DM streaming with patched code — smooth sendMessageDraft animation confirmed
- Edge cases checked: Fallback behavior preserved in draft-stream.ts (line 318-322) for servers without sendMessageDraft support
- What you did **not** verify: Group/topic streaming (unchanged), reasoning stream (unchanged)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `useMessagePreviewTransportForDm` to `threadSpec?.scope === "dm" && canStreamAnswerDraft`
- Files/config to restore: `extensions/telegram/src/bot-message-dispatch.ts`
- Known bad symptoms reviewers should watch for: Duplicate flash at finalize time in DMs (the original reason for the message transport override — may need a finalize fix if it resurfaces)

## Risks and Mitigations

- Risk: "Duplicate flash at finalize time" mentioned in the original comment may resurface
  - Mitigation: The draft-stream.ts `materialize()` path handles draft→message conversion. If flash occurs, it can be fixed in the finalize logic without reverting to editMessageText. The existing fallback also catches sendMessageDraft failures gracefully.