### PR TITLE
fix(reply): preserve debounced followup ordering

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -165,6 +165,57 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(harness.sequentializeKey).toBe(getTelegramSequentialKey);
   });
+  it("keeps the message handler pending until inbound debounce flush completes", async () => {
+    vi.useFakeTimers();
+    try {
+      loadConfig.mockReturnValue({
+        channels: {
+          telegram: { dmPolicy: "open", allowFrom: ["*"] },
+        },
+        messages: {
+          inbound: {
+            debounceMs: 50,
+          },
+        },
+      });
+      replySpy.mockImplementation(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+        await opts?.onReplyStart?.();
+        return undefined;
+      });
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      let settled = false;
+      const pending = handler({
+        message: {
+          chat: { id: 1234, type: "private" },
+          text: "hello world",
+          date: 1736380800,
+          message_id: 42,
+          from: { id: 99, username: "ada_bot" },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      }).then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(49);
+      expect(settled).toBe(false);
+      expect(replySpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pending;
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -37,6 +37,8 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  pending: Promise<void>;
+  resolvePending: () => void;
 };
 
 export type InboundDebounceCreateParams<T> = {
@@ -51,6 +53,14 @@ export type InboundDebounceCreateParams<T> = {
 export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>) {
   const buffers = new Map<string, DebounceBuffer<T>>();
   const defaultDebounceMs = Math.max(0, Math.trunc(params.debounceMs));
+
+  const createPending = () => {
+    let resolvePending!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      resolvePending = resolve;
+    });
+    return { pending, resolvePending };
+  };
 
   const resolveDebounceMs = (item: T) => {
     const resolved = params.resolveDebounceMs?.(item);
@@ -73,6 +83,8 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       await params.onFlush(buffer.items);
     } catch (err) {
       params.onError?.(err, buffer.items);
+    } finally {
+      buffer.resolvePending();
     }
   };
 
@@ -116,12 +128,21 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
       existing.items.push(item);
       existing.debounceMs = debounceMs;
       scheduleFlush(key, existing);
+      await existing.pending;
       return;
     }
 
-    const buffer: DebounceBuffer<T> = { items: [item], timeout: null, debounceMs };
+    const { pending, resolvePending } = createPending();
+    const buffer: DebounceBuffer<T> = {
+      items: [item],
+      timeout: null,
+      debounceMs,
+      pending,
+      resolvePending,
+    };
     buffers.set(key, buffer);
     scheduleFlush(key, buffer);
+    await buffer.pending;
   };
 
   return { enqueue, flushKey };

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -215,13 +215,25 @@ export async function runReplyAgent(params: {
     queueMode: resolvedQueue.mode,
   });
 
+  const queuedRunFollowupTurn = createFollowupRunner({
+    opts,
+    typing,
+    typingMode,
+    sessionEntry: activeSessionEntry,
+    sessionStore: activeSessionStore,
+    sessionKey,
+    storePath,
+    defaultModel,
+    agentCfgContextTokens,
+  });
+
   if (activeRunQueueAction === "drop") {
     typing.cleanup();
     return undefined;
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
+    enqueueFollowupRun(queueKey, followupRun, resolvedQueue, "message-id", queuedRunFollowupTurn);
     await touchActiveSessionEntry();
     typing.cleanup();
     return undefined;

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -22,6 +22,13 @@ const FOLLOWUP_RUN_CALLBACKS = resolveGlobalMap<string, (run: FollowupRun) => Pr
   FOLLOWUP_DRAIN_CALLBACKS_KEY,
 );
 
+export function rememberFollowupDrainCallback(
+  key: string,
+  runFollowup: (run: FollowupRun) => Promise<void>,
+): void {
+  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
+}
+
 export function clearFollowupDrainCallback(key: string): void {
   FOLLOWUP_RUN_CALLBACKS.delete(key);
 }
@@ -78,7 +85,7 @@ export function scheduleFollowupDrain(
   }
   // Cache callback only when a drain actually starts. Avoid keeping stale
   // callbacks around from finalize calls where no queue work is pending.
