### PR TITLE
fix(clawhub): resolve auth token for skill browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/probe: stop successful gateway handshakes from timing out as unreachable while post-connect detail RPCs are still loading, so slow devices report a reachable RPC failure instead of a false negative dead gateway. Fixes #52927. Thanks @vincentkoc.
 - Plugins/message tool: make Discord `components` and Slack `blocks` optional again so pin/unpin/react flows stop failing schema validation and Slack media sends are no longer forced into an invalid blocks-plus-media payload. Fixes #52970 and #52962. Thanks @vincentkoc.
 - Plugins/Feishu: route `message(..., media=...)` sends through the Feishu outbound media path so file and image attachments actually send instead of being silently dropped. Fixes #52962. Thanks @vincentkoc.
+- ClawHub/skills: resolve the local ClawHub auth token for gateway skill browsing and switch browse-all requests to search so ClawControl stops falling into unauthenticated 429s and empty authenticated skill lists. Fixes #52949. Thanks @vincentkoc.
 
 ## 2026.3.22
 

--- a/src/agents/skills-clawhub.test.ts
+++ b/src/agents/skills-clawhub.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchClawHubSkillDetailMock = vi.fn();
 const downloadClawHubSkillArchiveMock = vi.fn();
+const listClawHubSkillsMock = vi.fn();
 const resolveClawHubBaseUrlMock = vi.fn(() => "https://clawhub.ai");
+const searchClawHubSkillsMock = vi.fn();
 const withExtractedArchiveRootMock = vi.fn();
 const installPackageDirMock = vi.fn();
 const fileExistsMock = vi.fn();
