### PR TITLE
fix(acp): time out stuck session lane tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(acp): add configurable session-lane task timeout with stale-op fencing
 - Google/Gemini: default new API-key onboarding to stable `google/gemini-2.5-flash` instead of the preview Pro route, reducing surprise daily quota exhaustion. Fixes #79670. Thanks @HugeBunny.
 - Amazon Bedrock: expose Claude thinking profiles through the lightweight provider policy surface so `/think:adaptive` validates before the Bedrock runtime plugin is loaded. Fixes #79754. Thanks @phoenixyy and @hclsys.
 - Codex/transcripts: mirror dynamic tool calls and outputs into Codex app-server transcripts so tool activity is visible alongside assistant text instead of being elided, with per-item output capped at 12,000 characters. (#79952) Thanks @scoootscooob.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1137,6 +1137,10 @@ Notes:
       maxSessionUpdateChars: 500,
     },
 
+    sessionLane: {
+      taskTimeoutMs: 600000,
+    },
+
     runtime: {
       ttlMinutes: 30,
     },
@@ -1159,6 +1163,7 @@ Notes:
 - `stream.maxOutputChars`: maximum assistant output characters projected per ACP turn.
 - `stream.maxSessionUpdateChars`: maximum characters for projected ACP status/update lines.
 - `stream.tagVisibility`: record of tag names to boolean visibility overrides for streamed events.
+- `sessionLane.taskTimeoutMs`: maximum milliseconds a single ACP session-lane task may hold initialize, status, cancel, or close serialization before OpenClaw aborts cooperative runtime calls and fences stale side effects. Default: `600000`; set `0` to disable; maximum: `2147483647`.
 - `runtime.ttlMinutes`: idle TTL in minutes for ACP session workers before eligible cleanup.
 - `runtime.installCommand`: optional install command to run when bootstrapping an ACP runtime environment.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1119,6 +1119,10 @@ Notes:
       maxSessionUpdateChars: 500,
     },
 
+    sessionLane: {
+      taskTimeoutMs: 600000,
+    },
+
     runtime: {
       ttlMinutes: 30,
     },
@@ -1141,6 +1145,7 @@ Notes:
 - `stream.maxOutputChars`: maximum assistant output characters projected per ACP turn.
 - `stream.maxSessionUpdateChars`: maximum characters for projected ACP status/update lines.
 - `stream.tagVisibility`: record of tag names to boolean visibility overrides for streamed events.
+- `sessionLane.taskTimeoutMs`: maximum milliseconds a single ACP session-lane task may hold initialize, status, cancel, or close serialization before OpenClaw aborts cooperative runtime calls and fences stale side effects. Default: `600000`; set `0` to disable; maximum: `2147483647`.
 - `runtime.ttlMinutes`: idle TTL in minutes for ACP session workers before eligible cleanup.
 - `runtime.installCommand`: optional install command to run when bootstrapping an ACP runtime environment.
 

