### PR TITLE
release: automate macOS publishing

### DIFF
--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -37,7 +37,15 @@ Use this skill for release and publish-time workflow. Keep ordinary development 
 - For fallback correction tags like `vYYYY.M.D-N`, the repo version locations still stay at `YYYY.M.D`.
 - “Bump version everywhere” means all version locations above except `appcast.xml`.
 - Release signing and notary credentials live outside the repo in the private maintainer docs.
+- Every OpenClaw release ships the npm package and macOS app together.
 - The production Sparkle feed lives at `https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml`, and the canonical published file is `appcast.xml` on `main` in the `openclaw` repo.
+- That shared production Sparkle feed is stable-only. Beta mac releases may
+  upload assets to the GitHub prerelease, but they must not replace the shared
+  `appcast.xml` unless a separate beta feed exists.
+- For fallback correction tags like `vYYYY.M.D-N`, the repo version still stays
+  at `YYYY.M.D`, but the mac release must use a strictly higher numeric
+  `APP_BUILD` / Sparkle build than the original release so existing installs
+  see it as newer.
 
 ## Build changelog-backed release notes
 
@@ -80,6 +88,15 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Include mac release readiness in preflight by running or inspecting the mac
   packaging, notarization, and appcast flow for every release.
 - Treat the `appcast.xml` update on `main` as part of mac release readiness, not an optional follow-up.
+- Preflight must capture the exact tested release SHA. Publish must use that
+  same SHA, or fail if the tag no longer points to it.
+- Any fix after preflight means a new commit and a new tested SHA. Delete and
+  recreate the tag and matching GitHub release from the fixed commit, then rerun
+  preflight from scratch.
+- For stable mac releases, generate the signed `appcast.xml` before uploading
+  public release assets so the updater feed cannot lag the published binaries.
+- Serialize stable appcast-producing runs across tags so two releases do not
+  generate replacement `appcast.xml` files from the same stale seed.
 - For stable releases, confirm the latest beta already passed the broader release workflows before cutting stable.
 - If any required build, packaging step, or release workflow is red, do not say the release is ready.
 
@@ -91,12 +108,16 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   validation/build steps without entering the gated publish job.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
+- Both publish jobs should consume the preflight-tested SHA, not a fresh tag
+  lookup on a later runner.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
   notarization, release-asset upload, and signed `appcast.xml` artifact
   generation.
 - The agent must download the signed `appcast.xml` artifact from the successful
   mac workflow and then update `appcast.xml` on `main`.
+- For beta mac releases, do not update the shared production `appcast.xml`
+  unless a separate beta Sparkle feed exists.
 - `.github/workflows/macos-release.yml` still requires the `mac-release`
   environment approval.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for OpenClaw releases.
@@ -109,26 +130,30 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 2. Choose the exact target version and git tag.
 3. Make every repo version location match that tag before creating it.
 4. Update `CHANGELOG.md` and assemble the matching GitHub release notes.
-5. Run the full preflight for all relevant release builds, including mac readiness when applicable.
+5. Run the full preflight for all relevant release builds, including mac readiness.
 6. Confirm the target npm version is not already published.
 7. Create and push the git tag.
 8. Create or refresh the matching GitHub release.
 9. Start `.github/workflows/openclaw-npm-release.yml` with `preflight_only=true`
-   and wait for it to pass.
+   and wait for it to pass, capturing the tested release SHA.
 10. Start `.github/workflows/macos-release.yml` with `preflight_only=true` and
-    wait for it to pass.
+    wait for it to pass, capturing the tested release SHA.
 11. If either preflight fails, fix the issue on a new commit, delete the tag
-    and matching GitHub release, recreate them from the commit that passes, and
-    rerun both preflights before continuing.
+    and matching GitHub release, recreate them from the fixed commit, and rerun
+    both preflights from scratch before continuing. Never reuse old preflight
+    results after the commit changes.
 12. Start `.github/workflows/openclaw-npm-release.yml` with the same tag for
-    the real publish.
+    the real publish, pinned to the preflight-tested SHA.
 13. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
 14. Start `.github/workflows/macos-release.yml` for the real publish and wait
-    for `mac-release` approval and success.
-15. After the mac workflow succeeds, download the signed `appcast.xml`
-    artifact from that run, update `appcast.xml` on `main`, and verify the
+    for `mac-release` approval and success, pinned to the preflight-tested SHA.
+15. For stable releases, generate the signed `appcast.xml` before the public
+    mac assets are uploaded, then download the signed `appcast.xml` artifact
+    from the successful mac run, update `appcast.xml` on `main`, and verify the
     feed.
-16. After publish, verify npm and any attached release artifacts.
+16. For beta releases, publish the mac assets but do not update the shared
+    production `appcast.xml` unless a separate beta feed exists.
+17. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work
 

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -88,6 +88,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 
 - Core `openclaw` publish uses GitHub trusted publishing.
 - The publish run must be started manually with `workflow_dispatch`.
+- Both core release workflows accept `preflight_only=true` to run CI
+  validation/build steps without entering the gated publish job.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml`, requires the `mac-release` environment approval, and must update `appcast.xml` on `main`.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
@@ -104,10 +106,12 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 6. Confirm the target npm version is not already published.
 7. Create and push the git tag.
 8. Create or refresh the matching GitHub release.
-9. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
-10. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-11. If the release includes mac artifacts, start `.github/workflows/macos-release.yml`, wait for `mac-release` approval, and confirm it updates `appcast.xml` on `main`.
-12. After publish, verify npm and any attached release artifacts.
+9. If the operator wants CI confidence before publishing, start the relevant
+   release workflow with `preflight_only=true` first and wait for it to pass.
+10. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
+11. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
+12. If the release includes mac artifacts, start `.github/workflows/macos-release.yml`, wait for `mac-release` approval, and confirm it updates `appcast.xml` on `main`.
+13. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work
 

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -37,6 +37,7 @@ Use this skill for release and publish-time workflow. Keep ordinary development 
 - For fallback correction tags like `vYYYY.M.D-N`, the repo version locations still stay at `YYYY.M.D`.
 - “Bump version everywhere” means all version locations above except `appcast.xml`.
 - Release signing and notary credentials live outside the repo in the private maintainer docs.
+- The production Sparkle feed lives at `https://openclaw.ai/appcast.xml`, and the canonical published file is `openclaw.ai/public/appcast.xml` in the separate `openclaw.ai` repo.
 
 ## Build changelog-backed release notes
 
