### PR TITLE
fix(status): treat stale cached totalTokens as unknown

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -190,6 +190,29 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Context: 200k/1.0m");
   });
 
+  it("renders unknown context usage when cached totalTokens are stale", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/claude-opus-4-6",
+        contextTokens: 200_000,
+      },
+      sessionEntry: {
+        sessionId: "stale-zero",
+        updatedAt: 0,
+        totalTokens: 0,
+        totalTokensFresh: false,
+        contextTokens: 200_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Context: ?/200k");
+    expect(normalized).not.toContain("Context: 0/200k");
+  });
+
   it("recomputes context window from the active model after switching away from a smaller session override", () => {
     const sessionEntry = {
       sessionId: "switch-back",

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -15,6 +15,7 @@ import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveMainSessionKey,
+  resolveFreshSessionTotalTokens,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   type SessionEntry,
@@ -460,7 +461,10 @@ export function buildStatusMessage(args: StatusArgs): string {
   let outputTokens = entry?.outputTokens;
   let cacheRead = entry?.cacheRead;
   let cacheWrite = entry?.cacheWrite;
-  let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  const fallbackTurnTokens = (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  let totalTokens =
+    resolveFreshSessionTotalTokens(entry) ??
+    (fallbackTurnTokens > 0 ? fallbackTurnTokens : undefined);
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).


### PR DESCRIPTION
## Summary
- make `/status` respect `totalTokensFresh` when choosing cached context usage
- fall back to turn-level token counts only when they are nonzero
- add a regression test for stale `totalTokens: 0` sessions

## Problem
`/status` currently reads `sessionEntry.totalTokens` directly, which bypasses `totalTokensFresh`. When a session has stale or unknown cached usage represented as `totalTokens: 0` with `totalTokensFresh: false`, `/status` renders `Context: 0/<ctx>` instead of the intended unknown form.

## Fix
Use `resolveFreshSessionTotalTokens()` in `src/auto-reply/status.ts` so stale cached totals are treated as unknown. Keep the existing turn-level fallback, but only when the derived fallback is nonzero.

## Testing
- `corepack pnpm exec vitest run src/auto-reply/status.test.ts -t 'renders unknown context usage when cached totalTokens are stale' --maxWorkers 1 --pool forks --silent=passed-only`
- `corepack pnpm exec vitest run src/auto-reply/status.test.ts -t 'summarizes agent readiness and context usage|renders unknown context usage when cached totalTokens are stale' --maxWorkers 1 --pool forks --silent=passed-only`

Fixes #52595