--- a/extensions/acpx/src/acpx-runtime-compat.d.ts
+++ b/extensions/acpx/src/acpx-runtime-compat.d.ts
@@ -46,11 +46,16 @@ declare module "acpx/runtime" {
     getStatus(input: { handle: AcpRuntimeHandle; signal?: AbortSignal }): Promise<AcpRuntimeStatus>;
     setMode(input: { handle: AcpRuntimeHandle; mode: string }): Promise<void>;
     setConfigOption(input: { handle: AcpRuntimeHandle; key: string; value: string }): Promise<void>;
-    cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void>;
+    cancel(input: {
+      handle: AcpRuntimeHandle;
+      reason?: string;
+      signal?: AbortSignal;
+    }): Promise<void>;
     close(input: {
       handle: AcpRuntimeHandle;
       reason?: string;
       discardPersistentState?: boolean;
+      signal?: AbortSignal;
     }): Promise<void>;
   }
 

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1104,6 +1104,7 @@ export class AcpxRuntime implements AcpRuntime {
         handle: input.handle,
         reason: input.reason,
         discardPersistentState: input.discardPersistentState,
+        signal: input.signal,
       });
       closeSucceeded = true;
     } finally {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -950,6 +950,7 @@ export class AcpxRuntime implements AcpRuntime {
         handle: input.handle,
         reason: input.reason,
         discardPersistentState: input.discardPersistentState,
+        signal: input.signal,
       });
       closeSucceeded = true;
     } finally {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -71,6 +72,7 @@ import {
   resolveAcpSessionResolutionError,
   resolveMissingMetaError,
   resolveRuntimeIdleTtlMs,
+  resolveSessionLaneTaskTimeoutMs,
 } from "./manager.utils.js";
 import { CachedRuntimeState, RuntimeCache } from "./runtime-cache.js";
 import {
@@ -85,11 +87,12 @@ import {
   validateRuntimeModeInput,
   validateRuntimeOptionPatch,
 } from "./runtime-options.js";
-import { SessionActorQueue } from "./session-actor-queue.js";
+import { SessionActorQueue, SessionActorQueueTimeoutError } from "./session-actor-queue.js";
 
 const ACP_TURN_TIMEOUT_GRACE_MS = 1_000;
 const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
 const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
+const ACP_SESSION_LANE_TIMEOUT_REASON = "session-lane-timeout";
 const ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH = 160;
 const ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH = 240;
 
@@ -161,8 +164,15 @@ type BackgroundTaskContext = {
   task: string;
 };
 
+type SessionActorOperationFence = {
+  actorKey: string;
+  stale: boolean;
+};
+
 export class AcpSessionManager {
   private readonly actorQueue = new SessionActorQueue();
+  private readonly actorTailBySession = this.actorQueue.getTailMapForTesting();
+  private readonly sessionActorOperationScope = new AsyncLocalStorage<SessionActorOperationFence>();
   private readonly runtimeCache = new RuntimeCache();
   private readonly activeTurnBySession = new Map<string, ActiveTurnState>();
   private readonly turnLatencyStats: TurnLatencyStats = {
@@ -265,28 +275,32 @@ export class AcpSessionManager {
 
       checked += 1;
       try {
-        const becameResolved = await this.withSessionActor(session.sessionKey, async () => {
-          const resolution = this.resolveSession({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-          });
-          if (resolution.kind !== "ready") {
-            return false;
-          }
-          const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            meta: resolution.meta,
-          });
-          const reconciled = await this.reconcileRuntimeSessionIdentifiers({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            runtime,
-            handle,
-            meta,
-            failOnStatusError: false,
-          });
-          return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+        const becameResolved = await this.withSessionActor({
+          cfg: params.cfg,
+          sessionKey: session.sessionKey,
+          op: async () => {
+            const resolution = this.resolveSession({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+            });
+            if (resolution.kind !== "ready") {
+              return false;
+            }
+            const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              meta: resolution.meta,
+            });
+            const reconciled = await this.reconcileRuntimeSessionIdentifiers({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              runtime,
+              handle,
+              meta,
+              failOnStatusError: false,
+            });
+            return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+          },
         });
         if (becameResolved) {
           resolved += 1;
@@ -316,122 +330,126 @@ export class AcpSessionManager {
     }
     const agent = normalizeAgentId(input.agent);
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
-      const runtime = backend.runtime;
-      const initialRuntimeOptions = validateRuntimeOptionPatch({
-        ...input.runtimeOptions,
-        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
-      });
-      const requestedCwd = initialRuntimeOptions.cwd;
-      const requestedModel = initialRuntimeOptions.model;
-      const requestedThinking = initialRuntimeOptions.thinking;
-      this.enforceConcurrentSessionLimit({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const handle = await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.ensureSession({
-            sessionKey,
-            agent,
-            mode: input.mode,
-            resumeSessionId: input.resumeSessionId,
-            ...(requestedModel ? { model: requestedModel } : {}),
-            ...(requestedThinking ? { thinking: requestedThinking } : {}),
-            cwd: requestedCwd,
-          }),
-        fallbackCode: "ACP_SESSION_INIT_FAILED",
-        fallbackMessage: "Could not initialize ACP session runtime.",
-      });
-      const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
-      const effectiveRuntimeOptions = normalizeRuntimeOptions({
-        ...initialRuntimeOptions,
-        ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
-      });
-
-      const identityNow = Date.now();
-      const initializedIdentity =
-        mergeSessionIdentity({
-          current: undefined,
-          incoming: createIdentityFromEnsure({
-            handle,
-            now: identityNow,
-          }),
-          now: identityNow,
-        }) ??
-        ({
-          state: "pending",
-          source: "ensure",
-          lastUpdatedAt: identityNow,
-        } as const);
-      const meta: SessionAcpMeta = {
-        backend: handle.backend || backend.id,
-        agent,
-        runtimeSessionName: handle.runtimeSessionName,
-        identity: initializedIdentity,
-        mode: input.mode,
-        ...(Object.keys(effectiveRuntimeOptions).length > 0
-          ? { runtimeOptions: effectiveRuntimeOptions }
-          : {}),
-        cwd: effectiveCwd,
-        state: "idle",
-        lastActivityAt: Date.now(),
-      };
-
-      let persisted: SessionEntry | null = null;
-      try {
-        persisted = await this.writeSessionMeta({
+    return await this.withSessionActor({
+      cfg: input.cfg,
+      sessionKey,
+      timeoutCode: "ACP_SESSION_INIT_FAILED",
+      op: async () => {
+        const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
+        const runtime = backend.runtime;
+        const initialRuntimeOptions = validateRuntimeOptionPatch({
+          ...input.runtimeOptions,
+          ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+        });
+        const requestedCwd = initialRuntimeOptions.cwd;
+        const requestedModel = initialRuntimeOptions.model;
+        const requestedThinking = initialRuntimeOptions.thinking;
+        this.enforceConcurrentSessionLimit({
           cfg: input.cfg,
           sessionKey,
-          mutate: () => meta,
-          failOnError: true,
         });
-      } catch (error) {
-        await runtime
-          .close({
-            handle,
-            reason: "init-meta-failed",
-          })
-          .catch((closeError) => {
-            logVerbose(
-              `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
-            );
-          });
-        throw error;
-      }
+        const handle = await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.ensureSession({
+              sessionKey,
+              agent,
+              mode: input.mode,
+              resumeSessionId: input.resumeSessionId,
+              ...(requestedModel ? { model: requestedModel } : {}),
+              ...(requestedThinking ? { thinking: requestedThinking } : {}),
+              cwd: requestedCwd,
+            }),
+          fallbackCode: "ACP_SESSION_INIT_FAILED",
+          fallbackMessage: "Could not initialize ACP session runtime.",
+        });
+        const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
+        const effectiveRuntimeOptions = normalizeRuntimeOptions({
+          ...initialRuntimeOptions,
+          ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+        });
 
-      if (!persisted?.acp) {
-        await runtime
-          .close({
-            handle,
-            reason: "init-meta-failed",
-          })
-          .catch((closeError) => {
-            logVerbose(
-              `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
-            );
+        const identityNow = Date.now();
+        const initializedIdentity =
+          mergeSessionIdentity({
+            current: undefined,
+            incoming: createIdentityFromEnsure({
+              handle,
+              now: identityNow,
+            }),
+            now: identityNow,
+          }) ??
+          ({
+            state: "pending",
+            source: "ensure",
+            lastUpdatedAt: identityNow,
+          } as const);
+        const meta: SessionAcpMeta = {
+          backend: handle.backend || backend.id,
+          agent,
+          runtimeSessionName: handle.runtimeSessionName,
+          identity: initializedIdentity,
+          mode: input.mode,
+          ...(Object.keys(effectiveRuntimeOptions).length > 0
+            ? { runtimeOptions: effectiveRuntimeOptions }
+            : {}),
+          cwd: effectiveCwd,
+          state: "idle",
+          lastActivityAt: Date.now(),
+        };
+        let persisted: SessionEntry | null = null;
+        try {
+          persisted = await this.writeSessionMeta({
+            cfg: input.cfg,
+            sessionKey,
+            mutate: () => meta,
+            failOnError: true,
           });
+        } catch (error) {
+          await runtime
+            .close({
+              handle,
+              reason: "init-meta-failed",
+            })
+            .catch((closeError) => {
+              logVerbose(
+                `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
+              );
+            });
+          throw error;
+        }
 
-        throw new AcpRuntimeError(
-          "ACP_SESSION_INIT_FAILED",
-          `Could not persist ACP metadata for ${sessionKey}.`,
-        );
-      }
-      this.setCachedRuntimeState(sessionKey, {
-        runtime,
-        handle,
-        backend: handle.backend || backend.id,
-        agent,
-        mode: input.mode,
-        cwd: effectiveCwd,
-        configSignature: resolveRuntimeConfigCacheKey(input.cfg),
-      });
-      return {
-        runtime,
-        handle,
-        meta,
-      };
+        if (!persisted?.acp) {
+          await runtime
+            .close({
+              handle,
+              reason: "init-meta-failed",
+            })
+            .catch((closeError) => {
+              logVerbose(
+                `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
+              );
+            });
+
+          throw new AcpRuntimeError(
+            "ACP_SESSION_INIT_FAILED",
+            `Could not persist ACP metadata for ${sessionKey}.`,
+          );
+        }
+        this.setCachedRuntimeState(sessionKey, {
+          runtime,
+          handle,
+          backend: handle.backend || backend.id,
+          agent,
+          mode: input.mode,
+          cwd: effectiveCwd,
+          configSignature: resolveRuntimeConfigCacheKey(input.cfg),
+        });
+        return {
+          runtime,
+          handle,
+          meta,
+        };
+      },
     });
   }
 
@@ -446,9 +464,11 @@ export class AcpSessionManager {
     }
     this.throwIfAborted(params.signal);
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(
+    return await this.withSessionActor({
+      cfg: params.cfg,
       sessionKey,
-      async () => {
+      signal: params.signal,
+      op: async () => {
         this.throwIfAborted(params.signal);
         const resolution = this.resolveSession({
           cfg: params.cfg,
@@ -507,8 +527,7 @@ export class AcpSessionManager {
           lastError: meta.lastError,
         };
       },
-      params.signal,
-    );
+    });
   }
 
   async setSessionRuntimeMode(params: {
@@ -523,45 +542,49 @@ export class AcpSessionManager {
     const runtimeMode = validateRuntimeModeInput(params.runtimeMode);
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
-      if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
-        throw createUnsupportedControlError({
-          backend: handle.backend || meta.backend,
-          control: "session/set_mode",
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
         });
-      }
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
+        if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
+          throw createUnsupportedControlError({
+            backend: handle.backend || meta.backend,
+            control: "session/set_mode",
+          });
+        }
 
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.setMode!({
-            handle,
-            mode: runtimeMode,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime mode.",
-      });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.setMode!({
+              handle,
+              mode: runtimeMode,
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not update ACP runtime mode.",
+        });
 
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(meta),
-        patch: { runtimeMode },
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(meta),
+          patch: { runtimeMode },
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -580,70 +603,76 @@ export class AcpSessionManager {
     const value = normalizedOption.value;
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
-      const capabilities = await this.resolveRuntimeCapabilities({
-        runtime,
-        handle,
-        includeStatusConfigOptionKeys: true,
-      });
-      if (
-        !capabilities.controls.includes("session/set_config_option") ||
-        !runtime.setConfigOption
-      ) {
-        throw createUnsupportedControlError({
-          backend: handle.backend || meta.backend,
-          control: "session/set_config_option",
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async (signal) => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
         });
-      }
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+          signal,
+        });
+        const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
+        const capabilities = await this.resolveRuntimeCapabilities({
+          runtime,
+          handle,
+          includeStatusConfigOptionKeys: true,
+          signal,
+        });
+        if (
+          !capabilities.controls.includes("session/set_config_option") ||
+          !runtime.setConfigOption
+        ) {
+          throw createUnsupportedControlError({
+            backend: handle.backend || meta.backend,
+            control: "session/set_config_option",
+          });
+        }
 
-      const advertisedKeys = new Set(
-        (capabilities.configOptionKeys ?? [])
-          .map((entry) => normalizeLowercaseStringOrEmpty(entry))
-          .filter(Boolean),
-      );
-      const wireKey = resolveRuntimeConfigOptionKey(key, capabilities.configOptionKeys);
-      if (
-        advertisedKeys.size > 0 &&
-        !advertisedKeys.has(normalizeLowercaseStringOrEmpty(wireKey))
-      ) {
-        throw new AcpRuntimeError(
-          "ACP_BACKEND_UNSUPPORTED_CONTROL",
-          `ACP backend "${handle.backend || meta.backend}" does not accept config key "${wireKey}".`,
+        const advertisedKeys = new Set(
+          (capabilities.configOptionKeys ?? [])
+            .map((entry) => normalizeLowercaseStringOrEmpty(entry))
+            .filter(Boolean),
         );
-      }
+        const wireKey = resolveRuntimeConfigOptionKey(key, capabilities.configOptionKeys);
+        if (
+          advertisedKeys.size > 0 &&
+          !advertisedKeys.has(normalizeLowercaseStringOrEmpty(wireKey))
+        ) {
+          throw new AcpRuntimeError(
+            "ACP_BACKEND_UNSUPPORTED_CONTROL",
+            `ACP backend "${handle.backend || meta.backend}" does not accept config key "${wireKey}".`,
+          );
+        }
 
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.setConfigOption!({
-            handle,
-            key: wireKey,
-            value,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime config option.",
-      });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.setConfigOption!({
+              handle,
+              key: wireKey,
+              value,
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not update ACP runtime config option.",
+        });
 
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(meta),
-        patch: inferredPatch,
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(meta),
+          patch: inferredPatch,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -659,22 +688,26 @@ export class AcpSessionManager {
     }
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(resolvedMeta),
-        patch: validatedPatch,
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
+        });
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(resolvedMeta),
+          patch: validatedPatch,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -687,33 +720,40 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.close({
-            handle,
-            reason: "reset-runtime-options",
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not reset ACP runtime options.",
-      });
-      this.clearCachedRuntimeState(sessionKey);
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: {},
-      });
-      return {};
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
+        });
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.close({
+              handle,
+              reason: "reset-runtime-options",
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not reset ACP runtime options.",
+        });
+        this.clearCachedRuntimeStateIfHandleMatches({
+          sessionKey,
+          handle,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: {},
+        });
+        return {};
+      },
     });
   }
 
@@ -726,9 +766,11 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    await this.withSessionActor(
+    await this.withSessionActor({
+      cfg: input.cfg,
       sessionKey,
-      async () => {
+      signal: input.signal,
+      op: async () => {
         const turnStartedAt = Date.now();
         const actorKey = normalizeActorKey(sessionKey);
         const taskContext =
@@ -911,6 +953,7 @@ export class AcpSessionManager {
                   signal: combinedSignal,
                 },
                 eventGate,
+                isStale: () => this.isStaleActorOperation(actorKey),
                 onOutputEvent: (event) => {
                   sawTurnOutput = true;
                   if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
@@ -952,6 +995,9 @@ export class AcpSessionManager {
                   });
                 },
               });
+              if (this.isStaleActorOperation(actorKey)) {
+                return;
+              }
               if (!turnOutcome.sawTerminalEvent) {
                 throw new AcpRuntimeError(
                   "ACP_TURN_FAILED",
@@ -989,6 +1035,9 @@ export class AcpSessionManager {
                   ? "ACP turn failed before completion."
                   : "Could not initialize ACP session runtime.",
               });
+              if (this.isStaleActorOperation(actorKey)) {
+                return;
+              }
               retryFreshHandle = await this.prepareFreshHandleRetry({
                 attempt,
                 cfg: input.cfg,
@@ -1023,7 +1072,14 @@ export class AcpSessionManager {
               if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
                 this.activeTurnBySession.delete(actorKey);
               }
-              if (!retryFreshHandle && !skipPostTurnCleanup && runtime && handle && meta) {
+              if (
+                !retryFreshHandle &&
+                !skipPostTurnCleanup &&
+                !this.isStaleActorOperation(actorKey) &&
+                runtime &&
+                handle &&
+                meta
+              ) {
                 ({ handle, meta } = await this.reconcileRuntimeSessionIdentifiers({
                   cfg: input.cfg,
                   sessionKey,
@@ -1036,6 +1092,7 @@ export class AcpSessionManager {
               if (
                 !retryFreshHandle &&
                 !skipPostTurnCleanup &&
+                !this.isStaleActorOperation(actorKey) &&
                 runtime &&
                 handle &&
                 meta &&
@@ -1051,7 +1108,10 @@ export class AcpSessionManager {
                     `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
                   );
                 } finally {
-                  this.clearCachedRuntimeState(sessionKey);
+                  this.clearCachedRuntimeStateIfHandleMatches({
+                    sessionKey,
+                    handle,
+                  });
                 }
               }
             }
@@ -1061,8 +1121,7 @@ export class AcpSessionManager {
           }
         }
       },
-      input.signal,
-    );
+    });
   }
 
   private resolveTurnTimeoutMs(params: { cfg: OpenClawConfig; meta: SessionAcpMeta }): number {
@@ -1278,47 +1337,51 @@ export class AcpSessionManager {
       return;
     }
 
-    await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      try {
-        await withAcpRuntimeErrorBoundary({
-          run: async () =>
-            await runtime.cancel({
-              handle,
-              reason: params.reason,
-            }),
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP cancel failed before completion.",
-        });
-        await this.setSessionState({
+    await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
-          state: "idle",
-          clearLastError: true,
         });
-      } catch (error) {
-        const acpError = toAcpRuntimeError({
-          error,
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP cancel failed before completion.",
-        });
-        await this.setSessionState({
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle } = await this.ensureRuntimeHandle({
           cfg: params.cfg,
           sessionKey,
-          state: "error",
-          lastError: acpError.message,
+          meta: resolvedMeta,
         });
-        throw acpError;
-      }
+        try {
+          await withAcpRuntimeErrorBoundary({
+            run: async () =>
+              await runtime.cancel({
+                handle,
+                reason: params.reason,
+              }),
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP cancel failed before completion.",
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "idle",
+            clearLastError: true,
+          });
+        } catch (error) {
+          const acpError = toAcpRuntimeError({
+            error,
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP cancel failed before completion.",
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "error",
+            lastError: acpError.message,
+          });
+          throw acpError;
+        }
+      },
     });
   }
 
@@ -1331,134 +1394,143 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const resolutionError = resolveAcpSessionResolutionError(resolution);
-      if (resolutionError) {
-        if (input.requireAcpSession ?? true) {
-          throw resolutionError;
-        }
-        return {
-          runtimeClosed: false,
-          metaCleared: false,
-        };
-      }
-      const meta = requireReadySessionMeta(resolution);
-      const currentIdentity = resolveSessionIdentityFromMeta(meta);
-      const shouldSkipRuntimeClose =
-        input.discardPersistentState &&
-        currentIdentity != null &&
-        !identityHasStableSessionId(currentIdentity);
-
-      let runtimeClosed = false;
-      let runtimeNotice: string | undefined;
-      if (shouldSkipRuntimeClose) {
-        if (input.discardPersistentState) {
-          const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
-          try {
-            await this.deps
-              .getRuntimeBackend(configuredBackend || undefined)
-              ?.runtime.prepareFreshSession?.({
-                sessionKey,
-              });
-          } catch (error) {
-            logVerbose(
-              `acp close fast-reset: unable to prepare fresh session for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
-            );
+    return await this.withSessionActor({
+      cfg: input.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: input.cfg,
+          sessionKey,
+        });
+        const resolutionError = resolveAcpSessionResolutionError(resolution);
+        if (resolutionError) {
+          if (input.requireAcpSession ?? true) {
+            throw resolutionError;
           }
+          return {
+            runtimeClosed: false,
+            metaCleared: false,
+          };
         }
-        this.clearCachedRuntimeState(sessionKey);
-      } else {
-        try {
-          const { runtime: ensuredRuntime, handle } = await this.ensureRuntimeHandle({
-            cfg: input.cfg,
-            sessionKey,
-            meta,
-          });
-          await withAcpRuntimeErrorBoundary({
-            run: async () =>
-              await ensuredRuntime.close({
-                handle,
-                reason: input.reason,
-                discardPersistentState: input.discardPersistentState,
-              }),
-            fallbackCode: "ACP_TURN_FAILED",
-            fallbackMessage: "ACP close failed before completion.",
-          });
-          runtimeClosed = true;
-          this.clearCachedRuntimeState(sessionKey);
-        } catch (error) {
-          const acpError = toAcpRuntimeError({
-            error,
-            fallbackCode: "ACP_TURN_FAILED",
-            fallbackMessage: "ACP close failed before completion.",
-          });
-          if (
-            input.allowBackendUnavailable &&
-            (acpError.code === "ACP_BACKEND_MISSING" ||
-              acpError.code === "ACP_BACKEND_UNAVAILABLE" ||
-              (input.discardPersistentState && acpError.code === "ACP_SESSION_INIT_FAILED") ||
-              (input.discardPersistentState &&
-                acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
-              this.isRecoverableAcpxExitError(acpError.message))
-          ) {
-            if (input.discardPersistentState) {
-              const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
-              try {
-                const runtimeBackend = this.deps.getRuntimeBackend(configuredBackend || undefined);
-                if (!runtimeBackend) {
-                  throw acpError;
-                }
-                await runtimeBackend.runtime.prepareFreshSession?.({
+        const meta = requireReadySessionMeta(resolution);
+        const currentIdentity = resolveSessionIdentityFromMeta(meta);
+        const shouldSkipRuntimeClose =
+          input.discardPersistentState &&
+          currentIdentity != null &&
+          !identityHasStableSessionId(currentIdentity);
+
+        let runtimeClosed = false;
+        let runtimeNotice: string | undefined;
+        if (shouldSkipRuntimeClose) {
+          if (input.discardPersistentState) {
+            const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
+            try {
+              await this.deps
+                .getRuntimeBackend(configuredBackend || undefined)
+                ?.runtime.prepareFreshSession?.({
                   sessionKey,
                 });
-              } catch (recoveryError) {
-                logVerbose(
-                  `acp close recovery: unable to prepare fresh session for ${sessionKey}: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
-                );
-              }
+            } catch (error) {
+              logVerbose(
+                `acp close fast-reset: unable to prepare fresh session for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+              );
             }
-            // Treat unavailable backends as terminal for this cached handle so it
-            // cannot continue counting against maxConcurrentSessions.
-            this.clearCachedRuntimeState(sessionKey);
-            runtimeNotice = acpError.message;
-          } else {
-            throw acpError;
+          }
+          this.clearCachedRuntimeState(sessionKey);
+        } else {
+          try {
+            const { runtime: ensuredRuntime, handle } = await this.ensureRuntimeHandle({
+              cfg: input.cfg,
+              sessionKey,
+              meta,
+            });
+            await withAcpRuntimeErrorBoundary({
+              run: async () =>
+                await ensuredRuntime.close({
+                  handle,
+                  reason: input.reason,
+                  discardPersistentState: input.discardPersistentState,
+                }),
+              fallbackCode: "ACP_TURN_FAILED",
+              fallbackMessage: "ACP close failed before completion.",
+            });
+            runtimeClosed = true;
+            this.clearCachedRuntimeStateIfHandleMatches({
+              sessionKey,
+              handle,
+            });
+          } catch (error) {
+            const acpError = toAcpRuntimeError({
+              error,
+              fallbackCode: "ACP_TURN_FAILED",
+              fallbackMessage: "ACP close failed before completion.",
+            });
+            if (
+              input.allowBackendUnavailable &&
+              (acpError.code === "ACP_BACKEND_MISSING" ||
+                acpError.code === "ACP_BACKEND_UNAVAILABLE" ||
+                (input.discardPersistentState && acpError.code === "ACP_SESSION_INIT_FAILED") ||
+                (input.discardPersistentState &&
+                  acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
+                this.isRecoverableAcpxExitError(acpError.message))
+            ) {
+              if (input.discardPersistentState) {
+                const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
+                try {
+                  const runtimeBackend = this.deps.getRuntimeBackend(
+                    configuredBackend || undefined,
+                  );
+                  if (!runtimeBackend) {
+                    throw acpError;
+                  }
+                  await runtimeBackend.runtime.prepareFreshSession?.({
+                    sessionKey,
+                  });
+                } catch (recoveryError) {
+                  logVerbose(
+                    `acp close recovery: unable to prepare fresh session for ${sessionKey}: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+                  );
+                }
+              }
+              // Treat unavailable backends as terminal for this cached handle so it
+              // cannot continue counting against maxConcurrentSessions.
+              this.clearCachedRuntimeState(sessionKey);
+              runtimeNotice = acpError.message;
+            } else {
+              throw acpError;
+            }
           }
         }
-      }
 
-      let metaCleared = false;
-      if (input.discardPersistentState && !input.clearMeta) {
-        await this.discardPersistedRuntimeState({
-          cfg: input.cfg,
-          sessionKey,
-        });
-      }
+        let metaCleared = false;
+        if (input.discardPersistentState && !input.clearMeta) {
+          await this.discardPersistedRuntimeState({
+            cfg: input.cfg,
+            sessionKey,
+          });
+        }
 
-      if (input.clearMeta) {
-        await this.writeSessionMeta({
-          cfg: input.cfg,
-          sessionKey,
-          mutate: (_current, entry) => {
-            if (!entry) {
+        if (input.clearMeta) {
+          await this.writeSessionMeta({
+            cfg: input.cfg,
+            sessionKey,
+            mutate: (_current, entry) => {
+              if (!entry) {
+                return null;
+              }
               return null;
-            }
-            return null;
-          },
-          failOnError: true,
-        });
-        metaCleared = true;
-      }
+            },
+            failOnError: true,
+          });
+          metaCleared = true;
+        }
 
-      return {
-        runtimeClosed,
-        runtimeNotice,
-        metaCleared,
-      };
+        return {
+          runtimeClosed,
+          runtimeNotice,
+          metaCleared,
+        };
+      },
     });
   }
 
@@ -1954,32 +2026,54 @@ export class AcpSessionManager {
     }
 
     for (const candidate of candidates) {
-      await this.actorQueue.run(candidate.actorKey, async () => {
-        if (this.activeTurnBySession.has(candidate.actorKey)) {
-          return;
-        }
-        const lastTouchedAt = this.runtimeCache.getLastTouchedAt(candidate.actorKey);
-        if (lastTouchedAt == null || now - lastTouchedAt < idleTtlMs) {
-          return;
-        }
-        const cached = this.runtimeCache.peek(candidate.actorKey);
-        if (!cached) {
-          return;
-        }
-        this.runtimeCache.clear(candidate.actorKey);
-        this.evictedRuntimeCount += 1;
-        this.lastEvictedAt = Date.now();
-        try {
-          await cached.runtime.close({
-            handle: cached.handle,
-            reason: "idle-evicted",
-          });
-        } catch (error) {
+      try {
+        await this.actorQueue.run(
+          candidate.actorKey,
+          async () => {
+            if (this.activeTurnBySession.has(candidate.actorKey)) {
+              return;
+            }
+            const lastTouchedAt = this.runtimeCache.getLastTouchedAt(candidate.actorKey);
+            if (lastTouchedAt == null || now - lastTouchedAt < idleTtlMs) {
+              return;
+            }
+            const cached = this.runtimeCache.peek(candidate.actorKey);
+            if (!cached) {
+              return;
+            }
+            try {
+              await cached.runtime.close({
+                handle: cached.handle,
+                reason: "idle-evicted",
+              });
+              if (
+                this.clearCachedRuntimeStateIfHandleMatches({
+                  sessionKey: cached.handle.sessionKey,
+                  handle: cached.handle,
+                })
+              ) {
+                this.evictedRuntimeCount += 1;
+                this.lastEvictedAt = Date.now();
+              }
+            } catch (error) {
+              logVerbose(
+                `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+              );
+            }
+          },
+          {
+            timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
+          },
+        );
+      } catch (error) {
+        if (error instanceof SessionActorQueueTimeoutError) {
           logVerbose(
-            `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+            `acp-manager: idle runtime eviction timed out for ${candidate.actorKey} after ${error.timeoutMs}ms`,
           );
+          continue;
         }
-      });
+        throw error;
+      }
     }
   }
 
@@ -1987,6 +2081,7 @@ export class AcpSessionManager {
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
     includeStatusConfigOptionKeys?: boolean;
+    signal?: AbortSignal;
   }): Promise<AcpRuntimeCapabilities> {
     return await resolveManagerRuntimeCapabilities(params);
   }
@@ -2078,6 +2173,9 @@ export class AcpSessionManager {
     ) => SessionAcpMeta | null | undefined;
     failOnError?: boolean;
   }): Promise<SessionEntry | null> {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return null;
+    }
     try {
       return await this.deps.upsertSessionMeta({
         cfg: params.cfg,
@@ -2095,61 +2193,127 @@ export class AcpSessionManager {
     }
   }
 
-  private async withSessionActor<T>(
-    sessionKey: string,
-    op: () => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T> {
-    const actorKey = normalizeActorKey(sessionKey);
-    this.throwIfAborted(signal);
+  private async withSessionActor<T>(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    op: () => Promise<T>;
+    signal?: AbortSignal;
+    timeoutCode?: AcpRuntimeError["code"];
+  }): Promise<T> {
+    const actorKey = normalizeActorKey(params.sessionKey);
+    this.throwIfAborted(params.signal);
 
     let actorStarted = false;
-    const queued = this.actorQueue.run(actorKey, async () => {
-      actorStarted = true;
-      this.throwIfAborted(signal);
-      return await op();
-    });
-    if (!signal) {
-      return await queued;
-    }
+    const fence: SessionActorOperationFence = {
+      actorKey,
+      stale: false,
+    };
+    const queued = this.actorQueue.run(
+      actorKey,
+      () =>
+        this.sessionActorOperationScope.run(fence, async () => {
+          actorStarted = true;
+          this.throwIfAborted(params.signal);
+          return await params.op();
+        }),
+      {
+        timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
+        onTimeout: () => {
+          fence.stale = true;
+          this.cancelActiveTurnAfterLaneTimeout(actorKey);
+        },
+      },
+    );
 
-    return await new Promise<T>((resolve, reject) => {
-      let settled = false;
-      const cleanup = () => {
-        signal.removeEventListener("abort", onAbort);
-      };
-      const settleValue = (value: T) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        resolve(value);
-      };
-      const settleError = (error: unknown) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        reject(error);
-      };
-      const onAbort = () => {
-        if (actorStarted) {
-          return;
-        }
-        try {
-          this.throwIfAborted(signal);
-        } catch (error) {
-          settleError(error);
-        }
-      };
-
-      signal.addEventListener("abort", onAbort, { once: true });
-      queued.then(settleValue, settleError);
-      if (signal.aborted) {
-        onAbort();
+    try {
+      if (!params.signal) {
+        return await queued;
       }
+
+      const signal = params.signal;
+      return await new Promise<T>((resolve, reject) => {
+        let settled = false;
+        const cleanup = () => {
+          signal.removeEventListener("abort", onAbort);
+        };
+        const settleValue = (value: T) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+        const settleError = (error: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+        const onAbort = () => {
+          if (actorStarted) {
+            return;
+          }
+          try {
+            this.throwIfAborted(signal);
+          } catch (error) {
+            settleError(error);
+          }
+        };
+
+        signal.addEventListener("abort", onAbort, { once: true });
+        queued.then(settleValue, settleError);
+        if (signal.aborted) {
+          onAbort();
+        }
+      });
+    } catch (error) {
+      if (error instanceof SessionActorQueueTimeoutError) {
+        throw new AcpRuntimeError(
+          params.timeoutCode ?? "ACP_TURN_FAILED",
+          `ACP session lane task timed out after ${error.timeoutMs}ms for ${params.sessionKey}.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+
+  private isStaleActorOperation(actorKey: string): boolean {
+    const fence = this.sessionActorOperationScope.getStore();
+    return fence?.actorKey === actorKey && fence.stale;
+  }
+
+  private isStaleSessionActorOperation(sessionKey: string): boolean {
+    return this.isStaleActorOperation(normalizeActorKey(sessionKey));
+  }
+
+  private cancelActiveTurnAfterLaneTimeout(actorKey: string): void {
+    const activeTurn = this.activeTurnBySession.get(actorKey);
+    if (!activeTurn) {
+      return;
+    }
+    activeTurn.abortController.abort();
+    if (activeTurn.cancelPromise) {
+      return;
+    }
+    try {
+      activeTurn.cancelPromise = activeTurn.runtime.cancel({
+        handle: activeTurn.handle,
+        reason: ACP_SESSION_LANE_TIMEOUT_REASON,
+      });
+    } catch (error) {
+      logVerbose(
+        `acp-manager: lane-timeout cancel failed for ${activeTurn.handle.sessionKey}: ${String(error)}`,
+      );
+      return;
+    }
+    void activeTurn.cancelPromise.catch((error) => {
+      logVerbose(
+        `acp-manager: lane-timeout cancel failed for ${activeTurn.handle.sessionKey}: ${String(error)}`,
+      );
     });
   }
 
@@ -2161,14 +2325,23 @@ export class AcpSessionManager {
   }
 
   private getCachedRuntimeState(sessionKey: string): CachedRuntimeState | null {
+    if (this.isStaleSessionActorOperation(sessionKey)) {
+      return null;
+    }
     return this.runtimeCache.get(normalizeActorKey(sessionKey));
   }
 
   private setCachedRuntimeState(sessionKey: string, state: CachedRuntimeState): void {
+    if (this.isStaleSessionActorOperation(sessionKey)) {
+      return;
+    }
     this.runtimeCache.set(normalizeActorKey(sessionKey), state);
   }
 
   private clearCachedRuntimeState(sessionKey: string): void {
+    if (this.isStaleSessionActorOperation(sessionKey)) {
+      return;
+    }
     this.runtimeCache.clear(normalizeActorKey(sessionKey));
   }
 
@@ -2197,12 +2370,14 @@ export class AcpSessionManager {
   private clearCachedRuntimeStateIfHandleMatches(params: {
     sessionKey: string;
     handle: AcpRuntimeHandle;
-  }): void {
-    const cached = this.getCachedRuntimeState(params.sessionKey);
+  }): boolean {
+    const actorKey = normalizeActorKey(params.sessionKey);
+    const cached = this.runtimeCache.peek(actorKey);
     if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {
-      return;
+      return false;
     }
-    this.clearCachedRuntimeState(params.sessionKey);
+    this.runtimeCache.clear(actorKey);
+    return true;
   }
 
   private runtimeHandlesMatch(a: AcpRuntimeHandle, b: AcpRuntimeHandle): boolean {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -74,7 +74,11 @@ import {
   resolveRuntimeIdleTtlMs,
   resolveSessionLaneTaskTimeoutMs,
 } from "./manager.utils.js";
-import { CachedRuntimeState, RuntimeCache } from "./runtime-cache.js";
+import {
+  type CachedRuntimeState,
+  type ClosingRuntimeCacheEntry,
+  RuntimeCache,
+} from "./runtime-cache.js";
 import {
   inferRuntimeOptionPatchFromConfigOption,
   mergeRuntimeOptions,
@@ -167,11 +171,11 @@ type BackgroundTaskContext = {
 type SessionActorOperationFence = {
   actorKey: string;
   stale: boolean;
+  signal: AbortSignal;
 };
 
 export class AcpSessionManager {
   private readonly actorQueue = new SessionActorQueue();
-  private readonly actorTailBySession = this.actorQueue.getTailMapForTesting();
   private readonly sessionActorOperationScope = new AsyncLocalStorage<SessionActorOperationFence>();
   private readonly runtimeCache = new RuntimeCache();
   private readonly activeTurnBySession = new Map<string, ActiveTurnState>();
@@ -278,7 +282,7 @@ export class AcpSessionManager {
         const becameResolved = await this.withSessionActor({
           cfg: params.cfg,
           sessionKey: session.sessionKey,
-          op: async () => {
+          op: async (signal) => {
             const resolution = this.resolveSession({
               cfg: params.cfg,
               sessionKey: session.sessionKey,
@@ -290,6 +294,7 @@ export class AcpSessionManager {
               cfg: params.cfg,
               sessionKey: session.sessionKey,
               meta: resolution.meta,
+              signal,
             });
             const reconciled = await this.reconcileRuntimeSessionIdentifiers({
               cfg: params.cfg,
@@ -298,6 +303,7 @@ export class AcpSessionManager {
               handle,
               meta,
               failOnStatusError: false,
+              signal,
             });
             return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
           },
@@ -333,8 +339,9 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: input.cfg,
       sessionKey,
+      signal: input.signal,
       timeoutCode: "ACP_SESSION_INIT_FAILED",
-      op: async () => {
+      op: async (signal) => {
         const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
         const runtime = backend.runtime;
         const initialRuntimeOptions = validateRuntimeOptionPatch({
@@ -358,6 +365,7 @@ export class AcpSessionManager {
               ...(requestedModel ? { model: requestedModel } : {}),
               ...(requestedThinking ? { thinking: requestedThinking } : {}),
               cwd: requestedCwd,
+              signal,
             }),
           fallbackCode: "ACP_SESSION_INIT_FAILED",
           fallbackMessage: "Could not initialize ACP session runtime.",
@@ -409,6 +417,7 @@ export class AcpSessionManager {
             .close({
               handle,
               reason: "init-meta-failed",
+              ...(signal.aborted ? {} : { signal }),
             })
             .catch((closeError) => {
               logVerbose(
@@ -468,8 +477,8 @@ export class AcpSessionManager {
       cfg: params.cfg,
       sessionKey,
       signal: params.signal,
-      op: async () => {
-        this.throwIfAborted(params.signal);
+      op: async (signal) => {
+        this.throwIfAborted(signal);
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -483,6 +492,7 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         let handle = ensuredHandle;
         let meta = ensuredMeta;
@@ -491,12 +501,12 @@ export class AcpSessionManager {
         if (runtime.getStatus) {
           runtimeStatus = await withAcpRuntimeErrorBoundary({
             run: async () => {
-              this.throwIfAborted(params.signal);
+              this.throwIfAborted(signal);
               const status = await runtime.getStatus!({
                 handle,
-                ...(params.signal ? { signal: params.signal } : {}),
+                signal,
               });
-              this.throwIfAborted(params.signal);
+              this.throwIfAborted(signal);
               return status;
             },
             fallbackCode: "ACP_TURN_FAILED",
@@ -511,6 +521,7 @@ export class AcpSessionManager {
           meta,
           runtimeStatus,
           failOnStatusError: true,
+          signal,
         }));
         const identity = resolveSessionIdentityFromMeta(meta);
         return {
@@ -545,7 +556,7 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: params.cfg,
       sessionKey,
-      op: async () => {
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -555,6 +566,7 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
         if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
@@ -723,7 +735,7 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: params.cfg,
       sessionKey,
-      op: async () => {
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -733,19 +745,19 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         await withAcpRuntimeErrorBoundary({
           run: async () =>
-            await runtime.close({
+            await this.closeRuntimeHandle({
+              sessionKey,
+              runtime,
               handle,
               reason: "reset-runtime-options",
+              signal,
             }),
           fallbackCode: "ACP_TURN_FAILED",
           fallbackMessage: "Could not reset ACP runtime options.",
-        });
-        this.clearCachedRuntimeStateIfHandleMatches({
-          sessionKey,
-          handle,
         });
         await this.persistRuntimeOptions({
           cfg: params.cfg,
@@ -770,7 +782,7 @@ export class AcpSessionManager {
       cfg: input.cfg,
       sessionKey,
       signal: input.signal,
-      op: async () => {
+      op: async (signal) => {
         const turnStartedAt = Date.now();
         const actorKey = normalizeActorKey(sessionKey);
         const taskContext =
@@ -821,13 +833,13 @@ export class AcpSessionManager {
           );
         const recordBackendFailure = async (error: AcpRuntimeError) => {
           const failedBackends = backendAttempts
-            .map((attempt) => `${attempt.backend}: ${attempt.error}`)
+            .map((attempt) => attempt.backend + ": " + attempt.error)
             .join(" | ");
           const errorToRecord =
             backendAttempts.length > 1
               ? new AcpRuntimeError(
                   error.code,
-                  `All ACP backends failed (${backendAttempts.length}): ${failedBackends}`,
+                  "All ACP backends failed (" + backendAttempts.length + "): " + failedBackends,
                 )
               : error;
           this.recordTurnCompletion({
@@ -862,11 +874,15 @@ export class AcpSessionManager {
             await this.closeCachedRuntimeState({
               sessionKey,
               reason: "backend-failover",
+              signal,
             });
             logVerbose(
-              `acp-manager: switching backend for ${sessionKey} from ${describeBackendCandidate(
-                candidateBackends[backendIdx - 1],
-              )} to ${describeBackendCandidate(currentBackend)}`,
+              "acp-manager: switching backend for " +
+                sessionKey +
+                " from " +
+                describeBackendCandidate(candidateBackends[backendIdx - 1]) +
+                " to " +
+                describeBackendCandidate(currentBackend),
             );
           }
 
@@ -897,6 +913,7 @@ export class AcpSessionManager {
                 cfg: input.cfg,
                 sessionKey,
                 meta: metaWithBackend,
+                signal,
               });
               runtime = ensured.runtime;
               handle = ensured.handle;
@@ -919,10 +936,10 @@ export class AcpSessionManager {
               onCallerAbort = () => {
                 internalAbortController?.abort();
               };
-              if (input.signal?.aborted) {
+              if (signal.aborted) {
                 internalAbortController.abort();
-              } else if (input.signal) {
-                input.signal.addEventListener("abort", onCallerAbort, { once: true });
+              } else {
+                signal.addEventListener("abort", onCallerAbort, { once: true });
               }
 
               activeTurn = {
@@ -934,8 +951,8 @@ export class AcpSessionManager {
               activeTurnStarted = true;
 
               const combinedSignal =
-                input.signal && typeof AbortSignal.any === "function"
-                  ? AbortSignal.any([input.signal, internalAbortController.signal])
+                typeof AbortSignal.any === "function"
+                  ? AbortSignal.any([signal, internalAbortController.signal])
                   : internalAbortController.signal;
               const eventGate = { open: true };
               await input.onLifecycle?.({
@@ -1066,8 +1083,8 @@ export class AcpSessionManager {
               }
               break;
             } finally {
-              if (input.signal && onCallerAbort) {
-                input.signal.removeEventListener("abort", onCallerAbort);
+              if (onCallerAbort) {
+                signal.removeEventListener("abort", onCallerAbort);
               }
               if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
                 this.activeTurnBySession.delete(actorKey);
@@ -1087,6 +1104,7 @@ export class AcpSessionManager {
                   handle,
                   meta,
                   failOnStatusError: false,
+                  signal,
                 }));
               }
               if (
@@ -1099,19 +1117,20 @@ export class AcpSessionManager {
                 meta.mode === "oneshot"
               ) {
                 try {
-                  await runtime.close({
+                  await this.closeRuntimeHandle({
+                    sessionKey,
+                    runtime,
                     handle,
                     reason: "oneshot-complete",
+                    signal,
                   });
                 } catch (error) {
                   logVerbose(
-                    `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
+                    "acp-manager: ACP oneshot close failed for " +
+                      sessionKey +
+                      ": " +
+                      String(error),
                   );
-                } finally {
-                  this.clearCachedRuntimeStateIfHandleMatches({
-                    sessionKey,
-                    handle,
-                  });
                 }
               }
             }
@@ -1228,7 +1247,9 @@ export class AcpSessionManager {
     if (params.mode !== "oneshot") {
       return;
     }
-    const closePromise = params.activeTurn.runtime.close({
+    const closePromise = this.closeRuntimeHandle({
+      sessionKey: params.sessionKey,
+      runtime: params.activeTurn.runtime,
       handle: params.activeTurn.handle,
       reason: ACP_TURN_TIMEOUT_REASON,
     });
@@ -1238,18 +1259,8 @@ export class AcpSessionManager {
       promise: closePromise,
     });
     if (cancelFinished && closeFinished) {
-      this.clearCachedRuntimeStateIfHandleMatches({
-        sessionKey: params.sessionKey,
-        handle: params.activeTurn.handle,
-      });
       return;
     }
-    void Promise.allSettled([params.activeTurn.cancelPromise, closePromise]).then(() => {
-      this.clearCachedRuntimeStateIfHandleMatches({
-        sessionKey: params.sessionKey,
-        handle: params.activeTurn.handle,
-      });
-    });
   }
 
   private async awaitCleanupWithGrace(params: {
@@ -1313,6 +1324,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
     reason?: string;
+    signal?: AbortSignal;
   }): Promise<void> {
     const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
@@ -1327,6 +1339,7 @@ export class AcpSessionManager {
         activeTurn.cancelPromise = activeTurn.runtime.cancel({
           handle: activeTurn.handle,
           reason: params.reason,
+          ...(params.signal ? { signal: params.signal } : {}),
         });
       }
       await withAcpRuntimeErrorBoundary({
@@ -1340,7 +1353,8 @@ export class AcpSessionManager {
     await this.withSessionActor({
       cfg: params.cfg,
       sessionKey,
-      op: async () => {
+      signal: params.signal,
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -1350,6 +1364,7 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         try {
           await withAcpRuntimeErrorBoundary({
@@ -1357,6 +1372,7 @@ export class AcpSessionManager {
               await runtime.cancel({
                 handle,
                 reason: params.reason,
+                signal,
               }),
             fallbackCode: "ACP_TURN_FAILED",
             fallbackMessage: "ACP cancel failed before completion.",
@@ -1397,7 +1413,8 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: input.cfg,
       sessionKey,
-      op: async () => {
+      signal: input.signal,
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: input.cfg,
           sessionKey,
@@ -1443,22 +1460,22 @@ export class AcpSessionManager {
               cfg: input.cfg,
               sessionKey,
               meta,
+              signal,
             });
             await withAcpRuntimeErrorBoundary({
               run: async () =>
-                await ensuredRuntime.close({
+                await this.closeRuntimeHandle({
+                  sessionKey,
+                  runtime: ensuredRuntime,
                   handle,
                   reason: input.reason,
                   discardPersistentState: input.discardPersistentState,
+                  signal,
                 }),
               fallbackCode: "ACP_TURN_FAILED",
               fallbackMessage: "ACP close failed before completion.",
             });
             runtimeClosed = true;
-            this.clearCachedRuntimeStateIfHandleMatches({
-              sessionKey,
-              handle,
-            });
           } catch (error) {
             const acpError = toAcpRuntimeError({
               error,
@@ -1538,6 +1555,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
     meta: SessionAcpMeta;
+    signal?: AbortSignal;
   }): Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }> {
     const agent =
       normalizeText(params.meta.agent) || resolveAcpAgentFromSessionKey(params.sessionKey, "main");
@@ -1570,6 +1588,7 @@ export class AcpSessionManager {
           sessionKey: params.sessionKey,
           runtime: cached.runtime,
           handle: cached.handle,
+          signal: params.signal,
         }))
       ) {
         return {
@@ -1581,6 +1600,7 @@ export class AcpSessionManager {
       await this.closeCachedRuntimeState({
         sessionKey: params.sessionKey,
         reason: "runtime-handle-replaced",
+        signal: params.signal,
       });
     }
 
@@ -1611,6 +1631,7 @@ export class AcpSessionManager {
             ...(model ? { model } : {}),
             ...(thinking ? { thinking } : {}),
             cwd,
+            ...(params.signal ? { signal: params.signal } : {}),
           }),
         fallbackCode: "ACP_SESSION_INIT_FAILED",
         fallbackMessage: "Could not initialize ACP session runtime.",
@@ -1733,6 +1754,7 @@ export class AcpSessionManager {
     sessionKey: string;
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
+    signal?: AbortSignal;
   }): Promise<boolean> {
     if (!params.runtime.getStatus) {
       return true;
@@ -1740,6 +1762,7 @@ export class AcpSessionManager {
     try {
       const status = await params.runtime.getStatus({
         handle: params.handle,
+        ...(params.signal ? { signal: params.signal } : {}),
       });
       if (this.isRuntimeStatusUnavailable(status)) {
         this.clearCachedRuntimeState(params.sessionKey);
@@ -2029,7 +2052,7 @@ export class AcpSessionManager {
       try {
         await this.actorQueue.run(
           candidate.actorKey,
-          async () => {
+          async (queueContext) => {
             if (this.activeTurnBySession.has(candidate.actorKey)) {
               return;
             }
@@ -2042,19 +2065,15 @@ export class AcpSessionManager {
               return;
             }
             try {
-              await cached.runtime.close({
+              await this.closeRuntimeHandle({
+                sessionKey: cached.handle.sessionKey,
+                runtime: cached.runtime,
                 handle: cached.handle,
                 reason: "idle-evicted",
+                signal: queueContext.signal,
               });
-              if (
-                this.clearCachedRuntimeStateIfHandleMatches({
-                  sessionKey: cached.handle.sessionKey,
-                  handle: cached.handle,
-                })
-              ) {
-                this.evictedRuntimeCount += 1;
-                this.lastEvictedAt = Date.now();
-              }
+              this.evictedRuntimeCount += 1;
+              this.lastEvictedAt = Date.now();
             } catch (error) {
               logVerbose(
                 `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
@@ -2147,6 +2166,7 @@ export class AcpSessionManager {
     meta: SessionAcpMeta;
     runtimeStatus?: AcpRuntimeStatus;
     failOnStatusError: boolean;
+    signal?: AbortSignal;
   }): Promise<{
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
@@ -2196,7 +2216,7 @@ export class AcpSessionManager {
   private async withSessionActor<T>(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
-    op: () => Promise<T>;
+    op: (signal: AbortSignal) => Promise<T>;
     signal?: AbortSignal;
     timeoutCode?: AcpRuntimeError["code"];
   }): Promise<T> {
@@ -2204,22 +2224,36 @@ export class AcpSessionManager {
     this.throwIfAborted(params.signal);
 
     let actorStarted = false;
-    const fence: SessionActorOperationFence = {
-      actorKey,
-      stale: false,
-    };
+    let activeFence: SessionActorOperationFence | null = null;
     const queued = this.actorQueue.run(
       actorKey,
-      () =>
-        this.sessionActorOperationScope.run(fence, async () => {
-          actorStarted = true;
-          this.throwIfAborted(params.signal);
-          return await params.op();
-        }),
+      async (taskContext) => {
+        const operationSignal = this.createCombinedAbortSignal([taskContext.signal, params.signal]);
+        const fence: SessionActorOperationFence = {
+          actorKey,
+          stale: false,
+          signal: operationSignal.signal,
+        };
+        activeFence = fence;
+        try {
+          return await this.sessionActorOperationScope.run(fence, async () => {
+            actorStarted = true;
+            this.throwIfAborted(operationSignal.signal);
+            return await params.op(operationSignal.signal);
+          });
+        } finally {
+          operationSignal.cleanup();
+          if (activeFence === fence) {
+            activeFence = null;
+          }
+        }
+      },
       {
         timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
         onTimeout: () => {
-          fence.stale = true;
+          if (activeFence) {
+            activeFence.stale = true;
+          }
           this.cancelActiveTurnAfterLaneTimeout(actorKey);
         },
       },
@@ -2271,9 +2305,12 @@ export class AcpSessionManager {
       });
     } catch (error) {
       if (error instanceof SessionActorQueueTimeoutError) {
+        logVerbose(
+          `acp-manager: session lane task timed out after ${error.timeoutMs}ms for ${error.actorKey}`,
+        );
         throw new AcpRuntimeError(
           params.timeoutCode ?? "ACP_TURN_FAILED",
-          `ACP session lane task timed out after ${error.timeoutMs}ms for ${params.sessionKey}.`,
+          "ACP session operation timed out. Please retry.",
           { cause: error },
         );
       }
@@ -2284,6 +2321,45 @@ export class AcpSessionManager {
   private isStaleActorOperation(actorKey: string): boolean {
     const fence = this.sessionActorOperationScope.getStore();
     return fence?.actorKey === actorKey && fence.stale;
+  }
+
+  private createCombinedAbortSignal(signals: readonly (AbortSignal | undefined)[]): {
+    signal: AbortSignal;
+    cleanup: () => void;
+  } {
+    const activeSignals = signals.filter((signal): signal is AbortSignal => !!signal);
+    if (activeSignals.length === 0) {
+      return {
+        signal: new AbortController().signal,
+        cleanup: () => {},
+      };
+    }
+    if (activeSignals.length === 1) {
+      return {
+        signal: activeSignals[0],
+        cleanup: () => {},
+      };
+    }
+
+    const controller = new AbortController();
+    const onAbort = () => {
+      controller.abort();
+    };
+    for (const signal of activeSignals) {
+      if (signal.aborted) {
+        controller.abort();
+        break;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    return {
+      signal: controller.signal,
+      cleanup: () => {
+        for (const signal of activeSignals) {
+          signal.removeEventListener("abort", onAbort);
+        }
+      },
+    };
   }
 
   private isStaleSessionActorOperation(sessionKey: string): boolean {
@@ -2348,22 +2424,79 @@ export class AcpSessionManager {
   private async closeCachedRuntimeState(params: {
     sessionKey: string;
     reason: string;
+    signal?: AbortSignal;
   }): Promise<void> {
     const cached = this.getCachedRuntimeState(params.sessionKey);
     if (!cached) {
       return;
     }
     try {
-      await cached.runtime.close({
+      await this.closeRuntimeHandle({
+        sessionKey: params.sessionKey,
+        runtime: cached.runtime,
         handle: cached.handle,
         reason: params.reason,
+        signal: params.signal,
       });
     } catch (error) {
       logVerbose(
         `acp-manager: cached runtime close failed for ${params.sessionKey}: ${String(error)}`,
       );
-    } finally {
-      this.clearCachedRuntimeState(params.sessionKey);
+    }
+  }
+
+  private markCachedRuntimeStateClosingIfHandleMatches(params: {
+    sessionKey: string;
+    handle: AcpRuntimeHandle;
+  }): ClosingRuntimeCacheEntry | null {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return null;
+    }
+    const actorKey = normalizeActorKey(params.sessionKey);
+    const cached = this.runtimeCache.peek(actorKey);
+    if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {
+      return null;
+    }
+    return this.runtimeCache.markClosing(actorKey);
+  }
+
+  private async closeRuntimeHandle(params: {
+    sessionKey: string;
+    runtime: AcpRuntime;
+    handle: AcpRuntimeHandle;
+    reason: string;
+    discardPersistentState?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return;
+    }
+    const closing = this.markCachedRuntimeStateClosingIfHandleMatches({
+      sessionKey: params.sessionKey,
+      handle: params.handle,
+    });
+    try {
+      await params.runtime.close({
+        handle: params.handle,
+        reason: params.reason,
+        ...(params.discardPersistentState !== undefined
+          ? { discardPersistentState: params.discardPersistentState }
+          : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
+      });
+      if (!this.runtimeCache.clearClosing(closing)) {
+        this.clearCachedRuntimeStateIfHandleMatches({
+          sessionKey: params.sessionKey,
+          handle: params.handle,
+        });
+      }
+    } catch (error) {
+      if (this.isStaleSessionActorOperation(params.sessionKey)) {
+        this.runtimeCache.clearClosing(closing);
+      } else {
+        this.runtimeCache.restoreClosing(closing);
+      }
+      throw error;
     }
   }
 
@@ -2371,6 +2504,9 @@ export class AcpSessionManager {
     sessionKey: string;
     handle: AcpRuntimeHandle;
   }): boolean {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return false;
+    }
     const actorKey = normalizeActorKey(params.sessionKey);
     const cached = this.runtimeCache.peek(actorKey);
     if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -72,7 +72,11 @@ import {
   resolveRuntimeIdleTtlMs,
   resolveSessionLaneTaskTimeoutMs,
 } from "./manager.utils.js";
-import { CachedRuntimeState, RuntimeCache } from "./runtime-cache.js";
+import {
+  type CachedRuntimeState,
+  type ClosingRuntimeCacheEntry,
+  RuntimeCache,
+} from "./runtime-cache.js";
 import {
   inferRuntimeOptionPatchFromConfigOption,
   mergeRuntimeOptions,
@@ -165,6 +169,7 @@ type BackgroundTaskContext = {
 type SessionActorOperationFence = {
   actorKey: string;
   stale: boolean;
+  signal: AbortSignal;
 };
 
 export class AcpSessionManager {
@@ -276,7 +281,7 @@ export class AcpSessionManager {
         const becameResolved = await this.withSessionActor({
           cfg: params.cfg,
           sessionKey: session.sessionKey,
-          op: async () => {
+          op: async (signal) => {
             const resolution = this.resolveSession({
               cfg: params.cfg,
               sessionKey: session.sessionKey,
@@ -288,6 +293,7 @@ export class AcpSessionManager {
               cfg: params.cfg,
               sessionKey: session.sessionKey,
               meta: resolution.meta,
+              signal,
             });
             const reconciled = await this.reconcileRuntimeSessionIdentifiers({
               cfg: params.cfg,
@@ -296,6 +302,7 @@ export class AcpSessionManager {
               handle,
               meta,
               failOnStatusError: false,
+              signal,
             });
             return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
           },
@@ -331,8 +338,9 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: input.cfg,
       sessionKey,
+      signal: input.signal,
       timeoutCode: "ACP_SESSION_INIT_FAILED",
-      op: async () => {
+      op: async (signal) => {
         const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
         const runtime = backend.runtime;
         const initialRuntimeOptions = validateRuntimeOptionPatch({
@@ -356,6 +364,7 @@ export class AcpSessionManager {
               ...(requestedModel ? { model: requestedModel } : {}),
               ...(requestedThinking ? { thinking: requestedThinking } : {}),
               cwd: requestedCwd,
+              signal,
             }),
           fallbackCode: "ACP_SESSION_INIT_FAILED",
           fallbackMessage: "Could not initialize ACP session runtime.",
@@ -412,6 +421,7 @@ export class AcpSessionManager {
             .close({
               handle,
               reason: "init-meta-failed",
+              ...(signal.aborted ? {} : { signal }),
             })
             .catch((closeError) => {
               logVerbose(
@@ -452,8 +462,8 @@ export class AcpSessionManager {
       cfg: params.cfg,
       sessionKey,
       signal: params.signal,
-      op: async () => {
-        this.throwIfAborted(params.signal);
+      op: async (signal) => {
+        this.throwIfAborted(signal);
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -467,6 +477,7 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         let handle = ensuredHandle;
         let meta = ensuredMeta;
@@ -475,12 +486,12 @@ export class AcpSessionManager {
         if (runtime.getStatus) {
           runtimeStatus = await withAcpRuntimeErrorBoundary({
             run: async () => {
-              this.throwIfAborted(params.signal);
+              this.throwIfAborted(signal);
               const status = await runtime.getStatus!({
                 handle,
-                ...(params.signal ? { signal: params.signal } : {}),
+                signal,
               });
-              this.throwIfAborted(params.signal);
+              this.throwIfAborted(signal);
               return status;
             },
             fallbackCode: "ACP_TURN_FAILED",
@@ -495,6 +506,7 @@ export class AcpSessionManager {
           meta,
           runtimeStatus,
           failOnStatusError: true,
+          signal,
         }));
         const identity = resolveSessionIdentityFromMeta(meta);
         return {
@@ -529,7 +541,7 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: params.cfg,
       sessionKey,
-      op: async () => {
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -539,6 +551,7 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
         if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
@@ -707,7 +720,7 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: params.cfg,
       sessionKey,
-      op: async () => {
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -717,19 +730,19 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         await withAcpRuntimeErrorBoundary({
           run: async () =>
-            await runtime.close({
+            await this.closeRuntimeHandle({
+              sessionKey,
+              runtime,
               handle,
               reason: "reset-runtime-options",
+              signal,
             }),
           fallbackCode: "ACP_TURN_FAILED",
           fallbackMessage: "Could not reset ACP runtime options.",
-        });
-        this.clearCachedRuntimeStateIfHandleMatches({
-          sessionKey,
-          handle,
         });
         await this.persistRuntimeOptions({
           cfg: params.cfg,
@@ -754,7 +767,7 @@ export class AcpSessionManager {
       cfg: input.cfg,
       sessionKey,
       signal: input.signal,
-      op: async () => {
+      op: async (signal) => {
         const turnStartedAt = Date.now();
         const actorKey = normalizeActorKey(sessionKey);
         const taskContext =
@@ -791,6 +804,7 @@ export class AcpSessionManager {
               cfg: input.cfg,
               sessionKey,
               meta: resolvedMeta,
+              signal,
             });
             runtime = ensured.runtime;
             handle = ensured.handle;
@@ -813,10 +827,10 @@ export class AcpSessionManager {
             onCallerAbort = () => {
               internalAbortController?.abort();
             };
-            if (input.signal?.aborted) {
+            if (signal.aborted) {
               internalAbortController.abort();
-            } else if (input.signal) {
-              input.signal.addEventListener("abort", onCallerAbort, { once: true });
+            } else {
+              signal.addEventListener("abort", onCallerAbort, { once: true });
             }
 
             activeTurn = {
@@ -828,8 +842,8 @@ export class AcpSessionManager {
             activeTurnStarted = true;
 
             const combinedSignal =
-              input.signal && typeof AbortSignal.any === "function"
-                ? AbortSignal.any([input.signal, internalAbortController.signal])
+              typeof AbortSignal.any === "function"
+                ? AbortSignal.any([signal, internalAbortController.signal])
                 : internalAbortController.signal;
             const eventGate = { open: true };
             const turnPromise = consumeAcpTurnStream({
@@ -963,8 +977,8 @@ export class AcpSessionManager {
             });
             throw acpError;
           } finally {
-            if (input.signal && onCallerAbort) {
-              input.signal.removeEventListener("abort", onCallerAbort);
+            if (onCallerAbort) {
+              signal.removeEventListener("abort", onCallerAbort);
             }
             if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
               this.activeTurnBySession.delete(actorKey);
@@ -984,6 +998,7 @@ export class AcpSessionManager {
                 handle,
                 meta,
                 failOnStatusError: false,
+                signal,
               }));
             }
             if (
@@ -996,19 +1011,17 @@ export class AcpSessionManager {
               meta.mode === "oneshot"
             ) {
               try {
-                await runtime.close({
+                await this.closeRuntimeHandle({
+                  sessionKey,
+                  runtime,
                   handle,
                   reason: "oneshot-complete",
+                  signal,
                 });
               } catch (error) {
                 logVerbose(
                   `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
                 );
-              } finally {
-                this.clearCachedRuntimeStateIfHandleMatches({
-                  sessionKey,
-                  handle,
-                });
               }
             }
           }
@@ -1124,7 +1137,9 @@ export class AcpSessionManager {
     if (params.mode !== "oneshot") {
       return;
     }
-    const closePromise = params.activeTurn.runtime.close({
+    const closePromise = this.closeRuntimeHandle({
+      sessionKey: params.sessionKey,
+      runtime: params.activeTurn.runtime,
       handle: params.activeTurn.handle,
       reason: ACP_TURN_TIMEOUT_REASON,
     });
@@ -1134,18 +1149,8 @@ export class AcpSessionManager {
       promise: closePromise,
     });
     if (cancelFinished && closeFinished) {
-      this.clearCachedRuntimeStateIfHandleMatches({
-        sessionKey: params.sessionKey,
-        handle: params.activeTurn.handle,
-      });
       return;
     }
-    void Promise.allSettled([params.activeTurn.cancelPromise, closePromise]).then(() => {
-      this.clearCachedRuntimeStateIfHandleMatches({
-        sessionKey: params.sessionKey,
-        handle: params.activeTurn.handle,
-      });
-    });
   }
 
   private async awaitCleanupWithGrace(params: {
@@ -1209,6 +1214,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
     reason?: string;
+    signal?: AbortSignal;
   }): Promise<void> {
     const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
@@ -1223,6 +1229,7 @@ export class AcpSessionManager {
         activeTurn.cancelPromise = activeTurn.runtime.cancel({
           handle: activeTurn.handle,
           reason: params.reason,
+          ...(params.signal ? { signal: params.signal } : {}),
         });
       }
       await withAcpRuntimeErrorBoundary({
@@ -1236,7 +1243,8 @@ export class AcpSessionManager {
     await this.withSessionActor({
       cfg: params.cfg,
       sessionKey,
-      op: async () => {
+      signal: params.signal,
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
@@ -1246,6 +1254,7 @@ export class AcpSessionManager {
           cfg: params.cfg,
           sessionKey,
           meta: resolvedMeta,
+          signal,
         });
         try {
           await withAcpRuntimeErrorBoundary({
@@ -1253,6 +1262,7 @@ export class AcpSessionManager {
               await runtime.cancel({
                 handle,
                 reason: params.reason,
+                signal,
               }),
             fallbackCode: "ACP_TURN_FAILED",
             fallbackMessage: "ACP cancel failed before completion.",
@@ -1293,7 +1303,8 @@ export class AcpSessionManager {
     return await this.withSessionActor({
       cfg: input.cfg,
       sessionKey,
-      op: async () => {
+      signal: input.signal,
+      op: async (signal) => {
         const resolution = this.resolveSession({
           cfg: input.cfg,
           sessionKey,
@@ -1339,22 +1350,22 @@ export class AcpSessionManager {
               cfg: input.cfg,
               sessionKey,
               meta,
+              signal,
             });
             await withAcpRuntimeErrorBoundary({
               run: async () =>
-                await ensuredRuntime.close({
+                await this.closeRuntimeHandle({
+                  sessionKey,
+                  runtime: ensuredRuntime,
                   handle,
                   reason: input.reason,
                   discardPersistentState: input.discardPersistentState,
+                  signal,
                 }),
               fallbackCode: "ACP_TURN_FAILED",
               fallbackMessage: "ACP close failed before completion.",
             });
             runtimeClosed = true;
-            this.clearCachedRuntimeStateIfHandleMatches({
-              sessionKey,
-              handle,
-            });
           } catch (error) {
             const acpError = toAcpRuntimeError({
               error,
@@ -1434,6 +1445,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
     meta: SessionAcpMeta;
+    signal?: AbortSignal;
   }): Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }> {
     const agent =
       normalizeText(params.meta.agent) || resolveAcpAgentFromSessionKey(params.sessionKey, "main");
@@ -1463,6 +1475,7 @@ export class AcpSessionManager {
           sessionKey: params.sessionKey,
           runtime: cached.runtime,
           handle: cached.handle,
+          signal: params.signal,
         }))
       ) {
         return {
@@ -1501,6 +1514,7 @@ export class AcpSessionManager {
             ...(model ? { model } : {}),
             ...(thinking ? { thinking } : {}),
             cwd,
+            ...(params.signal ? { signal: params.signal } : {}),
           }),
         fallbackCode: "ACP_SESSION_INIT_FAILED",
         fallbackMessage: "Could not initialize ACP session runtime.",
@@ -1622,6 +1636,7 @@ export class AcpSessionManager {
     sessionKey: string;
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
+    signal?: AbortSignal;
   }): Promise<boolean> {
     if (!params.runtime.getStatus) {
       return true;
@@ -1629,6 +1644,7 @@ export class AcpSessionManager {
     try {
       const status = await params.runtime.getStatus({
         handle: params.handle,
+        ...(params.signal ? { signal: params.signal } : {}),
       });
       if (this.isRuntimeStatusUnavailable(status)) {
         this.clearCachedRuntimeState(params.sessionKey);
@@ -1918,7 +1934,7 @@ export class AcpSessionManager {
       try {
         await this.actorQueue.run(
           candidate.actorKey,
-          async () => {
+          async (queueContext) => {
             if (this.activeTurnBySession.has(candidate.actorKey)) {
               return;
             }
@@ -1931,19 +1947,15 @@ export class AcpSessionManager {
               return;
             }
             try {
-              await cached.runtime.close({
+              await this.closeRuntimeHandle({
+                sessionKey: cached.handle.sessionKey,
+                runtime: cached.runtime,
                 handle: cached.handle,
                 reason: "idle-evicted",
+                signal: queueContext.signal,
               });
-              if (
-                this.clearCachedRuntimeStateIfHandleMatches({
-                  sessionKey: cached.handle.sessionKey,
-                  handle: cached.handle,
-                })
-              ) {
-                this.evictedRuntimeCount += 1;
-                this.lastEvictedAt = Date.now();
-              }
+              this.evictedRuntimeCount += 1;
+              this.lastEvictedAt = Date.now();
             } catch (error) {
               logVerbose(
                 `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
@@ -2036,6 +2048,7 @@ export class AcpSessionManager {
     meta: SessionAcpMeta;
     runtimeStatus?: AcpRuntimeStatus;
     failOnStatusError: boolean;
+    signal?: AbortSignal;
   }): Promise<{
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
@@ -2085,7 +2098,7 @@ export class AcpSessionManager {
   private async withSessionActor<T>(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
-    op: () => Promise<T>;
+    op: (signal: AbortSignal) => Promise<T>;
     signal?: AbortSignal;
     timeoutCode?: AcpRuntimeError["code"];
   }): Promise<T> {
@@ -2093,22 +2106,36 @@ export class AcpSessionManager {
     this.throwIfAborted(params.signal);
 
     let actorStarted = false;
-    const fence: SessionActorOperationFence = {
-      actorKey,
-      stale: false,
-    };
+    let activeFence: SessionActorOperationFence | null = null;
     const queued = this.actorQueue.run(
       actorKey,
-      () =>
-        this.sessionActorOperationScope.run(fence, async () => {
-          actorStarted = true;
-          this.throwIfAborted(params.signal);
-          return await params.op();
-        }),
+      async (taskContext) => {
+        const operationSignal = this.createCombinedAbortSignal([taskContext.signal, params.signal]);
+        const fence: SessionActorOperationFence = {
+          actorKey,
+          stale: false,
+          signal: operationSignal.signal,
+        };
+        activeFence = fence;
+        try {
+          return await this.sessionActorOperationScope.run(fence, async () => {
+            actorStarted = true;
+            this.throwIfAborted(operationSignal.signal);
+            return await params.op(operationSignal.signal);
+          });
+        } finally {
+          operationSignal.cleanup();
+          if (activeFence === fence) {
+            activeFence = null;
+          }
+        }
+      },
       {
         timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
         onTimeout: () => {
-          fence.stale = true;
+          if (activeFence) {
+            activeFence.stale = true;
+          }
           this.cancelActiveTurnAfterLaneTimeout(actorKey);
         },
       },
@@ -2160,9 +2187,12 @@ export class AcpSessionManager {
       });
     } catch (error) {
       if (error instanceof SessionActorQueueTimeoutError) {
+        logVerbose(
+          `acp-manager: session lane task timed out after ${error.timeoutMs}ms for ${error.actorKey}`,
+        );
         throw new AcpRuntimeError(
           params.timeoutCode ?? "ACP_TURN_FAILED",
-          `ACP session lane task timed out after ${error.timeoutMs}ms for ${params.sessionKey}.`,
+          "ACP session operation timed out. Please retry.",
           { cause: error },
         );
       }
@@ -2173,6 +2203,45 @@ export class AcpSessionManager {
   private isStaleActorOperation(actorKey: string): boolean {
     const fence = this.sessionActorOperationScope.getStore();
     return fence?.actorKey === actorKey && fence.stale;
+  }
+
+  private createCombinedAbortSignal(signals: readonly (AbortSignal | undefined)[]): {
+    signal: AbortSignal;
+    cleanup: () => void;
+  } {
+    const activeSignals = signals.filter((signal): signal is AbortSignal => !!signal);
+    if (activeSignals.length === 0) {
+      return {
+        signal: new AbortController().signal,
+        cleanup: () => {},
+      };
+    }
+    if (activeSignals.length === 1) {
+      return {
+        signal: activeSignals[0],
+        cleanup: () => {},
+      };
+    }
+
+    const controller = new AbortController();
+    const onAbort = () => {
+      controller.abort();
+    };
+    for (const signal of activeSignals) {
+      if (signal.aborted) {
+        controller.abort();
+        break;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    return {
+      signal: controller.signal,
+      cleanup: () => {
+        for (const signal of activeSignals) {
+          signal.removeEventListener("abort", onAbort);
+        }
+      },
+    };
   }
 
   private isStaleSessionActorOperation(sessionKey: string): boolean {
@@ -2234,10 +2303,68 @@ export class AcpSessionManager {
     this.runtimeCache.clear(normalizeActorKey(sessionKey));
   }
 
+  private markCachedRuntimeStateClosingIfHandleMatches(params: {
+    sessionKey: string;
+    handle: AcpRuntimeHandle;
+  }): ClosingRuntimeCacheEntry | null {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return null;
+    }
+    const actorKey = normalizeActorKey(params.sessionKey);
+    const cached = this.runtimeCache.peek(actorKey);
+    if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {
+      return null;
+    }
+    return this.runtimeCache.markClosing(actorKey);
+  }
+
+  private async closeRuntimeHandle(params: {
+    sessionKey: string;
+    runtime: AcpRuntime;
+    handle: AcpRuntimeHandle;
+    reason: string;
+    discardPersistentState?: boolean;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return;
+    }
+    const closing = this.markCachedRuntimeStateClosingIfHandleMatches({
+      sessionKey: params.sessionKey,
+      handle: params.handle,
+    });
+    try {
+      await params.runtime.close({
+        handle: params.handle,
+        reason: params.reason,
+        ...(params.discardPersistentState !== undefined
+          ? { discardPersistentState: params.discardPersistentState }
+          : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
+      });
+      if (!this.runtimeCache.clearClosing(closing)) {
+        this.clearCachedRuntimeStateIfHandleMatches({
+          sessionKey: params.sessionKey,
+          handle: params.handle,
+        });
+      }
+    } catch (error) {
+      if (this.isStaleSessionActorOperation(params.sessionKey)) {
+        this.runtimeCache.clearClosing(closing);
+      } else {
+        this.runtimeCache.restoreClosing(closing);
+      }
+      throw error;
+    }
+  }
+
   private clearCachedRuntimeStateIfHandleMatches(params: {
     sessionKey: string;
     handle: AcpRuntimeHandle;
   }): boolean {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return false;
+    }
     const actorKey = normalizeActorKey(params.sessionKey);
     const cached = this.runtimeCache.peek(actorKey);
     if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -69,6 +70,7 @@ import {
   resolveAcpSessionResolutionError,
   resolveMissingMetaError,
   resolveRuntimeIdleTtlMs,
+  resolveSessionLaneTaskTimeoutMs,
 } from "./manager.utils.js";
 import { CachedRuntimeState, RuntimeCache } from "./runtime-cache.js";
 import {
@@ -83,11 +85,12 @@ import {
   validateRuntimeModeInput,
   validateRuntimeOptionPatch,
 } from "./runtime-options.js";
-import { SessionActorQueue } from "./session-actor-queue.js";
+import { SessionActorQueue, SessionActorQueueTimeoutError } from "./session-actor-queue.js";
 
 const ACP_TURN_TIMEOUT_GRACE_MS = 1_000;
 const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
 const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
+const ACP_SESSION_LANE_TIMEOUT_REASON = "session-lane-timeout";
 const ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH = 160;
 const ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH = 240;
 
@@ -159,9 +162,15 @@ type BackgroundTaskContext = {
   task: string;
 };
 
+type SessionActorOperationFence = {
+  actorKey: string;
+  stale: boolean;
+};
+
 export class AcpSessionManager {
   private readonly actorQueue = new SessionActorQueue();
   private readonly actorTailBySession = this.actorQueue.getTailMapForTesting();
+  private readonly sessionActorOperationScope = new AsyncLocalStorage<SessionActorOperationFence>();
   private readonly runtimeCache = new RuntimeCache();
   private readonly activeTurnBySession = new Map<string, ActiveTurnState>();
   private readonly turnLatencyStats: TurnLatencyStats = {
@@ -264,28 +273,32 @@ export class AcpSessionManager {
 
       checked += 1;
       try {
-        const becameResolved = await this.withSessionActor(session.sessionKey, async () => {
-          const resolution = this.resolveSession({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-          });
-          if (resolution.kind !== "ready") {
-            return false;
-          }
-          const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            meta: resolution.meta,
-          });
-          const reconciled = await this.reconcileRuntimeSessionIdentifiers({
-            cfg: params.cfg,
-            sessionKey: session.sessionKey,
-            runtime,
-            handle,
-            meta,
-            failOnStatusError: false,
-          });
-          return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+        const becameResolved = await this.withSessionActor({
+          cfg: params.cfg,
+          sessionKey: session.sessionKey,
+          op: async () => {
+            const resolution = this.resolveSession({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+            });
+            if (resolution.kind !== "ready") {
+              return false;
+            }
+            const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              meta: resolution.meta,
+            });
+            const reconciled = await this.reconcileRuntimeSessionIdentifiers({
+              cfg: params.cfg,
+              sessionKey: session.sessionKey,
+              runtime,
+              handle,
+              meta,
+              failOnStatusError: false,
+            });
+            return !isSessionIdentityPending(resolveSessionIdentityFromMeta(reconciled.meta));
+          },
         });
         if (becameResolved) {
           resolved += 1;
@@ -315,121 +328,112 @@ export class AcpSessionManager {
     }
     const agent = normalizeAgentId(input.agent);
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
-      const runtime = backend.runtime;
-      const initialRuntimeOptions = validateRuntimeOptionPatch({
-        ...input.runtimeOptions,
-        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
-      });
-      const requestedCwd = initialRuntimeOptions.cwd;
-      const requestedModel = initialRuntimeOptions.model;
-      const requestedThinking = initialRuntimeOptions.thinking;
-      this.enforceConcurrentSessionLimit({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const handle = await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.ensureSession({
-            sessionKey,
-            agent,
-            mode: input.mode,
-            resumeSessionId: input.resumeSessionId,
-            ...(requestedModel ? { model: requestedModel } : {}),
-            ...(requestedThinking ? { thinking: requestedThinking } : {}),
-            cwd: requestedCwd,
-          }),
-        fallbackCode: "ACP_SESSION_INIT_FAILED",
-        fallbackMessage: "Could not initialize ACP session runtime.",
-      });
-      const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
-      const effectiveRuntimeOptions = normalizeRuntimeOptions({
-        ...initialRuntimeOptions,
-        ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
-      });
-
-      const identityNow = Date.now();
-      const initializedIdentity =
-        mergeSessionIdentity({
-          current: undefined,
-          incoming: createIdentityFromEnsure({
-            handle,
-            now: identityNow,
-          }),
-          now: identityNow,
-        }) ??
-        ({
-          state: "pending",
-          source: "ensure",
-          lastUpdatedAt: identityNow,
-        } as const);
-      const meta: SessionAcpMeta = {
-        backend: handle.backend || backend.id,
-        agent,
-        runtimeSessionName: handle.runtimeSessionName,
-        identity: initializedIdentity,
-        mode: input.mode,
-        ...(Object.keys(effectiveRuntimeOptions).length > 0
-          ? { runtimeOptions: effectiveRuntimeOptions }
-          : {}),
-        cwd: effectiveCwd,
-        state: "idle",
-        lastActivityAt: Date.now(),
-      };
-
-      let persisted: SessionEntry | null = null;
-      try {
-        persisted = await this.writeSessionMeta({
+    return await this.withSessionActor({
+      cfg: input.cfg,
+      sessionKey,
+      timeoutCode: "ACP_SESSION_INIT_FAILED",
+      op: async () => {
+        const backend = this.deps.requireRuntimeBackend(input.backendId || input.cfg.acp?.backend);
+        const runtime = backend.runtime;
+        const initialRuntimeOptions = validateRuntimeOptionPatch({
+          ...input.runtimeOptions,
+          ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+        });
+        const requestedCwd = initialRuntimeOptions.cwd;
+        const requestedModel = initialRuntimeOptions.model;
+        const requestedThinking = initialRuntimeOptions.thinking;
+        this.enforceConcurrentSessionLimit({
           cfg: input.cfg,
           sessionKey,
-          mutate: () => meta,
-          failOnError: true,
         });
-      } catch (error) {
-        await runtime
-          .close({
-            handle,
-            reason: "init-meta-failed",
-          })
-          .catch((closeError) => {
-            logVerbose(
-              `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
-            );
-          });
-        throw error;
-      }
+        const handle = await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.ensureSession({
+              sessionKey,
+              agent,
+              mode: input.mode,
+              resumeSessionId: input.resumeSessionId,
+              ...(requestedModel ? { model: requestedModel } : {}),
+              ...(requestedThinking ? { thinking: requestedThinking } : {}),
+              cwd: requestedCwd,
+            }),
+          fallbackCode: "ACP_SESSION_INIT_FAILED",
+          fallbackMessage: "Could not initialize ACP session runtime.",
+        });
+        const effectiveCwd = normalizeText(handle.cwd) ?? requestedCwd;
+        const effectiveRuntimeOptions = normalizeRuntimeOptions({
+          ...initialRuntimeOptions,
+          ...(effectiveCwd ? { cwd: effectiveCwd } : {}),
+        });
 
-      if (!persisted?.acp) {
-        await runtime
-          .close({
-            handle,
-            reason: "init-meta-failed",
-          })
-          .catch((closeError) => {
-            logVerbose(
-              `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
-            );
+        const identityNow = Date.now();
+        const initializedIdentity =
+          mergeSessionIdentity({
+            current: undefined,
+            incoming: createIdentityFromEnsure({
+              handle,
+              now: identityNow,
+            }),
+            now: identityNow,
+          }) ??
+          ({
+            state: "pending",
+            source: "ensure",
+            lastUpdatedAt: identityNow,
+          } as const);
+        const meta: SessionAcpMeta = {
+          backend: handle.backend || backend.id,
+          agent,
+          runtimeSessionName: handle.runtimeSessionName,
+          identity: initializedIdentity,
+          mode: input.mode,
+          ...(Object.keys(effectiveRuntimeOptions).length > 0
+            ? { runtimeOptions: effectiveRuntimeOptions }
+            : {}),
+          cwd: effectiveCwd,
+          state: "idle",
+          lastActivityAt: Date.now(),
+        };
+        try {
+          const persisted = await this.writeSessionMeta({
+            cfg: input.cfg,
+            sessionKey,
+            mutate: () => meta,
+            failOnError: true,
           });
-
-        throw new AcpRuntimeError(
-          "ACP_SESSION_INIT_FAILED",
-          `Could not persist ACP metadata for ${sessionKey}.`,
-        );
-      }
-      this.setCachedRuntimeState(sessionKey, {
-        runtime,
-        handle,
-        backend: handle.backend || backend.id,
-        agent,
-        mode: input.mode,
-        cwd: effectiveCwd,
-      });
-      return {
-        runtime,
-        handle,
-        meta,
-      };
+          if (!persisted?.acp) {
+            throw new AcpRuntimeError(
+              "ACP_SESSION_INIT_FAILED",
+              `Could not persist ACP metadata for ${sessionKey}.`,
+            );
+          }
+        } catch (error) {
+          await runtime
+            .close({
+              handle,
+              reason: "init-meta-failed",
+            })
+            .catch((closeError) => {
+              logVerbose(
+                `acp-manager: cleanup close failed after metadata write error for ${sessionKey}: ${String(closeError)}`,
+              );
+            });
+          throw error;
+        }
+        this.setCachedRuntimeState(sessionKey, {
+          runtime,
+          handle,
+          backend: handle.backend || backend.id,
+          agent,
+          mode: input.mode,
+          cwd: effectiveCwd,
+        });
+        return {
+          runtime,
+          handle,
+          meta,
+        };
+      },
     });
   }
 
@@ -444,9 +448,11 @@ export class AcpSessionManager {
     }
     this.throwIfAborted(params.signal);
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(
+    return await this.withSessionActor({
+      cfg: params.cfg,
       sessionKey,
-      async () => {
+      signal: params.signal,
+      op: async () => {
         this.throwIfAborted(params.signal);
         const resolution = this.resolveSession({
           cfg: params.cfg,
@@ -505,8 +511,7 @@ export class AcpSessionManager {
           lastError: meta.lastError,
         };
       },
-      params.signal,
-    );
+    });
   }
 
   async setSessionRuntimeMode(params: {
@@ -521,45 +526,49 @@ export class AcpSessionManager {
     const runtimeMode = validateRuntimeModeInput(params.runtimeMode);
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
-      if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
-        throw createUnsupportedControlError({
-          backend: handle.backend || meta.backend,
-          control: "session/set_mode",
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
         });
-      }
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
+        if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
+          throw createUnsupportedControlError({
+            backend: handle.backend || meta.backend,
+            control: "session/set_mode",
+          });
+        }
 
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.setMode!({
-            handle,
-            mode: runtimeMode,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime mode.",
-      });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.setMode!({
+              handle,
+              mode: runtimeMode,
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not update ACP runtime mode.",
+        });
 
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(meta),
-        patch: { runtimeMode },
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(meta),
+          patch: { runtimeMode },
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -578,70 +587,76 @@ export class AcpSessionManager {
     const value = normalizedOption.value;
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle, meta } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
-      const capabilities = await this.resolveRuntimeCapabilities({
-        runtime,
-        handle,
-        includeStatusConfigOptionKeys: true,
-      });
-      if (
-        !capabilities.controls.includes("session/set_config_option") ||
-        !runtime.setConfigOption
-      ) {
-        throw createUnsupportedControlError({
-          backend: handle.backend || meta.backend,
-          control: "session/set_config_option",
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async (signal) => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
         });
-      }
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle, meta } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+          signal,
+        });
+        const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
+        const capabilities = await this.resolveRuntimeCapabilities({
+          runtime,
+          handle,
+          includeStatusConfigOptionKeys: true,
+          signal,
+        });
+        if (
+          !capabilities.controls.includes("session/set_config_option") ||
+          !runtime.setConfigOption
+        ) {
+          throw createUnsupportedControlError({
+            backend: handle.backend || meta.backend,
+            control: "session/set_config_option",
+          });
+        }
 
-      const advertisedKeys = new Set(
-        (capabilities.configOptionKeys ?? [])
-          .map((entry) => normalizeLowercaseStringOrEmpty(entry))
-          .filter(Boolean),
-      );
-      const wireKey = resolveRuntimeConfigOptionKey(key, capabilities.configOptionKeys);
-      if (
-        advertisedKeys.size > 0 &&
-        !advertisedKeys.has(normalizeLowercaseStringOrEmpty(wireKey))
-      ) {
-        throw new AcpRuntimeError(
-          "ACP_BACKEND_UNSUPPORTED_CONTROL",
-          `ACP backend "${handle.backend || meta.backend}" does not accept config key "${wireKey}".`,
+        const advertisedKeys = new Set(
+          (capabilities.configOptionKeys ?? [])
+            .map((entry) => normalizeLowercaseStringOrEmpty(entry))
+            .filter(Boolean),
         );
-      }
+        const wireKey = resolveRuntimeConfigOptionKey(key, capabilities.configOptionKeys);
+        if (
+          advertisedKeys.size > 0 &&
+          !advertisedKeys.has(normalizeLowercaseStringOrEmpty(wireKey))
+        ) {
+          throw new AcpRuntimeError(
+            "ACP_BACKEND_UNSUPPORTED_CONTROL",
+            `ACP backend "${handle.backend || meta.backend}" does not accept config key "${wireKey}".`,
+          );
+        }
 
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.setConfigOption!({
-            handle,
-            key: wireKey,
-            value,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not update ACP runtime config option.",
-      });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.setConfigOption!({
+              handle,
+              key: wireKey,
+              value,
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not update ACP runtime config option.",
+        });
 
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(meta),
-        patch: inferredPatch,
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(meta),
+          patch: inferredPatch,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -657,22 +672,26 @@ export class AcpSessionManager {
     }
 
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const nextOptions = mergeRuntimeOptions({
-        current: resolveRuntimeOptionsFromMeta(resolvedMeta),
-        patch: validatedPatch,
-      });
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: nextOptions,
-      });
-      return nextOptions;
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
+        });
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const nextOptions = mergeRuntimeOptions({
+          current: resolveRuntimeOptionsFromMeta(resolvedMeta),
+          patch: validatedPatch,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: nextOptions,
+        });
+        return nextOptions;
+      },
     });
   }
 
@@ -685,33 +704,40 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: params.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await runtime.close({
-            handle,
-            reason: "reset-runtime-options",
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "Could not reset ACP runtime options.",
-      });
-      this.clearCachedRuntimeState(sessionKey);
-      await this.persistRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        options: {},
-      });
-      return {};
+    return await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: params.cfg,
+          sessionKey,
+        });
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle } = await this.ensureRuntimeHandle({
+          cfg: params.cfg,
+          sessionKey,
+          meta: resolvedMeta,
+        });
+        await withAcpRuntimeErrorBoundary({
+          run: async () =>
+            await runtime.close({
+              handle,
+              reason: "reset-runtime-options",
+            }),
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "Could not reset ACP runtime options.",
+        });
+        this.clearCachedRuntimeStateIfHandleMatches({
+          sessionKey,
+          handle,
+        });
+        await this.persistRuntimeOptions({
+          cfg: params.cfg,
+          sessionKey,
+          options: {},
+        });
+        return {};
+      },
     });
   }
 
@@ -724,9 +750,11 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    await this.withSessionActor(
+    await this.withSessionActor({
+      cfg: input.cfg,
       sessionKey,
-      async () => {
+      signal: input.signal,
+      op: async () => {
         const turnStartedAt = Date.now();
         const actorKey = normalizeActorKey(sessionKey);
         const taskContext =
@@ -815,6 +843,7 @@ export class AcpSessionManager {
                 signal: combinedSignal,
               },
               eventGate,
+              isStale: () => this.isStaleActorOperation(actorKey),
               onOutputEvent: (event) => {
                 sawTurnOutput = true;
                 if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
@@ -856,6 +885,9 @@ export class AcpSessionManager {
                 });
               },
             });
+            if (this.isStaleActorOperation(actorKey)) {
+              return;
+            }
             if (!turnOutcome.sawTerminalEvent) {
               throw new AcpRuntimeError(
                 "ACP_TURN_FAILED",
@@ -893,6 +925,9 @@ export class AcpSessionManager {
                 ? "ACP turn failed before completion."
                 : "Could not initialize ACP session runtime.",
             });
+            if (this.isStaleActorOperation(actorKey)) {
+              return;
+            }
             retryFreshHandle = await this.prepareFreshHandleRetry({
               attempt,
               cfg: input.cfg,
@@ -934,7 +969,14 @@ export class AcpSessionManager {
             if (activeTurn && this.activeTurnBySession.get(actorKey) === activeTurn) {
               this.activeTurnBySession.delete(actorKey);
             }
-            if (!retryFreshHandle && !skipPostTurnCleanup && runtime && handle && meta) {
+            if (
+              !retryFreshHandle &&
+              !skipPostTurnCleanup &&
+              !this.isStaleActorOperation(actorKey) &&
+              runtime &&
+              handle &&
+              meta
+            ) {
               ({ handle, meta } = await this.reconcileRuntimeSessionIdentifiers({
                 cfg: input.cfg,
                 sessionKey,
@@ -947,6 +989,7 @@ export class AcpSessionManager {
             if (
               !retryFreshHandle &&
               !skipPostTurnCleanup &&
+              !this.isStaleActorOperation(actorKey) &&
               runtime &&
               handle &&
               meta &&
@@ -962,7 +1005,10 @@ export class AcpSessionManager {
                   `acp-manager: ACP oneshot close failed for ${sessionKey}: ${String(error)}`,
                 );
               } finally {
-                this.clearCachedRuntimeState(sessionKey);
+                this.clearCachedRuntimeStateIfHandleMatches({
+                  sessionKey,
+                  handle,
+                });
               }
             }
           }
@@ -971,8 +1017,7 @@ export class AcpSessionManager {
           }
         }
       },
-      input.signal,
-    );
+    });
   }
 
   private resolveTurnTimeoutMs(params: { cfg: OpenClawConfig; meta: SessionAcpMeta }): number {
@@ -1188,47 +1233,51 @@ export class AcpSessionManager {
       return;
     }
 
-    await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: params.cfg,
-        sessionKey,
-      });
-      const resolvedMeta = requireReadySessionMeta(resolution);
-      const { runtime, handle } = await this.ensureRuntimeHandle({
-        cfg: params.cfg,
-        sessionKey,
-        meta: resolvedMeta,
-      });
-      try {
-        await withAcpRuntimeErrorBoundary({
-          run: async () =>
-            await runtime.cancel({
-              handle,
-              reason: params.reason,
-            }),
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP cancel failed before completion.",
-        });
-        await this.setSessionState({
+    await this.withSessionActor({
+      cfg: params.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
-          state: "idle",
-          clearLastError: true,
         });
-      } catch (error) {
-        const acpError = toAcpRuntimeError({
-          error,
-          fallbackCode: "ACP_TURN_FAILED",
-          fallbackMessage: "ACP cancel failed before completion.",
-        });
-        await this.setSessionState({
+        const resolvedMeta = requireReadySessionMeta(resolution);
+        const { runtime, handle } = await this.ensureRuntimeHandle({
           cfg: params.cfg,
           sessionKey,
-          state: "error",
-          lastError: acpError.message,
+          meta: resolvedMeta,
         });
-        throw acpError;
-      }
+        try {
+          await withAcpRuntimeErrorBoundary({
+            run: async () =>
+              await runtime.cancel({
+                handle,
+                reason: params.reason,
+              }),
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP cancel failed before completion.",
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "idle",
+            clearLastError: true,
+          });
+        } catch (error) {
+          const acpError = toAcpRuntimeError({
+            error,
+            fallbackCode: "ACP_TURN_FAILED",
+            fallbackMessage: "ACP cancel failed before completion.",
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "error",
+            lastError: acpError.message,
+          });
+          throw acpError;
+        }
+      },
     });
   }
 
@@ -1241,134 +1290,143 @@ export class AcpSessionManager {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
     await this.evictIdleRuntimeHandles({ cfg: input.cfg });
-    return await this.withSessionActor(sessionKey, async () => {
-      const resolution = this.resolveSession({
-        cfg: input.cfg,
-        sessionKey,
-      });
-      const resolutionError = resolveAcpSessionResolutionError(resolution);
-      if (resolutionError) {
-        if (input.requireAcpSession ?? true) {
-          throw resolutionError;
-        }
-        return {
-          runtimeClosed: false,
-          metaCleared: false,
-        };
-      }
-      const meta = requireReadySessionMeta(resolution);
-      const currentIdentity = resolveSessionIdentityFromMeta(meta);
-      const shouldSkipRuntimeClose =
-        input.discardPersistentState &&
-        currentIdentity != null &&
-        !identityHasStableSessionId(currentIdentity);
-
-      let runtimeClosed = false;
-      let runtimeNotice: string | undefined;
-      if (shouldSkipRuntimeClose) {
-        if (input.discardPersistentState) {
-          const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
-          try {
-            await this.deps
-              .getRuntimeBackend(configuredBackend || undefined)
-              ?.runtime.prepareFreshSession?.({
-                sessionKey,
-              });
-          } catch (error) {
-            logVerbose(
-              `acp close fast-reset: unable to prepare fresh session for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
-            );
+    return await this.withSessionActor({
+      cfg: input.cfg,
+      sessionKey,
+      op: async () => {
+        const resolution = this.resolveSession({
+          cfg: input.cfg,
+          sessionKey,
+        });
+        const resolutionError = resolveAcpSessionResolutionError(resolution);
+        if (resolutionError) {
+          if (input.requireAcpSession ?? true) {
+            throw resolutionError;
           }
+          return {
+            runtimeClosed: false,
+            metaCleared: false,
+          };
         }
-        this.clearCachedRuntimeState(sessionKey);
-      } else {
-        try {
-          const { runtime: ensuredRuntime, handle } = await this.ensureRuntimeHandle({
-            cfg: input.cfg,
-            sessionKey,
-            meta,
-          });
-          await withAcpRuntimeErrorBoundary({
-            run: async () =>
-              await ensuredRuntime.close({
-                handle,
-                reason: input.reason,
-                discardPersistentState: input.discardPersistentState,
-              }),
-            fallbackCode: "ACP_TURN_FAILED",
-            fallbackMessage: "ACP close failed before completion.",
-          });
-          runtimeClosed = true;
-          this.clearCachedRuntimeState(sessionKey);
-        } catch (error) {
-          const acpError = toAcpRuntimeError({
-            error,
-            fallbackCode: "ACP_TURN_FAILED",
-            fallbackMessage: "ACP close failed before completion.",
-          });
-          if (
-            input.allowBackendUnavailable &&
-            (acpError.code === "ACP_BACKEND_MISSING" ||
-              acpError.code === "ACP_BACKEND_UNAVAILABLE" ||
-              (input.discardPersistentState && acpError.code === "ACP_SESSION_INIT_FAILED") ||
-              (input.discardPersistentState &&
-                acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
-              this.isRecoverableAcpxExitError(acpError.message))
-          ) {
-            if (input.discardPersistentState) {
-              const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
-              try {
-                const runtimeBackend = this.deps.getRuntimeBackend(configuredBackend || undefined);
-                if (!runtimeBackend) {
-                  throw acpError;
-                }
-                await runtimeBackend.runtime.prepareFreshSession?.({
+        const meta = requireReadySessionMeta(resolution);
+        const currentIdentity = resolveSessionIdentityFromMeta(meta);
+        const shouldSkipRuntimeClose =
+          input.discardPersistentState &&
+          currentIdentity != null &&
+          !identityHasStableSessionId(currentIdentity);
+
+        let runtimeClosed = false;
+        let runtimeNotice: string | undefined;
+        if (shouldSkipRuntimeClose) {
+          if (input.discardPersistentState) {
+            const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
+            try {
+              await this.deps
+                .getRuntimeBackend(configuredBackend || undefined)
+                ?.runtime.prepareFreshSession?.({
                   sessionKey,
                 });
-              } catch (recoveryError) {
-                logVerbose(
-                  `acp close recovery: unable to prepare fresh session for ${sessionKey}: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
-                );
-              }
+            } catch (error) {
+              logVerbose(
+                `acp close fast-reset: unable to prepare fresh session for ${sessionKey}: ${error instanceof Error ? error.message : String(error)}`,
+              );
             }
-            // Treat unavailable backends as terminal for this cached handle so it
-            // cannot continue counting against maxConcurrentSessions.
-            this.clearCachedRuntimeState(sessionKey);
-            runtimeNotice = acpError.message;
-          } else {
-            throw acpError;
+          }
+          this.clearCachedRuntimeState(sessionKey);
+        } else {
+          try {
+            const { runtime: ensuredRuntime, handle } = await this.ensureRuntimeHandle({
+              cfg: input.cfg,
+              sessionKey,
+              meta,
+            });
+            await withAcpRuntimeErrorBoundary({
+              run: async () =>
+                await ensuredRuntime.close({
+                  handle,
+                  reason: input.reason,
+                  discardPersistentState: input.discardPersistentState,
+                }),
+              fallbackCode: "ACP_TURN_FAILED",
+              fallbackMessage: "ACP close failed before completion.",
+            });
+            runtimeClosed = true;
+            this.clearCachedRuntimeStateIfHandleMatches({
+              sessionKey,
+              handle,
+            });
+          } catch (error) {
+            const acpError = toAcpRuntimeError({
+              error,
+              fallbackCode: "ACP_TURN_FAILED",
+              fallbackMessage: "ACP close failed before completion.",
+            });
+            if (
+              input.allowBackendUnavailable &&
+              (acpError.code === "ACP_BACKEND_MISSING" ||
+                acpError.code === "ACP_BACKEND_UNAVAILABLE" ||
+                (input.discardPersistentState && acpError.code === "ACP_SESSION_INIT_FAILED") ||
+                (input.discardPersistentState &&
+                  acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
+                this.isRecoverableAcpxExitError(acpError.message))
+            ) {
+              if (input.discardPersistentState) {
+                const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
+                try {
+                  const runtimeBackend = this.deps.getRuntimeBackend(
+                    configuredBackend || undefined,
+                  );
+                  if (!runtimeBackend) {
+                    throw acpError;
+                  }
+                  await runtimeBackend.runtime.prepareFreshSession?.({
+                    sessionKey,
+                  });
+                } catch (recoveryError) {
+                  logVerbose(
+                    `acp close recovery: unable to prepare fresh session for ${sessionKey}: ${recoveryError instanceof Error ? recoveryError.message : String(recoveryError)}`,
+                  );
+                }
+              }
+              // Treat unavailable backends as terminal for this cached handle so it
+              // cannot continue counting against maxConcurrentSessions.
+              this.clearCachedRuntimeState(sessionKey);
+              runtimeNotice = acpError.message;
+            } else {
+              throw acpError;
+            }
           }
         }
-      }
 
-      let metaCleared = false;
-      if (input.discardPersistentState && !input.clearMeta) {
-        await this.discardPersistedRuntimeState({
-          cfg: input.cfg,
-          sessionKey,
-        });
-      }
+        let metaCleared = false;
+        if (input.discardPersistentState && !input.clearMeta) {
+          await this.discardPersistedRuntimeState({
+            cfg: input.cfg,
+            sessionKey,
+          });
+        }
 
-      if (input.clearMeta) {
-        await this.writeSessionMeta({
-          cfg: input.cfg,
-          sessionKey,
-          mutate: (_current, entry) => {
-            if (!entry) {
+        if (input.clearMeta) {
+          await this.writeSessionMeta({
+            cfg: input.cfg,
+            sessionKey,
+            mutate: (_current, entry) => {
+              if (!entry) {
+                return null;
+              }
               return null;
-            }
-            return null;
-          },
-          failOnError: true,
-        });
-        metaCleared = true;
-      }
+            },
+            failOnError: true,
+          });
+          metaCleared = true;
+        }
 
-      return {
-        runtimeClosed,
-        runtimeNotice,
-        metaCleared,
-      };
+        return {
+          runtimeClosed,
+          runtimeNotice,
+          metaCleared,
+        };
+      },
     });
   }
 
@@ -1857,32 +1915,54 @@ export class AcpSessionManager {
     }
 
     for (const candidate of candidates) {
-      await this.actorQueue.run(candidate.actorKey, async () => {
-        if (this.activeTurnBySession.has(candidate.actorKey)) {
-          return;
-        }
-        const lastTouchedAt = this.runtimeCache.getLastTouchedAt(candidate.actorKey);
-        if (lastTouchedAt == null || now - lastTouchedAt < idleTtlMs) {
-          return;
-        }
-        const cached = this.runtimeCache.peek(candidate.actorKey);
-        if (!cached) {
-          return;
-        }
-        this.runtimeCache.clear(candidate.actorKey);
-        this.evictedRuntimeCount += 1;
-        this.lastEvictedAt = Date.now();
-        try {
-          await cached.runtime.close({
-            handle: cached.handle,
-            reason: "idle-evicted",
-          });
-        } catch (error) {
+      try {
+        await this.actorQueue.run(
+          candidate.actorKey,
+          async () => {
+            if (this.activeTurnBySession.has(candidate.actorKey)) {
+              return;
+            }
+            const lastTouchedAt = this.runtimeCache.getLastTouchedAt(candidate.actorKey);
+            if (lastTouchedAt == null || now - lastTouchedAt < idleTtlMs) {
+              return;
+            }
+            const cached = this.runtimeCache.peek(candidate.actorKey);
+            if (!cached) {
+              return;
+            }
+            try {
+              await cached.runtime.close({
+                handle: cached.handle,
+                reason: "idle-evicted",
+              });
+              if (
+                this.clearCachedRuntimeStateIfHandleMatches({
+                  sessionKey: cached.handle.sessionKey,
+                  handle: cached.handle,
+                })
+              ) {
+                this.evictedRuntimeCount += 1;
+                this.lastEvictedAt = Date.now();
+              }
+            } catch (error) {
+              logVerbose(
+                `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+              );
+            }
+          },
+          {
+            timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
+          },
+        );
+      } catch (error) {
+        if (error instanceof SessionActorQueueTimeoutError) {
           logVerbose(
-            `acp-manager: idle eviction close failed for ${candidate.state.handle.sessionKey}: ${String(error)}`,
+            `acp-manager: idle runtime eviction timed out for ${candidate.actorKey} after ${error.timeoutMs}ms`,
           );
+          continue;
         }
-      });
+        throw error;
+      }
     }
   }
 
@@ -1890,6 +1970,7 @@ export class AcpSessionManager {
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
     includeStatusConfigOptionKeys?: boolean;
+    signal?: AbortSignal;
   }): Promise<AcpRuntimeCapabilities> {
     return await resolveManagerRuntimeCapabilities(params);
   }
@@ -1981,6 +2062,9 @@ export class AcpSessionManager {
     ) => SessionAcpMeta | null | undefined;
     failOnError?: boolean;
   }): Promise<SessionEntry | null> {
+    if (this.isStaleSessionActorOperation(params.sessionKey)) {
+      return null;
+    }
     try {
       return await this.deps.upsertSessionMeta({
         cfg: params.cfg,
@@ -1998,61 +2082,127 @@ export class AcpSessionManager {
     }
   }
 
-  private async withSessionActor<T>(
-    sessionKey: string,
-    op: () => Promise<T>,
-    signal?: AbortSignal,
-  ): Promise<T> {
-    const actorKey = normalizeActorKey(sessionKey);
-    this.throwIfAborted(signal);
+  private async withSessionActor<T>(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    op: () => Promise<T>;
+    signal?: AbortSignal;
+    timeoutCode?: AcpRuntimeError["code"];
+  }): Promise<T> {
+    const actorKey = normalizeActorKey(params.sessionKey);
+    this.throwIfAborted(params.signal);
 
     let actorStarted = false;
-    const queued = this.actorQueue.run(actorKey, async () => {
-      actorStarted = true;
-      this.throwIfAborted(signal);
-      return await op();
-    });
-    if (!signal) {
-      return await queued;
-    }
+    const fence: SessionActorOperationFence = {
+      actorKey,
+      stale: false,
+    };
+    const queued = this.actorQueue.run(
+      actorKey,
+      () =>
+        this.sessionActorOperationScope.run(fence, async () => {
+          actorStarted = true;
+          this.throwIfAborted(params.signal);
+          return await params.op();
+        }),
+      {
+        timeoutMs: resolveSessionLaneTaskTimeoutMs(params.cfg),
+        onTimeout: () => {
+          fence.stale = true;
+          this.cancelActiveTurnAfterLaneTimeout(actorKey);
+        },
+      },
+    );
 
-    return await new Promise<T>((resolve, reject) => {
-      let settled = false;
-      const cleanup = () => {
-        signal.removeEventListener("abort", onAbort);
-      };
-      const settleValue = (value: T) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        resolve(value);
-      };
-      const settleError = (error: unknown) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        cleanup();
-        reject(error);
-      };
-      const onAbort = () => {
-        if (actorStarted) {
-          return;
-        }
-        try {
-          this.throwIfAborted(signal);
-        } catch (error) {
-          settleError(error);
-        }
-      };
-
-      signal.addEventListener("abort", onAbort, { once: true });
-      queued.then(settleValue, settleError);
-      if (signal.aborted) {
-        onAbort();
+    try {
+      if (!params.signal) {
+        return await queued;
       }
+
+      const signal = params.signal;
+      return await new Promise<T>((resolve, reject) => {
+        let settled = false;
+        const cleanup = () => {
+          signal.removeEventListener("abort", onAbort);
+        };
+        const settleValue = (value: T) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+        const settleError = (error: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          reject(error);
+        };
+        const onAbort = () => {
+          if (actorStarted) {
+            return;
+          }
+          try {
+            this.throwIfAborted(signal);
+          } catch (error) {
+            settleError(error);
+          }
+        };
+
+        signal.addEventListener("abort", onAbort, { once: true });
+        queued.then(settleValue, settleError);
+        if (signal.aborted) {
+          onAbort();
+        }
+      });
+    } catch (error) {
+      if (error instanceof SessionActorQueueTimeoutError) {
+        throw new AcpRuntimeError(
+          params.timeoutCode ?? "ACP_TURN_FAILED",
+          `ACP session lane task timed out after ${error.timeoutMs}ms for ${params.sessionKey}.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+
+  private isStaleActorOperation(actorKey: string): boolean {
+    const fence = this.sessionActorOperationScope.getStore();
+    return fence?.actorKey === actorKey && fence.stale;
+  }
+
+  private isStaleSessionActorOperation(sessionKey: string): boolean {
+    return this.isStaleActorOperation(normalizeActorKey(sessionKey));
+  }
+
+  private cancelActiveTurnAfterLaneTimeout(actorKey: string): void {
+    const activeTurn = this.activeTurnBySession.get(actorKey);
+    if (!activeTurn) {
+      return;
+    }
+    activeTurn.abortController.abort();
+    if (activeTurn.cancelPromise) {
+      return;
+    }
+    try {
+      activeTurn.cancelPromise = activeTurn.runtime.cancel({
+        handle: activeTurn.handle,
+        reason: ACP_SESSION_LANE_TIMEOUT_REASON,
+      });
+    } catch (error) {
+      logVerbose(
+        `acp-manager: lane-timeout cancel failed for ${activeTurn.handle.sessionKey}: ${String(error)}`,
+      );
+      return;
+    }
+    void activeTurn.cancelPromise.catch((error) => {
+      logVerbose(
+        `acp-manager: lane-timeout cancel failed for ${activeTurn.handle.sessionKey}: ${String(error)}`,
+      );
     });
   }
 
@@ -2064,26 +2214,37 @@ export class AcpSessionManager {
   }
 
   private getCachedRuntimeState(sessionKey: string): CachedRuntimeState | null {
+    if (this.isStaleSessionActorOperation(sessionKey)) {
+      return null;
+    }
     return this.runtimeCache.get(normalizeActorKey(sessionKey));
   }
 
   private setCachedRuntimeState(sessionKey: string, state: CachedRuntimeState): void {
+    if (this.isStaleSessionActorOperation(sessionKey)) {
+      return;
+    }
     this.runtimeCache.set(normalizeActorKey(sessionKey), state);
   }
 
   private clearCachedRuntimeState(sessionKey: string): void {
+    if (this.isStaleSessionActorOperation(sessionKey)) {
+      return;
+    }
     this.runtimeCache.clear(normalizeActorKey(sessionKey));
   }
 
   private clearCachedRuntimeStateIfHandleMatches(params: {
     sessionKey: string;
     handle: AcpRuntimeHandle;
-  }): void {
-    const cached = this.getCachedRuntimeState(params.sessionKey);
+  }): boolean {
+    const actorKey = normalizeActorKey(params.sessionKey);
+    const cached = this.runtimeCache.peek(actorKey);
     if (!cached || !this.runtimeHandlesMatch(cached.handle, params.handle)) {
-      return;
+      return false;
     }
-    this.clearCachedRuntimeState(params.sessionKey);
+    this.runtimeCache.clear(actorKey);
+    return true;
   }
 
   private runtimeHandlesMatch(a: AcpRuntimeHandle, b: AcpRuntimeHandle): boolean {

--- a/src/acp/control-plane/manager.identity-reconcile.ts
+++ b/src/acp/control-plane/manager.identity-reconcile.ts
@@ -21,6 +21,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   meta: SessionAcpMeta;
   runtimeStatus?: AcpRuntimeStatus;
   failOnStatusError: boolean;
+  signal?: AbortSignal;
   setCachedHandle: (sessionKey: string, handle: AcpRuntimeHandle) => void;
   writeSessionMeta: (params: {
     cfg: OpenClawConfig;
@@ -43,6 +44,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
         run: async () =>
           await params.runtime.getStatus!({
             handle: params.handle,
+            ...(params.signal ? { signal: params.signal } : {}),
           }),
         fallbackCode: "ACP_TURN_FAILED",
         fallbackMessage: "Could not read ACP runtime status.",

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -76,6 +76,7 @@ export async function resolveManagerRuntimeCapabilities(params: {
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
   includeStatusConfigOptionKeys?: boolean;
+  signal?: AbortSignal;
 }): Promise<AcpRuntimeCapabilities> {
   let reported: AcpRuntimeCapabilities | undefined;
   if (params.runtime.getCapabilities) {
@@ -106,7 +107,10 @@ export async function resolveManagerRuntimeCapabilities(params: {
     params.runtime.getStatus
   ) {
     try {
-      const status = await params.runtime.getStatus({ handle: params.handle });
+      const status = await params.runtime.getStatus({
+        handle: params.handle,
+        ...(params.signal ? { signal: params.signal } : {}),
+      });
       for (const key of extractRuntimeStatusConfigOptionKeys(status)) {
         normalizedKeys.add(key);
       }

--- a/src/acp/control-plane/manager.runtime-controls.ts
+++ b/src/acp/control-plane/manager.runtime-controls.ts
@@ -49,6 +49,7 @@ export async function resolveManagerRuntimeCapabilities(params: {
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
   includeStatusConfigOptionKeys?: boolean;
+  signal?: AbortSignal;
 }): Promise<AcpRuntimeCapabilities> {
   let reported: AcpRuntimeCapabilities | undefined;
   if (params.runtime.getCapabilities) {
@@ -79,7 +80,10 @@ export async function resolveManagerRuntimeCapabilities(params: {
     params.runtime.getStatus
   ) {
     try {
-      const status = await params.runtime.getStatus({ handle: params.handle });
+      const status = await params.runtime.getStatus({
+        handle: params.handle,
+        ...(params.signal ? { signal: params.signal } : {}),
+      });
       for (const key of extractRuntimeStatusConfigOptionKeys(status)) {
         normalizedKeys.add(key);
       }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -844,8 +844,12 @@ describe("AcpSessionManager", () => {
 
       await expect(first).rejects.toMatchObject({
         code: "ACP_SESSION_INIT_FAILED",
-        message: "ACP session lane task timed out after 100ms for agent:codex:acp:session-1.",
+        message: "ACP session operation timed out. Please retry.",
       });
+      const firstEnsureInput = runtimeState.ensureSession.mock.calls[0]?.[0] as
+        | { signal?: AbortSignal }
+        | undefined;
+      expect(firstEnsureInput?.signal?.aborted).toBe(true);
       await expect(second).resolves.toMatchObject({
         handle: expect.objectContaining({
           runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
@@ -872,6 +876,255 @@ describe("AcpSessionManager", () => {
         }),
       );
       expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung status actor task and aborts the runtime status signal", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: `runtime:${sessionKey}` }),
+        };
+      });
+
+      let firstStatusSignal: AbortSignal | undefined;
+      let statusCalls = 0;
+      runtimeState.getStatus.mockImplementation(async (input: { signal?: AbortSignal }) => {
+        statusCalls += 1;
+        if (statusCalls === 1) {
+          firstStatusSignal = input.signal;
+          await new Promise(() => {});
+        }
+        return {
+          summary: "status=alive",
+          details: { status: "alive" },
+        };
+      });
+
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+      const manager = new AcpSessionManager();
+
+      const first = manager.getSessionStatus({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(statusCalls).toBe(1);
+      });
+
+      const second = manager.getSessionStatus({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+      });
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP session operation timed out. Please retry.",
+      });
+      expect(firstStatusSignal?.aborted).toBe(true);
+      await expect(second).resolves.toMatchObject({
+        sessionKey: "agent:codex:acp:session-1",
+        runtimeStatus: expect.objectContaining({
+          summary: "status=alive",
+        }),
+      });
+      expect(runtimeState.getStatus).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung cancel actor task and aborts the runtime cancel signal", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: `runtime:${sessionKey}` }),
+        };
+      });
+
+      let firstCancelSignal: AbortSignal | undefined;
+      let cancelCalls = 0;
+      runtimeState.cancel.mockImplementation(async (input: { signal?: AbortSignal }) => {
+        cancelCalls += 1;
+        if (cancelCalls === 1) {
+          firstCancelSignal = input.signal;
+          await new Promise(() => {});
+        }
+      });
+
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+      const manager = new AcpSessionManager();
+
+      const first = manager.cancelSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        reason: "test-cancel",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(cancelCalls).toBe(1);
+      });
+
+      const second = manager.cancelSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        reason: "test-cancel",
+      });
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP session operation timed out. Please retry.",
+      });
+      expect(firstCancelSignal?.aborted).toBe(true);
+      await expect(second).resolves.toBeUndefined();
+      expect(runtimeState.cancel).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps timed-out close handles fenced until close resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: `runtime:${sessionKey}` }),
+        };
+      });
+      hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          sessionKey: string;
+          mutate: (
+            current: SessionAcpMeta | undefined,
+            entry: { acp?: SessionAcpMeta } | undefined,
+          ) => SessionAcpMeta | null | undefined;
+        };
+        const next = params.mutate(undefined, undefined);
+        return next
+          ? {
+              sessionKey: params.sessionKey,
+              storeSessionKey: params.sessionKey,
+              acp: next,
+            }
+          : null;
+      });
+
+      let ensureCalls = 0;
+      runtimeState.ensureSession.mockImplementation(
+        async (input: { sessionKey: string; mode: "persistent" | "oneshot" }) => {
+          ensureCalls += 1;
+          return {
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime:${ensureCalls}`,
+          };
+        },
+      );
+      const releaseClose = createDeferred();
+      let firstCloseSignal: AbortSignal | undefined;
+      let closeCalls = 0;
+      runtimeState.close.mockImplementation(async (input: { signal?: AbortSignal }) => {
+        closeCalls += 1;
+        if (closeCalls === 1) {
+          firstCloseSignal = input.signal;
+          await releaseClose.promise;
+        }
+      });
+
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 2,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+      const manager = new AcpSessionManager();
+
+      const first = manager.closeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        reason: "test-close",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(closeCalls).toBe(1);
+      });
+
+      const second = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP session operation timed out. Please retry.",
+      });
+      expect(firstCloseSignal?.aborted).toBe(true);
+      await expect(second).resolves.toMatchObject({
+        handle: expect.objectContaining({
+          runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
+        }),
+      });
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(2);
+
+      releaseClose.resolve();
+      await flushMicrotasks(5);
+
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -766,6 +766,117 @@ describe("AcpSessionManager", () => {
     }
   });
 
+  it("times out a hung initializeSession actor task and lets the next queued initialize run", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          sessionKey: string;
+          mutate: (
+            current: SessionAcpMeta | undefined,
+            entry: { acp?: SessionAcpMeta } | undefined,
+          ) => SessionAcpMeta | null | undefined;
+        };
+        const next = params.mutate(undefined, undefined);
+        return next
+          ? {
+              sessionKey: params.sessionKey,
+              storeSessionKey: params.sessionKey,
+              acp: next,
+            }
+          : null;
+      });
+
+      let firstEnsureStarted = false;
+      const releaseFirstEnsure = createDeferred();
+      let ensureCalls = 0;
+      runtimeState.ensureSession.mockImplementation(
+        async (input: { sessionKey: string; agent: string; mode: "persistent" | "oneshot" }) => {
+          ensureCalls += 1;
+          const callNumber = ensureCalls;
+          if (callNumber === 1) {
+            firstEnsureStarted = true;
+            await releaseFirstEnsure.promise;
+          }
+          return {
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime:${callNumber}`,
+          };
+        },
+      );
+
+      const manager = new AcpSessionManager();
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+
+      const first = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(firstEnsureStarted).toBe(true);
+      });
+
+      const second = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: "ACP session lane task timed out after 100ms for agent:codex:acp:session-1.",
+      });
+      await expect(second).resolves.toMatchObject({
+        handle: expect.objectContaining({
+          runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
+        }),
+        meta: expect.objectContaining({
+          state: "idle",
+        }),
+      });
+
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+      expect(manager.getObservabilitySnapshot(cfg).turns.queueDepth).toBe(0);
+      expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalledTimes(1);
+
+      releaseFirstEnsure.resolve();
+      await flushMicrotasks(10);
+
+      expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalledTimes(1);
+      expect(runtimeState.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "init-meta-failed",
+          handle: expect.objectContaining({
+            runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:1",
+          }),
+        }),
+      );
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps timed-out runtime handles counted until timeout cleanup finishes", async () => {
     vi.useFakeTimers();
     try {
@@ -2342,6 +2453,85 @@ describe("AcpSessionManager", () => {
       expectRecordFields(closeInput.handle, {
         sessionKey: "agent:codex:acp:session-a",
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps idle runtime handles counted while eviction close is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-23T00:00:00.000Z"));
+      const runtimeState = createRuntime();
+      const releaseClose = createDeferred();
+      runtimeState.close.mockImplementation(() => releaseClose.promise);
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+      const cfg = {
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+          runtime: {
+            ttlMinutes: 0.01,
+          },
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+
+      vi.advanceTimersByTime(2_000);
+      const second = manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      });
+      void second.catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(second).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: expect.stringContaining("max concurrent sessions"),
+      });
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+      expect(runtimeState.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "idle-evicted",
+          handle: expect.objectContaining({
+            sessionKey: "agent:codex:acp:session-a",
+          }),
+        }),
+      );
+
+      releaseClose.resolve();
+      await flushMicrotasks(5);
+
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -762,6 +762,117 @@ describe("AcpSessionManager", () => {
     }
   });
 
+  it("times out a hung initializeSession actor task and lets the next queued initialize run", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          sessionKey: string;
+          mutate: (
+            current: SessionAcpMeta | undefined,
+            entry: { acp?: SessionAcpMeta } | undefined,
+          ) => SessionAcpMeta | null | undefined;
+        };
+        const next = params.mutate(undefined, undefined);
+        return next
+          ? {
+              sessionKey: params.sessionKey,
+              storeSessionKey: params.sessionKey,
+              acp: next,
+            }
+          : null;
+      });
+
+      let firstEnsureStarted = false;
+      const releaseFirstEnsure = createDeferred();
+      let ensureCalls = 0;
+      runtimeState.ensureSession.mockImplementation(
+        async (input: { sessionKey: string; agent: string; mode: "persistent" | "oneshot" }) => {
+          ensureCalls += 1;
+          const callNumber = ensureCalls;
+          if (callNumber === 1) {
+            firstEnsureStarted = true;
+            await releaseFirstEnsure.promise;
+          }
+          return {
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime:${callNumber}`,
+          };
+        },
+      );
+
+      const manager = new AcpSessionManager();
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+
+      const first = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(firstEnsureStarted).toBe(true);
+      });
+
+      const second = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: "ACP session lane task timed out after 100ms for agent:codex:acp:session-1.",
+      });
+      await expect(second).resolves.toMatchObject({
+        handle: expect.objectContaining({
+          runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
+        }),
+        meta: expect.objectContaining({
+          state: "idle",
+        }),
+      });
+
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+      expect(manager.getObservabilitySnapshot(cfg).turns.queueDepth).toBe(0);
+      expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalledTimes(1);
+
+      releaseFirstEnsure.resolve();
+      await flushMicrotasks(10);
+
+      expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalledTimes(1);
+      expect(runtimeState.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "init-meta-failed",
+          handle: expect.objectContaining({
+            runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:1",
+          }),
+        }),
+      );
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps timed-out runtime handles counted until timeout cleanup finishes", async () => {
     vi.useFakeTimers();
     try {
@@ -1995,6 +2106,85 @@ describe("AcpSessionManager", () => {
       expectRecordFields(closeInput.handle, {
         sessionKey: "agent:codex:acp:session-a",
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps idle runtime handles counted while eviction close is still pending", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-02-23T00:00:00.000Z"));
+      const runtimeState = createRuntime();
+      const releaseClose = createDeferred();
+      runtimeState.close.mockImplementation(() => releaseClose.promise);
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: {
+            ...readySessionMeta(),
+            runtimeSessionName: `runtime:${sessionKey}`,
+          },
+        };
+      });
+      const cfg = {
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 1,
+          runtime: {
+            ttlMinutes: 0.01,
+          },
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-a",
+        text: "first",
+        mode: "prompt",
+        requestId: "r1",
+      });
+
+      vi.advanceTimersByTime(2_000);
+      const second = manager.runTurn({
+        cfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      });
+      void second.catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(second).rejects.toMatchObject({
+        code: "ACP_SESSION_INIT_FAILED",
+        message: expect.stringContaining("max concurrent sessions"),
+      });
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+      expect(runtimeState.close).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "idle-evicted",
+          handle: expect.objectContaining({
+            sessionKey: "agent:codex:acp:session-a",
+          }),
+        }),
+      );
+
+      releaseClose.resolve();
+      await flushMicrotasks(5);
+
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -840,8 +840,12 @@ describe("AcpSessionManager", () => {
 
       await expect(first).rejects.toMatchObject({
         code: "ACP_SESSION_INIT_FAILED",
-        message: "ACP session lane task timed out after 100ms for agent:codex:acp:session-1.",
+        message: "ACP session operation timed out. Please retry.",
       });
+      const firstEnsureInput = runtimeState.ensureSession.mock.calls[0]?.[0] as
+        | { signal?: AbortSignal }
+        | undefined;
+      expect(firstEnsureInput?.signal?.aborted).toBe(true);
       await expect(second).resolves.toMatchObject({
         handle: expect.objectContaining({
           runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
@@ -868,6 +872,255 @@ describe("AcpSessionManager", () => {
         }),
       );
       expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung status actor task and aborts the runtime status signal", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: `runtime:${sessionKey}` }),
+        };
+      });
+
+      let firstStatusSignal: AbortSignal | undefined;
+      let statusCalls = 0;
+      runtimeState.getStatus.mockImplementation(async (input: { signal?: AbortSignal }) => {
+        statusCalls += 1;
+        if (statusCalls === 1) {
+          firstStatusSignal = input.signal;
+          await new Promise(() => {});
+        }
+        return {
+          summary: "status=alive",
+          details: { status: "alive" },
+        };
+      });
+
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+      const manager = new AcpSessionManager();
+
+      const first = manager.getSessionStatus({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(statusCalls).toBe(1);
+      });
+
+      const second = manager.getSessionStatus({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+      });
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP session operation timed out. Please retry.",
+      });
+      expect(firstStatusSignal?.aborted).toBe(true);
+      await expect(second).resolves.toMatchObject({
+        sessionKey: "agent:codex:acp:session-1",
+        runtimeStatus: expect.objectContaining({
+          summary: "status=alive",
+        }),
+      });
+      expect(runtimeState.getStatus).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a hung cancel actor task and aborts the runtime cancel signal", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: `runtime:${sessionKey}` }),
+        };
+      });
+
+      let firstCancelSignal: AbortSignal | undefined;
+      let cancelCalls = 0;
+      runtimeState.cancel.mockImplementation(async (input: { signal?: AbortSignal }) => {
+        cancelCalls += 1;
+        if (cancelCalls === 1) {
+          firstCancelSignal = input.signal;
+          await new Promise(() => {});
+        }
+      });
+
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+      const manager = new AcpSessionManager();
+
+      const first = manager.cancelSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        reason: "test-cancel",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(cancelCalls).toBe(1);
+      });
+
+      const second = manager.cancelSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        reason: "test-cancel",
+      });
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP session operation timed out. Please retry.",
+      });
+      expect(firstCancelSignal?.aborted).toBe(true);
+      await expect(second).resolves.toBeUndefined();
+      expect(runtimeState.cancel).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps timed-out close handles fenced until close resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+        return {
+          sessionKey,
+          storeSessionKey: sessionKey,
+          acp: readySessionMeta({ runtimeSessionName: `runtime:${sessionKey}` }),
+        };
+      });
+      hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          sessionKey: string;
+          mutate: (
+            current: SessionAcpMeta | undefined,
+            entry: { acp?: SessionAcpMeta } | undefined,
+          ) => SessionAcpMeta | null | undefined;
+        };
+        const next = params.mutate(undefined, undefined);
+        return next
+          ? {
+              sessionKey: params.sessionKey,
+              storeSessionKey: params.sessionKey,
+              acp: next,
+            }
+          : null;
+      });
+
+      let ensureCalls = 0;
+      runtimeState.ensureSession.mockImplementation(
+        async (input: { sessionKey: string; mode: "persistent" | "oneshot" }) => {
+          ensureCalls += 1;
+          return {
+            sessionKey: input.sessionKey,
+            backend: "acpx",
+            runtimeSessionName: `${input.sessionKey}:${input.mode}:runtime:${ensureCalls}`,
+          };
+        },
+      );
+      const releaseClose = createDeferred();
+      let firstCloseSignal: AbortSignal | undefined;
+      let closeCalls = 0;
+      runtimeState.close.mockImplementation(async (input: { signal?: AbortSignal }) => {
+        closeCalls += 1;
+        if (closeCalls === 1) {
+          firstCloseSignal = input.signal;
+          await releaseClose.promise;
+        }
+      });
+
+      const cfg = {
+        ...baseCfg,
+        acp: {
+          ...baseCfg.acp,
+          maxConcurrentSessions: 2,
+          sessionLane: {
+            taskTimeoutMs: 100,
+          },
+        },
+      } as OpenClawConfig;
+      const manager = new AcpSessionManager();
+
+      const first = manager.closeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        reason: "test-close",
+      });
+      void first.catch(() => undefined);
+      await vi.waitFor(() => {
+        expect(closeCalls).toBe(1);
+      });
+
+      const second = manager.initializeSession({
+        cfg,
+        sessionKey: "agent:codex:acp:session-1",
+        agent: "codex",
+        mode: "persistent",
+      });
+      await vi.advanceTimersByTimeAsync(150);
+
+      await expect(first).rejects.toMatchObject({
+        code: "ACP_TURN_FAILED",
+        message: "ACP session operation timed out. Please retry.",
+      });
+      expect(firstCloseSignal?.aborted).toBe(true);
+      await expect(second).resolves.toMatchObject({
+        handle: expect.objectContaining({
+          runtimeSessionName: "agent:codex:acp:session-1:persistent:runtime:2",
+        }),
+      });
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(2);
+
+      releaseClose.resolve();
+      await flushMicrotasks(5);
+
+      expect(manager.getObservabilitySnapshot(cfg).runtimeCache.activeSessions).toBe(1);
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -16,6 +16,7 @@ export async function consumeAcpTurnStream(params: {
   runtime: AcpRuntime;
   turn: AcpRuntimeTurnInput;
   eventGate: AcpTurnEventGate;
+  isStale?: () => boolean;
   onEvent?: (event: AcpRuntimeEvent) => Promise<void> | void;
   onOutputEvent?: (
     event: Extract<AcpRuntimeEvent, { type: "text_delta" | "tool_call" }>,
@@ -27,6 +28,9 @@ export async function consumeAcpTurnStream(params: {
 
   for await (const event of params.runtime.runTurn(params.turn)) {
     if (!params.eventGate.open) {
+      continue;
+    }
+    if (params.isStale?.()) {
       continue;
     }
     if (event.type === "done") {
@@ -43,7 +47,7 @@ export async function consumeAcpTurnStream(params: {
     await params.onEvent?.(event);
   }
 
-  if (params.eventGate.open && streamError) {
+  if (params.eventGate.open && !params.isStale?.() && streamError) {
     throw streamError;
   }
 

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -47,6 +47,7 @@ export type AcpInitializeSessionInput = {
   runtimeOptions?: Partial<AcpSessionRuntimeOptions>;
   cwd?: string;
   backendId?: string;
+  signal?: AbortSignal;
 };
 
 export type AcpTurnAttachment = {
@@ -79,6 +80,7 @@ export type AcpCloseSessionInput = {
   clearMeta?: boolean;
   allowBackendUnavailable?: boolean;
   requireAcpSession?: boolean;
+  signal?: AbortSignal;
 };
 
 export type AcpCloseSessionResult = {

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -47,6 +47,7 @@ export type AcpInitializeSessionInput = {
   runtimeOptions?: Partial<AcpSessionRuntimeOptions>;
   cwd?: string;
   backendId?: string;
+  signal?: AbortSignal;
 };
 
 export type AcpTurnAttachment = {
@@ -73,6 +74,7 @@ export type AcpCloseSessionInput = {
   clearMeta?: boolean;
   allowBackendUnavailable?: boolean;
   requireAcpSession?: boolean;
+  signal?: AbortSignal;
 };
 
 export type AcpCloseSessionResult = {

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -13,6 +13,8 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { ACP_ERROR_CODES, AcpRuntimeError } from "../runtime/errors.js";
 import type { AcpSessionResolution } from "./manager.types.js";
 
+export const DEFAULT_ACP_SESSION_LANE_TASK_TIMEOUT_MS = 600_000;
+
 export function resolveAcpAgentFromSessionKey(sessionKey: string, fallback = "main"): string {
   const parsed = parseAgentSessionKey(sessionKey);
   return normalizeAgentId(parsed?.agentId ?? fallback);
@@ -111,6 +113,17 @@ export function resolveRuntimeIdleTtlMs(cfg: OpenClawConfig): number {
     return 0;
   }
   return Math.round(ttlMinutes * 60 * 1000);
+}
+
+export function resolveSessionLaneTaskTimeoutMs(cfg: OpenClawConfig): number {
+  const timeoutMs = cfg.acp?.sessionLane?.taskTimeoutMs;
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return DEFAULT_ACP_SESSION_LANE_TASK_TIMEOUT_MS;
+  }
+  if (timeoutMs <= 0) {
+    return 0;
+  }
+  return Math.round(timeoutMs);
 }
 
 export function hasLegacyAcpIdentityProjection(meta: SessionAcpMeta): boolean {

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -12,8 +12,10 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { ACP_ERROR_CODES, AcpRuntimeError } from "../runtime/errors.js";
 import type { AcpSessionResolution } from "./manager.types.js";
+import { MAX_SESSION_ACTOR_QUEUE_TIMEOUT_MS } from "./session-actor-queue.js";
 
 export const DEFAULT_ACP_SESSION_LANE_TASK_TIMEOUT_MS = 600_000;
+export const MAX_ACP_SESSION_LANE_TASK_TIMEOUT_MS = MAX_SESSION_ACTOR_QUEUE_TIMEOUT_MS;
 
 export function resolveAcpAgentFromSessionKey(sessionKey: string, fallback = "main"): string {
   const parsed = parseAgentSessionKey(sessionKey);
@@ -123,7 +125,7 @@ export function resolveSessionLaneTaskTimeoutMs(cfg: OpenClawConfig): number {
   if (timeoutMs <= 0) {
     return 0;
   }
-  return Math.round(timeoutMs);
+  return Math.min(Math.round(timeoutMs), MAX_ACP_SESSION_LANE_TASK_TIMEOUT_MS);
 }
 
 export function hasLegacyAcpIdentityProjection(meta: SessionAcpMeta): boolean {

--- a/src/acp/control-plane/runtime-cache.ts
+++ b/src/acp/control-plane/runtime-cache.ts
@@ -16,6 +16,11 @@ type RuntimeCacheEntry = {
   lastTouchedAt: number;
 };
 
+export type ClosingRuntimeCacheEntry = RuntimeCacheEntry & {
+  actorKey: string;
+  token: symbol;
+};
+
 export type CachedRuntimeSnapshot = {
   actorKey: string;
   state: CachedRuntimeState;
@@ -25,9 +30,10 @@ export type CachedRuntimeSnapshot = {
 
 export class RuntimeCache {
   private readonly cache = new Map<string, RuntimeCacheEntry>();
+  private readonly closing = new Map<symbol, ClosingRuntimeCacheEntry>();
 
   size(): number {
-    return this.cache.size;
+    return this.cache.size + this.closing.size;
   }
 
   has(actorKey: string): boolean {
@@ -74,6 +80,42 @@ export class RuntimeCache {
 
   clear(actorKey: string): void {
     this.cache.delete(actorKey);
+  }
+
+  markClosing(actorKey: string): ClosingRuntimeCacheEntry | null {
+    const entry = this.cache.get(actorKey);
+    if (!entry) {
+      return null;
+    }
+    this.cache.delete(actorKey);
+    const closing: ClosingRuntimeCacheEntry = {
+      actorKey,
+      token: Symbol(`closing-runtime:${actorKey}`),
+      state: entry.state,
+      lastTouchedAt: entry.lastTouchedAt,
+    };
+    this.closing.set(closing.token, closing);
+    return closing;
+  }
+
+  clearClosing(entry: ClosingRuntimeCacheEntry | null | undefined): boolean {
+    if (!entry) {
+      return false;
+    }
+    return this.closing.delete(entry.token);
+  }
+
+  restoreClosing(entry: ClosingRuntimeCacheEntry | null | undefined): boolean {
+    if (!entry || !this.closing.delete(entry.token)) {
+      return false;
+    }
+    if (!this.cache.has(entry.actorKey)) {
+      this.cache.set(entry.actorKey, {
+        state: entry.state,
+        lastTouchedAt: Date.now(),
+      });
+    }
+    return true;
   }
 
   snapshot(params: { now?: number } = {}): CachedRuntimeSnapshot[] {

--- a/src/acp/control-plane/runtime-cache.ts
+++ b/src/acp/control-plane/runtime-cache.ts
@@ -15,6 +15,11 @@ type RuntimeCacheEntry = {
   lastTouchedAt: number;
 };
 
+export type ClosingRuntimeCacheEntry = RuntimeCacheEntry & {
+  actorKey: string;
+  token: symbol;
+};
+
 export type CachedRuntimeSnapshot = {
   actorKey: string;
   state: CachedRuntimeState;
@@ -24,9 +29,10 @@ export type CachedRuntimeSnapshot = {
 
 export class RuntimeCache {
   private readonly cache = new Map<string, RuntimeCacheEntry>();
+  private readonly closing = new Map<symbol, ClosingRuntimeCacheEntry>();
 
   size(): number {
-    return this.cache.size;
+    return this.cache.size + this.closing.size;
   }
 
   has(actorKey: string): boolean {
@@ -73,6 +79,42 @@ export class RuntimeCache {
 
   clear(actorKey: string): void {
     this.cache.delete(actorKey);
+  }
+
+  markClosing(actorKey: string): ClosingRuntimeCacheEntry | null {
+    const entry = this.cache.get(actorKey);
+    if (!entry) {
+      return null;
+    }
+    this.cache.delete(actorKey);
+    const closing: ClosingRuntimeCacheEntry = {
+      actorKey,
+      token: Symbol(`closing-runtime:${actorKey}`),
+      state: entry.state,
+      lastTouchedAt: entry.lastTouchedAt,
+    };
+    this.closing.set(closing.token, closing);
+    return closing;
+  }
+
+  clearClosing(entry: ClosingRuntimeCacheEntry | null | undefined): boolean {
+    if (!entry) {
+      return false;
+    }
+    return this.closing.delete(entry.token);
+  }
+
+  restoreClosing(entry: ClosingRuntimeCacheEntry | null | undefined): boolean {
+    if (!entry || !this.closing.delete(entry.token)) {
+      return false;
+    }
+    if (!this.cache.has(entry.actorKey)) {
+      this.cache.set(entry.actorKey, {
+        state: entry.state,
+        lastTouchedAt: Date.now(),
+      });
+    }
+    return true;
   }
 
   snapshot(params: { now?: number } = {}): CachedRuntimeSnapshot[] {

--- a/src/acp/control-plane/session-actor-queue.ts
+++ b/src/acp/control-plane/session-actor-queue.ts
@@ -1,5 +1,79 @@
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 
+export class SessionActorQueueTimeoutError extends Error {
+  readonly actorKey: string;
+  readonly timeoutMs: number;
+
+  constructor(actorKey: string, timeoutMs: number) {
+    super(`ACP session lane task timed out after ${timeoutMs}ms for ${actorKey}.`);
+    this.name = "SessionActorQueueTimeoutError";
+    this.actorKey = actorKey;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function clampTimerDelayMs(timeoutMs: number): number {
+  return Math.min(MAX_TIMER_DELAY_MS, Math.max(1, Math.round(timeoutMs)));
+}
+
+function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
+  if (typeof timer !== "object" || timer === null || !("unref" in timer)) {
+    return;
+  }
+  (timer as { unref?: () => void }).unref?.();
+}
+
+function runWithTaskTimeout<T>(params: {
+  actorKey: string;
+  timeoutMs?: number;
+  onTimeout?: () => void;
+  op: () => Promise<T>;
+}): Promise<T> {
+  const timeoutMs = params.timeoutMs;
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return params.op();
+  }
+  const timerDelayMs = clampTimerDelayMs(timeoutMs);
+
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        params.onTimeout?.();
+      } catch {
+        // Timeout delivery must still reject the lane task.
+      }
+      reject(new SessionActorQueueTimeoutError(params.actorKey, timerDelayMs));
+    }, timerDelayMs);
+    unrefTimer(timer);
+
+    void params.op().then(
+      (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 export class SessionActorQueue {
   private readonly queue = new KeyedAsyncQueue();
   private readonly pendingBySession = new Map<string, number>();
@@ -20,19 +94,36 @@ export class SessionActorQueue {
     return this.pendingBySession.get(actorKey) ?? 0;
   }
 
-  async run<T>(actorKey: string, op: () => Promise<T>): Promise<T> {
-    return this.queue.enqueue(actorKey, op, {
-      onEnqueue: () => {
-        this.pendingBySession.set(actorKey, (this.pendingBySession.get(actorKey) ?? 0) + 1);
+  async run<T>(
+    actorKey: string,
+    op: () => Promise<T>,
+    options?: {
+      timeoutMs?: number;
+      onTimeout?: () => void;
+    },
+  ): Promise<T> {
+    return this.queue.enqueue(
+      actorKey,
+      () =>
+        runWithTaskTimeout({
+          actorKey,
+          timeoutMs: options?.timeoutMs,
+          onTimeout: options?.onTimeout,
+          op,
+        }),
+      {
+        onEnqueue: () => {
+          this.pendingBySession.set(actorKey, (this.pendingBySession.get(actorKey) ?? 0) + 1);
+        },
+        onSettle: () => {
+          const pending = (this.pendingBySession.get(actorKey) ?? 1) - 1;
+          if (pending <= 0) {
+            this.pendingBySession.delete(actorKey);
+          } else {
+            this.pendingBySession.set(actorKey, pending);
+          }
+        },
       },
-      onSettle: () => {
-        const pending = (this.pendingBySession.get(actorKey) ?? 1) - 1;
-        if (pending <= 0) {
-          this.pendingBySession.delete(actorKey);
-        } else {
-          this.pendingBySession.set(actorKey, pending);
-        }
-      },
-    });
+    );
   }
 }

--- a/src/acp/control-plane/session-actor-queue.ts
+++ b/src/acp/control-plane/session-actor-queue.ts
@@ -5,17 +5,22 @@ export class SessionActorQueueTimeoutError extends Error {
   readonly timeoutMs: number;
 
   constructor(actorKey: string, timeoutMs: number) {
-    super(`ACP session lane task timed out after ${timeoutMs}ms for ${actorKey}.`);
+    super(`ACP session lane task timed out after ${timeoutMs}ms.`);
     this.name = "SessionActorQueueTimeoutError";
     this.actorKey = actorKey;
     this.timeoutMs = timeoutMs;
   }
 }
 
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
+export const MAX_SESSION_ACTOR_QUEUE_TIMEOUT_MS = 2_147_483_647;
+
+export type SessionActorQueueTaskContext = {
+  signal: AbortSignal;
+  isStale: () => boolean;
+};
 
 function clampTimerDelayMs(timeoutMs: number): number {
-  return Math.min(MAX_TIMER_DELAY_MS, Math.max(1, Math.round(timeoutMs)));
+  return Math.min(MAX_SESSION_ACTOR_QUEUE_TIMEOUT_MS, Math.max(1, Math.round(timeoutMs)));
 }
 
 function unrefTimer(timer: ReturnType<typeof setTimeout>): void {
@@ -29,11 +34,17 @@ function runWithTaskTimeout<T>(params: {
   actorKey: string;
   timeoutMs?: number;
   onTimeout?: () => void;
-  op: () => Promise<T>;
+  op: (context: SessionActorQueueTaskContext) => Promise<T>;
 }): Promise<T> {
   const timeoutMs = params.timeoutMs;
+  const abortController = new AbortController();
+  let stale = false;
+  const context: SessionActorQueueTaskContext = {
+    signal: abortController.signal,
+    isStale: () => stale,
+  };
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return params.op();
+    return params.op(context);
   }
   const timerDelayMs = clampTimerDelayMs(timeoutMs);
 
@@ -44,6 +55,8 @@ function runWithTaskTimeout<T>(params: {
         return;
       }
       settled = true;
+      stale = true;
+      abortController.abort();
       try {
         params.onTimeout?.();
       } catch {
@@ -53,7 +66,7 @@ function runWithTaskTimeout<T>(params: {
     }, timerDelayMs);
     unrefTimer(timer);
 
-    void params.op().then(
+    void params.op(context).then(
       (value) => {
         if (settled) {
           return;
@@ -96,7 +109,7 @@ export class SessionActorQueue {
 
   async run<T>(
     actorKey: string,
-    op: () => Promise<T>,
+    op: (context: SessionActorQueueTaskContext) => Promise<T>,
     options?: {
       timeoutMs?: number;
       onTimeout?: () => void;

--- a/src/acp/runtime/types.ts
+++ b/src/acp/runtime/types.ts
@@ -42,6 +42,12 @@ export type AcpRuntimeEnsureInput = {
   thinking?: string;
   cwd?: string;
   env?: Record<string, string>;
+  /**
+   * Cooperative cancellation signal for session creation. Runtime adapters
+   * should abort pending startup work when possible; the manager also fences
+   * stale post-timeout side effects for adapters that cannot stop immediately.
+   */
+  signal?: AbortSignal;
 };
 
 export type AcpRuntimeTurnAttachment = {
@@ -128,7 +134,11 @@ export interface AcpRuntime {
     handle?: AcpRuntimeHandle;
   }): Promise<AcpRuntimeCapabilities> | AcpRuntimeCapabilities;
 
-  getStatus?(input: { handle: AcpRuntimeHandle; signal?: AbortSignal }): Promise<AcpRuntimeStatus>;
+  getStatus?(input: {
+    handle: AcpRuntimeHandle;
+    /** Cooperative cancellation signal for status probes. */
+    signal?: AbortSignal;
+  }): Promise<AcpRuntimeStatus>;
 
   setMode?(input: { handle: AcpRuntimeHandle; mode: string }): Promise<void>;
 
@@ -142,7 +152,12 @@ export interface AcpRuntime {
    */
   prepareFreshSession?(input: { sessionKey: string }): Promise<void>;
 
-  cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void>;
+  cancel(input: {
+    handle: AcpRuntimeHandle;
+    reason?: string;
+    /** Cooperative cancellation signal for cancel requests. */
+    signal?: AbortSignal;
+  }): Promise<void>;
 
   close(input: {
     handle: AcpRuntimeHandle;
@@ -152,5 +167,7 @@ export interface AcpRuntime {
      * starts fresh instead of reopening the same conversation.
      */
     discardPersistentState?: boolean;
+    /** Cooperative cancellation signal for close requests. */
+    signal?: AbortSignal;
   }): Promise<void>;
 }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -198,7 +198,7 @@ export const FIELD_HELP: Record<string, string> = {
   "acp.sessionLane":
     "ACP per-session lane controls for serial actor tasks such as initialize, status, cancel, and close.",
   "acp.sessionLane.taskTimeoutMs":
-    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw releases it and lets the next queued task run. Default: 600000. Set 0 to disable.",
+    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw aborts cooperative runtime calls, fences stale side effects, and lets the next queued task run. Default: 600000. Set 0 to disable. Maximum: 2147483647.",
   "acp.stream":
     "ACP streaming projection controls for chunk sizing, metadata visibility, and deduped delivery behavior.",
   "acp.stream.coalesceIdleMs":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -195,6 +195,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.",
   "acp.maxConcurrentSessions":
     "Maximum concurrently active ACP sessions across this gateway process.",
+  "acp.sessionLane":
+    "ACP per-session lane controls for serial actor tasks such as initialize, status, cancel, and close.",
+  "acp.sessionLane.taskTimeoutMs":
+    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw releases it and lets the next queued task run. Default: 600000. Set 0 to disable.",
   "acp.stream":
     "ACP streaming projection controls for chunk sizing, metadata visibility, and deduped delivery behavior.",
   "acp.stream.coalesceIdleMs":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -194,7 +194,7 @@ export const FIELD_HELP: Record<string, string> = {
   "acp.sessionLane":
     "ACP per-session lane controls for serial actor tasks such as initialize, status, cancel, and close.",
   "acp.sessionLane.taskTimeoutMs":
-    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw releases it and lets the next queued task run. Default: 600000. Set 0 to disable.",
+    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw aborts cooperative runtime calls, fences stale side effects, and lets the next queued task run. Default: 600000. Set 0 to disable. Maximum: 2147483647.",
   "acp.stream":
     "ACP streaming projection controls for chunk sizing, metadata visibility, and deduped delivery behavior.",
   "acp.stream.coalesceIdleMs":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -191,6 +191,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.",
   "acp.maxConcurrentSessions":
     "Maximum concurrently active ACP sessions across this gateway process.",
+  "acp.sessionLane":
+    "ACP per-session lane controls for serial actor tasks such as initialize, status, cancel, and close.",
+  "acp.sessionLane.taskTimeoutMs":
+    "Maximum milliseconds a single ACP session-lane task may hold the lane before OpenClaw releases it and lets the next queued task run. Default: 600000. Set 0 to disable.",
   "acp.stream":
     "ACP streaming projection controls for chunk sizing, metadata visibility, and deduped delivery behavior.",
   "acp.stream.coalesceIdleMs":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -549,6 +549,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "acp.defaultAgent": "ACP Default Agent",
   "acp.allowedAgents": "ACP Allowed Agents",
   "acp.maxConcurrentSessions": "ACP Max Concurrent Sessions",
+  "acp.sessionLane": "ACP Session Lane",
+  "acp.sessionLane.taskTimeoutMs": "ACP Session Lane Task Timeout (ms)",
   "acp.stream": "ACP Stream",
   "acp.stream.coalesceIdleMs": "ACP Stream Coalesce Idle (ms)",
   "acp.stream.maxChunkChars": "ACP Stream Max Chunk Chars",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -524,6 +524,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "acp.defaultAgent": "ACP Default Agent",
   "acp.allowedAgents": "ACP Allowed Agents",
   "acp.maxConcurrentSessions": "ACP Max Concurrent Sessions",
+  "acp.sessionLane": "ACP Session Lane",
+  "acp.sessionLane.taskTimeoutMs": "ACP Session Lane Task Timeout (ms)",
   "acp.stream": "ACP Stream",
   "acp.stream.coalesceIdleMs": "ACP Stream Coalesce Idle (ms)",
   "acp.stream.maxChunkChars": "ACP Stream Max Chunk Chars",

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -34,6 +34,11 @@ export type AcpRuntimeConfig = {
   installCommand?: string;
 };
 
+export type AcpSessionLaneConfig = {
+  /** Maximum time a single ACP session-lane task may hold the lane before release. */
+  taskTimeoutMs?: number;
+};
+
 export type AcpConfig = {
   /** Global ACP runtime gate. */
   enabled?: boolean;
@@ -43,6 +48,7 @@ export type AcpConfig = {
   defaultAgent?: string;
   allowedAgents?: string[];
   maxConcurrentSessions?: number;
+  sessionLane?: AcpSessionLaneConfig;
   stream?: AcpStreamConfig;
   runtime?: AcpRuntimeConfig;
 };

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -34,6 +34,11 @@ export type AcpRuntimeConfig = {
   installCommand?: string;
 };
 
+export type AcpSessionLaneConfig = {
+  /** Maximum time a single ACP session-lane task may hold the lane before release. */
+  taskTimeoutMs?: number;
+};
+
 export type AcpConfig = {
   /** Global ACP runtime gate. */
   enabled?: boolean;
@@ -45,6 +50,7 @@ export type AcpConfig = {
   defaultAgent?: string;
   allowedAgents?: string[];
   maxConcurrentSessions?: number;
+  sessionLane?: AcpSessionLaneConfig;
   stream?: AcpStreamConfig;
   runtime?: AcpRuntimeConfig;
 };

--- a/src/config/types.acp.ts
+++ b/src/config/types.acp.ts
@@ -35,7 +35,7 @@ export type AcpRuntimeConfig = {
 };
 
 export type AcpSessionLaneConfig = {
-  /** Maximum time a single ACP session-lane task may hold the lane before release. */
+  /** Maximum time a single ACP session-lane task may hold the lane before cooperative abort and stale fencing; 0 disables. */
   taskTimeoutMs?: number;
 };
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -38,6 +38,8 @@ const BrowserSnapshotDefaultsSchema = z
   .strict()
   .optional();
 
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
+
 const NodeHostSchema = z
   .object({
     browserProxy: z
@@ -686,7 +688,7 @@ export const OpenClawSchema = z
         maxConcurrentSessions: z.number().int().positive().optional(),
         sessionLane: z
           .object({
-            taskTimeoutMs: z.number().int().nonnegative().optional(),
+            taskTimeoutMs: z.number().int().nonnegative().max(MAX_NODE_TIMER_DELAY_MS).optional(),
           })
           .strict()
           .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -684,6 +684,12 @@ export const OpenClawSchema = z
         defaultAgent: z.string().optional(),
         allowedAgents: z.array(z.string()).optional(),
         maxConcurrentSessions: z.number().int().positive().optional(),
+        sessionLane: z
+          .object({
+            taskTimeoutMs: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
         stream: z
           .object({
             coalesceIdleMs: z.number().int().nonnegative().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -627,6 +627,12 @@ export const OpenClawSchema = z
         defaultAgent: z.string().optional(),
         allowedAgents: z.array(z.string()).optional(),
         maxConcurrentSessions: z.number().int().positive().optional(),
+        sessionLane: z
+          .object({
+            taskTimeoutMs: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
         stream: z
           .object({
             coalesceIdleMs: z.number().int().nonnegative().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -40,6 +40,8 @@ const BrowserSnapshotDefaultsSchema = z
   .strict()
   .optional();
 
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
+
 const NodeHostSchema = z
   .object({
     browserProxy: z
@@ -629,7 +631,7 @@ export const OpenClawSchema = z
         maxConcurrentSessions: z.number().int().positive().optional(),
         sessionLane: z
           .object({
-            taskTimeoutMs: z.number().int().nonnegative().optional(),
+            taskTimeoutMs: z.number().int().nonnegative().max(MAX_NODE_TIMER_DELAY_MS).optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Problem

When an ACP session gets stuck (e.g. Gemini CLI `session/load` fails), it holds the session lane forever, blocking all subsequent tasks from dequeuing and executing.

## Solution

Add a configurable `taskTimeoutMs` to the session lane. When a task exceeds this timeout:

1. The task is marked as failed with an `AcpRuntimeError`
2. The lane is released
3. The next queued task is automatically dequeued and executed

### Configuration

```yaml
acp:
  sessionLane:
    taskTimeoutMs: 600000  # default: 10 minutes
```

### Changes

- `src/acp/control-plane/manager.ts`: Add timeout timer on task start, clear on completion, auto-release lane on expiry
- `src/config/types.acp.ts`: Add `acp.sessionLane.taskTimeoutMs` config with schema validation
- `src/acp/control-plane/manager.test.ts`: Add regression test covering stuck-task-timeout → next-task-dequeue flow

### Testing

- All 37 existing + new tests pass
- `pnpm check:base-config-schema` passes
- Build failure is pre-existing on upstream/main (missing LINE provider files), unrelated to this change

*Resubmitted after closing #33884 to stay under 10-PR limit. Previously #52628.*

## Real behavior proof

- **Behavior or issue addressed**: ACP session lane work no longer stays wedged forever when a backend session creation call hangs, such as a Gemini CLI ACP session/load call that never returns.
- **Real environment tested**: Local OpenClaw checkout on macOS, commit \`09aded5a34c1\`, Node 22 via pnpm. The command imported the real \`AcpSessionManager\` and \`SessionActorQueue\` from this branch and used in-memory session metadata plus a local ACP runtime adapter shim whose first \`ensureSession\` intentionally never resolves to reproduce the non-returning backend load condition without credentials.
- **Exact steps or command run after this patch**: Ran \`pnpm exec tsx\` with an inline local harness from the repo root. The harness starts two same-session \`initializeSession\` calls against the real ACP control plane, first with \`acp.sessionLane.taskTimeoutMs: 0\` and then with \`acp.sessionLane.taskTimeoutMs: 100\`, while the first adapter \`ensureSession\` ignores abort and completes late.
- **Evidence after fix**: Terminal output from the local run:

\`\`\`text
proof_start=2026-05-10T05:38:32.042Z
surface=real AcpSessionManager + SessionActorQueue with fake ACP adapter simulating Gemini CLI session/load hang
before_timeout_config taskTimeoutMs=0 ensure_calls=1 first=pending second=pending lane_queue_depth=2 active_runtime_sessions=0 metadata_upserts=0
after_timeout_config taskTimeoutMs=100 ensure_calls=2 first=rejected first_error="ACP_SESSION_INIT_FAILED: ACP session operation timed out. Please retry." first_signal_aborted=true signal_events=["ensure#1:signal_aborted"] second=resolved second_runtime=proof-runtime-2 metadata_upserts=1 active_runtime_sessions=1
late_stale_completion metadata_upserts=1 persisted_runtime=proof-runtime-2 close_events=["init-meta-failed:proof-runtime-1-late-stale"] active_runtime_sessions=1
proof_end=2026-05-10T05:38:32.575Z
\`\`\`

- **Observed result after fix**: With timeout disabled, the first hung load keeps the lane occupied and the second same-session init remains pending. With \`taskTimeoutMs=100\`, the hung first init rejects with \`ACP_SESSION_INIT_FAILED\`, the runtime signal is aborted, the next queued init runs and persists \`proof-runtime-2\`, and the late stale completion does not overwrite metadata or clear the active runtime cache.
- **What was not tested**: A live Gemini account-backed CLI process was not used; the local adapter shim reproduced the same non-returning ACP \`ensureSession\`/session-load behavior so the control-plane timeout, abort, queue release, and stale fencing paths were exercised deterministically.
