### PR TITLE
ACPX: align pinned runtime version

### DIFF
--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -67,7 +67,7 @@
     },
     "expectedVersion": {
       "label": "Expected acpx Version",
-      "help": "Exact version to enforce (for example 0.1.16) or \"any\" to skip strict version matching."
+      "help": "Exact version to enforce (for example 0.3.1) or \"any\" to skip strict version matching."
     },
     "cwd": {
       "label": "Default Working Directory",

--- a/extensions/acpx/openclaw.plugin.json
+++ b/extensions/acpx/openclaw.plugin.json
@@ -67,7 +67,7 @@
     },
     "expectedVersion": {
       "label": "Expected acpx Version",
-      "help": "Exact version to enforce (for example 0.3.1) or \"any\" to skip strict version matching."
+      "help": "Exact version to enforce or \"any\" to skip strict version matching."
     },
     "cwd": {
       "label": "Default Working Directory",

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -9,7 +9,7 @@ export type AcpxPermissionMode = (typeof ACPX_PERMISSION_MODES)[number];
 export const ACPX_NON_INTERACTIVE_POLICIES = ["deny", "fail"] as const;
 export type AcpxNonInteractivePermissionPolicy = (typeof ACPX_NON_INTERACTIVE_POLICIES)[number];
 
-export const ACPX_PINNED_VERSION = "0.1.16";
+export const ACPX_PINNED_VERSION = "0.3.1";
 export const ACPX_VERSION_ANY = "any";
 const ACPX_BIN_NAME = process.platform === "win32" ? "acpx.cmd" : "acpx";
 

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -88,7 +88,7 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
         },
         expectedVersion: {
           label: "Expected acpx Version",
-          help: 'Exact version to enforce (for example 0.1.16) or "any" to skip strict version matching.',
+          help: 'Exact version to enforce (for example 0.3.1) or "any" to skip strict version matching.',
         },
         cwd: {
           label: "Default Working Directory",

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -88,7 +88,7 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
         },
         expectedVersion: {
           label: "Expected acpx Version",
-          help: 'Exact version to enforce (for example 0.3.1) or "any" to skip strict version matching.',
+          help: 'Exact version to enforce or "any" to skip strict version matching.',
         },
         cwd: {
           label: "Default Working Directory",


### PR DESCRIPTION
## Summary

- Problem: `extensions/acpx` already installs `acpx@0.3.1`, but the runtime default pin still enforced `0.1.16`.
- Why it matters: plugin-local install/version checks could report a mismatch against the bundled dependency, and the surfaced config help text advertised an outdated version example.
- What changed: updated `ACPX_PINNED_VERSION` to `0.3.1`, updated the ACPX manifest help text example, and regenerated bundled plugin metadata.
- What did NOT change (scope boundary): no ACPX permission model, command resolution, or dependency graph changes beyond aligning the existing pin with the already-installed package.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

The ACPX plugin now defaults to enforcing `acpx@0.3.1`, which matches the bundled dependency already declared in `extensions/acpx/package.json`. The config UI/help text example now shows `0.3.1` instead of `0.1.16`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): ACPX runtime plugin
- Relevant config (redacted): default bundled ACPX config

### Steps

1. Verify the published latest `acpx` version from npm and compare it with the repo pin points.
2. Update the stale runtime pin and ACPX manifest example text.
3. Regenerate bundled plugin metadata and run targeted ACPX tests plus a full build.

### Expected

- Default ACPX version enforcement matches the bundled `acpx` dependency.
- Generated metadata stays in sync with the manifest.
- ACPX plugin tests and build pass.

### Actual

- `npm view acpx version dist-tags.latest time --json` reports latest `0.3.1`.
- Repo runtime pin now matches `0.3.1`, metadata is regenerated, targeted tests pass, and `pnpm build` passes.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed npm registry latest is `0.3.1`; confirmed `extensions/acpx/package.json` was already pinned to `0.3.1`; updated the runtime pin and surfaced manifest example; regenerated `src/plugins/bundled-plugin-metadata.generated.ts`; ran targeted ACPX tests and `pnpm build` successfully.
- Edge cases checked: bundled plugin metadata remained in sync via `pnpm check:bundled-plugin-metadata`.
- What you did **not** verify: a live ACPX-backed OpenClaw session against a real external `acpx` binary.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or explicitly set `plugins.entries.acpx.expectedVersion` to the desired override.
- Files/config to restore: `extensions/acpx/src/config.ts`, `extensions/acpx/openclaw.plugin.json`, and regenerated `src/plugins/bundled-plugin-metadata.generated.ts`.
- Known bad symptoms reviewers should watch for: ACPX startup/version-check failures if `0.3.1` proves incompatible with a live runtime environment.

## Risks and Mitigations

- Risk: latest `acpx` may behave differently than older runtime assumptions in untested live environments.
  - Mitigation: the repo already bundles `acpx@0.3.1`; this change only aligns the runtime pin with that existing dependency, and targeted ACPX tests plus `pnpm build` passed.
