### PR TITLE
fix(docker): avoid pnpm prune in partial workspaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,24 @@ RUN mkdir -p /out && \
     done
 
 # ── Stage 2: Build ──────────────────────────────────────────────
+FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS prod-deps
+
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+
+COPY --from=ext-deps /out/ ./extensions/
+
+# Install only runtime dependencies while the workspace still contains just the
+# root manifests plus opted-in extensions. This avoids pnpm prune --prod
+# removing extension dependencies after COPY . adds the full workspace.
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+    NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile --prod
+
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build
 
 # Install Bun (required for build scripts). Retry the whole bootstrap flow to
@@ -94,11 +112,9 @@ RUN pnpm build:docker
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
 
-# Prune dev dependencies and strip build-only metadata before copying
-# runtime assets into the final image.
+# Strip build-only metadata before copying runtime assets into the final image.
 FROM build AS runtime-assets
-RUN CI=true pnpm prune --prod && \
-    find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
+RUN find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
 
 # ── Runtime base images ─────────────────────────────────────────
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS base-default
@@ -145,7 +161,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN chown node:node /app
 
 COPY --from=runtime-assets --chown=node:node /app/dist ./dist
-COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/extensions ./extensions

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -37,14 +37,24 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
 
-  it("prunes runtime dependencies after the build stage", async () => {
+  it("installs runtime dependencies in a dedicated prod-deps stage", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
+    const extDepsCopyIndex = dockerfile.indexOf("COPY --from=ext-deps /out/ ./extensions/");
+    const prodInstallIndex = dockerfile.indexOf("pnpm install --frozen-lockfile --prod");
+    const fullCopyIndex = dockerfile.indexOf("COPY . .");
+
+    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS prod-deps");
+    expect(extDepsCopyIndex).toBeGreaterThan(-1);
+    expect(prodInstallIndex).toBeGreaterThan(-1);
+    expect(fullCopyIndex).toBeGreaterThan(-1);
+    expect(extDepsCopyIndex).toBeLessThan(prodInstallIndex);
+    expect(fullCopyIndex).toBeGreaterThan(prodInstallIndex);
     expect(dockerfile).toContain("FROM build AS runtime-assets");
-    expect(dockerfile).toContain("CI=true pnpm prune --prod");
-    expect(dockerfile).not.toContain('npm install --prefix "extensions/$ext" --omit=dev --silent');
     expect(dockerfile).toContain(
-      "COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules",
+      "COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules",
     );
+    expect(dockerfile).not.toContain("CI=true pnpm prune --prod");
+    expect(dockerfile).not.toContain('npm install --prefix "extensions/$ext" --omit=dev --silent');
   });
 
   it("pins bundled plugin discovery to copied source extensions in runtime images", async () => {


### PR DESCRIPTION
## Summary

- Problem: `pnpm prune --prod` on pnpm 10 wipes production dependencies for already-installed workspace extensions once the Docker build copies the full workspace into place.
- Why it matters: Docker images built with `OPENCLAW_EXTENSIONS` can ship with missing runtime dependencies, breaking extension-backed deployments.
- What changed: added a dedicated `prod-deps` stage that installs production dependencies before `COPY . .`, then copied runtime `node_modules` from that stage into the final image.
- What did NOT change (scope boundary): build outputs, extension opt-in behavior, and runtime assets other than how production dependencies are assembled.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #49501
- Related #49501

## User-visible / Behavior Changes

Docker builds no longer rely on `pnpm prune --prod` after the full workspace copy, so opted-in extension dependencies stay present in the final runtime image under pnpm 10.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 host
- Runtime/container: Docker Desktop (desktop-linux), Node 24 bookworm Dockerfile, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Docker builds with `OPENCLAW_EXTENSIONS`
- Relevant config (redacted): `OPENCLAW_EXTENSIONS=matrix`

### Steps

1. Install production deps for only a subset of workspace packages during the Docker build.
2. Copy the full workspace into the image filesystem.
3. Run `pnpm prune --prod`.

### Expected

- Existing production dependencies for the already-installed extension packages remain available in the runtime image.

### Actual

- pnpm 10 reconciles against the now-full workspace and wipes the previously installed extension dependencies.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The new `src/dockerfile.test.ts` assertions fail against the pre-fix Dockerfile because it still uses `pnpm prune --prod`, lacks the `prod-deps` stage, and installs prod deps only after `COPY . .`. They pass with this patch.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run --config vitest.unit.config.ts src/dockerfile.test.ts src/docker-build-cache.test.ts` successfully.
- Edge cases checked: confirmed the prod-deps stage copies opted-in extension manifests before install, runs before the full workspace copy, and is the source of runtime `node_modules`.
- What you did **not** verify: attempted a Docker build for `--target prod-deps`, but Docker Hub auth timed out while fetching `node:24-bookworm`, so I did not complete an end-to-end image build in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR's commit to restore the previous single-path dependency flow.
- Files/config to restore: `Dockerfile`, `src/dockerfile.test.ts`
- Known bad symptoms reviewers should watch for: missing extension runtime dependencies in Docker images, or regressions in the Dockerfile structure tests.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a future runtime workspace package could need additional manifest copies in `prod-deps`.
  - Mitigation: the fix is scoped to the current runtime packaging model (root, UI, opted-in extensions), and the regression test now locks the required install ordering.
