### PR TITLE
Fix QMD status-only memory counts

### DIFF
--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -232,7 +232,15 @@ describe("getMemorySearchManager caching", () => {
     process.env.OPENCLAW_STATE_DIR = stateDir;
 
     try {
-      const dbPath = path.join(stateDir, "agents", agentId, "qmd", "xdg-cache", "qmd", "index.sqlite");
+      const dbPath = path.join(
+        stateDir,
+        "agents",
+        agentId,
+        "qmd",
+        "xdg-cache",
+        "qmd",
+        "index.sqlite",
+      );
       fs.mkdirSync(path.dirname(dbPath), { recursive: true });
       const db = new DatabaseSync(dbPath);
       try {
@@ -247,15 +255,18 @@ describe("getMemorySearchManager caching", () => {
             modified_at TEXT NOT NULL,
             active INTEGER NOT NULL DEFAULT 1
           );
-          CREATE TABLE content_vectors (
-            rowid INTEGER PRIMARY KEY,
-            embedding BLOB
-          );
         `);
         const insert = db.prepare(
           "INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active) VALUES (?, ?, ?, ?, ?, ?, 1)",
         );
-        insert.run("memory-dir-main", "2026-03-23.md", "daily", "hash-1", "2026-03-23", "2026-03-23");
+        insert.run(
+          "memory-dir-main",
+          "2026-03-23.md",
+          "daily",
+          "hash-1",
+          "2026-03-23",
+          "2026-03-23",
+        );
         insert.run("memory-root-main", "MEMORY.md", "memory", "hash-2", "2026-03-23", "2026-03-23");
       } finally {
         db.close();
@@ -276,8 +287,11 @@ describe("getMemorySearchManager caching", () => {
         },
       });
     } finally {
-      if (previousStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
-      else process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
       await closeAllMemorySearchManagers();
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
@@ -219,6 +223,64 @@ describe("getMemorySearchManager caching", () => {
     expect(createQmdManagerMock).not.toHaveBeenCalled();
     expect(mockMemoryIndexGet).not.toHaveBeenCalled();
     expect(second.manager).toBe(first.manager);
+  });
+
+  it("reads sqlite-backed counts for status-only qmd requests", async () => {
+    const agentId = "status-agent-db";
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-qmd-status-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      const dbPath = path.join(stateDir, "agents", agentId, "qmd", "xdg-cache", "qmd", "index.sqlite");
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec(`
+          CREATE TABLE documents (
+            id INTEGER PRIMARY KEY,
+            collection TEXT NOT NULL,
+            path TEXT NOT NULL,
+            title TEXT NOT NULL,
+            hash TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            modified_at TEXT NOT NULL,
+            active INTEGER NOT NULL DEFAULT 1
+          );
+          CREATE TABLE content_vectors (
+            rowid INTEGER PRIMARY KEY,
+            embedding BLOB
+          );
+        `);
+        const insert = db.prepare(
+          "INSERT INTO documents (collection, path, title, hash, created_at, modified_at, active) VALUES (?, ?, ?, ?, ?, ?, 1)",
+        );
+        insert.run("memory-dir-main", "2026-03-23.md", "daily", "hash-1", "2026-03-23", "2026-03-23");
+        insert.run("memory-root-main", "MEMORY.md", "memory", "hash-2", "2026-03-23", "2026-03-23");
+      } finally {
+        db.close();
+      }
+
+      const cfg = createQmdCfg(agentId);
+      const result = await getMemorySearchManager({ cfg, agentId, purpose: "status" });
+      const manager = requireManager(result);
+      expect(manager.status()).toMatchObject({
+        backend: "qmd",
+        files: 2,
+        chunks: 2,
+        sourceCounts: [{ source: "memory", files: 2, chunks: 2 }],
+        custom: {
+          qmd: {
+            lightweightStatus: true,
+          },
+        },
+      });
+    } finally {
+      if (previousStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+      else process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      await closeAllMemorySearchManagers();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("does not evict a newer cached wrapper when closing an older failed wrapper", async () => {

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -113,6 +114,7 @@ class QmdStatusOnlyManager implements MemorySearchManager {
   private readonly workspaceDir: string;
   private readonly indexPath: string;
   private readonly sourceSet: Set<"memory" | "sessions">;
+  private readonly collectionKinds: Map<string, "memory" | "sessions">;
 
   constructor(
     private readonly params: {
@@ -137,6 +139,12 @@ class QmdStatusOnlyManager implements MemorySearchManager {
         collection.kind === "sessions" ? "sessions" : "memory",
       ),
     );
+    this.collectionKinds = new Map(
+      params.resolved.collections.map((collection) => [
+        collection.name,
+        collection.kind === "sessions" ? "sessions" : "memory",
+      ]),
+    );
   }
 
   async search(): Promise<never> {
@@ -147,18 +155,80 @@ class QmdStatusOnlyManager implements MemorySearchManager {
     throw new Error("memory read unavailable in status-only mode");
   }
 
+  private readCounts(): {
+    totalFiles: number;
+    totalChunks: number;
+    sourceCounts: Array<{ source: "memory" | "sessions"; files: number; chunks: number }>;
+  } {
+    const zeroSourceCounts = Array.from(this.sourceSet).map((source) => ({
+      source,
+      files: 0,
+      chunks: 0,
+    }));
+
+    try {
+      const db = new DatabaseSync(this.indexPath, { readonly: true });
+      try {
+        const docRows = db
+          .prepare("SELECT collection, COUNT(*) as c FROM documents WHERE active = 1 GROUP BY collection")
+          .all() as Array<{ collection: string; c: number }>;
+
+        // Read vector rows once so the status path can report a database-backed snapshot without
+        // constructing the full QMD manager. We still keep the legacy chunk=count semantics here,
+        // matching the full QMD manager and existing CLI formatting expectations.
+        db.prepare("SELECT COUNT(*) as c FROM content_vectors").get() as { c: number } | undefined;
+
+        const bySource = new Map<"memory" | "sessions", { files: number; chunks: number }>(
+          zeroSourceCounts.map((entry) => [entry.source, { files: 0, chunks: 0 }]),
+        );
+        let totalFiles = 0;
+        for (const row of docRows) {
+          const source = this.collectionKinds.get(row.collection) ?? "memory";
+          const count = row.c ?? 0;
+          const entry = bySource.get(source) ?? { files: 0, chunks: 0 };
+          entry.files += count;
+          bySource.set(source, entry);
+          totalFiles += count;
+        }
+        for (const entry of bySource.values()) {
+          entry.chunks = totalFiles;
+        }
+        return {
+          totalFiles,
+          totalChunks: totalFiles,
+          sourceCounts: Array.from(bySource.entries()).map(([source, value]) => ({
+            source,
+            files: value.files,
+            chunks: value.chunks,
+          })),
+        };
+      } finally {
+        db.close();
+      }
+    } catch (err) {
+      log.warn(`failed to read qmd lightweight status: ${String(err)}`);
+      return {
+        totalFiles: 0,
+        totalChunks: 0,
+        sourceCounts: zeroSourceCounts,
+      };
+    }
+  }
+
   status() {
+    const counts = this.readCounts();
     return {
       backend: "qmd" as const,
       provider: "qmd",
       model: "qmd",
       requestedProvider: "qmd",
-      files: 0,
-      chunks: 0,
+      files: counts.totalFiles,
+      chunks: counts.totalChunks,
       dirty: false,
       workspaceDir: this.workspaceDir,
       dbPath: this.indexPath,
       sources: Array.from(this.sourceSet),
+      sourceCounts: counts.sourceCounts,
       vector: { enabled: true, available: true },
       batch: {
         enabled: false,

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -167,16 +167,13 @@ class QmdStatusOnlyManager implements MemorySearchManager {
     }));
 
     try {
-      const db = new DatabaseSync(this.indexPath, { readonly: true });
+      const db = new DatabaseSync(this.indexPath, { readOnly: true });
       try {
         const docRows = db
-          .prepare("SELECT collection, COUNT(*) as c FROM documents WHERE active = 1 GROUP BY collection")
+          .prepare(
+            "SELECT collection, COUNT(*) as c FROM documents WHERE active = 1 GROUP BY collection",
+          )
           .all() as Array<{ collection: string; c: number }>;
-
-        // Read vector rows once so the status path can report a database-backed snapshot without
-        // constructing the full QMD manager. We still keep the legacy chunk=count semantics here,
-        // matching the full QMD manager and existing CLI formatting expectations.
-        db.prepare("SELECT COUNT(*) as c FROM content_vectors").get() as { c: number } | undefined;
 
         const bySource = new Map<"memory" | "sessions", { files: number; chunks: number }>(
           zeroSourceCounts.map((entry) => [entry.source, { files: 0, chunks: 0 }]),
@@ -187,11 +184,9 @@ class QmdStatusOnlyManager implements MemorySearchManager {
           const count = row.c ?? 0;
           const entry = bySource.get(source) ?? { files: 0, chunks: 0 };
           entry.files += count;
+          entry.chunks += count;
           bySource.set(source, entry);
           totalFiles += count;
-        }
-        for (const entry of bySource.values()) {
-          entry.chunks = totalFiles;
         }
         return {
           totalFiles,


### PR DESCRIPTION
## Summary
- make the lightweight QMD status manager read counts directly from the sqlite index
- preserve the existing lightweight status path without constructing the full QMD manager
- add a regression test covering sqlite-backed status counts

## Problem
`openclaw memory status` in QMD mode could report `0/N files · 0 chunks` even when the QMD sqlite index already contained documents and `memory_search` was working.

The root cause is that `QmdStatusOnlyManager.status()` returned hard-coded zero counts instead of reading the existing sqlite index.

## Verification
I verified the bug and fix with these commands on a live OpenClaw install:

```bash
openclaw memory status --json
python3 - <<'PY'
import sqlite3
p='/home/sisu/.openclaw/agents/main/qmd/xdg-cache/qmd/index.sqlite'
con=sqlite3.connect(p)
cur=con.cursor()
cur.execute('select count(*) from documents where active=1')
print(cur.fetchone()[0])
PY
```

Before the fix, the CLI showed zero indexed files while the sqlite DB contained real documents.

After applying the equivalent runtime patch locally, the live install reported real counts and `memory_search` remained functional.

## Notes
I also added a focused test for the sqlite-backed lightweight status path in `src/memory/search-manager.test.ts`.
