### PR TITLE
Fix Anthropic setup-token sibling auth sync

### DIFF
--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -19,11 +19,6 @@ vi.mock("../plugins/provider-auth-choice.runtime.js", () => ({
   runProviderModelSelectedHook,
 }));
 
-const upsertAuthProfile = vi.hoisted(() => vi.fn());
-vi.mock("../agents/auth-profiles.js", () => ({
-  upsertAuthProfile,
-}));
-
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "default"));
 const resolveAgentWorkspaceDir = vi.hoisted(() => vi.fn(() => "/tmp/workspace"));
 const resolveAgentDir = vi.hoisted(() => vi.fn(() => "/tmp/agent"));
@@ -44,8 +39,12 @@ vi.mock("../agents/agent-paths.js", () => ({
 }));
 
 const applyAuthProfileConfig = vi.hoisted(() => vi.fn((config) => config));
+const shouldSyncSiblingAgentsForCredential = vi.hoisted(() => vi.fn(() => false));
+const writeAuthProfile = vi.hoisted(() => vi.fn());
 vi.mock("../plugins/provider-auth-helpers.js", () => ({
   applyAuthProfileConfig,
+  shouldSyncSiblingAgentsForCredential,
+  writeAuthProfile,
 }));
 
 const isRemoteEnvironment = vi.hoisted(() => vi.fn(() => false));
