### PR TITLE
feat(venice): add E2EE support for Venice AI models

### DIFF
--- a/extensions/venice/index.ts
+++ b/extensions/venice/index.ts
@@ -1,5 +1,9 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyXaiModelCompat } from "openclaw/plugin-sdk/provider-models";
+import {
+  createVeniceE2EEStreamWrapper,
+  isVeniceE2EEModel,
+} from "openclaw/plugin-sdk/provider-stream";
 import { applyVeniceConfig, VENICE_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildVeniceProvider } from "./provider-catalog.js";
 
@@ -40,6 +44,10 @@ export default defineSingleProviderPluginEntry({
     ],
     catalog: {
       buildProvider: buildVeniceProvider,
+    },
+    wrapStreamFn: (ctx) => {
+      if (!isVeniceE2EEModel(ctx.modelId)) return undefined;
+      return createVeniceE2EEStreamWrapper(ctx.streamFn);
     },
     normalizeResolvedModel: ({ modelId, model }) =>
       isXaiBackedVeniceModel(modelId) ? applyXaiModelCompat(model) : undefined,

--- a/package.json
+++ b/package.json
@@ -790,6 +790,7 @@
     "tslog": "^4.10.2",
     "undici": "^7.24.5",
     "uuid": "^13.0.0",
+    "venice-e2ee": "github:elkimek/venice-e2ee",
     "ws": "^8.20.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      venice-e2ee:
+        specifier: github:elkimek/venice-e2ee
+        version: https://codeload.github.com/elkimek/venice-e2ee/tar.gz/55fb689f29708bb068cd1059c09432725848da29
       ws:
         specifier: ^8.20.0
         version: 8.20.0
@@ -1995,6 +1998,9 @@ packages:
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
     engines: {node: '>= 20.19.0'}
+
+  '@noble/secp256k1@2.3.0':
+    resolution: {integrity: sha512-0TQed2gcBbIrh7Ccyw+y/uZQvbJwm7Ao4scBUxqpBCcsOlZG0O4KGfjtNAy/li4W8n1xt3dxrwJ0beZ2h2G6Kw==}
 
   '@node-llama-cpp/linux-arm64@3.16.2':
     resolution: {integrity: sha512-CxzgPsS84wL3W5sZRgxP3c9iJKEW+USrak1SmX6EAJxW/v9QGzehvT6W/aR1FyfidiIyQtOp3ga0Gg/9xfJPGw==}
@@ -6453,6 +6459,10 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  venice-e2ee@https://codeload.github.com/elkimek/venice-e2ee/tar.gz/55fb689f29708bb068cd1059c09432725848da29:
+    resolution: {tarball: https://codeload.github.com/elkimek/venice-e2ee/tar.gz/55fb689f29708bb068cd1059c09432725848da29}
+    version: 0.1.0
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -8497,6 +8507,8 @@ snapshots:
   '@noble/ed25519@3.0.1': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@noble/secp256k1@2.3.0': {}
 
   '@node-llama-cpp/linux-arm64@3.16.2':
     optional: true
@@ -13328,6 +13340,10 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  venice-e2ee@https://codeload.github.com/elkimek/venice-e2ee/tar.gz/55fb689f29708bb068cd1059c09432725848da29:
+    dependencies:
+      '@noble/secp256k1': 2.3.0
 
   vfile-message@4.0.3:
     dependencies:

--- a/src/agents/pi-embedded-runner/venice-e2ee-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/venice-e2ee-stream-wrapper.ts
@@ -1,0 +1,213 @@
+/**
+ * Venice E2EE stream wrapper.
+ *
+ * Encrypts outgoing messages (system prompt + all conversation turns) and
+ * decrypts incoming `text_delta` / `text_end` events so the agent runtime
+ * sees plaintext while the wire traffic is fully encrypted.
+ *
+ * Protocol: ECDH (secp256k1) key exchange → HKDF-SHA256 → AES-256-GCM.
+ * Each response chunk uses a per-chunk server ephemeral key.
+ */
+
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import {
+  streamSimple,
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type AssistantMessageEvent,
+  type Context,
+} from "@mariozechner/pi-ai";
+import { createVeniceE2EE, encryptMessage, decryptChunk, type E2EESession } from "venice-e2ee";
+
+// ── Module-level session cache ──────────────────────────────────────────────
+
+interface E2EEInstance {
+  createSession: (modelId: string) => Promise<E2EESession>;
+  clearSession: () => void;
+}
+
+let _e2ee: E2EEInstance | null = null;
+let _e2eeKey: string | null = null;
+
+function getE2EE(apiKey: string): E2EEInstance {
+  if (!_e2ee || _e2eeKey !== apiKey) {
+    _e2ee = createVeniceE2EE({ apiKey });
+    _e2eeKey = apiKey;
+  }
+  return _e2ee;
+}
+
+// ── Public wrapper ──────────────────────────────────────────────────────────
+
+export function isVeniceE2EEModel(modelId: string): boolean {
+  return modelId.startsWith("e2ee-");
+}
+
+/**
+ * Wraps a base StreamFn with Venice E2EE encryption/decryption.
+ *
+ * - Encrypts `context.systemPrompt` and all message text blocks before the
+ *   request leaves the process.
+ * - Adds `X-Venice-TEE-*` headers and `venice_parameters.enable_e2ee`.
+ * - Decrypts every `text_delta` / `text_end` event in the response stream
+ *   using per-chunk ECDH key derivation.
+ */
+export function createVeniceE2EEStreamWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+
+  return async (model, context, options) => {
+    const apiKey = options?.apiKey;
+    if (!apiKey) {
+      return underlying(model, context, options);
+    }
+
+    // ── Establish E2EE session (fetches TEE attestation, derives keys) ───
+    const e2ee = getE2EE(apiKey);
+    let session: E2EESession;
+    try {
+      session = await e2ee.createSession(model.id);
+    } catch {
+      // If attestation fails, fall back to plaintext
+      return underlying(model, context, options);
+    }
+
+    // ── Encrypt context ─────────────────────────────────────────────────
+    const encryptedContext = await encryptContext(context, session);
+
+    // ── Call underlying with E2EE headers ────────────────────────────────
+    const originalOnPayload = options?.onPayload;
+    const sourceStream = await underlying(model, encryptedContext, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        "X-Venice-TEE-Client-Pub-Key": session.pubKeyHex,
+        "X-Venice-TEE-Model-Pub-Key": session.modelPubKeyHex,
+        "X-Venice-TEE-Signing-Algo": "ecdsa",
+      },
+      onPayload: (payload: unknown) => {
+        if (payload && typeof payload === "object") {
+          (payload as Record<string, unknown>).venice_parameters = {
+            enable_e2ee: true,
+          };
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+
+    // ── Wrap response stream: decrypt text deltas ───────────────────────
+    const resultStream = createAssistantMessageEventStream();
+    const decryptedAccum = new Map<number, string>();
+
+    void (async () => {
+      try {
+        for await (const event of sourceStream) {
+          resultStream.push(await decryptEvent(event, session, decryptedAccum));
+        }
+      } catch {
+        resultStream.end();
+      }
+    })();
+
+    return resultStream;
+  };
+}
+
+// ── Encrypt outgoing context ────────────────────────────────────────────────
+
+async function encryptContext(context: Context, session: E2EESession): Promise<Context> {
+  const encryptedSystemPrompt = context.systemPrompt
+    ? await encryptMessage(session.aesKey, session.publicKey, context.systemPrompt)
+    : undefined;
+
+  const encryptedMessages = await Promise.all(
+    context.messages.map(async (msg) => {
+      if (!("content" in msg) || !Array.isArray(msg.content)) {
+        return msg;
+      }
+      return {
+        ...msg,
+        content: await Promise.all(
+          (msg.content as Array<{ type: string; text?: string }>).map(async (block) => {
+            if (block.type !== "text" || typeof block.text !== "string") {
+              return block;
+            }
+            return {
+              ...block,
+              text: await encryptMessage(session.aesKey, session.publicKey, block.text),
+            };
+          }),
+        ),
+      };
+    }),
+  );
+
+  return {
+    ...context,
+    systemPrompt: encryptedSystemPrompt,
+    messages: encryptedMessages as Context["messages"],
+  };
+}
+
+// ── Decrypt incoming events ─────────────────────────────────────────────────
+
+async function decryptEvent(
+  event: AssistantMessageEvent,
+  session: E2EESession,
+  accum: Map<number, string>,
+): Promise<AssistantMessageEvent> {
+  if (event.type === "text_delta") {
+    const decrypted = await decryptChunk(session.privateKey, event.delta);
+    const accumulated = (accum.get(event.contentIndex) || "") + decrypted;
+    accum.set(event.contentIndex, accumulated);
+    return {
+      ...event,
+      delta: decrypted,
+      partial: patchPartialText(event.partial, event.contentIndex, accumulated),
+    };
+  }
+
+  if (event.type === "text_end") {
+    const accumulated = accum.get(event.contentIndex) || event.content;
+    return {
+      ...event,
+      content: accumulated,
+      partial: patchPartialText(event.partial, event.contentIndex, accumulated),
+    };
+  }
+
+  if (event.type === "done") {
+    return { ...event, message: patchAllPartialText(event.message, accum) };
+  }
+
+  if (event.type === "error") {
+    return { ...event, error: patchAllPartialText(event.error, accum) };
+  }
+
+  return event;
+}
+
+function patchPartialText(
+  partial: AssistantMessage,
+  contentIndex: number,
+  decryptedText: string,
+): AssistantMessage {
+  const content = [...partial.content];
+  const block = content[contentIndex];
+  if (block && block.type === "text") {
+    content[contentIndex] = { ...block, text: decryptedText };
+  }
+  return { ...partial, content };
+}
+
+function patchAllPartialText(
+  message: AssistantMessage,
+  accum: Map<number, string>,
+): AssistantMessage {
+  const content = message.content.map((block, i) => {
+    if (block.type === "text" && accum.has(i)) {
+      return { ...block, text: accum.get(i)! };
+    }
+    return block;
+  });
+  return { ...message, content };
+}

--- a/src/agents/pi-embedded-runner/venice-e2ee-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/venice-e2ee-stream-wrapper.ts
@@ -26,15 +26,15 @@ interface E2EEInstance {
   clearSession: () => void;
 }
 
-let _e2ee: E2EEInstance | null = null;
-let _e2eeKey: string | null = null;
+const _e2eeCache = new Map<string, E2EEInstance>();
 
 function getE2EE(apiKey: string): E2EEInstance {
-  if (!_e2ee || _e2eeKey !== apiKey) {
-    _e2ee = createVeniceE2EE({ apiKey });
-    _e2eeKey = apiKey;
+  let instance = _e2eeCache.get(apiKey);
+  if (!instance) {
+    instance = createVeniceE2EE({ apiKey });
+    _e2eeCache.set(apiKey, instance);
   }
-  return _e2ee;
+  return instance;
 }
 
 // ── Public wrapper ──────────────────────────────────────────────────────────
@@ -66,9 +66,12 @@ export function createVeniceE2EEStreamWrapper(baseStreamFn: StreamFn | undefined
     let session: E2EESession;
     try {
       session = await e2ee.createSession(model.id);
-    } catch {
-      // If attestation fails, fall back to plaintext
-      return underlying(model, context, options);
+    } catch (err) {
+      throw new Error(
+        `Venice E2EE setup failed: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Refusing to send plaintext to an E2EE model.`,
+        { cause: err },
+      );
     }
 
     // ── Encrypt context ─────────────────────────────────────────────────
@@ -86,7 +89,11 @@ export function createVeniceE2EEStreamWrapper(baseStreamFn: StreamFn | undefined
       },
       onPayload: (payload: unknown) => {
         if (payload && typeof payload === "object") {
-          (payload as Record<string, unknown>).venice_parameters = {
+          const p = payload as Record<string, unknown>;
+          p.venice_parameters = {
+            ...(p.venice_parameters && typeof p.venice_parameters === "object"
+              ? (p.venice_parameters as Record<string, unknown>)
+              : {}),
             enable_e2ee: true,
           };
         }
@@ -103,7 +110,7 @@ export function createVeniceE2EEStreamWrapper(baseStreamFn: StreamFn | undefined
         for await (const event of sourceStream) {
           resultStream.push(await decryptEvent(event, session, decryptedAccum));
         }
-      } catch {
+      } finally {
         resultStream.end();
       }
     })();

--- a/src/plugin-sdk/provider-stream.ts
+++ b/src/plugin-sdk/provider-stream.ts
@@ -30,3 +30,7 @@ export {
   getOpenRouterModelCapabilities,
   loadOpenRouterModelCapabilities,
 } from "../agents/pi-embedded-runner/openrouter-model-capabilities.js";
+export {
+  createVeniceE2EEStreamWrapper,
+  isVeniceE2EEModel,
+} from "../agents/pi-embedded-runner/venice-e2ee-stream-wrapper.js";


### PR DESCRIPTION
## Summary

- Adds end-to-end encryption for Venice AI's `e2ee-` prefixed models
- Prompts are encrypted client-side (ECDH secp256k1 + AES-256-GCM) and only decryptable inside Venice's AMD SEV-SNP TEE
- Response chunks are decrypted per-chunk using server ephemeral keys
- Activates automatically when the model ID starts with `e2ee-` — no config needed

## How it works

1. On first request to an E2EE model, the wrapper fetches the TEE attestation and performs an ECDH key exchange
2. All message text (system prompt + conversation) is AES-256-GCM encrypted before the request leaves the process
3. E2EE headers (`X-Venice-TEE-Client-Pub-Key`, `X-Venice-TEE-Model-Pub-Key`) and `venice_parameters.enable_e2ee` are added to the request
4. Response `text_delta` events are decrypted using per-chunk ECDH derivation before reaching the agent runtime
5. Sessions are cached with a 30-minute TTL

## Changes

- `src/agents/pi-embedded-runner/venice-e2ee-stream-wrapper.ts` — E2EE stream wrapper (encrypts context, decrypts response events)
- `src/plugin-sdk/provider-stream.ts` — exports the wrapper for extensions
- `extensions/venice/index.ts` — adds `wrapStreamFn` hook for E2EE models
- `package.json` — adds [`venice-e2ee`](https://github.com/elkimek/venice-e2ee) dependency

## Test plan

- [ ] Send a message to a Venice `e2ee-` model and verify the response is decrypted correctly
- [ ] Verify non-E2EE Venice models are unaffected
- [ ] Verify session caching works across multiple requests to the same model
- [ ] Verify attestation failure falls back to plaintext gracefully

## Notes

- The `venice-e2ee` library handles the full crypto protocol: TEE attestation fetch, ECDH key exchange, HKDF-SHA256 key derivation, AES-256-GCM encrypt/decrypt
- Attestation verification (validating AMD SEV-SNP report against root of trust) is not yet implemented — tracked as v2 scope in the library
- Tool calls are not encrypted (E2EE is designed for text chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)