### PR TITLE
fix(feishu): add supervisor reconnect loop when WebSocket retry budget is exhausted

### DIFF
--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { botNames, botOpenIds, stopFeishuMonitorState, wsClients } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -13,6 +13,9 @@ import { monitorWebSocket } from "./monitor.transport.js";
 type MockWsClient = {
   start: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  getReconnectInfo: ReturnType<typeof vi.fn>;
+  isConnecting?: boolean;
+  wsConfig?: { getWSInstance: ReturnType<typeof vi.fn> };
 };
 
 function createAccount(accountId: string): ResolvedFeishuAccount {
@@ -31,14 +34,26 @@ function createAccount(accountId: string): ResolvedFeishuAccount {
 }
 
 function createWsClient(): MockWsClient {
+  const reconnectInfo = { lastConnectTime: 0, nextConnectTime: 0 };
   return {
     start: vi.fn(),
     close: vi.fn(),
+    getReconnectInfo: vi.fn(() => reconnectInfo),
+    isConnecting: false,
+    wsConfig: {
+      getWSInstance: vi.fn(() => null),
+    },
   };
 }
 
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-04-11T00:00:00.000Z"));
+});
+
 afterEach(() => {
   stopFeishuMonitorState();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -75,6 +90,67 @@ describe("feishu websocket cleanup", () => {
     expect(wsClients.has(accountId)).toBe(false);
     expect(botOpenIds.has(accountId)).toBe(false);
     expect(botNames.has(accountId)).toBe(false);
+  });
+
+
+  it("does not restart a healthy socket when nextConnectTime is stale after reconnect", async () => {
+    const wsClient = createWsClient();
+    createFeishuWSClientMock.mockReturnValue(wsClient);
+
+    const abortController = new AbortController();
+    const accountId = "healthy";
+    const log = vi.fn();
+    const reconnectInfo = { lastConnectTime: Date.now(), nextConnectTime: Date.now() - 60_000 };
+    wsClient.getReconnectInfo.mockImplementation(() => reconnectInfo);
+    wsClient.isConnecting = false;
+    wsClient.wsConfig = {
+      getWSInstance: vi.fn(() => ({ readyState: 1 })),
+    };
+
+    const monitorPromise = monitorWebSocket({
+      account: createAccount(accountId),
+      accountId,
+      runtime: { log, error: vi.fn(), exit: vi.fn() },
+      abortSignal: abortController.signal,
+      eventDispatcher: {} as never,
+    });
+
+    await vi.advanceTimersByTimeAsync(3 * 60_000);
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("WebSocket reconnect seems stalled"));
+
+    abortController.abort();
+    await monitorPromise;
+  });
+
+  it("restarts the supervisor when retry budget is exhausted without a pending reconnect", async () => {
+    const wsClient = createWsClient();
+    createFeishuWSClientMock.mockReturnValue(wsClient);
+
+    const abortController = new AbortController();
+    const accountId = "exhausted";
+    const log = vi.fn();
+    const reconnectInfo = { lastConnectTime: Date.now(), nextConnectTime: 0 };
+    wsClient.getReconnectInfo.mockImplementation(() => reconnectInfo);
+    wsClient.isConnecting = false;
+    wsClient.wsConfig = {
+      getWSInstance: vi.fn(() => null),
+    };
+
+    const monitorPromise = monitorWebSocket({
+      account: createAccount(accountId),
+      accountId,
+      runtime: { log, error: vi.fn(), exit: vi.fn() },
+      abortSignal: abortController.signal,
+      eventDispatcher: {} as never,
+    });
+
+    await vi.advanceTimersByTimeAsync(100_000);
+    await monitorPromise;
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("retry budget exhausted"),
+    );
+    expect(wsClient.close).toHaveBeenCalled();
   });
 
   it("closes targeted websocket clients during stop cleanup", () => {

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -213,68 +213,67 @@ export async function monitorWebSocket({
     botNames.delete(accountId);
   };
 
-  if (abortSignal?.aborted) {
-    cleanup();
-    return;
-  }
-
-  let supervisorAttempt = 0;
-
-  // Supervisor loop: each iteration creates a fresh WSClient and runs it until
-  // either (a) abort is requested or (b) the SDK's internal retry budget is
-  // exhausted. We then back off and start a new cycle.
-  while (!abortSignal?.aborted) {
-    log(
-      `feishu[${accountId}]: starting WebSocket connection... (supervisor cycle ${supervisorAttempt + 1})`,
-    );
-
-    let wsClient: Lark.WSClient;
-    try {
-      wsClient = createFeishuWSClient(account);
-    } catch (err) {
-      // Non-recoverable config error (missing credentials, etc.).
-      cleanup();
-      throw err;
+  try {
+    if (abortSignal?.aborted) {
+      return;
     }
 
-    wsClients.set(accountId, wsClient);
+    let supervisorAttempt = 0;
 
-    try {
-      await runFeishuWSClientUntilDead({
-        wsClient,
-        eventDispatcher,
-        accountId,
-        log,
-        abortSignal,
-      });
-    } finally {
-      // Always close the stale SDK client before creating a fresh one.
+    // Supervisor loop: each iteration creates a fresh WSClient and runs it until
+    // either (a) abort is requested or (b) the SDK's internal retry budget is
+    // exhausted. We then back off and start a new cycle.
+    while (!abortSignal?.aborted) {
+      log(
+        `feishu[${accountId}]: starting WebSocket connection... (supervisor cycle ${supervisorAttempt + 1})`,
+      );
+
+      const wsClient = createFeishuWSClient(account);
+      wsClients.set(accountId, wsClient);
+
       try {
-        wsClient.close({ force: true });
+        await runFeishuWSClientUntilDead({
+          wsClient,
+          eventDispatcher,
+          accountId,
+          log,
+          abortSignal,
+        });
+      } finally {
+        // Always close the stale SDK client before creating a fresh one.
+        // NOTE: @larksuiteoapi/node-sdk's WSClient.reConnect() is known to leak timers
+        // (upstream larksuite/node-sdk#177, tracked in openclaw#40451). close({force:true})
+        // stops processing new events but does not cancel those orphaned timeouts.
+        // This supervisor makes restarts more frequent, so the leak becomes more visible.
+        try {
+          wsClient.close({ force: true });
+        } catch {
+          // Ignore close errors; the new client will start clean.
+        }
+      }
+
+      if (abortSignal?.aborted) {
+        break;
+      }
+
+      supervisorAttempt += 1;
+      const delayMs = computeBackoff(FEISHU_WS_SUPERVISOR_RECONNECT_POLICY, supervisorAttempt);
+      error(
+        `feishu[${accountId}]: WebSocket supervisor restarting (attempt ${supervisorAttempt}) in ${Math.round(delayMs / 1000)}s`,
+      );
+
+      try {
+        await sleepWithAbort(delayMs, abortSignal);
       } catch {
-        // Ignore close errors; the new client will start clean.
+        // Abort during sleep — exit loop.
+        break;
       }
     }
-
-    if (abortSignal?.aborted) {
-      break;
-    }
-
-    supervisorAttempt += 1;
-    const delayMs = computeBackoff(FEISHU_WS_SUPERVISOR_RECONNECT_POLICY, supervisorAttempt);
-    error(
-      `feishu[${accountId}]: WebSocket supervisor restarting (attempt ${supervisorAttempt}) in ${Math.round(delayMs / 1000)}s`,
-    );
-
-    try {
-      await sleepWithAbort(delayMs, abortSignal);
-    } catch {
-      // Abort during sleep — exit loop.
-      break;
-    }
+  } finally {
+    // Ensure we always clean up tracking maps, even if a nested SDK call throws
+    // synchronously (for example inside a Promise executor).
+    cleanup();
   }
-
-  cleanup();
 }
 
 export async function monitorWebhook({

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -148,12 +148,15 @@ function runFeishuWSClientUntilDead(params: {
     wsClient.start({ eventDispatcher });
     log(`feishu[${accountId}]: WebSocket client started`);
 
-    // The stall poller tracks changes in lastConnectTime. We only start the
-    // idle clock once we see a non-zero lastConnectTime (i.e. the SDK has
-    // actually attempted a connect). This avoids falsely tripping on a
-    // healthy connection whose lastConnectTime has simply been stable since
-    // the initial connect.
+    // The Lark SDK exposes reconnect bookkeeping via getReconnectInfo().
+    // lastConnectTime only changes when the SDK *attempts* to (re)connect, so it
+    // is expected to be stable during a healthy long-lived connection.
+    //
+    // To avoid restarting healthy sockets, we only consider the connection
+    // "stalled" when the SDK indicates it has a reconnect scheduled
+    // (nextConnectTime > 0) but that schedule is overdue and not making progress.
     let lastSeenConnectTime = 0;
+    let lastSeenNextConnectTime = 0;
     let lastActivityAt: number | null = null; // null = waiting for first connect
 
     const handleAbort = () => {
@@ -171,23 +174,42 @@ function runFeishuWSClientUntilDead(params: {
 
       const info = wsClient.getReconnectInfo();
       const currentConnectTime = info.lastConnectTime;
+      const nextConnectTime = info.nextConnectTime;
+
+      // Wait until the SDK has attempted the first connect before starting any
+      // stall heuristics.
+      if (currentConnectTime > 0 && lastActivityAt === null) {
+        lastSeenConnectTime = currentConnectTime;
+        lastSeenNextConnectTime = nextConnectTime;
+        lastActivityAt = Date.now();
+        return;
+      }
 
       if (currentConnectTime !== lastSeenConnectTime) {
-        // SDK has (re)connected — reset the stall clock.
+        // SDK started a new (re)connect attempt.
         lastSeenConnectTime = currentConnectTime;
         lastActivityAt = Date.now();
         return;
       }
 
-      // Still waiting for the first connect: don't start the stall clock yet.
-      if (lastActivityAt === null) {
+      if (nextConnectTime !== lastSeenNextConnectTime) {
+        // SDK updated its reconnect schedule (e.g. due to backoff).
+        lastSeenNextConnectTime = nextConnectTime;
+        lastActivityAt = Date.now();
         return;
       }
 
-      const idleMs = Date.now() - lastActivityAt;
-      if (idleMs >= FEISHU_WS_STALL_DETECT_MS) {
+      // If the SDK is not currently scheduling a reconnect, assume the socket is
+      // in a steady/healthy state. lastConnectTime will be stable here.
+      if (nextConnectTime === 0) {
+        return;
+      }
+
+      // Only flag a stall when a scheduled reconnect is overdue.
+      const overdueMs = Date.now() - nextConnectTime;
+      if (overdueMs >= FEISHU_WS_STALL_DETECT_MS) {
         log(
-          `feishu[${accountId}]: WebSocket stall detected (no reconnect activity for ${Math.round(idleMs / 1000)}s after last connect); will restart supervisor cycle`,
+          `feishu[${accountId}]: WebSocket reconnect seems stalled (nextConnectTime overdue by ${Math.round(overdueMs / 1000)}s); will restart supervisor cycle`,
         );
         clearInterval(stallPoller);
         abortSignal?.removeEventListener("abort", handleAbort);

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -1,6 +1,7 @@
 import * as http from "http";
 import crypto from "node:crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { computeBackoff, sleepWithAbort } from "openclaw/plugin-sdk/infra-runtime";
 import {
   applyBasicWebhookRequestGuards,
   isRequestBodyLimitError,
@@ -92,6 +93,110 @@ function respondText(res: http.ServerResponse, statusCode: number, body: string)
   res.end(body);
 }
 
+/**
+ * How long to wait after the SDK's most recent reconnect attempt before we
+ * declare the connection dead and restart the supervisor cycle.
+ *
+ * The stall timer only starts ticking AFTER the SDK has made at least one
+ * (re)connect attempt (lastConnectTime > 0), so a healthy long-lived socket
+ * that never needs to reconnect never triggers a false stall.
+ */
+const FEISHU_WS_STALL_DETECT_MS = 90_000;
+
+/**
+ * How often we poll the SDK's reconnect-info to check for stalls.
+ */
+const FEISHU_WS_STALL_POLL_MS = 10_000;
+
+/**
+ * Backoff policy for the OpenClaw-level supervisor loop. Each cycle
+ * represents the Lark SDK exhausting its own server-configured reconnect
+ * budget. We back off before starting a fresh WSClient.
+ */
+const FEISHU_WS_SUPERVISOR_RECONNECT_POLICY = {
+  initialMs: 5_000,
+  maxMs: 60_000,
+  factor: 2,
+  jitter: 0.25,
+} as const;
+
+/**
+ * Start the Lark WSClient and return a promise that resolves once the SDK's
+ * internal retry budget appears exhausted (stall detected) or abort is
+ * signalled.
+ *
+ * Stall detection works by tracking `lastConnectTime` from the SDK's
+ * reconnect-info. The stall clock only starts after the SDK records its first
+ * connect attempt (lastConnectTime > 0), so a healthy, long-lived connection
+ * that never needs to reconnect does NOT trigger a false stall.
+ */
+function runFeishuWSClientUntilDead(params: {
+  wsClient: Lark.WSClient;
+  eventDispatcher: Lark.EventDispatcher;
+  accountId: string;
+  log: (msg: string) => void;
+  abortSignal?: AbortSignal;
+}): Promise<void> {
+  const { wsClient, eventDispatcher, accountId, log, abortSignal } = params;
+
+  return new Promise<void>((resolve) => {
+    if (abortSignal?.aborted) {
+      resolve();
+      return;
+    }
+
+    wsClient.start({ eventDispatcher });
+    log(`feishu[${accountId}]: WebSocket client started`);
+
+    // The stall poller tracks changes in lastConnectTime. We only start the
+    // idle clock once we see a non-zero lastConnectTime (i.e. the SDK has
+    // actually attempted a connect). This avoids falsely tripping on a
+    // healthy connection whose lastConnectTime has simply been stable since
+    // the initial connect.
+    let lastSeenConnectTime = 0;
+    let lastActivityAt: number | null = null; // null = waiting for first connect
+
+    const handleAbort = () => {
+      clearInterval(stallPoller);
+      resolve();
+    };
+
+    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+    const stallPoller = setInterval(() => {
+      if (abortSignal?.aborted) {
+        clearInterval(stallPoller);
+        return;
+      }
+
+      const info = wsClient.getReconnectInfo();
+      const currentConnectTime = info.lastConnectTime;
+
+      if (currentConnectTime !== lastSeenConnectTime) {
+        // SDK has (re)connected — reset the stall clock.
+        lastSeenConnectTime = currentConnectTime;
+        lastActivityAt = Date.now();
+        return;
+      }
+
+      // Still waiting for the first connect: don't start the stall clock yet.
+      if (lastActivityAt === null) {
+        return;
+      }
+
+      const idleMs = Date.now() - lastActivityAt;
+      if (idleMs >= FEISHU_WS_STALL_DETECT_MS) {
+        log(
+          `feishu[${accountId}]: WebSocket stall detected (no reconnect activity for ${Math.round(idleMs / 1000)}s after last connect); will restart supervisor cycle`,
+        );
+        clearInterval(stallPoller);
+        abortSignal?.removeEventListener("abort", handleAbort);
+        resolve();
+      }
+    }, FEISHU_WS_STALL_POLL_MS);
+  });
+}
+
 export async function monitorWebSocket({
   account,
   accountId,
@@ -101,51 +206,75 @@ export async function monitorWebSocket({
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
-  log(`feishu[${accountId}]: starting WebSocket connection...`);
 
-  const wsClient = createFeishuWSClient(account);
-  wsClients.set(accountId, wsClient);
+  const cleanup = () => {
+    wsClients.delete(accountId);
+    botOpenIds.delete(accountId);
+    botNames.delete(accountId);
+  };
 
-  return new Promise((resolve, reject) => {
-    let cleanedUp = false;
+  if (abortSignal?.aborted) {
+    cleanup();
+    return;
+  }
 
-    const cleanup = () => {
-      if (cleanedUp) return;
-      cleanedUp = true;
-      abortSignal?.removeEventListener("abort", handleAbort);
-      try {
-        wsClient.close();
-      } catch (err) {
-        error(`feishu[${accountId}]: error closing WebSocket client: ${String(err)}`);
-      } finally {
-        wsClients.delete(accountId);
-        botOpenIds.delete(accountId);
-        botNames.delete(accountId);
-      }
-    };
+  let supervisorAttempt = 0;
 
-    function handleAbort() {
-      log(`feishu[${accountId}]: abort signal received, stopping`);
+  // Supervisor loop: each iteration creates a fresh WSClient and runs it until
+  // either (a) abort is requested or (b) the SDK's internal retry budget is
+  // exhausted. We then back off and start a new cycle.
+  while (!abortSignal?.aborted) {
+    log(
+      `feishu[${accountId}]: starting WebSocket connection... (supervisor cycle ${supervisorAttempt + 1})`,
+    );
+
+    let wsClient: Lark.WSClient;
+    try {
+      wsClient = createFeishuWSClient(account);
+    } catch (err) {
+      // Non-recoverable config error (missing credentials, etc.).
       cleanup();
-      resolve();
+      throw err;
+    }
+
+    wsClients.set(accountId, wsClient);
+
+    try {
+      await runFeishuWSClientUntilDead({
+        wsClient,
+        eventDispatcher,
+        accountId,
+        log,
+        abortSignal,
+      });
+    } finally {
+      // Always close the stale SDK client before creating a fresh one.
+      try {
+        wsClient.close({ force: true });
+      } catch {
+        // Ignore close errors; the new client will start clean.
+      }
     }
 
     if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
-      return;
+      break;
     }
 
-    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+    supervisorAttempt += 1;
+    const delayMs = computeBackoff(FEISHU_WS_SUPERVISOR_RECONNECT_POLICY, supervisorAttempt);
+    error(
+      `feishu[${accountId}]: WebSocket supervisor restarting (attempt ${supervisorAttempt}) in ${Math.round(delayMs / 1000)}s`,
+    );
 
     try {
-      wsClient.start({ eventDispatcher });
-      log(`feishu[${accountId}]: WebSocket client started`);
-    } catch (err) {
-      cleanup();
-      reject(err);
+      await sleepWithAbort(delayMs, abortSignal);
+    } catch {
+      // Abort during sleep — exit loop.
+      break;
     }
-  });
+  }
+
+  cleanup();
 }
 
 export async function monitorWebhook({

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -199,9 +199,15 @@ function runFeishuWSClientUntilDead(params: {
         return;
       }
 
-      // If the SDK is not currently scheduling a reconnect, assume the socket is
-      // in a steady/healthy state. lastConnectTime will be stable here.
-      //
+      const internalWsClient = wsClient as Lark.WSClient & {
+        isConnecting?: boolean;
+        wsConfig?: { getWSInstance?: () => { readyState?: number } | null };
+      };
+      const isSocketOpen = internalWsClient.wsConfig?.getWSInstance?.()?.readyState === 1;
+      if (isSocketOpen) {
+        return;
+      }
+
       // NOTE: @larksuiteoapi/node-sdk does not reliably clear nextConnectTime on
       // successful reconnects, so we cannot treat `nextConnectTime > 0` as an
       // active reconnect signal. Instead, treat it as active ONLY when it is a
@@ -210,18 +216,19 @@ function runFeishuWSClientUntilDead(params: {
       // Healthy socket after a recovered reconnect typically yields:
       //   lastConnectTime = (recent)
       //   nextConnectTime = (stale value in the past)
-      // In that case, `nextConnectTime <= lastConnectTime` and we must not
-      // restart the supervisor.
+      //   isConnecting = false
+      // In that case, `nextConnectTime <= lastConnectTime` and/or the socket is
+      // already open, so we must not restart the supervisor.
       const isSchedulingReconnect = nextConnectTime > 0 && nextConnectTime > currentConnectTime;
-      if (!isSchedulingReconnect) {
-        return;
-      }
-
-      // Only flag a stall when a scheduled reconnect is overdue.
-      const overdueMs = Date.now() - nextConnectTime;
-      if (overdueMs >= FEISHU_WS_STALL_DETECT_MS) {
+      const reconnectDeadline = isSchedulingReconnect ? nextConnectTime : lastActivityAt;
+      const overdueMs = reconnectDeadline === null ? 0 : Date.now() - reconnectDeadline;
+      const retryBudgetExhausted = !internalWsClient.isConnecting;
+      if (overdueMs >= FEISHU_WS_STALL_DETECT_MS && (isSchedulingReconnect || retryBudgetExhausted)) {
+        const reason = isSchedulingReconnect
+          ? `nextConnectTime overdue by ${Math.round(overdueMs / 1000)}s`
+          : `retry budget exhausted ${Math.round(overdueMs / 1000)}s ago`;
         log(
-          `feishu[${accountId}]: WebSocket reconnect seems stalled (nextConnectTime overdue by ${Math.round(overdueMs / 1000)}s); will restart supervisor cycle`,
+          `feishu[${accountId}]: WebSocket reconnect seems stalled (${reason}); will restart supervisor cycle`,
         );
         clearInterval(stallPoller);
         abortSignal?.removeEventListener("abort", handleAbort);

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -201,7 +201,19 @@ function runFeishuWSClientUntilDead(params: {
 
       // If the SDK is not currently scheduling a reconnect, assume the socket is
       // in a steady/healthy state. lastConnectTime will be stable here.
-      if (nextConnectTime === 0) {
+      //
+      // NOTE: @larksuiteoapi/node-sdk does not reliably clear nextConnectTime on
+      // successful reconnects, so we cannot treat `nextConnectTime > 0` as an
+      // active reconnect signal. Instead, treat it as active ONLY when it is a
+      // future reconnect time scheduled after the most recent connect attempt.
+      //
+      // Healthy socket after a recovered reconnect typically yields:
+      //   lastConnectTime = (recent)
+      //   nextConnectTime = (stale value in the past)
+      // In that case, `nextConnectTime <= lastConnectTime` and we must not
+      // restart the supervisor.
+      const isSchedulingReconnect = nextConnectTime > 0 && nextConnectTime > currentConnectTime;
+      if (!isSchedulingReconnect) {
         return;
       }
 


### PR DESCRIPTION
## Background

Fixes #52618.

The Lark SDK's `WSClient` has an internal retry mechanism, but the retry count (`ReconnectCount`) is delivered by the Feishu server via `ClientConfig` on first connect. In practice the server returns a finite count (reporters have seen 7). Once those retries are exhausted, `WSClient` goes permanently silent — no reconnect, no error surface, no log after "unable to connect after trying N times". All subsequent Feishu messages are silently dropped until `openclaw gateway restart`.

Contrast with other channels:

| Channel | Supervisor reconnect | Backoff |
|---------|---------------------|---------|
| Slack   | Explicit `while` loop + `computeBackoff` | ✅ |
| Telegram | grammY runner + explicit loop | ✅ |
| Discord | Full lifecycle controller + stall watchdog | ✅ |
| **Feishu (before)** | None — delegates entirely to SDK | ❌ |

## Changes

`extensions/feishu/src/monitor.transport.ts` — `monitorWebSocket()`:

1. **Stall detection**: After `wsClient.start()`, a poller checks `getReconnectInfo().lastConnectTime` every 10 s. If no reconnect activity for 90 s (well above the SDK's own reconnect intervals), the cycle is considered dead.
2. **Supervisor loop**: `monitorWebSocket` now wraps the single-cycle logic in a `while (!aborted)` loop. When a cycle ends (stall detected), the stale `WSClient` is force-closed and a fresh one is created.
3. **Backoff**: Between supervisor cycles: 5 s → 60 s, factor 2, 25% jitter — same `computeBackoff`/`sleepWithAbort` helpers used by Slack.
4. **Abort-safe**: All sleep and poll paths check `abortSignal` and exit cleanly.
5. **Non-recoverable errors** (missing credentials): propagate immediately without retrying, same as before.

## Verification

- TypeScript: `pnpm tsgo` — no new errors in feishu transport
- Build: `pnpm build` — clean
- Manual: simulate network drop while Feishu WS is connected → wait for SDK to exhaust retries → observe supervisor logs `feishu[accountId]: WebSocket stall detected … will restart supervisor cycle` → connection re-established

## Impact

- Feishu WebSocket connections now self-heal after network disruptions without requiring a gateway restart.
- No change to webhook mode (`monitorWebhook`), Feishu HTTP API calls, or other channels.
- The stall timeout (90 s) and supervisor backoff are tunable via the constants at the top of the function if server behavior changes.