@@ -79,6 +80,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Include mac release readiness in preflight:
   - if the release includes mac artifacts, run or inspect the mac packaging/notary/appcast flow
   - if the release does not include mac artifacts, explicitly confirm that exception before continuing
+- Treat the `openclaw.ai` appcast update as part of mac release readiness, not an optional follow-up.
 - For stable releases, confirm the latest beta already passed the broader release workflows before cutting stable.
 - If any required build, packaging step, or release workflow is red, do not say the release is ready.
 
@@ -87,6 +89,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Core `openclaw` publish uses GitHub trusted publishing.
 - The publish run must be started manually with `workflow_dispatch`.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
+- Mac publish uses `.github/workflows/macos-release.yml`, requires the `mac-release` environment approval, and also needs credentials that can push `openclaw.ai/public/appcast.xml`.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
@@ -103,7 +106,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 8. Create or refresh the matching GitHub release.
 9. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
 10. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-11. After publish, verify npm and any attached release artifacts.
+11. If the release includes mac artifacts, start `.github/workflows/macos-release.yml`, wait for `mac-release` approval, and confirm it updates `openclaw.ai/public/appcast.xml`.
+12. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work
 

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -92,9 +92,10 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   validation/build steps without entering the gated publish job.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
-  notarization, and release-asset upload only.
-- The agent, not the GitHub Action, must update `appcast.xml` on `main` after
-  the mac workflow succeeds.
+  notarization, release-asset upload, and signed `appcast.xml` artifact
+  generation.
+- The agent must download the signed `appcast.xml` artifact from the successful
+  mac workflow and then update `appcast.xml` on `main`.
 - `.github/workflows/macos-release.yml` still requires the `mac-release`
   environment approval.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
@@ -116,7 +117,9 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 10. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
 11. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
 12. If the release includes mac artifacts, start `.github/workflows/macos-release.yml` and wait for `mac-release` approval and success.
-13. After the mac workflow succeeds, download the released `OpenClaw-<version>.zip`, run `scripts/make_appcast.sh` locally, update `appcast.xml` on `main`, and verify the feed.
+13. After the mac workflow succeeds, download the signed `appcast.xml`
+    artifact from that run, update `appcast.xml` on `main`, and verify the
+    feed.
 14. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -37,7 +37,7 @@ Use this skill for release and publish-time workflow. Keep ordinary development 
 - For fallback correction tags like `vYYYY.M.D-N`, the repo version locations still stay at `YYYY.M.D`.
 - “Bump version everywhere” means all version locations above except `appcast.xml`.
 - Release signing and notary credentials live outside the repo in the private maintainer docs.
-- The production Sparkle feed lives at `https://openclaw.ai/appcast.xml`, and the canonical published file is `openclaw.ai/public/appcast.xml` in the separate `openclaw.ai` repo.
+- The production Sparkle feed lives at `https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml`, and the canonical published file is `appcast.xml` on `main` in the `openclaw` repo.
 
 ## Build changelog-backed release notes
 
@@ -80,7 +80,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Include mac release readiness in preflight:
   - if the release includes mac artifacts, run or inspect the mac packaging/notary/appcast flow
   - if the release does not include mac artifacts, explicitly confirm that exception before continuing
-- Treat the `openclaw.ai` appcast update as part of mac release readiness, not an optional follow-up.
+- Treat the `appcast.xml` update on `main` as part of mac release readiness, not an optional follow-up.
 - For stable releases, confirm the latest beta already passed the broader release workflows before cutting stable.
 - If any required build, packaging step, or release workflow is red, do not say the release is ready.
 
@@ -89,7 +89,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Core `openclaw` publish uses GitHub trusted publishing.
 - The publish run must be started manually with `workflow_dispatch`.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
-- Mac publish uses `.github/workflows/macos-release.yml`, requires the `mac-release` environment approval, and also needs credentials that can push `openclaw.ai/public/appcast.xml`.
+- Mac publish uses `.github/workflows/macos-release.yml`, requires the `mac-release` environment approval, and must update `appcast.xml` on `main`.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
@@ -106,7 +106,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 8. Create or refresh the matching GitHub release.
 9. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
 10. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-11. If the release includes mac artifacts, start `.github/workflows/macos-release.yml`, wait for `mac-release` approval, and confirm it updates `openclaw.ai/public/appcast.xml`.
+11. If the release includes mac artifacts, start `.github/workflows/macos-release.yml`, wait for `mac-release` approval, and confirm it updates `appcast.xml` on `main`.
 12. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -69,8 +69,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 
 ## Check all relevant release builds
 
-- Always validate the core npm release path before creating the tag.
-- Default core release checks:
+- Always validate the OpenClaw npm release path before creating the tag.
+- Default release checks:
   - `pnpm check`
   - `pnpm build`
   - `node --import tsx scripts/release-check.ts`
@@ -85,9 +85,9 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 
 ## Use the right auth flow
 
-- Core `openclaw` publish uses GitHub trusted publishing.
+- OpenClaw publish uses GitHub trusted publishing.
 - The publish run must be started manually with `workflow_dispatch`.
-- Both core release workflows accept `preflight_only=true` to run CI
+- Both release workflows accept `preflight_only=true` to run CI
   validation/build steps without entering the gated publish job.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
@@ -99,7 +99,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   mac workflow and then update `appcast.xml` on `main`.
 - `.github/workflows/macos-release.yml` still requires the `mac-release`
   environment approval.
-- Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
+- Do not use `NPM_TOKEN` or the plugin OTP flow for OpenClaw releases.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
 

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -77,9 +77,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   - `pnpm release:check`
   - `OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke`
 - Check all release-related build surfaces touched by the release, not only the npm package.
-- Include mac release readiness in preflight:
-  - if the release includes mac artifacts, run or inspect the mac packaging/notary/appcast flow
-  - if the release does not include mac artifacts, explicitly confirm that exception before continuing
+- Include mac release readiness in preflight by running or inspecting the mac
+  packaging, notarization, and appcast flow for every release.
 - Treat the `appcast.xml` update on `main` as part of mac release readiness, not an optional follow-up.
 - For stable releases, confirm the latest beta already passed the broader release workflows before cutting stable.
 - If any required build, packaging step, or release workflow is red, do not say the release is ready.
@@ -90,8 +89,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - The publish run must be started manually with `workflow_dispatch`.
 - Both core release workflows accept `preflight_only=true` to run CI
   validation/build steps without entering the gated publish job.
