### PR TITLE
UI: localize Control UI shell labels

### DIFF
--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:20.795Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:54.549Z",
   "locale": "de",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:21.116Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:55.114Z",
   "locale": "es",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:22.097Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:56.938Z",
   "locale": "fr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:23.072Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:58.708Z",
   "locale": "id",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:21.442Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:55.711Z",
   "locale": "ja-JP",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:21.771Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:56.280Z",
   "locale": "ko",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:23.392Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:59.310Z",
   "locale": "pl",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:20.461Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:53.963Z",
   "locale": "pt-BR",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T08:12:09.551Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:59.897Z",
   "locale": "th",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:22.430Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:57.554Z",
   "locale": "tr",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:22.755Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:58.146Z",
   "locale": "uk",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:19.772Z",
+  "generatedAt": "2026-04-27T12:03:52.815Z",
   "locale": "zh-CN",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 774,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,27 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-04-27T07:37:20.133Z",
+  "fallbackKeys": [
+    "chat.settings",
+    "shell.colorMode",
+    "shell.colorModeCurrent",
+    "shell.dismissUpdateBanner",
+    "shell.docsNewTab",
+    "shell.gatewayStatus",
+    "shell.openCommandPalette",
+    "shell.runningVersion",
+    "shell.searchJump",
+    "shell.updateAvailable",
+    "shell.updateNow",
+    "shell.updating",
+    "theme.modes.dark",
+    "theme.modes.light",
+    "theme.modes.system"
+  ],
+  "generatedAt": "2026-04-27T12:03:53.396Z",
   "locale": "zh-TW",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "802e1bbb6a0e64584ec06cab4c61b65808c23669206a3a216646cf1a558ba657",
