### PR TITLE
Tests: fix fresh-main regressions

### DIFF
--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -81,9 +81,14 @@ const installRunEmbeddedMocks = () => {
       modelRegistry: {},
     }),
   }));
-  vi.doMock("../plugins/provider-runtime.js", () => ({
-    prepareProviderRuntimeAuth: vi.fn(async () => undefined),
-  }));
+  vi.doMock("../plugins/provider-runtime.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
+    return {
+      ...actual,
+      prepareProviderRuntimeAuth: vi.fn(async () => undefined),
+      resolveProviderCapabilitiesWithPlugin: vi.fn(() => undefined),
+    };
+  });
 };
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;

--- a/src/browser/server-context.existing-session.test.ts
+++ b/src/browser/server-context.existing-session.test.ts
@@ -80,13 +80,19 @@ describe("browser server-context existing-session profile", () => {
         { targetId: "7", title: "", url: "https://example.com", type: "page" },
       ])
       .mockResolvedValueOnce([
-        { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
+        { targetId: "7", title: "", url: "https://example.com", type: "page" },
       ])
       .mockResolvedValueOnce([
+        { targetId: "7", title: "", url: "https://example.com", type: "page" },
         { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
       ])
       .mockResolvedValueOnce([
         { targetId: "7", title: "", url: "https://example.com", type: "page" },
+        { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
+      ])
+      .mockResolvedValueOnce([
+        { targetId: "7", title: "", url: "https://example.com", type: "page" },
+        { targetId: "8", title: "", url: "https://openclaw.ai", type: "page" },
       ]);
 
     await live.ensureBrowserAvailable();

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -37,7 +37,6 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
           key: "main",
           kind: "direct",
           updatedAt: null,
-          totalTokens: 3_800,
           inputTokens: 3_800,
           contextTokens: 4_000,
         },
@@ -64,10 +63,72 @@ describe("chat context notice", () => {
     document.body.innerHTML = "";
   });
 
+  it("falls back to default notice colors when theme vars are not hex", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    document.documentElement.style.setProperty("--warn", "rgb(1, 2, 3)");
+    document.documentElement.style.setProperty("--danger", "tomato");
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                totalTokens: 3_800,
+                inputTokens: 3_800,
+                contextTokens: 4_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const notice = container.querySelector<HTMLElement>(".context-notice");
+    expect(notice).not.toBeNull();
+    expect(notice?.style.getPropertyValue("--ctx-color")).toContain("rgb(");
+    expect(notice?.style.getPropertyValue("--ctx-color")).not.toContain("NaN");
+    expect(notice?.style.getPropertyValue("--ctx-bg")).not.toContain("NaN");
+
+    document.documentElement.style.removeProperty("--warn");
+    document.documentElement.style.removeProperty("--danger");
+  });
+
   it("keeps the warning icon badge-sized", async () => {
     const container = document.createElement("div");
     document.body.append(container);
-    render(renderChat(createProps()), container);
+    render(
+      renderChat(
+        createProps({
+          sessions: {
+            ts: 0,
+            path: "",
+            count: 1,
+            defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+            sessions: [
+              {
+                key: "main",
+                kind: "direct",
+                updatedAt: null,
+                totalTokens: 3_800,
+                inputTokens: 3_800,
+                contextTokens: 4_000,
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
     const icon = container.querySelector<SVGElement>(".context-notice__icon");
@@ -80,23 +141,5 @@ describe("chat context notice", () => {
     expect(iconStyle.width).toBe("16px");
     expect(iconStyle.height).toBe("16px");
     expect(icon.getBoundingClientRect().width).toBeLessThan(24);
-  });
-
-  it("falls back to default notice colors when theme vars are not hex", async () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    document.documentElement.style.setProperty("--warn", "rgb(1, 2, 3)");
-    document.documentElement.style.setProperty("--danger", "tomato");
-    render(renderChat(createProps()), container);
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-
-    const notice = container.querySelector<HTMLElement>(".context-notice");
-    expect(notice).not.toBeNull();
-    expect(notice?.style.getPropertyValue("--ctx-color")).toContain("rgb(");
-    expect(notice?.style.getPropertyValue("--ctx-color")).not.toContain("NaN");
-    expect(notice?.style.getPropertyValue("--ctx-bg")).not.toContain("NaN");
-
-    document.documentElement.style.removeProperty("--warn");
-    document.documentElement.style.removeProperty("--danger");
   });
 });

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -37,6 +37,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
           key: "main",
           kind: "direct",
           updatedAt: null,
+          totalTokens: 3_800,
           inputTokens: 3_800,
           contextTokens: 4_000,
         },


### PR DESCRIPTION
## Summary
- fix the chat browser fixture to include total token state expected by the current UI notice logic
- preserve the provider-runtime mock shape in the run-embedded fallback e2e so fresh-main imports initialize cleanly
- update the existing-session browser test tab-list sequence to match the current Chrome MCP readiness flow

## Verification
- CI=1 pnpm --dir ui test -- src/ui/views/chat.browser.test.ts
- CI=1 pnpm test -- src/agents/model-fallback.run-embedded.e2e.test.ts src/browser/server-context.existing-session.test.ts
- pnpm test -- extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts src/agents/model-fallback.run-embedded.e2e.test.ts