### PR TITLE
fix(auto-reply): pass topicId when cleaning up transcript after session reset

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -349,7 +349,9 @@ export async function runReplyAgent(params: {
       if (resolved) {
         transcriptCandidates.add(resolved);
       }
-      transcriptCandidates.add(resolveSessionTranscriptPath(prevSessionId, agentId));
+      transcriptCandidates.add(
+        resolveSessionTranscriptPath(prevSessionId, agentId, sessionCtx.MessageThreadId),
+      );
       for (const candidate of transcriptCandidates) {
         try {
           fs.unlinkSync(candidate);


### PR DESCRIPTION
## Summary

- When a session resets due to role ordering conflict (`cleanupTranscripts: true`), the cleanup code calls `resolveSessionTranscriptPath(prevSessionId, agentId)` without the `topicId` parameter
- The new-session creation (lines 320-324) correctly passes `sessionCtx.MessageThreadId` as the third argument
- For Telegram forum topic sessions, this mismatch means cleanup targets a path without the topic suffix, leaving the actual transcript file behind

## Root cause

The `resolveSessionTranscriptPath` function accepts an optional `topicId` parameter that appends a topic-specific suffix to the transcript file path. The session-creation code passes `sessionCtx.MessageThreadId`, but the cleanup code (line 352) omits it, producing a different path than the one actually written to disk.

## Fix

Pass `sessionCtx.MessageThreadId` to the cleanup call at line 352, matching the pattern used at lines 320-324 for creating the new session transcript path.

## Test plan

- [x] Code inspection confirms the cleanup path now matches the creation path
- [x] The fix is a one-line change adding the third parameter — no behavior change for non-topic sessions (where `MessageThreadId` is undefined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)