### PR TITLE
feat(tools): add Bocha web search provider

### DIFF
--- a/src/agents/runtime.ts
+++ b/src/agents/runtime.ts
@@ -1,0 +1,4 @@
+/**
+ * Re-export runtime for agents so tools and other agents code can use "../runtime.js".
+ */
+export { defaultRuntime, type RuntimeEnv } from "../runtime.js";

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -126,6 +126,31 @@ export function readStringOrNumberParam(
   return undefined;
 }
 
+export function readBooleanParam(
+  params: Record<string, unknown>,
+  key: string,
+  options: { required?: boolean; label?: string } = {},
+): boolean | undefined {
+  const { required = false, label = key } = options;
+  const raw = readParamRaw(params, key);
+  if (typeof raw === "boolean") {
+    return raw;
+  }
+  if (typeof raw === "string") {
+    const lowered = raw.trim().toLowerCase();
+    if (lowered === "true") {
+      return true;
+    }
+    if (lowered === "false") {
+      return false;
+    }
+  }
+  if (required) {
+    throw new ToolInputError(`${label} required`);
+  }
+  return undefined;
+}
+
 export function readNumberParam(
   params: Record<string, unknown>,
   key: string,

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -22,11 +22,15 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveBochaApiKey,
+  resolveBochaModel,
+  resolveBochaBaseUrl,
   resolveBraveMode,
 } = __testing;
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
 const moonshotApiKeyEnv = ["MOONSHOT_API", "KEY"].join("_");
+const bochaApiKeyEnv = ["BOCHA_API", "KEY"].join("_");
 const openRouterApiKeyEnv = ["OPENROUTER_API", "KEY"].join("_");
 const perplexityApiKeyEnv = ["PERPLEXITY_API", "KEY"].join("_");
 const openRouterPerplexityApiKey = ["sk", "or", "v1", "test"].join("-");
