### PR TITLE
feat(slack): exec approval Block Kit surface

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -699,29 +699,5 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         });
       },
     },
-    sendPayload: async ({ to, payload, accountId, deps, replyToId, threadId, cfg }) => {
-      const slackData = payload.channelData?.slack;
-      const rawBlocks =
-        slackData && typeof slackData === "object" && !Array.isArray(slackData)
-          ? (slackData as { blocks?: unknown }).blocks
-          : undefined;
-      const blocks = rawBlocks ? parseSlackBlocksInput(rawBlocks) : undefined;
-      const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
-        cfg,
-        accountId: accountId ?? undefined,
-        deps,
-        replyToId,
-        threadId,
-      });
-      const result = await send(to, payload.text ?? "", {
-        cfg,
-        ...(blocks && blocks.length > 0 ? { blocks } : {}),
-        mediaUrl: payload.mediaUrl,
-        threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
-        accountId: accountId ?? undefined,
-        ...(tokenOverride ? { token: tokenOverride } : {}),
-      });
-      return { channel: "slack" as const, ...result };
-    },
   },
 });

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -44,6 +44,12 @@ import {
   listSlackDirectoryGroupsFromConfig,
   listSlackDirectoryPeersFromConfig,
 } from "./directory-config.js";
+import {
+  buildSlackExecApprovalPendingBlocks,
+  buildSlackExecApprovalPendingFallbackText,
+  buildSlackExecApprovalResolvedBlocks,
+  buildSlackExecApprovalResolvedFallbackText,
+} from "./exec-approval-blocks.js";
 import { resolveSlackGroupRequireMention, resolveSlackGroupToolPolicy } from "./group-policy.js";
 import { isSlackInteractiveRepliesEnabled } from "./interactive-replies.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
@@ -550,6 +556,24 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
         });
       },
     },
+    execApprovals: {
+      getInitiatingSurfaceState: ({ cfg }) => {
+        const hasTarget = cfg.approvals?.exec?.targets?.some(
+          (t: { channel?: string }) => t.channel === "slack",
+        );
+        return hasTarget ? { kind: "enabled" } : { kind: "disabled" };
+      },
+      buildPendingPayload: ({ request, nowMs }) => {
+        const blocks = buildSlackExecApprovalPendingBlocks(request, nowMs);
+        const text = buildSlackExecApprovalPendingFallbackText(request, nowMs);
+        return { text, channelData: { slack: { blocks } } };
+      },
+      buildResolvedPayload: ({ resolved }) => {
+        const blocks = buildSlackExecApprovalResolvedBlocks(resolved);
+        const text = buildSlackExecApprovalResolvedFallbackText(resolved);
+        return { text, channelData: { slack: { blocks } } };
+      },
+    },
   },
   pairing: {
     text: {
@@ -674,6 +698,30 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
           ...(tokenOverride ? { token: tokenOverride } : {}),
         });
       },
+    },
+    sendPayload: async ({ to, payload, accountId, deps, replyToId, threadId, cfg }) => {
+      const slackData = payload.channelData?.slack;
+      const rawBlocks =
+        slackData && typeof slackData === "object" && !Array.isArray(slackData)
+          ? (slackData as { blocks?: unknown }).blocks
+          : undefined;
+      const blocks = rawBlocks ? parseSlackBlocksInput(rawBlocks) : undefined;
+      const { send, threadTsValue, tokenOverride } = resolveSlackSendContext({
+        cfg,
+        accountId: accountId ?? undefined,
+        deps,
+        replyToId,
+        threadId,
+      });
+      const result = await send(to, payload.text ?? "", {
+        cfg,
+        ...(blocks && blocks.length > 0 ? { blocks } : {}),
+        mediaUrl: payload.mediaUrl,
+        threadTs: threadTsValue != null ? String(threadTsValue) : undefined,
+        accountId: accountId ?? undefined,
+        ...(tokenOverride ? { token: tokenOverride } : {}),
+      });
+      return { channel: "slack" as const, ...result };
     },
   },
 });

