### PR TITLE
fix(feishu): ghost WebSocket connections persist after monitor stop, causing duplicate events and resource leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
+- Feishu: close WebSocket connections on monitor stop/abort so ghost connections no longer persist, preventing duplicate event processing and resource leaks across restart cycles. (#52844) Thanks @schumilin.
 
 ## 2026.3.24-beta.2
 

--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  botNames,
+  botOpenIds,
+  stopFeishuMonitorState,
+  wsClients,
+} from "./monitor.state.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const createFeishuWSClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuWSClient: createFeishuWSClientMock,
+}));
+
+import { monitorWebSocket } from "./monitor.transport.js";
+
+type MockWsClient = {
+  start: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+function createAccount(accountId: string): ResolvedFeishuAccount {
+  return {
+    accountId,
+    enabled: true,
+    configured: true,
+    appId: `cli_${accountId}`,
+    appSecret: `secret_${accountId}`, // pragma: allowlist secret
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+function createWsClient(): MockWsClient {
+  return {
+    start: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  stopFeishuMonitorState();
+  vi.clearAllMocks();
+});
+
+describe("feishu websocket cleanup", () => {
+  it("closes the websocket client when the monitor aborts", async () => {
+    const wsClient = createWsClient();
+    createFeishuWSClientMock.mockReturnValue(wsClient);
+
+    const abortController = new AbortController();
+    const accountId = "alpha";
+
+    botOpenIds.set(accountId, "ou_alpha");
+    botNames.set(accountId, "Alpha");
+
+    const monitorPromise = monitorWebSocket({
+      account: createAccount(accountId),
+      accountId,
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      abortSignal: abortController.signal,
+      eventDispatcher: {} as never,
+    });
+
+    expect(wsClient.start).toHaveBeenCalledTimes(1);
+    expect(wsClients.get(accountId)).toBe(wsClient);
+
+    abortController.abort();
+    await monitorPromise;
+
+    expect(wsClient.close).toHaveBeenCalledTimes(1);
+    expect(wsClients.has(accountId)).toBe(false);
+    expect(botOpenIds.has(accountId)).toBe(false);
+    expect(botNames.has(accountId)).toBe(false);
+  });
+
+  it("closes targeted websocket clients during stop cleanup", () => {
+    const alphaClient = createWsClient();
+    const betaClient = createWsClient();
+
+    wsClients.set("alpha", alphaClient as never);
+    wsClients.set("beta", betaClient as never);
+    botOpenIds.set("alpha", "ou_alpha");
+    botOpenIds.set("beta", "ou_beta");
+    botNames.set("alpha", "Alpha");
+    botNames.set("beta", "Beta");
+
+    stopFeishuMonitorState("alpha");
+
+    expect(alphaClient.close).toHaveBeenCalledTimes(1);
+    expect(betaClient.close).not.toHaveBeenCalled();
+    expect(wsClients.has("alpha")).toBe(false);
+    expect(wsClients.has("beta")).toBe(true);
+    expect(botOpenIds.has("alpha")).toBe(false);
+    expect(botOpenIds.has("beta")).toBe(true);
+    expect(botNames.has("alpha")).toBe(false);
+    expect(botNames.has("beta")).toBe(true);
+  });
+
+  it("closes all websocket clients during global stop cleanup", () => {
+    const alphaClient = createWsClient();
+    const betaClient = createWsClient();
+
+    wsClients.set("alpha", alphaClient as never);
+    wsClients.set("beta", betaClient as never);
+    botOpenIds.set("alpha", "ou_alpha");
+    botOpenIds.set("beta", "ou_beta");
+    botNames.set("alpha", "Alpha");
+    botNames.set("beta", "Beta");
+
+    stopFeishuMonitorState();
+
+    expect(alphaClient.close).toHaveBeenCalledTimes(1);
+    expect(betaClient.close).toHaveBeenCalledTimes(1);
+    expect(wsClients.size).toBe(0);
+    expect(botOpenIds.size).toBe(0);
+    expect(botNames.size).toBe(0);
+  });
+});

--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  botNames,
-  botOpenIds,
-  stopFeishuMonitorState,
-  wsClients,
-} from "./monitor.state.js";
+import { botNames, botOpenIds, stopFeishuMonitorState, wsClients } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const createFeishuWSClientMock = vi.hoisted(() => vi.fn());

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -104,6 +104,15 @@ const feishuWebhookAnomalyTracker = createWebhookAnomalyTracker({
   logEvery: feishuWebhookAnomalyDefaults.logEvery,
 });
 
+function closeWsClient(client: Lark.WSClient | undefined): void {
+  if (!client) return;
+  try {
+    client.close();
+  } catch {
+    /* Best-effort cleanup */
+  }
+}
+
 export function clearFeishuWebhookRateLimitStateForTest(): void {
   feishuWebhookRateLimiter.clear();
   feishuWebhookAnomalyTracker.clear();
@@ -134,6 +143,7 @@ export function recordWebhookStatus(
 
 export function stopFeishuMonitorState(accountId?: string): void {
   if (accountId) {
+    closeWsClient(wsClients.get(accountId));
     wsClients.delete(accountId);
     const server = httpServers.get(accountId);
     if (server) {
@@ -145,6 +155,9 @@ export function stopFeishuMonitorState(accountId?: string): void {
     return;
   }
 
+  for (const client of wsClients.values()) {
+    closeWsClient(client);
+  }
   wsClients.clear();
   for (const server of httpServers.values()) {
     server.close();

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -1,11 +1,11 @@
 import { vi } from "vitest";
 
 export function createFeishuClientMockModule(): {
-  createFeishuWSClient: () => { start: () => void };
+  createFeishuWSClient: () => { start: () => void; close: () => void };
   createEventDispatcher: () => { register: () => void };
 } {
   return {
-    createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
+    createFeishuWSClient: vi.fn(() => ({ start: vi.fn(), close: vi.fn() })),
     createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
   };
 }

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -89,23 +89,35 @@ export async function monitorWebSocket({
   eventDispatcher,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
   log(`feishu[${accountId}]: starting WebSocket connection...`);
 
   const wsClient = createFeishuWSClient(account);
   wsClients.set(accountId, wsClient);
 
   return new Promise((resolve, reject) => {
+    let cleanedUp = false;
+
     const cleanup = () => {
-      wsClients.delete(accountId);
-      botOpenIds.delete(accountId);
-      botNames.delete(accountId);
+      if (cleanedUp) return;
+      cleanedUp = true;
+      abortSignal?.removeEventListener("abort", handleAbort);
+      try {
+        wsClient.close();
+      } catch (err) {
+        error(`feishu[${accountId}]: error closing WebSocket client: ${String(err)}`);
+      } finally {
+        wsClients.delete(accountId);
+        botOpenIds.delete(accountId);
+        botNames.delete(accountId);
+      }
     };
 
-    const handleAbort = () => {
+    function handleAbort() {
       log(`feishu[${accountId}]: abort signal received, stopping`);
       cleanup();
       resolve();
-    };
+    }
 
     if (abortSignal?.aborted) {
       cleanup();
@@ -120,7 +132,6 @@ export async function monitorWebSocket({
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
       cleanup();
-      abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     }
   });


### PR DESCRIPTION
## Summary

Stopping the Feishu monitor should fully tear down all live WebSocket connections. Today it only clears in-memory state (`wsClients`, `botOpenIds`, `botNames` maps) but never calls `wsClient.close()` on the underlying WS client. This leaves **ghost connections that continue to receive events after the monitor is stopped**.

In practice this causes:

- **Unexpected bot activity after a stop** — the ghost connection keeps dispatching events to an agent that the operator believes is offline
- **Duplicate event processing** — when the monitor restarts, a new connection is opened while the old one is still alive, causing the same event to be processed twice
- **Resource leaks on both sides** — from the Feishu Open Platform's perspective, these undead connections accumulate as long-lived connections that are never released; from the operator's side, file descriptors and stale identity caches pile up
- **Hard-to-debug behavior across multiple accounts** — with N accounts, a stop/restart cycle can leave up to N ghost connections, each silently processing events in parallel with the new ones

This is a correctness and stability issue: operators expect stop/abort to be a clean shutdown, not a partial cleanup. And as the Feishu platform side, we can confirm that accumulated ghost connections create significant unexpected resource consumption that affects both the user and the platform.

The fix is straightforward — the HTTP server path in `stopFeishuMonitorState` already calls `server.close()` before cleanup. WebSocket clients should receive the same treatment.

### Origin and validation

This fix was originally proposed in #38926 by @zhangyineo19811102-dotcom (stale since early March). We independently confirmed this issue through production Feishu bot instances — ghost connections and duplicate event processing were observed after monitor restarts. This re-submission rebases the fix onto the latest `main` with all conflicts resolved, retaining the original design which we reviewed and validated against the current codebase. Credit to @zhangyineo19811102-dotcom for identifying the root cause.

### What changed

- **`monitor.transport.ts`** — `cleanup()` is now idempotent (guarded by a `cleanedUp` flag), removes the abort listener, calls `wsClient.close()` in try/catch, and clears state maps in a `finally` block.
- **`monitor.state.ts`** — New `closeWsClient()` helper (best-effort, try/catch). `stopFeishuMonitorState` now calls it before deleting from `wsClients` in both the single-account and global paths — mirroring the existing `server.close()` pattern for HTTP.
- **`monitor.test-mocks.ts`** — Mock updated to include `close: vi.fn()`.
- **`monitor.cleanup.test.ts`** (new) — 3 test cases covering abort, single-account stop, and global stop.

No new dependencies. No changes to event dispatching, reconnection, or HTTP webhook paths.

### Testing

Three dedicated test cases in `monitor.cleanup.test.ts`:

- **Abort path** — start monitor → abort → verify `close()` called, all state maps cleared
- **Single-account stop** — two accounts → stop one → verify only that account is cleaned up
- **Global stop** — two accounts → `stopFeishuMonitorState()` → verify all clients closed, all maps cleared

### AI disclosure

- **Testing level:** Fully tested — 3 dedicated test cases covering all cleanup paths
- **Code understanding:** The fix ensures `Lark.WSClient.close()` is called in every shutdown path (abort signal, single-account stop, global stop). Cleanup is idempotent and best-effort to avoid masking other errors during shutdown.
- **Local Codex review:** Not available (no Codex access)

### Context

I'm the lead for [Feishu Open Platform](https://open.feishu.cn/) and a returning OpenClaw contributor. Happy to help keep the Feishu extension maintained and unblock stale PRs where I can validate the fix from the platform side.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)