### PR TITLE
read: recover from out-of-range offsets

### DIFF
--- a/src/agents/pi-tools.read.offset-recovery.test.ts
+++ b/src/agents/pi-tools.read.offset-recovery.test.ts
@@ -1,0 +1,115 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSandboxedReadTool } from "./pi-tools.read.js";
+import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
+
+function extractToolText(result: unknown): string {
+  if (!result || typeof result !== "object") {
+    return "";
+  }
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const textBlock = content.find((block) => {
+    return (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text === "string"
+    );
+  }) as { text?: string } | undefined;
+  return textBlock?.text ?? "";
+}
+
+const tempDirs: string[] = [];
+
+async function createReadFixture(lines: string[]) {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-offset-recovery-"));
+  tempDirs.push(root);
+  await fs.writeFile(path.join(root, "sample.txt"), lines.join("\n"), "utf8");
+  return createSandboxedReadTool({
+    root,
+    bridge: createHostSandboxFsBridge(root),
+  });
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("createOpenClawReadTool offset recovery", () => {
+  it("returns a non-fatal recovery result when offset is beyond EOF", async () => {
+    const readTool = await createReadFixture(["line-1", "line-2", "line-3", "line-4"]);
+
+    const result = await readTool.execute("read-offset-recovery-1", {
+      path: "sample.txt",
+      offset: 200,
+    });
+
+    const text = extractToolText(result);
+    expect(text).toContain("Requested offset 200 is beyond end of file (4 lines total)");
+    expect(text).toContain("Returning the last 4 lines from offset=1 instead");
+    expect(text).toContain("line-1");
+    expect(text).toContain("line-4");
+    expect(
+      (
+        result as {
+          details?: {
+            offsetRecovery?: Record<string, unknown>;
+          };
+        }
+      ).details?.offsetRecovery,
+    ).toMatchObject({
+      code: "offset_out_of_range",
+      requestedOffset: 200,
+      totalLines: 4,
+      recoveredOffset: 1,
+    });
+  });
+
+  it("clamps limited reads to the last valid window instead of throwing", async () => {
+    const readTool = await createReadFixture([
+      "line-1",
+      "line-2",
+      "line-3",
+      "line-4",
+      "line-5",
+      "line-6",
+    ]);
+
+    const result = await readTool.execute("read-offset-recovery-2", {
+      path: "sample.txt",
+      offset: 200,
+      limit: 2,
+    });
+
+    const text = extractToolText(result);
+    expect(text).toContain("Requested offset 200 is beyond end of file (6 lines total)");
+    expect(text).toContain("Returning the last 2 lines from offset=5 instead");
+    expect(text).toContain("line-5");
+    expect(text).toContain("line-6");
+    expect(text).not.toContain("line-1");
+    expect(
+      (
+        result as {
+          details?: {
+            offsetRecovery?: Record<string, unknown>;
+          };
+        }
+      ).details?.offsetRecovery,
+    ).toMatchObject({
+      code: "offset_out_of_range",
+      requestedOffset: 200,
+      totalLines: 6,
+      recoveredOffset: 5,
+    });
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -42,6 +42,9 @@ type ImageContentBlock = Extract<ToolContentBlock, { type: "image" }>;
 type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
 
 const DEFAULT_READ_PAGE_MAX_BYTES = 50 * 1024;
+// Align recovery paging with pi-coding-agent's default line window so out-of-range
+// reads still return a useful tail chunk instead of aborting the run.
+const DEFAULT_READ_RECOVERY_WINDOW_LINES = 2_000;
 const MAX_ADAPTIVE_READ_MAX_BYTES = 512 * 1024;
 const ADAPTIVE_READ_CONTEXT_SHARE = 0.2;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
@@ -60,6 +63,16 @@ type ReadTruncationDetails = {
 
 const READ_CONTINUATION_NOTICE_RE =
   /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
+const READ_OFFSET_OUT_OF_RANGE_RE = /^Offset (\d+) is beyond end of file \((\d+) lines total\)$/;
+
+type ReadOffsetOutOfRangeDiagnostic = {
+  requestedOffset: number;
+  totalLines: number;
+};
+
+type ReadOffsetRecoveryDetails = ReadOffsetOutOfRangeDiagnostic & {
+  recoveredOffset: number;
+};
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -205,6 +218,115 @@ function stripReadTruncationContentDetails(
   };
 }
 
+function parseReadOffsetOutOfRangeError(error: unknown): ReadOffsetOutOfRangeDiagnostic | null {
+  const message =
+    error instanceof Error ? error.message : typeof error === "string" ? error.trim() : "";
+  if (!message) {
+    return null;
+  }
+  const match = READ_OFFSET_OUT_OF_RANGE_RE.exec(message);
+  if (!match) {
+    return null;
+  }
+  const requestedOffset = Number.parseInt(match[1] ?? "", 10);
+  const totalLines = Number.parseInt(match[2] ?? "", 10);
+  if (!Number.isFinite(requestedOffset) || !Number.isFinite(totalLines)) {
+    return null;
+  }
+  return {
+    requestedOffset,
+    totalLines: Math.max(0, totalLines),
+  };
+}
+
+function resolveReadRecoveryOffset(args: Record<string, unknown>, totalLines: number): number {
+  const limitRaw = args.limit;
+  const recoveryWindow =
+    typeof limitRaw === "number" && Number.isFinite(limitRaw) && limitRaw > 0
+      ? Math.floor(limitRaw)
+      : DEFAULT_READ_RECOVERY_WINDOW_LINES;
+  return Math.max(1, totalLines - recoveryWindow + 1);
+}
+
+function prependReadRecoveryNotice(
+  result: AgentToolResult<unknown>,
+  details: ReadOffsetRecoveryDetails,
+): AgentToolResult<unknown> {
+  const returnedLines = Math.max(1, details.totalLines - details.recoveredOffset + 1);
+  const lineLabel = returnedLines === 1 ? "line" : "lines";
+  const notice = `[Requested offset ${details.requestedOffset} is beyond end of file (${details.totalLines} lines total). Returning the last ${returnedLines} ${lineLabel} from offset=${details.recoveredOffset} instead.]`;
+  const existingText = getToolResultText(result);
+  const withNotice = withToolResultText(
+    result,
+    existingText && existingText.trim().length > 0 ? `${notice}\n\n${existingText}` : notice,
+  );
+  const existingDetails = (withNotice as { details?: unknown }).details;
+  const detailsRecord =
+    existingDetails && typeof existingDetails === "object"
+      ? (existingDetails as Record<string, unknown>)
+      : {};
+  return {
+    ...withNotice,
+    details: {
+      ...detailsRecord,
+      offsetRecovery: {
+        code: "offset_out_of_range",
+        requestedOffset: details.requestedOffset,
+        totalLines: details.totalLines,
+        recoveredOffset: details.recoveredOffset,
+      },
+    },
+  };
+}
+
+function createReadOffsetDiagnosticResult(
+  details: ReadOffsetOutOfRangeDiagnostic,
+): AgentToolResult<unknown> {
+  const notice = `[Requested offset ${details.requestedOffset} is beyond end of file (${details.totalLines} lines total). Use offset=1 to read from the beginning.]`;
+  return {
+    content: [{ type: "text", text: notice }],
+    details: {
+      offsetRecovery: {
+        code: "offset_out_of_range",
+        requestedOffset: details.requestedOffset,
+        totalLines: details.totalLines,
+        recoveredOffset: 1,
+      },
+    },
+  };
+}
+
+async function executeReadPageWithRecovery(params: {
+  base: AnyAgentTool;
+  toolCallId: string;
+  args: Record<string, unknown>;
+  signal?: AbortSignal;
+}): Promise<AgentToolResult<unknown>> {
+  try {
+    return await params.base.execute(params.toolCallId, params.args, params.signal);
+  } catch (error) {
+    const diagnostic = parseReadOffsetOutOfRangeError(error);
+    if (!diagnostic) {
+      throw error;
+    }
+
+    const recoveredOffset = resolveReadRecoveryOffset(params.args, diagnostic.totalLines);
+    try {
+      const recovered = await params.base.execute(
+        params.toolCallId,
+        { ...params.args, offset: recoveredOffset },
+        params.signal,
+      );
+      return prependReadRecoveryNotice(recovered, {
+        ...diagnostic,
+        recoveredOffset,
+      });
+    } catch {
+      return createReadOffsetDiagnosticResult(diagnostic);
+    }
+  }
+}
+
 async function executeReadWithAdaptivePaging(params: {
   base: AnyAgentTool;
   toolCallId: string;
@@ -216,7 +338,12 @@ async function executeReadWithAdaptivePaging(params: {
   const hasExplicitLimit =
     typeof userLimit === "number" && Number.isFinite(userLimit) && userLimit > 0;
   if (hasExplicitLimit) {
-    return await params.base.execute(params.toolCallId, params.args, params.signal);
+    return await executeReadPageWithRecovery({
+      base: params.base,
+      toolCallId: params.toolCallId,
+      args: params.args,
+      signal: params.signal,
+    });
   }
 
   const offsetRaw = params.args.offset;
@@ -232,7 +359,12 @@ async function executeReadWithAdaptivePaging(params: {
 
   for (let page = 0; page < MAX_ADAPTIVE_READ_PAGES; page += 1) {
     const pageArgs = { ...params.args, offset: nextOffset };
-    const pageResult = await params.base.execute(params.toolCallId, pageArgs, params.signal);
+    const pageResult = await executeReadPageWithRecovery({
+      base: params.base,
+      toolCallId: params.toolCallId,
+      args: pageArgs,
+      signal: params.signal,
+    });
     firstResult ??= pageResult;
 
     const rawText = getToolResultText(pageResult);
@@ -273,7 +405,12 @@ async function executeReadWithAdaptivePaging(params: {
   }
 
   if (!firstResult) {
-    return await params.base.execute(params.toolCallId, params.args, params.signal);
+    return await executeReadPageWithRecovery({
+      base: params.base,
+      toolCallId: params.toolCallId,
+      args: params.args,
+      signal: params.signal,
+    });
   }
 
   let finalText = aggregatedText;


### PR DESCRIPTION
## Summary

- Problem: `read` aborts the whole run when the requested `offset` is past EOF.
- Why it matters: models regularly guess stale offsets after file changes, so this turns a recoverable paging mistake into a fatal tool failure.
- What changed: the OpenClaw read wrapper now catches the upstream out-of-range offset error, recovers to a valid offset, and returns a diagnostic note plus content instead of throwing.
- What did NOT change (scope boundary): this does not patch `@mariozechner/pi-coding-agent` itself or change normal in-range read behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52680
- Related #49501

## User-visible / Behavior Changes

- `read` no longer aborts a run when `offset` is beyond EOF.
- Out-of-range reads now return a diagnostic note and recover to a valid offset.
- Limited reads recover to the last valid window instead of throwing.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node via `pnpm test`
- Model/provider: N/A
- Integration/channel (if any): agent `read` tool wrapper
- Relevant config (redacted): default local test config

### Steps

1. Create a file with a few lines.
2. Call `read` with `offset` larger than the file length.
3. Observe the current tool error aborting the run.

### Expected

- The run should continue.
- The tool should return a diagnostic and a valid recovery result.

### Actual

- Before this patch, the upstream `read` tool throws `Offset ... is beyond end of file (...)`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Vitest coverage for out-of-range recovery and workspace-root guard behavior; manual `tsx` repro showing non-fatal recovery text for `offset=200` on a 4-line file.
- Edge cases checked: explicit `limit` now recovers to the last valid tail window instead of falling back to line 1.
- What you did **not** verify: full repo `pnpm test`; a broad existing test file currently fails locally due a missing `@modelcontextprotocol/sdk` import chain unrelated to this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Read: recover from out-of-range offsets`.
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms reviewers should watch for: unexpected `read` diagnostic notes on in-range offsets.

## Risks and Mitigations

- Risk: recovery window could return an unexpected chunk if upstream `read` paging defaults change again.
- Mitigation: the wrapper only uses recovery for the specific upstream EOF-offset error and adds focused regression coverage for both unlimited and limited reads.