-- For releases that include mac artifacts, npm preflight and macOS preflight
-  must both pass before any publish run starts.
+- npm preflight and macOS preflight must both pass before any publish run
+  starts.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
   notarization, release-asset upload, and signed `appcast.xml` artifact
@@ -116,18 +115,16 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 8. Create or refresh the matching GitHub release.
 9. Start `.github/workflows/openclaw-npm-release.yml` with `preflight_only=true`
    and wait for it to pass.
-10. If the release includes mac artifacts, start
-    `.github/workflows/macos-release.yml` with `preflight_only=true` and wait
-    for it to pass.
+10. Start `.github/workflows/macos-release.yml` with `preflight_only=true` and
+    wait for it to pass.
 11. If either preflight fails, fix the issue on a new commit, delete the tag
     and matching GitHub release, recreate them from the commit that passes, and
     rerun both preflights before continuing.
 12. Start `.github/workflows/openclaw-npm-release.yml` with the same tag for
     the real publish.
 13. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-14. If the release includes mac artifacts, start
-    `.github/workflows/macos-release.yml` for the real publish and wait for
-    `mac-release` approval and success.
+14. Start `.github/workflows/macos-release.yml` for the real publish and wait
+    for `mac-release` approval and success.
 15. After the mac workflow succeeds, download the signed `appcast.xml`
     artifact from that run, update `appcast.xml` on `main`, and verify the
     feed.

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -124,6 +124,23 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
 
+## Fallback local mac publish
+
+- Keep the original local macOS publish workflow available as a fallback in case
+  CI/CD mac publishing is unavailable or broken.
+- Preserve the existing maintainer workflow Peter uses: run it on a real Mac
+  with local signing, notary, and Sparkle credentials already configured.
+- Follow the private maintainer macOS runbook for the local steps:
+  `scripts/package-mac-dist.sh` to build, sign, notarize, and package the app;
+  manual GitHub release asset upload; then `scripts/make_appcast.sh` plus the
+  `appcast.xml` commit to `main`.
+- For stable tags, the local fallback may update the shared production
+  `appcast.xml`.
+- For beta tags, the local fallback still publishes the mac assets but must not
+  update the shared production `appcast.xml` unless a separate beta feed exists.
+- Treat the local workflow as fallback only. Prefer the CI/CD publish workflow
+  when it is working.
+
 ## Run the release sequence
 
 1. Confirm the operator explicitly wants to cut a release.

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -91,7 +91,12 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Both core release workflows accept `preflight_only=true` to run CI
   validation/build steps without entering the gated publish job.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
-- Mac publish uses `.github/workflows/macos-release.yml`, requires the `mac-release` environment approval, and must update `appcast.xml` on `main`.
+- Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
+  notarization, and release-asset upload only.
+- The agent, not the GitHub Action, must update `appcast.xml` on `main` after
+  the mac workflow succeeds.
+- `.github/workflows/macos-release.yml` still requires the `mac-release`
+  environment approval.
 - Do not use `NPM_TOKEN` or the plugin OTP flow for core releases.
 - `@openclaw/*` plugin publishes use a separate maintainer-only flow.
 - Only publish plugins that already exist on npm; bundled disk-tree-only plugins stay unpublished.
@@ -110,8 +115,9 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
    release workflow with `preflight_only=true` first and wait for it to pass.
 10. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
 11. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-12. If the release includes mac artifacts, start `.github/workflows/macos-release.yml`, wait for `mac-release` approval, and confirm it updates `appcast.xml` on `main`.
-13. After publish, verify npm and any attached release artifacts.
+12. If the release includes mac artifacts, start `.github/workflows/macos-release.yml` and wait for `mac-release` approval and success.
+13. After the mac workflow succeeds, download the released `OpenClaw-<version>.zip`, run `scripts/make_appcast.sh` locally, update `appcast.xml` on `main`, and verify the feed.
+14. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work
 

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -88,11 +88,11 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - Include mac release readiness in preflight by running or inspecting the mac
   packaging, notarization, and appcast flow for every release.
 - Treat the `appcast.xml` update on `main` as part of mac release readiness, not an optional follow-up.
-- Preflight must capture the exact tested release SHA. Publish must use that
-  same SHA, or fail if the tag no longer points to it.
-- Any fix after preflight means a new commit and a new tested SHA. Delete and
-  recreate the tag and matching GitHub release from the fixed commit, then rerun
-  preflight from scratch.
+- The workflows remain tag-based. The agent is responsible for making sure
+  preflight runs complete successfully before any publish run starts.
+- Any fix after preflight means a new commit. Delete and recreate the tag and
+  matching GitHub release from the fixed commit, then rerun preflight from
+  scratch before publishing.
 - For stable mac releases, generate the signed `appcast.xml` before uploading
   public release assets so the updater feed cannot lag the published binaries.
 - Serialize stable appcast-producing runs across tags so two releases do not
@@ -108,8 +108,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   validation/build steps without entering the gated publish job.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
-- Both publish jobs should consume the preflight-tested SHA, not a fresh tag
-  lookup on a later runner.
+- The release workflows stay tag-based; rely on the documented release sequence
+  rather than workflow-level SHA pinning.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
   notarization, release-asset upload, and signed `appcast.xml` artifact
@@ -135,18 +135,18 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 7. Create and push the git tag.
 8. Create or refresh the matching GitHub release.
 9. Start `.github/workflows/openclaw-npm-release.yml` with `preflight_only=true`
-   and wait for it to pass, capturing the tested release SHA.
+   and wait for it to pass.
 10. Start `.github/workflows/macos-release.yml` with `preflight_only=true` and
-    wait for it to pass, capturing the tested release SHA.
+    wait for it to pass.
 11. If either preflight fails, fix the issue on a new commit, delete the tag
     and matching GitHub release, recreate them from the fixed commit, and rerun
     both preflights from scratch before continuing. Never reuse old preflight
     results after the commit changes.
 12. Start `.github/workflows/openclaw-npm-release.yml` with the same tag for
-    the real publish, pinned to the preflight-tested SHA.
+    the real publish.
 13. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
 14. Start `.github/workflows/macos-release.yml` for the real publish and wait