@@ -104,6 +103,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     applyAuthProfileConfig.mockImplementation((config) => config);
+    shouldSyncSiblingAgentsForCredential.mockReturnValue(false);
   });
 
   it("returns an agent model override when default model application is deferred", async () => {
@@ -140,14 +140,22 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(result?.config.agents?.defaults?.model).toEqual({
       primary: "ollama/qwen3:4b",
     });
-    expect(upsertAuthProfile).toHaveBeenCalledWith({
-      profileId: "ollama:default",
-      credential: {
+    expect(writeAuthProfile).toHaveBeenCalledWith(
+      "ollama:default",
+      {
         type: "api_key",
         provider: "ollama",
         key: "ollama-local",
       },
-      agentDir: "/tmp/agent",
+      "/tmp/agent",
+      {
+        syncSiblingAgents: false,
+      },
+    );
+    expect(shouldSyncSiblingAgentsForCredential).toHaveBeenCalledWith({
+      type: "api_key",
+      provider: "ollama",
+      key: "ollama-local",
     });
     expect(runProviderModelSelectedHook).toHaveBeenCalledWith({
       config: result?.config,

--- a/src/plugins/contracts/auth-choice.contract.test.ts
+++ b/src/plugins/contracts/auth-choice.contract.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createAuthTestLifecycle,
@@ -240,5 +243,63 @@ describe("provider auth-choice contract", () => {
       access: "access-token",
       refresh: "refresh-token",
     });
+  });
+
+  it("syncs Anthropic setup-token profiles to sibling agent dirs", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-provider-auth-token-sync-"));
+    activeStateDir = stateDir;
+    lifecycle.setStateDir(stateDir);
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const mainAgentDir = path.join(stateDir, "agents", "main", "agent");
+    const kidAgentDir = path.join(stateDir, "agents", "kid", "agent");
+    const workerAgentDir = path.join(stateDir, "agents", "worker", "agent");
+    await fs.mkdir(mainAgentDir, { recursive: true });
+    await fs.mkdir(kidAgentDir, { recursive: true });
+    await fs.mkdir(workerAgentDir, { recursive: true });
+
+    process.env.OPENCLAW_AGENT_DIR = kidAgentDir;
+    process.env.PI_CODING_AGENT_DIR = kidAgentDir;
+
+    const token = `sk-ant-oat01-${"a".repeat(80)}`;
+    const result = await runProviderPluginAuthMethod({
+      config: {},
+      prompter: createWizardPrompter({}),
+      runtime: createExitThrowingRuntime(),
+      method: {
+        id: "setup-token",
+        label: "Setup token",
+        kind: "token",
+        run: async () => ({
+          profiles: [
+            {
+              profileId: "anthropic:default",
+              credential: {
+                type: "token",
+                provider: "anthropic",
+                token,
+              },
+            },
+          ],
+        }),
+      },
+      allowSecretRefPrompt: false,
+    });
+
+    expect(result.config.auth?.profiles?.["anthropic:default"]).toMatchObject({
+      provider: "anthropic",
+      mode: "token",
+    });
+
+    for (const dir of [mainAgentDir, kidAgentDir, workerAgentDir]) {
+      const stored = await readAuthProfilesForAgent<{ profiles?: Record<string, StoredAuthProfile> }>(
+        dir,
+      );
+      expect(stored.profiles?.["anthropic:default"]).toMatchObject({
+        type: "token",
+        provider: "anthropic",
+        token,
+      });
+    }
   });
 });

--- a/src/plugins/contracts/auth-choice.contract.test.ts
+++ b/src/plugins/contracts/auth-choice.contract.test.ts
@@ -292,9 +292,9 @@ describe("provider auth-choice contract", () => {
     });
 
     for (const dir of [mainAgentDir, kidAgentDir, workerAgentDir]) {
-      const stored = await readAuthProfilesForAgent<{ profiles?: Record<string, StoredAuthProfile> }>(
-        dir,
-      );
+      const stored = await readAuthProfilesForAgent<{
+        profiles?: Record<string, StoredAuthProfile>;
+      }>(dir);
       expect(stored.profiles?.["anthropic:default"]).toMatchObject({
         type: "token",
         provider: "anthropic",

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -5,6 +5,7 @@ import chutesPlugin from "../../../extensions/chutes/index.js";
 import cloudflareAiGatewayPlugin from "../../../extensions/cloudflare-ai-gateway/index.js";
 import copilotProxyPlugin from "../../../extensions/copilot-proxy/index.js";
 import deepgramPlugin from "../../../extensions/deepgram/index.js";
+import deepseekPlugin from "../../../extensions/deepseek/index.js";
 import elevenLabsPlugin from "../../../extensions/elevenlabs/index.js";
 import falPlugin from "../../../extensions/fal/index.js";
 import githubCopilotPlugin from "../../../extensions/github-copilot/index.js";
@@ -357,6 +358,7 @@ const bundledProviderPlugins = dedupePlugins([
   chutesPlugin,
   cloudflareAiGatewayPlugin,
   copilotProxyPlugin,
+  deepseekPlugin,
   githubCopilotPlugin,
   falPlugin,
   googlePlugin,

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -4,7 +4,6 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { upsertAuthProfile } from "../agents/auth-profiles.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -16,7 +15,11 @@ import {
   pickAuthMethod,
   resolveProviderMatch,
 } from "./provider-auth-choice-helpers.js";
-import { applyAuthProfileConfig } from "./provider-auth-helpers.js";
+import {
+  applyAuthProfileConfig,
+  shouldSyncSiblingAgentsForCredential,
+  writeAuthProfile,
+} from "./provider-auth-helpers.js";
 import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
 import { isRemoteEnvironment, openUrl } from "./setup-browser.js";
 import type { ProviderAuthMethod, ProviderAuthOptionBag } from "./types.js";
@@ -130,10 +133,8 @@ export async function runProviderPluginAuthMethod(params: {
   }
 
   for (const profile of result.profiles) {
-    upsertAuthProfile({
-      profileId: profile.profileId,
-      credential: profile.credential,
-      agentDir,
+    writeAuthProfile(profile.profileId, profile.credential, agentDir, {
+      syncSiblingAgents: shouldSyncSiblingAgentsForCredential(profile.credential),
     });
 
     nextConfig = applyAuthProfileConfig(nextConfig, {

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
 import { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
+import type { AuthProfileCredential } from "../agents/auth-profiles/types.js";
 import { normalizeProviderIdForAuth } from "../agents/provider-id.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -25,6 +26,10 @@ export type ApiKeyStorageOptions = {
 };
 
 export type WriteOAuthCredentialsOptions = {
+  syncSiblingAgents?: boolean;
+};
+
+export type WriteAuthProfileOptions = {
   syncSiblingAgents?: boolean;
 };
 
@@ -214,6 +219,53 @@ function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
   return result;
 }
 
+export function shouldSyncSiblingAgentsForCredential(credential: AuthProfileCredential): boolean {
+  return (
+    credential.type === "oauth" ||
+    (credential.type === "token" &&
+      normalizeProviderIdForAuth(credential.provider) === "anthropic")
+  );
+}
+
+export function writeAuthProfile(
+  profileId: string,
+  credential: AuthProfileCredential,
+  agentDir?: string,
+  options?: WriteAuthProfileOptions,
+): void {
+  const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
+  const targetAgentDirs = options?.syncSiblingAgents
+    ? resolveSiblingAgentDirs(resolvedAgentDir)
+    : [resolvedAgentDir];
+
+  upsertAuthProfile({
+    profileId,
+    credential,
+    agentDir: resolvedAgentDir,
+  });
+
+  if (!options?.syncSiblingAgents) {
+    return;
+  }
+
+  const primaryReal = safeRealpathSync(resolvedAgentDir);
+  for (const targetAgentDir of targetAgentDirs) {
+    const targetReal = safeRealpathSync(targetAgentDir);
+    if (targetReal && primaryReal && targetReal === primaryReal) {
+      continue;
+    }
+    try {
+      upsertAuthProfile({
+        profileId,
+        credential,
+        agentDir: targetAgentDir,
+      });
+    } catch {
+      // Best-effort: sibling sync failure must not block primary setup.
+    }
+  }
+}
+
 export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
@@ -223,40 +275,17 @@ export async function writeOAuthCredentials(
   const email =
     typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
   const profileId = `${provider}:${email}`;
-  const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
-  const targetAgentDirs = options?.syncSiblingAgents
-    ? resolveSiblingAgentDirs(resolvedAgentDir)
-    : [resolvedAgentDir];
-
   const credential = {
     type: "oauth" as const,
     provider,
     ...creds,
   };
 
-  upsertAuthProfile({
+  writeAuthProfile(
     profileId,
     credential,
-    agentDir: resolvedAgentDir,
-  });
-
-  if (options?.syncSiblingAgents) {
-    const primaryReal = safeRealpathSync(resolvedAgentDir);
-    for (const targetAgentDir of targetAgentDirs) {
-      const targetReal = safeRealpathSync(targetAgentDir);
-      if (targetReal && primaryReal && targetReal === primaryReal) {
-        continue;
-      }
-      try {
-        upsertAuthProfile({
-          profileId,
-          credential,
-          agentDir: targetAgentDir,
-        });
-      } catch {
-        // Best-effort: sibling sync failure must not block primary setup.
-      }
-    }
-  }
+    agentDir,
+    options,
+  );
   return profileId;
 }

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -222,8 +222,7 @@ function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
 export function shouldSyncSiblingAgentsForCredential(credential: AuthProfileCredential): boolean {
   return (
     credential.type === "oauth" ||
-    (credential.type === "token" &&
-      normalizeProviderIdForAuth(credential.provider) === "anthropic")
+    (credential.type === "token" && normalizeProviderIdForAuth(credential.provider) === "anthropic")
   );
 }
 
@@ -281,11 +280,6 @@ export async function writeOAuthCredentials(
     ...creds,
   };
 
-  writeAuthProfile(
-    profileId,
-    credential,
-    agentDir,
-    options,
-  );
+  writeAuthProfile(profileId, credential, agentDir, options);
   return profileId;
 }


### PR DESCRIPTION
Fixes #51911

## Summary
- sync Anthropic setup-token auth profiles to sibling agent dirs
- reuse the shared auth-profile writer in plugin auth flows
- add regression coverage for Anthropic token sibling sync

## Testing
- `corepack pnpm exec vitest run --config vitest.unit.config.ts src/commands/auth-choice.apply.plugin-provider.test.ts`
- `corepack pnpm exec vitest run src/plugins/contracts/auth-choice.contract.test.ts`
- `corepack pnpm exec vitest run src/commands/onboard-auth.test.ts`
