### PR TITLE
fix: preserve CLI session ID in text output mode

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -395,7 +395,7 @@ export async function runCliAgent(params: {
         const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
 
         if (outputMode === "text") {
-          return { text: stdout, sessionId: undefined };
+          return { text: stdout, sessionId: resolvedSessionId };
         }
         if (outputMode === "jsonl") {
           const parsed = parseCliJsonl(stdout, backend);


### PR DESCRIPTION
## Summary

- When the CLI backend output mode is `"text"`, `sessionId` was hardcoded to `undefined` in the return value at `src/agents/cli-runner.ts:398`
- This caused the fallback chain to store the OpenClaw internal UUID as the CLI session ID instead of the actual Claude CLI session UUID
- On resume, `--resume` was called with the wrong UUID, resulting in **"No conversation found with session ID"**
- **Fix:** return `resolvedSessionId` instead of `undefined` so the correct CLI session ID is persisted and resume works correctly

## Test plan

- [ ] Start a new conversation with a CLI backend using text output mode
- [ ] Verify the stored session ID matches the Claude CLI session UUID (not the OpenClaw internal UUID)
- [ ] Send a follow-up message and confirm `--resume` succeeds without "No conversation found" error