### PR TITLE
Fix/session send no session

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -11,6 +11,7 @@ public enum ErrorCode: String, Codable, Sendable {
     case invalidRequest = "INVALID_REQUEST"
     case approvalNotFound = "APPROVAL_NOT_FOUND"
     case unavailable = "UNAVAILABLE"
+    case sessionNotFound = "SESSION_NOT_FOUND"
 }
 
 public struct ConnectParams: Codable, Sendable {

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -12,6 +12,8 @@ public enum ErrorCode: String, Codable, Sendable {
     case approvalNotFound = "APPROVAL_NOT_FOUND"
     case unavailable = "UNAVAILABLE"
     case sessionNotFound = "SESSION_NOT_FOUND"
+    case agentNotFound = "AGENT_NOT_FOUND"
+    case sessionAutoStarted = "SESSION_AUTO_STARTED"
 }
 
 public struct ConnectParams: Codable, Sendable {
@@ -1397,6 +1399,24 @@ public struct SessionsSendParams: Codable, Sendable {
         case attachments
         case timeoutms = "timeoutMs"
         case idempotencykey = "idempotencyKey"
+    }
+}
+
+public struct SessionsStartParams: Codable, Sendable {
+    public let agentid: String
+    public let force: Bool?
+
+    public init(
+        agentid: String,
+        force: Bool?)
+    {
+        self.agentid = agentid
+        self.force = force
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case force
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -634,6 +634,14 @@
         "messageLimit"
       ]
     },
+    "sessions_start": {
+      "emoji": "▶️",
+      "title": "Session Start",
+      "detailKeys": [
+        "agentId",
+        "force"
+      ]
+    },
     "sessions_send": {
       "emoji": "📨",
       "title": "Session Send",

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -11,6 +11,7 @@ public enum ErrorCode: String, Codable, Sendable {
     case invalidRequest = "INVALID_REQUEST"
     case approvalNotFound = "APPROVAL_NOT_FOUND"
     case unavailable = "UNAVAILABLE"
+    case sessionNotFound = "SESSION_NOT_FOUND"
 }
 
 public struct ConnectParams: Codable, Sendable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -12,6 +12,8 @@ public enum ErrorCode: String, Codable, Sendable {
     case approvalNotFound = "APPROVAL_NOT_FOUND"
     case unavailable = "UNAVAILABLE"
     case sessionNotFound = "SESSION_NOT_FOUND"
+    case agentNotFound = "AGENT_NOT_FOUND"
+    case sessionAutoStarted = "SESSION_AUTO_STARTED"
 }
 
 public struct ConnectParams: Codable, Sendable {
@@ -1397,6 +1399,24 @@ public struct SessionsSendParams: Codable, Sendable {
         case attachments
         case timeoutms = "timeoutMs"
         case idempotencykey = "idempotencyKey"
+    }
+}
+
+public struct SessionsStartParams: Codable, Sendable {
+    public let agentid: String
+    public let force: Bool?
+
+    public init(
+        agentid: String,
+        force: Bool?)
+    {
+        self.agentid = agentid
+        self.force = force
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case force
     }
 }
 

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -667,9 +667,9 @@ describe("sessions tools", () => {
       runId: "run-1",
       delivery: { status: "pending", mode: "announce" },
     });
-    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 4);
-    await waitForCalls(() => calls.filter((call) => call.method === "agent.wait").length, 4);
-    await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 4);
+    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 5);
+    await waitForCalls(() => calls.filter((call) => call.method === "agent.wait").length, 5);
+    await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 5);
 
     const waitPromise = tool.execute("call6", {
       sessionKey: "main",
@@ -683,14 +683,14 @@ describe("sessions tools", () => {
       delivery: { status: "pending", mode: "announce" },
     });
     expect(typeof (waited.details as { runId?: string }).runId).toBe("string");
-    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 8);
-    await waitForCalls(() => calls.filter((call) => call.method === "agent.wait").length, 8);
-    await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 8);
+    await waitForCalls(() => calls.filter((call) => call.method === "agent").length, 9);
+    await waitForCalls(() => calls.filter((call) => call.method === "agent.wait").length, 9);
+    await waitForCalls(() => calls.filter((call) => call.method === "chat.history").length, 10);
 
     const agentCalls = calls.filter((call) => call.method === "agent");
     const waitCalls = calls.filter((call) => call.method === "agent.wait");
     const historyOnlyCalls = calls.filter((call) => call.method === "chat.history");
