### PR TITLE
docs(feishu): replace botName with name in config examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs/Feishu: replace `botName` with `name` in the channel config examples so the docs match the strict account schema for per-account display names. (#52753) Thanks @haroldfabla2-hue.
+
 ## 2026.3.23
 
 ### Breaking

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -185,7 +185,7 @@ Edit `~/.openclaw/openclaw.json`:
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "My AI assistant",
+          name: "My AI assistant",
         },
       },
     },
@@ -494,12 +494,12 @@ openclaw pairing list feishu
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "Primary bot",
+          name: "Primary bot",
         },
         backup: {
           appId: "cli_yyy",
           appSecret: "yyy",
-          botName: "Backup bot",
+          name: "Backup bot",
           enabled: false,
         },
       },

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -190,7 +190,7 @@ openclaw channels add
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "My AI assistant",
+          name: "My AI assistant",
         },
       },
     },
@@ -499,12 +499,12 @@ openclaw pairing list feishu
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "Primary bot",
+          name: "Primary bot",
         },
         backup: {
           appId: "cli_yyy",
           appSecret: "yyy",
-          botName: "Backup bot",
+          name: "Backup bot",
           enabled: false,
         },
       },


### PR DESCRIPTION
## Summary
Fixes docs examples that still used `botName` under `channels.feishu.accounts.<id>`.

The current Feishu account schema is strict and accepts `name` (display name), not `botName`.

## Changes
- `docs/channels/feishu.md`
  - Updated single-account example to use `name`
  - Updated multi-account examples to use `name`
- `docs/zh-CN/channels/feishu.md`
  - Updated corresponding examples to use `name`

## Why
Issue report: docs mismatch with runtime schema can cause config validation errors in real setups.

Closes #52718
