### PR TITLE
fix: populate currentThreadTs in threading tool context fallback (#52217)

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -48,10 +48,13 @@ export function buildThreadingToolContext(params: {
   // Fallback for unrecognized/plugin channels (e.g., BlueBubbles before plugin registry init)
   const threading = provider ? getChannelPlugin(provider)?.threading : undefined;
   if (!threading?.buildToolContext) {
+    const threadTs =
+      sessionCtx.MessageThreadId != null ? String(sessionCtx.MessageThreadId) : undefined;
     return {
       currentChannelId: originTo?.trim() || undefined,
       currentChannelProvider: provider ?? (rawProvider as ChannelId),
       currentMessageId,
+      currentThreadTs: threadTs || undefined,
       hasRepliedRef,
     };
   }


### PR DESCRIPTION
## Problem

When a channel plugin lacks a custom `buildToolContext` in its threading adapter (e.g. Telegram), the fallback path in `buildThreadingToolContext()` did not include `currentThreadTs` from the inbound `MessageThreadId`. 

This caused `resolveTelegramAutoThreadId()` to return `undefined` (because it requires both `currentThreadTs` AND `currentChannelId`), so any `message(action=send)` without an explicit `threadId` would route to the main chat instead of the originating DM topic.

## Reproduction

1. Open a DM topic with the bot (e.g. topic `1045687`)
2. Send a message in another topic or main chat (updates `lastThreadId` in session entry)
3. Return to original topic - agent sends `message(action=send)` with buttons/media without explicit `threadId`
4. **Result:** Message arrives in main chat instead of topic

## Fix

Add `currentThreadTs` derived from `sessionCtx.MessageThreadId` to the fallback return in `buildThreadingToolContext()` when `threading?.buildToolContext` is absent.

This ensures `resolveTelegramAutoThreadId()` can auto-inject the correct `message_thread_id` for Telegram DM topics, matching the behavior that channels with custom `buildToolContext` already have.

## Changes

- `src/auto-reply/reply/agent-runner-utils.ts`: Add `currentThreadTs` to fallback path (3 lines)

## Testing

- Existing threading tests pass (`message-action-runner.threading.test.ts`, `channel.test.ts`)
- Manually verified: `message(action=send)` without `threadId` now correctly routes to topic after the user interacts with main chat

Fixes #52217