-  FOLLOWUP_RUN_CALLBACKS.set(key, runFollowup);
+  rememberFollowupDrainCallback(key, runFollowup);
   void (async () => {
     try {
       const collectState = { forceIndividualCollect: false };

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,6 +1,6 @@
 import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
 import { applyQueueDropPolicy, shouldSkipQueueItem } from "../../../utils/queue-helpers.js";
-import { kickFollowupDrainIfIdle } from "./drain.js";
+import { kickFollowupDrainIfIdle, rememberFollowupDrainCallback } from "./drain.js";
 import { getExistingFollowupQueue, getFollowupQueue } from "./state.js";
 import type { FollowupRun, QueueDedupeMode, QueueSettings } from "./types.js";
 
@@ -59,6 +59,7 @@ export function enqueueFollowupRun(
   run: FollowupRun,
   settings: QueueSettings,
   dedupeMode: QueueDedupeMode = "message-id",
+  runFollowup?: (run: FollowupRun) => Promise<void>,
 ): boolean {
   const queue = getFollowupQueue(key, settings);
   const recentMessageIdKey = dedupeMode !== "none" ? buildRecentMessageIdKey(run, key) : undefined;
@@ -91,6 +92,9 @@ export function enqueueFollowupRun(
   queue.items.push(run);
   if (recentMessageIdKey) {
     RECENT_QUEUE_MESSAGE_IDS.check(recentMessageIdKey);
+  }
+  if (runFollowup) {
+    rememberFollowupDrainCallback(key, runFollowup);
   }
   // If drain finished and deleted the queue before this item arrived, a new queue
   // object was created (draining: false) but nobody scheduled a drain for it.

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1496,6 +1496,45 @@ describe("followup queue drain restart after idle window", () => {
     expect(calls[1]?.prompt).toBe("after-idle");
   });
 
+  it("restarts an idle drain with the newest followup callback", async () => {
+    const key = `test-idle-window-fresh-callback-${Date.now()}`;
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const staleCalls: FollowupRun[] = [];
+    const freshCalls: FollowupRun[] = [];
+    const firstProcessed = createDeferred<void>();
+    const secondProcessed = createDeferred<void>();
+
+    const staleFollowup = async (run: FollowupRun) => {
+      staleCalls.push(run);
+      if (staleCalls.length === 1) {
+        firstProcessed.resolve();
+      }
+    };
+    const freshFollowup = async (run: FollowupRun) => {
+      freshCalls.push(run);
+      secondProcessed.resolve();
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "before-idle" }), settings);
+    scheduleFollowupDrain(key, staleFollowup);
+    await firstProcessed.promise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    enqueueFollowupRun(
+      key,
+      createRun({ prompt: "after-idle" }),
+      settings,
+      "message-id",
+      freshFollowup,
+    );
+    await secondProcessed.promise;
+
+    expect(staleCalls).toHaveLength(1);
+    expect(staleCalls[0]?.prompt).toBe("before-idle");
+    expect(freshCalls).toHaveLength(1);
+    expect(freshCalls[0]?.prompt).toBe("after-idle");
+  });
+
   it("restarts an idle drain across distinct enqueue and drain module instances", async () => {
     const drainA = await importFreshModule<typeof import("./queue/drain.js")>(
       import.meta.url,

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -49,11 +49,58 @@ describe("createChannelInboundDebouncer", () => {
 
       expect(debounceMs).toBe(25);
 
-      await debouncer.enqueue({ id: "a" });
-      await debouncer.enqueue({ id: "a" });
+      const first = debouncer.enqueue({ id: "a" });
+      const second = debouncer.enqueue({ id: "a" });
       await vi.advanceTimersByTimeAsync(30);
+      await Promise.all([first, second]);
 
       expect(flushed).toEqual([["a", "a"]]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps enqueue pending until the debounced flush finishes", async () => {
+    vi.useFakeTimers();
+    try {
+      const flushed = vi.fn();
+      let releaseFlush!: () => void;
+      const flushGate = new Promise<void>((resolve) => {
+        releaseFlush = resolve;
+      });
+      const cfg = {
+        messages: {
+          inbound: {
+            debounceMs: 25,
+          },
+        },
+      } as Parameters<typeof createChannelInboundDebouncer<{ id: string }>>[0]["cfg"];
+
+      const { debouncer } = createChannelInboundDebouncer<{ id: string }>({
+        cfg,
+        channel: "telegram",
+        buildKey: (item) => item.id,
+        onFlush: async (items) => {
+          flushed(items.map((entry) => entry.id));
+          await flushGate;
+        },
+      });
+
+      let settled = false;
+      const pending = debouncer.enqueue({ id: "a" }).then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(flushed).toHaveBeenCalledWith(["a"]);
+      expect(settled).toBe(false);
+
+      releaseFlush();
+      await pending;
+      expect(settled).toBe(true);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary
- make inbound debounced handlers await the actual flush instead of returning after timer scheduling
- refresh the followup queue drain callback from the newest run before idle-drain restarts
- add regression coverage for the generic debounce primitive, the followup idle-window callback race, and Telegram's debounced handler path

## Why
This fixes the reply desync race from #52982 where long outputs could cause responses to arrive one message late on debounced channels.

Fixes #52982.

## Validation
- `pnpm test -- src/channels/inbound-debounce-policy.test.ts src/auto-reply/reply/reply-flow.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts`
- `pnpm build`