@@ -138,22 +142,33 @@ describe("web_search brave language param normalization", () => {
 });
 
 describe("web_search freshness normalization", () => {
-  it("accepts Brave shortcut values and maps for Perplexity", () => {
+  it("accepts Brave shortcut values and maps for Perplexity and Bocha", () => {
     expect(normalizeFreshness("pd", "brave")).toBe("pd");
     expect(normalizeFreshness("PW", "brave")).toBe("pw");
     expect(normalizeFreshness("pd", "perplexity")).toBe("day");
     expect(normalizeFreshness("pw", "perplexity")).toBe("week");
+    expect(normalizeFreshness("pd", "bocha")).toBe("oneDay");
+    expect(normalizeFreshness("pw", "bocha")).toBe("oneWeek");
   });
 
-  it("accepts Perplexity values and maps for Brave", () => {
+  it("accepts Perplexity values and maps for Brave and Bocha", () => {
     expect(normalizeFreshness("day", "perplexity")).toBe("day");
     expect(normalizeFreshness("week", "perplexity")).toBe("week");
     expect(normalizeFreshness("day", "brave")).toBe("pd");
     expect(normalizeFreshness("week", "brave")).toBe("pw");
+    expect(normalizeFreshness("day", "bocha")).toBe("oneDay");
+    expect(normalizeFreshness("week", "bocha")).toBe("oneWeek");
   });
 
-  it("accepts valid date ranges for Brave", () => {
+  it("accepts valid date ranges for Brave and Bocha", () => {
     expect(normalizeFreshness("2024-01-01to2024-01-31", "brave")).toBe("2024-01-01to2024-01-31");
+    expect(normalizeFreshness("2024-01-01to2024-01-31", "bocha")).toBe("2024-01-01..2024-01-31");
+  });
+
+  it("accepts Bocha specific values", () => {
+    expect(normalizeFreshness("noLimit", "bocha")).toBe("noLimit");
+    expect(normalizeFreshness("oneDay", "bocha")).toBe("oneDay");
+    expect(normalizeFreshness("2024-01-01", "bocha")).toBe("2024-01-01");
   });
 
   it("rejects invalid values", () => {
@@ -369,6 +384,38 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search bocha config resolution", () => {
+  it("uses config apiKey when provided", () => {
+    expect(resolveBochaApiKey({ apiKey: "bocha-test-key" })).toBe("bocha-test-key"); // pragma: allowlist secret
+  });
+
+  it("falls back to BOCHA_API_KEY", () => {
+    const bochaEnvValue = "bocha-env"; // pragma: allowlist secret
+    withEnv({ [bochaApiKeyEnv]: bochaEnvValue }, () => {
+      expect(resolveBochaApiKey({})).toBe(bochaEnvValue);
+    });
+  });
+
+  it("returns undefined when no Bocha key is configured", () => {
+    withEnv({ BOCHA_API_KEY: undefined }, () => {
+      expect(resolveBochaApiKey({})).toBeUndefined();
+      expect(resolveBochaApiKey(undefined)).toBeUndefined();
+    });
+  });
+
+  it("resolves default model and baseUrl", () => {
+    expect(resolveBochaModel({})).toBe("web-search");
+    expect(resolveBochaBaseUrl({})).toBe("https://api.bocha.cn/v1");
+  });
+
+  it("uses config model and baseUrl when provided", () => {
+    expect(resolveBochaModel({ model: "bocha-model" })).toBe("bocha-model");
+    expect(resolveBochaBaseUrl({ baseUrl: "https://example.com/bocha" })).toBe(
+      "https://example.com/bocha",
+    );
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -6,7 +6,13 @@ import { logVerbose } from "../../globals.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import type { AnyAgentTool } from "./common.js";
-import { jsonResult, readNumberParam, readStringArrayParam, readStringParam } from "./common.js";
+import {
+  jsonResult,
+  readBooleanParam,
+  readNumberParam,
+  readStringArrayParam,
+  readStringParam,
+} from "./common.js";
 import { withTrustedWebToolsEndpoint } from "./web-guarded-fetch.js";
 import { resolveCitationRedirectUrl } from "./web-search-citation-redirect.js";
 import {
@@ -21,7 +27,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi", "bocha"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -42,6 +48,8 @@ const KIMI_WEB_SEARCH_TOOL = {
   type: "builtin_function",
   function: { name: "$web_search" },
 } as const;
+const DEFAULT_BOCHA_BASE_URL = "https://api.bocha.cn/v1";
+const DEFAULT_BOCHA_MODEL = "web-search";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -123,6 +131,22 @@ const RECENCY_TO_FRESHNESS: Record<string, string> = {
   year: "py",
 };
 
+const FRESHNESS_TO_BOCHA: Record<string, string> = {
+  pd: "oneDay",
+  pw: "oneWeek",
+  pm: "oneMonth",
+  py: "oneYear",
+};
+
+const RECENCY_TO_BOCHA: Record<string, string> = {
+  day: "oneDay",
+  week: "oneWeek",
+  month: "oneMonth",
+  year: "oneYear",
+};
+
+const BOCHA_RECENCY_VALUES = new Set(["noLimit", "oneDay", "oneWeek", "oneMonth", "oneYear"]);
+
 const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 const PERPLEXITY_DATE_PATTERN = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
 
@@ -178,7 +202,10 @@ function createWebSearchSchema(params: {
     ),
     freshness: Type.Optional(
       Type.String({
-        description: "Filter by time: 'day' (24h), 'week', 'month', or 'year'.",
+        description:
+          params.provider === "bocha"
+            ? "Filter by time: 'noLimit', 'oneDay', 'oneWeek', 'oneMonth', 'oneYear', or date/range."
+            : "Filter by time: 'day' (24h), 'week', 'month', or 'year'.",
       }),
     ),
     date_after: Type.Optional(
@@ -207,6 +234,18 @@ function createWebSearchSchema(params: {
         Type.String({
           description:
             "Locale code for UI elements in language-region format (e.g., 'en-US', 'de-DE', 'fr-FR', 'tr-TR'). Must include region subtag.",
+        }),
+      ),
+    });
+  }
+
+  if (params.provider === "bocha") {
+    return Type.Object({
+      ...querySchema,
+      ...filterSchema,
+      summary: Type.Optional(
+        Type.Boolean({
+          description: "Whether to include original web contents in the results.",
         }),
       ),
     });
@@ -305,6 +344,13 @@ type KimiConfig = {
   model?: string;
 };
 
+type BochaConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+  summary?: boolean;
+};
+
 type GrokSearchResponse = {
   output?: Array<{
     type?: string;
@@ -362,6 +408,24 @@ type KimiSearchResponse = {
     url?: string;
     content?: string;
   }>;
+};
+
+type BochaSearchResponse = {
+  code?: number;
+  msg?: string;
+  log_id?: string;
+  data?: {
+    webPages?: {
+      value?: Array<{
+        name?: string;
+        url?: string;
+        snippet?: string;
+        summary?: string;
+        datePublished?: string;
+        dateLastCrawled?: string;
+      }>;
+    };
+  };
 };
 
 type PerplexitySearchResponse = {
@@ -524,6 +588,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "bocha") {
+    return {
+      error: "missing_bocha_api_key",
+      message:
+        "web_search (bocha) needs a Bocha API key. Set BOCHA_API_KEY in the Gateway environment, or configure tools.web.search.bocha.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
@@ -547,6 +619,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "kimi") {
     return "kimi";
+  }
+  if (raw === "bocha") {
+    return "bocha";
   }
   if (raw === "brave") {
     return "brave";
@@ -593,6 +668,14 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
         'web_search: no provider configured, auto-detected "grok" from available API keys',
       );
       return "grok";
+    }
+    // 6. Bocha
+    const bochaConfig = resolveBochaConfig(search);
+    if (resolveBochaApiKey(bochaConfig)) {
+      logVerbose(
+        'web_search: no provider configured, auto-detected "bocha" from available API keys',
+      );
+      return "bocha";
     }
   }
 
@@ -809,6 +892,38 @@ function resolveKimiBaseUrl(kimi?: KimiConfig): string {
   return fromConfig || DEFAULT_KIMI_BASE_URL;
 }
 
+function resolveBochaConfig(search?: WebSearchConfig): BochaConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const bocha = "bocha" in search ? search.bocha : undefined;
+  if (!bocha || typeof bocha !== "object") {
+    return {};
+  }
+  return bocha as BochaConfig;
+}
+
+function resolveBochaApiKey(bocha?: BochaConfig): string | undefined {
+  const fromConfig = normalizeApiKey(bocha?.apiKey);
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnv = normalizeApiKey(process.env.BOCHA_API_KEY);
+  return fromEnv || undefined;
+}
+
+function resolveBochaModel(bocha?: BochaConfig): string {
+  const fromConfig =
+    bocha && "model" in bocha && typeof bocha.model === "string" ? bocha.model.trim() : "";
+  return fromConfig || DEFAULT_BOCHA_MODEL;
+}
+
+function resolveBochaBaseUrl(bocha?: BochaConfig): string {
+  const fromConfig =
+    bocha && "baseUrl" in bocha && typeof bocha.baseUrl === "string" ? bocha.baseUrl.trim() : "";
+  return fromConfig || DEFAULT_BOCHA_BASE_URL;
+}
+
 function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
   if (!search || typeof search !== "object") {
     return {};
@@ -941,6 +1056,87 @@ async function runGeminiSearch(params: {
   );
 }
 
+async function runBochaSearch(params: {
+  query: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  count: number;
+  timeoutSeconds: number;
+  freshness?: string;
+  summary?: boolean;
+}): Promise<
+  Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>
+> {
+  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  const model = params.model || DEFAULT_BOCHA_MODEL;
+  const endpoint = `${baseUrl}/${model}`;
+
+  const body: Record<string, unknown> = {
+    query: params.query,
+    count: params.count,
+  };
+
+  if (params.freshness) {
+    body.freshness = params.freshness;
+  } else {
+    body.freshness = "noLimit";
+  }
+
+  if (params.summary !== undefined) {
+    body.summary = params.summary;
+  }
+
+  logVerbose(`runBochaSearch: posting to ${endpoint} with query="${params.query}" count=${params.count} freshness=${params.freshness || "none"} summary=${params.summary}`);
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: endpoint,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${params.apiKey}`,
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+        const detail = detailResult.text;
+        logVerbose(`Bocha API HTTP error (${res.status}): ${detail}`);
+        throw new Error(`Bocha API error (${res.status}): ${detail || res.statusText}`);
+      }
+
+      const data = (await res.json()) as BochaSearchResponse;
+
+      if (data.code !== undefined && data.code !== 200) {
+        logVerbose(`Bocha API business error (${data.code}): ${data.msg} (log_id: ${data.log_id})`);
+        throw new Error(
+          `Bocha API error (${data.code}): ${data.msg || "unknown error"} (log_id: ${data.log_id || "none"})`,
+        );
+      }
+
+      const results = Array.isArray(data.data?.webPages?.value) ? data.data.webPages.value : [];
+
+      return results.map((entry) => {
+        const title = entry.name ?? "";
+        const url = entry.url ?? "";
+        const snippet = entry.summary || entry.snippet || "";
+        return {
+          title: title ? wrapWebContent(title, "web_search") : "",
+          url,
+          description: snippet ? wrapWebContent(snippet, "web_search") : "",
+          published: entry.datePublished || entry.dateLastCrawled || undefined,
+          siteName: resolveSiteName(url) || undefined,
+        };
+      });
+    },
+  );
+}
+
 function resolveSearchCount(value: unknown, fallback: number): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? value : fallback;
   const clamped = Math.max(1, Math.min(MAX_SEARCH_COUNT, Math.floor(parsed)));
@@ -1027,21 +1223,35 @@ function normalizeFreshness(
   const lower = trimmed.toLowerCase();
 
   if (BRAVE_FRESHNESS_SHORTCUTS.has(lower)) {
-    return provider === "brave" ? lower : FRESHNESS_TO_RECENCY[lower];
+    if (provider === "brave") {
+      return lower;
+    }
+    return provider === "bocha" ? FRESHNESS_TO_BOCHA[lower] : FRESHNESS_TO_RECENCY[lower];
   }
 
   if (PERPLEXITY_RECENCY_VALUES.has(lower)) {
-    return provider === "perplexity" ? lower : RECENCY_TO_FRESHNESS[lower];
+    if (provider === "perplexity") {
+      return lower;
+    }
+    return provider === "bocha" ? RECENCY_TO_BOCHA[lower] : RECENCY_TO_FRESHNESS[lower];
   }
 
-  // Brave date range support
-  if (provider === "brave") {
+  if (provider === "bocha" && BOCHA_RECENCY_VALUES.has(trimmed)) {
+    return trimmed;
+  }
+
+  // Brave date range support (also support Bocha .. format if needed, but let's stick to ISO ranges first)
+  if (provider === "brave" || provider === "bocha") {
     const match = trimmed.match(BRAVE_FRESHNESS_RANGE);
     if (match) {
       const [, start, end] = match;
       if (isValidIsoDate(start) && isValidIsoDate(end) && start <= end) {
-        return `${start}to${end}`;
+        return provider === "bocha" ? `${start}..${end}` : `${start}to${end}`;
       }
+    }
+    // Bocha specific single date
+    if (provider === "bocha" && isValidIsoDate(trimmed)) {
+      return trimmed;
     }
   }
 
@@ -1515,6 +1725,9 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  bochaBaseUrl?: string;
+  bochaModel?: string;
+  bochaSummary?: boolean;
   braveMode?: "web" | "llm-context";
 }): Promise<Record<string, unknown>> {
   const effectiveBraveMode = params.braveMode ?? "web";
@@ -1527,7 +1740,9 @@ async function runWebSearch(params: {
           ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
           : params.provider === "kimi"
             ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-            : "";
+            : params.provider === "bocha"
+              ? `${params.bochaBaseUrl ?? DEFAULT_BOCHA_BASE_URL}:${params.bochaModel ?? DEFAULT_BOCHA_MODEL}:${String(params.bochaSummary ?? false)}`
+              : "";
   const cacheKey = normalizeCacheKey(
     params.provider === "brave" && effectiveBraveMode === "llm-context"
       ? `${params.provider}:llm-context:${params.query}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.freshness || "default"}`
@@ -1682,6 +1897,35 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "bocha") {
+    const results = await runBochaSearch({
+      query: params.query,
+      apiKey: params.apiKey,
+      baseUrl: params.bochaBaseUrl ?? DEFAULT_BOCHA_BASE_URL,
+      model: params.bochaModel ?? DEFAULT_BOCHA_MODEL,
+      count: params.count,
+      timeoutSeconds: params.timeoutSeconds,
+      freshness: params.freshness,
+      summary: params.bochaSummary,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      count: results.length,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1816,6 +2060,7 @@ export function createWebSearchTool(options?: {
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
+  const bochaConfig = resolveBochaConfig(search);
   const braveConfig = resolveBraveConfig(search);
   const braveMode = resolveBraveMode(braveConfig);
 
@@ -1830,9 +2075,11 @@ export function createWebSearchTool(options?: {
           ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
           : provider === "gemini"
             ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : braveMode === "llm-context"
-              ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
-              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+            : provider === "bocha"
+              ? "Search the web using Bocha. Supports time-range (freshness), original web contents (summary), and Bing-compatible response format. Optimized for AI grounding."
+              : braveMode === "llm-context"
+                ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content (text chunks, tables, code blocks) optimized for LLM grounding."
+                : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1853,7 +2100,9 @@ export function createWebSearchTool(options?: {
               ? resolveKimiApiKey(kimiConfig)
               : provider === "gemini"
                 ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+                : provider === "bocha"
+                  ? resolveBochaApiKey(bochaConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -1865,6 +2114,9 @@ export function createWebSearchTool(options?: {
       const query = readStringParam(params, "query", { required: true });
       const count =
         readNumberParam(params, "count", { integer: true }) ?? search?.maxResults ?? undefined;
+      const bochaSummary =
+        readBooleanParam(params, "summary") ??
+        (provider === "bocha" ? bochaConfig.summary : undefined);
       const country = readStringParam(params, "country");
       if (
         country &&
@@ -1935,10 +2187,10 @@ export function createWebSearchTool(options?: {
         });
       }
       const rawFreshness = readStringParam(params, "freshness");
-      if (rawFreshness && provider !== "brave" && provider !== "perplexity") {
+      if (rawFreshness && provider !== "brave" && provider !== "perplexity" && provider !== "bocha") {
         return jsonResult({
           error: "unsupported_freshness",
-          message: `freshness filtering is not supported by the ${provider} provider. Only Brave and Perplexity support freshness.`,
+          message: `freshness filtering is not supported by the ${provider} provider. Only Brave, Perplexity and Bocha support freshness.`,
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
@@ -1951,13 +2203,14 @@ export function createWebSearchTool(options?: {
         });
       }
       const freshness = rawFreshness ? normalizeFreshness(rawFreshness, provider) : undefined;
-      if (rawFreshness && !freshness) {
+      if (rawFreshness && !freshness && provider !== "bocha") {
         return jsonResult({
           error: "invalid_freshness",
           message: "freshness must be day, week, month, or year.",
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
+      const effectiveFreshness = provider === "bocha" ? rawFreshness : freshness;
       const rawDateAfter = readStringParam(params, "date_after");
       const rawDateBefore = readStringParam(params, "date_before");
       if (rawFreshness && (rawDateAfter || rawDateBefore)) {
@@ -2075,7 +2328,7 @@ export function createWebSearchTool(options?: {
         language,
         search_lang: resolvedSearchLang,
         ui_lang: resolvedUiLang,
-        freshness,
+        freshness: effectiveFreshness,
         dateAfter,
         dateBefore,
         searchDomainFilter: domainFilter,
@@ -2089,6 +2342,9 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        bochaBaseUrl: resolveBochaBaseUrl(bochaConfig),
+        bochaModel: resolveBochaModel(bochaConfig),
+        bochaSummary,
         braveMode,
       });
       return jsonResult(result);
@@ -2120,6 +2376,9 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveBochaApiKey,
+  resolveBochaModel,
+  resolveBochaBaseUrl,
   resolveRedirectUrl: resolveCitationRedirectUrl,
   resolveBraveMode,
 } as const;

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -68,7 +68,29 @@ function createKimiSearchTool(kimiConfig?: { apiKey?: string; baseUrl?: string; 
   });
 }
 
-function createProviderSearchTool(provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi") {
+function createBochaSearchTool(bochaConfig?: {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}) {
+  return createWebSearchTool({
+    config: {
+      tools: {
+        web: {
+          search: {
+            provider: "bocha",
+            ...(bochaConfig ? { bocha: bochaConfig } : {}),
+          },
+        },
+      },
+    },
+    sandboxed: true,
+  });
+}
+
+function createProviderSearchTool(
+  provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "bocha",
+) {
   const searchConfig =
     provider === "perplexity"
       ? { provider, perplexity: { apiKey: "pplx-config-test" } } // pragma: allowlist secret
@@ -78,7 +100,9 @@ function createProviderSearchTool(provider: "brave" | "perplexity" | "grok" | "g
           ? { provider, gemini: { apiKey: "gemini-config-test" } } // pragma: allowlist secret
           : provider === "kimi"
             ? { provider, kimi: { apiKey: "moonshot-config-test" } } // pragma: allowlist secret
-            : { provider, apiKey: "brave-config-test" }; // pragma: allowlist secret
+            : provider === "bocha"
+              ? { provider, bocha: { apiKey: "bocha-config-test" } } // pragma: allowlist secret
+              : { provider, apiKey: "brave-config-test" }; // pragma: allowlist secret
   return createWebSearchTool({
     config: {
       tools: {
@@ -121,7 +145,7 @@ function installPerplexityChatFetch() {
 }
 
 function createProviderSuccessPayload(
-  provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi",
+  provider: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "bocha",
 ) {
   if (provider === "brave") {
     return { web: { results: [] } };
@@ -141,6 +165,9 @@ function createProviderSuccessPayload(
         },
       ],
     };
+  }
+  if (provider === "bocha") {
+    return { data: { webPages: { value: [] } } };
   }
   return {
     choices: [{ finish_reason: "stop", message: { role: "assistant", content: "ok" } }],
@@ -270,7 +297,7 @@ describe("web_search provider proxy dispatch", () => {
     global.fetch = priorFetch;
   });
 
-  it.each(["brave", "perplexity", "grok", "gemini", "kimi"] as const)(
+  it.each(["brave", "perplexity", "grok", "gemini", "kimi", "bocha"] as const)(
     "uses proxy-aware dispatcher for %s provider when HTTP_PROXY is configured",
     async (provider) => {
       vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
@@ -612,6 +639,80 @@ describe("web_search kimi provider", () => {
     expect(details.provider).toBe("kimi");
     expect(details.citations).toEqual(["https://openclaw.ai/docs"]);
     expect(details.content).toContain("final answer");
+  });
+});
+
+describe("web_search bocha provider", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+    webSearchTesting.SEARCH_CACHE.clear();
+  });
+
+  it("returns a setup hint when Bocha key is missing", async () => {
+    vi.stubEnv("BOCHA_API_KEY", "");
+    const tool = createBochaSearchTool();
+    const result = await tool?.execute?.("call-1", { query: "test" });
+    expect(result?.details).toMatchObject({ error: "missing_bocha_api_key" });
+  });
+
+  it("calls Bocha API and returns results", async () => {
+    vi.stubEnv("BOCHA_API_KEY", "bocha-test-key"); // pragma: allowlist secret
+    const mockFetch = installMockFetch({
+      data: {
+        webPages: {
+          value: [
+            {
+              name: "Bocha",
+              url: "https://bocha.cn",
+              snippet: "Bocha search",
+              summary: "Bocha summary",
+              datePublished: "2025-02-23T08:18:30+08:00",
+              dateLastCrawled: "2024-01-01",
+            },
+          ],
+        },
+      },
+    });
+
+    const tool = createBochaSearchTool();
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).toHaveBeenCalled();
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://api.bocha.cn/v1/web-search");
+    const body = parseFirstRequestBody(mockFetch);
+    expect(body.query).toBe("test");
+    expect(result?.details).toMatchObject({
+      provider: "bocha",
+      results: [
+        {
+          title: expect.stringContaining("Bocha"),
+          url: "https://bocha.cn",
+          description: expect.stringContaining("Bocha summary"),
+          published: "2025-02-23T08:18:30+08:00",
+        },
+      ],
+    });
+  });
+
+  it("passes count, freshness and summary to Bocha API", async () => {
+    vi.stubEnv("BOCHA_API_KEY", "bocha-test-key"); // pragma: allowlist secret
+    const mockFetch = installMockFetch({ data: { webPages: { value: [] } } });
+    const tool = createBochaSearchTool();
+    await tool?.execute?.("call-1", {
+      query: "test-params",
+      count: 7,
+      freshness: "oneDay",
+      summary: true,
+    });
+
+    const body = parseFirstRequestBody(mockFetch);
+    expect(body.query).toBe("test-params");
+    expect(body.count).toBe(7);
+    expect(body.freshness).toBe("oneDay");
+    expect(body.summary).toBe(true);
   });
 });
 

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -10,7 +10,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
-export type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi";
+export type SearchProvider = "perplexity" | "brave" | "gemini" | "grok" | "kimi" | "bocha";
 
 type SearchProviderEntry = {
   value: SearchProvider;
@@ -22,6 +22,14 @@ type SearchProviderEntry = {
 };
 
 export const SEARCH_PROVIDER_OPTIONS: readonly SearchProviderEntry[] = [
+  {
+    value: "bocha",
+    label: "Bocha Search",
+    hint: "Structured results · time filters · Bing-compatible",
+    envKeys: ["BOCHA_API_KEY"],
+    placeholder: "sk-...",
+    signupUrl: "https://open.bocha.cn/",
+  },
   {
     value: "brave",
     label: "Brave Search",
@@ -81,6 +89,8 @@ function rawKeyValue(config: OpenClawConfig, provider: SearchProvider): unknown 
       return search?.grok?.apiKey;
     case "kimi":
       return search?.kimi?.apiKey;
+    case "bocha":
+      return search?.bocha?.apiKey;
   }
 }
 
@@ -143,6 +153,9 @@ export function applySearchKey(
       break;
     case "kimi":
       search.kimi = { ...search.kimi, apiKey: key };
+      break;
+    case "bocha":
+      search.bocha = { ...search.bocha, apiKey: key };
       break;
   }
   return {

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -51,6 +51,33 @@ describe("web search provider config", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts bocha provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "bocha",
+        providerConfig: {
+          apiKey: "test-key", // pragma: allowlist secret
+          baseUrl: "https://api.bocha.cn/v1",
+          model: "web-search",
+          summary: true,
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts bocha provider with no extra config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "bocha",
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts brave llm-context mode config", () => {
     const res = validateConfigObject(
       buildWebSearchProviderConfig({
@@ -91,6 +118,7 @@ describe("web search provider auto-detection", () => {
     delete process.env.XAI_API_KEY;
     delete process.env.KIMI_API_KEY;
     delete process.env.MOONSHOT_API_KEY;
+    delete process.env.BOCHA_API_KEY;
   });
 
   afterEach(() => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -649,7 +649,7 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
   "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
   "tools.web.search.provider":
-    'Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). Auto-detected from available API keys if omitted.',
+    'Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "bocha"). Auto-detected from available API keys if omitted.',
   "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
@@ -664,6 +664,12 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.kimi.baseUrl":
     'Kimi base URL override (default: "https://api.moonshot.ai/v1").',
   "tools.web.search.kimi.model": 'Kimi model override (default: "moonshot-v1-128k").',
+  "tools.web.search.bocha.apiKey": "Bocha API key (fallback: BOCHA_API_KEY env var).",
+  "tools.web.search.bocha.baseUrl":
+    'Bocha base URL override (default: "https://api.bocha.cn/v1").',
+  "tools.web.search.bocha.model": 'Bocha model override (default: "web-search").',
+  "tools.web.search.bocha.summary":
+    "Whether to include original web contents in the results (default: false).",
   "tools.web.search.perplexity.apiKey":
     "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var). Direct Perplexity keys default to the Search API; OpenRouter keys use Sonar chat completions.",
   "tools.web.search.perplexity.baseUrl":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -229,6 +229,10 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.kimi.apiKey": "Kimi Search API Key", // pragma: allowlist secret
   "tools.web.search.kimi.baseUrl": "Kimi Search Base URL",
   "tools.web.search.kimi.model": "Kimi Search Model",
+  "tools.web.search.bocha.apiKey": "Bocha API Key", // pragma: allowlist secret
+  "tools.web.search.bocha.baseUrl": "Bocha Search Base URL",
+  "tools.web.search.bocha.model": "Bocha Search Model",
+  "tools.web.search.bocha.summary": "Bocha Search Original Web Contents",
   "tools.web.fetch.enabled": "Enable Web Fetch Tool",
   "tools.web.fetch.maxChars": "Web Fetch Max Chars",
   "tools.web.fetch.maxCharsCap": "Web Fetch Hard Max Chars",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -441,8 +441,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "bocha"). */
+      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "bocha";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: SecretInput;
       /** Default search results count (1-10). */
@@ -484,6 +484,17 @@ export type ToolsConfig = {
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
         model?: string;
+      };
+      /** Bocha-specific configuration (used when provider="bocha"). */
+      bocha?: {
+        /** Bocha API key (defaults to BOCHA_API_KEY env var). */
+        apiKey?: SecretInput;
+        /** Base URL for API requests (defaults to "https://api.bocha.cn/v1"). */
+        baseUrl?: string;
+        /** Model to use (defaults to "web-search"). */
+        model?: string;
+        /** Whether to include original web contents in the results (default: false). */
+        summary?: boolean;
       };
       /** Brave-specific configuration (used when provider="brave"). */
       brave?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -269,6 +269,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("bocha"),
       ])
       .optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
@@ -305,6 +306,15 @@ export const ToolsWebSearchSchema = z
         apiKey: SecretInputSchema.optional().register(sensitive),
         baseUrl: z.string().optional(),
         model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    bocha: z
+      .object({
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        model: z.string().optional(),
+        summary: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,12 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.bocha?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.BOCHA_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary

- **Problem**: Users lacked a high-quality, AI-optimized domestic (Chinese) search provider for the `web_search` tool.
- **Why it matters**: Existing providers (Brave/Perplexity) may have connectivity or regional data coverage limitations for Chinese users. Bocha provides compliant and accurate search results optimized for LLM grounding.
- **What changed**: Integrated Bocha AI Search API into the `web_search` tool, including support for `summary` (original web content), `freshness` filters, and `datePublished` prioritization.
- **What did NOT change**: Core logic for other search providers remains untouched.

## Change Type (select all)

- [x] Feature
- [x] Refactor required for the fix (Added `readBooleanParam` helper)
- [x] Docs (Updated schema help text)
- [x] Security hardening (Added Bocha to API key security audit)

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Auth / tokens
- [x] Integrations
- [x] API / contracts (Config schema)

## User-visible / Behavior Changes

- New search provider `bocha` added to `tools.web.search.provider`.
- New config section `tools.web.search.bocha` with `apiKey`, `baseUrl`, `model`, and `summary` options.
- Bocha is now an option in the `openclaw onboard` and `configure` interactive wizards.
- `web_search` tool now accepts a `summary` boolean parameter when using Bocha to fetch original page content.

## Security Impact (required)

- **New permissions/capabilities?**: Yes (Ability to search via Bocha AI).
- **Secrets/tokens handling changed?**: Yes (Introduced `BOCHA_API_KEY`).
- **New/changed network calls?**: Yes (Outbound calls to `api.bocha.cn`).
- **Command/tool execution surface changed?**: No.
- **Data access scope changed?**: No.
- **Mitigation**: `BOCHA_API_KEY` is integrated into the security audit system (`audit-extra.sync.ts`) and is treated as a sensitive secret.

## Repro + Verification

### Environment

- **OS**: Windows / Linux
- **Runtime**: Node.js v22
- **Relevant config**: `tools.web.search.provider: "bocha"`

### Steps

1. Run `pnpm test src/agents/tools/web-search.test.ts`
2. Run `pnpm test src/agents/tools/web-tools.enabled-defaults.test.ts`
3. Verify config setting via `node openclaw.mjs config set tools.web.search.provider bocha`

### Expected

- All Bocha-specific tests pass.
- Config validation accepts the new Bocha schema.
- API requests correctly map `freshness` and `summary` parameters.

## Human Verification (required)

- **Verified scenarios**: Config auto-detection from env, manual config override, API parameter mapping (freshness shortcuts), and result timestamp prioritization.
- **Edge cases checked**: Invalid `summary` values, missing API keys, and large result counts (capped at 10 to avoid LLM token limits).

## Compatibility / Migration

- **Backward compatible?**: Yes.
- **Config/env changes?**: Yes (New optional config fields).
- **Migration needed?**: No.

## Risks and Mitigations
