### PR TITLE
fix(memory-core): register memory tools independently to prevent coupled failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
 - Web tools/Exa: add Exa as a bundled web-search plugin with Exa-native date filters, search-mode selection, and optional content extraction under `plugins.entries.exa.config.webSearch.*`. Thanks @V-Gutierrez and @vincentkoc.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
+- Memory/core tools: register `memory_search` and `memory_get` independently so one unavailable memory tool no longer suppresses the other in new sessions. (#50198) Thanks @artwalker.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,10 @@ Docs: https://docs.openclaw.ai
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
 - Web tools/Exa: add Exa as a bundled web-search plugin with Exa-native date filters, search-mode selection, and optional content extraction under `plugins.entries.exa.config.webSearch.*`. Thanks @V-Gutierrez and @vincentkoc.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
-- Memory/core tools: register `memory_search` and `memory_get` independently so one unavailable memory tool no longer suppresses the other in new sessions. (#50198) Thanks @artwalker.
 
 ### Fixes
 
+- Memory/core tools: register `memory_search` and `memory_get` independently so one unavailable memory tool no longer suppresses the other in new sessions. (#50198) Thanks @artwalker.
 - Web tools/Exa: align the bundled Exa plugin with the current Exa API by supporting newer search types and richer `contents` options, while fixing the result-count cap to honor Exa's higher limit. Thanks @vincentkoc.
 - Plugins/Matrix: move bundled plugin `KeyedAsyncQueue` imports onto the stable `plugin-sdk/core` surface so Matrix Docker/runtime builds do not depend on the brittle keyed-async-queue subpath. Thanks @ecohash-co and @vincentkoc.
 - Nostr/security: enforce inbound DM policy before decrypt, route Nostr DMs through the standard reply pipeline, and add pre-crypto rate and size guards so unknown senders cannot bypass pairing or force unbounded crypto work. Thanks @kuranikaran.

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildPromptSection } from "./index.js";
+import { describe, expect, it, vi } from "vitest";
+import plugin, { buildPromptSection } from "./index.js";
 
 describe("buildPromptSection", () => {
   it("returns empty when no memory tools are available", () => {
@@ -28,5 +28,41 @@ describe("buildPromptSection", () => {
     expect(result).toContain(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
     );
+  });
+
+  it("registers memory tools independently so one unavailable tool does not suppress the other", () => {
+    const registerTool = vi.fn();
+    const registerMemoryPromptSection = vi.fn();
+    const registerCli = vi.fn();
+    const searchTool = { name: "memory_search" };
+    const getTool = null;
+    const api = {
+      registerTool,
+      registerMemoryPromptSection,
+      registerCli,
+      runtime: {
+        tools: {
+          createMemorySearchTool: vi.fn(() => searchTool),
+          createMemoryGetTool: vi.fn(() => getTool),
+          registerMemoryCli: vi.fn(),
+        },
+      },
+    };
+
+    plugin.register(api as never);
+
+    expect(registerMemoryPromptSection).toHaveBeenCalledWith(buildPromptSection);
+    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(registerTool.mock.calls[0]?.[1]).toEqual({ names: ["memory_search"] });
+    expect(registerTool.mock.calls[1]?.[1]).toEqual({ names: ["memory_get"] });
+
+    const searchFactory = registerTool.mock.calls[0]?.[0] as
+      | ((ctx: unknown) => unknown)
+      | undefined;
+    const getFactory = registerTool.mock.calls[1]?.[0] as ((ctx: unknown) => unknown) | undefined;
+    const ctx = { config: { plugins: {} }, sessionKey: "agent:main:slack:dm:u123" };
+
+    expect(searchFactory?.(ctx)).toBe(searchTool);
+    expect(getFactory?.(ctx)).toBeNull();
   });
 });

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -29,7 +29,9 @@ describe("buildPromptSection", () => {
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",
     );
   });
+});
 
+describe("plugin registration", () => {
   it("registers memory tools independently so one unavailable tool does not suppress the other", () => {
     const registerTool = vi.fn();
     const registerMemoryPromptSection = vi.fn();

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -6,18 +6,31 @@ describe("buildPromptSection", () => {
     expect(buildPromptSection({ availableTools: new Set() })).toEqual([]);
   });
 
-  it("returns Memory Recall section when memory_search is available", () => {
-    const result = buildPromptSection({ availableTools: new Set(["memory_search"]) });
+  it("describes the two-step flow when both memory tools are available", () => {
+    const result = buildPromptSection({
+      availableTools: new Set(["memory_search", "memory_get"]),
+    });
     expect(result[0]).toBe("## Memory Recall");
+    expect(result[1]).toContain("run memory_search");
+    expect(result[1]).toContain("then use memory_get");
     expect(result).toContain(
       "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
     );
     expect(result.at(-1)).toBe("");
   });
 
-  it("returns Memory Recall section when memory_get is available", () => {
+  it("limits the guidance to memory_search when only search is available", () => {
+    const result = buildPromptSection({ availableTools: new Set(["memory_search"]) });
+    expect(result[0]).toBe("## Memory Recall");
+    expect(result[1]).toContain("run memory_search");
+    expect(result[1]).not.toContain("then use memory_get");
+  });
+
+  it("limits the guidance to memory_get when only get is available", () => {
     const result = buildPromptSection({ availableTools: new Set(["memory_get"]) });
     expect(result[0]).toBe("## Memory Recall");
+    expect(result[1]).toContain("run memory_get");
+    expect(result[1]).not.toContain("run memory_search");
   });
 
   it("includes citations-off instruction when citationsMode is off", () => {

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -34,21 +34,21 @@ export default definePluginEntry({
     api.registerMemoryPromptSection(buildPromptSection);
 
     api.registerTool(
-      (ctx) => {
-        const memorySearchTool = api.runtime.tools.createMemorySearchTool({
+      (ctx) =>
+        api.runtime.tools.createMemorySearchTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
-        });
-        const memoryGetTool = api.runtime.tools.createMemoryGetTool({
+        }),
+      { names: ["memory_search"] },
+    );
+
+    api.registerTool(
+      (ctx) =>
+        api.runtime.tools.createMemoryGetTool({
           config: ctx.config,
           agentSessionKey: ctx.sessionKey,
-        });
-        if (!memorySearchTool || !memoryGetTool) {
-          return null;
-        }
-        return [memorySearchTool, memoryGetTool];
-      },
-      { names: ["memory_search", "memory_get"] },
+        }),
+      { names: ["memory_get"] },
     );
 
     api.registerCli(

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -5,13 +5,26 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
   availableTools,
   citationsMode,
 }) => {
-  if (!availableTools.has("memory_search") && !availableTools.has("memory_get")) {
+  const hasMemorySearch = availableTools.has("memory_search");
+  const hasMemoryGet = availableTools.has("memory_get");
+
+  if (!hasMemorySearch && !hasMemoryGet) {
     return [];
   }
-  const lines = [
-    "## Memory Recall",
-    "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.",
-  ];
+
+  let toolGuidance: string;
+  if (hasMemorySearch && hasMemoryGet) {
+    toolGuidance =
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.";
+  } else if (hasMemorySearch) {
+    toolGuidance =
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md and answer from the matching results. If low confidence after search, say you checked.";
+  } else {
+    toolGuidance =
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos that already point to a specific memory file or note: run memory_get to pull only the needed lines. If low confidence after reading them, say you checked.";
+  }
+
+  const lines = ["## Memory Recall", toolGuidance];
   if (citationsMode === "off") {
     lines.push(
       "Citations are disabled: do not mention file paths or line numbers in replies unless the user explicitly asks.",

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -101,6 +101,7 @@ const telegramDepsForTest: TelegramBotDeps = {
   enqueueSystemEvent: enqueueSystemEvent as TelegramBotDeps["enqueueSystemEvent"],
   dispatchReplyWithBufferedBlockDispatcher:
     dispatchReplyWithBufferedBlockDispatcher as TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"],
+  loadWebMedia: vi.fn() as TelegramBotDeps["loadWebMedia"],
   buildModelsProviderData: buildModelsProviderData as TelegramBotDeps["buildModelsProviderData"],
   listSkillCommandsForAgents:
     listSkillCommandsForAgents as TelegramBotDeps["listSkillCommandsForAgents"],

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -109,6 +109,7 @@ export function createNativeCommandTestParams(
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
     })) as TelegramBotDeps["buildModelsProviderData"],
+    loadWebMedia: vi.fn() as TelegramBotDeps["loadWebMedia"],
     listSkillCommandsForAgents,
     wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],
   };

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -208,6 +208,7 @@ function registerAndResolveCommandHandlerBase(params: {
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
     })),
+    loadWebMedia: vi.fn() as TelegramBotDeps["loadWebMedia"],
     listSkillCommandsForAgents: vi.fn(() => []),
     wasSentByBot: vi.fn(() => false),
   };

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -4,6 +4,7 @@ import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { MockFn } from "openclaw/plugin-sdk/testing";
 import { vi } from "vitest";
+import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   createNativeCommandTestParams,
   type NativeCommandTestParams,
@@ -121,6 +122,7 @@ export function createNativeCommandsHarness(params?: {
     enqueueSystemEvent: vi.fn(),
     dispatchReplyWithBufferedBlockDispatcher:
       replyPipelineMocks.dispatchReplyWithBufferedBlockDispatcher,
+    loadWebMedia: vi.fn() as TelegramBotDeps["loadWebMedia"],
     buildModelsProviderData: vi.fn(async () => ({
       byProvider: new Map<string, Set<string>>(),
       providers: [],

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -68,6 +68,7 @@ function createNativeCommandTestParams(
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
     })) as TelegramBotDeps["buildModelsProviderData"],
+    loadWebMedia: vi.fn() as TelegramBotDeps["loadWebMedia"],
     listSkillCommandsForAgents: skillCommandMocks.listSkillCommandsForAgents,
     wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],
   };

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -161,6 +161,7 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-4.1" },
   })) as TelegramBotDeps["buildModelsProviderData"],
+  loadWebMedia: vi.fn() as TelegramBotDeps["loadWebMedia"],
   listSkillCommandsForAgents: vi.fn(() => []) as TelegramBotDeps["listSkillCommandsForAgents"],
   wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],
 };

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -104,6 +104,11 @@ export function resolvePluginTools(params: {
       continue;
     }
     if (!resolved) {
+      if (entry.names.length > 0) {
+        log.debug(
+          `plugin tool factory returned null (${entry.pluginId}): [${entry.names.join(", ")}]`,
+        );
+      }
       continue;
     }
     const listRaw = Array.isArray(resolved) ? resolved : [resolved];


### PR DESCRIPTION
## Summary

- Problem: `memory-core` registered `memory_search` and `memory_get` in one factory, so if either tool was unavailable the factory returned `null` and both tools disappeared from new sessions.
- Why it matters: a partial memory-tool failure should not silently remove the other working memory tool.
- What changed: split the two tool registrations in `extensions/memory-core/index.ts`, keep the PR's debug log in `src/plugins/tools.ts`, add a regression test for independent registration, and add the required changelog line.
- What did NOT change (scope boundary): no runtime semantics changed outside memory tool registration; the extra Telegram test-helper updates only keep current main green for `check`/`test` after rebasing the replacement branch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #50173
- Related #50198
- Supersedes #50198
- Original contributor: @artwalker

## User-visible / Behavior Changes

New sessions no longer lose both `memory_search` and `memory_get` when only one of the memory tool factories is unavailable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): memory-core plugin registration path
- Relevant config (redacted): default plugin runtime on current `origin/main`

### Steps

1. Review `extensions/memory-core/index.ts` on current main: one `registerTool(...)` factory creates both tools and returns `null` if either tool is unavailable.
2. Run the new regression test that forces one tool factory to return `null`.
3. Run full repository gates on the replacement branch rebased onto current `origin/main`.

### Expected

- `memory_search` stays registered when `memory_get` is unavailable.
- Full repo gates pass on the replacement branch.

### Actual

- Replacement branch preserves partial registration and full repo gates pass.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm build`
- `pnpm check`
- `pnpm test`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: independent `memory_search`/`memory_get` registration via the new regression in `extensions/memory-core/index.test.ts`, plus full `build/check/test` on the rebased replacement branch.
- Edge cases checked: one tool factory returning `null` no longer suppresses the other tool; changelog entry is appended at the tail of `## Unreleased` -> `### Changes`.
- What you did **not** verify: live external channel/session reproduction beyond code-path and test coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two replacement-PR commits.
- Files/config to restore: `extensions/memory-core/index.ts`, `src/plugins/tools.ts`, `extensions/memory-core/index.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: either memory tool disappearing from new sessions when only the other tool is unavailable.

## Risks and Mitigations

- Risk: the replacement branch carries minimal Telegram test-helper updates that are not part of the user-facing bug fix.
  - Mitigation: those edits are limited to test scaffolding, were only needed to keep current-main gates green after rebase, and do not alter runtime behavior.
