### PR TITLE
fix(ui): install dev dependencies for ui:build instead of --prod

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -128,10 +128,7 @@ if (action === "install") {
   run(runner.cmd, ["install", ...rest]);
 } else {
   if (!depsInstalled(action === "test" ? "test" : "build")) {
-    const installEnv =
-      action === "build" ? { ...process.env, NODE_ENV: "production" } : process.env;
-    const installArgs = action === "build" ? ["install", "--prod"] : ["install"];
-    runSync(runner.cmd, installArgs, installEnv);
+    runSync(runner.cmd, ["install"]);
   }
   run(runner.cmd, ["run", script, ...rest]);
 }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -128,7 +128,7 @@ if (action === "install") {
   run(runner.cmd, ["install", ...rest]);
 } else {
   if (!depsInstalled(action === "test" ? "test" : "build")) {
-    runSync(runner.cmd, ["install"]);
+    runSync(runner.cmd, ["install", "--ignore-workspace"]);
   }
   run(runner.cmd, ["run", script, ...rest]);
 }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -128,7 +128,7 @@ if (action === "install") {
   run(runner.cmd, ["install", ...rest]);
 } else {
   if (!depsInstalled(action === "test" ? "test" : "build")) {
-    runSync(runner.cmd, ["install", "--ignore-workspace"]);
+    runSync(runner.cmd, ["install", "--filter", "openclaw-control-ui"]);
   }
   run(runner.cmd, ["run", script, ...rest]);
 }


### PR DESCRIPTION
## Summary
- Remove --prod flag from ui:build install
- Vite and other dev-only deps are needed to run the build
- Fixes fresh clone builds failing with 'Cannot find module vite'

## Issue
Fixes #52494

## Testing
- Build passes locally