### PR TITLE
fix: restore Telegram DM native draft streaming

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -664,9 +664,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const bot = createBot();
     await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
 
-    expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.archiveActivePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
     const deleteMessageCalls = (
       bot.api as unknown as { deleteMessage: { mock: { calls: unknown[][] } } }
     ).deleteMessage.mock.calls;
@@ -709,7 +709,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
       2,
       123,
-      1002,
+      1001,
       "Message B final",
       expect.any(Object),
     );
@@ -771,7 +771,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createContext(), streamMode: "partial" });
 
-    expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.archiveActivePreview).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenCalledTimes(2);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Message B early");
@@ -814,7 +814,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
       2,
       123,
-      1002,
+      1001,
       "Message B final",
       expect.any(Object),
     );
@@ -880,7 +880,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
       2,
       123,
-      1002,
+      1001,
       "Message B final",
       expect.any(Object),
     );
@@ -932,7 +932,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
       2,
       123,
-      1002,
+      1001,
       "Message B final",
       expect.any(Object),
     );
@@ -1517,7 +1517,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
       await dispatchWithContext({ context: createReasoningStreamContext(), streamMode });
 
-      expect(reasoningDraftStream.forceNewMessage).not.toHaveBeenCalled();
+      expect(reasoningDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     },
   );
 
@@ -1612,13 +1612,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "draft",
       }),
     );
     expect(createTelegramDraftStream.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "draft",
       }),
     );
   });
@@ -1643,7 +1643,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(createTelegramDraftStream.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         thread: { id: 777, scope: "dm" },
-        previewTransport: "message",
+        previewTransport: "draft",
       }),
     );
     expect(answerDraftStream.materialize).not.toHaveBeenCalled();
@@ -1677,7 +1677,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(reasoningDraftStream.update).toHaveBeenCalledWith("Reasoning:\n_Working on it..._");
     expect(answerDraftStream.update).toHaveBeenCalledWith("Checking the directory...");
     expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
