### PR TITLE
fix(reasoning): apply reasoningDefault independently of thinking level

### DIFF
--- a/src/auto-reply/reply/directive-handling.levels.test.ts
+++ b/src/auto-reply/reply/directive-handling.levels.test.ts
@@ -121,4 +121,19 @@ describe("resolveCurrentDirectiveLevels", () => {
 
     expect(result.currentReasoningLevel).toBe("off");
   });
+
+  it("respects agent reasoningDefault: off as explicit override", async () => {
+    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue("off");
+
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentEntry: {
+        reasoningDefault: "off",
+      },
+      resolveDefaultThinkingLevel,
+    });
+
+    // Agent explicitly setting "off" should be respected, not overridden by model default
+    expect(result.currentReasoningLevel).toBe("off");
+  });
 });

--- a/src/auto-reply/reply/directive-handling.levels.test.ts
+++ b/src/auto-reply/reply/directive-handling.levels.test.ts
@@ -94,14 +94,28 @@ describe("resolveCurrentDirectiveLevels", () => {
     expect(result.currentReasoningLevel).toBe("stream");
   });
 
-  it("skips agent reasoningDefault when thinking is active", async () => {
-    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue("low");
+  it("applies agent reasoningDefault even when thinking is active", async () => {
+    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue("high");
 
     const result = await resolveCurrentDirectiveLevels({
       sessionEntry: {},
       agentEntry: {
         reasoningDefault: "stream",
       },
+      resolveDefaultThinkingLevel,
+    });
+
+    // reasoningDefault should work independently of thinking level
+    expect(result.currentThinkLevel).toBe("high");
+    expect(result.currentReasoningLevel).toBe("stream");
+  });
+
+  it("defaults reasoning to off when no agent default is set", async () => {
+    const resolveDefaultThinkingLevel = vi.fn().mockResolvedValue("low");
+
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentEntry: {},
       resolveDefaultThinkingLevel,
     });
 

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -39,12 +39,10 @@ export async function resolveCurrentDirectiveLevels(params: {
   const currentVerboseLevel =
     (params.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
-  const sessionReasoningLevel = params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined;
   const currentReasoningLevel =
-    sessionReasoningLevel ??
-    (currentThinkLevel === "off"
-      ? ((params.agentEntry?.reasoningDefault as ReasoningLevel | undefined) ?? "off")
-      : "off");
+    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (params.agentEntry?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -434,11 +434,16 @@ export async function resolveReplyDirectives(params: {
     (agentCfg?.thinkingDefault as ThinkLevel | undefined);
 
   // When neither directive nor session nor agent set reasoning, default to model capability
-  // (e.g. OpenRouter with reasoning: true).
+  // (e.g. OpenRouter with reasoning: true). Skip model default when thinking is active
+  // to avoid redundant Reasoning: output alongside internal thinking blocks.
+  const hasAgentReasoningDefault =
+    agentEntry?.reasoningDefault !== undefined && agentEntry?.reasoningDefault !== null;
   const reasoningExplicitlySet =
     directives.reasoningLevel !== undefined ||
-    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
-  if (!reasoningExplicitlySet && resolvedReasoningLevel === "off") {
+    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null) ||
+    hasAgentReasoningDefault;
+  const thinkingActive = resolvedThinkLevelWithDefault !== "off";
+  if (!reasoningExplicitlySet && resolvedReasoningLevel === "off" && !thinkingActive) {
     resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
   }
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -386,9 +386,8 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentEntry?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
-  const agentReasoningDefault = agentEntry?.reasoningDefault as ReasoningLevel | undefined;
-  const hasAgentReasoningDefault = agentReasoningDefault !== undefined;
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
@@ -434,20 +433,13 @@ export async function resolveReplyDirectives(params: {
     (await modelState.resolveDefaultThinkingLevel()) ??
     (agentCfg?.thinkingDefault as ThinkLevel | undefined);
 
-  // When neither directive nor session set reasoning, default to model capability
-  // (e.g. OpenRouter with reasoning: true). Skip auto-enabling when thinking is
-  // active, including model-inferred defaults, or internal thinking blocks can
-  // be emitted as visible "Reasoning:" messages.
+  // When neither directive nor session nor agent set reasoning, default to model capability
+  // (e.g. OpenRouter with reasoning: true).
   const reasoningExplicitlySet =
     directives.reasoningLevel !== undefined ||
     (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
-  const thinkingActive = resolvedThinkLevelWithDefault !== "off";
-  if (!reasoningExplicitlySet && resolvedReasoningLevel === "off" && !thinkingActive) {
-    if (hasAgentReasoningDefault) {
-      resolvedReasoningLevel = agentReasoningDefault;
-    } else {
-      resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
-    }
+  if (!reasoningExplicitlySet && resolvedReasoningLevel === "off") {
+    resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
   }
 
   let contextTokens = resolveContextTokens({


### PR DESCRIPTION
## Summary

- **Problem**: `reasoningDefault` configuration was incorrectly skipped when `thinking` was active, forcing reasoning level to "off" even when a user had explicitly configured `reasoningDefault`.
- **Why it matters**: `thinking` and `reasoning` are conceptually independent - thinking controls reasoning **depth/level**, while reasoning controls **visibility** of the thought process. Users should be able to configure both independently.
- **What changed**:
  1. `reasoningDefault` is now always respected as a fallback value (independent of thinking level)
  2. Added `hasAgentReasoningDefault` to `reasoningExplicitlySet` check to prevent model default from overriding agent's explicit "off"
  3. Restored `!thinkingActive` guard for model default fallback to avoid redundant Reasoning: output
- **What did NOT change**: Resolution order remains the same; only the incorrect thinking-based skip was removed for agent-configured defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Users can now set `reasoningDefault` on an agent and have it respected even when `thinkingDefault` is also configured.
- Example: Setting `thinkingDefault: "high"` and `reasoningDefault: "stream"` will now correctly enable high-depth thinking with streaming reasoning visibility (previously reasoning would be forced to "off").
- Agent's explicit `reasoningDefault: "off"` is now treated as an explicit override and won't be replaced by model default.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Node.js
- Model/provider: Any reasoning-capable model
- Integration/channel: N/A
- Relevant config:
```yaml
agents:
  list:
    - id: test-agent
      thinkingDefault: "high"
      reasoningDefault: "stream"
```

### Steps

1. Configure an agent with both `thinkingDefault` and `reasoningDefault`
2. Send a message to the agent without any inline directives
3. Observe the resolved thinking and reasoning levels

### Expected

- `thinkingLevel` = "high"
- `reasoningLevel` = "stream"

### Actual (before fix)

- `thinkingLevel` = "high"
- `reasoningLevel` = "off" (incorrectly forced)

### Actual (after fix)

- `thinkingLevel` = "high"
- `reasoningLevel` = "stream" (correctly applied)

## Evidence

- [x] Failing test/log before + passing after

Test `directive-handling.levels.test.ts`:
- Before: Test "skips agent reasoningDefault when thinking is active" verified the buggy behavior
- After: Tests verify:
  - "applies agent reasoningDefault even when thinking is active"
  - "respects agent reasoningDefault: off as explicit override"

## Human Verification (required)

- Verified scenarios:
  - `reasoningDefault` applied when `thinkingDefault` is active
  - `reasoningDefault` applied when `thinkingDefault` is "off"
  - Agent `reasoningDefault: "off"` treated as explicit override (not replaced by model default)
  - Session override takes precedence over agent default
  - Inline directive takes precedence over all defaults
  - Model default reasoning only kicks in when thinking is NOT active
- Edge cases checked:
  - No agent default → falls back to model default (if thinking inactive) or "off"
  - Only session reasoning set → uses session value
- What you did **not** verify:
  - End-to-end test with actual model API calls
  - Integration tests with real messaging platforms

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commits `29b0eb6bbe` and `552a32b8d2` or use `/reasoning off` inline directive to explicitly disable reasoning.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for:
  - Unexpected reasoning output when `reasoningDefault` is set
  - Mitigation: User can explicitly set `reasoningDefault: "off"` or use `/reasoning off` inline directive

## Risks and Mitigations

- Risk: Users who relied on the buggy behavior (reasoning forced off when thinking active) may see unexpected reasoning output.
  - Mitigation: This is the correct behavior per documentation. Users can explicitly set `reasoningDefault: "off"` if they want reasoning disabled, or use `/reasoning off` inline directive.