### PR TITLE
fix(agents): skip tool-call ID sanitization for Anthropic providers

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -39,14 +39,14 @@ describe("resolveTranscriptPolicy", () => {
     await loadFreshTranscriptPolicyModuleForTest();
   });
 
-  it("enables sanitizeToolCallIds for Anthropic provider", () => {
+  it("disables sanitizeToolCallIds for Anthropic provider (#52612)", () => {
     const policy = resolveTranscriptPolicy({
       provider: "anthropic",
       modelId: "claude-opus-4-5",
       modelApi: "anthropic-messages",
     });
-    expect(policy.sanitizeToolCallIds).toBe(true);
-    expect(policy.toolCallIdMode).toBe("strict");
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
   });
 
   it("enables sanitizeToolCallIds for Google provider", () => {
@@ -111,7 +111,7 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.repairToolUseResultPairing).toBe(true);
     expect(policy.validateAnthropicTurns).toBe(true);
     expect(policy.allowSyntheticToolResults).toBe(true);
-    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.sanitizeToolCallIds).toBe(false);
     expect(policy.sanitizeMode).toBe("full");
   });
 

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -91,8 +91,12 @@ export function resolveTranscriptPolicy(params: {
   const needsNonImageSanitize =
     isGoogle || isAnthropic || isMistral || shouldSanitizeGeminiThoughtSignaturesForProvider;
 
-  const sanitizeToolCallIds =
-    isGoogle || isMistral || isAnthropic || requiresOpenAiCompatibleToolIdSanitization;
+  // Anthropic generates tool IDs with underscores (toolu_01XYZ) that their API
+  // accepts natively. Sanitizing them strips underscores, and the order-dependent
+  // ID rewriting in createOccurrenceAwareResolver causes cache prefix instability
+  // after subagent turns (repairToolUseResultPairing can reorder messages, changing
+  // encounter order → different sanitized IDs → full cacheWrite). See #52612.
+  const sanitizeToolCallIds = isGoogle || isMistral || requiresOpenAiCompatibleToolIdSanitization;
   const toolCallIdMode: ToolCallIdMode | undefined = providerToolCallIdMode
     ? providerToolCallIdMode
     : isMistral


### PR DESCRIPTION
## Summary

- **Problem**: After using subagents, Anthropic API calls trigger a full `cacheWrite` instead of cache hits, causing unexpected cost increases. This affects all Anthropic users who use tool calls with subagents.
- **Why it matters**: Cache misses mean every turn after a subagent interaction pays full input token cost instead of the discounted cached rate. For long conversations with frequent tool use, this can multiply costs significantly.
- **What changed**:
  - Removed `isAnthropic` from the `sanitizeToolCallIds` flag in `resolveTranscriptPolicy`
  - Updated tests to reflect that Anthropic and Bedrock providers no longer sanitize tool call IDs
- **What did NOT change** (scope boundary):
  - Google, Mistral, and OpenAI-compatible providers still sanitize tool call IDs as before
  - `repairToolUseResultPairing` is unchanged — it still runs for all providers
  - The `sanitizeToolCallId` function itself is unchanged
  - No changes to how tool results are matched or how sessions are persisted

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52612
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause**: Anthropic generates tool IDs with underscores (`toolu_01AbCdEf`). The "strict" sanitization mode stripped non-alphanumeric characters via `createOccurrenceAwareResolver`, which generates replacement IDs based on **encounter order** in the message array. After a subagent turn, `repairToolUseResultPairing` can reorder, insert, or drop messages. This changes the encounter order → the same original tool ID maps to a different sanitized ID → Anthropic sees different bytes in the cache prefix → full `cacheWrite`.
- **Missing detection / guardrail**: No test asserted that Anthropic tool IDs should bypass sanitization. The `sanitizeToolCallIds` flag was set uniformly for all non-OpenAI providers without distinguishing providers whose APIs accept their own native ID format.
- **Prior context**: `sanitizeToolCallIds` was introduced to handle providers that reject certain characters in tool call IDs (Google, Mistral, OpenAI-completions). Anthropic was included in this group despite generating IDs its own API accepts natively.
- **Why this regressed now**: The cache instability only surfaces after subagent turns because `repairToolUseResultPairing` reorders messages, changing the encounter order for `createOccurrenceAwareResolver`. Single-agent sessions have stable message order, so the sanitized IDs happen to stay consistent.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `src/agents/transcript-policy.test.ts`
- **Scenario the test should lock in**: `resolveTranscriptPolicy` returns `sanitizeToolCallIds: false` and `toolCallIdMode: undefined` for Anthropic providers
- **Why this is the smallest reliable guardrail**: The policy resolution function is the single decision point for whether IDs get sanitized. If the policy says `false`, no downstream code will rewrite IDs regardless of message ordering.
- **Existing test that already covers this**: Updated existing `"disables sanitizeToolCallIds for Anthropic provider"` test (was asserting `true`, now correctly asserts `false`)

## User-visible / Behavior Changes

- Anthropic and Bedrock users will see restored cache hits after subagent interactions, reducing input token costs
- No config changes required — the fix takes effect immediately

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (from issue reporter)
- Runtime/container: podman
- Model/provider: anthropic/claude-sonnet-4.6
- Integration/channel: N/A
- Relevant config: default (no custom sanitization settings)

### Steps

1. Create a new conversation
2. Ask the agent to use a tool: `Read the IDENTITY.md file. Do exactly as I ask.`
3. Ask the agent to spawn a subagent: `Ask a subagent to respond with a random emoji, then tell me which emoji it was.`
4. Open the session logs (dashboard or `agent/:id/sessions` folder)
5. Check the `cacheWrite` value for the last message in the chain

### Expected

`cacheWrite` marginally increased, `cacheRead` is non-zero (cache prefix matches prior turns).

### Actual

`cacheWrite` is large (entire conversation rewritten), `cacheRead` is zero (cache prefix changed due to ID rewriting).

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ disables sanitizeToolCallIds for Anthropic provider (#52612)
 ✓ enables sanitizeToolCallIds for Google provider
 ✓ enables sanitizeToolCallIds for Mistral provider
 ✓ disables sanitizeToolCallIds for OpenAI provider
 ✓ enables Anthropic-compatible policies for Bedrock provider
 ...
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

## Human Verification (required)

- Verified scenarios:
  - [x] `resolveTranscriptPolicy` returns `sanitizeToolCallIds: false` for Anthropic provider
  - [x] `resolveTranscriptPolicy` returns `sanitizeToolCallIds: false` for Bedrock Anthropic provider
  - [x] Google, Mistral, and OpenAI-compat providers still return `sanitizeToolCallIds: true`
  - [x] All 19 transcript-policy tests pass
- Edge cases checked:
  - [x] `toolCallIdMode` falls through to `undefined` (not `"strict"`) when `sanitizeToolCallIds` is `false`
- What I did **not** verify:
  - Live Anthropic API call confirming cache hit improvement (requires real API key + subagent session)
  - Whether any downstream code path assumes Anthropic tool IDs are alphanumeric-only
  - Bedrock Converse API behavior with underscored tool IDs (assumed compatible since Bedrock proxies Anthropic)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- **How to disable/revert**: Re-add `isAnthropic` to the `sanitizeToolCallIds` flag in `resolveTranscriptPolicy` (1-line revert)
- **Files/config to restore**: `src/agents/transcript-policy.ts` only
- **Known bad symptoms**: Anthropic API 400 errors mentioning invalid `tool_use_id` format

## Risks and Mitigations

- **Risk**: Bedrock Converse API might reject native `toolu_*` IDs with underscores (unverified assumption that it accepts them since it proxies Anthropic)
  - Mitigation: 1-line revert. Symptom would be HTTP 400 from Bedrock only; Anthropic direct unaffected.
- **Risk**: Third-party providers routed through `anthropic-messages` modelApi but generating non-`toolu_*` IDs would skip sanitization
  - Mitigation: Such providers would need explicit registration as Anthropic-family. No known provider fits this case currently.