### PR TITLE
fix: guard zsh compdef with compinit; store DM channel ID in Slack lastRoute

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -118,7 +118,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         sessionKey: route.mainSessionKey,
         deliveryContext: {
           channel: "slack",
-          to: `user:${message.user}`,
+          // Use the DM channel ID (D-prefix) rather than the user ID (U-prefix) so
+          // routed replies skip the conversations.open lookup (which requires im:write).
+          to: `channel:${message.channel}`,
           accountId: route.accountId,
           threadId: prepared.ctxPayload.MessageThreadId,
         },

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -746,7 +746,12 @@ export async function prepareSlackMessage(params: {
       ? {
           sessionKey: route.mainSessionKey,
           channel: "slack",
-          to: `user:${message.user}`,
+          // Store the DM channel ID (D-prefix) rather than the user ID (U-prefix)
+          // to avoid a conversations.open lookup (which requires im:write scope)
+          // when routing replies back through the lastRoute path. The DM channel ID
+          // is stable for the lifetime of the DM and can be used directly in
+          // chat.postMessage without any additional API calls.
+          to: `channel:${message.channel}`,
           accountId: route.accountId,
           threadId: threadContext.messageThreadId,
           mainDmOwnerPin:

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -27,6 +27,21 @@ describe("completion-cli", () => {
     expect(script).toContain("--force[Force the action]");
   });
 
+  it("zsh completion script includes compinit guard before compdef call (issue #14289)", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    // On fresh zsh setups compinit is not called, so compdef is unavailable.
+    // The generated script must guard against this by autoloading compinit first.
+    expect(script).toContain("compinit");
+    expect(script).toContain("type compdef");
+
+    // Guard must appear before the compdef invocation
+    const compdefIndex = script.indexOf("compdef _openclaw_root_completion");
+    const guardIndex = script.indexOf("compinit");
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeLessThan(compdefIndex);
+  });
+
   it("generates PowerShell command paths without the executable prefix", () => {
     const script = getCompletionScript("powershell", createCompletionProgram());
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -401,6 +401,9 @@ _${rootCmd}_root_completion() {
 
 ${generateZshSubcommands(program, rootCmd)}
 
+if ! type compdef > /dev/null 2>&1; then
+  autoload -Uz compinit && compinit
+fi
 compdef _${rootCmd}_root_completion ${rootCmd}
 `;
   return script;


### PR DESCRIPTION
## Summary

- Fixes #14289: generated zsh completion script used `compdef` without guarding for `compinit`, causing `command not found: compdef` on fresh macOS zsh setups
- Fixes #7663: Slack DM replies routed through the lastRoute path were triggering a `conversations.open` API call (which requires `im:write` scope), causing `missing_scope` errors for bots that only have `chat:write`

**#14289 — zsh completion `compdef` fails without `compinit`**

The generated zsh completion script called `compdef` unconditionally. On fresh macOS zsh setups where `compinit` is not called automatically, this produced `command not found: compdef`. Added a guard block that auto-loads and runs `compinit` if `compdef` is not already available.

**#7663 — Slack DM replies failing with `missing_scope`**

When a Slack DM is processed, `updateLastRoute` was storing the Slack user ID (`user:UXXXXXX`) as the delivery target in the session store. When the main agent session later routed a reply through the lastRoute path, `sendMessageSlack` tried to resolve the user ID to a DM channel ID via `conversations.open`, which requires the `im:write` OAuth scope. Bots configured with only `chat:write` would fail.

Fix: store the DM channel ID (`channel:DXXXXXXX`) directly instead of the user ID. DM channel IDs are D-prefixed and are accepted directly by `chat.postMessage` without any additional API calls — the `resolveChannelId` path already short-circuits for non-U-prefixed IDs.

Changed in both `updateLastRoute` call sites:
- `extensions/slack/src/monitor/message-handler/prepare.ts`
- `extensions/slack/src/monitor/message-handler/dispatch.ts`

## Test plan
- [x] `pnpm test -- src/cli/completion-cli.test.ts` — 4 tests pass including new compinit guard test
- [x] `pnpm test -- extensions/slack/src/monitor/message-handler/` — 25 tests pass
- [x] `pnpm check` — clean (no lint/format/type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)