### PR TITLE
fix(gateway): allow localhost control-ui auth through container port-forwards

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,6 +450,9 @@ importers:
 
   extensions/mattermost:
     dependencies:
+      '@sinclair/typebox':
+        specifier: 0.34.48
+        version: 0.34.48
       ws:
         specifier: ^8.20.0
         version: 8.20.0

--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   evaluateMissingDeviceIdentity,
+  isContainerForwardedLocalControlUiRequest,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
   shouldSkipControlUiPairing,
@@ -117,13 +118,14 @@ describe("ws connect policy", () => {
       evaluateMissingDeviceIdentity({
         hasDeviceIdentity: false,
         role: "operator",
-        isControlUi: false,
-        controlUiAuthPolicy: policy,
+        isControlUi: true,
+        controlUiAuthPolicy: controlUiStrict,
         trustedProxyAuthOk: false,
         sharedAuthOk: true,
         authOk: true,
         hasSharedAuth: true,
         isLocalClient: false,
+        isContainerForwardedLocalControlUiRequest: true,
       }).kind,
     ).toBe("allow");
 
@@ -207,6 +209,62 @@ describe("ws connect policy", () => {
         isLocalClient: false,
       }).kind,
     ).toBe("reject-device-required");
+  });
+
+  test("recognizes container-forwarded localhost control ui requests", () => {
+    expect(
+      isContainerForwardedLocalControlUiRequest({
+        isControlUi: true,
+        requestHost: "localhost:18789",
+        requestOrigin: "http://localhost:18789",
+        hasUntrustedProxyHeaders: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isContainerForwardedLocalControlUiRequest({
+        isControlUi: true,
+        requestHost: "127.0.0.1:18789",
+        requestOrigin: "http://127.0.0.1:18789",
+        hasUntrustedProxyHeaders: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isContainerForwardedLocalControlUiRequest({
+        isControlUi: true,
+        requestHost: "localhost:18789",
+        requestOrigin: "http://gateway.example:18789",
+        hasUntrustedProxyHeaders: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isContainerForwardedLocalControlUiRequest({
+        isControlUi: true,
+        requestHost: "localhost:18789",
+        requestOrigin: "http://localhost:18789",
+        hasUntrustedProxyHeaders: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      isContainerForwardedLocalControlUiRequest({
+        isControlUi: false,
+        requestHost: "localhost:18789",
+        requestOrigin: "http://localhost:18789",
+        hasUntrustedProxyHeaders: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isContainerForwardedLocalControlUiRequest({
+        isControlUi: true,
+        requestHost: "my-machine.ts.net:18789",
+        requestOrigin: "http://my-machine.ts.net:18789",
+        hasUntrustedProxyHeaders: false,
+      }),
+    ).toBe(false);
   });
 
   test("dangerouslyDisableDeviceAuth skips pairing for operator control-ui only", () => {

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -1,3 +1,4 @@
+import { isLoopbackAddress, resolveHostName } from "../../net.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { GatewayRole } from "../../role-policy.js";
 import { roleCanSkipDeviceIdentity } from "../../role-policy.js";
@@ -81,6 +82,43 @@ export type MissingDeviceIdentityDecision =
   | { kind: "reject-unauthorized" }
   | { kind: "reject-device-required" };
 
+export function isContainerForwardedLocalControlUiRequest(params: {
+  isControlUi: boolean;
+  requestHost?: string;
+  requestOrigin?: string;
+  hasUntrustedProxyHeaders: boolean;
+}): boolean {
+  const isStrictLoopbackHost = (hostHeader?: string): boolean => {
+    const hostName = resolveHostName(hostHeader);
+    return hostName === "localhost" || isLoopbackAddress(hostName);
+  };
+
+  if (!params.isControlUi || params.hasUntrustedProxyHeaders) {
+    return false;
+  }
+  if (!isStrictLoopbackHost(params.requestHost)) {
+    return false;
+  }
+  const origin = params.requestOrigin?.trim();
+  if (!origin) {
+    return false;
+  }
+  try {
+    const url = new URL(origin);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      !isStrictLoopbackHost(url.host)
+    ) {
+      return false;
+    }
+    const originHostName = resolveHostName(url.host);
+    const requestHostName = resolveHostName(params.requestHost);
+    return Boolean(originHostName && requestHostName && originHostName === requestHostName);
+  } catch {
+    return false;
+  }
+}
+
 export function evaluateMissingDeviceIdentity(params: {
   hasDeviceIdentity: boolean;
   role: GatewayRole;
@@ -91,6 +129,7 @@ export function evaluateMissingDeviceIdentity(params: {
   authOk: boolean;
   hasSharedAuth: boolean;
   isLocalClient: boolean;
+  isContainerForwardedLocalControlUiRequest?: boolean;
 }): MissingDeviceIdentityDecision {
   if (params.hasDeviceIdentity) {
     return { kind: "allow" };
@@ -112,7 +151,10 @@ export function evaluateMissingDeviceIdentity(params: {
     // (needed for device identity) is unavailable in insecure HTTP contexts.
     // Remote connections are still rejected to preserve the MitM protection
     // that the security fix (#20684) intended.
-    if (!params.controlUiAuthPolicy.allowInsecureAuthConfigured || !params.isLocalClient) {
+    if (
+      !params.controlUiAuthPolicy.allowInsecureAuthConfigured ||
+      !(params.isLocalClient || params.isContainerForwardedLocalControlUiRequest)
+    ) {
       return { kind: "reject-control-ui-insecure-auth" };
     }
   }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -81,6 +81,7 @@ import { resolveConnectAuthDecision, resolveConnectAuthState } from "./auth-cont
 import { formatGatewayAuthFailureMessage } from "./auth-messages.js";
 import {
   evaluateMissingDeviceIdentity,
+  isContainerForwardedLocalControlUiRequest,
   isTrustedProxyControlUiOperatorAuth,
   resolveControlUiAuthPolicy,
   shouldSkipControlUiPairing,
@@ -513,6 +514,13 @@ export function attachGatewayWsMessageHandler(params: {
           }
         };
         const handleMissingDeviceIdentity = (): boolean => {
+          const isContainerForwardedLocalControlUi = isContainerForwardedLocalControlUiRequest({
+            isControlUi,
+            requestHost,
+            requestOrigin,
+            hasUntrustedProxyHeaders,
+          });
+          const isTrustedLocalControlUiClient = isLocalClient || isContainerForwardedLocalControlUi;
           const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
             isControlUi,
             role,
@@ -523,7 +531,7 @@ export function attachGatewayWsMessageHandler(params: {
           const preserveInsecureLocalControlUiScopes =
             isControlUi &&
             controlUiAuthPolicy.allowInsecureAuthConfigured &&
-            isLocalClient &&
+            isTrustedLocalControlUiClient &&
             (authMethod === "token" || authMethod === "password");
           const decision = evaluateMissingDeviceIdentity({
             hasDeviceIdentity: Boolean(device),
@@ -535,6 +543,7 @@ export function attachGatewayWsMessageHandler(params: {
             authOk,
             hasSharedAuth,
             isLocalClient,
+            isContainerForwardedLocalControlUiRequest: isContainerForwardedLocalControlUi,
           });
           // Shared token/password auth can bypass pairing for trusted operators.
           // Device-less clients only keep self-declared scopes on the explicit


### PR DESCRIPTION

## Summary

 - Problem: recent Control UI auth hardening exposed failures in proxied browser access paths, where token-authenticated Control UI sessions could still lose operator scopes or fall into pairing/auth failures when the Gateway did not consider the connection "local".
  - Why it matters: this showed up not only in local Podman/Docker forwarded-localhost setups, but also in trusted reverse-proxy / SSO deployments where the old tokenized-dashboard + bypass-device-auth flow no longer works.
  - What changed: this PR attempted to treat forwarded localhost Control UI requests as eligible for the local insecure-auth path based on strict localhost `Host` / `Origin` checks, so `allowInsecureAuth=true` could work without requiring `dangerouslyDisableDeviceAuth=true`.
  - What did NOT change (scope boundary): this was still limited to Control UI/webchat and did not broaden generic remote auth or remove pairing as the intended security boundary.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [x] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [x] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related # 
  
  ## User-visible / Behavior Changes

  - Local Podman/Docker deployments using gateway.controlUi.allowInsecureAuth=true no longer require dangerouslyDisableDeviceAuth=true just to get past forwarded-localhost auth classification.
  - First browser connect can still require pairing, but the auth flow now behaves correctly for container-forwarded localhost.

  ## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation:

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Podman local container deployment
  - Model/provider: N/A
  - Integration/channel (if any): Control UI / webchat
  - Relevant config (redacted): gateway.controlUi.allowInsecureAuth=true, browser origin http://localhost:18789, gateway running in local container with forwarded localhost port

  ### Steps

  1. Run OpenClaw in a local Podman container and expose the gateway on http://localhost:<port>.
  2. Configure Control UI for local HTTP auth with gateway.controlUi.allowInsecureAuth=true.
  3. Open the dashboard from the browser and attempt first connect.

  ### Expected

  - Local forwarded localhost Control UI auth is treated like local insecure-auth traffic.
  - Browser reaches the normal pairing/auth path without requiring dangerouslyDisableDeviceAuth.

  ### Actual

  - Before fix, the gateway treated the request as non-local because the socket peer was a Podman bridge IP, causing auth/pairing behavior to fail or require the broader dangerous bypass.

  ## Evidence

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  - Verified scenarios:
      - Reproduced the problem with a real local Podman deployment and browser Control UI.
      - Confirmed the running container included the patch.
      - Verified the patched runtime plus allowInsecureAuth=true works without dangerouslyDisableDeviceAuth.
      - Verified first-connect pairing still works and the UI connects after approval.
  - Edge cases checked:
      - Host/Origin localhost path only.
      - No change to non-Control-UI auth flow.
  - What you did not verify:
      - Docker-specific runtime behavior on another machine.
      - K8s/OpenShift paths, which should be unaffected.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps:

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: revert this patch, or fall back to the previous local workaround using dangerouslyDisableDeviceAuth=true.
  - Files/config to restore: src/gateway/server/ws-connection/connect-policy.ts, src/gateway/server/ws-connection/message-handler.ts
  - Known bad symptoms reviewers should watch for:
      - local containerized Control UI still showing pairing required unexpectedly
      - localhost Control UI failing to connect despite allowInsecureAuth=true

  ## Risks and Mitigations

  - Risk: localhost-origin checks could be broadened too far for insecure-auth handling.
      - Mitigation: logic is narrowly scoped to Control UI/webchat, requires localhost/127.0.0.1 Host and Origin, and rejects untrusted proxy-header paths.