--- a/extensions/slack/src/exec-approval-blocks.ts
+++ b/extensions/slack/src/exec-approval-blocks.ts
@@ -1,0 +1,181 @@
+import {
+  resolveExecApprovalCommandDisplay,
+  type ExecApprovalRequest,
+  type ExecApprovalResolved,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
+import { truncateSlackText } from "./truncate.js";
+
+const SLACK_SECTION_TEXT_MAX = 3000;
+// Reserve 6 chars for the triple-backtick wrapper (``` ... ```)
+const SLACK_CODE_BLOCK_CONTENT_MAX = SLACK_SECTION_TEXT_MAX - 6;
+
+const SLACK_EXEC_APPROVE_ACTION_ID = "openclaw:exec_approve";
+const SLACK_EXEC_APPROVE_ALWAYS_ACTION_ID = "openclaw:exec_approve_always";
+const SLACK_EXEC_APPROVE_DENY_ACTION_ID = "openclaw:exec_approve_deny";
+
+export const SLACK_EXEC_APPROVE_ACTION_PREFIX = "openclaw:exec_approve";
+
+/** Escape text for use inside a mrkdwn triple-backtick code block. */
+function escapeCodeBlock(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("`", "\u02CB");
+}
+
+function decisionLabel(decision: string): string {
+  switch (decision) {
+    case "allow-once":
+      return "Allowed (once)";
+    case "allow-always":
+      return "Always allowed";
+    case "deny":
+      return "Denied";
+    default:
+      return escapeSlackMrkdwn(decision);
+  }
+}
+
+export function buildSlackExecApprovalPendingBlocks(
+  request: ExecApprovalRequest,
+  nowMs: number,
+): unknown[] {
+  const commandDisplay = resolveExecApprovalCommandDisplay(request.request).commandText;
+  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
+
+  const metaLines: string[] = [`*ID:* \`${escapeSlackMrkdwn(request.id)}\``];
+  if (request.request.cwd) {
+    metaLines.push(`*CWD:* ${escapeSlackMrkdwn(request.request.cwd)}`);
+  }
+  if (request.request.host) {
+    metaLines.push(`*Host:* ${escapeSlackMrkdwn(request.request.host)}`);
+  }
+  if (request.request.agentId) {
+    metaLines.push(`*Agent:* ${escapeSlackMrkdwn(request.request.agentId)}`);
+  }
+  if (request.request.security) {
+    metaLines.push(`*Security:* ${escapeSlackMrkdwn(request.request.security)}`);
+  }
+  if (request.request.ask) {
+    metaLines.push(`*Ask:* ${escapeSlackMrkdwn(request.request.ask)}`);
+  }
+  metaLines.push(`*Expires in:* ${expiresIn}s`);
+
+  return [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Exec approval required", emoji: true },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `\`\`\`${truncateSlackText(escapeCodeBlock(commandDisplay), SLACK_CODE_BLOCK_CONTENT_MAX)}\`\`\``,
+      },
+    },
+    {
+      type: "context",
+      elements: [{ type: "mrkdwn", text: metaLines.join("  |  ") }],
+    },
+    {
+      type: "actions",
+      block_id: `exec_approval_${request.id}`,
+      elements: [
+        {
+          type: "button",
+          action_id: SLACK_EXEC_APPROVE_ACTION_ID,
+          text: { type: "plain_text", text: "Allow Once", emoji: true },
+          value: `${request.id}:allow-once`,
+          style: "primary",
+        },
+        {
+          type: "button",
+          action_id: SLACK_EXEC_APPROVE_ALWAYS_ACTION_ID,
+          text: { type: "plain_text", text: "Always Allow", emoji: true },
+          value: `${request.id}:allow-always`,
+        },
+        {
+          type: "button",
+          action_id: SLACK_EXEC_APPROVE_DENY_ACTION_ID,
+          text: { type: "plain_text", text: "Deny", emoji: true },
+          value: `${request.id}:deny`,
+          style: "danger",
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Extract the command text from a pending approval message's blocks.
+ * The pending message renders the command in a section block as ``` ```commandText``` ```.
+ */
+export function extractCommandFromPendingBlocks(blocks: unknown[] | undefined): string | undefined {
+  if (!Array.isArray(blocks)) {
+    return undefined;
+  }
+  for (const block of blocks) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typed = block as { type?: string; text?: { type?: string; text?: string } };
+    if (typed.type === "section" && typed.text?.type === "mrkdwn") {
+      const match = typed.text.text?.match(/^```([\s\S]*)```$/);
+      if (match) {
+        return match[1];
+      }
+    }
+  }
+  return undefined;
+}
+
+export function buildSlackExecApprovalResolvedBlocks(
+  resolved: ExecApprovalResolved & { commandText?: string },
+): unknown[] {
+  const commandDisplay =
+    resolved.commandText ??
+    (resolved.request
+      ? resolveExecApprovalCommandDisplay(resolved.request).commandText
+      : "unknown");
+  const decision = decisionLabel(resolved.decision);
+  const byText = resolved.resolvedBy ? ` by ${escapeSlackMrkdwn(resolved.resolvedBy)}` : "";
+  return [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "Exec approval resolved", emoji: true },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `\`\`\`${truncateSlackText(escapeCodeBlock(commandDisplay), SLACK_CODE_BLOCK_CONTENT_MAX)}\`\`\``,
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: `*${decision}*${byText}. ID: \`${escapeSlackMrkdwn(resolved.id)}\``,
+        },
+      ],
+    },
+  ];
+}
+
+export function buildSlackExecApprovalPendingFallbackText(
+  request: ExecApprovalRequest,
+  nowMs: number,
+): string {
+  const commandDisplay = resolveExecApprovalCommandDisplay(request.request).commandText;
+  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
+  return `Exec approval required: \`${escapeSlackMrkdwn(commandDisplay)}\` (expires in ${expiresIn}s) [${escapeSlackMrkdwn(request.id)}]`;
+}
+
+export function buildSlackExecApprovalResolvedFallbackText(resolved: ExecApprovalResolved): string {
+  const decision = decisionLabel(resolved.decision);
+  const byText = resolved.resolvedBy ? ` by ${escapeSlackMrkdwn(resolved.resolvedBy)}` : "";
+  return `Exec approval resolved: ${decision}${byText} [${escapeSlackMrkdwn(resolved.id)}]`;
+}

