### PR TITLE
fix: keep whatsapp bundled in default npm builds

### DIFF
--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -41,6 +41,9 @@
     },
     "release": {
       "publishToNpm": true
+    },
+    "bundle": {
+      "stageRuntimeDependencies": true
     }
   }
 }

--- a/scripts/lib/optional-bundled-clusters.mjs
+++ b/scripts/lib/optional-bundled-clusters.mjs
@@ -10,7 +10,6 @@ export const optionalBundledClusters = [
   "tlon",
   "twitch",
   "ui",
-  "whatsapp",
   "zalouser",
 ];
 

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -373,7 +373,13 @@ describe("copyBundledPluginMetadata", () => {
     });
     writeJson(path.join(pluginDir, "package.json"), {
       name: "@openclaw/whatsapp",
-      openclaw: { extensions: ["./index.ts"] },
+      openclaw: {
+        extensions: ["./index.ts"],
+        bundle: { stageRuntimeDependencies: true },
+      },
+      dependencies: {
+        "@whiskeysockets/baileys": "7.0.0-rc.9",
+      },
     });
 
     copyBundledPluginMetadataWithEnv({ repoRoot, env: {} });
@@ -386,5 +392,9 @@ describe("copyBundledPluginMetadata", () => {
       ),
     ) as { channels?: string[] };
     expect(bundledManifest.channels).toEqual(["whatsapp"]);
+    const bundledPackage = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "dist", "extensions", "whatsapp", "package.json"), "utf8"),
+    ) as { openclaw?: { bundle?: { stageRuntimeDependencies?: boolean } } };
+    expect(bundledPackage.openclaw?.bundle?.stageRuntimeDependencies).toBe(true);
   });
 });

--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -361,4 +361,30 @@ describe("copyBundledPluginMetadata", () => {
 
     expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", "acpx"))).toBe(false);
   });
+
+  it("keeps whatsapp metadata in default bundled builds", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-whatsapp-default-");
+    const pluginDir = path.join(repoRoot, "extensions", "whatsapp");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    writeJson(path.join(pluginDir, "openclaw.plugin.json"), {
+      id: "whatsapp",
+      channels: ["whatsapp"],
+      configSchema: { type: "object" },
+    });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "@openclaw/whatsapp",
+      openclaw: { extensions: ["./index.ts"] },
+    });
+
+    copyBundledPluginMetadataWithEnv({ repoRoot, env: {} });
+
+    expect(fs.existsSync(path.join(repoRoot, "dist", "extensions", "whatsapp"))).toBe(true);
+    const bundledManifest = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "dist", "extensions", "whatsapp", "openclaw.plugin.json"),
+        "utf8",
+      ),
+    ) as { channels?: string[] };
+    expect(bundledManifest.channels).toEqual(["whatsapp"]);
+  });
 });


### PR DESCRIPTION
## Summary
- remove `whatsapp` from the optional bundled cluster list so default npm builds keep the WhatsApp runtime/metadata
- add a regression test that verifies `copyBundledPluginMetadata` still emits `dist/extensions/whatsapp` without `OPENCLAW_INCLUDE_OPTIONAL_BUNDLED=1`

## Why
Recent npm releases can come up without a working WhatsApp channel runtime because `whatsapp` is currently classified as an optional bundled cluster. That means the default packaging path may omit the bundled WhatsApp extension even though the CLI/docs still present WhatsApp as a supported built-in channel.

This lines up with regressions like:
- `Unknown channel: whatsapp`
- WhatsApp configured in onboarding/status, but missing at runtime after upgrade
- production installs where Telegram recovers but WhatsApp does not after update/rollback testing

## Validation
- lightweight local reproduction against `copyBundledPluginMetadata` confirms WhatsApp metadata is copied by default after this change
- added regression test coverage for the default bundled-build path

## Notes
I wasn't able to run the full Vitest suite in this temp clone because dependencies were not installed in the scratch checkout, so this PR includes the targeted regression test and a direct script-level validation.