-    for `mac-release` approval and success, pinned to the preflight-tested SHA.
+    for `mac-release` approval and success.
 15. For stable releases, generate the signed `appcast.xml` before the public
     mac assets are uploaded, then download the signed `appcast.xml` artifact
     from the successful mac run, update `appcast.xml` on `main`, and verify the

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -112,10 +112,10 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   rather than workflow-level SHA pinning.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
-  notarization, release-asset upload, and signed `appcast.xml` artifact
-  generation.
-- The agent must download the signed `appcast.xml` artifact from the successful
-  mac workflow and then update `appcast.xml` on `main`.
+  notarization, stable-feed `appcast.xml` artifact generation, and release-asset
+  upload.
+- The agent must download the signed `appcast.xml` artifact from a successful
+  stable mac workflow and then update `appcast.xml` on `main`.
 - For beta mac releases, do not update the shared production `appcast.xml`
   unless a separate beta Sparkle feed exists.
 - `.github/workflows/macos-release.yml` still requires the `mac-release`
@@ -147,12 +147,13 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 13. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
 14. Start `.github/workflows/macos-release.yml` for the real publish and wait
     for `mac-release` approval and success.
-15. For stable releases, generate the signed `appcast.xml` before the public
-    mac assets are uploaded, then download the signed `appcast.xml` artifact
-    from the successful mac run, update `appcast.xml` on `main`, and verify the
-    feed.
-16. For beta releases, publish the mac assets but do not update the shared
-    production `appcast.xml` unless a separate beta feed exists.
+15. For stable releases, let the mac workflow generate the signed
+    `appcast.xml` artifact before it uploads the public mac assets, then
+    download that artifact from the successful run, update `appcast.xml` on
+    `main`, and verify the feed.
+16. For beta releases, publish the mac assets but expect no shared production
+    `appcast.xml` artifact and do not update the shared production feed unless a
+    separate beta feed exists.
 17. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -90,6 +90,8 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - The publish run must be started manually with `workflow_dispatch`.
 - Both core release workflows accept `preflight_only=true` to run CI
   validation/build steps without entering the gated publish job.
+- For releases that include mac artifacts, npm preflight and macOS preflight
+  must both pass before any publish run starts.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.
 - Mac publish uses `.github/workflows/macos-release.yml` for build, signing,
   notarization, release-asset upload, and signed `appcast.xml` artifact
@@ -112,15 +114,24 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 6. Confirm the target npm version is not already published.
 7. Create and push the git tag.
 8. Create or refresh the matching GitHub release.
-9. If the operator wants CI confidence before publishing, start the relevant
-   release workflow with `preflight_only=true` first and wait for it to pass.
-10. Start `.github/workflows/openclaw-npm-release.yml` with `workflow_dispatch` and the same tag.
-11. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
-12. If the release includes mac artifacts, start `.github/workflows/macos-release.yml` and wait for `mac-release` approval and success.
-13. After the mac workflow succeeds, download the signed `appcast.xml`
+9. Start `.github/workflows/openclaw-npm-release.yml` with `preflight_only=true`
+   and wait for it to pass.
+10. If the release includes mac artifacts, start
+    `.github/workflows/macos-release.yml` with `preflight_only=true` and wait
+    for it to pass.
+11. If either preflight fails, fix the issue on a new commit, delete the tag
+    and matching GitHub release, recreate them from the commit that passes, and
+    rerun both preflights before continuing.
+12. Start `.github/workflows/openclaw-npm-release.yml` with the same tag for
+    the real publish.
+13. Wait for `npm-release` approval from `@openclaw/openclaw-release-managers`.
+14. If the release includes mac artifacts, start
+    `.github/workflows/macos-release.yml` for the real publish and wait for
+    `mac-release` approval and success.
+15. After the mac workflow succeeds, download the signed `appcast.xml`
     artifact from that run, update `appcast.xml` on `main`, and verify the
     feed.
-14. After publish, verify npm and any attached release artifacts.
+16. After publish, verify npm and any attached release artifacts.
 
 ## GHSA advisory work
 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -7,6 +7,11 @@ on:
         description: Existing release tag to build macOS artifacts for (for example v2026.3.22 or v2026.3.22-beta.1)
         required: true
         type: string
+      preflight_only:
+        description: Run validation/build only and skip the gated publish job
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: macos-release-${{ inputs.tag }}
@@ -104,6 +109,7 @@ jobs:
 
   publish_macos_release:
     needs: [preflight_macos_release]
+    if: ${{ !inputs.preflight_only }}
     runs-on: macos-latest
     environment: mac-release
     permissions:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -1,0 +1,291 @@