--- a/extensions/slack/src/exec-approval-blocks.ts
+++ b/extensions/slack/src/exec-approval-blocks.ts
@@ -25,6 +25,15 @@ function escapeCodeBlock(text: string): string {
     .replaceAll("`", "\u02CB");
 }
 
+/** Reverse escapeCodeBlock so extracted text can be re-escaped without doubling. */
+function unescapeCodeBlock(text: string): string {
+  return text
+    .replaceAll("\u02CB", "`")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&");
+}
+
 function decisionLabel(decision: string): string {
   switch (decision) {
     case "allow-once":
@@ -60,6 +69,9 @@ export function buildSlackExecApprovalPendingBlocks(
   }
   if (request.request.ask) {
     metaLines.push(`*Ask:* ${escapeSlackMrkdwn(request.request.ask)}`);
+  }
+  if (request.request.envKeys?.length) {
+    metaLines.push(`*Env:* ${escapeSlackMrkdwn(request.request.envKeys.join(", "))}`);
   }
   metaLines.push(`*Expires in:* ${expiresIn}s`);
 
@@ -124,7 +136,7 @@ export function extractCommandFromPendingBlocks(blocks: unknown[] | undefined): 
     if (typed.type === "section" && typed.text?.type === "mrkdwn") {
       const match = typed.text.text?.match(/^```([\s\S]*)```$/);
       if (match) {
-        return match[1];
+        return unescapeCodeBlock(match[1]);
       }
     }
   }

--- a/extensions/slack/src/exec-approval-blocks.ts
+++ b/extensions/slack/src/exec-approval-blocks.ts
@@ -89,7 +89,12 @@ export function buildSlackExecApprovalPendingBlocks(
     },
     {
       type: "context",
-      elements: [{ type: "mrkdwn", text: metaLines.join("  |  ") }],
+      elements: [
+        {
+          type: "mrkdwn",
+          text: truncateSlackText(metaLines.join("  |  "), SLACK_SECTION_TEXT_MAX),
+        },
+      ],
     },
     {
       type: "actions",
@@ -177,13 +182,18 @@ export function buildSlackExecApprovalResolvedBlocks(
   ];
 }
 
+const SLACK_FALLBACK_TEXT_MAX = 3000;
+
 export function buildSlackExecApprovalPendingFallbackText(
   request: ExecApprovalRequest,
   nowMs: number,
 ): string {
   const commandDisplay = resolveExecApprovalCommandDisplay(request.request).commandText;
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
-  return `Exec approval required: \`${escapeSlackMrkdwn(commandDisplay)}\` (expires in ${expiresIn}s) [${escapeSlackMrkdwn(request.id)}]`;
+  return truncateSlackText(
+    `Exec approval required: \`${escapeSlackMrkdwn(commandDisplay)}\` (expires in ${expiresIn}s) [${escapeSlackMrkdwn(request.id)}]`,
+    SLACK_FALLBACK_TEXT_MAX,
+  );
 }
 
 export function buildSlackExecApprovalResolvedFallbackText(resolved: ExecApprovalResolved): string {

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -5,9 +5,15 @@ import {
   parsePluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { callGatewayLeastPrivilege } from "openclaw/plugin-sdk/gateway-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
 import { dispatchPluginInteractiveHandler } from "openclaw/plugin-sdk/plugin-runtime";
 import { SLACK_REPLY_BUTTON_ACTION_ID, SLACK_REPLY_SELECT_ACTION_ID } from "../../blocks-render.js";
+import {
+  SLACK_EXEC_APPROVE_ACTION_PREFIX,
+  buildSlackExecApprovalResolvedBlocks,
+  extractCommandFromPendingBlocks,
+} from "../../exec-approval-blocks.js";
 import { authorizeSlackSystemEventSender } from "../auth.js";
 import type { SlackMonitorContext } from "../context.js";
 import { escapeSlackMrkdwn } from "../mrkdwn.js";
@@ -712,6 +718,64 @@ async function updateSlackLegacyBlockAction(params: {
   }
 }
 
+async function handleSlackExecApprovalAction(params: {
+  ctx: SlackMonitorContext;
+  parsed: ParsedSlackBlockAction;
+}): Promise<boolean> {
+  const { actionId } = params.parsed;
+  if (!actionId.startsWith(SLACK_EXEC_APPROVE_ACTION_PREFIX)) {
+    return false;
+  }
+  const buttonValue = params.parsed.actionSummary.value ?? "";
+  const separatorIndex = buttonValue.lastIndexOf(":");
+  if (separatorIndex <= 0) {
+    return false;
+  }
+  const approvalId = buttonValue.slice(0, separatorIndex);
+  const decision = buttonValue.slice(separatorIndex + 1);
+  if (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny") {
+    return false;
+  }
+  let gatewayOk = false;
+  try {
+    await callGatewayLeastPrivilege({
+      method: "exec.approval.resolve",
+      params: { id: approvalId, decision },
+    });
+    gatewayOk = true;
+  } catch (err) {
+    params.ctx.runtime.log?.(
+      `slack:exec-approval resolve failed for ${approvalId}: ${String(err)}`,
+    );
+  }
+  if (gatewayOk) {
+    try {
+      // Extract the original command text from the pending message's code block
+      // so the resolved card echoes it back instead of showing "unknown".
+      const originalCommand = extractCommandFromPendingBlocks(
+        params.parsed.typedBody.message?.blocks,
+      );
+      const resolvedBlocks = buildSlackExecApprovalResolvedBlocks({
+        id: approvalId,
+        decision,
+        resolvedBy: params.parsed.userId ?? undefined,
+        ts: Date.now(),
+        commandText: originalCommand,
+      });
+      await updateSlackInteractionMessage({
+        ctx: params.ctx,
+        channelId: params.parsed.channelId,
+        messageTs: params.parsed.messageTs,
+        text: `Exec approval resolved: ${decision}`,
+        blocks: resolvedBlocks as (Block | KnownBlock)[],
+      });
+    } catch {
+      // Best-effort message update
+    }
+  }
+  return true;
+}
+
 async function handleSlackBlockAction(params: {
   ctx: SlackMonitorContext;
   args: SlackActionMiddlewareArgs;
@@ -737,6 +801,9 @@ async function handleSlackBlockAction(params: {
     respond,
   });
   if (!auth.allowed) {
+    return;
+  }
+  if (await handleSlackExecApprovalAction({ ctx: params.ctx, parsed })) {
     return;
   }
   const pluginInteractionData = buildSlackPluginInteractionData({

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -3,4 +3,5 @@
 export * from "../gateway/channel-status-patches.js";
 export { GatewayClient } from "../gateway/client.js";
 export { createOperatorApprovalsGatewayClient } from "../gateway/operator-approvals-client.js";
+export { callGatewayLeastPrivilege } from "../gateway/call.js";
 export type { EventFrame } from "../gateway/protocol/index.js";


### PR DESCRIPTION
## Summary

- Implement `ChannelExecApprovalAdapter` for Slack using the plugin architecture
- Approval requests render as Block Kit messages with Allow Once / Always Allow / Deny buttons
- Button clicks resolve approvals via the gateway and update the message in-place
- All user-controlled fields are escaped with `escapeSlackMrkdwn` / `escapeCodeBlock` to prevent mrkdwn injection

Closes #48529

## Changes

| File | Description |
|------|-------------|
| `extensions/slack/src/exec-approval-blocks.ts` | Block Kit block generation with mrkdwn sanitization |
| `extensions/slack/src/channel.ts` | `execApprovals` adapter + `sendPayload` for Block Kit |
| `extensions/slack/src/monitor/events/interactions.block-actions.ts` | Button click handler → gateway resolve + in-place update |
| `src/plugin-sdk/gateway-runtime.ts` | Re-export `callGatewayLeastPrivilege` for extensions |

## Known Limitations

- Approval timeout (expiry) sends a new message instead of updating the original in-place, because the forwarder does not track sent message references. Button-click resolution does update in-place. This can be addressed in a follow-up PR.

## Test plan

- [x] `pnpm build` passes
- [x] Boundary check (`check-channel-agnostic-boundaries.mjs`) passes
- [x] Runtime tested with `openclaw doctor`
- [x] Verified Block Kit rendering in Slack (buttons, approval flow)
- [x] Verified mrkdwn escape: backtick breakout, `*bold*` injection, `<url|text>` link injection all neutralized

🤖 Generated with [Claude Code](https://claude.com/claude-code)