### PR TITLE
docs(feishu): fix botName to name in config examples

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -185,7 +185,7 @@ Edit `~/.openclaw/openclaw.json`:
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "My AI assistant",
+          name: "My AI assistant",
         },
       },
     },
@@ -494,12 +494,12 @@ openclaw pairing list feishu
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "Primary bot",
+          name: "Primary bot",
         },
         backup: {
           appId: "cli_yyy",
           appSecret: "yyy",
-          botName: "Backup bot",
+          name: "Backup bot",
           enabled: false,
         },
       },

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -190,7 +190,7 @@ openclaw channels add
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "My AI assistant",
+          name: "My AI assistant",
         },
       },
     },
@@ -499,12 +499,12 @@ openclaw pairing list feishu
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "Primary bot",
+          name: "Primary bot",
         },
         backup: {
           appId: "cli_yyy",
           appSecret: "yyy",
-          botName: "Backup bot",
+          name: "Backup bot",
           enabled: false,
         },
       },


### PR DESCRIPTION
## Summary

Fixes #52718 — The Feishu channel docs use `botName` in config examples, but the current schema only accepts `name` for per-account display names.

## Changes

- Updated `docs/channels/feishu.md` (3 occurrences)
- Updated `docs/zh-CN/channels/feishu.md` (3 occurrences)

All instances of `botName` in the Feishu account config examples are now `name` to match the actual schema:

```ts
export const FeishuAccountConfigSchema = z
  .object({
    enabled: z.boolean().optional(),
    name: z.string().optional(), // Display name for this account
    // ...
  })
  .strict();
```

## Testing

- Verified the schema at `extensions/feishu/src/config-schema.ts` uses `name`
- Config examples now match the strict schema validation