### PR TITLE
feat(ui): move chat sessions into the sidebar

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -521,11 +521,58 @@
   background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
 }
 
+.nav-section__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-section__header .nav-section__label {
+  flex: 1;
+  min-width: 0;
+}
+
 .nav-section__label-text {
   font-size: 12px;
   font-weight: 700;
   letter-spacing: 0.06em;
   text-transform: uppercase;
+}
+
+.nav-section__action {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) ease,
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
+}
+
+.nav-section__action:hover:not(:disabled) {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg-hover) 72%, transparent);
+  border-color: color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.nav-section__action:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.nav-section__action svg {
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
 }
 
 .nav-section__chevron {
@@ -609,6 +656,20 @@
 
 .nav-item:hover .nav-item__icon {
   opacity: 1;
+}
+
+.nav-item--session .nav-item__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nav-item__icon--session {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
+  border-radius: 999px;
+  background: currentColor;
 }
 
 .nav-item.active,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -20,11 +20,46 @@ import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
 import type { ModelCatalogEntry, SessionsListResult } from "./types.ts";
+import type { ChatAttachment } from "./ui-types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
   mainKey?: string;
 };
+
+type SessionDefaultsAgentSnapshot = {
+  defaultAgentId?: string;
+};
+
+type ComposerSnapshot = {
+  message: string;
+  attachments: ChatAttachment[];
+};
+
+function cloneComposerSnapshot(state: AppViewState): ComposerSnapshot {
+  return {
+    message: state.chatMessage,
+    attachments: [...state.chatAttachments],
+  };
+}
+
+function resolveActiveChatAgentId(
+  state: Pick<AppViewState, "sessionKey" | "hello" | "agentsList">,
+) {
+  const parsed = parseAgentSessionKey(state.sessionKey);
+  if (parsed?.agentId) {
+    return parsed.agentId;
+  }
+  const snapshot = state.hello?.snapshot as
+    | { sessionDefaults?: SessionDefaultsAgentSnapshot }
+    | undefined;
+  const fallback = snapshot?.sessionDefaults?.defaultAgentId?.trim();
+  if (fallback) {
+    return fallback;
+  }
+  const listFallback = state.agentsList?.defaultId?.trim();
+  return listFallback || "main";
+}
 
 function resolveSidebarChatSessionKey(state: AppViewState): string {
   const snapshot = state.hello?.snapshot as
@@ -133,42 +168,103 @@ function renderCronFilterIcon(hiddenCount: number) {
   `;
 }
 
-export function renderChatSessionSelect(state: AppViewState) {
+function resolveSidebarChatSessions(state: AppViewState) {
   const sessionGroups = resolveSessionOptionGroups(state, state.sessionKey, state.sessionsResult);
-  const modelSelect = renderChatModelSelect(state);
+  const sessions = sessionGroups.flatMap((group) => group.options);
+
+  if (!sessions.some((entry) => entry.key === state.sessionKey)) {
+    const parsed = parseAgentSessionKey(state.sessionKey);
+    sessions.unshift({
+      key: state.sessionKey,
+      label: resolveSessionScopedOptionLabel(
+        state.sessionKey,
+        state.sessionsResult?.sessions?.find((candidate) => candidate.key === state.sessionKey),
+        parsed?.rest,
+      ),
+      scopeLabel: "",
+      title: state.sessionKey,
+    });
+  }
+
+  return sessions.map((option) => ({
+    key: option.key,
+    label: option.label,
+    title: option.title,
+  }));
+}
+
+export function renderChatSidebarSection(state: AppViewState) {
+  if (state.settings.navCollapsed) {
+    return html`<section class="nav-section nav-section--chat">
+      ${renderTab(state, "chat", { collapsed: true })}
+    </section>`;
+  }
+
+  const isGroupCollapsed = state.settings.navGroupsCollapsed.chat ?? false;
+  const showItems = !isGroupCollapsed;
+  const sessions = resolveSidebarChatSessions(state);
+  const canCreate = state.connected && !state.chatRunId && !state.newChatSessionPending;
+
+  const toggleSection = () => {
+    const next = { ...state.settings.navGroupsCollapsed };
+    next.chat = !isGroupCollapsed;
+    state.applySettings({
+      ...state.settings,
+      navGroupsCollapsed: next,
+    });
+  };
+
+  const handleSessionClick = (sessionKey: string) => {
+    if (state.tab !== "chat") {
+      state.setTab("chat");
+    }
+    if (sessionKey === state.sessionKey) {
+      return;
+    }
+    switchChatSession(state, sessionKey);
+  };
+
   return html`
-    <div class="chat-controls__session-row">
-      <label class="field chat-controls__session">
-        <select
-          .value=${state.sessionKey}
-          ?disabled=${!state.connected || sessionGroups.length === 0}
-          @change=${(e: Event) => {
-            const next = (e.target as HTMLSelectElement).value;
-            if (state.sessionKey === next) {
-              return;
-            }
-            switchChatSession(state, next);
-          }}
+    <section class="nav-section nav-section--chat ${!showItems ? "nav-section--collapsed" : ""}">
+      <div class="nav-section__header">
+        <button class="nav-section__label" @click=${toggleSection} aria-expanded=${showItems}>
+          <span class="nav-section__label-text">${t("nav.chat")}</span>
+          <span class="nav-section__chevron">${icons.chevronDown}</span>
+        </button>
+        <button
+          type="button"
+          class="nav-section__action"
+          title="New chat session"
+          aria-label="New chat session"
+          ?disabled=${!canCreate}
+          @click=${() => void createNewChatSession(state)}
         >
-          ${repeat(
-            sessionGroups,
-            (group) => group.id,
-            (group) =>
-              html`<optgroup label=${group.label}>
-                ${repeat(
-                  group.options,
-                  (entry) => entry.key,
-                  (entry) =>
-                    html`<option value=${entry.key} title=${entry.title}>
-                      ${entry.label}
-                    </option>`,
-                )}
-              </optgroup>`,
-          )}
-        </select>
-      </label>
-      ${modelSelect}
-    </div>
+          ${icons.plus}
+        </button>
+      </div>
+      <div class="nav-section__items nav-section__items--chat">
+        ${repeat(
+          sessions,
+          (entry) => entry.key,
+          (entry) => {
+            const isActive = entry.key === state.sessionKey && state.tab === "chat";
+            return html`
+              <button
+                type="button"
+                class="nav-item nav-item--session ${isActive ? "nav-item--active" : ""}"
+                data-chat-session-key=${entry.key}
+                title=${entry.title}
+                aria-current=${isActive ? "page" : "false"}
+                @click=${() => handleSessionClick(entry.key)}
+              >
+                <span class="nav-item__icon nav-item__icon--session" aria-hidden="true"></span>
+                <span class="nav-item__text">${entry.label}</span>
+              </button>
+            `;
+          },
+        )}
+      </div>
+    </section>
   `;
 }
 
@@ -512,6 +608,46 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   void refreshSessionOptions(state);
 }
 
+export async function createNewChatSession(state: AppViewState) {
+  const client = (state as unknown as OpenClawApp).client;
+  if (!client || !state.connected || state.newChatSessionPending) {
+    return;
+  }
+  const raw = window.prompt("Session name (optional):");
+  if (raw === null) {
+    return;
+  }
+  const label = raw.trim() || undefined;
+  const composerSnapshot = cloneComposerSnapshot(state);
+  const agentId = resolveActiveChatAgentId(state);
+  state.newChatSessionPending = true;
+  state.lastError = null;
+  try {
+    const result = await client.request<{ ok: boolean; key?: string }>("sessions.create", {
+      agentId,
+      ...(label ? { label } : {}),
+    });
+    if (!result?.key) {
+      state.lastError = "Session was created but no session key was returned.";
+      await refreshSessionOptions(state);
+      return;
+    }
+    const restoreCurrentDraft = state.chatMessage !== composerSnapshot.message;
+    const draftToRestore = restoreCurrentDraft ? state.chatMessage : composerSnapshot.message;
+    const attachmentsToRestore = restoreCurrentDraft
+      ? [...state.chatAttachments]
+      : composerSnapshot.attachments;
+    state.chatAttachments = [];
+    switchChatSession(state, result.key);
+    state.chatMessage = draftToRestore;
+    state.chatAttachments = attachmentsToRestore;
+  } catch (err) {
+    state.lastError = String(err);
+  } finally {
+    state.newChatSessionPending = false;
+  }
+}
+
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
     activeMinutes: 0,
@@ -583,7 +719,7 @@ function buildChatModelOptions(
   return options;
 }
 
-function renderChatModelSelect(state: AppViewState) {
+export function renderChatModelSelect(state: AppViewState) {
   const currentOverride = resolveModelOverrideValue(state);
   const defaultModel = resolveDefaultModelValue(state);
   const options = buildChatModelOptions(

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -9,8 +9,9 @@ import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
 import {
   renderChatControls,
+  renderChatModelSelect,
   renderChatMobileToggle,
-  renderChatSessionSelect,
+  renderChatSidebarSection,
   renderTab,
   renderSidebarConnectionStatus,
   renderTopbarThemeModeToggle,
@@ -483,6 +484,9 @@ export function renderApp(state: AppViewState) {
             <div class="sidebar-shell__body">
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
+                  if (group.label === "chat") {
+                    return renderChatSidebarSection(state);
+                  }
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
                   const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
                   const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
@@ -602,7 +606,7 @@ export function renderApp(state: AppViewState) {
               <div>
                 ${
                   isChat
-                    ? renderChatSessionSelect(state)
+                    ? html`<div class="chat-controls__session-row">${renderChatModelSelect(state)}</div>`
                     : html`<div class="page-title">${titleForTab(state.tab)}</div>`
                 }
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
@@ -1439,7 +1443,6 @@ export function renderApp(state: AppViewState) {
                 canAbort: Boolean(state.chatRunId),
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
-                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
                 onClearHistory: async () => {
                   if (!state.client || !state.connected) {
                     return;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -60,6 +60,7 @@ export type AppViewState = {
   sessionKey: string;
   chatLoading: boolean;
   chatSending: boolean;
+  newChatSessionPending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
   chatMessages: unknown[];

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -148,6 +148,7 @@ export class OpenClawApp extends LitElement {
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
   @state() chatSending = false;
+  @state() newChatSessionPending = false;
   @state() chatMessage = "";
   @state() chatMessages: unknown[] = [];
   @state() chatToolMessages: unknown[] = [];

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -50,7 +50,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onDraftChange: () => undefined,
     onSend: () => undefined,
     onQueueRemove: () => undefined,
-    onNewSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1,10 +1,14 @@
 /* @vitest-environment jsdom */
 
-import { render } from "lit";
+import { html, render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
-import { renderChatSessionSelect } from "../app-render.helpers.ts";
+import {
+  createNewChatSession,
+  renderChatModelSelect,
+  renderChatSidebarSection,
+} from "../app-render.helpers.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type { ModelCatalogEntry } from "../types.ts";
@@ -27,15 +31,26 @@ function createChatHeaderState(
     model?: string | null;
     models?: ModelCatalogEntry[];
     omitSessionFromList?: boolean;
+    sessionKey?: string;
+    hello?: AppViewState["hello"];
+    agentsList?: AppViewState["agentsList"];
+    createResult?: { ok: boolean; key?: string };
   } = {},
 ): { state: AppViewState; request: ReturnType<typeof vi.fn> } {
   let currentModel = overrides.model ?? null;
   let currentModelProvider = currentModel ? "openai" : null;
   const omitSessionFromList = overrides.omitSessionFromList ?? false;
+  const sessionKey = overrides.sessionKey ?? "main";
   const catalog = overrides.models ?? [
     { id: "gpt-5", name: "GPT-5", provider: "openai" },
     { id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai" },
   ];
+  let createdSession: {
+    key: string;
+    kind: "direct";
+    updatedAt: number;
+    label?: string;
+  } | null = null;
   const request = vi.fn(async (method: string, params: Record<string, unknown>) => {
     if (method === "sessions.patch") {
       const nextModel = (params.model as string | null | undefined) ?? null;
@@ -60,26 +75,45 @@ function createChatHeaderState(
       }
       return { ok: true, key: "main" };
     }
+    if (method === "sessions.create") {
+      const agentId =
+        typeof params.agentId === "string" && params.agentId.trim() ? params.agentId : "main";
+      const result = overrides.createResult ?? {
+        ok: true,
+        key: `agent:${agentId}:dashboard:new-session`,
+      };
+      if (result.key) {
+        createdSession = {
+          key: result.key,
+          kind: "direct",
+          updatedAt: 1,
+          label: typeof params.label === "string" ? params.label : undefined,
+        };
+      }
+      return result;
+    }
     if (method === "chat.history") {
       return { messages: [], thinkingLevel: null };
     }
     if (method === "sessions.list") {
+      const baseSessions = omitSessionFromList
+        ? []
+        : [
+            {
+              key: sessionKey,
+              kind: "direct",
+              updatedAt: null,
+              modelProvider: currentModelProvider,
+              model: currentModel,
+            },
+          ];
+      const sessions = createdSession ? [...baseSessions, createdSession] : baseSessions;
       return {
         ts: 0,
         path: "",
-        count: omitSessionFromList ? 0 : 1,
+        count: sessions.length,
         defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-        sessions: omitSessionFromList
-          ? []
-          : [
-              {
-                key: "main",
-                kind: "direct",
-                updatedAt: null,
-                modelProvider: currentModelProvider,
-                model: currentModel,
-              },
-            ],
+        sessions,
       };
     }
     if (method === "models.list") {
@@ -88,7 +122,7 @@ function createChatHeaderState(
     throw new Error(`Unexpected request: ${method}`);
   });
   const state = {
-    sessionKey: "main",
+    sessionKey,
     connected: true,
     sessionsHideCron: true,
     sessionsResult: {
@@ -100,7 +134,7 @@ function createChatHeaderState(
         ? []
         : [
             {
-              key: "main",
+              key: sessionKey,
               kind: "direct",
               updatedAt: null,
               modelProvider: currentModelProvider,
@@ -116,8 +150,8 @@ function createChatHeaderState(
       gatewayUrl: "",
       token: "",
       locale: "en",
-      sessionKey: "main",
-      lastActiveSessionKey: "main",
+      sessionKey,
+      lastActiveSessionKey: sessionKey,
       theme: "claw",
       themeMode: "dark",
       splitRatio: 0.6,
@@ -128,21 +162,27 @@ function createChatHeaderState(
       chatShowThinking: false,
     },
     chatMessage: "",
+    chatAttachments: [],
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunId: null,
+    newChatSessionPending: false,
     chatQueue: [],
     chatMessages: [],
     chatLoading: false,
     chatThinkingLevel: null,
     lastError: null,
+    tab: "chat",
     chatAvatarUrl: null,
     basePath: "",
-    hello: null,
-    agentsList: null,
+    hello: overrides.hello ?? null,
+    agentsList: overrides.agentsList ?? null,
     applySettings(next: AppViewState["settings"]) {
       state.settings = next;
     },
+    setTab: vi.fn((next: AppViewState["tab"]) => {
+      state.tab = next;
+    }),
     loadAssistantIdentity: vi.fn(),
     resetToolStream: vi.fn(),
     resetChatScroll: vi.fn(),
@@ -155,6 +195,52 @@ function createChatHeaderState(
 
 function flushTasks() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+async function withPromptStub(run: () => Promise<void> | void, value = "Session label") {
+  const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(value);
+  try {
+    await run();
+  } finally {
+    promptSpy.mockRestore();
+  }
+}
+
+function setSidebarSessions(
+  state: AppViewState,
+  sessions: NonNullable<SessionsListResult["sessions"]>,
+  count = sessions.length,
+) {
+  state.sessionsResult = {
+    ts: 0,
+    path: "",
+    count,
+    defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+    sessions,
+  };
+}
+
+function renderSidebar(state: AppViewState) {
+  const container = document.createElement("div");
+  const rerender = () => render(renderChatSidebarSection(state), container);
+  rerender();
+  return {
+    container,
+    rerender,
+    labels: () =>
+      Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button[data-chat-session-key]"),
+      ).map((entry) => entry.textContent?.trim() ?? ""),
+    row: (sessionKey: string) =>
+      container.querySelector<HTMLButtonElement>(`button[data-chat-session-key="${sessionKey}"]`),
+    createButton: () =>
+      container.querySelector<HTMLButtonElement>('button[title="New chat session"]'),
+  };
+}
+
+function setSessionKey(state: AppViewState, sessionKey: string) {
+  state.sessionKey = sessionKey;
+  state.settings.sessionKey = sessionKey;
 }
 
 function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
@@ -190,7 +276,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     onDraftChange: () => undefined,
     onSend: () => undefined,
     onQueueRemove: () => undefined,
-    onNewSession: () => undefined,
     agentsList: null,
     currentAgentId: "",
     onAgentChange: () => undefined,
@@ -646,26 +731,20 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("New session");
   });
 
-  it("shows a new session button when aborting is unavailable", () => {
+  it("does not render horizontal session pills in the chat view", () => {
     const container = document.createElement("div");
-    const onNewSession = vi.fn();
-    render(
-      renderChat(
-        createProps({
-          canAbort: false,
-          onNewSession,
-        }),
-      ),
-      container,
-    );
+    render(renderChat(createProps()), container);
 
-    const newSessionButton = container.querySelector<HTMLButtonElement>(
-      'button[title="New session"]',
-    );
-    expect(newSessionButton).not.toBeUndefined();
-    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onNewSession).toHaveBeenCalledTimes(1);
-    expect(container.textContent).not.toContain("Stop");
+    expect(container.querySelector(".chat-session-tabs")).toBeNull();
+    expect(container.querySelector('button[title="New chat session"]')).toBeNull();
+  });
+
+  it("keeps focus mode free of horizontal session pills", () => {
+    const container = document.createElement("div");
+    render(renderChat(createProps({ focusMode: true })), container);
+
+    expect(container.querySelector(".chat-focus-exit")).not.toBeNull();
+    expect(container.querySelector(".chat-session-tabs")).toBeNull();
   });
 
   it("shows sender labels from sanitized gateway messages instead of generic You", () => {
@@ -803,7 +882,7 @@ describe("chat view", () => {
     );
     const { state, request } = createChatHeaderState();
     const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    render(renderChatModelSelect(state), container);
 
     const modelSelect = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
@@ -834,7 +913,7 @@ describe("chat view", () => {
     );
     const { state, request } = createChatHeaderState({ model: "gpt-5-mini" });
     const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    render(renderChatModelSelect(state), container);
 
     const modelSelect = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
@@ -859,7 +938,7 @@ describe("chat view", () => {
     state.chatRunId = "run-123";
     state.chatStream = "Working";
     const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    render(renderChatModelSelect(state), container);
 
     const modelSelect = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
@@ -877,7 +956,7 @@ describe("chat view", () => {
     );
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    render(renderChatModelSelect(state), container);
 
     const modelSelect = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
@@ -887,7 +966,7 @@ describe("chat view", () => {
     modelSelect!.value = "openai/gpt-5-mini";
     modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
     await flushTasks();
-    render(renderChatSessionSelect(state), container);
+    render(renderChatModelSelect(state), container);
 
     const rerendered = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
@@ -901,7 +980,7 @@ describe("chat view", () => {
     state.chatModelOverrides = { main: { kind: "raw", value: "gpt-5-mini" } };
 
     const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    render(renderChatModelSelect(state), container);
 
     const modelSelect = container.querySelector<HTMLSelectElement>(
       'select[data-chat-model-select="true"]',
@@ -916,127 +995,96 @@ describe("chat view", () => {
     expect(optionValues).not.toContain("gpt-5-mini");
   });
 
-  it("prefers the session label over displayName in the grouped chat session selector", () => {
-    const { state } = createChatHeaderState({ omitSessionFromList: true });
-    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
-    state.settings.sessionKey = state.sessionKey;
-    state.sessionsResult = {
-      ts: 0,
-      path: "",
-      count: 1,
-      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-      sessions: [
-        {
-          key: state.sessionKey,
-          kind: "direct",
-          updatedAt: null,
-          label: "cron-config-check",
-          displayName: "webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
-        },
+  it("does not render a desktop chat header session dropdown", () => {
+    const { state } = createChatHeaderState();
+    const container = document.createElement("div");
+    render(
+      html`<div class="chat-controls__session-row">${renderChatModelSelect(state)}</div>`,
+      container,
+    );
+
+    expect(container.querySelectorAll("select")).toHaveLength(1);
+    expect(container.querySelector('select[data-chat-model-select="true"]')).not.toBeNull();
+    expect(container.querySelector('select:not([data-chat-model-select="true"])')).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "prefers the session label over displayName in the chat sidebar list",
+      setup(state: AppViewState) {
+        setSessionKey(state, "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b");
+        setSidebarSessions(state, [
+          {
+            key: state.sessionKey,
+            kind: "direct",
+            updatedAt: null,
+            label: "cron-config-check",
+            displayName: "webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
+          },
+        ]);
+      },
+      includes: ["Subagent: cron-config-check"],
+      excludes: [
+        "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b",
+        "subagent:4f2146de-887b-4176-9abe-91140082959b · webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
       ],
-    };
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
-
-    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
-    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
-      option.textContent?.trim(),
-    );
-
-    expect(labels).toContain("Subagent: cron-config-check");
-    expect(labels).not.toContain(state.sessionKey);
-    expect(labels).not.toContain(
-      "subagent:4f2146de-887b-4176-9abe-91140082959b · webchat:g-agent-main-subagent-4f2146de-887b-4176-9abe-91140082959b",
-    );
-  });
-
-  it("keeps a unique scoped fallback when the current grouped session is missing from sessions.list", () => {
-    const { state } = createChatHeaderState({ omitSessionFromList: true });
-    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
-    state.settings.sessionKey = state.sessionKey;
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
-
-    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
-    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
-      option.textContent?.trim(),
-    );
-
-    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
-    expect(labels).not.toContain("Subagent:");
-  });
-
-  it("keeps a unique scoped fallback when a grouped session row has no label or displayName", () => {
-    const { state } = createChatHeaderState({ omitSessionFromList: true });
-    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
-    state.settings.sessionKey = state.sessionKey;
-    state.sessionsResult = {
-      ts: 0,
-      path: "",
-      count: 1,
-      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-      sessions: [
-        {
-          key: state.sessionKey,
-          kind: "direct",
-          updatedAt: null,
-        },
+    },
+    {
+      name: "keeps a unique scoped fallback when the current sidebar session is missing from sessions.list",
+      setup(state: AppViewState) {
+        setSessionKey(state, "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b");
+      },
+      includes: ["subagent:4f2146de-887b-4176-9abe-91140082959b"],
+      excludes: ["Subagent:"],
+    },
+    {
+      name: "keeps a unique scoped fallback when a sidebar session row has no label or displayName",
+      setup(state: AppViewState) {
+        setSessionKey(state, "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b");
+        setSidebarSessions(state, [{ key: state.sessionKey, kind: "direct", updatedAt: null }]);
+      },
+      includes: ["subagent:4f2146de-887b-4176-9abe-91140082959b"],
+      excludes: ["Subagent:"],
+    },
+    {
+      name: "disambiguates duplicate sidebar labels with the scoped key suffix",
+      setup(state: AppViewState) {
+        setSessionKey(state, "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b");
+        setSidebarSessions(state, [
+          {
+            key: "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b",
+            kind: "direct",
+            updatedAt: null,
+            label: "cron-config-check",
+          },
+          {
+            key: "agent:main:subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
+            kind: "direct",
+            updatedAt: null,
+            label: "cron-config-check",
+          },
+        ]);
+      },
+      includes: [
+        "Subagent: cron-config-check · subagent:4f2146de-887b-4176-9abe-91140082959b",
+        "Subagent: cron-config-check · subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
       ],
-    };
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
-
-    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
-    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
-      option.textContent?.trim(),
-    );
-
-    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
-    expect(labels).not.toContain("Subagent:");
-  });
-
-  it("disambiguates duplicate grouped labels with the scoped key suffix", () => {
+      excludes: ["Subagent: cron-config-check"],
+    },
+  ])("$name", (testCase) => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
-    state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
-    state.settings.sessionKey = state.sessionKey;
-    state.sessionsResult = {
-      ts: 0,
-      path: "",
-      count: 2,
-      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-      sessions: [
-        {
-          key: "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b",
-          kind: "direct",
-          updatedAt: null,
-          label: "cron-config-check",
-        },
-        {
-          key: "agent:main:subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
-          kind: "direct",
-          updatedAt: null,
-          label: "cron-config-check",
-        },
-      ],
-    };
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
+    testCase.setup(state);
+    const labels = renderSidebar(state).labels();
 
-    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
-    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
-      option.textContent?.trim(),
-    );
-
-    expect(labels).toContain(
-      "Subagent: cron-config-check · subagent:4f2146de-887b-4176-9abe-91140082959b",
-    );
-    expect(labels).toContain(
-      "Subagent: cron-config-check · subagent:6fb8b84b-c31f-410f-b7df-1553c82e43c9",
-    );
-    expect(labels).not.toContain("Subagent: cron-config-check");
+    for (const label of testCase.includes) {
+      expect(labels).toContain(label);
+    }
+    for (const label of testCase.excludes) {
+      expect(labels).not.toContain(label);
+    }
   });
 
-  it("prefixes duplicate agent session labels with the agent name", () => {
+  it("prefixes duplicate agent session labels in the sidebar list with the agent name", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionKey = "agent:alpha:main";
     state.settings.sessionKey = state.sessionKey;
@@ -1067,20 +1115,13 @@ describe("chat view", () => {
         },
       ],
     };
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
-
-    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
-    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
-      option.textContent?.trim(),
-    );
+    const labels = renderSidebar(state).labels();
 
     expect(labels).toContain("Deep Chat (alpha) / main");
-    expect(labels).toContain("Coding (beta) / main");
     expect(labels).not.toContain("main");
   });
 
-  it("keeps agent-prefixed labels unique when a custom label already matches the prefix", () => {
+  it("keeps agent-prefixed sidebar labels unique when a custom label already matches the prefix", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionKey = "agent:alpha:main";
     state.settings.sessionKey = state.sessionKey;
@@ -1117,16 +1158,187 @@ describe("chat view", () => {
         },
       ],
     };
-    const container = document.createElement("div");
-    render(renderChatSessionSelect(state), container);
-
-    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
-    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
-      option.textContent?.trim(),
-    );
+    const labels = renderSidebar(state).labels();
 
     expect(labels.filter((label) => label === "Deep Chat (alpha) / main")).toHaveLength(1);
     expect(labels).toContain("Deep Chat (alpha) / main · named-main");
-    expect(labels).toContain("Coding (beta) / main");
+  });
+
+  it("shows sidebar sessions across agents and keeps the current session when it is missing from sessions.list", () => {
+    const { state } = createChatHeaderState({
+      sessionKey: "agent:main:dashboard:missing-current",
+      agentsList: {
+        defaultId: "main",
+        agents: [{ id: "main" }, { id: "research" }],
+      } as AppViewState["agentsList"],
+    });
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "agent:main:dashboard:recent-main",
+          kind: "direct",
+          label: "Recent Main",
+          updatedAt: 20,
+        },
+        {
+          key: "agent:research:dashboard:notes",
+          kind: "direct",
+          label: "Research Notes",
+          updatedAt: 10,
+        },
+      ],
+    };
+
+    const sidebar = renderSidebar(state);
+
+    expect(sidebar.row("agent:main:dashboard:recent-main")).not.toBeNull();
+    expect(sidebar.row("agent:main:dashboard:missing-current")).not.toBeNull();
+    expect(sidebar.labels()).toContain("Recent Main");
+    expect(sidebar.row("agent:research:dashboard:notes")).not.toBeNull();
+  });
+
+  it("renders sidebar sessions across agents and highlights the active session", () => {
+    const { state } = createChatHeaderState({
+      sessionKey: "agent:main:dashboard:test3",
+    });
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 3,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        { key: "agent:main:dashboard:heartbeat", kind: "direct", label: "heartbeat", updatedAt: 3 },
+        { key: "agent:main:dashboard:test3", kind: "direct", label: "test3", updatedAt: 2 },
+        { key: "agent:research:dashboard:notes", kind: "direct", label: "notes", updatedAt: 1 },
+      ],
+    };
+    const sidebar = renderSidebar(state);
+
+    expect(sidebar.labels()).toEqual(["heartbeat", "test3", "notes"]);
+
+    const active = sidebar.container.querySelector<HTMLButtonElement>(".nav-item--active");
+    expect(active?.dataset.chatSessionKey).toBe("agent:main:dashboard:test3");
+  });
+
+  it("collapses and re-expands the chat sidebar section while on the chat page", async () => {
+    const { state } = createChatHeaderState({
+      sessionKey: "agent:main:dashboard:test1",
+    });
+    setSidebarSessions(state, [
+      { key: "agent:main:dashboard:test1", kind: "direct", label: "test1", updatedAt: 2 },
+      { key: "agent:main:dashboard:test2", kind: "direct", label: "test2", updatedAt: 1 },
+    ]);
+    const sidebar = renderSidebar(state);
+
+    const toggle = sidebar.container.querySelector<HTMLButtonElement>(".nav-section__label");
+    expect(sidebar.container.querySelector(".nav-section--collapsed")).toBeNull();
+
+    toggle?.click();
+    await flushTasks();
+    sidebar.rerender();
+
+    expect(state.settings.navGroupsCollapsed.chat).toBe(true);
+    expect(sidebar.container.querySelector(".nav-section--collapsed")).not.toBeNull();
+
+    sidebar.container.querySelector<HTMLButtonElement>(".nav-section__label")?.click();
+    await flushTasks();
+    sidebar.rerender();
+
+    expect(state.settings.navGroupsCollapsed.chat).toBe(false);
+    expect(sidebar.container.querySelector(".nav-section--collapsed")).toBeNull();
+  });
+
+  it("switches across agent sessions from the sidebar list", async () => {
+    const { state, request } = createChatHeaderState({
+      sessionKey: "agent:main:dashboard:test1",
+    });
+    setSidebarSessions(state, [
+      { key: "agent:main:dashboard:test1", kind: "direct", label: "test1", updatedAt: 2 },
+      { key: "agent:beta:dashboard:test2", kind: "direct", label: "test2", updatedAt: 1 },
+    ]);
+    renderSidebar(state).row("agent:beta:dashboard:test2")?.click();
+    await flushTasks();
+
+    expect(state.sessionKey).toBe("agent:beta:dashboard:test2");
+    expect(state.settings.sessionKey).toBe("agent:beta:dashboard:test2");
+    expect(request).toHaveBeenCalledWith("chat.history", {
+      sessionKey: "agent:beta:dashboard:test2",
+      limit: 200,
+    });
+  });
+
+  it("creates a real session from the sidebar plus button", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+      renderSidebar(state).createButton()?.click();
+      await flushTasks();
+
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "main",
+        label: "Session label",
+      });
+      expect(state.sessionKey).toBe("agent:main:dashboard:new-session");
+      expect(state.newChatSessionPending).toBe(false);
+    });
+  });
+
+  it("disables the sidebar plus button while session creation is pending", () => {
+    const { state } = createChatHeaderState();
+    state.newChatSessionPending = true;
+    expect(renderSidebar(state).createButton()?.disabled).toBe(true);
+  });
+
+  it("creates a real session and switches to it", async () => {
+    await withPromptStub(async () => {
+      const { state, request } = createChatHeaderState();
+
+      await createNewChatSession(state);
+      await flushTasks();
+
+      expect(request).toHaveBeenCalledWith("sessions.create", {
+        agentId: "main",
+        label: "Session label",
+      });
+      expect(state.sessionKey).toBe("agent:main:dashboard:new-session");
+      expect(state.settings.sessionKey).toBe("agent:main:dashboard:new-session");
+      expect(state.settings.lastActiveSessionKey).toBe("agent:main:dashboard:new-session");
+      expect(state.newChatSessionPending).toBe(false);
+      expect(request).toHaveBeenCalledWith("chat.history", {
+        sessionKey: "agent:main:dashboard:new-session",
+        limit: 200,
+      });
+    });
+  });
+
+  it("preserves the current draft and attachments when creating a new session", async () => {
+    await withPromptStub(async () => {
+      const { state } = createChatHeaderState();
+      state.chatMessage = "Carry this into the next session";
+      state.chatAttachments = [
+        {
+          id: "attachment-1",
+          dataUrl: "data:image/png;base64,abc",
+          mimeType: "image/png",
+        },
+      ];
+
+      await createNewChatSession(state);
+      await flushTasks();
+
+      expect(state.sessionKey).toBe("agent:main:dashboard:new-session");
+      expect(state.chatMessage).toBe("Carry this into the next session");
+      expect(state.chatAttachments).toEqual([
+        {
+          id: "attachment-1",
+          dataUrl: "data:image/png;base64,abc",
+          mimeType: "image/png",
+        },
+      ]);
+    });
   });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -94,7 +94,6 @@ export type ChatProps = {
   onSend: () => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
-  onNewSession: () => void;
   onClearHistory?: () => void;
   agentsList: {
     agents: Array<{ id: string; name?: string; identity?: { name?: string; avatarUrl?: string } }>;
@@ -1318,20 +1317,6 @@ export function renderChat(props: ChatProps) {
 
           <div class="agent-chat__toolbar-right">
             ${nothing /* search hidden for now */}
-            ${
-              canAbort
-                ? nothing
-                : html`
-                    <button
-                      class="btn-ghost"
-                      @click=${props.onNewSession}
-                      title="New session"
-                      aria-label="New session"
-                    >
-                      ${icons.plus}
-                    </button>
-                  `
-            }
             <button class="btn-ghost" @click=${() => exportMarkdown(props)} title="Export" ?disabled=${props.messages.length === 0}>
               ${icons.download}
             </button>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: webchat session switching was split across multiple desktop controls, including a header selector and an in-chat session switcher, which made multi-chat navigation feel redundant and harder to scan.
- Why it matters: a sidebar session list matches the Control UI navigation model better and makes recent chat switching more discoverable without adding another session surface inside the chat canvas.
- What changed: this PR moves chat session switching into the left `CHAT` sidebar section, adds a sidebar `+` action backed by real `sessions.create`, and removes the desktop chat header session selector while keeping the model picker and existing chat controls.
- What did NOT change (scope boundary): this does not add rename/delete session management, backend session/schema changes, or a new storage/API contract; broader session management still lives on the Sessions page.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #51793
- Related #52266
- Related #26517

## User-visible / Behavior Changes

- Desktop chat sessions are listed directly under the `CHAT` sidebar section.
- The `CHAT` section header now has a `+` action that creates a real new chat session.
- The desktop chat header no longer shows a session selector; it keeps the model picker and the existing chat control buttons.
- The `CHAT` sidebar section can be collapsed and expanded independently.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local `pnpm` dev build
- Model/provider: not specific to the UI change
- Integration/channel (if any): none
- Relevant config (redacted): local Control UI / gateway dev flow

### Steps

1. Open the Control UI chat page with multiple sessions for the active agent.
2. Confirm the session list appears under the left `CHAT` sidebar section and the chat canvas does not show a second desktop session-switching surface.
3. Click a different sidebar session, then use the sidebar `+` button to create a new session.
4. Collapse and re-expand the `CHAT` section.

### Expected

- Session switching happens from the sidebar list.
- The header keeps the model picker but not a second session selector.
- Creating a session from `+` switches to the created session.
- The `CHAT` section collapse button hides and restores the session list.

### Actual

- Matches expected behavior in the updated UI implementation and targeted automated coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted automated verification for chat sidebar rendering, session switching, create-session behavior, and collapse/expand behavior.
- Edge cases checked: missing current session fallback, duplicate/disambiguated labels, create-button pending state, and focus mode parity.
- What you did **not** verify:

## Diff Summary

Current diff against `upstream/main`:

| File | Added | Deleted | Total changed |
| --- | ---: | ---: | ---: |
| `ui/src/styles/layout.css` | 61 | 0 | 61 |
| `ui/src/ui/app-render.helpers.ts` | 168 | 34 | 202 |
| `ui/src/ui/app-render.ts` | 6 | 3 | 9 |
| `ui/src/ui/app-view-state.ts` | 1 | 0 | 1 |
| `ui/src/ui/app.ts` | 1 | 0 | 1 |
| `ui/src/ui/views/chat.browser.test.ts` | 0 | 1 | 1 |
| `ui/src/ui/views/chat.test.ts` | 358 | 173 | 531 |
| `ui/src/ui/views/chat.ts` | 0 | 15 | 15 |

Totals:

- Files changed: `8`
- Insertions: `595`
- Deletions: `226`
- Total changed lines: `821`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `9854527612`.
- Files/config to restore: the chat sidebar/header UI files in this PR branch.
- Known bad symptoms reviewers should watch for: duplicate session-switching UI reappearing, sidebar session list not collapsing, or inability to switch/create sessions from the sidebar.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the sidebar list may become crowded for agents with many sessions.
  - Mitigation: this PR keeps the Sessions page as the fallback for broader session management and stays scoped to current-agent session navigation.
