### PR TITLE
fix(telegram): preserve inbound debounce order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,6 +353,7 @@ Docs: https://docs.openclaw.ai
 - Memory/core tools: register `memory_search` and `memory_get` independently so one unavailable memory tool no longer suppresses the other in new sessions. (#50198) Thanks @artwalker.
 - Telegram/Mattermost message tool: keep plugin button schemas optional in isolated and cron sessions so plain sends do not fail validation when no current channel is active. (#52589) Thanks @tylerliu612.
 - Release/npm publish: fail the npm release check when `dist/control-ui/index.html` is missing from the packed tarball, so broken Control UI asset releases are blocked before publish. Fixes #52808. (#52852) Thanks @kevinheinrichs.
+- Channels/inbound debounce: reserve same-conversation timer-backed flush order so a buffered run cannot be overtaken by a newer message for the same key, preventing Telegram reply desync after long debounced turns. Fixes #52982.
 
 ## 2026.3.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Voice-call/Plivo: stabilize Plivo v2 replay keys so webhook retries and replay protection stop colliding on valid follow-up deliveries.
 - Release/install: keep previously released bundled plugins and Control UI assets in published openclaw npm installs, and fail release checks when those shipped artifacts are missing. Thanks @vincentkoc.
 - Mistral/models: lower bundled Mistral max-token defaults to safe output budgets and teach `openclaw doctor --fix` to repair old persisted Mistral provider configs that still carry context-sized output limits, avoiding deterministic Mistral 422 rejects on fresh and existing setups. Fixes #52599. Thanks @vincentkoc.
+- Telegram/auto-reply: preserve same-chat inbound debounce order without stranding stale busy-session followups, and keep same-key overflow turns ordered when tracked debounce keys are saturated. (#52998) Thanks @osolmaz.
 
 ## 2026.3.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Agents/media replies: migrate the remaining browser, canvas, and nodes snapshot outputs onto `details.media` so generated media keeps attaching to assistant replies after the collect-then-attach refactor. (#51731) Thanks @christianklotz.
 - Android/contacts search: escape literal `%` and `_` in contact-name queries so searches like `100%` or `_id` no longer match unrelated contacts through SQL `LIKE` wildcards. (#41891) Thanks @Kaneki-x.
 - Gateway/usage: include reset and deleted archived session transcripts in usage totals, session discovery, and archived-only session detail fallback so the Usage view no longer undercounts rotated sessions. (#43215) Thanks @rcrick.
+- Channels/inbound debounce: reserve same-conversation timer-backed flush order so a buffered run cannot be overtaken by a newer message for the same key, preventing Telegram reply desync after long debounced turns. Fixes #52982. Thanks @vincentkoc and @osolmaz.
 
 ### Changes
 
@@ -353,7 +354,6 @@ Docs: https://docs.openclaw.ai
 - Memory/core tools: register `memory_search` and `memory_get` independently so one unavailable memory tool no longer suppresses the other in new sessions. (#50198) Thanks @artwalker.
 - Telegram/Mattermost message tool: keep plugin button schemas optional in isolated and cron sessions so plain sends do not fail validation when no current channel is active. (#52589) Thanks @tylerliu612.
 - Release/npm publish: fail the npm release check when `dist/control-ui/index.html` is missing from the packed tarball, so broken Control UI asset releases are blocked before publish. Fixes #52808. (#52852) Thanks @kevinheinrichs.
-- Channels/inbound debounce: reserve same-conversation timer-backed flush order so a buffered run cannot be overtaken by a newer message for the same key, preventing Telegram reply desync after long debounced turns. Fixes #52982.
 
 ## 2026.3.13
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -165,6 +165,162 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(harness.sequentializeKey).toBe(getTelegramSequentialKey);
   });
+
+  it("preserves same-chat reply order when a debounced run is still active", async () => {
+    const DEBOUNCE_MS = 4321;
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      messages: {
+        inbound: {
+          debounceMs: DEBOUNCE_MS,
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    sequentializeSpy.mockImplementationOnce(() => {
+      const lanes = new Map<string, Promise<void>>();
+      return async (ctx: Record<string, unknown>, next: () => Promise<void>) => {
+        const key = harness.sequentializeKey?.(ctx) ?? "default";
+        const previous = lanes.get(key) ?? Promise.resolve();
+        const current = previous.then(async () => {
+          await next();
+        });
+        lanes.set(
+          key,
+          current.catch(() => undefined),
+        );
+        try {
+          await current;
+        } finally {
+          if (lanes.get(key) === current) {
+            lanes.delete(key);
+          }
+        }
+      };
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const startedBodies: string[] = [];
+    let releaseFirstRun!: () => void;
+    const firstRunGate = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve;
+    });
+
+    replySpy.mockImplementation(async (ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onReplyStart?.();
+      const body = String(ctx.Body ?? "");
+      startedBodies.push(body);
+      if (body.includes("first")) {
+        await firstRunGate;
+      }
+      return { text: `reply:${body}` };
+    });
+
+    const runMiddlewareChain = async (ctx: Record<string, unknown>) => {
+      const middlewares = middlewareUseSpy.mock.calls
+        .map((call) => call[0])
+        .filter(
+          (fn): fn is (ctx: Record<string, unknown>, next: () => Promise<void>) => Promise<void> =>
+            typeof fn === "function",
+        );
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      let idx = -1;
+      const dispatch = async (i: number): Promise<void> => {
+        if (i <= idx) {
+          throw new Error("middleware dispatch called multiple times");
+        }
+        idx = i;
+        const fn = middlewares[i];
+        if (!fn) {
+          await handler(ctx);
+          return;
+        }
+        await fn(ctx, async () => dispatch(i + 1));
+      };
+      await dispatch(0);
+    };
+
+    const extractLatestDebounceFlush = () => {
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === DEBOUNCE_MS,
+      );
+      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => Promise<void>) | undefined;
+    };
+
+    try {
+      createTelegramBot({ token: "tok" });
+
+      await runMiddlewareChain({
+        update: { update_id: 101 },
+        message: {
+          chat: { id: 7, type: "private" },
+          text: "first",
+          date: 1736380800,
+          message_id: 101,
+          from: { id: 42, first_name: "Ada" },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      const flushFirst = extractLatestDebounceFlush();
+      const firstFlush = flushFirst?.();
+
+      await vi.waitFor(() => {
+        expect(startedBodies).toHaveLength(1);
+        expect(startedBodies[0]).toContain("first");
+      });
+
+      await runMiddlewareChain({
+        update: { update_id: 102 },
+        message: {
+          chat: { id: 7, type: "private" },
+          text: "second",
+          date: 1736380801,
+          message_id: 102,
+          from: { id: 42, first_name: "Ada" },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      const flushSecond = extractLatestDebounceFlush();
+      const secondFlush = flushSecond?.();
+      await Promise.resolve();
+
+      expect(startedBodies).toHaveLength(1);
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+
+      releaseFirstRun();
+      await Promise.all([firstFlush, secondFlush]);
+
+      await vi.waitFor(() => {
+        expect(startedBodies).toHaveLength(2);
+        expect(sendMessageSpy).toHaveBeenCalledTimes(2);
+      });
+
+      expect(startedBodies[0]).toContain("first");
+      expect(startedBodies[1]).toContain("second");
+      expect(sendMessageSpy.mock.calls.map((call) => call[1])).toEqual([
+        expect.stringContaining("first"),
+        expect.stringContaining("second"),
+      ]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -203,7 +203,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return;
     }
     if (!canTrackKey(key)) {
-      await runFlush([item]);
+      // When the debounce map is saturated, fall back to immediate keyed work
+      // instead of buffering, but still preserve same-key ordering.
+      await enqueueKeyTask(key, async () => {
+        await runFlush([item]);
+      });
       return;
     }
 

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -68,7 +68,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     try {
       await params.onFlush(items);
     } catch (err) {
-      params.onError?.(err, items);
+      try {
+        params.onError?.(err, items);
+      } catch {
+        // Keep the keyed chain alive even if the error handler fails.
+      }
     }
   };
 
@@ -153,23 +157,27 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
 
     if (!canDebounce || !key) {
       if (key) {
-        if (!buffers.has(key)) {
+        if (buffers.has(key)) {
+          // Reserve the keyed immediate slot before forcing the pending buffer
+          // to flush so fire-and-forget callers cannot be overtaken.
+          const reservedTask = enqueueReservedKeyTask(key, async () => {
+            await runFlush([item]);
+          });
+          try {
+            await flushKey(key);
+          } finally {
+            reservedTask.release();
+          }
+          await reservedTask.task;
+          return;
+        }
+        if (keyChains.has(key)) {
           await enqueueKeyTask(key, async () => {
             await runFlush([item]);
           });
           return;
         }
-        // Reserve the keyed immediate slot before forcing the pending buffer
-        // to flush so fire-and-forget callers cannot be overtaken.
-        const reservedTask = enqueueReservedKeyTask(key, async () => {
-          await runFlush([item]);
-        });
-        try {
-          await flushKey(key);
-        } finally {
-          reservedTask.release();
-        }
-        await reservedTask.task;
+        await runFlush([item]);
       } else {
         await runFlush([item]);
       }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -37,6 +37,10 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  ready: Promise<void>;
+  releaseReady: () => void;
+  readyReleased: boolean;
+  task: Promise<void>;
 };
 
 export type InboundDebounceCreateParams<T> = {
@@ -50,6 +54,7 @@ export type InboundDebounceCreateParams<T> = {
 
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
+  const keyChains = new Map<string, Promise<void>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
 
   const resolveDebounceMs = (item: T) => {
@@ -60,20 +65,47 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return Math.max(0, Math.trunc(resolved));
   };
 
+  const runFlush = async (items: T[]) => {
+    try {
+      await params.onFlush(items);
+    } catch (err) {
+      params.onError?.(err, items);
+    }
+  };
+
+  const enqueueKeyTask = (key: string, task: () => Promise<void>) => {
+    const previous = keyChains.get(key) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(task);
+    const settled = next.catch(() => undefined);
+    keyChains.set(key, settled);
+    void settled.finally(() => {
+      if (keyChains.get(key) === settled) {
+        keyChains.delete(key);
+      }
+    });
+    return next;
+  };
+
+  const releaseBuffer = (buffer: DebounceBuffer<T>) => {
+    if (buffer.readyReleased) {
+      return;
+    }
+    buffer.readyReleased = true;
+    buffer.releaseReady();
+  };
+
   const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
-    buffers.delete(key);
+    if (buffers.get(key) === buffer) {
+      buffers.delete(key);
+    }
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
       buffer.timeout = null;
     }
-    if (buffer.items.length === 0) {
-      return;
-    }
-    try {
-      await params.onFlush(buffer.items);
-    } catch (err) {
-      params.onError?.(err, buffer.items);
-    }
+    // Reserve each key's execution slot as soon as the first buffered item
+    // arrives, so later same-key work cannot overtake a timer-backed flush.
+    releaseBuffer(buffer);
+    await buffer.task;
   };
 
   const flushKey = async (key: string) => {
@@ -103,10 +135,12 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       if (key && buffers.has(key)) {
         await flushKey(key);
       }
-      try {
-        await params.onFlush([item]);
-      } catch (err) {
-        params.onError?.(err, [item]);
+      if (key) {
+        await enqueueKeyTask(key, async () => {
+          await runFlush([item]);
+        });
+      } else {
+        await runFlush([item]);
       }
       return;
     }
@@ -119,7 +153,25 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return;
     }
 
-    const buffer: DebounceBuffer<T> = { items: [item], timeout: null, debounceMs };
+    let releaseReady!: () => void;
+    const buffer: DebounceBuffer<T> = {
+      items: [item],
+      timeout: null,
+      debounceMs,
+      ready: new Promise<void>((resolve) => {
+        releaseReady = resolve;
+      }),
+      releaseReady,
+      readyReleased: false,
+      task: Promise.resolve(),
+    };
+    buffer.task = enqueueKeyTask(key, async () => {
+      await buffer.ready;
+      if (buffer.items.length === 0) {
+        return;
+      }
+      await runFlush(buffer.items);
+    });
     buffers.set(key, buffer);
     scheduleFlush(key, buffer);
   };

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -42,8 +42,11 @@ type DebounceBuffer<T> = {
   task: Promise<void>;
 };
 
+const DEFAULT_MAX_TRACKED_KEYS = 2048;
+
 export type InboundDebounceCreateParams<T> = {
   debounceMs: number;
+  maxTrackedKeys?: number;
   buildKey: (item: T) => string | null | undefined;
   shouldDebounce?: (item: T) => boolean;
   resolveDebounceMs?: (item: T) => number | undefined;
@@ -55,6 +58,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
   const buffers = new Map<string, DebounceBuffer<T>>();
   const keyChains = new Map<string, Promise<void>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
+  const maxTrackedKeys = Math.max(1, Math.trunc(params.maxTrackedKeys ?? DEFAULT_MAX_TRACKED_KEYS));
 
   const resolveDebounceMs = (item: T) => {
     const resolved = params.resolveDebounceMs?.(item);
@@ -150,6 +154,13 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     buffer.timeout.unref?.();
   };
 
+  const canTrackKey = (key: string) => {
+    if (buffers.has(key) || keyChains.has(key)) {
+      return true;
+    }
+    return Math.max(buffers.size, keyChains.size) < maxTrackedKeys;
+  };
+
   const enqueue = async (item: T) => {
     const key = params.buildKey(item);
     const debounceMs = resolveDebounceMs(item);
@@ -189,6 +200,10 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       existing.items.push(item);
       existing.debounceMs = debounceMs;
       scheduleFlush(key, existing);
+      return;
+    }
+    if (!canTrackKey(key)) {
+      await runFlush([item]);
       return;
     }
 

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -37,7 +37,6 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
-  ready: Promise<void>;
   releaseReady: () => void;
   readyReleased: boolean;
   task: Promise<void>;
@@ -86,6 +85,27 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     return next;
   };
 
+  const enqueueReservedKeyTask = (key: string, task: () => Promise<void>) => {
+    let readyReleased = false;
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    return {
+      task: enqueueKeyTask(key, async () => {
+        await ready;
+        await task();
+      }),
+      release: () => {
+        if (readyReleased) {
+          return;
+        }
+        readyReleased = true;
+        releaseReady();
+      },
+    };
+  };
+
   const releaseBuffer = (buffer: DebounceBuffer<T>) => {
     if (buffer.readyReleased) {
       return;
@@ -132,13 +152,24 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     const canDebounce = debounceMs > 0 && (params.shouldDebounce?.(item) ?? true);
 
     if (!canDebounce || !key) {
-      if (key && buffers.has(key)) {
-        await flushKey(key);
-      }
       if (key) {
-        await enqueueKeyTask(key, async () => {
+        if (!buffers.has(key)) {
+          await enqueueKeyTask(key, async () => {
+            await runFlush([item]);
+          });
+          return;
+        }
+        // Reserve the keyed immediate slot before forcing the pending buffer
+        // to flush so fire-and-forget callers cannot be overtaken.
+        const reservedTask = enqueueReservedKeyTask(key, async () => {
           await runFlush([item]);
         });
+        try {
+          await flushKey(key);
+        } finally {
+          reservedTask.release();
+        }
+        await reservedTask.task;
       } else {
         await runFlush([item]);
       }
@@ -153,25 +184,21 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       return;
     }
 
-    let releaseReady!: () => void;
-    const buffer: DebounceBuffer<T> = {
-      items: [item],
-      timeout: null,
-      debounceMs,
-      ready: new Promise<void>((resolve) => {
-        releaseReady = resolve;
-      }),
-      releaseReady,
-      readyReleased: false,
-      task: Promise.resolve(),
-    };
-    buffer.task = enqueueKeyTask(key, async () => {
-      await buffer.ready;
+    let buffer!: DebounceBuffer<T>;
+    const reservedTask = enqueueReservedKeyTask(key, async () => {
       if (buffer.items.length === 0) {
         return;
       }
       await runFlush(buffer.items);
     });
+    buffer = {
+      items: [item],
+      timeout: null,
+      debounceMs,
+      releaseReady: reservedTask.release,
+      readyReleased: false,
+      task: reservedTask.task,
+    };
     buffers.set(key, buffer);
     scheduleFlush(key, buffer);
   };

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -401,6 +401,74 @@ describe("createInboundDebouncer", () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  it("keeps fire-and-forget keyed work ahead of a later buffered item", async () => {
+    const started: string[] = [];
+    const finished: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const debouncer = createInboundDebouncer<{ key: string; id: string; debounce: boolean }>({
+      debounceMs: 50,
+      buildKey: (item) => item.key,
+      shouldDebounce: (item) => item.debounce,
+      onFlush: async (items) => {
+        const ids = items.map((entry) => entry.id).join(",");
+        started.push(ids);
+        if (ids === "1") {
+          await firstGate;
+        }
+        finished.push(ids);
+      },
+    });
+
+    try {
+      await debouncer.enqueue({ key: "a", id: "1", debounce: true });
+
+      const firstTimerIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 50);
+      expect(firstTimerIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[firstTimerIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      const firstFlush = (
+        setTimeoutSpy.mock.calls[firstTimerIndex]?.[0] as (() => Promise<void>) | undefined
+      )?.();
+
+      await vi.waitFor(() => {
+        expect(started).toEqual(["1"]);
+      });
+
+      const secondEnqueue = debouncer.enqueue({ key: "a", id: "2", debounce: false });
+      const thirdEnqueue = debouncer.enqueue({ key: "a", id: "3", debounce: true });
+
+      const thirdTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call, index) => index > firstTimerIndex && call[1] === 50,
+      );
+      expect(thirdTimerIndex).toBeGreaterThan(firstTimerIndex);
+      clearTimeout(
+        setTimeoutSpy.mock.results[thirdTimerIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      const thirdFlush = (
+        setTimeoutSpy.mock.calls[thirdTimerIndex]?.[0] as (() => Promise<void>) | undefined
+      )?.();
+
+      await Promise.resolve();
+
+      expect(started).toEqual(["1"]);
+      expect(finished).toEqual([]);
+
+      releaseFirst();
+      await Promise.all([firstFlush, secondEnqueue, thirdFlush, thirdEnqueue]);
+
+      expect(started).toEqual(["1", "2", "3"]);
+      expect(finished).toEqual(["1", "2", "3"]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -347,6 +347,60 @@ describe("createInboundDebouncer", () => {
 
     vi.useRealTimers();
   });
+
+  it("keeps later same-key work behind a timer-backed flush that already started", async () => {
+    const started: string[] = [];
+    const finished: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const debouncer = createInboundDebouncer<{ key: string; id: string; debounce: boolean }>({
+      debounceMs: 50,
+      buildKey: (item) => item.key,
+      shouldDebounce: (item) => item.debounce,
+      onFlush: async (items) => {
+        const ids = items.map((entry) => entry.id).join(",");
+        started.push(ids);
+        if (ids === "1") {
+          await firstGate;
+        }
+        finished.push(ids);
+      },
+    });
+
+    try {
+      await debouncer.enqueue({ key: "a", id: "1", debounce: true });
+
+      const timerIndex = setTimeoutSpy.mock.calls.findLastIndex((call) => call[1] === 50);
+      expect(timerIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(setTimeoutSpy.mock.results[timerIndex]?.value as ReturnType<typeof setTimeout>);
+      const flushTimer = setTimeoutSpy.mock.calls[timerIndex]?.[0] as
+        | (() => Promise<void>)
+        | undefined;
+      const firstFlush = flushTimer?.();
+
+      await vi.waitFor(() => {
+        expect(started).toEqual(["1"]);
+      });
+
+      const secondEnqueue = debouncer.enqueue({ key: "a", id: "2", debounce: false });
+      await Promise.resolve();
+
+      expect(started).toEqual(["1"]);
+      expect(finished).toEqual([]);
+
+      releaseFirst();
+      await Promise.all([firstFlush, secondEnqueue]);
+
+      expect(started).toEqual(["1", "2"]);
+      expect(finished).toEqual(["1", "2"]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -469,6 +469,56 @@ describe("createInboundDebouncer", () => {
       setTimeoutSpy.mockRestore();
     }
   });
+
+  it("does not serialize keyed turns when debounce is disabled and no keyed chain exists", async () => {
+    const started: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 0,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        const id = items[0]?.id ?? "";
+        started.push(id);
+        if (id === "1") {
+          await firstGate;
+        }
+      },
+    });
+
+    const first = debouncer.enqueue({ key: "a", id: "1" });
+    await Promise.resolve();
+    const second = debouncer.enqueue({ key: "a", id: "2" });
+    await Promise.resolve();
+
+    expect(started).toEqual(["1", "2"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+  });
+
+  it("swallows onError failures so keyed chains still complete", async () => {
+    const calls: string[] = [];
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 0,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items[0]?.id ?? "");
+        throw new Error("flush failed");
+      },
+      onError: () => {
+        throw new Error("handler failed");
+      },
+    });
+
+    await expect(debouncer.enqueue({ key: "a", id: "1" })).resolves.toBeUndefined();
+    await expect(debouncer.enqueue({ key: "a", id: "2" })).resolves.toBeUndefined();
+
+    expect(calls).toEqual(["1", "2"]);
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -543,6 +543,69 @@ describe("createInboundDebouncer", () => {
 
     vi.useRealTimers();
   });
+
+  it("keeps same-key overflow work ordered after falling back to immediate flushes", async () => {
+    const started: string[] = [];
+    const finished: string[] = [];
+    let releaseOverflow!: () => void;
+    const overflowGate = new Promise<void>((resolve) => {
+      releaseOverflow = resolve;
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 50,
+      maxTrackedKeys: 1,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        const ids = items.map((entry) => entry.id).join(",");
+        started.push(ids);
+        if (ids === "2") {
+          await overflowGate;
+        }
+        finished.push(ids);
+      },
+    });
+
+    try {
+      await debouncer.enqueue({ key: "a", id: "1" });
+      const callCountBeforeOverflow = setTimeoutSpy.mock.calls.length;
+      clearTimeout(
+        setTimeoutSpy.mock.results[callCountBeforeOverflow - 1]?.value as ReturnType<
+          typeof setTimeout
+        >,
+      );
+
+      const overflowEnqueue = debouncer.enqueue({ key: "b", id: "2" });
+      await vi.waitFor(() => {
+        expect(started).toEqual(["2"]);
+      });
+
+      const bufferedEnqueue = debouncer.enqueue({ key: "b", id: "3" });
+      const bufferedTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call, index) => index >= callCountBeforeOverflow && call[1] === 50,
+      );
+      expect(bufferedTimerIndex).toBeGreaterThanOrEqual(callCountBeforeOverflow);
+      clearTimeout(
+        setTimeoutSpy.mock.results[bufferedTimerIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      const bufferedFlush = (
+        setTimeoutSpy.mock.calls[bufferedTimerIndex]?.[0] as (() => Promise<void>) | undefined
+      )?.();
+
+      await Promise.resolve();
+      expect(started).toEqual(["2"]);
+      expect(finished).toEqual([]);
+
+      releaseOverflow();
+      await Promise.all([overflowEnqueue, bufferedEnqueue, bufferedFlush]);
+
+      expect(started).toEqual(["2", "3"]);
+      expect(finished).toEqual(["2", "3"]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -519,6 +519,30 @@ describe("createInboundDebouncer", () => {
 
     expect(calls).toEqual(["1", "2"]);
   });
+
+  it("bypasses debouncing for new keys once the tracked-key cap is reached", async () => {
+    vi.useFakeTimers();
+    const calls: Array<string[]> = [];
+
+    const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+      debounceMs: 50,
+      maxTrackedKeys: 1,
+      buildKey: (item) => item.key,
+      onFlush: async (items) => {
+        calls.push(items.map((entry) => entry.id));
+      },
+    });
+
+    await debouncer.enqueue({ key: "a", id: "1" });
+    await debouncer.enqueue({ key: "b", id: "2" });
+
+    expect(calls).toEqual([["2"]]);
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(calls).toEqual([["2"], ["1"]]);
+
+    vi.useRealTimers();
+  });
 });
 
 describe("initSessionState BodyStripped", () => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -114,6 +114,7 @@ function createMinimalRun(params?: {
   typingMode?: TypingMode;
   blockStreamingEnabled?: boolean;
   isActive?: boolean;
+  isRunActive?: () => boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
   runOverrides?: Partial<FollowupRun["run"]>;
@@ -169,6 +170,7 @@ function createMinimalRun(params?: {
         shouldSteer: false,
         shouldFollowup: params?.shouldFollowup ?? false,
         isActive: params?.isActive ?? false,
+        isRunActive: params?.isRunActive,
         isStreaming: false,
         opts,
         typing,
@@ -323,6 +325,23 @@ describe("runReplyAgent heartbeat followup guard", () => {
 
     expect(result).toBeUndefined();
     expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("starts draining immediately when the active snapshot is already stale", async () => {
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      isRunActive: () => false,
+      shouldFollowup: true,
+      resolvedQueueMode: "collect",
+    });
+
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(scheduleFollowupDrain)).toHaveBeenCalledTimes(1);
     expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -233,7 +233,14 @@ export async function runReplyAgent(params: {
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(queueKey, followupRun, resolvedQueue, "message-id", queuedRunFollowupTurn);
+    enqueueFollowupRun(
+      queueKey,
+      followupRun,
+      resolvedQueue,
+      "message-id",
+      queuedRunFollowupTurn,
+      false,
+    );
     await touchActiveSessionEntry();
     typing.cleanup();
     return undefined;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -215,13 +215,25 @@ export async function runReplyAgent(params: {
     queueMode: resolvedQueue.mode,
   });
 
+  const queuedRunFollowupTurn = createFollowupRunner({
+    opts,
+    typing,
+    typingMode,
+    sessionEntry: activeSessionEntry,
+    sessionStore: activeSessionStore,
+    sessionKey,
+    storePath,
+    defaultModel,
+    agentCfgContextTokens,
+  });
+
   if (activeRunQueueAction === "drop") {
     typing.cleanup();
     return undefined;
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
+    enqueueFollowupRun(queueKey, followupRun, resolvedQueue, "message-id", queuedRunFollowupTurn);
     await touchActiveSessionEntry();
     typing.cleanup();
     return undefined;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -73,6 +73,7 @@ export async function runReplyAgent(params: {
   shouldSteer: boolean;
   shouldFollowup: boolean;
   isActive: boolean;
+  isRunActive?: () => boolean;
   isStreaming: boolean;
   opts?: GetReplyOptions;
   typing: TypingController;
@@ -104,6 +105,7 @@ export async function runReplyAgent(params: {
     shouldSteer,
     shouldFollowup,
     isActive,
+    isRunActive,
     isStreaming,
     opts,
     typing,
@@ -241,6 +243,11 @@ export async function runReplyAgent(params: {
       queuedRunFollowupTurn,
       false,
     );
+    // Re-check liveness after enqueue so a stale active snapshot cannot leave
+    // the followup queue idle if the original run already finished.
+    if (!isRunActive?.()) {
+      finalizeWithFollowup(undefined, queueKey, queuedRunFollowupTurn);
+    }
     await touchActiveSessionEntry();
     typing.cleanup();
     return undefined;

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -585,6 +585,7 @@ export async function runPreparedReply(
     shouldSteer,
     shouldFollowup,
     isActive,
+    isRunActive: () => isEmbeddedPiRunActive(sessionIdFinal),
     isStreaming,
     opts,
     typing,

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -178,6 +178,7 @@ export function scheduleFollowupDrain(
       queue.draining = false;
       if (queue.items.length === 0 && queue.droppedCount === 0) {
         FOLLOWUP_QUEUES.delete(key);
+        clearFollowupDrainCallback(key);
       } else {
         scheduleFollowupDrain(key, effectiveRunFollowup);
       }

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -22,6 +22,13 @@ const FOLLOWUP_RUN_CALLBACKS = resolveGlobalMap<string, (run: FollowupRun) => Pr
   FOLLOWUP_DRAIN_CALLBACKS_KEY,
 );
 
+export function rememberFollowupDrainCallback(
+  key: string,
+  runFollowup: (run: FollowupRun) => Promise<void>,
+): void {
+  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
+}
+
 export function clearFollowupDrainCallback(key: string): void {
   FOLLOWUP_RUN_CALLBACKS.delete(key);
 }
@@ -78,7 +85,7 @@ export function scheduleFollowupDrain(
   }
   // Cache callback only when a drain actually starts. Avoid keeping stale
   // callbacks around from finalize calls where no queue work is pending.
-  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
+  rememberFollowupDrainCallback(key, runFollowup);
   void (async () => {
     try {
       const collectState = { forceIndividualCollect: false };

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -83,9 +83,10 @@ export function scheduleFollowupDrain(
   if (!queue) {
     return;
   }
+  const effectiveRunFollowup = FOLLOWUP_RUN_CALLBACKS.get(key) ?? runFollowup;
   // Cache callback only when a drain actually starts. Avoid keeping stale
   // callbacks around from finalize calls where no queue work is pending.
-  rememberFollowupDrainCallback(key, runFollowup);
+  rememberFollowupDrainCallback(key, effectiveRunFollowup);
   void (async () => {
     try {
       const collectState = { forceIndividualCollect: false };
@@ -104,7 +105,7 @@ export function scheduleFollowupDrain(
             collectState,
             isCrossChannel,
             items: queue.items,
-            run: runFollowup,
+            run: effectiveRunFollowup,
           });
           if (collectDrainResult === "empty") {
             break;
@@ -128,7 +129,7 @@ export function scheduleFollowupDrain(
             summary,
             renderItem: (item, idx) => `---\nQueued #${idx + 1}\n${item.prompt}`.trim(),
           });
-          await runFollowup({
+          await effectiveRunFollowup({
             prompt,
             run,
             enqueuedAt: Date.now(),
@@ -149,7 +150,7 @@ export function scheduleFollowupDrain(
           }
           if (
             !(await drainNextQueueItem(queue.items, async (item) => {
-              await runFollowup({
+              await effectiveRunFollowup({
                 prompt: summaryPrompt,
                 run,
                 enqueuedAt: Date.now(),
@@ -166,7 +167,7 @@ export function scheduleFollowupDrain(
           continue;
         }
 
-        if (!(await drainNextQueueItem(queue.items, runFollowup))) {
+        if (!(await drainNextQueueItem(queue.items, effectiveRunFollowup))) {
           break;
         }
       }
@@ -178,7 +179,7 @@ export function scheduleFollowupDrain(
       if (queue.items.length === 0 && queue.droppedCount === 0) {
         FOLLOWUP_QUEUES.delete(key);
       } else {
-        scheduleFollowupDrain(key, runFollowup);
+        scheduleFollowupDrain(key, effectiveRunFollowup);
       }
     }
   })();

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,6 +1,6 @@
 import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
 import { applyQueueDropPolicy, shouldSkipQueueItem } from "../../../utils/queue-helpers.js";
-import { kickFollowupDrainIfIdle } from "./drain.js";
+import { kickFollowupDrainIfIdle, rememberFollowupDrainCallback } from "./drain.js";
 import { getExistingFollowupQueue, getFollowupQueue } from "./state.js";
 import type { FollowupRun, QueueDedupeMode, QueueSettings } from "./types.js";
 
@@ -59,6 +59,7 @@ export function enqueueFollowupRun(
   run: FollowupRun,
   settings: QueueSettings,
   dedupeMode: QueueDedupeMode = "message-id",
+  runFollowup?: (run: FollowupRun) => Promise<void>,
 ): boolean {
   const queue = getFollowupQueue(key, settings);
   const recentMessageIdKey = dedupeMode !== "none" ? buildRecentMessageIdKey(run, key) : undefined;
@@ -91,6 +92,9 @@ export function enqueueFollowupRun(
   queue.items.push(run);
   if (recentMessageIdKey) {
     RECENT_QUEUE_MESSAGE_IDS.check(recentMessageIdKey);
+  }
+  if (runFollowup) {
+    rememberFollowupDrainCallback(key, runFollowup);
   }
   // If drain finished and deleted the queue before this item arrived, a new queue
   // object was created (draining: false) but nobody scheduled a drain for it.

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -60,6 +60,7 @@ export function enqueueFollowupRun(
   settings: QueueSettings,
   dedupeMode: QueueDedupeMode = "message-id",
   runFollowup?: (run: FollowupRun) => Promise<void>,
+  restartIfIdle = true,
 ): boolean {
   const queue = getFollowupQueue(key, settings);
   const recentMessageIdKey = dedupeMode !== "none" ? buildRecentMessageIdKey(run, key) : undefined;
@@ -99,7 +100,7 @@ export function enqueueFollowupRun(
   // If drain finished and deleted the queue before this item arrived, a new queue
   // object was created (draining: false) but nobody scheduled a drain for it.
   // Use the cached callback to restart the drain now.
-  if (!queue.draining) {
+  if (restartIfIdle && !queue.draining) {
     kickFollowupDrainIfIdle(key);
   }
   return true;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1685,6 +1685,33 @@ describe("followup queue drain restart after idle window", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]?.prompt).toBe("before-clear");
   });
+
+  it("clears the remembered callback after a queue drains fully", async () => {
+    const key = `test-auto-clear-callback-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const firstProcessed = createDeferred<void>();
+
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      firstProcessed.resolve();
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "before-idle" }), settings);
+    scheduleFollowupDrain(key, runFollowup);
+    await firstProcessed.promise;
+
+    // Let the idle drain finish and clear its callback.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // Enqueueing after a clean drain should not auto-start anything until a
+    // fresh finalize path supplies a new callback.
+    enqueueFollowupRun(key, createRun({ prompt: "after-idle" }), settings);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toBe("before-idle");
+  });
 });
 
 const emptyCfg = {} as OpenClawConfig;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1496,6 +1496,45 @@ describe("followup queue drain restart after idle window", () => {
     expect(calls[1]?.prompt).toBe("after-idle");
   });
 
+  it("restarts an idle drain with the newest followup callback", async () => {
+    const key = `test-idle-window-fresh-callback-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const staleCalls: FollowupRun[] = [];
+    const freshCalls: FollowupRun[] = [];
+    const firstProcessed = createDeferred<void>();
+    const secondProcessed = createDeferred<void>();
+
+    const staleFollowup = async (run: FollowupRun) => {
+      staleCalls.push(run);
+      if (staleCalls.length === 1) {
+        firstProcessed.resolve();
+      }
+    };
+    const freshFollowup = async (run: FollowupRun) => {
+      freshCalls.push(run);
+      secondProcessed.resolve();
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "before-idle" }), settings);
+    scheduleFollowupDrain(key, staleFollowup);
+    await firstProcessed.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    enqueueFollowupRun(
+      key,
+      createRun({ prompt: "after-idle" }),
+      settings,
+      "message-id",
+      freshFollowup,
+    );
+    await secondProcessed.promise;
+
+    expect(staleCalls).toHaveLength(1);
+    expect(staleCalls[0]?.prompt).toBe("before-idle");
+    expect(freshCalls).toHaveLength(1);
+    expect(freshCalls[0]?.prompt).toBe("after-idle");
+  });
+
   it("restarts an idle drain across distinct enqueue and drain module instances", async () => {
     const drainA = await importFreshModule<typeof import("./queue/drain.js")>(
       import.meta.url,

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1535,6 +1535,40 @@ describe("followup queue drain restart after idle window", () => {
     expect(freshCalls[0]?.prompt).toBe("after-idle");
   });
 
+  it("does not auto-start a drain when a busy run only refreshes the callback", async () => {
+    const key = `test-busy-run-refreshes-callback-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const staleCalls: FollowupRun[] = [];
+    const freshCalls: FollowupRun[] = [];
+
+    const staleFollowup = async (run: FollowupRun) => {
+      staleCalls.push(run);
+    };
+    const freshFollowup = async (run: FollowupRun) => {
+      freshCalls.push(run);
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({ prompt: "queued-while-busy" }),
+      settings,
+      "message-id",
+      freshFollowup,
+      false,
+    );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(freshCalls).toHaveLength(0);
+
+    scheduleFollowupDrain(key, staleFollowup);
+    await vi.waitFor(() => {
+      expect(freshCalls).toHaveLength(1);
+    });
+
+    expect(staleCalls).toHaveLength(0);
+    expect(freshCalls[0]?.prompt).toBe("queued-while-busy");
+  });
+
   it("restarts an idle drain across distinct enqueue and drain module instances", async () => {
     const drainA = await importFreshModule<typeof import("./queue/drain.js")>(
       import.meta.url,


### PR DESCRIPTION
## Summary

- Problem: Telegram inbound debounce buffered a same-chat message without reserving its execution slot, so a later message for the same chat could overtake the timer-backed flush and receive the earlier reply out of order.
- Why it matters: after a long debounced turn, replies could appear shifted by one in Telegram, matching the user-visible desync reported in #52982.
- What changed: reserve per-key flush order inside `createInboundDebouncer(...)`, serialize later same-key work behind that reservation, and add both a shared debouncer regression and a Telegram middleware-level regression.
- What did NOT change (scope boundary): this does not change queue/followup routing, dispatcher semantics, or unrelated group-mention behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52982
- Related #31902

## User-visible / Behavior Changes

Telegram same-chat debounced messages now keep reply order even when the first run is still active when the second debounce window fires.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram inbound debounce path
- Relevant config (redacted): `messages.inbound.debounceMs=4321`, Telegram DM policy open for test harness

### Steps

1. Send Telegram message A in a debounced chat and let its debounce timer fire.
2. Keep A's reply generation active so its run has started but not finished.
3. Send message B in the same chat and let B's debounce timer fire.

### Expected

- Message B stays queued behind message A and replies are delivered in A, then B order.

### Actual

- Before this change, B could start and deliver before A because the buffered A flush had not reserved same-key execution order.
- After this change, both the shared debouncer regression and Telegram regression keep A ahead of B.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/auto-reply/inbound.test.ts -t "createInboundDebouncer"`
  - `pnpm test -- extensions/telegram/src/bot.create-telegram-bot.test.ts -t "preserves same-chat reply order when a debounced run is still active"`
  - `pnpm test -- extensions/telegram/src/bot.create-telegram-bot.test.ts`
  - `scripts/committer "Telegram: preserve inbound debounce order" ...` (`pnpm check` passed inside the wrapper)
- Edge cases checked:
  - timer-backed buffered flush already started
  - later same-key non-debounced work stays behind the pending buffered flush
  - Telegram sequentialize + debounce integration keeps first/second reply order intact
- What you did **not** verify:
  - full cross-channel manual repro outside Telegram
  - `pnpm test -- src/auto-reply/inbound.test.ts` currently still has unrelated existing failures in `resolveGroupRequireMention` on current `main`, so verification stayed scoped to the `createInboundDebouncer` slice

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commit `0f2b99fa03`
- Files/config to restore:
  - `src/auto-reply/inbound-debounce.ts`
  - `src/auto-reply/inbound.test.ts`
  - `extensions/telegram/src/bot.create-telegram-bot.test.ts`
- Known bad symptoms reviewers should watch for:
  - buffered same-chat turns starting concurrently again
  - Telegram replies for adjacent debounced turns arriving in reverse order

## Risks and Mitigations

- Risk:
  - Reserving same-key execution order could accidentally serialize unrelated buffered work for too long if key scoping is too broad.
  - Mitigation:
  - The reservation is strictly per debounce key, and the new shared regression covers the exact timer-backed overtake case.