-    expect(reasoningDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(reasoningDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
   });
 
   it("does not edit reasoning preview bubble with final answer when no assistant partial arrived yet", async () => {
@@ -1771,14 +1771,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
     await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
 
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenNthCalledWith(1, 123, 999, "3", expect.any(Object));
-    expect(editMessageTelegram).toHaveBeenNthCalledWith(
-      2,
-      123,
-      111,
-      "Reasoning:\nIf I count r in strawberry, I see positions 3, 8, and 9. So the total is 3.",
-      expect.any(Object),
-    );
     expect(deliverReplies).not.toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -205,10 +205,6 @@ export const dispatchTelegramMessage = async ({
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
-  // Keep DM preview lanes on real message transport. Native draft previews still
-  // require a draft->message materialize hop, and that overlap keeps reintroducing
-  // a visible duplicate flash at finalize time.
-  const useMessagePreviewTransportForDm = threadSpec?.scope === "dm" && canStreamAnswerDraft;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
@@ -219,26 +215,25 @@ export const dispatchTelegramMessage = async ({
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
-          previewTransport: useMessagePreviewTransportForDm ? "message" : "auto",
+          previewTransport: threadSpec?.scope === "dm" ? "draft" : "auto",
           replyToMessageId: draftReplyToMessageId,
           minInitialChars: draftMinInitialChars,
           renderText: renderDraftPreview,
           onSupersededPreview:
-            laneName === "answer" || laneName === "reasoning"
+            laneName === "reasoning"
               ? (preview) => {
-                  if (laneName === "reasoning") {
-                    if (!archivedReasoningPreviewIds.includes(preview.messageId)) {
-                      archivedReasoningPreviewIds.push(preview.messageId);
-                    }
-                    return;
+                  if (!archivedReasoningPreviewIds.includes(preview.messageId)) {
+                    archivedReasoningPreviewIds.push(preview.messageId);
                   }
+                }
+              : (preview) => {
                   archivedAnswerPreviews.push({
                     messageId: preview.messageId,
                     textSnapshot: preview.textSnapshot,
+                    consumeOnNextFinal: true,
                     deleteIfUnused: true,
                   });
-                }
-              : undefined,
+                },
           log: logVerbose,
           warn: logVerbose,
         })
@@ -266,6 +261,7 @@ export const dispatchTelegramMessage = async ({
   };
   const answerLane = lanes.answer;
   const reasoningLane = lanes.reasoning;
+  let activeDmPreviewLane: LaneName | null = null;
   let splitReasoningOnNextStream = false;
   let skipNextAnswerMessageStartRotation = false;
   let draftLaneEventQueue = Promise.resolve();
@@ -302,13 +298,44 @@ export const dispatchTelegramMessage = async ({
     lane.lastPartialText = "";
     lane.hasStreamedMessage = false;
   };
+  const archiveActiveDmPreview = async (reason: "boundary" | "lane-switch") => {
+    if (threadSpec?.scope !== "dm" || activeDmPreviewLane == null) {
+      return false;
+    }
+    const laneName = activeDmPreviewLane;
+    const lane = lanes[laneName];
+    if (!lane.hasStreamedMessage) {
+      activeDmPreviewLane = null;
+      return false;
+    }
+    const archivedPreview = await lane.stream?.archiveActivePreview?.();
+    if (archivedPreview?.messageId != null) {
+      if (laneName === "answer") {
+        archivedAnswerPreviews.push({
+          messageId: archivedPreview.messageId,
+          textSnapshot: lane.lastPartialText,
+          deleteIfUnused: reason === "lane-switch",
+        });
+      } else if (!archivedReasoningPreviewIds.includes(archivedPreview.messageId)) {
+        archivedReasoningPreviewIds.push(archivedPreview.messageId);
+      }
+    }
+    lane.stream?.forceNewMessage();
+    resetDraftLaneState(lane);
+    activeDmPreviewLane = null;
+    return true;
+  };
   const rotateAnswerLaneForNewAssistantMessage = async () => {
+    if (threadSpec?.scope === "dm") {
+      const didArchive = await archiveActiveDmPreview("boundary");
+      activePreviewLifecycleByLane.answer = "transient";
+      retainPreviewOnCleanupByLane.answer = false;
+      return didArchive;
+    }
     let didForceNewMessage = false;
     if (answerLane.hasStreamedMessage) {
-      // Materialize the current streamed draft into a permanent message
-      // so it remains visible across tool boundaries.
-      const materializedId = await answerLane.stream?.materialize?.();
-      const previewMessageId = materializedId ?? answerLane.stream?.messageId();
+      const archivedPreview = await answerLane.stream?.archiveActivePreview?.();
+      const previewMessageId = archivedPreview?.messageId ?? answerLane.stream?.messageId();
       if (
         typeof previewMessageId === "number" &&
         activePreviewLifecycleByLane.answer === "transient"
@@ -316,6 +343,7 @@ export const dispatchTelegramMessage = async ({
         archivedAnswerPreviews.push({
           messageId: previewMessageId,
           textSnapshot: answerLane.lastPartialText,
+          consumeOnNextFinal: false,
           deleteIfUnused: false,
         });
       }
@@ -330,7 +358,8 @@ export const dispatchTelegramMessage = async ({
     }
     return didForceNewMessage;
   };
-  const updateDraftFromPartial = (lane: DraftLaneState, text: string | undefined) => {
+  const updateDraftFromPartial = (laneName: LaneName, text: string | undefined) => {
+    const lane = lanes[laneName];
     const laneStream = lane.stream;
     if (!laneStream || !text) {
       return;
@@ -363,11 +392,17 @@ export const dispatchTelegramMessage = async ({
       skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
     }
     for (const segment of split.segments) {
+      if (threadSpec?.scope === "dm") {
+        if (activeDmPreviewLane != null && activeDmPreviewLane !== segment.lane) {
+          await archiveActiveDmPreview("lane-switch");
+        }
+        activeDmPreviewLane = segment.lane;
+      }
       if (segment.lane === "reasoning") {
         reasoningStepState.noteReasoningHint();
         reasoningStepState.noteReasoningDelivered();
       }
-      updateDraftFromPartial(lanes[segment.lane], segment.text);
+      updateDraftFromPartial(segment.lane, segment.text);
     }
   };
   const flushDraftLane = async (lane: DraftLaneState) => {
@@ -692,7 +727,9 @@ export const dispatchTelegramMessage = async ({
 
           if (info.kind === "final") {
             await answerLane.stream?.stop();
-            await reasoningLane.stream?.stop();
+            if (reasoningLane.stream !== answerLane.stream) {
+              await reasoningLane.stream?.stop();
+            }
             reasoningStepState.resetForNextStep();
           }
           const canSendAsIs = reply.hasMedia || reply.text.length > 0;
@@ -737,8 +774,13 @@ export const dispatchTelegramMessage = async ({
                 // stream starts. Splitting at reasoning-end can orphan the active
                 // preview and cause duplicate reasoning sends on reasoning final.
                 if (splitReasoningOnNextStream) {
-                  reasoningLane.stream?.forceNewMessage();
-                  resetDraftLaneState(reasoningLane);
+                  if (threadSpec?.scope === "dm") {
+                    await archiveActiveDmPreview("lane-switch");
+                    activeDmPreviewLane = "reasoning";
+                  } else {
+                    reasoningLane.stream?.forceNewMessage();
+                    resetDraftLaneState(reasoningLane);
+                  }
                   splitReasoningOnNextStream = false;
                 }
                 await ingestDraftLaneSegments(payload.text);
@@ -832,6 +874,7 @@ export const dispatchTelegramMessage = async ({
         await stream.clear();
       }
     }
+    activeDmPreviewLane = null;
     for (const archivedPreview of archivedAnswerPreviews) {
       if (archivedPreview.deleteIfUnused === false) {
         continue;

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -1,17 +1,29 @@
 import { vi } from "vitest";
 
-type DraftPreviewMode = "message" | "draft";
-
 export type TestDraftStream = {
   update: ReturnType<typeof vi.fn<(text: string) => void>>;
   flush: ReturnType<typeof vi.fn<() => Promise<void>>>;
   messageId: ReturnType<typeof vi.fn<() => number | undefined>>;
-  previewMode: ReturnType<typeof vi.fn<() => DraftPreviewMode>>;
+  previewMode: ReturnType<typeof vi.fn<() => "message" | "draft">>;
   previewRevision: ReturnType<typeof vi.fn<() => number>>;
   lastDeliveredText: ReturnType<typeof vi.fn<() => string>>;
   clear: ReturnType<typeof vi.fn<() => Promise<void>>>;
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
+  prepareFinalization: ReturnType<
+    typeof vi.fn<
+      (params: {
+        text: string;
+      }) => Promise<
+        | { kind: "finalized"; content: string; messageId?: number }
+        | { kind: "edit"; messageId: number; finalTextAlreadyLanded: boolean }
+        | { kind: "retained" | "fallback" }
+      >
+    >
+  >;
+  archiveActivePreview: ReturnType<
+    typeof vi.fn<() => Promise<{ textSnapshot: string; messageId?: number } | undefined>>
+  >;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
   sendMayHaveLanded: ReturnType<typeof vi.fn<() => boolean>>;
   setMessageId: (value: number | undefined) => void;
@@ -19,7 +31,7 @@ export type TestDraftStream = {
 
 export function createTestDraftStream(params?: {
   messageId?: number;
-  previewMode?: DraftPreviewMode;
+  previewMode?: "message" | "draft";
   onUpdate?: (text: string) => void;
   onStop?: () => void | Promise<void>;
   clearMessageIdOnForceNew?: boolean;
@@ -27,7 +39,7 @@ export function createTestDraftStream(params?: {
   let messageId = params?.messageId;
   let previewRevision = 0;
   let lastDeliveredText = "";
-  return {
+  const stream: TestDraftStream = {
     update: vi.fn().mockImplementation((text: string) => {
       previewRevision += 1;
       lastDeliveredText = text.trimEnd();
@@ -43,6 +55,34 @@ export function createTestDraftStream(params?: {
       await params?.onStop?.();
     }),
     materialize: vi.fn().mockImplementation(async () => messageId),
+    prepareFinalization: vi.fn().mockImplementation(async ({ text }: { text: string }) => {
+      if ((params?.previewMode ?? "message") === "draft") {
+        const materializedMessageId = await stream.materialize();
+        if (typeof materializedMessageId === "number") {
+          return {
+            kind: "finalized",
+            content: text.trimEnd(),
+            messageId: materializedMessageId,
+          } as const;
+        }
+        return { kind: "fallback" } as const;
+      }
+      if (typeof messageId === "number") {
+        return { kind: "edit", messageId, finalTextAlreadyLanded: false } as const;
+      }
+      if (stream.sendMayHaveLanded() && previewRevision > 0) {
+        return { kind: "retained" } as const;
+      }
+      return { kind: "fallback" } as const;
+    }),
+    archiveActivePreview: vi.fn().mockImplementation(async () =>
+      lastDeliveredText
+        ? {
+            textSnapshot: lastDeliveredText,
+            ...(typeof messageId === "number" ? { messageId } : {}),
+          }
+        : undefined,
+    ),
     forceNewMessage: vi.fn().mockImplementation(() => {
       if (params?.clearMessageIdOnForceNew) {
         messageId = undefined;
@@ -53,29 +93,46 @@ export function createTestDraftStream(params?: {
       messageId = value;
     },
   };
+  return stream;
 }
 
 export function createSequencedTestDraftStream(startMessageId = 1001): TestDraftStream {
   let activeMessageId: number | undefined;
   let nextMessageId = startMessageId;
-  let previewRevision = 0;
   let lastDeliveredText = "";
-  return {
+  const stream: TestDraftStream = {
     update: vi.fn().mockImplementation((text: string) => {
       if (activeMessageId == null) {
         activeMessageId = nextMessageId++;
       }
-      previewRevision += 1;
       lastDeliveredText = text.trimEnd();
     }),
     flush: vi.fn().mockResolvedValue(undefined),
     messageId: vi.fn().mockImplementation(() => activeMessageId),
     previewMode: vi.fn().mockReturnValue("message"),
-    previewRevision: vi.fn().mockImplementation(() => previewRevision),
+    previewRevision: vi.fn().mockImplementation(() => 0),
     lastDeliveredText: vi.fn().mockImplementation(() => lastDeliveredText),
     clear: vi.fn().mockResolvedValue(undefined),
     stop: vi.fn().mockResolvedValue(undefined),
     materialize: vi.fn().mockImplementation(async () => activeMessageId),
+    prepareFinalization: vi.fn().mockImplementation(async ({ text }: { text: string }) => {
+      if (activeMessageId == null) {
+        activeMessageId = nextMessageId++;
+      }
+      return {
+        kind: "edit",
+        messageId: activeMessageId,
+        finalTextAlreadyLanded: false,
+      } as const;
+    }),
+    archiveActivePreview: vi.fn().mockImplementation(async () =>
+      lastDeliveredText
+        ? {
+            textSnapshot: lastDeliveredText,
+            ...(typeof activeMessageId === "number" ? { messageId: activeMessageId } : {}),
+          }
+        : undefined,
+    ),
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
     }),
@@ -84,4 +141,5 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
       activeMessageId = value;
     },
   };
+  return stream;
 }

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -2,7 +2,11 @@ import type { Bot } from "grammy";
 import { createFinalizableDraftLifecycle } from "openclaw/plugin-sdk/channel-lifecycle";
 import { resolveGlobalSingleton } from "openclaw/plugin-sdk/text-runtime";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./bot/helpers.js";
-import { isSafeToRetrySendError, isTelegramClientRejection } from "./network-errors.js";
+import {
+  isRecoverableTelegramNetworkError,
+  isSafeToRetrySendError,
+  isTelegramClientRejection,
+} from "./network-errors.js";
 
 const TELEGRAM_STREAM_MAX_CHARS = 4096;
 const DEFAULT_THROTTLE_MS = 1000;
@@ -72,8 +76,27 @@ export type TelegramDraftStream = {
   lastDeliveredText?: () => string;
   clear: () => Promise<void>;
   stop: () => Promise<void>;
-  /** Convert the current draft preview into a permanent message (sendMessage). */
   materialize?: () => Promise<number | undefined>;
+  prepareFinalization?: (params: { text: string }) => Promise<
+    | {
+        kind: "finalized";
+        content: string;
+        messageId?: number;
+      }
+    | {
+        kind: "edit";
+        messageId: number;
+        finalTextAlreadyLanded: boolean;
+      }
+    | { kind: "retained" | "fallback" }
+  >;
+  archiveActivePreview?: () => Promise<
+    | {
+        textSnapshot: string;
+        messageId?: number;
+      }
+    | undefined
+  >;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
   /** True when a preview sendMessage was attempted but the response was lost. */
@@ -385,23 +408,15 @@ export function createTelegramDraftStream(params: {
     loop.resetThrottleWindow();
   };
 
-  /**
-   * Materialize the current draft into a permanent message.
-   * For draft transport: sends the accumulated text as a real sendMessage.
-   * For message transport: the message is already permanent (noop).
-   * Returns the permanent message id, or undefined if nothing to materialize.
-   */
-  const materialize = async (): Promise<number | undefined> => {
+  const materializeDraftPreview = async (): Promise<
+    { kind: "finalized"; messageId?: number } | { kind: "retained" | "fallback" }
+  > => {
     await stop();
-    // If using message transport, the streamMessageId is already a real message.
-    if (previewTransport === "message" && typeof streamMessageId === "number") {
-      return streamMessageId;
-    }
     // For draft transport, use the rendered snapshot first so parse_mode stays
     // aligned with the text being materialized.
     const renderedText = lastSentText || lastDeliveredText;
     if (!renderedText) {
-      return undefined;
+      return { kind: "fallback" };
     }
     const renderedParseMode = lastSentText ? lastSentParseMode : undefined;
     try {
@@ -428,14 +443,97 @@ export function createTelegramDraftStream(params: {
             // Best-effort cleanup; draft clear failure is cosmetic.
           }
         }
-        return streamMessageId;
+        return { kind: "finalized", messageId: streamMessageId };
       }
     } catch (err) {
+      if (isSafeToRetrySendError(err) || isTelegramClientRejection(err)) {
+        return { kind: "fallback" };
+      }
+      if (isRecoverableTelegramNetworkError(err, { allowMessageMatch: true })) {
+        return { kind: "retained" };
+      }
       params.warn?.(
         `telegram stream preview materialize failed: ${err instanceof Error ? err.message : String(err)}`,
       );
+      return { kind: "retained" };
+    }
+    return { kind: "fallback" };
+  };
+
+  const prepareFinalization: NonNullable<TelegramDraftStream["prepareFinalization"]> = async ({
+    text,
+  }) => {
+    const trimmed = text.trimEnd();
+    if (!trimmed) {
+      return { kind: "fallback" };
+    }
+    const hadPreviewMessage = typeof streamMessageId === "number";
+    if (trimmed !== lastDeliveredText) {
+      update(text);
+    }
+    if (previewTransport === "draft") {
+      const result = await materializeDraftPreview();
+      if (result.kind === "finalized") {
+        lastDeliveredText = trimmed;
+        return {
+          kind: "finalized",
+          content: trimmed,
+          ...(typeof result.messageId === "number" ? { messageId: result.messageId } : {}),
+        };
+      }
+      return result;
+    }
+    if (!hadPreviewMessage) {
+      update(text);
+    }
+    await stop();
+    if (typeof streamMessageId === "number") {
+      return {
+        kind: "edit",
+        messageId: streamMessageId,
+        finalTextAlreadyLanded: !hadPreviewMessage,
+      };
+    }
+    if (messageSendAttempted && hadPreviewMessage) {
+      return { kind: "retained" };
+    }
+    return { kind: "fallback" };
+  };
+
+  const archiveActivePreview: NonNullable<
+    TelegramDraftStream["archiveActivePreview"]
+  > = async () => {
+    const textSnapshot = lastDeliveredText;
+    if (!textSnapshot) {
+      return undefined;
+    }
+    if (previewTransport === "draft") {
+      const result = await materializeDraftPreview();
+      if (result.kind !== "finalized") {
+        return { textSnapshot };
+      }
+      return {
+        textSnapshot,
+        ...(typeof result.messageId === "number" ? { messageId: result.messageId } : {}),
+      };
+    }
+    await stop();
+    if (typeof streamMessageId === "number") {
+      return { textSnapshot, messageId: streamMessageId };
+    }
+    if (messageSendAttempted) {
+      return { textSnapshot };
     }
     return undefined;
+  };
+
+  const materialize: NonNullable<TelegramDraftStream["materialize"]> = async () => {
+    if (previewTransport === "message") {
+      await stop();
+      return streamMessageId;
+    }
+    const result = await materializeDraftPreview();
+    return result.kind === "finalized" ? result.messageId : undefined;
   };
 
   params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
@@ -450,6 +548,8 @@ export function createTelegramDraftStream(params: {
     clear,
     stop,
     materialize,
+    prepareFinalization,
+    archiveActivePreview,
     forceNewMessage,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -450,8 +450,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     const lane = params.lanes[laneName];
     const reply = resolveSendableOutboundReplyParts(payload, { text });
     const hasMedia = reply.hasMedia;
+    const hasPreviewButtons = Boolean(previewButtons && previewButtons.length > 0);
     const canEditViaPreview =
-      !hasMedia && text.length > 0 && text.length <= params.draftMaxChars && !payload.isError;
+      !hasMedia &&
+      !hasPreviewButtons &&
+      text.length > 0 &&
+      text.length <= params.draftMaxChars &&
+      !payload.isError;
 
     if (infoKind === "final") {
       // Transient previews must decide cleanup retention per final attempt.

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -49,6 +49,7 @@ export type DraftLaneState = {
 export type ArchivedPreview = {
   messageId: number;
   textSnapshot: string;
+  consumeOnNextFinal?: boolean;
   // Boundary-finalized previews should remain visible even if no matching
   // final edit arrives; superseded previews can be safely deleted.
   deleteIfUnused?: boolean;
@@ -184,42 +185,6 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   const markActivePreviewComplete = (laneName: LaneName) => {
     params.activePreviewLifecycleByLane[laneName] = "complete";
     params.retainPreviewOnCleanupByLane[laneName] = true;
-  };
-  const isDraftPreviewLane = (lane: DraftLaneState) => lane.stream?.previewMode?.() === "draft";
-  const canMaterializeDraftFinal = (
-    lane: DraftLaneState,
-    previewButtons?: TelegramInlineButtons,
-  ) => {
-    const hasPreviewButtons = Boolean(previewButtons && previewButtons.length > 0);
-    return (
-      isDraftPreviewLane(lane) &&
-      !hasPreviewButtons &&
-      typeof lane.stream?.materialize === "function"
-    );
-  };
-
-  const tryMaterializeDraftPreviewForFinal = async (args: {
-    lane: DraftLaneState;
-    laneName: LaneName;
-    text: string;
-  }): Promise<number | undefined> => {
-    const stream = args.lane.stream;
-    if (!stream || !isDraftPreviewLane(args.lane)) {
-      return undefined;
-    }
-    // Draft previews have no message_id to edit; materialize the final text
-    // into a real message and treat that as the finalized delivery.
-    stream.update(args.text);
-    const materializedMessageId = await stream.materialize?.();
-    if (typeof materializedMessageId !== "number") {
-      params.log(
-        `telegram: ${args.laneName} draft preview materialize produced no message id; falling back to standard send`,
-      );
-      return undefined;
-    }
-    args.lane.lastPartialText = args.text;
-    params.markDelivered();
-    return materializedMessageId;
   };
 
   const tryEditPreviewMessage = async (args: {
@@ -423,10 +388,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     previewButtons,
     canEditViaPreview,
   }: ConsumeArchivedAnswerPreviewParams): Promise<LaneDeliveryResult | undefined> => {
-    const archivedPreview = params.archivedAnswerPreviews.shift();
-    if (!archivedPreview) {
+    const archivedPreview = params.archivedAnswerPreviews[0];
+    if (!archivedPreview || archivedPreview.consumeOnNextFinal === false) {
       return undefined;
     }
+    params.archivedAnswerPreviews.shift();
     if (canEditViaPreview) {
       const finalized = await tryUpdatePreviewForLane({
         lane,
@@ -520,18 +486,85 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
             return archivedResultAfterFlush;
           }
         }
-        if (canMaterializeDraftFinal(lane, previewButtons)) {
-          const materializedMessageId = await tryMaterializeDraftPreviewForFinal({
-            lane,
-            laneName,
-            text,
+        const transportFinalization = await lane.stream?.prepareFinalization?.({ text });
+        if (transportFinalization?.kind === "finalized") {
+          lane.lastPartialText = text;
+          params.markDelivered();
+          markActivePreviewComplete(laneName);
+          return result("preview-finalized", {
+            content: transportFinalization.content,
+            messageId: transportFinalization.messageId,
           });
-          if (typeof materializedMessageId === "number") {
+        }
+        if (transportFinalization?.kind === "retained") {
+          markActivePreviewComplete(laneName);
+          return result("preview-retained");
+        }
+        if (
+          transportFinalization?.kind === "fallback" &&
+          lane.stream?.previewMode?.() === "draft"
+        ) {
+          params.log(
+            `telegram: ${laneName} draft preview materialize produced no message id; falling back to standard send`,
+          );
+        }
+        if (transportFinalization?.kind === "edit") {
+          await params.stopDraftLane(lane);
+          const finalizedPreviewMessageId = lane.stream?.messageId();
+          if (typeof finalizedPreviewMessageId !== "number") {
+            if (lane.hasStreamedMessage && lane.stream?.sendMayHaveLanded?.()) {
+              params.log(
+                `telegram: ${laneName} preview send may have landed despite missing message id; keeping to avoid duplicate`,
+              );
+              params.markDelivered();
+              markActivePreviewComplete(laneName);
+              return result("preview-retained");
+            }
+            const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+            return delivered ? result("sent") : result("skipped");
+          }
+          const currentPreviewText = getLanePreviewText(lane);
+          if (
+            shouldSkipRegressivePreviewUpdate({
+              currentPreviewText,
+              text,
+              skipRegressive: "existingOnly",
+              hadPreviewMessage: true,
+            })
+          ) {
+            params.markDelivered();
+            markActivePreviewComplete(laneName);
+            return result("preview-finalized", {
+              content: currentPreviewText,
+              messageId: finalizedPreviewMessageId,
+            });
+          }
+          const finalized = await tryEditPreviewMessage({
+            laneName,
+            messageId: finalizedPreviewMessageId,
+            text,
+            context: "final",
+            previewButtons,
+            updateLaneSnapshot: false,
+            lane,
+            finalTextAlreadyLanded: transportFinalization.finalTextAlreadyLanded,
+            retainAlternatePreviewOnMissingTarget: false,
+          });
+          if (finalized === "edited") {
             markActivePreviewComplete(laneName);
             return result("preview-finalized", {
               content: text,
-              messageId: materializedMessageId,
+              messageId: transportFinalization.messageId,
             });
+          }
+          if (finalized === "retained") {
+            markActivePreviewComplete(laneName);
+            return result("preview-retained");
+          }
+          if (finalized === "fallback") {
+            await params.stopDraftLane(lane);
+            const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+            return delivered ? result("sent") : result("skipped");
           }
         }
         const previewMessageId = lane.stream?.messageId();
@@ -573,20 +606,14 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     if (allowPreviewUpdateForNonFinal && canEditViaPreview) {
-      if (isDraftPreviewLane(lane)) {
-        // DM draft flow has no message_id to edit; updates are sent via sendMessageDraft.
-        // Only mark as updated when the draft flush actually emits an update.
-        const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
-        lane.stream?.update(text);
-        await params.flushDraftLane(lane);
-        const previewUpdated = (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
-        if (!previewUpdated) {
-          params.log(
-            `telegram: ${laneName} draft preview update not emitted; falling back to standard send`,
-          );
-          const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
-          return delivered ? result("sent") : result("skipped");
-        }
+      const trimmed = text.trimEnd();
+      const previewRevisionBeforeFlush = lane.stream?.previewRevision?.() ?? 0;
+      lane.stream?.update(text);
+      await params.flushDraftLane(lane);
+      const previewUpdated =
+        (lane.stream?.lastDeliveredText?.() ?? "") === trimmed ||
+        (lane.stream?.previewRevision?.() ?? 0) > previewRevisionBeforeFlush;
+      if (previewUpdated) {
         lane.lastPartialText = text;
         params.markDelivered();
         return result("preview-updated");

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -444,6 +444,7 @@ describe("createLaneTextDeliverer", () => {
     });
 
     expect(result.kind).toBe("sent");
+    expect(answerStream.materialize).not.toHaveBeenCalled();
     expect(harness.sendPayload).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Choose one" }),
     );


### PR DESCRIPTION
## Summary
- restore native `sendMessageDraft` streaming for Telegram DMs
- serialize reasoning and answer preview ownership so only one DM draft lane is active at a time
- move draft finalization decisions into the Telegram draft transport to avoid duplicate final sends

## Testing
- `pnpm tsgo`
- `pnpm test -- extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- live Telegram DM smoke: answer lane + reasoning lane both streamed cleanly via `dispatchTelegramMessage()`