### PR TITLE
fix(ui): keep Discord allowFrom IDs as strings

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -333,6 +333,56 @@ describe("saveConfig", () => {
     expect(params.baseHash).toBe("hash-save-1");
   });
 
+  it("preserves numeric-looking Discord allowFrom entries as strings", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "form";
+    state.configForm = {
+      channels: {
+        discord: {
+          allowFrom: ["123456789012345678", '"987654321098765432"'],
+        },
+      },
+    };
+    state.configSchema = {
+      type: "object",
+      properties: {
+        channels: {
+          type: "object",
+          properties: {
+            discord: {
+              type: "object",
+              properties: {
+                allowFrom: {
+                  type: "array",
+                  items: {
+                    anyOf: [{ type: "string" }, { type: "number" }],
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    state.configSnapshot = { hash: "hash-save-discord-allowfrom" };
+
+    await saveConfig(state);
+
+    expect(request.mock.calls[0]?.[0]).toBe("config.set");
+    const params = request.mock.calls[0]?.[1] as { raw: string; baseHash: string };
+    const parsed = JSON.parse(params.raw) as {
+      channels: { discord: { allowFrom: unknown[] } };
+    };
+    expect(parsed.channels.discord.allowFrom).toEqual(["123456789012345678", "987654321098765432"]);
+    expect(parsed.channels.discord.allowFrom.every((value) => typeof value === "string")).toBe(
+      true,
+    );
+    expect(params.baseHash).toBe("hash-save-discord-allowfrom");
+  });
+
   it("skips coercion when schema is not an object", async () => {
     const request = createRequestWithConfigGet();
     const state = createState();

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -108,6 +108,175 @@ function asJsonSchema(value: unknown): JsonSchema | null {
   return value as JsonSchema;
 }
 
+function setDiscordAllowFromItemsToString(
+  schemaNode: Record<string, unknown> | null | undefined,
+): void {
+  if (!schemaNode || typeof schemaNode !== "object") {
+    return;
+  }
+  const allowFrom =
+    typeof schemaNode.allowFrom === "object" &&
+    schemaNode.allowFrom &&
+    !Array.isArray(schemaNode.allowFrom)
+      ? (schemaNode.allowFrom as Record<string, unknown>)
+      : null;
+  if (allowFrom && allowFrom.type === "array") {
+    allowFrom.items = { type: "string" };
+  }
+}
+
+function normalizeDiscordAllowFromSchema(schema: JsonSchema): JsonSchema {
+  const next = cloneConfigObject(schema) as JsonSchema;
+  const rootProperties =
+    next.properties && typeof next.properties === "object" ? next.properties : undefined;
+  const channels =
+    rootProperties?.channels && typeof rootProperties.channels === "object"
+      ? (rootProperties.channels as Record<string, unknown>)
+      : null;
+  const channelProperties =
+    channels?.properties && typeof channels.properties === "object"
+      ? (channels.properties as Record<string, unknown>)
+      : null;
+  const discord =
+    channelProperties?.discord && typeof channelProperties.discord === "object"
+      ? (channelProperties.discord as Record<string, unknown>)
+      : null;
+  const discordProperties =
+    discord?.properties && typeof discord.properties === "object"
+      ? (discord.properties as Record<string, unknown>)
+      : null;
+  if (!discordProperties) {
+    return next;
+  }
+
+  setDiscordAllowFromItemsToString(discordProperties);
+
+  const dm =
+    discordProperties.dm && typeof discordProperties.dm === "object"
+      ? (discordProperties.dm as Record<string, unknown>)
+      : null;
+  const dmProperties =
+    dm?.properties && typeof dm.properties === "object"
+      ? (dm.properties as Record<string, unknown>)
+      : null;
+  if (dmProperties) {
+    setDiscordAllowFromItemsToString(dmProperties);
+  }
+
+  const accounts =
+    discordProperties.accounts && typeof discordProperties.accounts === "object"
+      ? (discordProperties.accounts as Record<string, unknown>)
+      : null;
+  const accountSchema =
+    accounts?.additionalProperties &&
+    typeof accounts.additionalProperties === "object" &&
+    !Array.isArray(accounts.additionalProperties)
+      ? (accounts.additionalProperties as Record<string, unknown>)
+      : null;
+  const accountProperties =
+    accountSchema?.properties && typeof accountSchema.properties === "object"
+      ? (accountSchema.properties as Record<string, unknown>)
+      : null;
+  if (accountProperties) {
+    setDiscordAllowFromItemsToString(accountProperties);
+    const accountDm =
+      accountProperties.dm && typeof accountProperties.dm === "object"
+        ? (accountProperties.dm as Record<string, unknown>)
+        : null;
+    const accountDmProperties =
+      accountDm?.properties && typeof accountDm.properties === "object"
+        ? (accountDm.properties as Record<string, unknown>)
+        : null;
+    if (accountDmProperties) {
+      setDiscordAllowFromItemsToString(accountDmProperties);
+    }
+  }
+
+  return next;
+}
+
+function normalizeQuotedStringEntry(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (typeof parsed === "string") {
+        return parsed;
+      }
+    } catch {
+      // Preserve the original value when it is not a JSON string literal.
+    }
+  }
+  return value;
+}
+
+function normalizeDiscordAllowFromList(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value.map((entry) => {
+    if (typeof entry === "number" && Number.isFinite(entry)) {
+      return String(entry);
+    }
+    if (typeof entry === "string") {
+      return normalizeQuotedStringEntry(entry);
+    }
+    return entry;
+  });
+}
+
+function normalizeDiscordAllowFromConfig(value: Record<string, unknown>): Record<string, unknown> {
+  const next = cloneConfigObject(value);
+  const channels =
+    typeof next.channels === "object" && next.channels && !Array.isArray(next.channels)
+      ? (next.channels as Record<string, unknown>)
+      : null;
+  const discord =
+    typeof channels?.discord === "object" && channels.discord && !Array.isArray(channels.discord)
+      ? (channels.discord as Record<string, unknown>)
+      : null;
+  if (!discord) {
+    return next;
+  }
+
+  if ("allowFrom" in discord) {
+    discord.allowFrom = normalizeDiscordAllowFromList(discord.allowFrom);
+  }
+
+  const dm =
+    typeof discord.dm === "object" && discord.dm && !Array.isArray(discord.dm)
+      ? (discord.dm as Record<string, unknown>)
+      : null;
+  if (dm && "allowFrom" in dm) {
+    dm.allowFrom = normalizeDiscordAllowFromList(dm.allowFrom);
+  }
+
+  const accounts =
+    typeof discord.accounts === "object" && discord.accounts && !Array.isArray(discord.accounts)
+      ? (discord.accounts as Record<string, unknown>)
+      : null;
+  if (accounts) {
+    for (const account of Object.values(accounts)) {
+      if (typeof account !== "object" || !account || Array.isArray(account)) {
+        continue;
+      }
+      const accountRecord = account as Record<string, unknown>;
+      if ("allowFrom" in accountRecord) {
+        accountRecord.allowFrom = normalizeDiscordAllowFromList(accountRecord.allowFrom);
+      }
+      const accountDm =
+        typeof accountRecord.dm === "object" && accountRecord.dm && !Array.isArray(accountRecord.dm)
+          ? (accountRecord.dm as Record<string, unknown>)
+          : null;
+      if (accountDm && "allowFrom" in accountDm) {
+        accountDm.allowFrom = normalizeDiscordAllowFromList(accountDm.allowFrom);
+      }
+    }
+  }
+
+  return next;
+}
+
 /**
  * Serialize the form state for submission to `config.set` / `config.apply`.
  *
@@ -121,10 +290,11 @@ function serializeFormForSubmit(state: ConfigState): string {
     return state.configRaw;
   }
   const schema = asJsonSchema(state.configSchema);
-  const form = schema
-    ? (coerceFormValues(state.configForm, schema) as Record<string, unknown>)
+  const formSchema = schema ? normalizeDiscordAllowFromSchema(schema) : null;
+  const form = formSchema
+    ? (coerceFormValues(state.configForm, formSchema) as Record<string, unknown>)
     : state.configForm;
-  return serializeConfigForm(form);
+  return serializeConfigForm(normalizeDiscordAllowFromConfig(form));
 }
 
 export async function saveConfig(state: ConfigState) {


### PR DESCRIPTION
## Summary

Fixes #52615.

The Control UI config form was coercing `channels.discord.allowFrom` entries through the generic `string | number` union path before submit. That caused two bad outcomes for Discord IDs:

- plain numeric-looking IDs were converted to JSON numbers, so `config.set` failed with `Discord IDs must be strings`
- users who worked around that by typing quoted IDs could end up persisting the quotes themselves

## Root cause

`serializeFormForSubmit()` runs `coerceFormValues()` against the JSON schema before saving form-mode edits.
Discord `allowFrom` items are represented as `anyOf(string, number)` in the schema, so the generic number coercion path treated snowflake-like IDs as numbers even though Discord validation only accepts strings.

## What changed

- scope the submit-time schema view for Discord `allowFrom` paths to `string[]` so numeric-looking IDs do not get coerced to numbers before serialization
- normalize Discord `allowFrom` submit payloads back to canonical strings, including stripping one layer of JSON-style quotes from legacy workaround input
- add a regression test covering numeric-looking Discord IDs entered via the Control UI form save path

## Testing

- `pnpm install`
- `pnpm exec vitest run --config vitest.unit.config.ts` with `OPENCLAW_VITEST_INCLUDE_FILE` targeting:
  - `ui/src/ui/controllers/config/form-utils.node.test.ts`
  - `ui/src/ui/controllers/config.test.ts`
- `git diff --check -- ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts ui/src/ui/controllers/config/form-coerce.ts ui/src/ui/controllers/config/form-utils.node.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts ui/src/ui/controllers/config/form-coerce.ts ui/src/ui/controllers/config/form-utils.node.test.ts`

Additional repo-level checks I ran:

- `pnpm check` -> fails on a pre-existing generated-file check unrelated to this diff: `src/plugins/bundled-plugin-metadata.generated.ts`
- `pnpm build` -> fails in this Windows environment before reaching this code because `/bin/bash` is unavailable for `canvas:a2ui:bundle`
- `codex review --base origin/main` -> local Codex config rejects `approvals_reviewer=never`

## Risk

Low. The change is limited to Control UI form-mode submission for Discord `allowFrom` fields. It does not touch Discord runtime authorization or non-Discord config coercion.
