### PR TITLE
docs: fix Feishu config examples - use 'name' instead of 'botName'

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -185,7 +185,7 @@ Edit `~/.openclaw/openclaw.json`:
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "My AI assistant",
+          name: "My AI assistant",
         },
       },
     },
@@ -494,12 +494,12 @@ openclaw pairing list feishu
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "Primary bot",
+          name: "Primary bot",
         },
         backup: {
           appId: "cli_yyy",
           appSecret: "yyy",
-          botName: "Backup bot",
+          name: "Backup bot",
           enabled: false,
         },
       },

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -190,7 +190,7 @@ openclaw channels add
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "My AI assistant",
+          name: "My AI assistant",
         },
       },
     },
@@ -499,12 +499,12 @@ openclaw pairing list feishu
         main: {
           appId: "cli_xxx",
           appSecret: "xxx",
-          botName: "Primary bot",
+          name: "Primary bot",
         },
         backup: {
           appId: "cli_yyy",
           appSecret: "yyy",
-          botName: "Backup bot",
+          name: "Backup bot",
           enabled: false,
         },
       },


### PR DESCRIPTION
## Summary

Fixes #52718

The Feishu channel documentation was using the deprecated \otName\ field in config examples. This PR updates both English and Chinese docs to use the current \
ame\ field.

## Changes

- \docs/channels/feishu.md\: Updated 3 config examples
- \docs/zh-CN/channels/feishu.md\: Updated 3 config examples

## Testing

Documentation only change - no runtime impact.