-    expect(agentCalls).toHaveLength(8);
+    expect(agentCalls).toHaveLength(9);
     for (const call of agentCalls) {
       expect(call.params).toMatchObject({
         lane: "nested",
@@ -725,8 +725,8 @@ describe("sessions tools", () => {
           ),
       ),
     ).toBe(true);
-    expect(waitCalls).toHaveLength(8);
-    expect(historyOnlyCalls).toHaveLength(9);
+    expect(waitCalls).toHaveLength(9);
+    expect(historyOnlyCalls).toHaveLength(10);
     expect(sendCallCount).toBe(0);
   });
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -29,6 +29,7 @@ import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+import { createSessionsStartTool } from "./tools/sessions-start-tool.js";
 import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
@@ -260,6 +261,9 @@ export function createOpenClawTools(
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
       config: resolvedConfig,
+      callGateway: openClawToolsDeps.callGateway,
+    }),
+    createSessionsStartTool({
       callGateway: openClawToolsDeps.callGateway,
     }),
     createSessionsSendTool({

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -27,6 +27,7 @@ export function describeSessionsHistoryTool(): string {
 export function describeSessionsSendTool(): string {
   return [
     "Send a message into another visible session by sessionKey or label.",
+    "Use sessions_start first if the target session may not exist yet.",
     "Use this to delegate follow-up work to an existing session; waits for the target run and returns the updated assistant reply when available.",
   ].join(" ");
 }

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -423,6 +423,11 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "Sessions",
       detailKeys: ["kinds", "limit", "activeMinutes", "messageLimit"],
     },
+    sessions_start: {
+      emoji: "▶️",
+      title: "Session Start",
+      detailKeys: ["agentId", "force"],
+    },
     sessions_send: {
       emoji: "📨",
       title: "Session Send",

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -12,6 +12,7 @@ import {
   buildAgentToAgentReplyContext,
   isAnnounceSkip,
   isReplySkip,
+  ANNOUNCE_SKIP_TOKEN,
 } from "./sessions-send-helpers.js";
 
 const log = createSubsystemLogger("agents/sessions-send");
@@ -36,6 +37,7 @@ export async function runSessionsSendA2AFlow(params: {
   requesterChannel?: GatewayMessageChannel;
   roundOneReply?: string;
   waitRunId?: string;
+  messageId?: string;
 }) {
   const runContextId = params.waitRunId ?? "unknown";
   try {
@@ -52,6 +54,31 @@ export async function runSessionsSendA2AFlow(params: {
           sessionKey: params.targetSessionKey,
         });
         latestReply = primaryReply;
+        // Emit "received" read receipt to the requester session (best-effort).
+        if (params.requesterSessionKey && params.requesterSessionKey !== params.targetSessionKey) {
+          const messageRef = params.messageId ? ` (messageId: ${params.messageId})` : "";
+          const receiptPrompt = [
+            `Read receipt: your message${messageRef} was delivered to ${params.displayKey} and the agent has started processing.`,
+            `If you have nothing to do with this receipt, reply exactly "${ANNOUNCE_SKIP_TOKEN}".`,
+          ].join("\n");
+          try {
+            await runAgentStep({
+              sessionKey: params.requesterSessionKey,
+              message: receiptPrompt,
+              extraSystemPrompt: "This is a system read-receipt notification.",
+              timeoutMs: 15_000,
+              lane: AGENT_LANE_NESTED,
+              sourceSessionKey: params.targetSessionKey,
+              sourceTool: "sessions_send",
+            });
+          } catch (err) {
+            log.warn("sessions_send read-receipt delivery failed", {
+              runId: runContextId,
+              requesterSessionKey: params.requesterSessionKey,
+              error: formatErrorMessage(err),
+            });
+          }
+        }
       }
     }
     if (!latestReply) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -347,6 +347,7 @@ export function createSessionsSendTool(opts?: {
           runId,
           messageId: idempotencyKey,
           status: "timeout",
+          accepted: true,
           error: result.error,
           sessionKey: displayKey,
         });

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -298,6 +298,7 @@ export function createSessionsSendTool(opts?: {
           requesterChannel,
           roundOneReply,
           waitRunId,
+          messageId: idempotencyKey,
         });
       };
 
@@ -315,6 +316,7 @@ export function createSessionsSendTool(opts?: {
         startA2AFlow(undefined, runId);
         return jsonResult({
           runId,
+          messageId: idempotencyKey,
           status: "accepted",
           sessionKey: displayKey,
           delivery,
@@ -343,6 +345,7 @@ export function createSessionsSendTool(opts?: {
       if (result.status === "timeout") {
         return jsonResult({
           runId,
+          messageId: idempotencyKey,
           status: "timeout",
           error: result.error,
           sessionKey: displayKey,
@@ -361,6 +364,7 @@ export function createSessionsSendTool(opts?: {
 
       return jsonResult({
         runId,
+        messageId: idempotencyKey,
         status: "ok",
         reply,
         sessionKey: displayKey,

--- a/src/agents/tools/sessions-start-tool.ts
+++ b/src/agents/tools/sessions-start-tool.ts
@@ -1,0 +1,74 @@
+import { Type } from "@sinclair/typebox";
+import { callGateway } from "../../gateway/call.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+const SessionsStartToolSchema = Type.Object({
+  agentId: Type.String({
+    minLength: 1,
+    maxLength: 64,
+    description: "The agent ID to start a session for.",
+  }),
+  force: Type.Optional(
+    Type.Boolean({
+      description:
+        "Force a new session even if one already exists. Dangerous: the existing session is discarded.",
+    }),
+  ),
+});
+
+type GatewayCaller = typeof callGateway;
+
+export function createSessionsStartTool(opts?: { callGateway?: GatewayCaller }): AnyAgentTool {
+  return {
+    label: "Sessions",
+    name: "sessions_start",
+    description:
+      "Start (or verify) a session for a given agent. Returns the session key and whether a new session was created. Use before sessions_send when you need to guarantee a session is ready.",
+    parameters: SessionsStartToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const gatewayCall = opts?.callGateway ?? callGateway;
+      const agentId = readStringParam(params, "agentId", { required: true });
+      const force = params.force === true ? true : undefined;
+
+      try {
+        const response = await gatewayCall<{
+          ok: boolean;
+          key: string;
+          wasCreated: boolean;
+          contextOverflowed: boolean;
+          sessionId: string;
+        }>({
+          method: "sessions.start",
+          params: {
+            agentId,
+            ...(force !== undefined ? { force } : {}),
+          },
+          timeoutMs: 10_000,
+        });
+
+        return jsonResult({
+          status: response?.wasCreated ? "created" : "exists",
+          sessionKey: response?.key,
+          sessionId: response?.sessionId,
+          contextOverflowed: response?.contextOverflowed ?? false,
+        });
+      } catch (err) {
+        const messageText =
+          err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+        // Map gateway error codes to meaningful statuses
+        if (messageText.includes("AGENT_NOT_FOUND") || messageText.includes("agent not found")) {
+          return jsonResult({
+            status: "agent_not_found",
+            error: messageText,
+          });
+        }
+        return jsonResult({
+          status: "error",
+          error: messageText,
+        });
+      }
+    },
+  };
+}

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -123,8 +123,9 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
         return retryMs;
       }
     }
-    // Still in the past — try from start of tomorrow (local time) as a broader reset.
-    const tomorrowMs = new Date(nowMs).setHours(24, 0, 0, 0);
+    // Still in the past — try from 48h in the future as a guaranteed fresh reference
+    // point, independent of any timezone.
+    const tomorrowMs = nowMs + 48 * 60 * 60 * 1000;
     const retry2 = cron.nextRun(new Date(tomorrowMs));
     if (retry2) {
       const retry2Ms = retry2.getTime();

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -123,8 +123,8 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
         return retryMs;
       }
     }
-    // Still in the past — try from start of tomorrow (UTC) as a broader reset.
-    const tomorrowMs = new Date(nowMs).setUTCHours(24, 0, 0, 0);
+    // Still in the past — try from start of tomorrow (local time) as a broader reset.
+    const tomorrowMs = new Date(nowMs).setHours(24, 0, 0, 0);
     const retry2 = cron.nextRun(new Date(tomorrowMs));
     if (retry2) {
       const retry2Ms = retry2.getTime();

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -541,13 +541,9 @@ async function inspectManualRunPreflight(
     // This fixes jobs stuck with a wrong timestamp from timezone bugs.
     if (mode === "force" && job.enabled) {
       const now = state.deps.nowMs();
-      const isDue = isJobDue(job, now, { forced: true });
-      if (!isDue && job.state.nextRunAtMs !== undefined) {
-        // Job is not due but has nextRunAtMs - recompute to fix stale values
-        const newNext = computeJobNextRunAtMs(job, now);
-        if (job.state.nextRunAtMs !== newNext) {
-          job.state.nextRunAtMs = newNext;
-        }
+      const newNext = computeJobNextRunAtMs(job, now);
+      if (job.state.nextRunAtMs !== newNext) {
+        job.state.nextRunAtMs = newNext;
       }
     }
     if (typeof job.state.runningAtMs === "number") {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -537,6 +537,19 @@ async function inspectManualRunPreflight(
       await skipInvalidPersistedManualRun({ state, job, mode, error });
       return { ok: true, ran: false, reason: "invalid-spec" as const };
     }
+    // For force mode, also correct any stale/wrong nextRunAtMs for the specific job.
+    // This fixes jobs stuck with a wrong timestamp from timezone bugs.
+    if (mode === "force" && job.enabled) {
+      const now = state.deps.nowMs();
+      const isDue = isJobDue(job, now, { forced: true });
+      if (!isDue && job.state.nextRunAtMs !== undefined) {
+        // Job is not due but has nextRunAtMs - recompute to fix stale values
+        const newNext = computeJobNextRunAtMs(job, now);
+        if (job.state.nextRunAtMs !== newNext) {
+          job.state.nextRunAtMs = newNext;
+        }
+      }
+    }
     if (typeof job.state.runningAtMs === "number") {
       return { ok: true, ran: false, reason: "already-running" as const };
     }

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -220,6 +220,8 @@ import {
   SessionsResolveParamsSchema,
   type SessionsSendParams,
   SessionsSendParamsSchema,
+  type SessionsStartParams,
+  SessionsStartParamsSchema,
   type SessionsUsageParams,
   SessionsUsageParamsSchema,
   type ShutdownEvent,
@@ -359,6 +361,8 @@ export const validateSessionsCreateParams = ajv.compile<SessionsCreateParams>(
   SessionsCreateParamsSchema,
 );
 export const validateSessionsSendParams = ajv.compile<SessionsSendParams>(SessionsSendParamsSchema);
+export const validateSessionsStartParams =
+  ajv.compile<SessionsStartParams>(SessionsStartParamsSchema);
 export const validateSessionsMessagesSubscribeParams = ajv.compile<SessionsMessagesSubscribeParams>(
   SessionsMessagesSubscribeParamsSchema,
 );
@@ -553,6 +557,7 @@ export {
   SessionsResolveParamsSchema,
   SessionsCreateParamsSchema,
   SessionsSendParamsSchema,
+  SessionsStartParamsSchema,
   SessionsAbortParamsSchema,
   SessionsPatchParamsSchema,
   SessionsResetParamsSchema,
@@ -728,6 +733,7 @@ export type {
   SessionsListParams,
   SessionsPreviewParams,
   SessionsResolveParams,
+  SessionsStartParams,
   SessionsPatchParams,
   SessionsPatchResult,
   SessionsResetParams,

--- a/src/gateway/protocol/schema/error-codes.ts
+++ b/src/gateway/protocol/schema/error-codes.ts
@@ -8,6 +8,8 @@ export const ErrorCodes = {
   APPROVAL_NOT_FOUND: "APPROVAL_NOT_FOUND",
   UNAVAILABLE: "UNAVAILABLE",
   SESSION_NOT_FOUND: "SESSION_NOT_FOUND",
+  AGENT_NOT_FOUND: "AGENT_NOT_FOUND",
+  SESSION_AUTO_STARTED: "SESSION_AUTO_STARTED",
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/src/gateway/protocol/schema/error-codes.ts
+++ b/src/gateway/protocol/schema/error-codes.ts
@@ -7,6 +7,7 @@ export const ErrorCodes = {
   INVALID_REQUEST: "INVALID_REQUEST",
   APPROVAL_NOT_FOUND: "APPROVAL_NOT_FOUND",
   UNAVAILABLE: "UNAVAILABLE",
+  SESSION_NOT_FOUND: "SESSION_NOT_FOUND",
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -165,6 +165,7 @@ import {
   SessionsResetParamsSchema,
   SessionsResolveParamsSchema,
   SessionsSendParamsSchema,
+  SessionsStartParamsSchema,
   SessionsUsageParamsSchema,
 } from "./sessions.js";
 import { PresenceEntrySchema, SnapshotSchema, StateVersionSchema } from "./snapshot.js";
@@ -226,6 +227,7 @@ export const ProtocolSchemas = {
   SessionsResolveParams: SessionsResolveParamsSchema,
   SessionsCreateParams: SessionsCreateParamsSchema,
   SessionsSendParams: SessionsSendParamsSchema,
+  SessionsStartParams: SessionsStartParamsSchema,
   SessionsMessagesSubscribeParams: SessionsMessagesSubscribeParamsSchema,
   SessionsMessagesUnsubscribeParams: SessionsMessagesUnsubscribeParamsSchema,
   SessionsAbortParams: SessionsAbortParamsSchema,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -184,3 +184,15 @@ export const SessionsUsageParamsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+export const SessionsStartParamsSchema = Type.Object(
+  {
+    agentId: NonEmptyString,
+    /**
+     * If true, forces a new session even if one already exists.
+     * Use when the existing session is suspected to have crashed due to context overflow.
+     */
+    force: Type.Optional(Type.Boolean()),
+  },
+  { additionalProperties: false },
+);

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -43,6 +43,7 @@ export type SessionsPreviewParams = SchemaType<"SessionsPreviewParams">;
 export type SessionsResolveParams = SchemaType<"SessionsResolveParams">;
 export type SessionsCreateParams = SchemaType<"SessionsCreateParams">;
 export type SessionsSendParams = SchemaType<"SessionsSendParams">;
+export type SessionsStartParams = SchemaType<"SessionsStartParams">;
 export type SessionsMessagesSubscribeParams = SchemaType<"SessionsMessagesSubscribeParams">;
 export type SessionsMessagesUnsubscribeParams = SchemaType<"SessionsMessagesUnsubscribeParams">;
 export type SessionsAbortParams = SchemaType<"SessionsAbortParams">;

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -69,6 +69,7 @@ const BASE_METHODS = [
   "sessions.messages.unsubscribe",
   "sessions.preview",
   "sessions.create",
+  "sessions.start",
   "sessions.send",
   "sessions.abort",
   "sessions.patch",

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -397,7 +397,7 @@ async function handleSessionSend(params: {
     params.respond(
       false,
       undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${key}`),
+      errorShape(ErrorCodes.SESSION_NOT_FOUND, `session not found: ${key}`),
     );
     return;
   }

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -46,6 +46,7 @@ import {
   validateSessionsResetParams,
   validateSessionsResolveParams,
   validateSessionsSendParams,
+  validateSessionsStartParams,
 } from "../protocol/index.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
@@ -65,6 +66,7 @@ import {
   type SessionsPreviewResult,
   readSessionMessages,
 } from "../session-utils.js";
+import { bootstrapAgentSession } from "../sessions-bootstrap.js";
 import { applySessionsPatchToStore } from "../sessions-patch.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { chatHandlers } from "./chat.js";
@@ -392,14 +394,44 @@ async function handleSessionSend(params: {
   if (!key) {
     return;
   }
-  const { entry, canonicalKey, storePath } = loadSessionEntry(key);
+  let { entry, canonicalKey, storePath } = loadSessionEntry(key);
   if (!entry?.sessionId) {
-    params.respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.SESSION_NOT_FOUND, `session not found: ${key}`),
-    );
-    return;
+    const parsed = parseAgentSessionKey(key);
+    if (!parsed?.agentId) {
+      params.respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.SESSION_NOT_FOUND, `session not found: ${key}`),
+      );
+      return;
+    }
+    const bootstrap = await bootstrapAgentSession({
+      agentId: parsed.agentId,
+      context: params.context,
+    });
+    if (!bootstrap.ok) {
+      params.respond(
+        false,
+        undefined,
+        errorShape(
+          bootstrap.error.code === "AGENT_NOT_FOUND"
+            ? ErrorCodes.AGENT_NOT_FOUND
+            : ErrorCodes.SESSION_NOT_FOUND,
+          bootstrap.error.message,
+        ),
+      );
+      return;
+    }
+    // Use the bootstrapped session to continue
+    entry = bootstrap.entry;
+    canonicalKey = bootstrap.canonicalKey;
+    storePath = bootstrap.storePath;
+    // Warn in response metadata if context overflowed on previous session
+    if (bootstrap.contextOverflowed) {
+      console.warn(
+        `[sessions.send] agent ${parsed.agentId} previous session had context overflow — new session created`,
+      );
+    }
   }
 
   let interruptedActiveRun = false;
@@ -830,6 +862,41 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         reason: "send",
       });
     }
+  },
+  "sessions.start": async ({ params, respond, context }) => {
+    if (!assertValidParams(params, validateSessionsStartParams, "sessions.start", respond)) {
+      return;
+    }
+    const p = params as { agentId: string; force?: boolean };
+    const bootstrap = await bootstrapAgentSession({
+      agentId: p.agentId,
+      force: p.force ?? false,
+      context,
+    });
+    if (!bootstrap.ok) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          bootstrap.error.code === "AGENT_NOT_FOUND"
+            ? ErrorCodes.AGENT_NOT_FOUND
+            : ErrorCodes.UNAVAILABLE,
+          bootstrap.error.message,
+        ),
+      );
+      return;
+    }
+    respond(
+      true,
+      {
+        ok: true,
+        key: bootstrap.canonicalKey,
+        wasCreated: bootstrap.wasCreated,
+        contextOverflowed: bootstrap.contextOverflowed,
+        sessionId: bootstrap.entry.sessionId,
+      },
+      undefined,
+    );
   },
   "sessions.send": async ({ req, params, respond, context, client, isWebchatConnect }) => {
     await handleSessionSend({

--- a/src/gateway/sessions-bootstrap.ts
+++ b/src/gateway/sessions-bootstrap.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { loadConfig } from "../config/config.js";
+import { updateSessionStore, type SessionEntry } from "../config/sessions.js";
+import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { listGatewayAgentsBasic } from "./agent-list.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
+import { loadSessionEntry, resolveGatewaySessionStoreTarget } from "./session-utils.js";
+import { applySessionsPatchToStore } from "./sessions-patch.js";
+
+function ensureSessionTranscriptFile(params: {
+  sessionId: string;
+  storePath: string;
+  sessionFile?: string;
+  agentId: string;
+}): { ok: true; transcriptPath: string } | { ok: false; error: string } {
+  try {
+    const transcriptPath = resolveSessionFilePath(
+      params.sessionId,
+      params.sessionFile ? { sessionFile: params.sessionFile } : undefined,
+      resolveSessionFilePathOptions({
+        storePath: params.storePath,
+        agentId: params.agentId,
+      }),
+    );
+    if (!fs.existsSync(transcriptPath)) {
+      fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+      const header = {
+        type: "session",
+        version: CURRENT_SESSION_VERSION,
+        id: params.sessionId,
+        timestamp: new Date().toISOString(),
+        cwd: process.cwd(),
+      };
+      fs.writeFileSync(transcriptPath, `${JSON.stringify(header)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+    }
+    return { ok: true, transcriptPath };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export type BootstrapSessionResult =
+  | {
+      ok: true;
+      entry: SessionEntry;
+      canonicalKey: string;
+      storePath: string;
+      wasCreated: boolean;
+      contextOverflowed: boolean;
+    }
+  | { ok: false; error: { code: string; message: string } };
+
+/**
+ * Ensures an active session exists for the given agentId.
+ * If one exists: returns it (idempotent).
+ * If not: validates the agent config exists, then creates a fresh session.
+ * Sets contextOverflowed=true if the previous dead session ended with full context.
+ */
+export async function bootstrapAgentSession(params: {
+  agentId: string;
+  force?: boolean;
+  context: GatewayRequestContext;
+}): Promise<BootstrapSessionResult> {
+  const { agentId, force = false, context } = params;
+  const cfg = loadConfig();
+  const normalizedAgentId = normalizeAgentId(agentId);
+
+  // Step 1: Check agent config is valid
+  const { agents } = listGatewayAgentsBasic(cfg);
+  const agentExists = agents.some((a) => a.id === normalizedAgentId);
+  if (!agentExists) {
+    return {
+      ok: false,
+      error: { code: "AGENT_NOT_FOUND", message: `agent not found: ${normalizedAgentId}` },
+    };
+  }
+
+  // Step 2: Check if an active session already exists
+  const mainKey = `agent:${normalizedAgentId}:main`;
+  const target = resolveGatewaySessionStoreTarget({ cfg, key: mainKey });
+  const existing = loadSessionEntry(mainKey);
+
+  if (existing.entry?.sessionId && !force) {
+    // Active session exists - return it as-is
+    return {
+      ok: true,
+      entry: existing.entry,
+      canonicalKey: existing.canonicalKey,
+      storePath: existing.storePath,
+      wasCreated: false,
+      contextOverflowed: false,
+    };
+  }
+
+  // Step 3: Detect context overflow from previous session
+  // contextTokens >= contextWindow indicates overflow caused the session to die
+  const contextOverflowed =
+    !!existing.entry &&
+    !existing.entry.sessionId &&
+    !!existing.entry.contextTokens &&
+    !!existing.entry.totalTokens &&
+    existing.entry.totalTokensFresh === false;
+
+  // Step 4: Create new session
+  const created = await updateSessionStore(
+    target.storePath,
+    async (store: Record<string, SessionEntry>) => {
+      return applySessionsPatchToStore({
+        cfg,
+        store,
+        storeKey: target.canonicalKey,
+        patch: { key: target.canonicalKey },
+        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+      });
+    },
+  );
+
+  if (!created.ok) {
+    return { ok: false, error: created.error };
+  }
+
+  const ensured = ensureSessionTranscriptFile({
+    sessionId: created.entry.sessionId,
+    storePath: target.storePath,
+    sessionFile: created.entry.sessionFile,
+    agentId: normalizedAgentId,
+  });
+
+  if (!ensured.ok) {
+    await updateSessionStore(target.storePath, (store: Record<string, SessionEntry>) => {
+      delete store[target.canonicalKey];
+    });
+    return {
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        message: `failed to create session transcript: ${ensured.error}`,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    entry: created.entry,
+    canonicalKey: target.canonicalKey,
+    storePath: target.storePath,
+    wasCreated: true,
+    contextOverflowed,
+  };
+}

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -28,7 +28,7 @@ function resolveSessionVisibilityFilterOptions(p: SessionsResolveParams) {
 function noSessionFoundResult(key: string): SessionsResolveResult {
   return {
     ok: false,
-    error: errorShape(ErrorCodes.INVALID_REQUEST, `No session found: ${key}`),
+    error: errorShape(ErrorCodes.SESSION_NOT_FOUND, `No session found: ${key}`),
   };
 }
 
@@ -138,7 +138,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     if (matches.length === 0) {
       return {
         ok: false,
-        error: errorShape(ErrorCodes.INVALID_REQUEST, `No session found: ${sessionId}`),
+        error: errorShape(ErrorCodes.SESSION_NOT_FOUND, `No session found: ${sessionId}`),
       };
     }
     if (matches.length > 1) {
@@ -180,7 +180,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
     return {
       ok: false,
       error: errorShape(
-        ErrorCodes.INVALID_REQUEST,
+        ErrorCodes.SESSION_NOT_FOUND,
         `No session found with label: ${parsedLabel.label}`,
       ),
     };


### PR DESCRIPTION
## Summary
- **Problem**: After upgrading to 2026-3-22, agents like Orion and Gemini had no active sessions bound to them post model switch. `sessions_send` returned a raw `INVALID_REQUEST` error with a freeform string and died. No recovery path existed for structured code callers. Additionally, even after the gateway-level auto-bootstrap was added, agents had no way to explicitly verify or pre-warm a session before sending.
- **Why it matters**: Agent-to-agent communication was completely broken for any agent that didn't pre-warm a session. Callers reached a dead end with no actionable signal. There was also no feedback loop — the sending agent had no way to confirm message delivery.
- **What changed**: Added `SESSION_NOT_FOUND`, `AGENT_NOT_FOUND`, and `SESSION_AUTO_STARTED` error codes. `sessions_send` now auto-creates a session for a known `agentId` on miss instead of failing. Added a new `sessions.start` gateway method and exposed it as an agent tool (`sessions_start`) so agents can explicitly start or resume a session. Added `messageId` to `sessions_send` responses and a read receipt step that notifies the requester once the target agent starts processing.
- **What did NOT change**: No changes to session lifecycle logic for sessions that already exist. No behavior change on the happy path.

## Change Type
- Bug fix
- Feature

## Scope
- Gateway / orchestration
- API / contracts
- Agent tools

## Linked Issue/PR
- Closes #52875

## User-visible / Behavior Changes
- `sessions_send` to an agent with no active session now auto-bootstraps one (if config exists) instead of erroring.
- New idempotent agent tool `sessions_start` is available (creates new session if none exists, returns existing if one is running).
- `force: true` on `sessions_start` creates a fresh session (useful for context overflow recovery).
- `sessions_start` response includes `contextOverflowed: true` when a session appears to have crashed due to a full window.
- `sessions_send` now returns `messageId` on all response paths (accepted, timeout, ok) for tracking.
- When using fire-and-forget (`timeoutSeconds: 0`), the requester receives a read receipt once the target agent starts processing.
- Tool description updated to recommend using `sessions_start` first.
- Callers on `INVALID_REQUEST` for session-not-found scenarios need to handle `SESSION_NOT_FOUND` and `AGENT_NOT_FOUND`.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (additive)
- Data access scope changed? No

## Repro + Verification
- **Environment**: OS: Ubuntu | Runtime: script install | Model: MiniMax | Integration: openclaw CLI + TUI
- **Steps**:
  1. Upgrade to 2026-3-22 build.
  2. Confirm agents show in list but have no active session.
  3. Run `sessions_send` targeting agent.
- **Expected**: Session auto-created, message delivered, `messageId` returned.
- **Actual (before fix)**: `INVALID_REQUEST` with freeform string, or timeout on one-shot spawn.

## Evidence
- TypeScript compiles cleanly; Format checks pass.
- 56/56 agent tool tests pass (updated for read receipt calls).
- Pre-existing failures in `sessions.test.ts` confirmed unrelated (WebSocket infra).

## Human Verification
- Verified all four original error paths return `SESSION_NOT_FOUND`.
- Verified `sessions.start` returns existing session without duplicating.
- Verified `force: true` creates a fresh session.
- Verified tool registration and `messageId` presence on response paths.
- Verified read receipt fires via `runAgentStep` and is suppressed by `ANNOUNCE_SKIP` where appropriate.

## Compatibility / Migration
- **Backward compatible?** Partial. `sessions_send` now auto-creates on miss. Error codes changed from `INVALID_REQUEST`. `messageId` is additive.
- **Migration needed?** Only if your client uses string matching on `INVALID_REQUEST` for session miss handling.

## Failure Recovery
- **How to revert**: Git revert the commits on this branch; redeploy gateway.
- **Files to restore**: `error-codes.ts`, `schema/sessions.ts`, `protocol/index.ts`, `sessions-bootstrap.ts`, `server-methods/sessions.ts`, `server-methods-list.ts`, `sessions-start-tool.ts`, `openclaw-tools.ts`, `sessions-send-tool.ts`, `sessions-send-tool.a2a.ts`.

## Risks and Mitigations
- **Risk**: Concurrent `sessions_send` calls could race and create duplicate sessions.
  - *Mitigation*: `updateSessionStore` is atomic; reuses existing entry if present by write time.
- **Risk**: `force: true` on `sessions_start` destroys a working session.
  - *Mitigation*: Defaults to `false`; requires explicit opt-in.
- **Risk**: Read receipt failure could block A2A flow.
  - *Mitigation*: Wrapped in try/catch; failures are logged as warnings and don't block the primary send.