+name: macOS Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build macOS artifacts for (for example v2026.3.22 or v2026.3.22-beta.1)
+        required: true
+        type: string
+
+concurrency:
+  group: macos-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.x"
+  PNPM_VERSION: "10.23.0"
+  SPARKLE_FEED_URL: https://openclaw.ai/appcast.xml
+  OPENCLAW_AI_REPO: openclaw/openclaw.ai
+  OPENCLAW_AI_APPCAST_PATH: public/appcast.xml
+
+jobs:
+  preflight_macos_release:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-beta\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout selected tag
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Ensure matching GitHub release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
+      - name: Validate release tag and package metadata
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_MAIN_REF: origin/main
+        run: |
+          set -euo pipefail
+          RELEASE_SHA=$(git rev-parse HEAD)
+          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          pnpm release:openclaw:npm:check
+
+      - name: Resolve package version
+        id: package_version
+        run: echo "value=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Check
+        run: pnpm check
+
+      - name: Build
+        run: pnpm build
+
+      - name: Build Control UI
+        run: node scripts/ui.js build
+
+      - name: Verify release contents
+        run: pnpm release:check
+
+      - name: Swift build
+        run: swift build --package-path apps/macos --configuration release
+
+      - name: Swift test
+        run: swift test --package-path apps/macos --parallel
+
+      - name: Package macOS release with ad-hoc signing
+        env:
+          APP_VERSION: ${{ steps.package_version.outputs.value }}
+          BUNDLE_ID: ai.openclaw.mac
+          BUILD_CONFIG: release
+          CODESIGN_TIMESTAMP: "off"
+          SIGN_IDENTITY: "-"
+          SKIP_NOTARIZE: "1"
+          SKIP_PNPM_INSTALL: "1"
+          SKIP_TSC: "1"
+          SKIP_UI_BUILD: "1"
+          SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
+        run: scripts/package-mac-dist.sh
+
+  publish_macos_release:
+    needs: [preflight_macos_release]
+    runs-on: macos-latest
+    environment: mac-release
+    permissions:
+      contents: write
+    steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-beta\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout selected tag
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Ensure matching GitHub release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+
+      - name: Resolve package version
+        id: package_version
+        run: echo "value=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Import Developer ID certificate
+        env:
+          MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          CERT_PATH="$RUNNER_TEMP/openclaw-macos-release.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/openclaw-release.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+          echo "::add-mask::$KEYCHAIN_PASSWORD"
+          export CERT_PATH MACOS_DEVELOPER_ID_P12_BASE64
+          python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+
+          Path(os.environ["CERT_PATH"]).write_bytes(
+              base64.b64decode(os.environ["MACOS_DEVELOPER_ID_P12_BASE64"])
+          )
+          PY
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$MACOS_DEVELOPER_ID_P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          EXISTING_KEYCHAINS="$(security list-keychains -d user | tr -d '"')"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING_KEYCHAINS
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Resolve signing identity
+        run: |
+          set -euo pipefail
+          SIGN_IDENTITY="$(security find-identity -p codesigning -v "$KEYCHAIN_PATH" 2>/dev/null | awk -F'\"' '/Developer ID Application/ { print $2; exit }')"
+          if [[ -z "${SIGN_IDENTITY}" ]]; then
+            echo "Developer ID Application identity not found in imported keychain." >&2
+            exit 1
+          fi
+          echo "SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Write notary and Sparkle key files
+        env:
+          APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          NOTARYTOOL_KEY_PATH="$RUNNER_TEMP/openclaw-notary.p8"
+          SPARKLE_PRIVATE_KEY_PATH="$RUNNER_TEMP/openclaw-sparkle-ed25519.pem"
+          export NOTARYTOOL_KEY_PATH SPARKLE_PRIVATE_KEY_PATH
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          def write_secret(path_env: str, value_env: str) -> None:
+              value = os.environ[value_env].replace("\\n", "\n")
+              Path(os.environ[path_env]).write_text(value, encoding="utf-8")
+
+          write_secret("NOTARYTOOL_KEY_PATH", "APP_STORE_CONNECT_API_KEY_P8")
+          write_secret("SPARKLE_PRIVATE_KEY_PATH", "SPARKLE_PRIVATE_KEY")
+          PY
+          echo "NOTARYTOOL_KEY=$NOTARYTOOL_KEY_PATH" >> "$GITHUB_ENV"
+          echo "NOTARYTOOL_KEY_ID=$APP_STORE_CONNECT_KEY_ID" >> "$GITHUB_ENV"
+          echo "NOTARYTOOL_ISSUER=$APP_STORE_CONNECT_ISSUER_ID" >> "$GITHUB_ENV"
+          echo "SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Build, sign, notarize, and package macOS release
+        env:
+          APP_VERSION: ${{ steps.package_version.outputs.value }}
+          BUNDLE_ID: ai.openclaw.mac
+          BUILD_CONFIG: release
+          SIGN_IDENTITY: ${{ env.SIGN_IDENTITY }}
+          SKIP_PNPM_INSTALL: "1"
+          SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
+        run: scripts/package-mac-dist.sh
+
+      - name: Checkout openclaw.ai
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.OPENCLAW_AI_REPO }}
+          path: openclaw.ai
+          token: ${{ secrets.OPENCLAW_AI_REPO_TOKEN }}
+          fetch-depth: 0
+
+      - name: Seed appcast from openclaw.ai
+        run: |
+          set -euo pipefail
+          APPCAST_SOURCE="openclaw.ai/${OPENCLAW_AI_APPCAST_PATH}"
+          if [[ -f "$APPCAST_SOURCE" ]]; then
+            cp "$APPCAST_SOURCE" appcast.xml
+          else
+            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
+          fi
+
+      - name: Generate Sparkle appcast
+        env:
+          SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
+          SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
+        run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
+
+      - name: Upload macOS assets to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          VERSION: ${{ steps.package_version.outputs.value }}
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" \
+            "dist/OpenClaw-$VERSION.zip" \
+            "dist/OpenClaw-$VERSION.dmg" \
+            "dist/OpenClaw-$VERSION.dSYM.zip" \
+            --clobber \
+            --repo "$GITHUB_REPOSITORY"
+
+      - name: Publish appcast to openclaw.ai
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          APPCAST_DEST="openclaw.ai/${OPENCLAW_AI_APPCAST_PATH}"
+          mkdir -p "$(dirname "$APPCAST_DEST")"
+          cp appcast.xml "$APPCAST_DEST"
+          cd openclaw.ai
+          git config user.name "openclaw-release-bot"
+          git config user.email "releases@openclaw.ai"
+          if git diff --quiet -- "$OPENCLAW_AI_APPCAST_PATH"; then
+            echo "Appcast already up to date."
+            exit 0
+          fi
+          git add "$OPENCLAW_AI_APPCAST_PATH"
+          git commit -m "macos: update appcast for ${RELEASE_TAG}"
+          git push origin HEAD:main
+
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          if [[ -n "${KEYCHAIN_PATH:-}" ]]; then
+            security delete-keychain "$KEYCHAIN_PATH" >/dev/null 2>&1 || true
+          fi

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -16,9 +16,8 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   PNPM_VERSION: "10.23.0"
-  SPARKLE_FEED_URL: https://openclaw.ai/appcast.xml
-  OPENCLAW_AI_REPO: openclaw/openclaw.ai
-  OPENCLAW_AI_APPCAST_PATH: public/appcast.xml
+  SPARKLE_FEED_URL: https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml
+  APPCAST_PATH: appcast.xml
 
 jobs:
   preflight_macos_release:
@@ -226,18 +225,17 @@ jobs:
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
         run: scripts/package-mac-dist.sh
 
-      - name: Checkout openclaw.ai
+      - name: Checkout main branch for appcast
         uses: actions/checkout@v6
         with:
-          repository: ${{ env.OPENCLAW_AI_REPO }}
-          path: openclaw.ai
-          token: ${{ secrets.OPENCLAW_AI_REPO_TOKEN }}
+          path: openclaw-main
+          ref: main
           fetch-depth: 0
 
-      - name: Seed appcast from openclaw.ai
+      - name: Seed appcast from main
         run: |
           set -euo pipefail
-          APPCAST_SOURCE="openclaw.ai/${OPENCLAW_AI_APPCAST_PATH}"
+          APPCAST_SOURCE="openclaw-main/${APPCAST_PATH}"
           if [[ -f "$APPCAST_SOURCE" ]]; then
             cp "$APPCAST_SOURCE" appcast.xml
           else
