### PR TITLE
fix(irc): prevent silent send failures and fix NickServ nick reclaim

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -10,6 +10,17 @@ describe("irc client nickserv", () => {
     ).toEqual(["PRIVMSG NickServ :IDENTIFY secret"]);
   });
 
+  it("builds IDENTIFY with account nick when provided", () => {
+    expect(
+      buildIrcNickServCommands(
+        {
+          password: "secret",
+        },
+        "mrpink",
+      ),
+    ).toEqual(["PRIVMSG NickServ :IDENTIFY mrpink secret"]);
+  });
+
   it("builds REGISTER command when enabled with email", () => {
     expect(
       buildIrcNickServCommands({

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -93,7 +93,10 @@ function buildFallbackNick(nick: string): string {
   return `${base}${suffix}`;
 }
 
-export function buildIrcNickServCommands(options?: IrcNickServOptions): string[] {
+export function buildIrcNickServCommands(
+  options?: IrcNickServOptions,
+  accountNick?: string,
+): string[] {
   if (!options || options.enabled === false) {
     return [];
   }
@@ -102,7 +105,10 @@ export function buildIrcNickServCommands(options?: IrcNickServOptions): string[]
     return [];
   }
   const service = sanitizeIrcTarget(options.service?.trim() || "NickServ");
-  const commands = [`PRIVMSG ${service} :IDENTIFY ${password}`];
+  // Use "IDENTIFY <account> <password>" so it works even when connected
+  // with a fallback nick (e.g. mrpink_ identifying as mrpink).
+  const identifyArgs = accountNick ? `${accountNick} ${password}` : password;
+  const commands = [`PRIVMSG ${service} :IDENTIFY ${identifyArgs}`];
   if (options.register) {
     const registerEmail = sanitizeIrcOutboundText(options.registerEmail ?? "");
     if (!registerEmail) {
@@ -329,7 +335,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           currentNick = nickParam.trim();
         }
         try {
-          const nickServCommands = buildIrcNickServCommands(options.nickserv);
+          const nickServCommands = buildIrcNickServCommands(options.nickserv, desiredNick);
           for (const command of nickServCommands) {
             sendRaw(command);
           }

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -166,6 +166,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
     if (!cleaned) {
       throw new Error("IRC command cannot be empty");
     }
+    if (closed || socket.destroyed) {
+      throw new Error("IRC socket is closed; cannot send");
+    }
     socket.write(`${cleaned}\r\n`);
   };
 
@@ -212,7 +215,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
     const normalizedTarget = sanitizeIrcTarget(target);
     const cleaned = sanitizeIrcOutboundText(text);
     if (!cleaned) {
-      return;
+      throw new Error("IRC message is empty after sanitization");
     }
     let remaining = cleaned;
     while (remaining.length > 0) {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -334,7 +334,8 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
             sendRaw(command);
           }
           // If we're on a fallback nick and have NickServ credentials,
-          // GHOST the desired nick and reclaim it.
+          // wait for IDENTIFY to be processed, then GHOST the desired
+          // nick and reclaim it.
           if (
             currentNick.toLowerCase() !== desiredNick.toLowerCase() &&
             options.nickserv?.enabled !== false &&
@@ -342,15 +343,22 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           ) {
             const service = sanitizeIrcTarget(options.nickserv.service?.trim() || "NickServ");
             const nsPassword = sanitizeIrcOutboundText(options.nickserv.password);
-            sendRaw(`PRIVMSG ${service} :GHOST ${desiredNick} ${nsPassword}`);
-            // Delay the NICK reclaim slightly to let GHOST complete.
+            // Delay GHOST so IDENTIFY has time to complete first.
             setTimeout(() => {
               try {
-                sendRaw(`NICK ${desiredNick}`);
+                sendRaw(`PRIVMSG ${service} :GHOST ${desiredNick} ${nsPassword}`);
               } catch {
                 // Socket may have closed; ignore.
               }
-            }, 1000);
+              // Then reclaim the nick after GHOST processes.
+              setTimeout(() => {
+                try {
+                  sendRaw(`NICK ${desiredNick}`);
+                } catch {
+                  // Socket may have closed; ignore.
+                }
+              }, 2000);
+            }, 2000);
           }
         } catch (err) {
           fail(err);

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -334,8 +334,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
             sendRaw(command);
           }
           // If we're on a fallback nick and have NickServ credentials,
-          // wait for IDENTIFY to be processed, then GHOST the desired
-          // nick and reclaim it.
+          // wait for IDENTIFY to complete, then reclaim the desired nick.
+          // Handles both cases: nick reserved (Ergo enforce-nick) and
+          // nick held by zombie (needs GHOST first).
           if (
             currentNick.toLowerCase() !== desiredNick.toLowerCase() &&
             options.nickserv?.enabled !== false &&
@@ -343,21 +344,22 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           ) {
             const service = sanitizeIrcTarget(options.nickserv.service?.trim() || "NickServ");
             const nsPassword = sanitizeIrcOutboundText(options.nickserv.password);
-            // Delay GHOST so IDENTIFY has time to complete first.
+            // Wait for IDENTIFY to be processed by NickServ.
             setTimeout(() => {
               try {
+                // GHOST in case a zombie holds the nick (harmless if nick is free).
                 sendRaw(`PRIVMSG ${service} :GHOST ${desiredNick} ${nsPassword}`);
               } catch {
                 // Socket may have closed; ignore.
               }
-              // Then reclaim the nick after GHOST processes.
+              // Then reclaim — works whether nick was reserved or ghosted.
               setTimeout(() => {
                 try {
                   sendRaw(`NICK ${desiredNick}`);
                 } catch {
                   // Socket may have closed; ignore.
                 }
-              }, 2000);
+              }, 1500);
             }, 2000);
           }
         } catch (err) {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -333,6 +333,25 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           for (const command of nickServCommands) {
             sendRaw(command);
           }
+          // If we're on a fallback nick and have NickServ credentials,
+          // GHOST the desired nick and reclaim it.
+          if (
+            currentNick.toLowerCase() !== desiredNick.toLowerCase() &&
+            options.nickserv?.enabled !== false &&
+            options.nickserv?.password?.trim()
+          ) {
+            const service = sanitizeIrcTarget(options.nickserv.service?.trim() || "NickServ");
+            const nsPassword = sanitizeIrcOutboundText(options.nickserv.password);
+            sendRaw(`PRIVMSG ${service} :GHOST ${desiredNick} ${nsPassword}`);
+            // Delay the NICK reclaim slightly to let GHOST complete.
+            setTimeout(() => {
+              try {
+                sendRaw(`NICK ${desiredNick}`);
+              } catch {
+                // Socket may have closed; ignore.
+              }
+            }, 1000);
+          }
         } catch (err) {
           fail(err);
         }

--- a/extensions/irc/src/send.ts
+++ b/extensions/irc/src/send.ts
@@ -72,8 +72,14 @@ export async function sendMessageIrc(
         connectTimeoutMs: 12000,
       }),
     );
