### PR TITLE
feat(whatsapp): support native @mentions in outbound group replies

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -6,7 +6,7 @@ import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/text-runtime";
-import { jidToE164, resolveJidToE164 } from "openclaw/plugin-sdk/text-runtime";
+import { jidToE164, normalizeE164, resolveJidToE164 } from "openclaw/plugin-sdk/text-runtime";
 import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import { isRecentInboundMessage } from "./dedupe.js";
@@ -19,6 +19,7 @@ import {
 } from "./extract.js";
 import { attachEmitterListener, closeInboundMonitorSocket } from "./lifecycle.js";
 import { downloadInboundMedia } from "./media.js";
+import { extractOutboundMentions } from "./outbound-mentions.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
@@ -114,7 +115,12 @@ export async function monitorWebInbox(options: {
   });
   const groupMetaCache = new Map<
     string,
-    { subject?: string; participants?: string[]; expires: number }
+    {
+      subject?: string;
+      participants?: string[];
+      participantJidMap?: Map<string, string>;
+      expires: number;
+    }
   >();
   const GROUP_META_TTL_MS = 5 * 60 * 1000; // 5 minutes
   const lidLookup = sock.signalRepository?.lidMapping;
@@ -129,18 +135,27 @@ export async function monitorWebInbox(options: {
     }
     try {
       const meta = await sock.groupMetadata(jid);
+      const participantJidMap = new Map<string, string>();
       const participants =
         (
           await Promise.all(
             meta.participants?.map(async (p) => {
               const mapped = await resolveInboundJid(p.id);
-              return mapped ?? p.id;
+              const resolved = mapped ?? p.id;
+              // Map normalized display number → original JID so outbound mentions
+              // use the correct JID type (phone @s.whatsapp.net vs LID @lid).
+              const normalized = normalizeE164(resolved);
+              if (normalized) {
+                participantJidMap.set(normalized, p.id);
+              }
+              return resolved;
             }) ?? [],
           )
         ).filter(Boolean) ?? [];
       const entry = {
         subject: meta.subject,
         participants,
+        participantJidMap,
         expires: Date.now() + GROUP_META_TTL_MS,
       };
       groupMetaCache.set(jid, entry);
@@ -320,6 +335,9 @@ export async function monitorWebInbox(options: {
     enriched: EnrichedInboundMessage,
   ) => {
     const chatJid = inbound.remoteJid;
+    // Retrieve the participant JID map from the cached group metadata so
+    // outbound @mentions resolve to the correct JID type (phone vs LID).
+    const groupJidMap = inbound.group ? groupMetaCache.get(chatJid)?.participantJidMap : undefined;
     const sendComposing = async () => {
       try {
         await sock.sendPresenceUpdate("composing", chatJid);
@@ -328,9 +346,21 @@ export async function monitorWebInbox(options: {
       }
     };
     const reply = async (text: string) => {
-      await sock.sendMessage(chatJid, { text });
+      const mentions = extractOutboundMentions(text, groupJidMap);
+      await sock.sendMessage(chatJid, {
+        text,
+        ...(mentions.length > 0 ? { mentions } : {}),
+      });
     };
     const sendMedia = async (payload: AnyMessageContent) => {
+      const caption = "caption" in payload ? (payload as { caption?: string }).caption : undefined;
+      if (caption) {
+        const mentions = extractOutboundMentions(caption, groupJidMap);
+        if (mentions.length > 0) {
+          await sock.sendMessage(chatJid, { ...payload, mentions } as AnyMessageContent);
+          return;
+        }
+      }
       await sock.sendMessage(chatJid, payload);
     };
     const timestamp = inbound.messageTimestampMs;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -148,6 +148,13 @@ export async function monitorWebInbox(options: {
               if (normalized) {
                 participantJidMap.set(normalized, p.id);
               }
+              // Also map the raw JID digits so the agent can mention using
+              // either the resolved phone or the raw LID number it sees in
+              // inbound message bodies (e.g. "@101653353078797").
+              const rawDigits = p.id.replace(/:.*/, "").replace(/@.*/, "");
+              if (rawDigits && rawDigits !== normalized?.replace(/^\+/, "")) {
+                participantJidMap.set(`+${rawDigits}`, p.id);
+              }
               return resolved;
             }) ?? [],
           )

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { extractOutboundMentions } from "./outbound-mentions.js";
+
+describe("extractOutboundMentions", () => {
+  it("returns empty array for text with no mentions", () => {
+    expect(extractOutboundMentions("Hello world")).toEqual([]);
+  });
+
+  it("extracts single mention with plus prefix", () => {
+    expect(extractOutboundMentions("Hey @+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("extracts single mention without plus prefix", () => {
+    expect(extractOutboundMentions("Hey @1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("extracts multiple mentions", () => {
+    const result = extractOutboundMentions("Hey @+1234567890 and @+9876543210!");
+    expect(result).toEqual(["1234567890@s.whatsapp.net", "9876543210@s.whatsapp.net"]);
+  });
+
+  it("deduplicates repeated mentions", () => {
+    const result = extractOutboundMentions("@+1234567890 and @+1234567890 again");
+    expect(result).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("deduplicates same number with and without plus", () => {
+    const result = extractOutboundMentions("@+1234567890 and @1234567890");
+    expect(result).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("ignores too-short digit sequences (< 7 digits)", () => {
+    expect(extractOutboundMentions("@123456")).toEqual([]);
+    expect(extractOutboundMentions("@12345")).toEqual([]);
+  });
+
+  it("accepts 7-digit numbers", () => {
+    expect(extractOutboundMentions("@1234567")).toEqual(["1234567@s.whatsapp.net"]);
+  });
+
+  it("accepts 15-digit numbers (E.164 max)", () => {
+    expect(extractOutboundMentions("@123456789012345")).toEqual(["123456789012345@s.whatsapp.net"]);
+  });
+
+  it("accepts LID-length numbers (up to 25 digits)", () => {
+    expect(extractOutboundMentions("@1234567890123456789")).toEqual([
+      "1234567890123456789@s.whatsapp.net",
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(extractOutboundMentions("")).toEqual([]);
+  });
+
+  it("handles mention embedded in sentence", () => {
+    expect(extractOutboundMentions("Check with @+85291234567 about the plan")).toEqual([
+      "85291234567@s.whatsapp.net",
+    ]);
+  });
+
+  describe("with participantJidMap", () => {
+    it("uses original JID from map for phone-based participants", () => {
+      const jidMap = new Map([["+1234567890", "1234567890:0@s.whatsapp.net"]]);
+      expect(extractOutboundMentions("Hey @+1234567890", jidMap)).toEqual([
+        "1234567890:0@s.whatsapp.net",
+      ]);
+    });
+
+    it("uses original LID JID from map instead of defaulting to @s.whatsapp.net", () => {
+      const jidMap = new Map([["+1234567890123456789", "1234567890123456789:0@lid"]]);
+      expect(extractOutboundMentions("Hey @+1234567890123456789", jidMap)).toEqual([
+        "1234567890123456789:0@lid",
+      ]);
+    });
+
+    it("falls back to @s.whatsapp.net when number not in map", () => {
+      const jidMap = new Map([["+9999999999", "9999999999@s.whatsapp.net"]]);
+      expect(extractOutboundMentions("Hey @+1234567890", jidMap)).toEqual([
+        "1234567890@s.whatsapp.net",
+      ]);
+    });
+
+    it("handles mix of mapped and unmapped mentions", () => {
+      const jidMap = new Map([
+        ["+1234567890", "1234567890@s.whatsapp.net"],
+        ["+9876543210123456789", "9876543210123456789:0@lid"],
+      ]);
+      const result = extractOutboundMentions(
+        "Hey @+1234567890 and @+9876543210123456789 and @+5555555555",
+        jidMap,
+      );
+      expect(result).toEqual([
+        "1234567890@s.whatsapp.net",
+        "9876543210123456789:0@lid",
+        "5555555555@s.whatsapp.net",
+      ]);
+    });
+
+    it("resolves LID mention correctly with hosted.lid suffix", () => {
+      const jidMap = new Map([["+12345678901234567890", "12345678901234567890:1@hosted.lid"]]);
+      expect(extractOutboundMentions("@+12345678901234567890", jidMap)).toEqual([
+        "12345678901234567890:1@hosted.lid",
+      ]);
+    });
+  });
+});

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -1,0 +1,26 @@
+/**
+ * Extract native WhatsApp mention JIDs from outbound message text.
+ *
+ * Scans for `@+<digits>` or `@<digits>` patterns (7–25 digits, covers both
+ * E.164 phone numbers and WhatsApp LID identifiers) and returns a deduplicated
+ * array of JIDs suitable for Baileys' `mentions` field.
+ *
+ * When a `participantJidMap` is provided (mapping normalized "+digits" to the
+ * participant's original JID), the original JID is used — this ensures LID
+ * participants get `<lid>@lid` instead of the incorrect `<lid>@s.whatsapp.net`.
+ */
+export function extractOutboundMentions(
+  text: string,
+  participantJidMap?: Map<string, string>,
+): string[] {
+  const pattern = /@\+?(\d{7,25})/g;
+  const jids = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    const digits = match[1]!;
+    const normalized = `+${digits}`;
+    const originalJid = participantJidMap?.get(normalized);
+    jids.add(originalJid ?? `${digits}@s.whatsapp.net`);
+  }
+  return Array.from(jids);
+}

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -2,6 +2,7 @@ import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import type { ActiveWebSendOptions } from "../active-listener.js";
+import { extractOutboundMentions } from "./outbound-mentions.js";
 
 function recordWhatsAppOutbound(accountId: string) {
   recordChannelActivity({
@@ -15,6 +16,12 @@ function resolveOutboundMessageId(result: unknown): string {
   return typeof result === "object" && result && "key" in result
     ? String((result as { key?: { id?: string } }).key?.id ?? "unknown")
     : "unknown";
+}
+
+function mentionsSpread(text: string | undefined): { mentions: string[] } | Record<string, never> {
+  if (!text) return {};
+  const mentions = extractOutboundMentions(text);
+  return mentions.length > 0 ? { mentions } : {};
 }
 
 export function createWebSendApi(params: {
@@ -40,6 +47,7 @@ export function createWebSendApi(params: {
             image: mediaBuffer,
             caption: text || undefined,
             mimetype: mediaType,
+            ...mentionsSpread(text),
           };
         } else if (mediaType.startsWith("audio/")) {
           payload = { audio: mediaBuffer, ptt: true, mimetype: mediaType };
@@ -50,6 +58,7 @@ export function createWebSendApi(params: {
             caption: text || undefined,
             mimetype: mediaType,
             ...(gifPlayback ? { gifPlayback: true } : {}),
+            ...mentionsSpread(text),
           };
         } else {
           const fileName = sendOptions?.fileName?.trim() || "file";
@@ -61,7 +70,7 @@ export function createWebSendApi(params: {
           };
         }
       } else {
-        payload = { text };
+        payload = { text, ...mentionsSpread(text) };
       }
       const result = await params.sock.sendMessage(jid, payload);
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -67,6 +67,7 @@ export function createWebSendApi(params: {
             fileName,
             caption: text || undefined,
             mimetype: mediaType,
+            ...mentionsSpread(text),
           };
         }
       } else {

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -131,6 +131,12 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
   }
   if (members) {
     lines.push(`Participants: ${members}.`);
+    const rawProvider = params.sessionCtx.Provider?.trim().toLowerCase();
+    if (rawProvider === "whatsapp") {
+      lines.push(
+        "To @mention a participant, write @<their phone number> in your reply (e.g. @+1234567890). This sends a native mention notification.",
+      );
+    }
   }
   lines.push(
     "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group — just reply normally.",


### PR DESCRIPTION
## Summary

When the AI agent replies in a WhatsApp group, it can now @mention other participants with native WhatsApp mention notifications.

- The agent's system prompt tells it to use `@+<phone>` syntax (participants are shown with phone numbers).
- Outbound text is parsed for `@+<digits>` patterns and converted to Baileys' `mentions` field.
- A participant JID map is maintained so LID-based participants get the correct JID type (`@lid` vs `@s.whatsapp.net`).
- `extractOutboundMentions()` utility handles phone, LID, and standard JID resolution.
- The mention extraction is wired into `reply()` and `sendMedia()` closures in `monitor.ts`.
- CLI `openclaw message send` also supports mentions via the same extraction path (`send-api.ts`).

## Test plan

- 17 unit tests covering `extractOutboundMentions` (phone, LID, and JID map scenarios)
- `pnpm build` clean
- No regressions in existing WhatsApp tests