@@ -264,22 +262,23 @@ jobs:
             --clobber \
             --repo "$GITHUB_REPOSITORY"
 
-      - name: Publish appcast to openclaw.ai
+      - name: Publish appcast to main
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          APPCAST_DEST="openclaw.ai/${OPENCLAW_AI_APPCAST_PATH}"
+          APPCAST_DEST="openclaw-main/${APPCAST_PATH}"
           mkdir -p "$(dirname "$APPCAST_DEST")"
           cp appcast.xml "$APPCAST_DEST"
-          cd openclaw.ai
+          cd openclaw-main
           git config user.name "openclaw-release-bot"
           git config user.email "releases@openclaw.ai"
-          if git diff --quiet -- "$OPENCLAW_AI_APPCAST_PATH"; then
+          if git diff --quiet -- "$APPCAST_PATH"; then
             echo "Appcast already up to date."
             exit 0
           fi
-          git add "$OPENCLAW_AI_APPCAST_PATH"
+          git add "$APPCAST_PATH"
           git commit -m "macos: update appcast for ${RELEASE_TAG}"
           git push origin HEAD:main
 

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -193,25 +193,32 @@ jobs:
           fi
           echo "SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
 
-      - name: Write notary key file
+      - name: Write notary and Sparkle key files
         env:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           NOTARYTOOL_KEY_PATH="$RUNNER_TEMP/openclaw-notary.p8"
-          export NOTARYTOOL_KEY_PATH
+          SPARKLE_PRIVATE_KEY_PATH="$RUNNER_TEMP/openclaw-sparkle-ed25519.pem"
+          export NOTARYTOOL_KEY_PATH SPARKLE_PRIVATE_KEY_PATH
           python3 - <<'PY'
           import os
           from pathlib import Path
 
-          value = os.environ["APP_STORE_CONNECT_API_KEY_P8"].replace("\\n", "\n")
-          Path(os.environ["NOTARYTOOL_KEY_PATH"]).write_text(value, encoding="utf-8")
+          def write_secret(path_env: str, value_env: str) -> None:
+              value = os.environ[value_env].replace("\\n", "\n")
+              Path(os.environ[path_env]).write_text(value, encoding="utf-8")
+
+          write_secret("NOTARYTOOL_KEY_PATH", "APP_STORE_CONNECT_API_KEY_P8")
+          write_secret("SPARKLE_PRIVATE_KEY_PATH", "SPARKLE_PRIVATE_KEY")
           PY
           echo "NOTARYTOOL_KEY=$NOTARYTOOL_KEY_PATH" >> "$GITHUB_ENV"
           echo "NOTARYTOOL_KEY_ID=$APP_STORE_CONNECT_KEY_ID" >> "$GITHUB_ENV"
           echo "NOTARYTOOL_ISSUER=$APP_STORE_CONNECT_ISSUER_ID" >> "$GITHUB_ENV"
+          echo "SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build, sign, notarize, and package macOS release
         env:
@@ -236,6 +243,36 @@ jobs:
             "dist/OpenClaw-$VERSION.dSYM.zip" \
             --clobber \
             --repo "$GITHUB_REPOSITORY"
+
+      - name: Checkout main branch for appcast seed
+        uses: actions/checkout@v6
+        with:
+          path: openclaw-main
+          ref: main
+          fetch-depth: 0
+
+      - name: Seed appcast from main
+        run: |
+          set -euo pipefail
+          APPCAST_SOURCE="openclaw-main/appcast.xml"
+          if [[ -f "$APPCAST_SOURCE" ]]; then
+            cp "$APPCAST_SOURCE" appcast.xml
+          else
+            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
+          fi
+
+      - name: Generate signed appcast artifact
+        env:
+          SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
+          SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
+        run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
+
+      - name: Upload appcast artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-appcast-${{ inputs.tag }}
+          path: appcast.xml
+          if-no-files-found: error
 
       - name: Clean up signing keychain
         if: always()

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -22,7 +22,6 @@ env:
   NODE_VERSION: "24.x"
   PNPM_VERSION: "10.23.0"
   SPARKLE_FEED_URL: https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml
-  APPCAST_PATH: appcast.xml
 
 jobs:
   preflight_macos_release:
@@ -194,32 +193,25 @@ jobs:
           fi
           echo "SIGN_IDENTITY=$SIGN_IDENTITY" >> "$GITHUB_ENV"
 
-      - name: Write notary and Sparkle key files
+      - name: Write notary key file
         env:
           APP_STORE_CONNECT_API_KEY_P8: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8 }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           NOTARYTOOL_KEY_PATH="$RUNNER_TEMP/openclaw-notary.p8"
-          SPARKLE_PRIVATE_KEY_PATH="$RUNNER_TEMP/openclaw-sparkle-ed25519.pem"
-          export NOTARYTOOL_KEY_PATH SPARKLE_PRIVATE_KEY_PATH
+          export NOTARYTOOL_KEY_PATH
           python3 - <<'PY'
           import os
           from pathlib import Path
 
-          def write_secret(path_env: str, value_env: str) -> None:
-              value = os.environ[value_env].replace("\\n", "\n")
-              Path(os.environ[path_env]).write_text(value, encoding="utf-8")
-
-          write_secret("NOTARYTOOL_KEY_PATH", "APP_STORE_CONNECT_API_KEY_P8")
-          write_secret("SPARKLE_PRIVATE_KEY_PATH", "SPARKLE_PRIVATE_KEY")
+          value = os.environ["APP_STORE_CONNECT_API_KEY_P8"].replace("\\n", "\n")
+          Path(os.environ["NOTARYTOOL_KEY_PATH"]).write_text(value, encoding="utf-8")
           PY
           echo "NOTARYTOOL_KEY=$NOTARYTOOL_KEY_PATH" >> "$GITHUB_ENV"
           echo "NOTARYTOOL_KEY_ID=$APP_STORE_CONNECT_KEY_ID" >> "$GITHUB_ENV"
           echo "NOTARYTOOL_ISSUER=$APP_STORE_CONNECT_ISSUER_ID" >> "$GITHUB_ENV"
-          echo "SPARKLE_PRIVATE_KEY_FILE=$SPARKLE_PRIVATE_KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build, sign, notarize, and package macOS release
         env:
