### PR TITLE
fix(android): gate canvas bridge to trusted pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - CLI/config: make `config set --strict-json` enforce real JSON, prefer `JSON.parse` with JSON5 fallback for machine-written cron/subagent stores, and relabel raw config surfaces as `JSON/JSON5` to match actual compatibility. Related: #48415, #43127, #14529, #21332. Thanks @adhitShet and @vincentkoc.
 - CLI/Ollama onboarding: keep the interactive model picker for explicit `openclaw onboard --auth-choice ollama` runs so setup still selects a default model without reintroducing pre-picker auto-pulls. (#49249) Thanks @BruceMacD.
 - CLI/configure: clarify fresh-setup memory-search warnings so they say semantic recall needs at least one embedding provider, and scope the initial model allowlist picker to the provider selected in configure. Thanks @vincentkoc.
+- Android/canvas: ignore bridge messages from pages outside the bundled scaffold and trusted A2UI surfaces. Thanks @vincentkoc.
 - CLI/status: keep `status --json` stdout clean by skipping plugin compatibility scans that were not rendered in the JSON payload. (#52449) Thanks @cgdusek.
 - Browser/node proxy: enforce `nodeHost.browserProxy.allowProfiles` across `query.profile` and `body.profile`, block proxy-side profile create/delete when the allowlist is set, and keep the default full proxy surface when the allowlist is empty.
 - Web tools/Exa: align the bundled Exa plugin with the current Exa API by supporting newer search types and richer `contents` options, while fixing the result-count cap to honor Exa's higher limit. Thanks @vincentkoc.

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -237,6 +237,10 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
     ensureRuntime().handleCanvasA2UIActionFromWebView(payloadJson)
   }
 
+  fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean {
+    return ensureRuntime().isTrustedCanvasActionUrl(rawUrl)
+  }
+
   fun requestCanvasRehydrate(source: String = "screen_tab") {
     ensureRuntime().requestCanvasRehydrate(source = source, force = true)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -904,6 +904,10 @@ class NodeRuntime(
     }
   }
 
+  fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean {
+    return a2uiHandler.isTrustedCanvasActionUrl(rawUrl)
+  }
+
   fun loadChat(sessionKey: String) {
     val key = sessionKey.trim().ifEmpty { resolveMainSessionKey() }
     chat.load(key)

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/A2UIHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/A2UIHandler.kt
@@ -13,6 +13,13 @@ class A2UIHandler(
   private val getNodeCanvasHostUrl: () -> String?,
   private val getOperatorCanvasHostUrl: () -> String?,
 ) {
+  fun isTrustedCanvasActionUrl(rawUrl: String?): Boolean {
+    return CanvasActionTrust.isTrustedCanvasActionUrl(
+      rawUrl = rawUrl,
+      trustedA2uiUrls = listOfNotNull(resolveA2uiHostUrl()),
+    )
+  }
+
   fun resolveA2uiHostUrl(): String? {
     val nodeRaw = getNodeCanvasHostUrl()?.trim().orEmpty()
     val operatorRaw = getOperatorCanvasHostUrl()?.trim().orEmpty()

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CanvasActionTrust.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CanvasActionTrust.kt
@@ -23,7 +23,7 @@ object CanvasActionTrust {
   private fun isTrustedA2uiPage(candidateUri: URI, trustedUrl: String): Boolean {
     val trustedUri = parseUri(trustedUrl) ?: return false
     if (!candidateUri.scheme.equals(trustedUri.scheme, ignoreCase = true)) return false
-    if (!candidateUri.host.equals(trustedUri.host, ignoreCase = true)) return false
+    if (candidateUri.host?.equals(trustedUri.host, ignoreCase = true) != true) return false
     if (effectivePort(candidateUri) != effectivePort(trustedUri)) return false
 
     val trustedPath = trustedUri.rawPath?.takeIf { it.isNotBlank() } ?: return false

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CanvasActionTrust.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CanvasActionTrust.kt
@@ -1,0 +1,50 @@
+package ai.openclaw.app.node
+
+import java.net.URI
+
+object CanvasActionTrust {
+  const val scaffoldAssetUrl: String = "file:///android_asset/CanvasScaffold/scaffold.html"
+
+  fun isTrustedCanvasActionUrl(rawUrl: String?, trustedA2uiUrls: List<String>): Boolean {
+    val candidate = rawUrl?.trim().orEmpty()
+    if (candidate.isEmpty()) return false
+    if (candidate == scaffoldAssetUrl) return true
+
+    val candidateUri = parseUri(candidate) ?: return false
+    if (candidateUri.scheme.equals("file", ignoreCase = true)) {
+      return false
+    }
+
+    return trustedA2uiUrls.any { trusted ->
+      isTrustedA2uiPage(candidateUri, trusted)
+    }
+  }
+
+  private fun isTrustedA2uiPage(candidateUri: URI, trustedUrl: String): Boolean {
+    val trustedUri = parseUri(trustedUrl) ?: return false
+    if (!candidateUri.scheme.equals(trustedUri.scheme, ignoreCase = true)) return false
+    if (!candidateUri.host.equals(trustedUri.host, ignoreCase = true)) return false
+    if (effectivePort(candidateUri) != effectivePort(trustedUri)) return false
+
+    val trustedPath = trustedUri.rawPath?.takeIf { it.isNotBlank() } ?: return false
+    val candidatePath = candidateUri.rawPath?.takeIf { it.isNotBlank() } ?: return false
+    val trustedPrefix = if (trustedPath.endsWith("/")) trustedPath else "$trustedPath/"
+    return candidatePath == trustedPath || candidatePath.startsWith(trustedPrefix)
+  }
+
+  private fun effectivePort(uri: URI): Int {
+    if (uri.port >= 0) return uri.port
+    return when (uri.scheme?.lowercase()) {
+      "https" -> 443
+      "http" -> 80
+      else -> -1
+    }
+  }
+
+  private fun parseUri(raw: String): URI? =
+    try {
+      URI(raw)
+    } catch (_: Throwable) {
+      null
+    }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -122,7 +122,12 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
             }
           }
 
-        val bridge = CanvasA2UIActionBridge { payload -> viewModel.handleCanvasA2UIActionFromWebView(payload) }
+        val bridge =
+          CanvasA2UIActionBridge(
+            isTrustedPage = { viewModel.isTrustedCanvasActionUrl(this.url?.toString()) },
+          ) { payload ->
+            viewModel.handleCanvasA2UIActionFromWebView(payload)
+          }
         addJavascriptInterface(bridge, CanvasA2UIActionBridge.interfaceName)
         viewModel.canvas.attach(this)
         webViewRef.value = this
@@ -147,11 +152,15 @@ private fun disableForceDarkIfSupported(settings: WebSettings) {
   WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
 }
 
-private class CanvasA2UIActionBridge(private val onMessage: (String) -> Unit) {
+private class CanvasA2UIActionBridge(
+  private val isTrustedPage: () -> Boolean,
+  private val onMessage: (String) -> Unit,
+) {
   @JavascriptInterface
   fun postMessage(payload: String?) {
     val msg = payload?.trim().orEmpty()
     if (msg.isEmpty()) return
+    if (!isTrustedPage()) return
     onMessage(msg)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import ai.openclaw.app.MainViewModel
+import java.util.concurrent.atomic.AtomicReference
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -29,6 +30,7 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
   val context = LocalContext.current
   val isDebuggable = (context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE) != 0
   val webViewRef = remember { mutableStateOf<WebView?>(null) }
+  val currentPageUrlRef = remember { AtomicReference<String?>(null) }
 
   DisposableEffect(viewModel) {
     onDispose {
@@ -68,6 +70,14 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
         isHorizontalScrollBarEnabled = true
         webViewClient =
           object : WebViewClient() {
+            override fun onPageStarted(
+              view: WebView,
+              url: String?,
+              favicon: android.graphics.Bitmap?,
+            ) {
+              currentPageUrlRef.set(url)
+            }
+
             override fun onReceivedError(
               view: WebView,
               request: WebResourceRequest,
@@ -90,6 +100,7 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
             }
 
             override fun onPageFinished(view: WebView, url: String?) {
+              currentPageUrlRef.set(url)
               if (isDebuggable) {
                 Log.d("OpenClawWebView", "onPageFinished: $url")
               }
@@ -124,7 +135,7 @@ fun CanvasScreen(viewModel: MainViewModel, visible: Boolean, modifier: Modifier 
 
         val bridge =
           CanvasA2UIActionBridge(
-            isTrustedPage = { viewModel.isTrustedCanvasActionUrl(this.url?.toString()) },
+            isTrustedPage = { viewModel.isTrustedCanvasActionUrl(currentPageUrlRef.get()) },
           ) { payload ->
             viewModel.handleCanvasA2UIActionFromWebView(payload)
           }

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/CanvasActionTrustTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/CanvasActionTrustTest.kt
@@ -1,0 +1,42 @@
+package ai.openclaw.app.node
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CanvasActionTrustTest {
+  @Test
+  fun acceptsBundledScaffoldAsset() {
+    assertTrue(CanvasActionTrust.isTrustedCanvasActionUrl(CanvasActionTrust.scaffoldAssetUrl, emptyList()))
+  }
+
+  @Test
+  fun acceptsTrustedA2uiPageOnAdvertisedCanvasHost() {
+    assertTrue(
+      CanvasActionTrust.isTrustedCanvasActionUrl(
+        rawUrl = "https://canvas.example.com:9443/__openclaw__/cap/token/__openclaw__/a2ui/?platform=android",
+        trustedA2uiUrls = listOf("https://canvas.example.com:9443/__openclaw__/cap/token/__openclaw__/a2ui/?platform=android"),
+      ),
+    )
+  }
+
+  @Test
+  fun rejectsDifferentOriginEvenIfPathMatches() {
+    assertFalse(
+      CanvasActionTrust.isTrustedCanvasActionUrl(
+        rawUrl = "https://evil.example.com:9443/__openclaw__/cap/token/__openclaw__/a2ui/?platform=android",
+        trustedA2uiUrls = listOf("https://canvas.example.com:9443/__openclaw__/cap/token/__openclaw__/a2ui/?platform=android"),
+      ),
+    )
+  }
+
+  @Test
+  fun rejectsUntrustedCanvasPagePathOnTrustedOrigin() {
+    assertFalse(
+      CanvasActionTrust.isTrustedCanvasActionUrl(
+        rawUrl = "https://canvas.example.com:9443/untrusted/index.html",
+        trustedA2uiUrls = listOf("https://canvas.example.com:9443/__openclaw__/cap/token/__openclaw__/a2ui/?platform=android"),
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: the Android WebView canvas bridge accepted `postMessage` calls from any page loaded in the canvas WebView.
- Why it matters: untrusted pages could drive `handleCanvasA2UIActionFromWebView()` and reach agent request dispatch.
- What changed: added explicit trust checks so the bridge only accepts messages from the bundled scaffold asset or the resolved trusted A2UI origin/path.
- What did NOT change (scope boundary): this does not change the bridge payload format, canvas rendering, or non-Android surfaces.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #GHSA-cxmw-p77q-wchg

## User-visible / Behavior Changes

Android now ignores canvas bridge messages from pages outside the trusted canvas/scaffold surfaces.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - The WebView bridge now rejects messages unless the current page URL matches the bundled scaffold asset or the resolved trusted A2UI origin/path.

## Repro + Verification

### Environment

- OS: macOS host
- Runtime/container: local git worktree
- Model/provider: n/a
- Integration/channel (if any): Android app canvas WebView
- Relevant config (redacted): none

### Steps

1. Load an untrusted page in the Android canvas WebView.
2. Call `openclawCanvasA2UIAction.postMessage(...)` from that page.
3. Observe the bridge behavior.

### Expected

- Untrusted pages are ignored.
- Trusted scaffold/A2UI pages still dispatch bridge actions.

### Actual

- Before this change, any loaded page could reach the bridge.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the bridge call chain from `CanvasScreen.kt` through `MainViewModel`, `NodeRuntime`, and `A2UIHandler`; added unit coverage for bundled scaffold, trusted A2UI origin, mismatched origin, and mismatched path.
- Edge cases checked: empty URL, arbitrary `file:` URL, same origin with wrong path prefix.
- What you did **not** verify: Android Gradle unit execution in this shell, because the local Android SDK is not configured (`ANDROID_HOME` / `apps/android/local.properties` missing).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: Android canvas bridge files under `apps/android/app/src/main/java/ai/openclaw/app/`.
- Known bad symptoms reviewers should watch for: trusted in-app canvas actions failing to reach the runtime.

## Risks and Mitigations

- Risk: trusted canvas URLs may be matched too narrowly and block legitimate in-app actions.
- Mitigation: URL matching allows the bundled scaffold asset and the resolved trusted A2UI origin/path prefix, with unit coverage for accepted and rejected cases.