-    transient.sendPrivmsg(target, payload);
-    transient.quit("sent");
+    try {
+      transient.sendPrivmsg(target, payload);
+      // Give the server time to process the PRIVMSG before disconnecting.
+      // IRC has no delivery ACK, so a short drain delay is the best we can do.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    } finally {
+      transient.quit("sent");
+    }
   }
 
   runtime.channel.activity.record({


### PR DESCRIPTION
## Summary

Fixes multiple issues causing IRC messages to fail silently and NickServ nick reclamation to not work when connecting with a fallback nick.

## Changes

### Silent send failures
1. **`sendPrivmsg` throws on empty sanitized text** — previously returned silently, so callers never knew the message was dropped.
2. **`sendRaw` checks for closed/destroyed socket** — prevents silent writes to dead connections.
3. **Transient client drain delay** — adds 500ms wait between sending PRIVMSG and calling `quit()` on throwaway connections. Without this, the QUIT could race ahead of the message on the wire.

### NickServ nick reclamation
4. **`IDENTIFY <account> <password>` format** — when connected with a fallback nick (e.g. `mrpink_`), NickServ needs the account name explicitly. Previously sent just `IDENTIFY <password>`, which fails because the fallback nick isn't a registered account.
5. **Post-IDENTIFY GHOST + NICK** — after identifying, GHOSTs any zombie holding the desired nick, then sends `NICK` to reclaim. Handles both reserved-nick (Ergo enforce-nick) and zombie session cases.

## Testing
- All 53 existing IRC tests pass
- 1 new test added for `IDENTIFY <account> <password>` format
- All lints and checks clean
- Manually tested against Ergo IRCd — confirmed nick reclaim works end-to-end