### PR TITLE
CI: remove npm release preview workflow

### DIFF
--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -11,7 +11,8 @@ Use this skill for release and publish-time workflow. Keep ordinary development 
 
 - Do not change version numbers without explicit operator approval.
 - Ask permission before any npm publish or release step.
-- Use the private maintainer release docs for the actual runbook and `docs/reference/RELEASING.md` for public policy.
+- This skill should be sufficient to drive the normal release flow end-to-end.
+- Use the private maintainer release docs for credentials, recovery steps, and mac signing/notary specifics, and use `docs/reference/RELEASING.md` for public policy.
 - Core `openclaw` publish is manual `workflow_dispatch`; creating or pushing a tag does not publish by itself.
 
 ## Keep release channel naming aligned
@@ -65,6 +66,22 @@ For a non-root smoke path:
 OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 ```
 
+## Check all relevant release builds
+
+- Always validate the core npm release path before creating the tag.
+- Default core release checks:
+  - `pnpm check`
+  - `pnpm build`
+  - `node --import tsx scripts/release-check.ts`
+  - `pnpm release:check`
+  - `OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke`
+- Check all release-related build surfaces touched by the release, not only the npm package.
+- Include mac release readiness in preflight:
+  - if the release includes mac artifacts, run or inspect the mac packaging/notary/appcast flow
+  - if the release does not include mac artifacts, explicitly confirm that exception before continuing
+- For stable releases, confirm the latest beta already passed the broader release workflows before cutting stable.
+- If any required build, packaging step, or release workflow is red, do not say the release is ready.
+
 ## Use the right auth flow
 
 - Core `openclaw` publish uses GitHub trusted publishing.
@@ -73,6 +90,20 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
+
+## Run the release sequence
+
+1. Confirm the operator explicitly wants to cut a release.
+2. Choose the exact target version and git tag.
+3. Make every repo version location match that tag before creating it.
+4. Update `CHANGELOG.md` and assemble the matching GitHub release notes.
+5. Run the full preflight for all relevant release builds, including mac readiness when applicable.
+6. Confirm the target npm version is not already published.
+7. Create and push the git tag.
+8. Create or refresh the matching GitHub release.
+9. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
+10. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
+11. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work
 

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -12,6 +12,7 @@ Use this skill for release and publish-time workflow. Keep ordinary development 
 - Do not change version numbers without explicit operator approval.
 - Ask permission before any npm publish or release step.
 - Use the private maintainer release docs for the actual runbook and `docs/reference/RELEASING.md` for public policy.
+- Core `openclaw` publish is manual `workflow_dispatch`; creating or pushing a tag does not publish by itself.
 
 ## Keep release channel naming aligned
 
@@ -31,6 +32,8 @@ Use this skill for release and publish-time workflow. Keep ordinary development 
   - `apps/macos/Sources/OpenClaw/Resources/Info.plist`
   - `docs/install/updating.md`
   - Peekaboo Xcode project and plist version fields
+- Before creating a release tag, make every version location above match the version encoded by that tag.
+- For fallback correction tags like `vYYYY.M.D-N`, the repo version locations still stay at `YYYY.M.D`.
 - “Bump version everywhere” means all version locations above except `appcast.xml`.
 - Release signing and notary credentials live outside the repo in the private maintainer docs.
 
@@ -65,6 +68,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 ## Use the right auth flow
 
 - Core `openclaw` publish uses GitHub trusted publishing.
+- The publish run must be started manually with `workflow_dispatch`.
+- The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -1,9 +1,6 @@
 name: OpenClaw NPM Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -21,111 +18,7 @@ env:
   PNPM_VERSION: "10.23.0"
 
 jobs:
-  preview_openclaw_npm:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          pnpm-version: ${{ env.PNPM_VERSION }}
-          install-bun: "false"
-          use-sticky-disk: "false"
-
-      - name: Print release plan
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          RELEASE_SHA=$(git rev-parse HEAD)
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          if [[ "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*-[1-9][0-9]*$ ]]; then
-            TAG_KIND="fallback correction"
-          else
-            TAG_KIND="standard"
-          fi
-          echo "Release plan for ${RELEASE_TAG}:"
-          echo "Resolved release SHA: ${RELEASE_SHA}"
-          echo "Resolved package version: ${PACKAGE_VERSION}"
-          echo "Resolved tag kind: ${TAG_KIND}"
-          if [[ "${TAG_KIND}" == "fallback correction" ]]; then
-            echo "Correction tag note: npm version remains ${PACKAGE_VERSION}"
-          fi
-          echo "Would run: git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main"
-          echo "Would run with env: RELEASE_SHA=${RELEASE_SHA} RELEASE_TAG=${RELEASE_TAG} RELEASE_MAIN_REF=origin/main pnpm release:openclaw:npm:check"
-          echo "Would run: npm view openclaw@${PACKAGE_VERSION} version"
-          echo "Would run: pnpm check"
-          echo "Would run: pnpm build"
-          echo "Would run: pnpm release:check"
-
-      - name: Validate release tag and package metadata
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
-          RELEASE_MAIN_REF: origin/main
-        run: |
-          set -euxo pipefail
-          RELEASE_SHA=$(git rev-parse HEAD)
-          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
-          # Fetch the full main ref so merge-base ancestry checks keep working
-          # for older tagged commits that are still contained in main.
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          pnpm release:openclaw:npm:check
-
-      - name: Ensure version is not already published
-        env:
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          set -euxo pipefail
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          IS_CORRECTION_TAG=0
-          if [[ "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*-[1-9][0-9]*$ ]]; then
-            IS_CORRECTION_TAG=1
-          fi
-
-          if npm view "openclaw@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
-            if [[ "${IS_CORRECTION_TAG}" == "1" ]]; then
-              echo "openclaw@${PACKAGE_VERSION} is already published on npm."
-              echo "Correction tag ${RELEASE_TAG} is allowed as a fallback release tag, so preview will continue without treating this as an error."
-              exit 0
-            fi
-            echo "openclaw@${PACKAGE_VERSION} is already published on npm."
-            exit 1
-          fi
-
-          if [[ "${IS_CORRECTION_TAG}" == "1" ]]; then
-            echo "Previewing fallback correction tag ${RELEASE_TAG} for npm version openclaw@${PACKAGE_VERSION}"
-          else
-            echo "Previewing openclaw@${PACKAGE_VERSION}"
-          fi
-
-      - name: Check
-        run: |
-          set -euxo pipefail
-          pnpm check
-
-      - name: Build
-        run: |
-          set -euxo pipefail
-          pnpm build
-
-      - name: Verify release contents
-        run: |
-          set -euxo pipefail
-          pnpm release:check
-
-      - name: Preview publish command
-        run: bash scripts/openclaw-npm-publish.sh --dry-run
-
   publish_openclaw_npm:
-    if: github.event_name == 'workflow_dispatch'
     # npm trusted publishing + provenance requires a GitHub-hosted runner.
     runs-on: ubuntu-latest
     environment: npm-release

--- a/scripts/openclaw-npm-publish.sh
+++ b/scripts/openclaw-npm-publish.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 mode="${1:-}"
 
-if [[ "${mode}" != "--dry-run" && "${mode}" != "--publish" ]]; then
-  echo "usage: bash scripts/openclaw-npm-publish.sh [--dry-run|--publish]" >&2
+if [[ "${mode}" != "--publish" ]]; then
+  echo "usage: bash scripts/openclaw-npm-publish.sh --publish" >&2
   exit 2
 fi
 
@@ -25,9 +25,5 @@ echo "Publish auth: GitHub OIDC trusted publishing"
 printf 'Publish command:'
 printf ' %q' "${publish_cmd[@]}"
 printf '\n'
-
-if [[ "${mode}" == "--dry-run" ]]; then
-  exit 0
-fi
 
 "${publish_cmd[@]}"


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `.github/workflows/openclaw-npm-release.yml` had a tag-push preview job that only validated and ran a dry-run publish path.
- Why it matters: the preview path adds maintenance surface without publishing, and tags should no longer trigger any npm release workflow automatically.
- What changed: removed the tag-push trigger and preview job, and simplified `scripts/openclaw-npm-publish.sh` to only support the real `--publish` path used by manual dispatch.
- What did NOT change (scope boundary): the manual `workflow_dispatch` publish flow, release validations, and `npm-release` environment gate remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Creating a `v*` tag no longer triggers the OpenClaw npm release workflow.
- npm publish remains available only through manual `workflow_dispatch`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local git + shell
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions workflow YAML
- Relevant config (redacted): N/A

### Steps

1. Inspect `.github/workflows/openclaw-npm-release.yml` and `scripts/openclaw-npm-publish.sh`.
2. Remove the tag-push preview path and keep only `workflow_dispatch` publishing.
3. Parse the workflow YAML and run `bash -n` on the publish script.

### Expected

- The npm release workflow only supports manual dispatch.
- No tag push path remains.
- The publish script only supports `--publish`.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: workflow YAML parses with `node -e "const fs=require('fs'); const yaml=require('yaml'); yaml.parse(fs.readFileSync('.github/workflows/openclaw-npm-release.yml','utf8')); console.log('yaml-ok')"`; publish script passes `bash -n scripts/openclaw-npm-publish.sh`.
- Edge cases checked: confirmed no remaining references to `preview_openclaw_npm` or `scripts/openclaw-npm-publish.sh --dry-run` in the OpenClaw npm release workflow path.
- What you did **not** verify: did not run a live `workflow_dispatch` publish or a real npm publish.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the tag preview path and `--dry-run` support.
- Files/config to restore: `.github/workflows/openclaw-npm-release.yml`, `scripts/openclaw-npm-publish.sh`.
- Known bad symptoms reviewers should watch for: operators expecting tag creation to kick off the preview workflow will no longer see that run.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: maintainers may still expect a tag push to validate the npm release path.
- Mitigation: the PR explicitly leaves the manual dispatch publish flow intact and removes only the preview path.