@@ -10,9 +12,9 @@ const fileExistsMock = vi.fn();
 vi.mock("../infra/clawhub.js", () => ({
   fetchClawHubSkillDetail: fetchClawHubSkillDetailMock,
   downloadClawHubSkillArchive: downloadClawHubSkillArchiveMock,
-  listClawHubSkills: vi.fn(),
+  listClawHubSkills: listClawHubSkillsMock,
   resolveClawHubBaseUrl: resolveClawHubBaseUrlMock,
-  searchClawHubSkills: vi.fn(),
+  searchClawHubSkills: searchClawHubSkillsMock,
 }));
 
 vi.mock("../infra/install-flow.js", () => ({
@@ -27,13 +29,15 @@ vi.mock("../infra/archive.js", () => ({
   fileExists: fileExistsMock,
 }));
 
-const { installSkillFromClawHub } = await import("./skills-clawhub.js");
+const { installSkillFromClawHub, searchSkillsFromClawHub } = await import("./skills-clawhub.js");
 
 describe("skills-clawhub", () => {
   beforeEach(() => {
     fetchClawHubSkillDetailMock.mockReset();
     downloadClawHubSkillArchiveMock.mockReset();
+    listClawHubSkillsMock.mockReset();
     resolveClawHubBaseUrlMock.mockReset();
+    searchClawHubSkillsMock.mockReset();
     withExtractedArchiveRootMock.mockReset();
     installPackageDirMock.mockReset();
     fileExistsMock.mockReset();
@@ -56,6 +60,7 @@ describe("skills-clawhub", () => {
       archivePath: "/tmp/agentreceipt.zip",
       integrity: "sha256-test",
     });
+    searchClawHubSkillsMock.mockResolvedValue([]);
     withExtractedArchiveRootMock.mockImplementation(async (params) => {
       expect(params.rootMarkers).toEqual(["SKILL.md"]);
       return await params.onExtracted("/tmp/extracted-skill");
@@ -88,5 +93,35 @@ describe("skills-clawhub", () => {
       version: "1.0.0",
       targetDir: "/tmp/workspace/skills/agentreceipt",
     });
+  });
+
+  it("uses search for browse-all skill discovery", async () => {
+    searchClawHubSkillsMock.mockResolvedValueOnce([
+      {
+        score: 1,
+        slug: "calendar",
+        displayName: "Calendar",
+        summary: "Calendar skill",
+        version: "1.2.3",
+        updatedAt: 123,
+      },
+    ]);
+
+    await expect(searchSkillsFromClawHub({ limit: 20 })).resolves.toEqual([
+      {
+        score: 1,
+        slug: "calendar",
+        displayName: "Calendar",
+        summary: "Calendar skill",
+        version: "1.2.3",
+        updatedAt: 123,
+      },
+    ]);
+    expect(searchClawHubSkillsMock).toHaveBeenCalledWith({
+      query: "*",
+      limit: 20,
+      baseUrl: undefined,
+    });
+    expect(listClawHubSkillsMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/skills-clawhub.ts
+++ b/src/agents/skills-clawhub.ts
@@ -5,7 +5,6 @@ import { fileExists } from "../infra/archive.js";
 import {
   downloadClawHubSkillArchive,
   fetchClawHubSkillDetail,
-  listClawHubSkills,
   resolveClawHubBaseUrl,
   searchClawHubSkills,
   type ClawHubSkillDetail,
@@ -165,25 +164,11 @@ export async function searchSkillsFromClawHub(params: {
   limit?: number;
   baseUrl?: string;
 }): Promise<ClawHubSkillSearchResult[]> {
-  if (params.query?.trim()) {
-    return await searchClawHubSkills({
-      query: params.query,
-      limit: params.limit,
-      baseUrl: params.baseUrl,
-    });
-  }
-  const list = await listClawHubSkills({
+  return await searchClawHubSkills({
+    query: params.query?.trim() || "*",
     limit: params.limit,
     baseUrl: params.baseUrl,
   });
-  return list.items.map((item) => ({
-    score: 0,
-    slug: item.slug,
-    displayName: item.displayName,
-    summary: item.summary,
-    version: item.latestVersion?.version,
-    updatedAt: item.updatedAt,
-  }));
 }
 
 async function resolveInstallVersion(params: {

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -1,12 +1,26 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   parseClawHubPluginSpec,
+  resolveClawHubAuthToken,
+  searchClawHubSkills,
   resolveLatestVersionFromPackage,
   satisfiesGatewayMinimum,
   satisfiesPluginApiRange,
 } from "./clawhub.js";
 
 describe("clawhub helpers", () => {
+  afterEach(() => {
+    delete process.env.OPENCLAW_CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_TOKEN;
+    delete process.env.CLAWHUB_AUTH_TOKEN;
+    delete process.env.OPENCLAW_CLAWHUB_CONFIG_PATH;
+    delete process.env.CLAWHUB_CONFIG_PATH;
+    delete process.env.XDG_CONFIG_HOME;
+  });
+
   it("parses explicit ClawHub package specs", () => {
     expect(parseClawHubPluginSpec("clawhub:demo")).toEqual({
       name: "demo",
@@ -63,5 +77,33 @@ describe("clawhub helpers", () => {
     expect(satisfiesGatewayMinimum("OpenClaw 2026.3.22", "2026.3.0")).toBe(true);
     expect(satisfiesGatewayMinimum("2026.2.9", "2026.3.0")).toBe(false);
     expect(satisfiesGatewayMinimum("unknown", "2026.3.0")).toBe(false);
+  });
+
+  it("resolves ClawHub auth token from config.json", async () => {
+    const configRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-clawhub-config-"));
+    process.env.XDG_CONFIG_HOME = configRoot;
+    await fs.mkdir(path.join(configRoot, "clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(configRoot, "clawhub", "config.json"),
+      JSON.stringify({ auth: { token: "cfg-token-123" } }),
+      "utf8",
+    );
+
+    await expect(resolveClawHubAuthToken()).resolves.toBe("cfg-token-123");
+  });
+
+  it("injects resolved auth token into ClawHub requests", async () => {
+    process.env.OPENCLAW_CLAWHUB_TOKEN = "env-token-123";
+    const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      expect(url).toContain("/api/v1/search");
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer env-token-123");
+      return new Response(JSON.stringify({ results: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+
+    await expect(searchClawHubSkills({ query: "calendar", fetchImpl })).resolves.toEqual([]);
   });
 });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -179,6 +179,17 @@ type ClawHubRequestParams = {
   fetchImpl?: FetchLike;
 };
 
+type ClawHubConfigLike = {
+  token?: unknown;
+  accessToken?: unknown;
+  authToken?: unknown;
+  apiToken?: unknown;
+  auth?: ClawHubConfigLike | null;
+  session?: ClawHubConfigLike | null;
+  credentials?: ClawHubConfigLike | null;
+  user?: ClawHubConfigLike | null;
+};
+
 export class ClawHubRequestError extends Error {
   readonly status: number;
   readonly requestPath: string;
@@ -200,6 +211,56 @@ function normalizeBaseUrl(baseUrl?: string): string {
     DEFAULT_CLAWHUB_URL;
   const value = (baseUrl?.trim() || envValue).replace(/\/+$/, "");
   return value || DEFAULT_CLAWHUB_URL;
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function extractTokenFromClawHubConfig(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as ClawHubConfigLike;
+  return (
+    readNonEmptyString(record.accessToken) ??
+    readNonEmptyString(record.authToken) ??
+    readNonEmptyString(record.apiToken) ??
+    readNonEmptyString(record.token) ??
+    extractTokenFromClawHubConfig(record.auth) ??
+    extractTokenFromClawHubConfig(record.session) ??
+    extractTokenFromClawHubConfig(record.credentials) ??
+    extractTokenFromClawHubConfig(record.user)
+  );
+}
+
+function resolveClawHubConfigPath(): string {
+  const explicit =
+    process.env.OPENCLAW_CLAWHUB_CONFIG_PATH?.trim() || process.env.CLAWHUB_CONFIG_PATH?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME?.trim();
+  const configHome =
+    xdgConfigHome && xdgConfigHome.length > 0 ? xdgConfigHome : path.join(os.homedir(), ".config");
+  return path.join(configHome, "clawhub", "config.json");
+}
+
+export async function resolveClawHubAuthToken(): Promise<string | undefined> {
+  const envToken =
+    process.env.OPENCLAW_CLAWHUB_TOKEN?.trim() ||
+    process.env.CLAWHUB_TOKEN?.trim() ||
+    process.env.CLAWHUB_AUTH_TOKEN?.trim();
+  if (envToken) {
+    return envToken;
+  }
+
+  try {
+    const raw = await fs.readFile(resolveClawHubConfigPath(), "utf8");
+    return extractTokenFromClawHubConfig(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
 }
 
 function parseComparableSemver(version: string | null | undefined): ComparableSemver | null {
@@ -370,6 +431,7 @@ async function clawhubRequest(
   params: ClawHubRequestParams,
 ): Promise<{ response: Response; url: URL }> {
   const url = buildUrl(params);
+  const token = params.token?.trim() || (await resolveClawHubAuthToken());
   const controller = new AbortController();
   const timeout = setTimeout(
     () =>
@@ -382,7 +444,7 @@ async function clawhubRequest(
   );
   try {
     const response = await (params.fetchImpl ?? fetch)(url, {
-      headers: params.token ? { Authorization: `Bearer ${params.token}` } : undefined,
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
       signal: controller.signal,
     });
     return { response, url };


### PR DESCRIPTION
## Summary
- resolve the local ClawHub auth token from env or ClawHub config before marketplace requests
- route no-query skill browsing through ClawHub search instead of the authenticated skills list endpoint
- add focused regressions for token propagation and browse-all search behavior

## Testing
- `NODENV_VERSION=24.13.0 pnpm test -- src/infra/clawhub.test.ts`
- `NODENV_VERSION=24.13.0 pnpm test -- src/agents/skills-clawhub.test.ts`
- `NODENV_VERSION=24.13.0 pnpm build`

Fixes #52949