-  "totalKeys": 758,
-  "translatedKeys": 758,
+  "sourceHash": "5d4baf870c6da3aca14ec740cf921ef91de8412eb233434b3d509461be71a7ed",
+  "totalKeys": 774,
+  "translatedKeys": 759,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -63,6 +63,7 @@ export const de: TranslationMap = {
     relink: "Erneut verknüpfen",
     waitForScan: "Auf Scan warten",
     logout: "Abmelden",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -703,6 +704,7 @@ export const de: TranslationMap = {
     showCronSessions: "Cron-Sitzungen anzeigen",
     showCronSessionsHidden: "Cron-Sitzungen anzeigen ({count} ausgeblendet)",
     onboardingDisabled: "Während der Einrichtung deaktiviert",
+    settings: "Chat settings",
   },
   languages: {
     en: "Englisch",
@@ -938,6 +940,26 @@ export const de: TranslationMap = {
       systemEventTextRequired: "Text für Systemereignis erforderlich.",
       agentMessageRequiredShort: "Agentennachricht erforderlich.",
       nameRequiredShort: "Name erforderlich.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -62,6 +62,7 @@ export const en: TranslationMap = {
     relink: "Relink",
     waitForScan: "Wait for scan",
     logout: "Logout",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -691,6 +692,7 @@ export const en: TranslationMap = {
     showCronSessions: "Show cron sessions",
     showCronSessionsHidden: "Show cron sessions ({count} hidden)",
     onboardingDisabled: "Disabled during setup",
+    settings: "Chat settings",
   },
   languages: {
     en: "English",
@@ -917,6 +919,26 @@ export const en: TranslationMap = {
       systemEventTextRequired: "System event text required.",
       agentMessageRequiredShort: "Agent message required.",
       nameRequiredShort: "Name required.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -63,6 +63,7 @@ export const es: TranslationMap = {
     relink: "Volver a vincular",
     waitForScan: "Esperar escaneo",
     logout: "Cerrar sesión",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -702,6 +703,7 @@ export const es: TranslationMap = {
     showCronSessions: "Mostrar sesiones de cron",
     showCronSessionsHidden: "Mostrar sesiones de cron ({count} ocultas)",
     onboardingDisabled: "Deshabilitado durante el inicio guiado",
+    settings: "Chat settings",
   },
   languages: {
     en: "Inglés (English)",
@@ -935,6 +937,26 @@ export const es: TranslationMap = {
       systemEventTextRequired: "Texto de evento del sistema requerido.",
       agentMessageRequiredShort: "Mensaje del agente requerido.",
       nameRequiredShort: "Nombre requerido.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -63,6 +63,7 @@ export const fr: TranslationMap = {
     relink: "Relier à nouveau",
     waitForScan: "Attendre le scan",
     logout: "Se déconnecter",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -704,6 +705,7 @@ export const fr: TranslationMap = {
     showCronSessions: "Afficher les sessions cron",
     showCronSessionsHidden: "Afficher les sessions cron ({count} masquées)",
     onboardingDisabled: "Désactivé pendant la configuration",
+    settings: "Chat settings",
   },
   languages: {
     en: "Anglais",
@@ -935,6 +937,26 @@ export const fr: TranslationMap = {
       systemEventTextRequired: "Texte de l’événement système obligatoire.",
       agentMessageRequiredShort: "Message de l’agent obligatoire.",
       nameRequiredShort: "Nom obligatoire.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -63,6 +63,7 @@ export const id: TranslationMap = {
     relink: "Tautkan ulang",
     waitForScan: "Tunggu pemindaian",
     logout: "Keluar",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -697,6 +698,7 @@ export const id: TranslationMap = {
     showCronSessions: "Tampilkan sesi cron",
     showCronSessionsHidden: "Tampilkan sesi cron ({count} disembunyikan)",
     onboardingDisabled: "Dinonaktifkan selama penyiapan",
+    settings: "Chat settings",
   },
   languages: {
     en: "Inggris",
@@ -923,6 +925,26 @@ export const id: TranslationMap = {
       systemEventTextRequired: "Teks peristiwa sistem wajib diisi.",
       agentMessageRequiredShort: "Pesan agen wajib diisi.",
       nameRequiredShort: "Nama wajib diisi.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -63,6 +63,7 @@ export const ja_JP: TranslationMap = {
     relink: "再リンク",
     waitForScan: "スキャンを待機",
     logout: "ログアウト",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -700,6 +701,7 @@ export const ja_JP: TranslationMap = {
     showCronSessions: "Cron セッションを表示",
     showCronSessionsHidden: "Cron セッションを表示（{count} 件を非表示中）",
     onboardingDisabled: "セットアップ中は無効",
+    settings: "Chat settings",
   },
   languages: {
     en: "英語",
@@ -929,6 +931,26 @@ export const ja_JP: TranslationMap = {
       systemEventTextRequired: "システムイベントテキストは必須です。",
       agentMessageRequiredShort: "エージェントメッセージは必須です。",
       nameRequiredShort: "名前は必須です。",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -63,6 +63,7 @@ export const ko: TranslationMap = {
     relink: "다시 연결",
     waitForScan: "스캔 대기",
     logout: "로그아웃",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -693,6 +694,7 @@ export const ko: TranslationMap = {
     showCronSessions: "Cron 세션 표시",
     showCronSessionsHidden: "Cron 세션 표시({count}개 숨김)",
     onboardingDisabled: "설정 중에는 비활성화됨",
+    settings: "Chat settings",
   },
   languages: {
     en: "영어",
@@ -916,6 +918,26 @@ export const ko: TranslationMap = {
       systemEventTextRequired: "시스템 이벤트 텍스트가 필요합니다.",
       agentMessageRequiredShort: "에이전트 메시지가 필요합니다.",
       nameRequiredShort: "이름이 필요합니다.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -63,6 +63,7 @@ export const pl: TranslationMap = {
     relink: "Połącz ponownie",
     waitForScan: "Czekaj na zeskanowanie",
     logout: "Wyloguj",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -702,6 +703,7 @@ export const pl: TranslationMap = {
     showCronSessions: "Pokaż sesje Cron",
     showCronSessionsHidden: "Pokaż sesje Cron ({count} ukrytych)",
     onboardingDisabled: "Wyłączone podczas konfiguracji",
+    settings: "Chat settings",
   },
   languages: {
     en: "Angielski (English)",
@@ -935,6 +937,26 @@ export const pl: TranslationMap = {
       systemEventTextRequired: "Tekst zdarzenia systemowego jest wymagany.",
       agentMessageRequiredShort: "Wiadomość agenta jest wymagana.",
       nameRequiredShort: "Nazwa jest wymagana.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -63,6 +63,7 @@ export const pt_BR: TranslationMap = {
     relink: "Vincular novamente",
     waitForScan: "Aguardar leitura",
     logout: "Sair",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -699,6 +700,7 @@ export const pt_BR: TranslationMap = {
     showCronSessions: "Mostrar sessões de cron",
     showCronSessionsHidden: "Mostrar sessões de cron ({count} ocultas)",
     onboardingDisabled: "Desativado durante a integração",
+    settings: "Chat settings",
   },
   languages: {
     en: "Inglês",
@@ -927,6 +929,26 @@ export const pt_BR: TranslationMap = {
       systemEventTextRequired: "Texto do evento do sistema obrigatório.",
       agentMessageRequiredShort: "Mensagem do agente obrigatória.",
       nameRequiredShort: "Nome obrigatório.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -63,6 +63,7 @@ export const th: TranslationMap = {
     relink: "เชื่อมโยงใหม่",
     waitForScan: "รอการสแกน",
     logout: "ออกจากระบบ",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -685,6 +686,7 @@ export const th: TranslationMap = {
     showCronSessions: "แสดงเซสชัน cron",
     showCronSessionsHidden: "แสดงเซสชัน cron (ซ่อนอยู่ {count})",
     onboardingDisabled: "ปิดใช้งานระหว่างการตั้งค่า",
+    settings: "Chat settings",
   },
   languages: {
     en: "อังกฤษ",
@@ -908,6 +910,26 @@ export const th: TranslationMap = {
       systemEventTextRequired: "ต้องระบุข้อความเหตุการณ์ของระบบ",
       agentMessageRequiredShort: "ต้องระบุข้อความของเอเจนต์",
       nameRequiredShort: "ต้องระบุชื่อ",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -63,6 +63,7 @@ export const tr: TranslationMap = {
     relink: "Yeniden bağla",
     waitForScan: "Tarama için bekle",
     logout: "Çıkış yap",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -702,6 +703,7 @@ export const tr: TranslationMap = {
     showCronSessions: "Cron oturumlarını göster",
     showCronSessionsHidden: "Cron oturumlarını göster ({count} gizli)",
     onboardingDisabled: "Kurulum sırasında devre dışı",
+    settings: "Chat settings",
   },
   languages: {
     en: "İngilizce",
@@ -931,6 +933,26 @@ export const tr: TranslationMap = {
       systemEventTextRequired: "Sistem olayı metni gerekli.",
       agentMessageRequiredShort: "Aracı mesajı gerekli.",
       nameRequiredShort: "Ad gerekli.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -63,6 +63,7 @@ export const uk: TranslationMap = {
     relink: "Пов’язати знову",
     waitForScan: "Очікування сканування",
     logout: "Вийти",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -701,6 +702,7 @@ export const uk: TranslationMap = {
     showCronSessions: "Показати сеанси Cron",
     showCronSessionsHidden: "Показати сеанси Cron ({count} приховано)",
     onboardingDisabled: "Вимкнено під час налаштування",
+    settings: "Chat settings",
   },
   languages: {
     en: "Англійська",
@@ -931,6 +933,26 @@ export const uk: TranslationMap = {
       systemEventTextRequired: "Потрібен текст системної події.",
       agentMessageRequiredShort: "Потрібне повідомлення агента.",
       nameRequiredShort: "Потрібна назва.",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -63,6 +63,7 @@ export const zh_CN: TranslationMap = {
     relink: "重新关联",
     waitForScan: "等待扫描",
     logout: "退出登录",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -684,6 +685,7 @@ export const zh_CN: TranslationMap = {
     showCronSessions: "显示定时任务会话",
     showCronSessionsHidden: "显示定时任务会话 (已隐藏 {count} 个)",
     onboardingDisabled: "引导期间禁用",
+    settings: "聊天设置",
   },
   languages: {
     en: "英语",
@@ -907,6 +909,26 @@ export const zh_CN: TranslationMap = {
       systemEventTextRequired: "系统事件文本为必填。",
       agentMessageRequiredShort: "代理消息为必填。",
       nameRequiredShort: "名称为必填。",
+    },
+  },
+  shell: {
+    searchJump: "搜索或跳转… ({shortcut})",
+    openCommandPalette: "打开命令面板",
+    docsNewTab: "文档 (在新标签页中打开)",
+    updateAvailable: "有可用更新：",
+    runningVersion: "(当前运行 v{version})。",
+    updateNow: "立即更新",
+    updating: "更新中…",
+    dismissUpdateBanner: "关闭更新横幅",
+    gatewayStatus: "网关状态：{status}",
+    colorMode: "颜色模式",
+    colorModeCurrent: "颜色模式：{mode}",
+  },
+  theme: {
+    modes: {
+      system: "跟随系统",
+      light: "浅色",
+      dark: "深色",
     },
   },
 };

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -63,6 +63,7 @@ export const zh_TW: TranslationMap = {
     relink: "重新連結",
     waitForScan: "等待掃描",
     logout: "登出",
+    dismiss: "Dismiss",
   },
   channels: {
     health: {
@@ -685,6 +686,7 @@ export const zh_TW: TranslationMap = {
     showCronSessions: "顯示定時任務會話",
     showCronSessionsHidden: "顯示定時任務會話 (已隱藏 {count} 個)",
     onboardingDisabled: "引導期間禁用",
+    settings: "Chat settings",
   },
   languages: {
     en: "英文",
@@ -908,6 +910,26 @@ export const zh_TW: TranslationMap = {
       systemEventTextRequired: "系統事件文字為必填。",
       agentMessageRequiredShort: "Agent 訊息為必填。",
       nameRequiredShort: "名稱為必填。",
+    },
+  },
+  shell: {
+    searchJump: "Search or jump to… ({shortcut})",
+    openCommandPalette: "Open command palette",
+    docsNewTab: "Docs (opens in new tab)",
+    updateAvailable: "Update available:",
+    runningVersion: "(running v{version}).",
+    updateNow: "Update now",
+    updating: "Updating…",
+    dismissUpdateBanner: "Dismiss update banner",
+    gatewayStatus: "Gateway status: {status}",
+    colorMode: "Color mode",
+    colorModeCurrent: "Color mode: {mode}",
+  },
+  theme: {
+    modes: {
+      system: "System",
+      light: "Light",
+      dark: "Dark",
     },
   },
 };

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -154,8 +154,9 @@ function renderCronFilterIcon(hiddenCount: number) {
         <circle cx="12" cy="12" r="10"></circle>
         <polyline points="12 6 12 12 16 14"></polyline>
       </svg>
-      ${hiddenCount > 0
-        ? html`<span
+      ${
+        hiddenCount > 0
+          ? html`<span
             style="
               position: absolute;
               top: -5px;
@@ -170,7 +171,8 @@ function renderCronFilterIcon(hiddenCount: number) {
             "
             >${hiddenCount}</span
           >`
-        : ""}
+          : ""
+      }
     </span>
   `;
 }
@@ -420,8 +422,8 @@ export function renderChatMobileToggle(state: AppViewState) {
             }
           }
         }}
-        title="Chat settings"
-        aria-label="Chat settings"
+        title=${t("chat.settings")}
+        aria-label=${t("chat.settings")}
       >
         <svg
           width="18"
@@ -565,12 +567,16 @@ function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResul
   return sessions.sessions.filter((s) => isCronSessionKey(s.key) && s.key !== sessionKey).length;
 }
 
-type ThemeModeOption = { id: ThemeMode; label: string; short: string };
+type ThemeModeOption = { id: ThemeMode; short: string };
 const THEME_MODE_OPTIONS: ThemeModeOption[] = [
-  { id: "system", label: "System", short: "SYS" },
-  { id: "light", label: "Light", short: "LIGHT" },
-  { id: "dark", label: "Dark", short: "DARK" },
+  { id: "system", short: "SYS" },
+  { id: "light", short: "LIGHT" },
+  { id: "dark", short: "DARK" },
 ];
+
+function themeModeLabel(mode: ThemeMode): string {
+  return t(`theme.modes.${mode}`);
+}
 
 export function renderTopbarThemeModeToggle(state: AppViewState) {
   const modeIcon = (mode: ThemeMode) => {
@@ -591,23 +597,24 @@ export function renderTopbarThemeModeToggle(state: AppViewState) {
   };
 
   return html`
-    <div class="topbar-theme-mode" role="group" aria-label="Color mode">
-      ${THEME_MODE_OPTIONS.map(
-        (opt) => html`
+    <div class="topbar-theme-mode" role="group" aria-label=${t("shell.colorMode")}>
+      ${THEME_MODE_OPTIONS.map((opt) => {
+        const label = themeModeLabel(opt.id);
+        return html`
           <button
             type="button"
-            class="topbar-theme-mode__btn ${opt.id === state.themeMode
-              ? "topbar-theme-mode__btn--active"
-              : ""}"
-            title=${opt.label}
-            aria-label="Color mode: ${opt.label}"
+            class="topbar-theme-mode__btn ${
+              opt.id === state.themeMode ? "topbar-theme-mode__btn--active" : ""
+            }"
+            title=${label}
+            aria-label=${t("shell.colorModeCurrent", { mode: label })}
             aria-pressed=${opt.id === state.themeMode}
             @click=${(e: Event) => applyMode(opt.id, e)}
           >
             ${modeIcon(opt.id)}
           </button>
-        `,
-      )}
+        `;
+      })}
     </div>
   `;
 }
@@ -623,8 +630,8 @@ export function renderSidebarConnectionStatus(state: AppViewState) {
       class="sidebar-version__status ${toneClass}"
       role="img"
       aria-live="polite"
-      aria-label="Gateway status: ${label}"
-      title="Gateway status: ${label}"
+      aria-label=${t("shell.gatewayStatus", { status: label })}
+      title=${t("shell.gatewayStatus", { status: label })}
     ></span>
   `;
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -115,6 +115,7 @@ import {
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
+import { commandPaletteShortcutLabel } from "./keyboard-shortcuts.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import "./components/dashboard-header.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
@@ -633,6 +634,7 @@ function renderCronQuickCreateForTab(
 }
 
 export function renderApp(state: AppViewState) {
+  const commandPaletteShortcut = commandPaletteShortcutLabel();
   const updatableState = state as AppViewState & { requestUpdate?: () => void };
   const requestHostUpdate =
     typeof updatableState.requestUpdate === "function"
@@ -1317,11 +1319,11 @@ export function renderApp(state: AppViewState) {
       },
     })}
     <div
-      class="shell ${isChat ? "shell--chat" : ""} ${chatFocus
-        ? "shell--chat-focus"
-        : ""} ${navCollapsed ? "shell--nav-collapsed" : ""} ${navDrawerOpen
-        ? "shell--nav-drawer-open"
-        : ""} ${state.onboarding ? "shell--onboarding" : ""}"
+      class="shell ${isChat ? "shell--chat" : ""} ${
+        chatFocus ? "shell--chat-focus" : ""
+      } ${navCollapsed ? "shell--nav-collapsed" : ""} ${
+        navDrawerOpen ? "shell--nav-drawer-open" : ""
+      } ${state.onboarding ? "shell--onboarding" : ""}"
     >
       <button
         type="button"
@@ -1354,11 +1356,11 @@ export function renderApp(state: AppViewState) {
               @click=${() => {
                 state.paletteOpen = !state.paletteOpen;
               }}
-              title="Search or jump to… (⌘K)"
-              aria-label="Open command palette"
+              title=${t("shell.searchJump", { shortcut: commandPaletteShortcut })}
+              aria-label=${t("shell.openCommandPalette")}
             >
               <span class="topbar-search__label">${t("common.search")}</span>
-              <kbd class="topbar-search__kbd">⌘K</kbd>
+              <kbd class="topbar-search__kbd">${commandPaletteShortcut}</kbd>
             </button>
             <div class="topbar-status">
               ${isChat ? renderChatMobileToggle(state) : nothing}
@@ -1372,9 +1374,10 @@ export function renderApp(state: AppViewState) {
           <div class="sidebar-shell">
             <div class="sidebar-shell__header">
               <div class="sidebar-brand">
-                ${navCollapsed
-                  ? nothing
-                  : html`
+                ${
+                  navCollapsed
+                    ? nothing
+                    : html`
                       <img
                         class="sidebar-brand__logo"
                         src="${agentLogoUrl(basePath)}"
@@ -1384,7 +1387,8 @@ export function renderApp(state: AppViewState) {
                         <span class="sidebar-brand__eyebrow">${t("nav.control")}</span>
                         <span class="sidebar-brand__title">OpenClaw</span>
                       </span>
-                    `}
+                    `
+                }
               </div>
               <button
                 type="button"
@@ -1411,8 +1415,9 @@ export function renderApp(state: AppViewState) {
 
                   return html`
                     <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">
-                      ${!navCollapsed
-                        ? html`
+                      ${
+                        !navCollapsed
+                          ? html`
                             <button
                               class="nav-section__label"
                               @click=${() => {
@@ -1431,7 +1436,8 @@ export function renderApp(state: AppViewState) {
                               <span class="nav-section__chevron"> ${icons.chevronDown} </span>
                             </button>
                           `
-                        : nothing}
+                          : nothing
+                      }
                       <div class="nav-section__items">
                         ${group.tabs.map((tab) =>
                           renderTab(state, tab, { collapsed: navCollapsed }),
@@ -1449,15 +1455,17 @@ export function renderApp(state: AppViewState) {
                   href="https://docs.openclaw.ai"
                   target=${EXTERNAL_LINK_TARGET}
                   rel=${buildExternalLinkRel()}
-                  title="${t("common.docs")} (opens in new tab)"
+                  title=${t("shell.docsNewTab")}
                 >
                   <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
-                  ${!navCollapsed
-                    ? html`
+                  ${
+                    !navCollapsed
+                      ? html`
                         <span class="nav-item__text">${t("common.docs")}</span>
                         <span class="nav-item__external-icon">${icons.externalLink}</span>
                       `
-                    : nothing}
+                      : nothing
+                  }
                 </a>
                 <div class="sidebar-mode-switch">${renderTopbarThemeModeToggle(state)}</div>
                 ${(() => {
@@ -1465,13 +1473,15 @@ export function renderApp(state: AppViewState) {
                   return version
                     ? html`
                         <div class="sidebar-version" title=${`v${version}`}>
-                          ${!navCollapsed
-                            ? html`
+                          ${
+                            !navCollapsed
+                              ? html`
                                 <span class="sidebar-version__label">${t("common.version")}</span>
                                 <span class="sidebar-version__text">v${version}</span>
                                 ${renderSidebarConnectionStatus(state)}
                               `
-                            : html` ${renderSidebarConnectionStatus(state)} `}
+                              : html` ${renderSidebarConnectionStatus(state)} `
+                          }
                         </div>
                       `
                     : nothing;
@@ -1482,29 +1492,31 @@ export function renderApp(state: AppViewState) {
         </aside>
       </div>
       <main class="content ${isChat ? "content--chat" : ""}">
-        ${state.updateStatusBanner
-          ? html`<div class="callout ${state.updateStatusBanner.tone}" role="alert">
+        ${
+          state.updateStatusBanner
+            ? html`<div class="callout ${state.updateStatusBanner.tone}" role="alert">
               ${state.updateStatusBanner.text}
             </div>`
-          : nothing}
-        ${state.updateAvailable &&
-        state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
-        !isUpdateBannerDismissed(state.updateAvailable)
-          ? html`<div class="update-banner callout danger" role="alert">
-              <strong>Update available:</strong> v${state.updateAvailable.latestVersion} (running
-              v${state.updateAvailable.currentVersion}).
+            : nothing
+        }
+        ${
+          state.updateAvailable &&
+          state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
+          !isUpdateBannerDismissed(state.updateAvailable)
+            ? html`<div class="update-banner callout danger" role="alert">
+              <strong>${t("shell.updateAvailable")}</strong> v${state.updateAvailable.latestVersion} ${t("shell.runningVersion", { version: state.updateAvailable.currentVersion })}
               <button
                 class="btn btn--sm update-banner__btn"
                 ?disabled=${state.updateRunning || !state.connected}
                 @click=${() => runUpdate(state)}
               >
-                ${state.updateRunning ? "Updating…" : "Update now"}
+                ${state.updateRunning ? t("shell.updating") : t("shell.updateNow")}
               </button>
               <button
                 class="update-banner__close"
                 type="button"
-                title="Dismiss"
-                aria-label="Dismiss update banner"
+                title=${t("common.dismiss")}
+                aria-label=${t("shell.dismissUpdateBanner")}
                 @click=${() => {
                   dismissUpdateBanner(state.updateAvailable);
                   state.updateAvailable = null;
@@ -1513,33 +1525,40 @@ export function renderApp(state: AppViewState) {
                 ${icons.x}
               </button>
             </div>`
-          : nothing}
-        ${state.tab === "config"
-          ? nothing
-          : html`<section class="content-header">
+            : nothing
+        }
+        ${
+          state.tab === "config"
+            ? nothing
+            : html`<section class="content-header">
               <div>
-                ${isChat
-                  ? renderChatSessionSelect(state)
-                  : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
+                ${
+                  isChat
+                    ? renderChatSessionSelect(state)
+                    : html`<div class="page-title">${titleForTab(state.tab)}</div>`
+                }
                 ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
               </div>
               <div class="page-meta">
-                ${state.tab === "dreams"
-                  ? html`
+                ${
+                  state.tab === "dreams"
+                    ? html`
                       <div class="dreaming-header-controls">
                         <button
                           class="btn btn--subtle btn--sm"
                           ?disabled=${dreamingLoading || state.dreamDiaryLoading}
                           @click=${refreshDreaming}
                         >
-                          ${dreamingRefreshLoading
-                            ? t("dreaming.header.refreshing")
-                            : t("dreaming.header.refresh")}
+                          ${
+                            dreamingRefreshLoading
+                              ? t("dreaming.header.refreshing")
+                              : t("dreaming.header.refresh")
+                          }
                         </button>
                         <button
-                          class="dreams__phase-toggle ${dreamingOn
-                            ? "dreams__phase-toggle--on"
-                            : ""}"
+                          class="dreams__phase-toggle ${
+                            dreamingOn ? "dreams__phase-toggle--on" : ""
+                          }"
                           ?disabled=${dreamingLoading}
                           @click=${() => applyDreamingEnabled(!dreamingOn)}
                         >
@@ -1550,988 +1569,1017 @@ export function renderApp(state: AppViewState) {
                         </button>
                       </div>
                     `
-                  : nothing}
-                ${state.lastError
-                  ? html`<div class="pill danger">${state.lastError}</div>`
-                  : nothing}
+                    : nothing
+                }
+                ${
+                  state.lastError
+                    ? html`<div class="pill danger">${state.lastError}</div>`
+                    : nothing
+                }
                 ${isChat ? renderChatControls(state) : nothing}
               </div>
-            </section>`}
-        ${state.tab === "overview"
-          ? renderOverview({
-              connected: state.connected,
-              hello: state.hello,
-              settings: state.settings,
-              password: state.password,
-              lastError: state.lastError,
-              lastErrorCode: state.lastErrorCode,
-              presenceCount,
-              sessionsCount,
-              cronEnabled: state.cronStatus?.enabled ?? null,
-              cronNext,
-              lastChannelsRefresh: state.channelsLastSuccess,
-              warnQueryToken,
-              modelAuthStatus: state.modelAuthStatusResult,
-              usageResult: state.usageResult,
-              sessionsResult: state.sessionsResult,
-              skillsReport: state.skillsReport,
-              cronJobs: state.cronJobs,
-              cronStatus: state.cronStatus,
-              attentionItems: state.attentionItems,
-              eventLog: state.eventLog,
-              overviewLogLines: state.overviewLogLines,
-              showGatewayToken: state.overviewShowGatewayToken,
-              showGatewayPassword: state.overviewShowGatewayPassword,
-              onSettingsChange: (next) => state.applySettings(next),
-              onPasswordChange: (next) => (state.password = next),
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.resetChatInputHistoryNavigation();
-                state.chatMessages = [];
-                state.chatToolMessages = [];
-                state.chatStream = null;
-                state.chatRunId = null;
-                state.chatQueue = [];
-                state.resetToolStream();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-              },
-              onToggleGatewayTokenVisibility: () => {
-                state.overviewShowGatewayToken = !state.overviewShowGatewayToken;
-              },
-              onToggleGatewayPasswordVisibility: () => {
-                state.overviewShowGatewayPassword = !state.overviewShowGatewayPassword;
-              },
-              onConnect: () => state.connect(),
-              onRefresh: () => state.loadOverview({ refresh: true }),
-              onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
-              onRefreshLogs: () => state.loadOverview({ refresh: true }),
-            })
-          : nothing}
-        ${state.tab === "channels"
-          ? lazyRender(lazyChannels, (m) =>
-              m.renderChannels({
+            </section>`
+        }
+        ${
+          state.tab === "overview"
+            ? renderOverview({
                 connected: state.connected,
-                loading: state.channelsLoading,
-                snapshot: state.channelsSnapshot,
-                lastError: state.channelsError,
-                lastSuccessAt: state.channelsLastSuccess,
-                whatsappMessage: state.whatsappLoginMessage,
-                whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-                whatsappConnected: state.whatsappLoginConnected,
-                whatsappBusy: state.whatsappBusy,
-                configSchema: state.configSchema,
-                configSchemaLoading: state.configSchemaLoading,
-                configForm: state.configForm,
-                configUiHints: state.configUiHints,
-                configSaving: state.configSaving,
-                configFormDirty: state.configFormDirty,
-                nostrProfileFormState: state.nostrProfileFormState,
-                nostrProfileAccountId: state.nostrProfileAccountId,
-                onRefresh: (probe) => loadChannels(state, probe),
-                onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-                onWhatsAppWait: () => state.handleWhatsAppWait(),
-                onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-                onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-                onConfigSave: () => state.handleChannelConfigSave(),
-                onConfigReload: () => state.handleChannelConfigReload(),
-                onNostrProfileEdit: (accountId, profile) =>
-                  state.handleNostrProfileEdit(accountId, profile),
-                onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-                onNostrProfileFieldChange: (field, value) =>
-                  state.handleNostrProfileFieldChange(field, value),
-                onNostrProfileSave: () => state.handleNostrProfileSave(),
-                onNostrProfileImport: () => state.handleNostrProfileImport(),
-                onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-              }),
-            )
-          : nothing}
-        ${state.tab === "instances"
-          ? lazyRender(lazyInstances, (m) =>
-              m.renderInstances({
-                loading: state.presenceLoading,
-                entries: state.presenceEntries,
-                lastError: state.presenceError,
-                statusMessage: state.presenceStatus,
-                onRefresh: () => loadPresence(state),
-              }),
-            )
-          : nothing}
-        ${state.tab === "sessions"
-          ? lazyRender(lazySessions, (m) =>
-              m.renderSessions({
-                loading: state.sessionsLoading,
-                result: state.sessionsResult,
-                error: state.sessionsError,
-                activeMinutes: state.sessionsFilterActive,
-                limit: state.sessionsFilterLimit,
-                includeGlobal: state.sessionsIncludeGlobal,
-                includeUnknown: state.sessionsIncludeUnknown,
-                basePath: state.basePath,
-                searchQuery: state.sessionsSearchQuery,
-                agentIdentityById: state.agentIdentityById,
-                sortColumn: state.sessionsSortColumn,
-                sortDir: state.sessionsSortDir,
-                page: state.sessionsPage,
-                pageSize: state.sessionsPageSize,
-                selectedKeys: state.sessionsSelectedKeys,
-                expandedCheckpointKey: state.sessionsExpandedCheckpointKey,
-                checkpointItemsByKey: state.sessionsCheckpointItemsByKey,
-                checkpointLoadingKey: state.sessionsCheckpointLoadingKey,
-                checkpointBusyKey: state.sessionsCheckpointBusyKey,
-                checkpointErrorByKey: state.sessionsCheckpointErrorByKey,
-                onFiltersChange: (next) => {
-                  state.sessionsFilterActive = next.activeMinutes;
-                  state.sessionsFilterLimit = next.limit;
-                  state.sessionsIncludeGlobal = next.includeGlobal;
-                  state.sessionsIncludeUnknown = next.includeUnknown;
+                hello: state.hello,
+                settings: state.settings,
+                password: state.password,
+                lastError: state.lastError,
+                lastErrorCode: state.lastErrorCode,
+                presenceCount,
+                sessionsCount,
+                cronEnabled: state.cronStatus?.enabled ?? null,
+                cronNext,
+                lastChannelsRefresh: state.channelsLastSuccess,
+                warnQueryToken,
+                modelAuthStatus: state.modelAuthStatusResult,
+                usageResult: state.usageResult,
+                sessionsResult: state.sessionsResult,
+                skillsReport: state.skillsReport,
+                cronJobs: state.cronJobs,
+                cronStatus: state.cronStatus,
+                attentionItems: state.attentionItems,
+                eventLog: state.eventLog,
+                overviewLogLines: state.overviewLogLines,
+                showGatewayToken: state.overviewShowGatewayToken,
+                showGatewayPassword: state.overviewShowGatewayPassword,
+                onSettingsChange: (next) => state.applySettings(next),
+                onPasswordChange: (next) => (state.password = next),
+                onSessionKeyChange: (next) => {
+                  state.sessionKey = next;
+                  state.chatMessage = "";
+                  state.resetChatInputHistoryNavigation();
+                  state.chatMessages = [];
+                  state.chatToolMessages = [];
+                  state.chatStream = null;
+                  state.chatRunId = null;
+                  state.chatQueue = [];
+                  state.resetToolStream();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: next,
+                    lastActiveSessionKey: next,
+                  });
                 },
-                onSearchChange: (q) => {
-                  state.sessionsSearchQuery = q;
-                  state.sessionsPage = 0;
+                onToggleGatewayTokenVisibility: () => {
+                  state.overviewShowGatewayToken = !state.overviewShowGatewayToken;
                 },
-                onSortChange: (col, dir) => {
-                  state.sessionsSortColumn = col;
-                  state.sessionsSortDir = dir;
-                  state.sessionsPage = 0;
+                onToggleGatewayPasswordVisibility: () => {
+                  state.overviewShowGatewayPassword = !state.overviewShowGatewayPassword;
                 },
-                onPageChange: (p) => {
-                  state.sessionsPage = p;
-                },
-                onPageSizeChange: (s) => {
-                  state.sessionsPageSize = s;
-                  state.sessionsPage = 0;
-                },
-                onRefresh: () => loadSessions(state),
-                onPatch: (key, patch) => patchSession(state, key, patch),
-                onToggleSelect: (key) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  if (next.has(key)) {
-                    next.delete(key);
-                  } else {
-                    next.add(key);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onSelectPage: (keys) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  for (const k of keys) {
-                    next.add(k);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onDeselectPage: (keys) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  for (const k of keys) {
-                    next.delete(k);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onDeselectAll: () => {
-                  state.sessionsSelectedKeys = new Set();
-                },
-                onDeleteSelected: async () => {
-                  const keys = [...state.sessionsSelectedKeys];
-                  const deleted = await deleteSessionsAndRefresh(state, keys);
-                  if (deleted.length > 0) {
+                onConnect: () => state.connect(),
+                onRefresh: () => state.loadOverview({ refresh: true }),
+                onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
+                onRefreshLogs: () => state.loadOverview({ refresh: true }),
+              })
+            : nothing
+        }
+        ${
+          state.tab === "channels"
+            ? lazyRender(lazyChannels, (m) =>
+                m.renderChannels({
+                  connected: state.connected,
+                  loading: state.channelsLoading,
+                  snapshot: state.channelsSnapshot,
+                  lastError: state.channelsError,
+                  lastSuccessAt: state.channelsLastSuccess,
+                  whatsappMessage: state.whatsappLoginMessage,
+                  whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+                  whatsappConnected: state.whatsappLoginConnected,
+                  whatsappBusy: state.whatsappBusy,
+                  configSchema: state.configSchema,
+                  configSchemaLoading: state.configSchemaLoading,
+                  configForm: state.configForm,
+                  configUiHints: state.configUiHints,
+                  configSaving: state.configSaving,
+                  configFormDirty: state.configFormDirty,
+                  nostrProfileFormState: state.nostrProfileFormState,
+                  nostrProfileAccountId: state.nostrProfileAccountId,
+                  onRefresh: (probe) => loadChannels(state, probe),
+                  onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+                  onWhatsAppWait: () => state.handleWhatsAppWait(),
+                  onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+                  onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+                  onConfigSave: () => state.handleChannelConfigSave(),
+                  onConfigReload: () => state.handleChannelConfigReload(),
+                  onNostrProfileEdit: (accountId, profile) =>
+                    state.handleNostrProfileEdit(accountId, profile),
+                  onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+                  onNostrProfileFieldChange: (field, value) =>
+                    state.handleNostrProfileFieldChange(field, value),
+                  onNostrProfileSave: () => state.handleNostrProfileSave(),
+                  onNostrProfileImport: () => state.handleNostrProfileImport(),
+                  onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "instances"
+            ? lazyRender(lazyInstances, (m) =>
+                m.renderInstances({
+                  loading: state.presenceLoading,
+                  entries: state.presenceEntries,
+                  lastError: state.presenceError,
+                  statusMessage: state.presenceStatus,
+                  onRefresh: () => loadPresence(state),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "sessions"
+            ? lazyRender(lazySessions, (m) =>
+                m.renderSessions({
+                  loading: state.sessionsLoading,
+                  result: state.sessionsResult,
+                  error: state.sessionsError,
+                  activeMinutes: state.sessionsFilterActive,
+                  limit: state.sessionsFilterLimit,
+                  includeGlobal: state.sessionsIncludeGlobal,
+                  includeUnknown: state.sessionsIncludeUnknown,
+                  basePath: state.basePath,
+                  searchQuery: state.sessionsSearchQuery,
+                  agentIdentityById: state.agentIdentityById,
+                  sortColumn: state.sessionsSortColumn,
+                  sortDir: state.sessionsSortDir,
+                  page: state.sessionsPage,
+                  pageSize: state.sessionsPageSize,
+                  selectedKeys: state.sessionsSelectedKeys,
+                  expandedCheckpointKey: state.sessionsExpandedCheckpointKey,
+                  checkpointItemsByKey: state.sessionsCheckpointItemsByKey,
+                  checkpointLoadingKey: state.sessionsCheckpointLoadingKey,
+                  checkpointBusyKey: state.sessionsCheckpointBusyKey,
+                  checkpointErrorByKey: state.sessionsCheckpointErrorByKey,
+                  onFiltersChange: (next) => {
+                    state.sessionsFilterActive = next.activeMinutes;
+                    state.sessionsFilterLimit = next.limit;
+                    state.sessionsIncludeGlobal = next.includeGlobal;
+                    state.sessionsIncludeUnknown = next.includeUnknown;
+                  },
+                  onSearchChange: (q) => {
+                    state.sessionsSearchQuery = q;
+                    state.sessionsPage = 0;
+                  },
+                  onSortChange: (col, dir) => {
+                    state.sessionsSortColumn = col;
+                    state.sessionsSortDir = dir;
+                    state.sessionsPage = 0;
+                  },
+                  onPageChange: (p) => {
+                    state.sessionsPage = p;
+                  },
+                  onPageSizeChange: (s) => {
+                    state.sessionsPageSize = s;
+                    state.sessionsPage = 0;
+                  },
+                  onRefresh: () => loadSessions(state),
+                  onPatch: (key, patch) => patchSession(state, key, patch),
+                  onToggleSelect: (key) => {
                     const next = new Set(state.sessionsSelectedKeys);
-                    for (const k of deleted) {
+                    if (next.has(key)) {
+                      next.delete(key);
+                    } else {
+                      next.add(key);
+                    }
+                    state.sessionsSelectedKeys = next;
+                  },
+                  onSelectPage: (keys) => {
+                    const next = new Set(state.sessionsSelectedKeys);
+                    for (const k of keys) {
+                      next.add(k);
+                    }
+                    state.sessionsSelectedKeys = next;
+                  },
+                  onDeselectPage: (keys) => {
+                    const next = new Set(state.sessionsSelectedKeys);
+                    for (const k of keys) {
                       next.delete(k);
                     }
                     state.sessionsSelectedKeys = next;
-                  }
-                },
-                onNavigateToChat: (sessionKey) => {
-                  switchChatSession(state, sessionKey);
-                  state.setTab("chat" as import("./navigation.ts").Tab);
-                },
-                onToggleCheckpointDetails: (sessionKey) =>
-                  toggleSessionCompactionCheckpoints(state, sessionKey),
-                onBranchFromCheckpoint: async (sessionKey, checkpointId) => {
-                  const nextKey = await branchSessionFromCheckpoint(
-                    state,
-                    sessionKey,
-                    checkpointId,
-                  );
-                  if (nextKey) {
-                    switchChatSession(state, nextKey);
+                  },
+                  onDeselectAll: () => {
+                    state.sessionsSelectedKeys = new Set();
+                  },
+                  onDeleteSelected: async () => {
+                    const keys = [...state.sessionsSelectedKeys];
+                    const deleted = await deleteSessionsAndRefresh(state, keys);
+                    if (deleted.length > 0) {
+                      const next = new Set(state.sessionsSelectedKeys);
+                      for (const k of deleted) {
+                        next.delete(k);
+                      }
+                      state.sessionsSelectedKeys = next;
+                    }
+                  },
+                  onNavigateToChat: (sessionKey) => {
+                    switchChatSession(state, sessionKey);
                     state.setTab("chat" as import("./navigation.ts").Tab);
-                  }
-                },
-                onRestoreCheckpoint: (sessionKey, checkpointId) =>
-                  restoreSessionFromCheckpoint(state, sessionKey, checkpointId),
-              }),
-            )
-          : nothing}
+                  },
+                  onToggleCheckpointDetails: (sessionKey) =>
+                    toggleSessionCompactionCheckpoints(state, sessionKey),
+                  onBranchFromCheckpoint: async (sessionKey, checkpointId) => {
+                    const nextKey = await branchSessionFromCheckpoint(
+                      state,
+                      sessionKey,
+                      checkpointId,
+                    );
+                    if (nextKey) {
+                      switchChatSession(state, nextKey);
+                      state.setTab("chat" as import("./navigation.ts").Tab);
+                    }
+                  },
+                  onRestoreCheckpoint: (sessionKey, checkpointId) =>
+                    restoreSessionFromCheckpoint(state, sessionKey, checkpointId),
+                }),
+              )
+            : nothing
+        }
         ${renderUsageTab(state)}
         ${state.tab === "cron" ? renderCronQuickCreateForTab(state, requestHostUpdate) : nothing}
-        ${state.tab === "cron"
-          ? lazyRender(lazyCron, (m) =>
-              m.renderCron({
-                basePath: state.basePath,
-                loading: state.cronLoading,
-                status: state.cronStatus,
-                jobs: visibleCronJobs,
-                jobsLoadingMore: state.cronJobsLoadingMore,
-                jobsTotal: state.cronJobsTotal,
-                jobsHasMore: state.cronJobsHasMore,
-                jobsQuery: state.cronJobsQuery,
-                jobsEnabledFilter: state.cronJobsEnabledFilter,
-                jobsScheduleKindFilter: state.cronJobsScheduleKindFilter,
-                jobsLastStatusFilter: state.cronJobsLastStatusFilter,
-                jobsSortBy: state.cronJobsSortBy,
-                jobsSortDir: state.cronJobsSortDir,
-                editingJobId: state.cronEditingJobId,
-                error: state.cronError,
-                busy: state.cronBusy,
-                form: state.cronForm,
-                channels: state.channelsSnapshot?.channelMeta?.length
-                  ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
-                  : (state.channelsSnapshot?.channelOrder ?? []),
-                channelLabels: state.channelsSnapshot?.channelLabels ?? {},
-                channelMeta: state.channelsSnapshot?.channelMeta ?? [],
-                runsJobId: state.cronRunsJobId,
-                runs: state.cronRuns,
-                runsTotal: state.cronRunsTotal,
-                runsHasMore: state.cronRunsHasMore,
-                runsLoadingMore: state.cronRunsLoadingMore,
-                runsScope: state.cronRunsScope,
-                runsStatuses: state.cronRunsStatuses,
-                runsDeliveryStatuses: state.cronRunsDeliveryStatuses,
-                runsStatusFilter: state.cronRunsStatusFilter,
-                runsQuery: state.cronRunsQuery,
-                runsSortDir: state.cronRunsSortDir,
-                fieldErrors: state.cronFieldErrors,
-                canSubmit: !hasCronFormErrors(state.cronFieldErrors),
-                agentSuggestions: cronAgentSuggestions,
-                modelSuggestions: cronModelSuggestions,
-                thinkingSuggestions: CRON_THINKING_SUGGESTIONS,
-                timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
-                deliveryToSuggestions,
-                accountSuggestions,
-                onFormChange: (patch) => {
-                  state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
-                  state.cronFieldErrors = validateCronForm(state.cronForm);
-                },
-                onRefresh: () => state.loadCron(),
-                onAdd: () => addCronJob(state),
-                onEdit: (job) => startCronEdit(state, job),
-                onClone: (job) => startCronClone(state, job),
-                onCancelEdit: () => cancelCronEdit(state),
-                onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
-                onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),
-                onRemove: (job) => removeCronJob(state, job),
-                onQuickCreate: () => {
-                  state.cronQuickCreateOpen = true;
-                  state.cronQuickCreateStep = "what";
-                  state.cronQuickCreateDraft = createDefaultDraft();
-                  requestHostUpdate?.();
-                },
-                onLoadRuns: async (jobId) => {
-                  updateCronRunsFilter(state, { cronRunsScope: "job" });
-                  await loadCronRuns(state, jobId);
-                },
-                onLoadMoreJobs: () => loadCronJobsPage(state, { append: true }),
-                onJobsFiltersChange: async (patch) => {
-                  updateCronJobsFilter(state, patch);
-                  const shouldReload =
-                    typeof patch.cronJobsQuery === "string" ||
-                    Boolean(patch.cronJobsEnabledFilter) ||
-                    Boolean(patch.cronJobsSortBy) ||
-                    Boolean(patch.cronJobsSortDir);
-                  if (shouldReload) {
-                    await loadCronJobsPage(state, { append: false });
-                  }
-                },
-                onJobsFiltersReset: async () => {
-                  updateCronJobsFilter(state, {
-                    cronJobsQuery: "",
-                    cronJobsEnabledFilter: "all",
-                    cronJobsScheduleKindFilter: "all",
-                    cronJobsLastStatusFilter: "all",
-                    cronJobsSortBy: "nextRunAtMs",
-                    cronJobsSortDir: "asc",
-                  });
-                  await loadCronJobsPage(state, { append: false });
-                },
-                onLoadMoreRuns: () => loadMoreCronRuns(state),
-                onRunsFiltersChange: async (patch) => {
-                  updateCronRunsFilter(state, patch);
-                  if (state.cronRunsScope === "all") {
-                    await loadCronRuns(state, null);
-                    return;
-                  }
-                  await loadCronRuns(state, state.cronRunsJobId);
-                },
-                onNavigateToChat: (sessionKey) => {
-                  switchChatSession(state, sessionKey);
-                  state.setTab("chat" as import("./navigation.ts").Tab);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "agents"
-          ? lazyRender(lazyAgents, (m) =>
-              m.renderAgents({
-                basePath: state.basePath ?? "",
-                loading: state.agentsLoading,
-                error: state.agentsError,
-                agentsList: state.agentsList,
-                selectedAgentId: resolvedAgentId,
-                activePanel: state.agentsPanel,
-                config: {
-                  form: configValue,
-                  loading: state.configLoading,
-                  saving: state.configSaving,
-                  dirty: state.configFormDirty,
-                },
-                channels: {
-                  snapshot: state.channelsSnapshot,
-                  loading: state.channelsLoading,
-                  error: state.channelsError,
-                  lastSuccess: state.channelsLastSuccess,
-                },
-                cron: {
-                  status: state.cronStatus,
-                  jobs: state.cronJobs,
+        ${
+          state.tab === "cron"
+            ? lazyRender(lazyCron, (m) =>
+                m.renderCron({
+                  basePath: state.basePath,
                   loading: state.cronLoading,
+                  status: state.cronStatus,
+                  jobs: visibleCronJobs,
+                  jobsLoadingMore: state.cronJobsLoadingMore,
+                  jobsTotal: state.cronJobsTotal,
+                  jobsHasMore: state.cronJobsHasMore,
+                  jobsQuery: state.cronJobsQuery,
+                  jobsEnabledFilter: state.cronJobsEnabledFilter,
+                  jobsScheduleKindFilter: state.cronJobsScheduleKindFilter,
+                  jobsLastStatusFilter: state.cronJobsLastStatusFilter,
+                  jobsSortBy: state.cronJobsSortBy,
+                  jobsSortDir: state.cronJobsSortDir,
+                  editingJobId: state.cronEditingJobId,
                   error: state.cronError,
-                },
-                agentFiles: {
-                  list: state.agentFilesList,
-                  loading: state.agentFilesLoading,
-                  error: state.agentFilesError,
-                  active: state.agentFileActive,
-                  contents: state.agentFileContents,
-                  drafts: state.agentFileDrafts,
-                  saving: state.agentFileSaving,
-                },
-                agentIdentityLoading: state.agentIdentityLoading,
-                agentIdentityError: state.agentIdentityError,
-                agentIdentityById: state.agentIdentityById,
-                agentSkills: {
-                  report: state.agentSkillsReport,
-                  loading: state.agentSkillsLoading,
-                  error: state.agentSkillsError,
-                  agentId: state.agentSkillsAgentId,
-                  filter: state.skillsFilter,
-                },
-                toolsCatalog: {
-                  loading: state.toolsCatalogLoading,
-                  error: state.toolsCatalogError,
-                  result: state.toolsCatalogResult,
-                },
-                toolsEffective: {
-                  loading: state.toolsEffectiveLoading,
-                  error: state.toolsEffectiveError,
-                  result: state.toolsEffectiveResult,
-                },
-                runtimeSessionKey: state.sessionKey,
-                runtimeSessionMatchesSelectedAgent: toolsPanelUsesActiveSession,
-                modelCatalog: state.chatModelCatalog ?? [],
-                onRefresh: async () => {
-                  await loadAgents(state);
-                  const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
-                  if (agentIds.length > 0) {
-                    void loadAgentIdentities(state, agentIds);
-                  }
-                  loadAgentPanelDataForSelectedAgent(resolveSelectedAgentId());
-                  refreshAgentsPanelSupplementalData(state.agentsPanel);
-                },
-                onSelectAgent: (agentId) => {
-                  if (state.agentsSelectedId === agentId) {
-                    return;
-                  }
-                  state.agentsSelectedId = agentId;
-                  resetAgentSelectionPanelState();
-                  void loadAgentIdentity(state, agentId);
-                  loadAgentPanelDataForSelectedAgent(agentId);
-                },
-                onSelectPanel: (panel) => {
-                  state.agentsPanel = panel;
-                  if (
-                    panel === "files" &&
-                    resolvedAgentId &&
-                    state.agentFilesList?.agentId !== resolvedAgentId
-                  ) {
-                    resetAgentFilesState();
-                    void loadAgentFiles(state, resolvedAgentId);
-                  }
-                  if (panel === "skills" && resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                  if (panel === "tools" && resolvedAgentId) {
-                    if (
-                      state.toolsCatalogResult?.agentId !== resolvedAgentId ||
-                      state.toolsCatalogError
-                    ) {
-                      void loadToolsCatalog(state, resolvedAgentId);
+                  busy: state.cronBusy,
+                  form: state.cronForm,
+                  channels: state.channelsSnapshot?.channelMeta?.length
+                    ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+                    : (state.channelsSnapshot?.channelOrder ?? []),
+                  channelLabels: state.channelsSnapshot?.channelLabels ?? {},
+                  channelMeta: state.channelsSnapshot?.channelMeta ?? [],
+                  runsJobId: state.cronRunsJobId,
+                  runs: state.cronRuns,
+                  runsTotal: state.cronRunsTotal,
+                  runsHasMore: state.cronRunsHasMore,
+                  runsLoadingMore: state.cronRunsLoadingMore,
+                  runsScope: state.cronRunsScope,
+                  runsStatuses: state.cronRunsStatuses,
+                  runsDeliveryStatuses: state.cronRunsDeliveryStatuses,
+                  runsStatusFilter: state.cronRunsStatusFilter,
+                  runsQuery: state.cronRunsQuery,
+                  runsSortDir: state.cronRunsSortDir,
+                  fieldErrors: state.cronFieldErrors,
+                  canSubmit: !hasCronFormErrors(state.cronFieldErrors),
+                  agentSuggestions: cronAgentSuggestions,
+                  modelSuggestions: cronModelSuggestions,
+                  thinkingSuggestions: CRON_THINKING_SUGGESTIONS,
+                  timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
+                  deliveryToSuggestions,
+                  accountSuggestions,
+                  onFormChange: (patch) => {
+                    state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
+                    state.cronFieldErrors = validateCronForm(state.cronForm);
+                  },
+                  onRefresh: () => state.loadCron(),
+                  onAdd: () => addCronJob(state),
+                  onEdit: (job) => startCronEdit(state, job),
+                  onClone: (job) => startCronClone(state, job),
+                  onCancelEdit: () => cancelCronEdit(state),
+                  onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+                  onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),
+                  onRemove: (job) => removeCronJob(state, job),
+                  onQuickCreate: () => {
+                    state.cronQuickCreateOpen = true;
+                    state.cronQuickCreateStep = "what";
+                    state.cronQuickCreateDraft = createDefaultDraft();
+                    requestHostUpdate?.();
+                  },
+                  onLoadRuns: async (jobId) => {
+                    updateCronRunsFilter(state, { cronRunsScope: "job" });
+                    await loadCronRuns(state, jobId);
+                  },
+                  onLoadMoreJobs: () => loadCronJobsPage(state, { append: true }),
+                  onJobsFiltersChange: async (patch) => {
+                    updateCronJobsFilter(state, patch);
+                    const shouldReload =
+                      typeof patch.cronJobsQuery === "string" ||
+                      Boolean(patch.cronJobsEnabledFilter) ||
+                      Boolean(patch.cronJobsSortBy) ||
+                      Boolean(patch.cronJobsSortDir);
+                    if (shouldReload) {
+                      await loadCronJobsPage(state, { append: false });
                     }
-                    if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
-                        agentId: resolvedAgentId,
-                        sessionKey: state.sessionKey,
-                      });
+                  },
+                  onJobsFiltersReset: async () => {
+                    updateCronJobsFilter(state, {
+                      cronJobsQuery: "",
+                      cronJobsEnabledFilter: "all",
+                      cronJobsScheduleKindFilter: "all",
+                      cronJobsLastStatusFilter: "all",
+                      cronJobsSortBy: "nextRunAtMs",
+                      cronJobsSortDir: "asc",
+                    });
+                    await loadCronJobsPage(state, { append: false });
+                  },
+                  onLoadMoreRuns: () => loadMoreCronRuns(state),
+                  onRunsFiltersChange: async (patch) => {
+                    updateCronRunsFilter(state, patch);
+                    if (state.cronRunsScope === "all") {
+                      await loadCronRuns(state, null);
+                      return;
+                    }
+                    await loadCronRuns(state, state.cronRunsJobId);
+                  },
+                  onNavigateToChat: (sessionKey) => {
+                    switchChatSession(state, sessionKey);
+                    state.setTab("chat" as import("./navigation.ts").Tab);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "agents"
+            ? lazyRender(lazyAgents, (m) =>
+                m.renderAgents({
+                  basePath: state.basePath ?? "",
+                  loading: state.agentsLoading,
+                  error: state.agentsError,
+                  agentsList: state.agentsList,
+                  selectedAgentId: resolvedAgentId,
+                  activePanel: state.agentsPanel,
+                  config: {
+                    form: configValue,
+                    loading: state.configLoading,
+                    saving: state.configSaving,
+                    dirty: state.configFormDirty,
+                  },
+                  channels: {
+                    snapshot: state.channelsSnapshot,
+                    loading: state.channelsLoading,
+                    error: state.channelsError,
+                    lastSuccess: state.channelsLastSuccess,
+                  },
+                  cron: {
+                    status: state.cronStatus,
+                    jobs: state.cronJobs,
+                    loading: state.cronLoading,
+                    error: state.cronError,
+                  },
+                  agentFiles: {
+                    list: state.agentFilesList,
+                    loading: state.agentFilesLoading,
+                    error: state.agentFilesError,
+                    active: state.agentFileActive,
+                    contents: state.agentFileContents,
+                    drafts: state.agentFileDrafts,
+                    saving: state.agentFileSaving,
+                  },
+                  agentIdentityLoading: state.agentIdentityLoading,
+                  agentIdentityError: state.agentIdentityError,
+                  agentIdentityById: state.agentIdentityById,
+                  agentSkills: {
+                    report: state.agentSkillsReport,
+                    loading: state.agentSkillsLoading,
+                    error: state.agentSkillsError,
+                    agentId: state.agentSkillsAgentId,
+                    filter: state.skillsFilter,
+                  },
+                  toolsCatalog: {
+                    loading: state.toolsCatalogLoading,
+                    error: state.toolsCatalogError,
+                    result: state.toolsCatalogResult,
+                  },
+                  toolsEffective: {
+                    loading: state.toolsEffectiveLoading,
+                    error: state.toolsEffectiveError,
+                    result: state.toolsEffectiveResult,
+                  },
+                  runtimeSessionKey: state.sessionKey,
+                  runtimeSessionMatchesSelectedAgent: toolsPanelUsesActiveSession,
+                  modelCatalog: state.chatModelCatalog ?? [],
+                  onRefresh: async () => {
+                    await loadAgents(state);
+                    const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
+                    if (agentIds.length > 0) {
+                      void loadAgentIdentities(state, agentIds);
+                    }
+                    loadAgentPanelDataForSelectedAgent(resolveSelectedAgentId());
+                    refreshAgentsPanelSupplementalData(state.agentsPanel);
+                  },
+                  onSelectAgent: (agentId) => {
+                    if (state.agentsSelectedId === agentId) {
+                      return;
+                    }
+                    state.agentsSelectedId = agentId;
+                    resetAgentSelectionPanelState();
+                    void loadAgentIdentity(state, agentId);
+                    loadAgentPanelDataForSelectedAgent(agentId);
+                  },
+                  onSelectPanel: (panel) => {
+                    state.agentsPanel = panel;
+                    if (
+                      panel === "files" &&
+                      resolvedAgentId &&
+                      state.agentFilesList?.agentId !== resolvedAgentId
+                    ) {
+                      resetAgentFilesState();
+                      void loadAgentFiles(state, resolvedAgentId);
+                    }
+                    if (panel === "skills" && resolvedAgentId) {
+                      void loadAgentSkills(state, resolvedAgentId);
+                    }
+                    if (panel === "tools" && resolvedAgentId) {
                       if (
-                        state.toolsEffectiveResultKey !== toolsRequestKey ||
-                        state.toolsEffectiveError
+                        state.toolsCatalogResult?.agentId !== resolvedAgentId ||
+                        state.toolsCatalogError
                       ) {
-                        void loadToolsEffective(state, {
+                        void loadToolsCatalog(state, resolvedAgentId);
+                      }
+                      if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
+                        const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
                           agentId: resolvedAgentId,
                           sessionKey: state.sessionKey,
                         });
-                      }
-                    } else {
-                      resetToolsEffectiveState(state);
-                    }
-                  }
-                  refreshAgentsPanelSupplementalData(panel);
-                },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
-                onSelectFile: (name) => {
-                  state.agentFileActive = name;
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  void loadAgentFileContent(state, resolvedAgentId, name);
-                },
-                onFileDraftChange: (name, content) => {
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
-                },
-                onFileReset: (name) => {
-                  const base = state.agentFileContents[name] ?? "";
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
-                },
-                onFileSave: (name) => {
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  const content =
-                    state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
-                  void saveAgentFile(state, resolvedAgentId, name, content);
-                },
-                onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  const basePath = resolveAgentToolsPath(agentId, Boolean(profile || clearAllow));
-                  if (!basePath) {
-                    return;
-                  }
-                  if (profile) {
-                    updateConfigFormValue(state, [...basePath, "profile"], profile);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "profile"]);
-                  }
-                  if (clearAllow) {
-                    removeConfigFormValue(state, [...basePath, "allow"]);
-                  }
-                },
-                onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  const basePath = resolveAgentToolsPath(
-                    agentId,
-                    alsoAllow.length > 0 || deny.length > 0,
-                  );
-                  if (!basePath) {
-                    return;
-                  }
-                  if (alsoAllow.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "alsoAllow"]);
-                  }
-                  if (deny.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "deny"], deny);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "deny"]);
-                  }
-                },
-                onConfigReload: () => loadConfig(state),
-                onConfigSave: () => saveAgentsConfig(state),
-                onChannelsRefresh: () => loadChannels(state, false),
-                onCronRefresh: () => state.loadCron(),
-                onCronRunNow: (jobId) => {
-                  const job = state.cronJobs.find((entry) => entry.id === jobId);
-                  if (!job) {
-                    return;
-                  }
-                  void runCronJob(state, job, "force");
-                },
-                onSkillsFilterChange: (next) => (state.skillsFilter = next),
-                onSkillsRefresh: () => {
-                  if (resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                },
-                onAgentSkillToggle: (agentId, skillName, enabled) => {
-                  const index = ensureAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { skills?: unknown })
-                    : undefined;
-                  const normalizedSkill = skillName.trim();
-                  if (!normalizedSkill) {
-                    return;
-                  }
-                  const allSkills =
-                    state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
-                    [];
-                  const existing = Array.isArray(entry?.skills)
-                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
-                    : undefined;
-                  const base = existing ?? allSkills;
-                  const next = new Set(base);
-                  if (enabled) {
-                    next.add(normalizedSkill);
-                  } else {
-                    next.delete(normalizedSkill);
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
-                },
-                onAgentSkillsClear: (agentId) => {
-                  const index = findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  removeConfigFormValue(state, ["agents", "list", index, "skills"]);
-                },
-                onAgentSkillsDisableAll: (agentId) => {
-                  const index = ensureAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
-                },
-                onModelChange: (agentId, modelId) => {
-                  const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const modelEntry = resolveAgentModelFormEntry(index);
-                  const { basePath, existing } = modelEntry;
-                  if (!modelId) {
-                    removeConfigFormValue(state, basePath);
-                  } else {
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                      const next = {
-                        primary: modelId,
-                        ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                      };
-                      updateConfigFormValue(state, basePath, next);
-                    } else {
-                      updateConfigFormValue(state, basePath, modelId);
-                    }
-                  }
-                  void refreshVisibleToolsEffectiveForCurrentSession(state);
-                },
-                onModelFallbacksChange: (agentId, fallbacks) => {
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const currentConfig = getCurrentConfigValue();
-                  const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
-                  const effectivePrimary =
-                    resolveModelPrimary(resolvedConfig.entry?.model) ??
-                    resolveModelPrimary(resolvedConfig.defaults?.model);
-                  const effectiveFallbacks = resolveEffectiveModelFallbacks(
-                    resolvedConfig.entry?.model,
-                    resolvedConfig.defaults?.model,
-                  );
-                  const index =
-                    normalized.length > 0
-                      ? effectivePrimary
-                        ? ensureAgentIndex(agentId)
-                        : -1
-                      : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
-                        ? ensureAgentIndex(agentId)
-                        : -1;
-                  if (index < 0) {
-                    return;
-                  }
-                  const { basePath, existing } = resolveAgentModelFormEntry(index);
-                  const resolvePrimary = () => {
-                    if (typeof existing === "string") {
-                      return existing.trim() || null;
-                    }
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const primary = (existing as { primary?: unknown }).primary;
-                      if (typeof primary === "string") {
-                        const trimmed = primary.trim();
-                        return trimmed || null;
+                        if (
+                          state.toolsEffectiveResultKey !== toolsRequestKey ||
+                          state.toolsEffectiveError
+                        ) {
+                          void loadToolsEffective(state, {
+                            agentId: resolvedAgentId,
+                            sessionKey: state.sessionKey,
+                          });
+                        }
+                      } else {
+                        resetToolsEffectiveState(state);
                       }
                     }
-                    return null;
-                  };
-                  const primary = resolvePrimary() ?? effectivePrimary;
-                  if (normalized.length === 0) {
-                    if (primary) {
-                      updateConfigFormValue(state, basePath, primary);
+                    refreshAgentsPanelSupplementalData(panel);
+                  },
+                  onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+                  onSelectFile: (name) => {
+                    state.agentFileActive = name;
+                    if (!resolvedAgentId) {
+                      return;
+                    }
+                    void loadAgentFileContent(state, resolvedAgentId, name);
+                  },
+                  onFileDraftChange: (name, content) => {
+                    state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
+                  },
+                  onFileReset: (name) => {
+                    const base = state.agentFileContents[name] ?? "";
+                    state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
+                  },
+                  onFileSave: (name) => {
+                    if (!resolvedAgentId) {
+                      return;
+                    }
+                    const content =
+                      state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
+                    void saveAgentFile(state, resolvedAgentId, name, content);
+                  },
+                  onToolsProfileChange: (agentId, profile, clearAllow) => {
+                    const basePath = resolveAgentToolsPath(agentId, Boolean(profile || clearAllow));
+                    if (!basePath) {
+                      return;
+                    }
+                    if (profile) {
+                      updateConfigFormValue(state, [...basePath, "profile"], profile);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "profile"]);
+                    }
+                    if (clearAllow) {
+                      removeConfigFormValue(state, [...basePath, "allow"]);
+                    }
+                  },
+                  onToolsOverridesChange: (agentId, alsoAllow, deny) => {
+                    const basePath = resolveAgentToolsPath(
+                      agentId,
+                      alsoAllow.length > 0 || deny.length > 0,
+                    );
+                    if (!basePath) {
+                      return;
+                    }
+                    if (alsoAllow.length > 0) {
+                      updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "alsoAllow"]);
+                    }
+                    if (deny.length > 0) {
+                      updateConfigFormValue(state, [...basePath, "deny"], deny);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "deny"]);
+                    }
+                  },
+                  onConfigReload: () => loadConfig(state),
+                  onConfigSave: () => saveAgentsConfig(state),
+                  onChannelsRefresh: () => loadChannels(state, false),
+                  onCronRefresh: () => state.loadCron(),
+                  onCronRunNow: (jobId) => {
+                    const job = state.cronJobs.find((entry) => entry.id === jobId);
+                    if (!job) {
+                      return;
+                    }
+                    void runCronJob(state, job, "force");
+                  },
+                  onSkillsFilterChange: (next) => (state.skillsFilter = next),
+                  onSkillsRefresh: () => {
+                    if (resolvedAgentId) {
+                      void loadAgentSkills(state, resolvedAgentId);
+                    }
+                  },
+                  onAgentSkillToggle: (agentId, skillName, enabled) => {
+                    const index = ensureAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const list = (
+                      getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null
+                    )?.agents?.list;
+                    const entry = Array.isArray(list)
+                      ? (list[index] as { skills?: unknown })
+                      : undefined;
+                    const normalizedSkill = skillName.trim();
+                    if (!normalizedSkill) {
+                      return;
+                    }
+                    const allSkills =
+                      state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
+                      [];
+                    const existing = Array.isArray(entry?.skills)
+                      ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
+                      : undefined;
+                    const base = existing ?? allSkills;
+                    const next = new Set(base);
+                    if (enabled) {
+                      next.add(normalizedSkill);
+                    } else {
+                      next.delete(normalizedSkill);
+                    }
+                    updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
+                  },
+                  onAgentSkillsClear: (agentId) => {
+                    const index = findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    removeConfigFormValue(state, ["agents", "list", index, "skills"]);
+                  },
+                  onAgentSkillsDisableAll: (agentId) => {
+                    const index = ensureAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
+                  },
+                  onModelChange: (agentId, modelId) => {
+                    const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const modelEntry = resolveAgentModelFormEntry(index);
+                    const { basePath, existing } = modelEntry;
+                    if (!modelId) {
+                      removeConfigFormValue(state, basePath);
+                    } else {
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
+                        const next = {
+                          primary: modelId,
+                          ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
+                        };
+                        updateConfigFormValue(state, basePath, next);
+                      } else {
+                        updateConfigFormValue(state, basePath, modelId);
+                      }
+                    }
+                    void refreshVisibleToolsEffectiveForCurrentSession(state);
+                  },
+                  onModelFallbacksChange: (agentId, fallbacks) => {
+                    const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+                    const currentConfig = getCurrentConfigValue();
+                    const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
+                    const effectivePrimary =
+                      resolveModelPrimary(resolvedConfig.entry?.model) ??
+                      resolveModelPrimary(resolvedConfig.defaults?.model);
+                    const effectiveFallbacks = resolveEffectiveModelFallbacks(
+                      resolvedConfig.entry?.model,
+                      resolvedConfig.defaults?.model,
+                    );
+                    const index =
+                      normalized.length > 0
+                        ? effectivePrimary
+                          ? ensureAgentIndex(agentId)
+                          : -1
+                        : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
+                          ? ensureAgentIndex(agentId)
+                          : -1;
+                    if (index < 0) {
+                      return;
+                    }
+                    const { basePath, existing } = resolveAgentModelFormEntry(index);
+                    const resolvePrimary = () => {
+                      if (typeof existing === "string") {
+                        return existing.trim() || null;
+                      }
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const primary = (existing as { primary?: unknown }).primary;
+                        if (typeof primary === "string") {
+                          const trimmed = primary.trim();
+                          return trimmed || null;
+                        }
+                      }
+                      return null;
+                    };
+                    const primary = resolvePrimary() ?? effectivePrimary;
+                    if (normalized.length === 0) {
+                      if (primary) {
+                        updateConfigFormValue(state, basePath, primary);
+                      } else {
+                        removeConfigFormValue(state, basePath);
+                      }
+                      return;
+                    }
+                    if (!primary) {
+                      return;
+                    }
+                    updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                  },
+                  onSetDefault: (agentId) => {
+                    if (!configValue) {
+                      return;
+                    }
+                    updateConfigFormValue(state, ["agents", "defaultId"], agentId);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "skills"
+            ? lazyRender(lazySkills, (m) =>
+                m.renderSkills({
+                  connected: state.connected,
+                  loading: state.skillsLoading,
+                  report: state.skillsReport,
+                  error: state.skillsError,
+                  filter: state.skillsFilter,
+                  statusFilter: state.skillsStatusFilter,
+                  edits: state.skillEdits,
+                  messages: state.skillMessages,
+                  busyKey: state.skillsBusyKey,
+                  detailKey: state.skillsDetailKey,
+                  clawhubQuery: state.clawhubSearchQuery,
+                  clawhubResults: state.clawhubSearchResults,
+                  clawhubSearchLoading: state.clawhubSearchLoading,
+                  clawhubSearchError: state.clawhubSearchError,
+                  clawhubDetail: state.clawhubDetail,
+                  clawhubDetailSlug: state.clawhubDetailSlug,
+                  clawhubDetailLoading: state.clawhubDetailLoading,
+                  clawhubDetailError: state.clawhubDetailError,
+                  clawhubInstallSlug: state.clawhubInstallSlug,
+                  clawhubInstallMessage: state.clawhubInstallMessage,
+                  onFilterChange: (next) => (state.skillsFilter = next),
+                  onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
+                  onRefresh: () => loadSkills(state, { clearMessages: true }),
+                  onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
+                  onEdit: (key, value) => updateSkillEdit(state, key, value),
+                  onSaveKey: (key) => saveSkillApiKey(state, key),
+                  onInstall: (skillKey, name, installId) =>
+                    installSkill(state, skillKey, name, installId),
+                  onDetailOpen: (key) => (state.skillsDetailKey = key),
+                  onDetailClose: () => (state.skillsDetailKey = null),
+                  onClawHubQueryChange: (query) => {
+                    setClawHubSearchQuery(state, query);
+                    if (clawhubSearchTimer) {
+                      clearTimeout(clawhubSearchTimer);
+                    }
+                    clawhubSearchTimer = setTimeout(() => searchClawHub(state, query), 300);
+                  },
+                  onClawHubDetailOpen: (slug) => loadClawHubDetail(state, slug),
+                  onClawHubDetailClose: () => closeClawHubDetail(state),
+                  onClawHubInstall: (slug) => installFromClawHub(state, slug),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "nodes"
+            ? lazyRender(lazyNodes, (m) =>
+                m.renderNodes({
+                  loading: state.nodesLoading,
+                  nodes: state.nodes,
+                  devicesLoading: state.devicesLoading,
+                  devicesError: state.devicesError,
+                  devicesList: state.devicesList,
+                  configForm:
+                    state.configForm ??
+                    (state.configSnapshot?.config as Record<string, unknown> | null),
+                  configLoading: state.configLoading,
+                  configSaving: state.configSaving,
+                  configDirty: state.configFormDirty,
+                  configFormMode: state.configFormMode,
+                  execApprovalsLoading: state.execApprovalsLoading,
+                  execApprovalsSaving: state.execApprovalsSaving,
+                  execApprovalsDirty: state.execApprovalsDirty,
+                  execApprovalsSnapshot: state.execApprovalsSnapshot,
+                  execApprovalsForm: state.execApprovalsForm,
+                  execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
+                  execApprovalsTarget: state.execApprovalsTarget,
+                  execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
+                  onRefresh: () => loadNodes(state),
+                  onDevicesRefresh: () => loadDevices(state),
+                  onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
+                  onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
+                  onDeviceRotate: (deviceId, role, scopes) =>
+                    rotateDeviceToken(state, { deviceId, role, scopes }),
+                  onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
+                  onLoadConfig: () => loadConfig(state),
+                  onLoadExecApprovals: () => {
+                    const target =
+                      state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+                        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+                        : { kind: "gateway" as const };
+                    return loadExecApprovals(state, target);
+                  },
+                  onBindDefault: (nodeId) => {
+                    if (nodeId) {
+                      updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
+                    } else {
+                      removeConfigFormValue(state, ["tools", "exec", "node"]);
+                    }
+                  },
+                  onBindAgent: (agentIndex, nodeId) => {
+                    const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
+                    if (nodeId) {
+                      updateConfigFormValue(state, basePath, nodeId);
                     } else {
                       removeConfigFormValue(state, basePath);
                     }
-                    return;
-                  }
-                  if (!primary) {
-                    return;
-                  }
-                  updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                  },
+                  onSaveBindings: () => saveConfig(state),
+                  onExecApprovalsTargetChange: (kind, nodeId) => {
+                    state.execApprovalsTarget = kind;
+                    state.execApprovalsTargetNodeId = nodeId;
+                    state.execApprovalsSnapshot = null;
+                    state.execApprovalsForm = null;
+                    state.execApprovalsDirty = false;
+                    state.execApprovalsSelectedAgent = null;
+                  },
+                  onExecApprovalsSelectAgent: (agentId) => {
+                    state.execApprovalsSelectedAgent = agentId;
+                  },
+                  onExecApprovalsPatch: (path, value) =>
+                    updateExecApprovalsFormValue(state, path, value),
+                  onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
+                  onSaveExecApprovals: () => {
+                    const target =
+                      state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+                        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+                        : { kind: "gateway" as const };
+                    return saveExecApprovals(state, target);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "chat"
+            ? renderChat({
+                sessionKey: state.sessionKey,
+                onSessionKeyChange: (next) => {
+                  switchChatSession(state, next);
                 },
-                onSetDefault: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "defaultId"], agentId);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "skills"
-          ? lazyRender(lazySkills, (m) =>
-              m.renderSkills({
+                thinkingLevel: state.chatThinkingLevel,
+                showThinking,
+                showToolCalls,
+                loading: state.chatLoading,
+                sending: state.chatSending,
+                compactionStatus: state.compactionStatus,
+                fallbackStatus: state.fallbackStatus,
+                assistantAvatarUrl: chatAvatarUrl,
+                messages: state.chatMessages,
+                sideResult: state.chatSideResult,
+                toolMessages: state.chatToolMessages,
+                streamSegments: state.chatStreamSegments,
+                stream: state.chatStream,
+                streamStartedAt: state.chatStreamStartedAt,
+                draft: state.chatMessage,
+                queue: state.chatQueue,
+                realtimeTalkActive: state.realtimeTalkActive,
+                realtimeTalkStatus: state.realtimeTalkStatus,
+                realtimeTalkDetail: state.realtimeTalkDetail,
+                realtimeTalkTranscript: state.realtimeTalkTranscript,
                 connected: state.connected,
-                loading: state.skillsLoading,
-                report: state.skillsReport,
-                error: state.skillsError,
-                filter: state.skillsFilter,
-                statusFilter: state.skillsStatusFilter,
-                edits: state.skillEdits,
-                messages: state.skillMessages,
-                busyKey: state.skillsBusyKey,
-                detailKey: state.skillsDetailKey,
-                clawhubQuery: state.clawhubSearchQuery,
-                clawhubResults: state.clawhubSearchResults,
-                clawhubSearchLoading: state.clawhubSearchLoading,
-                clawhubSearchError: state.clawhubSearchError,
-                clawhubDetail: state.clawhubDetail,
-                clawhubDetailSlug: state.clawhubDetailSlug,
-                clawhubDetailLoading: state.clawhubDetailLoading,
-                clawhubDetailError: state.clawhubDetailError,
-                clawhubInstallSlug: state.clawhubInstallSlug,
-                clawhubInstallMessage: state.clawhubInstallMessage,
-                onFilterChange: (next) => (state.skillsFilter = next),
-                onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
-                onRefresh: () => loadSkills(state, { clearMessages: true }),
-                onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
-                onEdit: (key, value) => updateSkillEdit(state, key, value),
-                onSaveKey: (key) => saveSkillApiKey(state, key),
-                onInstall: (skillKey, name, installId) =>
-                  installSkill(state, skillKey, name, installId),
-                onDetailOpen: (key) => (state.skillsDetailKey = key),
-                onDetailClose: () => (state.skillsDetailKey = null),
-                onClawHubQueryChange: (query) => {
-                  setClawHubSearchQuery(state, query);
-                  if (clawhubSearchTimer) {
-                    clearTimeout(clawhubSearchTimer);
-                  }
-                  clawhubSearchTimer = setTimeout(() => searchClawHub(state, query), 300);
-                },
-                onClawHubDetailOpen: (slug) => loadClawHubDetail(state, slug),
-                onClawHubDetailClose: () => closeClawHubDetail(state),
-                onClawHubInstall: (slug) => installFromClawHub(state, slug),
-              }),
-            )
-          : nothing}
-        ${state.tab === "nodes"
-          ? lazyRender(lazyNodes, (m) =>
-              m.renderNodes({
-                loading: state.nodesLoading,
-                nodes: state.nodes,
-                devicesLoading: state.devicesLoading,
-                devicesError: state.devicesError,
-                devicesList: state.devicesList,
-                configForm:
-                  state.configForm ??
-                  (state.configSnapshot?.config as Record<string, unknown> | null),
-                configLoading: state.configLoading,
-                configSaving: state.configSaving,
-                configDirty: state.configFormDirty,
-                configFormMode: state.configFormMode,
-                execApprovalsLoading: state.execApprovalsLoading,
-                execApprovalsSaving: state.execApprovalsSaving,
-                execApprovalsDirty: state.execApprovalsDirty,
-                execApprovalsSnapshot: state.execApprovalsSnapshot,
-                execApprovalsForm: state.execApprovalsForm,
-                execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
-                execApprovalsTarget: state.execApprovalsTarget,
-                execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
-                onRefresh: () => loadNodes(state),
-                onDevicesRefresh: () => loadDevices(state),
-                onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
-                onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
-                onDeviceRotate: (deviceId, role, scopes) =>
-                  rotateDeviceToken(state, { deviceId, role, scopes }),
-                onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
-                onLoadConfig: () => loadConfig(state),
-                onLoadExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return loadExecApprovals(state, target);
-                },
-                onBindDefault: (nodeId) => {
-                  if (nodeId) {
-                    updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
-                  } else {
-                    removeConfigFormValue(state, ["tools", "exec", "node"]);
-                  }
-                },
-                onBindAgent: (agentIndex, nodeId) => {
-                  const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
-                  if (nodeId) {
-                    updateConfigFormValue(state, basePath, nodeId);
-                  } else {
-                    removeConfigFormValue(state, basePath);
-                  }
-                },
-                onSaveBindings: () => saveConfig(state),
-                onExecApprovalsTargetChange: (kind, nodeId) => {
-                  state.execApprovalsTarget = kind;
-                  state.execApprovalsTargetNodeId = nodeId;
-                  state.execApprovalsSnapshot = null;
-                  state.execApprovalsForm = null;
-                  state.execApprovalsDirty = false;
-                  state.execApprovalsSelectedAgent = null;
-                },
-                onExecApprovalsSelectAgent: (agentId) => {
-                  state.execApprovalsSelectedAgent = agentId;
-                },
-                onExecApprovalsPatch: (path, value) =>
-                  updateExecApprovalsFormValue(state, path, value),
-                onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
-                onSaveExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return saveExecApprovals(state, target);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "chat"
-          ? renderChat({
-              sessionKey: state.sessionKey,
-              onSessionKeyChange: (next) => {
-                switchChatSession(state, next);
-              },
-              thinkingLevel: state.chatThinkingLevel,
-              showThinking,
-              showToolCalls,
-              loading: state.chatLoading,
-              sending: state.chatSending,
-              compactionStatus: state.compactionStatus,
-              fallbackStatus: state.fallbackStatus,
-              assistantAvatarUrl: chatAvatarUrl,
-              messages: state.chatMessages,
-              sideResult: state.chatSideResult,
-              toolMessages: state.chatToolMessages,
-              streamSegments: state.chatStreamSegments,
-              stream: state.chatStream,
-              streamStartedAt: state.chatStreamStartedAt,
-              draft: state.chatMessage,
-              queue: state.chatQueue,
-              realtimeTalkActive: state.realtimeTalkActive,
-              realtimeTalkStatus: state.realtimeTalkStatus,
-              realtimeTalkDetail: state.realtimeTalkDetail,
-              realtimeTalkTranscript: state.realtimeTalkTranscript,
-              connected: state.connected,
-              canSend: state.connected,
-              disabledReason: chatDisabledReason,
-              error: state.lastError,
-              sessions: state.sessionsResult,
-              focusMode: chatFocus,
-              autoExpandToolCalls: false,
-              onRefresh: () => {
-                state.chatSideResult = null;
-                state.resetToolStream();
-                return refreshChat(state, { scheduleScroll: false });
-              },
-              onToggleFocusMode: () => {
-                if (state.onboarding) {
-                  return;
-                }
-                state.applySettings({
-                  ...state.settings,
-                  chatFocusMode: !state.settings.chatFocusMode,
-                });
-              },
-              onChatScroll: (event) => state.handleChatScroll(event),
-              getDraft: () => state.chatMessage,
-              onDraftChange: (next) => state.handleChatDraftChange(next),
-              onRequestUpdate: requestHostUpdate,
-              onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
-              attachments: state.chatAttachments,
-              onAttachmentsChange: (next) => (state.chatAttachments = next),
-              onSend: () => state.handleSendChat(),
-              onCompact: () => state.handleSendChat("/compact", { restoreDraft: true }),
-              onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),
-              canAbort: Boolean(state.chatRunId),
-              onAbort: () => void state.handleAbortChat(),
-              onQueueRemove: (id) => state.removeQueuedMessage(id),
-              onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
-              onDismissSideResult: () => {
-                state.chatSideResult = null;
-              },
-              onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
-              onClearHistory: async () => {
-                if (!state.client || !state.connected) {
-                  return;
-                }
-                try {
-                  await state.client.request("sessions.reset", { key: state.sessionKey });
-                  state.chatMessages = [];
+                canSend: state.connected,
+                disabledReason: chatDisabledReason,
+                error: state.lastError,
+                sessions: state.sessionsResult,
+                focusMode: chatFocus,
+                autoExpandToolCalls: false,
+                onRefresh: () => {
                   state.chatSideResult = null;
-                  state.chatStream = null;
-                  state.chatRunId = null;
-                  await loadChatHistory(state);
-                } catch (err) {
-                  state.lastError = String(err);
-                }
-              },
-              agentsList: state.agentsList,
-              currentAgentId: resolvedAgentId ?? "main",
-              onAgentChange: (agentId: string) => {
-                switchChatSession(state, buildAgentMainSessionKey({ agentId }));
-              },
-              onNavigateToAgent: () => {
-                state.agentsSelectedId = resolvedAgentId;
-                state.setTab("agents" as import("./navigation.ts").Tab);
-              },
-              onSessionSelect: (key: string) => {
-                switchChatSession(state, key);
-              },
-              showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-              onScrollToBottom: () => state.scrollToBottom(),
-              // Sidebar props for tool output viewing
-              sidebarOpen: state.sidebarOpen,
-              sidebarContent: state.sidebarContent,
-              sidebarError: state.sidebarError,
-              splitRatio: state.splitRatio,
-              canvasHostUrl: state.hello?.canvasHostUrl ?? null,
-              onOpenSidebar: (content) => state.handleOpenSidebar(content),
-              onCloseSidebar: () => state.handleCloseSidebar(),
-              onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-              assistantName: state.assistantName,
-              assistantAvatar: effectiveAssistantAvatar,
-              userName: state.userName ?? null,
-              userAvatar: state.userAvatar ?? null,
-              localMediaPreviewRoots: state.localMediaPreviewRoots,
-              embedSandboxMode: state.embedSandboxMode,
-              allowExternalEmbedUrls: state.allowExternalEmbedUrls,
-              assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
-              basePath: state.basePath ?? "",
-            })
-          : nothing}
-        ${renderConfigTabForActiveTab()}
-        ${state.tab === "debug"
-          ? lazyRender(lazyDebug, (m) =>
-              m.renderDebug({
-                loading: state.debugLoading,
-                status: state.debugStatus,
-                health: state.debugHealth,
-                models: state.debugModels,
-                heartbeat: state.debugHeartbeat,
-                eventLog: state.eventLog,
-                methods: (state.hello?.features?.methods ?? []).toSorted(),
-                callMethod: state.debugCallMethod,
-                callParams: state.debugCallParams,
-                callResult: state.debugCallResult,
-                callError: state.debugCallError,
-                onCallMethodChange: (next) => (state.debugCallMethod = next),
-                onCallParamsChange: (next) => (state.debugCallParams = next),
-                onRefresh: () => loadDebug(state),
-                onCall: () => callDebugMethod(state),
-              }),
-            )
-          : nothing}
-        ${state.tab === "logs"
-          ? lazyRender(lazyLogs, (m) =>
-              m.renderLogs({
-                loading: state.logsLoading,
-                error: state.logsError,
-                file: state.logsFile,
-                entries: state.logsEntries,
-                filterText: state.logsFilterText,
-                levelFilters: state.logsLevelFilters,
-                autoFollow: state.logsAutoFollow,
-                truncated: state.logsTruncated,
-                onFilterTextChange: (next) => (state.logsFilterText = next),
-                onLevelToggle: (level, enabled) => {
-                  state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  state.resetToolStream();
+                  return refreshChat(state, { scheduleScroll: false });
                 },
-                onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-                onRefresh: () => loadLogs(state, { reset: true }),
-                onExport: (lines, label) => state.exportLogs(lines, label),
-                onScroll: (event) => state.handleLogsScroll(event),
-              }),
-            )
-          : nothing}
-        ${state.tab === "dreams"
-          ? renderDreaming({
-              active: dreamingOn,
-              shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
-              groundedSignalCount: state.dreamingStatus?.groundedSignalCount ?? 0,
-              totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
-              promotedCount: state.dreamingStatus?.promotedToday ?? 0,
-              phases: state.dreamingStatus?.phases ?? undefined,
-              shortTermEntries: state.dreamingStatus?.shortTermEntries ?? [],
-              promotedEntries: state.dreamingStatus?.promotedEntries ?? [],
-              dreamingOf: null,
-              nextCycle: dreamingNextCycle,
-              timezone: state.dreamingStatus?.timezone ?? null,
-              statusLoading: state.dreamingStatusLoading,
-              statusError: state.dreamingStatusError,
-              modeSaving: state.dreamingModeSaving,
-              dreamDiaryLoading: state.dreamDiaryLoading,
-              dreamDiaryActionLoading: state.dreamDiaryActionLoading,
-              dreamDiaryActionMessage: state.dreamDiaryActionMessage,
-              dreamDiaryActionArchivePath: state.dreamDiaryActionArchivePath,
-              dreamDiaryError: state.dreamDiaryError,
-              dreamDiaryPath: state.dreamDiaryPath,
-              dreamDiaryContent: state.dreamDiaryContent,
-              memoryWikiEnabled: isPluginEnabledInConfigSnapshot(
-                state.configSnapshot,
-                "memory-wiki",
-                { enabledByDefault: false },
-              ),
-              wikiImportInsightsLoading: state.wikiImportInsightsLoading,
-              wikiImportInsightsError: state.wikiImportInsightsError,
-              wikiImportInsights: state.wikiImportInsights,
-              wikiMemoryPalaceLoading: state.wikiMemoryPalaceLoading,
-              wikiMemoryPalaceError: state.wikiMemoryPalaceError,
-              wikiMemoryPalace: state.wikiMemoryPalace,
-              onRefresh: refreshDreaming,
-              onRefreshDiary: () => loadDreamDiary(state),
-              onRefreshImports: () => {
-                void (async () => {
-                  await loadConfig(state);
-                  await loadWikiImportInsights(state);
-                })();
-              },
-              onRefreshMemoryPalace: () => {
-                void (async () => {
-                  await loadConfig(state);
-                  await loadWikiMemoryPalace(state);
-                })();
-              },
-              onOpenConfig: () => openConfigFile(state),
-              onOpenWikiPage: (lookup: string) => openWikiPage(lookup),
-              onBackfillDiary: () => backfillDreamDiary(state),
-              onCopyDreamingArchivePath: () => {
-                void copyDreamingArchivePath(state);
-              },
-              onDedupeDreamDiary: () => dedupeDreamDiary(state),
-              onResetDiary: () => resetDreamDiary(state),
-              onResetGroundedShortTerm: () => resetGroundedShortTerm(state),
-              onRepairDreamingArtifacts: () => repairDreamingArtifacts(state),
-              onRequestUpdate: requestHostUpdate,
-            })
-          : nothing}
+                onToggleFocusMode: () => {
+                  if (state.onboarding) {
+                    return;
+                  }
+                  state.applySettings({
+                    ...state.settings,
+                    chatFocusMode: !state.settings.chatFocusMode,
+                  });
+                },
+                onChatScroll: (event) => state.handleChatScroll(event),
+                getDraft: () => state.chatMessage,
+                onDraftChange: (next) => state.handleChatDraftChange(next),
+                onRequestUpdate: requestHostUpdate,
+                onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
+                attachments: state.chatAttachments,
+                onAttachmentsChange: (next) => (state.chatAttachments = next),
+                onSend: () => state.handleSendChat(),
+                onCompact: () => state.handleSendChat("/compact", { restoreDraft: true }),
+                onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),
+                canAbort: Boolean(state.chatRunId),
+                onAbort: () => void state.handleAbortChat(),
+                onQueueRemove: (id) => state.removeQueuedMessage(id),
+                onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
+                onDismissSideResult: () => {
+                  state.chatSideResult = null;
+                },
+                onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
+                onClearHistory: async () => {
+                  if (!state.client || !state.connected) {
+                    return;
+                  }
+                  try {
+                    await state.client.request("sessions.reset", { key: state.sessionKey });
+                    state.chatMessages = [];
+                    state.chatSideResult = null;
+                    state.chatStream = null;
+                    state.chatRunId = null;
+                    await loadChatHistory(state);
+                  } catch (err) {
+                    state.lastError = String(err);
+                  }
+                },
+                agentsList: state.agentsList,
+                currentAgentId: resolvedAgentId ?? "main",
+                onAgentChange: (agentId: string) => {
+                  switchChatSession(state, buildAgentMainSessionKey({ agentId }));
+                },
+                onNavigateToAgent: () => {
+                  state.agentsSelectedId = resolvedAgentId;
+                  state.setTab("agents" as import("./navigation.ts").Tab);
+                },
+                onSessionSelect: (key: string) => {
+                  switchChatSession(state, key);
+                },
+                showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+                onScrollToBottom: () => state.scrollToBottom(),
+                // Sidebar props for tool output viewing
+                sidebarOpen: state.sidebarOpen,
+                sidebarContent: state.sidebarContent,
+                sidebarError: state.sidebarError,
+                splitRatio: state.splitRatio,
+                canvasHostUrl: state.hello?.canvasHostUrl ?? null,
+                onOpenSidebar: (content) => state.handleOpenSidebar(content),
+                onCloseSidebar: () => state.handleCloseSidebar(),
+                onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                assistantName: state.assistantName,
+                assistantAvatar: effectiveAssistantAvatar,
+                userName: state.userName ?? null,
+                userAvatar: state.userAvatar ?? null,
+                localMediaPreviewRoots: state.localMediaPreviewRoots,
+                embedSandboxMode: state.embedSandboxMode,
+                allowExternalEmbedUrls: state.allowExternalEmbedUrls,
+                assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
+                basePath: state.basePath ?? "",
+              })
+            : nothing
+        }
+        ${renderConfigTabForActiveTab()}
+        ${
+          state.tab === "debug"
+            ? lazyRender(lazyDebug, (m) =>
+                m.renderDebug({
+                  loading: state.debugLoading,
+                  status: state.debugStatus,
+                  health: state.debugHealth,
+                  models: state.debugModels,
+                  heartbeat: state.debugHeartbeat,
+                  eventLog: state.eventLog,
+                  methods: (state.hello?.features?.methods ?? []).toSorted(),
+                  callMethod: state.debugCallMethod,
+                  callParams: state.debugCallParams,
+                  callResult: state.debugCallResult,
+                  callError: state.debugCallError,
+                  onCallMethodChange: (next) => (state.debugCallMethod = next),
+                  onCallParamsChange: (next) => (state.debugCallParams = next),
+                  onRefresh: () => loadDebug(state),
+                  onCall: () => callDebugMethod(state),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "logs"
+            ? lazyRender(lazyLogs, (m) =>
+                m.renderLogs({
+                  loading: state.logsLoading,
+                  error: state.logsError,
+                  file: state.logsFile,
+                  entries: state.logsEntries,
+                  filterText: state.logsFilterText,
+                  levelFilters: state.logsLevelFilters,
+                  autoFollow: state.logsAutoFollow,
+                  truncated: state.logsTruncated,
+                  onFilterTextChange: (next) => (state.logsFilterText = next),
+                  onLevelToggle: (level, enabled) => {
+                    state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  },
+                  onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+                  onRefresh: () => loadLogs(state, { reset: true }),
+                  onExport: (lines, label) => state.exportLogs(lines, label),
+                  onScroll: (event) => state.handleLogsScroll(event),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "dreams"
+            ? renderDreaming({
+                active: dreamingOn,
+                shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
+                groundedSignalCount: state.dreamingStatus?.groundedSignalCount ?? 0,
+                totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
+                promotedCount: state.dreamingStatus?.promotedToday ?? 0,
+                phases: state.dreamingStatus?.phases ?? undefined,
+                shortTermEntries: state.dreamingStatus?.shortTermEntries ?? [],
+                promotedEntries: state.dreamingStatus?.promotedEntries ?? [],
+                dreamingOf: null,
+                nextCycle: dreamingNextCycle,
+                timezone: state.dreamingStatus?.timezone ?? null,
+                statusLoading: state.dreamingStatusLoading,
+                statusError: state.dreamingStatusError,
+                modeSaving: state.dreamingModeSaving,
+                dreamDiaryLoading: state.dreamDiaryLoading,
+                dreamDiaryActionLoading: state.dreamDiaryActionLoading,
+                dreamDiaryActionMessage: state.dreamDiaryActionMessage,
+                dreamDiaryActionArchivePath: state.dreamDiaryActionArchivePath,
+                dreamDiaryError: state.dreamDiaryError,
+                dreamDiaryPath: state.dreamDiaryPath,
+                dreamDiaryContent: state.dreamDiaryContent,
+                memoryWikiEnabled: isPluginEnabledInConfigSnapshot(
+                  state.configSnapshot,
+                  "memory-wiki",
+                  { enabledByDefault: false },
+                ),
+                wikiImportInsightsLoading: state.wikiImportInsightsLoading,
+                wikiImportInsightsError: state.wikiImportInsightsError,
+                wikiImportInsights: state.wikiImportInsights,
+                wikiMemoryPalaceLoading: state.wikiMemoryPalaceLoading,
+                wikiMemoryPalaceError: state.wikiMemoryPalaceError,
+                wikiMemoryPalace: state.wikiMemoryPalace,
+                onRefresh: refreshDreaming,
+                onRefreshDiary: () => loadDreamDiary(state),
+                onRefreshImports: () => {
+                  void (async () => {
+                    await loadConfig(state);
+                    await loadWikiImportInsights(state);
+                  })();
+                },
+                onRefreshMemoryPalace: () => {
+                  void (async () => {
+                    await loadConfig(state);
+                    await loadWikiMemoryPalace(state);
+                  })();
+                },
+                onOpenConfig: () => openConfigFile(state),
+                onOpenWikiPage: (lookup: string) => openWikiPage(lookup),
+                onBackfillDiary: () => backfillDreamDiary(state),
+                onCopyDreamingArchivePath: () => {
+                  void copyDreamingArchivePath(state);
+                },
+                onDedupeDreamDiary: () => dedupeDreamDiary(state),
+                onResetDiary: () => resetDreamDiary(state),
+                onResetGroundedShortTerm: () => resetGroundedShortTerm(state),
+                onRepairDreamingArtifacts: () => repairDreamingArtifacts(state),
+                onRequestUpdate: requestHostUpdate,
+              })
+            : nothing
+        }
       </main>
       ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)}
       ${renderDreamingRestartConfirmation({

--- a/ui/src/ui/keyboard-shortcuts.test.ts
+++ b/ui/src/ui/keyboard-shortcuts.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { commandPaletteShortcutLabel } from "./keyboard-shortcuts.ts";
+
+describe("commandPaletteShortcutLabel", () => {
+  it("returns the mac shortcut on Apple user agents", () => {
+    expect(
+      commandPaletteShortcutLabel({ userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X)" }),
+    ).toBe("⌘K");
+    expect(commandPaletteShortcutLabel({ userAgent: "iPhone" })).toBe("⌘K");
+  });
+
+  it("returns the control shortcut on non-Apple user agents", () => {
+    expect(
+      commandPaletteShortcutLabel({ userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" }),
+    ).toBe("Ctrl+K");
+    expect(commandPaletteShortcutLabel({ userAgent: "Mozilla/5.0 (X11; Linux x86_64)" })).toBe(
+      "Ctrl+K",
+    );
+  });
+});

--- a/ui/src/ui/keyboard-shortcuts.ts
+++ b/ui/src/ui/keyboard-shortcuts.ts
@@ -1,0 +1,12 @@
+export type NavigatorFingerprint = Pick<Navigator, "userAgent">;
+
+export function commandPaletteShortcutLabel(
+  nav: NavigatorFingerprint | undefined = globalThis.navigator,
+): string {
+  const fingerprint = (nav?.userAgent ?? "").toLowerCase();
+  return fingerprint.includes("mac") ||
+    fingerprint.includes("iphone") ||
+    fingerprint.includes("ipad")
+    ? "⌘K"
+    : "Ctrl+K";
+}

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { i18n } from "../i18n/index.ts";
 import { mountApp as mountTestApp, registerAppMountHooks } from "./test-helpers/app-mount.ts";
 
 registerAppMountHooks();
 
-afterEach(() => {
+afterEach(async () => {
+  await i18n.setLocale("en");
   vi.restoreAllMocks();
 });
 
@@ -323,6 +325,22 @@ describe("control UI routing", () => {
     expect(version).not.toBeNull();
     expect(statusDot).not.toBeNull();
     expect(statusDot?.getAttribute("aria-label")).toContain("Online");
+
+    await i18n.setLocale("zh-CN");
+    app.requestUpdate();
+    await app.updateComplete;
+
+    const shortcut = app.querySelector<HTMLElement>(".topbar-search__kbd")?.textContent ?? "";
+    const searchButton = app.querySelector<HTMLButtonElement>(".topbar-search");
+    const themeMode = app.querySelector<HTMLElement>(".topbar-theme-mode");
+    const activeThemeModeButton = app.querySelector<HTMLElement>(
+      ".topbar-theme-mode__btn[aria-pressed='true']",
+    );
+    expect(searchButton?.getAttribute("title")).toBe(`搜索或跳转… (${shortcut})`);
+    expect(searchButton?.getAttribute("aria-label")).toBe("打开命令面板");
+    expect(themeMode?.getAttribute("aria-label")).toBe("颜色模式");
+    expect(activeThemeModeButton?.getAttribute("aria-label")).toContain("颜色模式：");
+    expect(statusDot?.getAttribute("aria-label")).toContain("网关状态：在线");
 
     app.applySettings({ ...app.settings, navWidth: 360 });
     await app.updateComplete;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI still had hard-coded English labels in the shell and login gate even though the repo already ships a UI i18n system and `zh-CN` locale.
- Why it matters: This made the initial internationalization support for #41703 incomplete and left core UI affordances untranslated.
- What changed: Wired shell/login-gate labels through the existing i18n maps, added `zh-CN` translations, and made the command palette shortcut label platform-aware (`⌘K` on Apple platforms, `Ctrl+K` elsewhere).
- What did NOT change (scope boundary): This PR does not translate every remaining Control UI screen; it focuses on the shared shell/login entry points and related accessibility labels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #41703
- Related #41703

## User-visible / Behavior Changes

- The Control UI shell now localizes the command-palette trigger, update banner, docs tooltip, theme controls, gateway status text, and login-gate password/token visibility labels.
- The command-palette shortcut hint now matches the platform: `⌘K` on Apple platforms and `Ctrl+K` on other platforms.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11 host
- Runtime/container: local repo checkout
- Model/provider: n/a
- Integration/channel (if any): Control UI
- Relevant config (redacted): default local UI config

### Steps

1. Open the Control UI with `zh-CN` selected.
2. View the top shell controls and the disconnected login gate.
3. Check the command palette shortcut hint on the current platform.

### Expected

- Shell/login-gate labels are translated through the existing locale maps.
- The shortcut hint matches the current platform.

### Actual

- Before this change, those labels were hard-coded in English and the shortcut hint always showed `⌘K`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: built the Control UI successfully with `corepack pnpm exec vite build` from `ui/`; inspected the affected render paths and locale output.
- Edge cases checked: platform-specific shortcut label generation for Apple vs non-Apple platforms; localized accessibility labels for the login gate and shell status indicator.
- What you did **not** verify: I did not complete local Vitest browser runs in this environment because the test runner failed during startup with `getaddrinfo EAI_FAIL localhost`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `ui/src/i18n/locales/en.ts`, `ui/src/i18n/locales/zh-CN.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/app-render.helpers.ts`, `ui/src/ui/views/login-gate.ts`.
- Known bad symptoms reviewers should watch for: untranslated or incorrect shell/login-gate labels; wrong shortcut hint for the current platform.

## Risks and Mitigations

- Risk: Some remaining Control UI screens still have hard-coded strings outside the shell/login-gate scope.
  - Mitigation: Keep this PR scoped and follow up with additional targeted i18n patches for other screens.

AI-assisted: Codex. Lightly tested (UI build passed; local Vitest browser startup was blocked by `localhost` DNS resolution in this environment).