@@ -230,29 +222,6 @@ jobs:
           SKIP_PNPM_INSTALL: "1"
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
         run: scripts/package-mac-dist.sh
-
-      - name: Checkout main branch for appcast
-        uses: actions/checkout@v6
-        with:
-          path: openclaw-main
-          ref: main
-          fetch-depth: 0
-
-      - name: Seed appcast from main
-        run: |
-          set -euo pipefail
-          APPCAST_SOURCE="openclaw-main/${APPCAST_PATH}"
-          if [[ -f "$APPCAST_SOURCE" ]]; then
-            cp "$APPCAST_SOURCE" appcast.xml
-          else
-            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
-          fi
-
-      - name: Generate Sparkle appcast
-        env:
-          SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
-          SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
-        run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
 
       - name: Upload macOS assets to GitHub release
         env:
@@ -267,26 +236,6 @@ jobs:
             "dist/OpenClaw-$VERSION.dSYM.zip" \
             --clobber \
             --repo "$GITHUB_REPOSITORY"
-
-      - name: Publish appcast to main
-        env:
-          RELEASE_TAG: ${{ inputs.tag }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          APPCAST_DEST="openclaw-main/${APPCAST_PATH}"
-          mkdir -p "$(dirname "$APPCAST_DEST")"
-          cp appcast.xml "$APPCAST_DEST"
-          cd openclaw-main
-          git config user.name "openclaw-release-bot"
-          git config user.email "releases@openclaw.ai"
-          if git diff --quiet -- "$APPCAST_PATH"; then
-            echo "Appcast already up to date."
-            exit 0
-          fi
-          git add "$APPCAST_PATH"
-          git commit -m "macos: update appcast for ${RELEASE_TAG}"
-          git push origin HEAD:main
 
       - name: Clean up signing keychain
         if: always()

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -111,6 +111,11 @@ jobs:
     if: ${{ !inputs.preflight_only }}
     runs-on: macos-latest
     environment: mac-release
+    concurrency:
+      # Stable releases all derive the same shared appcast.xml; serialize those
+      # runs so each artifact starts from the latest stable feed snapshot.
+      group: macos-release-publish-${{ contains(inputs.tag, '-beta.') && inputs.tag || 'stable-feed' }}
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -148,6 +153,18 @@ jobs:
         id: package_version
         run: echo "value=$(node -p 'require(\"./package.json\").version')" >> "$GITHUB_OUTPUT"
 
+      - name: Determine release channel
+        id: release_channel
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" == *-beta.* ]]; then
+            echo "is_beta=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_beta=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Import Developer ID certificate
         env:
           MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
@@ -181,7 +198,6 @@ jobs:
           security default-keychain -d user -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
-          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
 
       - name: Resolve signing identity
         run: |
@@ -230,6 +246,44 @@ jobs:
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
         run: scripts/package-mac-dist.sh
 
+      - name: Checkout main branch for appcast seed
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        uses: actions/checkout@v6
+        with:
+          path: openclaw-main
+          ref: main
+          fetch-depth: 0
+
+      - name: Seed appcast from main
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        run: |
+          set -euo pipefail
+          APPCAST_SOURCE="openclaw-main/appcast.xml"
+          if [[ -f "$APPCAST_SOURCE" ]]; then
+            cp "$APPCAST_SOURCE" appcast.xml
+          else
+            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
+          fi
+
+      - name: Generate signed appcast artifact
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        env:
+          SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
+          SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
+        run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
+
+      - name: Upload stable appcast artifact
+        if: ${{ steps.release_channel.outputs.is_beta != 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-appcast-${{ inputs.tag }}
+          path: appcast.xml
+          if-no-files-found: error
+
+      - name: Skip shared appcast for beta releases
+        if: ${{ steps.release_channel.outputs.is_beta == 'true' }}
+        run: echo "Beta release detected; skip shared production appcast artifact generation."
+
       - name: Upload macOS assets to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -243,36 +297,6 @@ jobs:
             "dist/OpenClaw-$VERSION.dSYM.zip" \
             --clobber \
             --repo "$GITHUB_REPOSITORY"
-
-      - name: Checkout main branch for appcast seed
-        uses: actions/checkout@v6
-        with:
-          path: openclaw-main
-          ref: main
-          fetch-depth: 0
-
-      - name: Seed appcast from main
-        run: |
-          set -euo pipefail
-          APPCAST_SOURCE="openclaw-main/appcast.xml"
-          if [[ -f "$APPCAST_SOURCE" ]]; then
-            cp "$APPCAST_SOURCE" appcast.xml
-          else
-            echo "No existing appcast at $APPCAST_SOURCE; generating a fresh feed."
-          fi
-
-      - name: Generate signed appcast artifact
-        env:
-          SPARKLE_DOWNLOAD_URL_PREFIX: https://github.com/openclaw/openclaw/releases/download/${{ inputs.tag }}/
-          SPARKLE_RELEASE_VERSION: ${{ steps.package_version.outputs.value }}
-        run: scripts/make_appcast.sh "dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip" "${{ env.SPARKLE_FEED_URL }}"
-
-      - name: Upload appcast artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: macos-appcast-${{ inputs.tag }}
-          path: appcast.xml
-          if-no-files-found: error
 
       - name: Clean up signing keychain
         if: always()

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -7,6 +7,11 @@ on:
         description: Release tag to publish (for example v2026.3.22, v2026.3.22-beta.1, or fallback v2026.3.22-1)
         required: true
         type: string
+      preflight_only:
+        description: Run validation/build only and skip the gated publish job
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: openclaw-npm-release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
@@ -18,13 +23,10 @@ env:
   PNPM_VERSION: "10.23.0"
 
 jobs:
-  publish_openclaw_npm:
-    # npm trusted publishing + provenance requires a GitHub-hosted runner.
+  preflight_openclaw_npm:
     runs-on: ubuntu-latest
-    environment: npm-release
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Validate tag input format
         env:
@@ -83,6 +85,65 @@ jobs:
 
       - name: Verify release contents
         run: pnpm release:check
+
+  publish_openclaw_npm:
+    # npm trusted publishing + provenance requires a GitHub-hosted runner.
+    needs: [preflight_openclaw_npm]
+    if: ${{ !inputs.preflight_only }}
+    runs-on: ubuntu-latest
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Validate tag input format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-beta\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Validate release tag and package metadata
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_MAIN_REF: origin/main
+        run: |
+          set -euo pipefail
+          RELEASE_SHA=$(git rev-parse HEAD)
+          export RELEASE_SHA RELEASE_TAG RELEASE_MAIN_REF
+          # Fetch the full main ref so merge-base ancestry checks keep working
+          # for older tagged commits that are still contained in main.
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          pnpm release:openclaw:npm:check
+
+      - name: Ensure version is not already published
+        run: |
+          set -euo pipefail
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "openclaw@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "openclaw@${PACKAGE_VERSION} is already published on npm."
+            exit 1
+          fi
+
+          echo "Publishing openclaw@${PACKAGE_VERSION}"
 
       - name: Publish
         run: bash scripts/openclaw-npm-publish.sh --publish

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -23,7 +23,7 @@ OpenClaw has three public release lanes:
 - Do not zero-pad month or day
 - `latest` means the current stable npm release
 - `beta` means the current prerelease npm release
-- Beta releases may ship before the macOS app catches up
+- Core releases ship the npm package and macOS app together
 
 ## Release cadence
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -23,7 +23,7 @@ OpenClaw has three public release lanes:
 - Do not zero-pad month or day
 - `latest` means the current stable npm release
 - `beta` means the current prerelease npm release
-- Core releases ship the npm package and macOS app together
+- Every OpenClaw release ships the npm package and macOS app together
 
 ## Release cadence
 

--- a/scripts/make_appcast.sh
+++ b/scripts/make_appcast.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 ZIP=${1:?"Usage: $0 OpenClaw-<ver>.zip"}
-FEED_URL=${2:-"https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml"}
+FEED_URL=${2:-"https://openclaw.ai/appcast.xml"}
 PRIVATE_KEY_FILE=${SPARKLE_PRIVATE_KEY_FILE:-}
 if [[ -z "$PRIVATE_KEY_FILE" ]]; then
   echo "Set SPARKLE_PRIVATE_KEY_FILE to your ed25519 private key (Sparkle)." >&2

--- a/scripts/make_appcast.sh
+++ b/scripts/make_appcast.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 ZIP=${1:?"Usage: $0 OpenClaw-<ver>.zip"}
-FEED_URL=${2:-"https://openclaw.ai/appcast.xml"}
+FEED_URL=${2:-"https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml"}
 PRIVATE_KEY_FILE=${SPARKLE_PRIVATE_KEY_FILE:-}
 if [[ -z "$PRIVATE_KEY_FILE" ]]; then
   echo "Set SPARKLE_PRIVATE_KEY_FILE to your ed25519 private key (Sparkle)." >&2

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -30,7 +30,7 @@ fi
 IFS=' ' read -r -a BUILD_ARCHS <<< "$BUILD_ARCHS_VALUE"
 PRIMARY_ARCH="${BUILD_ARCHS[0]}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-AGCY8w5vHirVfGGDGc8Szc5iuOqupZSh9pMj/Qs67XI=}"
-SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://openclaw.ai/appcast.xml}"
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml}"
 AUTO_CHECKS=true
 if [[ "$BUNDLE_ID" == *.debug ]]; then
   SPARKLE_FEED_URL=""

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -30,7 +30,7 @@ fi
 IFS=' ' read -r -a BUILD_ARCHS <<< "$BUILD_ARCHS_VALUE"
 PRIMARY_ARCH="${BUILD_ARCHS[0]}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-AGCY8w5vHirVfGGDGc8Szc5iuOqupZSh9pMj/Qs67XI=}"
-SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml}"
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://openclaw.ai/appcast.xml}"
 AUTO_CHECKS=true
 if [[ "$BUNDLE_ID" == *.debug ]]; then
   SPARKLE_FEED_URL=""
@@ -114,8 +114,12 @@ merge_framework_machos() {
   done < <(find "$primary" -type f -print0)
 }
 
-echo "📦 Ensuring deps (pnpm install)"
-(cd "$ROOT_DIR" && pnpm install --no-frozen-lockfile --config.node-linker=hoisted)
+if [[ "${SKIP_PNPM_INSTALL:-0}" != "1" ]]; then
+  echo "📦 Ensuring deps (pnpm install)"
+  (cd "$ROOT_DIR" && pnpm install --no-frozen-lockfile --config.node-linker=hoisted)
+else
+  echo "📦 Skipping pnpm install (SKIP_PNPM_INSTALL=1)"
+fi
 
 if [[ -z "${APP_BUILD:-}" ]]; then
   APP_BUILD="$GIT_BUILD_NUMBER"


### PR DESCRIPTION
## Summary
- add a manual macOS release workflow with an ungated preflight job and a gated publish job
- add `preflight_only` to both core release workflows so Actions can validate the npm and macOS build paths before any real publish run
- require npm preflight and macOS preflight to succeed before publishing any OpenClaw release
- require failed preflight runs to be fixed on a new commit, then recreate the tag and matching GitHub release from the passing commit before publish continues
- state clearly that every OpenClaw release ships the npm package and macOS app together
- keep the production Sparkle feed on `https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml`
- keep the shared production appcast stable-only: beta mac releases upload assets but do not generate a production `appcast.xml` artifact
- generate the stable signed `appcast.xml` artifact before uploading public macOS assets and serialize stable appcast-producing runs across tags
- keep the final `appcast.xml` commit as an agent-owned step on `main`
- extend the release maintainer skill and public release policy to describe the full preflight-first release sequence

## Validation
- `bash -n scripts/package-mac-app.sh scripts/make_appcast.sh`
- parsed `.github/workflows/openclaw-npm-release.yml` and `.github/workflows/macos-release.yml` with Ruby `YAML.load_file`
- `git diff --check`
- `scripts/committer "release: automate macOS publishing" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md scripts/package-mac-app.sh scripts/make_appcast.sh`
- `scripts/committer "release: keep mac appcast in openclaw repo" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md scripts/package-mac-app.sh scripts/make_appcast.sh`
- `scripts/committer "release: add preflight-only release workflow runs" .github/workflows/openclaw-npm-release.yml .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: keep appcast updates manual" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: generate signed appcast as workflow artifact" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: require preflight before publish" .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: require mac app for every release" docs/reference/RELEASING.md .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "docs: clarify every release ships mac app" docs/reference/RELEASING.md .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: document Sparkle feed and SHA rules" .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: keep publish flow tag-based" .agents/skills/openclaw-release-maintainer/SKILL.md`
- `scripts/committer "release: stabilize mac appcast flow" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md`
