### PR TITLE
perf(gateway): parallelize channel plugin startup

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -493,7 +493,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const startChannels = async () => {
-    await Promise.all(listChannelPlugins().map((plugin) => startChannel(plugin.id)));
+    await Promise.allSettled(listChannelPlugins().map((plugin) => startChannel(plugin.id)));
   };
 
   const markChannelLoggedOut = (channelId: ChannelId, cleared: boolean, accountId?: string) => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -493,9 +493,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const startChannels = async () => {
-    for (const plugin of listChannelPlugins()) {
-      await startChannel(plugin.id);
-    }
+    await Promise.all(listChannelPlugins().map((plugin) => startChannel(plugin.id)));
   };
 
   const markChannelLoggedOut = (channelId: ChannelId, cleared: boolean, accountId?: string) => {


### PR DESCRIPTION
## Summary
- Start all channel plugins concurrently via `Promise.all` instead of sequential `for...await`
- Each `startChannelInternal` already guards against duplicate boots with the `store.starting` gate, so cross-channel parallelism is safe
- Reduces gateway startup wall-time when multiple channels are configured

## Context
Related: #22972 (health check timeout on slow startups), #28587 (eager SDK loading)

Channel plugins (Telegram, WhatsApp, Matrix, etc.) are independent of each other and have no startup ordering dependency. The current sequential loop adds unnecessary latency equal to the sum of all-but-the-slowest channel init times.

## Test plan
- [ ] `vitest run src/gateway/server-channels` passes
- [ ] Gateway starts with multiple channels configured
- [ ] Startup logs show channels initializing concurrently

🤖 Generated with [Claude Code](https://claude.com/claude-code)