### PR TITLE
fix(channels): preserve external catalog overrides

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -52,7 +52,7 @@ const ORIGIN_PRIORITY: Record<PluginOrigin, number> = {
   bundled: 3,
 };
 
-const EXTERNAL_CATALOG_PRIORITY = ORIGIN_PRIORITY.bundled ?? 99;
+const EXTERNAL_CATALOG_PRIORITY = ORIGIN_PRIORITY.bundled + 1;
 const FALLBACK_CATALOG_PRIORITY = EXTERNAL_CATALOG_PRIORITY + 1;
 
 type ExternalCatalogEntry = {

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -52,6 +52,9 @@ const ORIGIN_PRIORITY: Record<PluginOrigin, number> = {
   bundled: 3,
 };
 
+const EXTERNAL_CATALOG_PRIORITY = ORIGIN_PRIORITY.bundled ?? 99;
+const FALLBACK_CATALOG_PRIORITY = EXTERNAL_CATALOG_PRIORITY + 1;
+
 type ExternalCatalogEntry = {
   name?: string;
   version?: string;
@@ -149,12 +152,10 @@ function resolveOfficialCatalogPaths(options: CatalogOptions): string[] {
     path.join(packageRoot, OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH),
   );
 
-  try {
+  if (process.execPath) {
     const execDir = path.dirname(process.execPath);
     candidates.push(path.join(execDir, OFFICIAL_CHANNEL_CATALOG_RELATIVE_PATH));
     candidates.push(path.join(execDir, "channel-catalog.json"));
-  } catch {
-    // ignore
   }
 
   return candidates.filter((entry, index, all) => entry && all.indexOf(entry) === index);
@@ -393,7 +394,7 @@ export function listChannelPluginCatalogEntries(
   }
 
   for (const entry of loadBundledMetadataCatalogEntries(options)) {
-    const priority = ORIGIN_PRIORITY.bundled ?? 99;
+    const priority = FALLBACK_CATALOG_PRIORITY;
     const existing = resolved.get(entry.id);
     if (!existing || priority < existing.priority) {
       resolved.set(entry.id, { entry, priority });
@@ -401,7 +402,7 @@ export function listChannelPluginCatalogEntries(
   }
 
   for (const entry of loadOfficialCatalogEntries(options)) {
-    const priority = ORIGIN_PRIORITY.bundled ?? 99;
+    const priority = FALLBACK_CATALOG_PRIORITY;
     const existing = resolved.get(entry.id);
     if (!existing || priority < existing.priority) {
       resolved.set(entry.id, { entry, priority });
@@ -412,8 +413,12 @@ export function listChannelPluginCatalogEntries(
     .map((entry) => buildExternalCatalogEntry(entry))
     .filter((entry): entry is ChannelPluginCatalogEntry => Boolean(entry));
   for (const entry of externalEntries) {
-    if (!resolved.has(entry.id)) {
-      resolved.set(entry.id, { entry, priority: 99 });
+    // External catalogs are the supported override seam for shipped fallback
+    // metadata, but discovered plugins should still win when they are present.
+    const priority = EXTERNAL_CATALOG_PRIORITY;
+    const existing = resolved.get(entry.id);
+    if (!existing || priority < existing.priority) {
+      resolved.set(entry.id, { entry, priority });
     }
   }
 

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -365,6 +365,165 @@ describe("channel plugin catalog", () => {
     expect(entry?.install.npmSpec).toBe("@openclaw/whatsapp");
     expect(entry?.pluginId).toBeUndefined();
   });
+
+  it("lets external catalogs override shipped fallback channel metadata", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-fallback-catalog-"));
+    const bundledDir = path.join(dir, "dist", "extensions", "whatsapp");
+    const officialCatalogPath = path.join(dir, "channel-catalog.json");
+    const externalCatalogPath = path.join(dir, "catalog.json");
+    fs.mkdirSync(bundledDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(bundledDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/whatsapp",
+        openclaw: {
+          channel: {
+            id: "whatsapp",
+            label: "WhatsApp Bundled",
+            selectionLabel: "WhatsApp Bundled",
+            docsPath: "/channels/whatsapp",
+            blurb: "bundled fallback",
+          },
+          install: {
+            npmSpec: "@openclaw/whatsapp",
+          },
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      officialCatalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/whatsapp",
+            openclaw: {
+              channel: {
+                id: "whatsapp",
+                label: "WhatsApp Official",
+                selectionLabel: "WhatsApp Official",
+                docsPath: "/channels/whatsapp",
+                blurb: "official fallback",
+              },
+              install: {
+                npmSpec: "@openclaw/whatsapp",
+              },
+            },
+          },
+        ],
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      externalCatalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@vendor/whatsapp-fork",
+            openclaw: {
+              channel: {
+                id: "whatsapp",
+                label: "WhatsApp Fork",
+                selectionLabel: "WhatsApp Fork",
+                docsPath: "/channels/whatsapp",
+                blurb: "external override",
+              },
+              install: {
+                npmSpec: "@vendor/whatsapp-fork",
+              },
+            },
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const entry = listChannelPluginCatalogEntries({
+      catalogPaths: [externalCatalogPath],
+      officialCatalogPaths: [officialCatalogPath],
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(dir, "dist", "extensions"),
+      },
+    }).find((item) => item.id === "whatsapp");
+
+    expect(entry?.install.npmSpec).toBe("@vendor/whatsapp-fork");
+    expect(entry?.meta.label).toBe("WhatsApp Fork");
+    expect(entry?.pluginId).toBeUndefined();
+  });
+
+  it("keeps discovered plugins ahead of external catalog overrides", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-state-"));
+    const pluginDir = path.join(stateDir, "extensions", "demo-channel-plugin");
+    const catalogPath = path.join(stateDir, "catalog.json");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@vendor/demo-channel-plugin",
+        openclaw: {
+          extensions: ["./index.js"],
+          channel: {
+            id: "demo-channel",
+            label: "Demo Channel Runtime",
+            selectionLabel: "Demo Channel Runtime",
+            docsPath: "/channels/demo-channel",
+            blurb: "discovered plugin",
+          },
+          install: {
+            npmSpec: "@vendor/demo-channel-plugin",
+          },
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "@vendor/demo-channel-runtime",
+        configSchema: {},
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "module.exports = {}", "utf8");
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@vendor/demo-channel-catalog",
+            openclaw: {
+              channel: {
+                id: "demo-channel",
+                label: "Demo Channel Catalog",
+                selectionLabel: "Demo Channel Catalog",
+                docsPath: "/channels/demo-channel",
+                blurb: "external catalog",
+              },
+              install: {
+                npmSpec: "@vendor/demo-channel-catalog",
+              },
+            },
+          },
+        ],
+      }),
+      "utf8",
+    );
+
+    const entry = listChannelPluginCatalogEntries({
+      catalogPaths: [catalogPath],
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        CLAWDBOT_STATE_DIR: undefined,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+      },
+    }).find((item) => item.id === "demo-channel");
+
+    expect(entry?.install.npmSpec).toBe("@vendor/demo-channel-plugin");
+    expect(entry?.meta.label).toBe("Demo Channel Runtime");
+    expect(entry?.pluginId).toBe("@vendor/demo-channel-runtime");
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -82,6 +82,29 @@ describe("plugin install plan helpers", () => {
     expect(result).toBeNull();
   });
 
+  it("rejects plugin-id bundled matches when the catalog npm spec was overridden", () => {
+    const findBundledSource = vi
+      .fn()
+      .mockImplementation(({ kind }: { kind: "pluginId" | "npmSpec"; value: string }) => {
+        if (kind === "pluginId") {
+          return {
+            pluginId: "whatsapp",
+            localPath: "/tmp/extensions/whatsapp",
+            npmSpec: "@openclaw/whatsapp",
+          };
+        }
+        return undefined;
+      });
+
+    const result = resolveBundledInstallPlanForCatalogEntry({
+      pluginId: "whatsapp",
+      npmSpec: "@vendor/whatsapp-fork",
+      findBundledSource,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("uses npm-spec bundled fallback only for package-not-found", () => {
     const findBundledSource = vi.fn().mockReturnValue({
       pluginId: "voice-call",

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -23,14 +23,6 @@ export function resolveBundledInstallPlanForCatalogEntry(params: {
     return null;
   }
 
-  const bundledById = params.findBundledSource({
-    kind: "pluginId",
-    value: pluginId,
-  });
-  if (bundledById?.pluginId === pluginId) {
-    return { bundledSource: bundledById };
-  }
-
   const bundledBySpec = params.findBundledSource({
     kind: "npmSpec",
     value: npmSpec,
@@ -39,7 +31,18 @@ export function resolveBundledInstallPlanForCatalogEntry(params: {
     return { bundledSource: bundledBySpec };
   }
 
-  return null;
+  const bundledById = params.findBundledSource({
+    kind: "pluginId",
+    value: pluginId,
+  });
+  if (bundledById?.pluginId !== pluginId) {
+    return null;
+  }
+  if (bundledById.npmSpec && bundledById.npmSpec !== npmSpec) {
+    return null;
+  }
+
+  return { bundledSource: bundledById };
 }
 
 export function resolveBundledInstallPlanBeforeNpm(params: {

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -248,6 +248,60 @@ describe("ensureChannelSetupPluginInstalled", () => {
     );
   });
 
+  it("does not default to bundled local path when an external catalog overrides the npm spec", async () => {
+    const runtime = makeRuntime();
+    const select = vi.fn((async <T extends string>() => "skip" as T) as WizardPrompter["select"]);
+    const prompter = makePrompter({ select: select as unknown as WizardPrompter["select"] });
+    const cfg: OpenClawConfig = { update: { channel: "beta" } };
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    resolveBundledPluginSources.mockReturnValue(
+      new Map([
+        [
+          "whatsapp",
+          {
+            pluginId: "whatsapp",
+            localPath: "/opt/openclaw/extensions/whatsapp",
+            npmSpec: "@openclaw/whatsapp",
+          },
+        ],
+      ]),
+    );
+
+    await ensureChannelSetupPluginInstalled({
+      cfg,
+      entry: {
+        id: "whatsapp",
+        meta: {
+          id: "whatsapp",
+          label: "WhatsApp",
+          selectionLabel: "WhatsApp",
+          docsPath: "/channels/whatsapp",
+          blurb: "Test",
+        },
+        install: {
+          npmSpec: "@vendor/whatsapp-fork",
+        },
+      },
+      prompter,
+      runtime,
+    });
+
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "npm",
+        options: [
+          expect.objectContaining({
+            value: "npm",
+            label: "Download from npm (@vendor/whatsapp-fork)",
+          }),
+          expect.objectContaining({
+            value: "skip",
+          }),
+        ],
+      }),
+    );
+  });
+
   it("falls back to local path after npm install failure", async () => {
     const runtime = makeRuntime();
     const note = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: shipped fallback channel metadata from bundled package manifests and `dist/channel-catalog.json` could take over a channel ID before external catalogs were merged.
- Why it matters: catalog-driven installs could ignore a user override like a private `whatsapp` fork and install the hard-coded shipped `npmSpec` instead.
- What changed: external catalogs now merge at higher precedence than shipped fallback metadata, while discovered plugins still keep the highest precedence they had before; added regressions for both cases.
- What did NOT change (scope boundary): discovered plugin precedence and runtime install behavior outside catalog entry selection.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #52913
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: shipped fallback sources were merged with bundled precedence before external catalogs, and external catalogs only appended missing IDs.
- Missing detection / guardrail: there was no unit test covering external-catalog overrides for a channel that also exists in shipped fallback metadata.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this behavior came in during the fallback catalog work in #52913.
- Why this regressed now: #52913 added more shipped fallback sources but kept external catalog merging as an add-only step.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/channels/plugins/plugins-core.test.ts`
- Scenario the test should lock in: external catalog entries override shipped fallback metadata for the same channel ID, but discovered plugins still outrank the external catalog.
- Why this is the smallest reliable guardrail: the bug is entirely in catalog merge precedence and does not require install-time integration to reproduce.
- Existing test that already covers this (if any): the file already covered external catalogs and shipped fallback entries separately.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Catalog-driven channel overrides work again for channels that are also present in shipped fallback metadata.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: `Darwin 25.3.0`
- Runtime/container: local workspace
- Model/provider: N/A
- Integration/channel (if any): channel plugin catalog / fallback WhatsApp entry
- Relevant config (redacted): temporary `OPENCLAW_BUNDLED_PLUGINS_DIR`, `OPENCLAW_PLUGIN_CATALOG_PATHS`, and `officialCatalogPaths`

### Steps

1. Create shipped fallback metadata for a channel ID such as `whatsapp`.
2. Provide an external catalog entry for the same channel ID with a different `install.npmSpec`.
3. Call `listChannelPluginCatalogEntries()` and inspect the selected entry.

### Expected

- The external catalog entry wins over shipped fallback metadata.
- A discovered installed plugin for the same channel ID still wins over the external catalog.

### Actual

- Before this fix, shipped fallback metadata won and masked the external override.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manual temp-dir repro of the precedence bug before the fix; `pnpm check`; `pnpm test -- src/channels/plugins/plugins-core.test.ts` after the fix.
- Edge cases checked: external override against bundled metadata, external override against official fallback catalog, and discovered plugin precedence over external catalog.
- What you did **not** verify: end-to-end channel setup flows beyond catalog resolution.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8dc07b87c5`.
- Files/config to restore: `src/channels/plugins/catalog.ts` and `src/channels/plugins/plugins-core.test.ts`.
- Known bad symptoms reviewers should watch for: shipped fallback entries unexpectedly outranking discovered plugins or external catalogs after merge changes.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: catalog precedence changes could accidentally let external catalogs outrank discovered plugins.
  - Mitigation: the new regression test locks in discovered-plugin precedence separately from shipped fallback precedence.
