### PR TITLE
fix: include optional bundled plugins (WhatsApp, ACPX, etc.) in npm and Docker releases

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -16,6 +16,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   PNPM_VERSION: "10.23.0"
+  # Include WhatsApp, ACPX, Google Chat, Matrix, and other optional bundled
+  # plugins in the npm release so end users get them out of the box.
+  OPENCLAW_INCLUDE_OPTIONAL_BUNDLED: "1"
 
 jobs:
   publish_openclaw_npm:

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,8 @@ RUN pnpm canvas:a2ui:bundle || \
      echo "/* A2UI bundle unavailable in this build */" > src/canvas-host/a2ui/a2ui.bundle.js && \
      echo "stub" > src/canvas-host/a2ui/.bundle.hash && \
      rm -rf vendor/a2ui apps/shared/OpenClawKit/Tools/CanvasA2UI)
+# Include all optional bundled plugins (WhatsApp, ACPX, Google Chat, Matrix, etc.)
+ENV OPENCLAW_INCLUDE_OPTIONAL_BUNDLED=1
 RUN pnpm build:docker
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1


### PR DESCRIPTION
## Summary

The npm release workflow and Dockerfile run `pnpm build` without setting `OPENCLAW_INCLUDE_OPTIONAL_BUNDLED=1`, so optional bundled clusters listed in `scripts/lib/optional-bundled-clusters.mjs` are excluded from `dist/extensions/`. This causes these channels to fail with `plugin not found: whatsapp` (and similar for ACPX, Google Chat, Matrix, etc.) on fresh installs or upgrades.

## Root Cause

`tsdown.config.ts` calls `shouldBuildBundledCluster()` for each extension, which checks `OPENCLAW_INCLUDE_OPTIONAL_BUNDLED`. When unset, extensions in the `optionalBundledClusters` list are skipped:

- whatsapp
- acpx
- googlechat
- matrix
- diagnostics-otel
- diffs
- memory-lancedb
- msteams
- nostr
- tlon
- twitch
- ui
- zalouser

Neither the npm release workflow nor the Dockerfile set this env var, so published artifacts (npm tarball + Docker image) ship without these extensions.

## Reproduction

1. `npm i -g openclaw@2026.3.22`
2. Configure WhatsApp channel
3. Start gateway → `plugin not found: whatsapp (stale config entry ignored)`
4. `ls $(npm root -g)/openclaw/dist/extensions/ | grep whatsapp` → empty

Confirmed: `npm pack openclaw@2026.3.22 --dry-run` shows no `dist/extensions/whatsapp/` in the tarball.

## Fix

Set `OPENCLAW_INCLUDE_OPTIONAL_BUNDLED=1` in:
- `.github/workflows/openclaw-npm-release.yml` (top-level env)
- `Dockerfile` (before `pnpm build:docker`)

## Impact

All optional bundled plugins are restored in npm and Docker releases. Users upgrading from 2026.3.13 (where WhatsApp was bundled) to 2026.3.22 no longer lose WhatsApp connectivity.

Related: #48422 (Docker-specific manifestation of the same root cause)