### PR TITLE
fix(test): complete env isolation in buildGatewayInstallPlan tests

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -147,7 +147,7 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
       warn,
@@ -166,7 +166,7 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
       config: {
@@ -195,7 +195,7 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
       config: {
@@ -216,7 +216,7 @@ describe("buildGatewayInstallPlan", () => {
     mockNodeGatewayPlanFixture();
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
       config: {
@@ -237,7 +237,7 @@ describe("buildGatewayInstallPlan", () => {
     mockNodeGatewayPlanFixture({ serviceEnvironment: {} });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
       config: {
@@ -263,7 +263,7 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
       config: {
@@ -304,6 +304,7 @@ describe("buildGatewayInstallPlan", () => {
 
     const plan = await buildGatewayInstallPlan({
       env: {
+        HOME: isolatedHome,
         OPENAI_API_KEY: "sk-openai-test", // pragma: allowlist secret
         ANTHROPIC_TOKEN: "ant-test-token",
       },
@@ -333,7 +334,7 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     const plan = await buildGatewayInstallPlan({
-      env: {},
+      env: { HOME: isolatedHome },
       port: 3000,
       runtime: "node",
     });


### PR DESCRIPTION
## Summary

Follow-up to #52492. The `isolatedHome` pattern added in dd860e76aa covered only 2 of 10 `buildGatewayInstallPlan` call sites. The remaining 8 still passed `env: {}` (or `env` without `HOME`), causing `readStateDirDotEnvVars` to fall back to `os.homedir()` and read the developer's real `~/.openclaw/.env` — producing non-deterministic test failures when that file contains keys matching test assertions.

This PR adds `HOME: isolatedHome` to all remaining call sites, completing the isolation.

### What changed
- 8 test call sites in `daemon-install-helpers.test.ts` updated from `env: {}` to `env: { HOME: isolatedHome }`
- 1 test (`merges env-backed auth-profile refs`) updated to include `HOME: isolatedHome` alongside existing API key env vars

### Why it was missed
The original fix commit only addressed tests using strict `toEqual` on the full environment object. Tests checking individual keys (`.GOOGLE_API_KEY`, `.NODE_OPTIONS`, etc.) didn't fail on CI because CI machines have no `~/.openclaw/.env`. The bug is latent — it only surfaces on developer machines with a populated `.env` whose keys collide with assertion targets.

## Test plan
- [x] `vitest run src/commands/daemon-install-helpers.test.ts` — 21/21 pass
- [x] All pre-commit checks pass (format, lint, typecheck, 28+ boundary lints)
- [x] Verified zero remaining `env: {}` calls in `buildGatewayInstallPlan` tests
- [x] Grep confirms only `HOME: isolatedHome` or `HOME: tmpDir` patterns remain

Closes the test-isolation feedback from the Greptile review on #52492.