### PR TITLE
fix(plugins): unblock Discord/Slack message tool sends and Feishu media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Docs: https://docs.openclaw.ai
 - Gateway/supervision: stop lock conflicts from crash-looping under launchd and systemd by keeping the duplicate process in a retry wait instead of exiting as a failure while another healthy gateway still owns the lock. Fixes #52922. Thanks @vincentkoc.
 - Browser/Chrome MCP: wait for existing-session browser tabs to become usable after attach instead of treating the initial Chrome MCP handshake as ready, which reduces user-profile timeouts and repeated consent churn on macOS Chrome attach flows. Fixes #52930. Thanks @vincentkoc.
 - Gateway/probe: stop successful gateway handshakes from timing out as unreachable while post-connect detail RPCs are still loading, so slow devices report a reachable RPC failure instead of a false negative dead gateway. Fixes #52927. Thanks @vincentkoc.
+- Plugins/message tool: make Discord `components` and Slack `blocks` optional again so pin/unpin/react flows stop failing schema validation and Slack media sends are no longer forced into an invalid blocks-plus-media payload. Fixes #52970 and #52962. Thanks @vincentkoc.
+- Plugins/Feishu: route `message(..., media=...)` sends through the Feishu outbound media path so file and image attachments actually send instead of being silently dropped. Fixes #52962. Thanks @vincentkoc.
 
 ## 2026.3.22
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -54,6 +55,24 @@ describe("discordMessageActions", () => {
     );
     expect(discovery?.actions).not.toContain("channel-create");
     expect(discovery?.actions).not.toContain("role-add");
+  });
+
+  it("keeps components optional in the message tool schema", () => {
+    const discovery = discordMessageActions.describeMessageTool?.({
+      cfg: {
+        channels: {
+          discord: {
+            token: "Bot token-main",
+          },
+        },
+      } as OpenClawConfig,
+    });
+    const schema = discovery?.schema;
+    if (!schema || Array.isArray(schema)) {
+      throw new Error("expected discord message-tool schema");
+    }
+
+    expect(Type.Object(schema.properties).required).toBeUndefined();
   });
 
   it("extracts send targets for message and thread reply actions", () => {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import {
   createUnionActionGate,
   listTokenSourcedAccounts,
@@ -124,7 +125,7 @@ function describeDiscordMessageTool({
     capabilities: ["interactive", "components"],
     schema: {
       properties: {
-        components: createDiscordMessageToolComponentsSchema(),
+        components: Type.Optional(createDiscordMessageToolComponentsSchema()),
       },
     },
   };

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -18,6 +18,7 @@ const getChatMembersMock = vi.hoisted(() => vi.fn());
 const getFeishuMemberInfoMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryPeersLiveMock = vi.hoisted(() => vi.fn());
 const listFeishuDirectoryGroupsLiveMock = vi.hoisted(() => vi.fn());
+const feishuOutboundSendMediaMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./probe.js", () => ({
   probeFeishu: probeFeishuMock,
@@ -47,7 +48,7 @@ vi.mock("./channel.runtime.js", () => ({
     sendMessageFeishu: sendMessageFeishuMock,
     feishuOutbound: {
       sendText: vi.fn(),
-      sendMedia: vi.fn(),
+      sendMedia: feishuOutboundSendMediaMock,
     },
   },
 }));
@@ -202,6 +203,38 @@ describe("feishuPlugin actions", () => {
       replyInThread: false,
     });
     expect(result?.details).toMatchObject({ ok: true, messageId: "om_card", chatId: "oc_group_1" });
+  });
+
+  it("sends media through the outbound adapter", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media",
+      details: { messageId: "om_media", chatId: "oc_group_1" },
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "test",
+        media: "/tmp/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "test",
+      mediaUrl: "/tmp/image.png",
+      accountId: undefined,
+      mediaLocalRoots: ["/tmp"],
+      replyToId: undefined,
+    });
+    expect(result?.details).toMatchObject({ messageId: "om_media" });
   });
 
   it("reads messages", async () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -51,6 +51,14 @@ import { feishuSetupWizard } from "./setup-surface.js";
 import { normalizeFeishuTarget, looksLikeFeishuId, formatFeishuTarget } from "./targets.js";
 import type { FeishuConfig, FeishuProbeResult, ResolvedFeishuAccount } from "./types.js";
 
+function readFeishuMediaParam(params: Record<string, unknown>): string | undefined {
+  const media = params.media;
+  if (typeof media !== "string") {
+    return undefined;
+  }
+  return media.trim() ? media : undefined;
+}
+
 const meta: ChannelMeta = {
   id: "feishu",
   label: "Feishu",
@@ -502,27 +510,49 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
                 ? (ctx.params.card as Record<string, unknown>)
                 : undefined;
             const text = readFirstString(ctx.params, ["text", "message"]);
-            if (!card && !text) {
-              throw new Error(`Feishu ${ctx.action} requires text/message or card.`);
+            const mediaUrl = readFeishuMediaParam(ctx.params);
+            if (card && mediaUrl) {
+              throw new Error(`Feishu ${ctx.action} does not support card with media.`);
+            }
+            if (!card && !text && !mediaUrl) {
+              throw new Error(`Feishu ${ctx.action} requires text/message, media, or card.`);
             }
             const runtime = await loadFeishuChannelRuntime();
-            const result = card
-              ? await runtime.sendCardFeishu({
-                  cfg: ctx.cfg,
-                  to,
-                  card,
-                  accountId: ctx.accountId ?? undefined,
-                  replyToMessageId,
-                  replyInThread: ctx.action === "thread-reply",
-                })
-              : await runtime.sendMessageFeishu({
-                  cfg: ctx.cfg,
-                  to,
-                  text: text!,
-                  accountId: ctx.accountId ?? undefined,
-                  replyToMessageId,
-                  replyInThread: ctx.action === "thread-reply",
-                });
+            const maybeSendMedia = runtime.feishuOutbound.sendMedia;
+            if (mediaUrl && !maybeSendMedia) {
+              throw new Error("Feishu media sending is not available.");
+            }
+            const sendMedia = maybeSendMedia;
+            let result;
+            if (card) {
+              result = await runtime.sendCardFeishu({
+                cfg: ctx.cfg,
+                to,
+                card,
+                accountId: ctx.accountId ?? undefined,
+                replyToMessageId,
+                replyInThread: ctx.action === "thread-reply",
+              });
+            } else if (mediaUrl) {
+              result = await sendMedia!({
+                cfg: ctx.cfg,
+                to,
+                text: text ?? "",
+                mediaUrl,
+                accountId: ctx.accountId ?? undefined,
+                mediaLocalRoots: ctx.mediaLocalRoots,
+                replyToId: replyToMessageId,
+              });
+            } else {
+              result = await runtime.sendMessageFeishu({
+                cfg: ctx.cfg,
+                to,
+                text: text!,
+                accountId: ctx.accountId ?? undefined,
+                replyToMessageId,
+                replyInThread: ctx.action === "thread-reply",
+              });
+            }
             return jsonActionResult({
               ok: true,
               channel: "feishu",

--- a/extensions/slack/src/channel-actions.ts
+++ b/extensions/slack/src/channel-actions.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
 import {
   type ChannelMessageActionAdapter,
   type ChannelMessageToolDiscovery,
@@ -40,7 +41,7 @@ export function createSlackActions(
       schema: actions.includes("send")
         ? {
             properties: {
-              blocks: createSlackMessageToolBlocksSchema(),
+              blocks: Type.Optional(createSlackMessageToolBlocksSchema()),
             },
           }
         : null,

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { describe, expect, it, vi } from "vitest";
 import { createRuntimeEnv } from "../../../test/helpers/extensions/runtime-env.js";
 import { slackOutbound } from "./outbound-adapter.js";
@@ -94,6 +95,25 @@ describe("slackPlugin actions", () => {
         blocks: expect.any(Object),
       },
     });
+  });
+
+  it("keeps blocks optional in the message tool schema", () => {
+    const discovery = slackPlugin.actions?.describeMessageTool({
+      cfg: {
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+            appToken: "xapp-test",
+          },
+        },
+      } as OpenClawConfig,
+    });
+    const schema = discovery?.schema;
+    if (!schema || Array.isArray(schema)) {
+      throw new Error("expected slack message-tool schema");
+    }
+
+    expect(Type.Object(schema.properties).required).toBeUndefined();
   });
 
   it("forwards read threadId to Slack action handler", async () => {


### PR DESCRIPTION
## Summary
- make Discord `components` and Slack `blocks` optional in message-tool discovery
- route Feishu `message(..., media=...)` sends through the outbound media path
- add focused regressions and changelog entries

## Testing
- `NODENV_VERSION=24.13.0 pnpm test -- extensions/discord/src/channel-actions.test.ts`
- `NODENV_VERSION=24.13.0 pnpm test -- extensions/slack/src/channel.test.ts`
- `NODENV_VERSION=24.13.0 pnpm test -- extensions/feishu/src/channel.test.ts`
- `NODENV_VERSION=24.13.0 pnpm build`

Fixes #52970
Fixes #52962