### PR TITLE
fix: catch missing packed UI canaries

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S node --import tsx
 
 import { execSync } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, posix, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   collectBundledExtensionManifestErrors,
@@ -16,8 +16,9 @@ export { collectBundledExtensionManifestErrors } from "./lib/bundled-extension-m
 
 type PackFile = { path: string };
 type PackResult = { files?: PackFile[]; filename?: string; unpackedSize?: number };
+type RequiredPackPathGroup = string | string[];
 
-const requiredPathGroups = [
+const requiredPathGroups: RequiredPackPathGroup[] = [
   ["dist/index.js", "dist/index.mjs"],
   ["dist/entry.js", "dist/entry.mjs"],
   ...listPluginSdkDistArtifacts(),
@@ -85,6 +86,49 @@ export function collectForbiddenPackPaths(paths: Iterable<string>): string[] {
         forbiddenPrefixes.some((prefix) => path.startsWith(prefix)) ||
         (/node_modules\//.test(path) && !isAllowedBundledPluginNodeModulesPath(path)),
     )
+    .toSorted();
+}
+
+export function collectBuiltArtifactPackRequirements(rootDir = process.cwd()): string[] {
+  const requirements = new Set<string>();
+
+  const controlUiIndexPath = resolve(rootDir, "dist", "control-ui", "index.html");
+  if (existsSync(controlUiIndexPath)) {
+    requirements.add(posix.join("dist", "control-ui", "index.html"));
+  }
+
+  const extensionsRoot = resolve(rootDir, "dist", "extensions");
+  if (!existsSync(extensionsRoot)) {
+    return [...requirements].toSorted();
+  }
+
+  for (const entry of readdirSync(extensionsRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    for (const canaryFile of ["index.js", "package.json"]) {
+      const absolutePath = resolve(extensionsRoot, entry.name, canaryFile);
+      if (existsSync(absolutePath)) {
+        requirements.add(posix.join("dist", "extensions", entry.name, canaryFile));
+      }
+    }
+  }
+
+  return [...requirements].toSorted();
+}
+
+export function collectMissingPackPaths(
+  paths: Iterable<string>,
+  requiredGroups: Iterable<RequiredPackPathGroup>,
+): string[] {
+  const availablePaths = paths instanceof Set ? paths : new Set(paths);
+  return [...requiredGroups]
+    .flatMap((group) => {
+      if (Array.isArray(group)) {
+        return group.some((path) => availablePaths.has(path)) ? [] : [group.join(" or ")];
+      }
+      return availablePaths.has(group) ? [] : [group];
+    })
     .toSorted();
 }
 
@@ -295,15 +339,10 @@ async function main() {
   const results = runPackDry();
   const files = results.flatMap((entry) => entry.files ?? []);
   const paths = new Set(files.map((file) => file.path));
-
-  const missing = requiredPathGroups
-    .flatMap((group) => {
-      if (Array.isArray(group)) {
-        return group.some((path) => paths.has(path)) ? [] : [group.join(" or ")];
-      }
-      return paths.has(group) ? [] : [group];
-    })
-    .toSorted();
+  const missing = collectMissingPackPaths(paths, [
+    ...requiredPathGroups,
+    ...collectBuiltArtifactPackRequirements(),
+  ]);
   const forbidden = collectForbiddenPackPaths(paths);
   const sizeErrors = collectPackUnpackedSizeErrors(results);
 

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,8 +1,13 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   collectAppcastSparkleVersionErrors,
+  collectBuiltArtifactPackRequirements,
   collectBundledExtensionManifestErrors,
   collectForbiddenPackPaths,
+  collectMissingPackPaths,
   collectPackUnpackedSizeErrors,
 } from "../scripts/release-check.ts";
 
@@ -112,6 +117,43 @@ describe("collectForbiddenPackPaths", () => {
         "node_modules/.bin/openclaw",
       ]),
     ).toEqual(["extensions/tlon/node_modules/.bin/tlon", "node_modules/.bin/openclaw"]);
+  });
+});
+
+describe("collectBuiltArtifactPackRequirements", () => {
+  it("requires built control UI and bundled extension canaries when present", () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-release-check-"));
+    try {
+      fs.mkdirSync(path.join(repoRoot, "dist", "control-ui"), { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, "dist", "control-ui", "index.html"), "<!doctype html>");
+
+      fs.mkdirSync(path.join(repoRoot, "dist", "extensions", "discord"), { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, "dist", "extensions", "discord", "index.js"), "");
+      fs.writeFileSync(path.join(repoRoot, "dist", "extensions", "discord", "package.json"), "{}");
+
+      expect(collectBuiltArtifactPackRequirements(repoRoot)).toEqual([
+        "dist/control-ui/index.html",
+        "dist/extensions/discord/index.js",
+        "dist/extensions/discord/package.json",
+      ]);
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectMissingPackPaths", () => {
+  it("flags missing exact and alternative required pack paths", () => {
+    expect(
+      collectMissingPackPaths(
+        ["dist/index.js", "dist/control-ui/index.html"],
+        [
+          ["dist/index.js", "dist/index.mjs"],
+          "dist/control-ui/index.html",
+          "dist/extensions/whatsapp/index.js",
+        ],
+      ),
+    ).toEqual(["dist/extensions/whatsapp/index.js"]);
   });
 });
 


### PR DESCRIPTION
## Summary
- compare `npm pack --dry-run` output against built `dist/` canary artifacts so release-check now fails if `dist/control-ui/index.html` or bundled extension entrypoints/package manifests are omitted from the published tarball
- extract the pack-missing logic into reusable helpers so the path checks are testable without a full pack run
- add unit coverage for built artifact canaries and mixed exact-or-alternative required pack paths

Fixes #52808.

AI-assisted: yes.
Testing: fully tested for this change.

## Test plan
- [x] `pnpm test -- test/release-check.test.ts`
- [x] `pnpm check`
- [x] `pnpm build`
- [x] `node --import tsx scripts/release-check.ts`

Made with [Cursor](https://cursor.com)