### PR TITLE
fix(browser): refresh browser route config from disk

### DIFF
--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -1,4 +1,8 @@
-import { createConfigIO, getRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  createConfigIO,
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSnapshotRefreshState,
+} from "../config/config.js";
 import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
@@ -79,7 +83,11 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
   // derived defaults that depend on non-browser config like gateway.port.
   const diskCfg = createConfigIO().loadConfig();
   const runtimeCfg = getRuntimeConfigSnapshot();
-  const cfg = runtimeCfg ? { ...runtimeCfg, browser: diskCfg.browser } : diskCfg;
+  const refreshState = getRuntimeConfigSnapshotRefreshState();
+  const cfg =
+    runtimeCfg && refreshState === "idle"
+      ? { ...runtimeCfg, browser: diskCfg.browser }
+      : (runtimeCfg ?? diskCfg);
   const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
   applyResolvedConfig(params.current, freshResolved);
 }

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -1,4 +1,4 @@
-import { createConfigIO } from "../config/config.js";
+import { createConfigIO, getRuntimeConfigSnapshot } from "../config/config.js";
 import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
@@ -73,11 +73,13 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
     return;
   }
 
-  // Route-level browser config hot reload must reflect the latest on-disk browser config,
-  // even when the broader runtime is still holding a stale config snapshot.
-  // Use createConfigIO().loadConfig() directly so browser routes pick up external/manual
-  // openclaw.json edits without flushing the global runtime snapshot or loadConfig() cache.
-  const cfg = createConfigIO().loadConfig();
+  // Route-level browser config hot reload should pick up the latest on-disk browser settings
+  // without bypassing the active runtime snapshot for unrelated root config. This keeps
+  // browser.* edits visible to routes while still honoring runtime-snapshot safety for
+  // derived defaults that depend on non-browser config like gateway.port.
+  const diskCfg = createConfigIO().loadConfig();
+  const runtimeCfg = getRuntimeConfigSnapshot();
+  const cfg = runtimeCfg ? { ...runtimeCfg, browser: diskCfg.browser } : diskCfg;
   const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
   applyResolvedConfig(params.current, freshResolved);
 }

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -1,4 +1,4 @@
-import { createConfigIO, getRuntimeConfigSnapshot } from "../config/config.js";
+import { createConfigIO } from "../config/config.js";
 import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
@@ -73,10 +73,11 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
     return;
   }
 
-  // Route-level browser config hot reload should observe on-disk changes immediately.
-  // The shared loadConfig() helper may return a cached snapshot for the configured TTL,
-  // which can leave request-time browser guards stale (for example evaluateEnabled).
-  const cfg = getRuntimeConfigSnapshot() ?? createConfigIO().loadConfig();
+  // Route-level browser config hot reload must reflect the latest on-disk browser config,
+  // even when the broader runtime is still holding a stale config snapshot.
+  // Use createConfigIO().loadConfig() directly so browser routes pick up external/manual
+  // openclaw.json edits without flushing the global runtime snapshot or loadConfig() cache.
+  const cfg = createConfigIO().loadConfig();
   const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
   applyResolvedConfig(params.current, freshResolved);
 }

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -1,6 +1,7 @@
 import {
   createConfigIO,
   getRuntimeConfigSnapshot,
+  getRuntimeConfigSnapshotFailedBrowserConfigJson,
   getRuntimeConfigSnapshotRefreshState,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -69,6 +70,27 @@ function applyResolvedConfig(
   }
 }
 
+function shouldMergeDiskBrowserConfig(params: {
+  runtimeCfg: OpenClawConfig | null;
+  refreshState: "idle" | "pending" | "failed";
+  diskCfg: OpenClawConfig;
+}): boolean {
+  if (!params.runtimeCfg) {
+    return false;
+  }
+  if (params.refreshState === "idle") {
+    return true;
+  }
+  if (params.refreshState === "pending") {
+    return false;
+  }
+  const failedBrowserConfigJson = getRuntimeConfigSnapshotFailedBrowserConfigJson();
+  if (!failedBrowserConfigJson) {
+    return false;
+  }
+  return JSON.stringify(params.diskCfg.browser ?? null) !== failedBrowserConfigJson;
+}
+
 export function refreshResolvedBrowserConfigFromDisk(params: {
   current: BrowserServerState;
   refreshConfigFromDisk: boolean;
@@ -95,10 +117,9 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
     applyResolvedConfig(params.current, freshResolved);
     return;
   }
-  const cfg =
-    runtimeCfg && refreshState === "idle"
-      ? { ...runtimeCfg, browser: diskCfg.browser }
-      : (runtimeCfg ?? diskCfg);
+  const cfg = shouldMergeDiskBrowserConfig({ runtimeCfg, refreshState, diskCfg })
+    ? { ...runtimeCfg!, browser: diskCfg.browser }
+    : (runtimeCfg ?? diskCfg);
   const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
   applyResolvedConfig(params.current, freshResolved);
 }

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -113,8 +113,6 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
     if (!runtimeCfg) {
       throw error;
     }
-    const freshResolved = resolveBrowserConfig(runtimeCfg.browser, runtimeCfg);
-    applyResolvedConfig(params.current, freshResolved);
     return;
   }
   const cfg = shouldMergeDiskBrowserConfig({ runtimeCfg, refreshState, diskCfg })

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -8,6 +8,12 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
+function loadDiskConfigForBrowserRouteHotReload(): OpenClawConfig {
+  // Browser-route hot reload should not let read-time config.env application mutate the
+  // live process environment before a runtime snapshot refresh has successfully activated.
+  return createConfigIO({ env: { ...process.env } }).loadConfig();
+}
+
 function changedProfileInvariants(
   current: ResolvedBrowserProfile,
   next: ResolvedBrowserProfile,
@@ -108,7 +114,7 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
   const refreshState = getRuntimeConfigSnapshotRefreshState();
   let diskCfg: OpenClawConfig;
   try {
-    diskCfg = createConfigIO().loadConfig();
+    diskCfg = loadDiskConfigForBrowserRouteHotReload();
   } catch (error) {
     if (!runtimeCfg) {
       throw error;

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -118,8 +118,14 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
   const cfg = shouldMergeDiskBrowserConfig({ runtimeCfg, refreshState, diskCfg })
     ? { ...runtimeCfg!, browser: diskCfg.browser }
     : (runtimeCfg ?? diskCfg);
-  const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
-  applyResolvedConfig(params.current, freshResolved);
+  try {
+    const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
+    applyResolvedConfig(params.current, freshResolved);
+  } catch (error) {
+    if (!runtimeCfg) {
+      throw error;
+    }
+  }
 }
 
 export function resolveBrowserProfileWithHotReload(params: {

--- a/src/browser/resolved-config-refresh.ts
+++ b/src/browser/resolved-config-refresh.ts
@@ -3,6 +3,7 @@ import {
   getRuntimeConfigSnapshot,
   getRuntimeConfigSnapshotRefreshState,
 } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
@@ -81,9 +82,19 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
   // without bypassing the active runtime snapshot for unrelated root config. This keeps
   // browser.* edits visible to routes while still honoring runtime-snapshot safety for
   // derived defaults that depend on non-browser config like gateway.port.
-  const diskCfg = createConfigIO().loadConfig();
   const runtimeCfg = getRuntimeConfigSnapshot();
   const refreshState = getRuntimeConfigSnapshotRefreshState();
+  let diskCfg: OpenClawConfig;
+  try {
+    diskCfg = createConfigIO().loadConfig();
+  } catch (error) {
+    if (!runtimeCfg) {
+      throw error;
+    }
+    const freshResolved = resolveBrowserConfig(runtimeCfg.browser, runtimeCfg);
+    applyResolvedConfig(params.current, freshResolved);
+    return;
+  }
   const cfg =
     runtimeCfg && refreshState === "idle"
       ? { ...runtimeCfg, browser: diskCfg.browser }

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -8,6 +8,7 @@ let cfgNoSandbox = false;
 let cfgDefaultProfile = "openclaw";
 let cfgGatewayPort: number | undefined;
 let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
+let runtimeRefreshState: "idle" | "pending" | "failed" = "idle";
 
 // Simulate module-level cache behavior
 let cachedConfig: ReturnType<typeof buildConfig> | null = null;
@@ -35,6 +36,7 @@ vi.mock("../config/config.js", () => ({
     },
   }),
   getRuntimeConfigSnapshot: () => runtimeConfigSnapshot,
+  getRuntimeConfigSnapshotRefreshState: () => runtimeRefreshState,
   loadConfig: () => {
     // simulate stale loadConfig that doesn't see updates unless cache cleared
     if (!cachedConfig) {
@@ -68,6 +70,7 @@ describe("server-context hot-reload profiles", () => {
     cfgDefaultProfile = "openclaw";
     cfgGatewayPort = undefined;
     runtimeConfigSnapshot = null;
+    runtimeRefreshState = "idle";
     cachedConfig = null; // Clear simulated cache
   });
 
@@ -285,4 +288,35 @@ describe("server-context hot-reload profiles", () => {
     expect(state.resolved.headless).toBe(false);
     expect(state.resolved.noSandbox).toBe(true);
   });
+
+  it.each(["pending", "failed"] as const)(
+    "preserves the last-known-good runtime browser config while refresh is %s",
+    async (refreshState) => {
+      const cfg = loadConfig();
+      const resolved = resolveBrowserConfig(cfg.browser, cfg);
+      const state = {
+        server: null,
+        port: 18791,
+        resolved,
+        profiles: new Map(),
+      };
+
+      runtimeConfigSnapshot = buildConfig();
+      runtimeRefreshState = refreshState;
+
+      cfgExecutablePath = "/opt/google/chrome/google-chrome";
+      cfgHeadless = false;
+      cfgNoSandbox = true;
+
+      refreshResolvedBrowserConfigFromDisk({
+        current: state,
+        refreshConfigFromDisk: true,
+        mode: "cached",
+      });
+
+      expect(state.resolved.executablePath).toBeUndefined();
+      expect(state.resolved.headless).toBe(true);
+      expect(state.resolved.noSandbox).toBe(false);
+    },
+  );
 });

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -9,6 +9,7 @@ let cfgDefaultProfile = "openclaw";
 let cfgGatewayPort: number | undefined;
 let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
 let runtimeRefreshState: "idle" | "pending" | "failed" = "idle";
+let runtimeFailedBrowserConfigJson: string | null = null;
 let diskConfigError: Error | null = null;
 
 // Simulate module-level cache behavior
@@ -40,6 +41,7 @@ vi.mock("../config/config.js", () => ({
     },
   }),
   getRuntimeConfigSnapshot: () => runtimeConfigSnapshot,
+  getRuntimeConfigSnapshotFailedBrowserConfigJson: () => runtimeFailedBrowserConfigJson,
   getRuntimeConfigSnapshotRefreshState: () => runtimeRefreshState,
   loadConfig: () => {
     // simulate stale loadConfig that doesn't see updates unless cache cleared
@@ -77,6 +79,7 @@ describe("server-context hot-reload profiles", () => {
     cfgGatewayPort = undefined;
     runtimeConfigSnapshot = null;
     runtimeRefreshState = "idle";
+    runtimeFailedBrowserConfigJson = null;
     diskConfigError = null;
     cachedConfig = null; // Clear simulated cache
   });
@@ -347,6 +350,8 @@ describe("server-context hot-reload profiles", () => {
       cfgExecutablePath = "/opt/google/chrome/google-chrome";
       cfgHeadless = false;
       cfgNoSandbox = true;
+      runtimeFailedBrowserConfigJson =
+        refreshState === "failed" ? JSON.stringify(buildConfig().browser ?? null) : null;
 
       refreshResolvedBrowserConfigFromDisk({
         current: state,
@@ -359,6 +364,37 @@ describe("server-context hot-reload profiles", () => {
       expect(state.resolved.noSandbox).toBe(false);
     },
   );
+
+  it("allows later browser-only edits through after an earlier refresh failure", async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+
+    cfgExecutablePath = "/first/failed/browser";
+    cfgHeadless = false;
+    runtimeRefreshState = "failed";
+    runtimeFailedBrowserConfigJson = JSON.stringify(buildConfig().browser ?? null);
+
+    cfgExecutablePath = "/second/browser/edit";
+    cfgNoSandbox = true;
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.executablePath).toBe("/second/browser/edit");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
+  });
 
   it("falls back to the runtime snapshot when disk config is temporarily invalid", async () => {
     const cfg = loadConfig();

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -9,6 +9,7 @@ let cfgDefaultProfile = "openclaw";
 let cfgGatewayPort: number | undefined;
 let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
 let runtimeRefreshState: "idle" | "pending" | "failed" = "idle";
+let diskConfigError: Error | null = null;
 
 // Simulate module-level cache behavior
 let cachedConfig: ReturnType<typeof buildConfig> | null = null;
@@ -31,6 +32,9 @@ function buildConfig() {
 vi.mock("../config/config.js", () => ({
   createConfigIO: () => ({
     loadConfig: () => {
+      if (diskConfigError) {
+        throw diskConfigError;
+      }
       // Always return fresh config for createConfigIO to simulate fresh disk read
       return buildConfig();
     },
@@ -71,6 +75,7 @@ describe("server-context hot-reload profiles", () => {
     cfgGatewayPort = undefined;
     runtimeConfigSnapshot = null;
     runtimeRefreshState = "idle";
+    diskConfigError = null;
     cachedConfig = null; // Clear simulated cache
   });
 
@@ -319,4 +324,50 @@ describe("server-context hot-reload profiles", () => {
       expect(state.resolved.noSandbox).toBe(false);
     },
   );
+
+  it("falls back to the runtime snapshot when disk config is temporarily invalid", async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+    diskConfigError = new Error("invalid config");
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.executablePath).toBeUndefined();
+    expect(state.resolved.headless).toBe(true);
+    expect(state.resolved.noSandbox).toBe(false);
+    expect(state.resolved.defaultProfile).toBe("openclaw");
+  });
+
+  it("still throws disk config errors when no runtime snapshot is active", async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    diskConfigError = new Error("invalid config");
+
+    expect(() =>
+      refreshResolvedBrowserConfigFromDisk({
+        current: state,
+        refreshConfigFromDisk: true,
+        mode: "cached",
+      }),
+    ).toThrow("invalid config");
+  });
 });

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -5,6 +5,7 @@ let cfgProfiles: Record<string, { cdpPort?: number; cdpUrl?: string; color?: str
 let cfgExecutablePath: string | undefined;
 let cfgHeadless = true;
 let cfgNoSandbox = false;
+let cfgCdpUrl: string | undefined;
 let cfgDefaultProfile = "openclaw";
 let cfgGatewayPort: number | undefined;
 let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
@@ -23,6 +24,7 @@ function buildConfig() {
       color: "#FF4500",
       headless: cfgHeadless,
       noSandbox: cfgNoSandbox,
+      cdpUrl: cfgCdpUrl,
       executablePath: cfgExecutablePath,
       defaultProfile: cfgDefaultProfile,
       profiles: { ...cfgProfiles },
@@ -75,6 +77,7 @@ describe("server-context hot-reload profiles", () => {
     cfgExecutablePath = undefined;
     cfgHeadless = true;
     cfgNoSandbox = false;
+    cfgCdpUrl = undefined;
     cfgDefaultProfile = "openclaw";
     cfgGatewayPort = undefined;
     runtimeConfigSnapshot = null;
@@ -462,6 +465,51 @@ describe("server-context hot-reload profiles", () => {
     expect(state.resolved.headless).toBe(false);
     expect(state.resolved.noSandbox).toBe(true);
     expect(state.resolved.defaultProfile).toBe("desktop");
+  });
+
+  it("preserves the last hot-reloaded browser state when browser config resolution throws", async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+
+    cfgExecutablePath = "/opt/google/chrome/google-chrome";
+    cfgHeadless = false;
+    cfgNoSandbox = true;
+    cfgDefaultProfile = "desktop";
+    cfgProfiles.desktop = { cdpUrl: "http://127.0.0.1:9222", color: "#0066CC" };
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.executablePath).toBe("/opt/google/chrome/google-chrome");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
+    expect(state.resolved.defaultProfile).toBe("desktop");
+    expect(state.resolved.profiles.desktop?.cdpUrl).toBe("http://127.0.0.1:9222");
+
+    cfgCdpUrl = "ftp://bad";
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.executablePath).toBe("/opt/google/chrome/google-chrome");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
+    expect(state.resolved.defaultProfile).toBe("desktop");
+    expect(state.resolved.profiles.desktop?.cdpUrl).toBe("http://127.0.0.1:9222");
   });
 
   it("still throws disk config errors when no runtime snapshot is active", async () => {

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -421,6 +421,49 @@ describe("server-context hot-reload profiles", () => {
     expect(state.resolved.defaultProfile).toBe("openclaw");
   });
 
+  it("preserves the last hot-reloaded browser state when disk config later becomes invalid", async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+
+    cfgExecutablePath = "/opt/google/chrome/google-chrome";
+    cfgHeadless = false;
+    cfgNoSandbox = true;
+    cfgDefaultProfile = "desktop";
+    cfgProfiles.desktop = { cdpPort: 19999, color: "#0066CC" };
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.executablePath).toBe("/opt/google/chrome/google-chrome");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
+    expect(state.resolved.defaultProfile).toBe("desktop");
+
+    diskConfigError = new Error("invalid config");
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.executablePath).toBe("/opt/google/chrome/google-chrome");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
+    expect(state.resolved.defaultProfile).toBe("desktop");
+  });
+
   it("still throws disk config errors when no runtime snapshot is active", async () => {
     const cfg = loadConfig();
     const resolved = resolveBrowserConfig(cfg.browser, cfg);

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -6,6 +6,7 @@ let cfgExecutablePath: string | undefined;
 let cfgHeadless = true;
 let cfgNoSandbox = false;
 let cfgDefaultProfile = "openclaw";
+let cfgGatewayPort: number | undefined;
 let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
 
 // Simulate module-level cache behavior
@@ -13,6 +14,7 @@ let cachedConfig: ReturnType<typeof buildConfig> | null = null;
 
 function buildConfig() {
   return {
+    gateway: cfgGatewayPort ? { port: cfgGatewayPort } : undefined,
     browser: {
       enabled: true,
       color: "#FF4500",
@@ -64,6 +66,7 @@ describe("server-context hot-reload profiles", () => {
     cfgHeadless = true;
     cfgNoSandbox = false;
     cfgDefaultProfile = "openclaw";
+    cfgGatewayPort = undefined;
     runtimeConfigSnapshot = null;
     cachedConfig = null; // Clear simulated cache
   });
@@ -248,5 +251,38 @@ describe("server-context hot-reload profiles", () => {
     expect(state.resolved.headless).toBe(false);
     expect(state.resolved.noSandbox).toBe(true);
     expect(state.resolved.defaultProfile).toBe("desktop");
+  });
+
+  it("keeps runtime-derived defaults stable while hot-reloading browser config from disk", async () => {
+    cfgGatewayPort = 4000;
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const previousControlPort = resolved.controlPort;
+    const previousCdpPortRangeStart = resolved.cdpPortRangeStart;
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+
+    cfgGatewayPort = 5000;
+    cfgExecutablePath = "/opt/google/chrome/google-chrome";
+    cfgHeadless = false;
+    cfgNoSandbox = true;
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.controlPort).toBe(previousControlPort);
+    expect(state.resolved.cdpPortRangeStart).toBe(previousCdpPortRangeStart);
+    expect(state.resolved.executablePath).toBe("/opt/google/chrome/google-chrome");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
   });
 });

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BrowserServerState } from "./server-context.types.js";
 
 let cfgProfiles: Record<string, { cdpPort?: number; cdpUrl?: string; color?: string }> = {};
+let cfgExecutablePath: string | undefined;
+let cfgHeadless = true;
+let cfgNoSandbox = false;
+let cfgDefaultProfile = "openclaw";
+let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
 
 // Simulate module-level cache behavior
 let cachedConfig: ReturnType<typeof buildConfig> | null = null;
@@ -11,8 +16,10 @@ function buildConfig() {
     browser: {
       enabled: true,
       color: "#FF4500",
-      headless: true,
-      defaultProfile: "openclaw",
+      headless: cfgHeadless,
+      noSandbox: cfgNoSandbox,
+      executablePath: cfgExecutablePath,
+      defaultProfile: cfgDefaultProfile,
       profiles: { ...cfgProfiles },
     },
   };
@@ -25,7 +32,7 @@ vi.mock("../config/config.js", () => ({
       return buildConfig();
     },
   }),
-  getRuntimeConfigSnapshot: () => null,
+  getRuntimeConfigSnapshot: () => runtimeConfigSnapshot,
   loadConfig: () => {
     // simulate stale loadConfig that doesn't see updates unless cache cleared
     if (!cachedConfig) {
@@ -53,6 +60,11 @@ describe("server-context hot-reload profiles", () => {
     cfgProfiles = {
       openclaw: { cdpPort: 18800, color: "#FF4500" },
     };
+    cfgExecutablePath = undefined;
+    cfgHeadless = true;
+    cfgNoSandbox = false;
+    cfgDefaultProfile = "openclaw";
+    runtimeConfigSnapshot = null;
     cachedConfig = null; // Clear simulated cache
   });
 
@@ -205,5 +217,36 @@ describe("server-context hot-reload profiles", () => {
     expect(runtime?.profile.cdpPort).toBe(19999);
     expect(runtime?.lastTargetId).toBeNull();
     expect(runtime?.reconcile?.reason).toContain("cdpPort");
+  });
+
+  it("bypasses stale runtime snapshots so browser route state picks up fresh disk config", async () => {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+    cfgProfiles.openclaw = { cdpPort: 19999, color: "#FF4500" };
+    cfgExecutablePath = "/opt/google/chrome/google-chrome";
+    cfgHeadless = false;
+    cfgNoSandbox = true;
+    cfgDefaultProfile = "desktop";
+    cfgProfiles.desktop = { cdpPort: 19998, color: "#0066CC" };
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(state.resolved.profiles.openclaw?.cdpPort).toBe(19999);
+    expect(state.resolved.executablePath).toBe("/opt/google/chrome/google-chrome");
+    expect(state.resolved.headless).toBe(false);
+    expect(state.resolved.noSandbox).toBe(true);
+    expect(state.resolved.defaultProfile).toBe("desktop");
   });
 });

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -53,6 +53,7 @@ vi.mock("../config/config.js", () => ({
 
 describe("server-context hot-reload profiles", () => {
   let loadConfig: typeof import("../config/config.js").loadConfig;
+  let createBrowserRouteContext: typeof import("./server-context.js").createBrowserRouteContext;
   let resolveBrowserConfig: typeof import("./config.js").resolveBrowserConfig;
   let resolveProfile: typeof import("./config.js").resolveProfile;
   let refreshResolvedBrowserConfigFromDisk: typeof import("./resolved-config-refresh.js").refreshResolvedBrowserConfigFromDisk;
@@ -61,6 +62,7 @@ describe("server-context hot-reload profiles", () => {
   beforeEach(async () => {
     vi.resetModules();
     ({ loadConfig } = await import("../config/config.js"));
+    ({ createBrowserRouteContext } = await import("./server-context.js"));
     ({ resolveBrowserConfig, resolveProfile } = await import("./config.js"));
     ({ refreshResolvedBrowserConfigFromDisk, resolveBrowserProfileWithHotReload } =
       await import("./resolved-config-refresh.js"));
@@ -169,6 +171,39 @@ describe("server-context hot-reload profiles", () => {
     });
     expect(after?.cdpPort).toBe(19999);
     expect(state.resolved.profiles.openclaw?.cdpPort).toBe(19999);
+  });
+
+  it("forProfile without an explicit name reselects the refreshed default profile", async () => {
+    cfgDefaultProfile = "legacy";
+    cfgProfiles = {
+      legacy: { cdpPort: 18800, color: "#8844FF" },
+    };
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    cfgDefaultProfile = "desktop";
+    cfgProfiles = {
+      desktop: { cdpPort: 19999, color: "#0066CC" },
+    };
+    cachedConfig = null;
+
+    const ctx = createBrowserRouteContext({
+      getState: () => state,
+      refreshConfigFromDisk: true,
+    });
+
+    const profile = ctx.forProfile().profile;
+    expect(profile.name).toBe("desktop");
+    expect(profile.cdpPort).toBe(19999);
+    expect(state.resolved.defaultProfile).toBe("desktop");
+    expect(state.resolved.profiles.legacy).toBeUndefined();
+    expect(state.resolved.profiles.desktop).toBeDefined();
   });
 
   it("listProfiles refreshes config before enumerating profiles", async () => {

--- a/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/src/browser/server-context.hot-reload-profiles.test.ts
@@ -12,6 +12,10 @@ let runtimeConfigSnapshot: ReturnType<typeof buildConfig> | null = null;
 let runtimeRefreshState: "idle" | "pending" | "failed" = "idle";
 let runtimeFailedBrowserConfigJson: string | null = null;
 let diskConfigError: Error | null = null;
+let diskConfigEnvMutation: {
+  key: string;
+  value: string;
+} | null = null;
 
 // Simulate module-level cache behavior
 let cachedConfig: ReturnType<typeof buildConfig> | null = null;
@@ -33,10 +37,14 @@ function buildConfig() {
 }
 
 vi.mock("../config/config.js", () => ({
-  createConfigIO: () => ({
+  createConfigIO: (overrides?: { env?: NodeJS.ProcessEnv }) => ({
     loadConfig: () => {
       if (diskConfigError) {
         throw diskConfigError;
+      }
+      if (diskConfigEnvMutation) {
+        const targetEnv = overrides?.env ?? process.env;
+        targetEnv[diskConfigEnvMutation.key] = diskConfigEnvMutation.value;
       }
       // Always return fresh config for createConfigIO to simulate fresh disk read
       return buildConfig();
@@ -84,6 +92,7 @@ describe("server-context hot-reload profiles", () => {
     runtimeRefreshState = "idle";
     runtimeFailedBrowserConfigJson = null;
     diskConfigError = null;
+    diskConfigEnvMutation = null;
     cachedConfig = null; // Clear simulated cache
   });
 
@@ -510,6 +519,32 @@ describe("server-context hot-reload profiles", () => {
     expect(state.resolved.noSandbox).toBe(true);
     expect(state.resolved.defaultProfile).toBe("desktop");
     expect(state.resolved.profiles.desktop?.cdpUrl).toBe("http://127.0.0.1:9222");
+  });
+
+  it("does not mutate process.env from browser-route disk config reads", async () => {
+    const envKey = "OPENCLAW_BROWSER_ROUTE_ENV_TEST";
+    delete process.env[envKey];
+    diskConfigEnvMutation = { key: envKey, value: "from-disk-config" };
+
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg.browser, cfg);
+    const state = {
+      server: null,
+      port: 18791,
+      resolved,
+      profiles: new Map(),
+    };
+
+    runtimeConfigSnapshot = buildConfig();
+    runtimeRefreshState = "pending";
+
+    refreshResolvedBrowserConfigFromDisk({
+      current: state,
+      refreshConfigFromDisk: true,
+      mode: "cached",
+    });
+
+    expect(process.env[envKey]).toBeUndefined();
   });
 
   it("still throws disk config errors when no runtime snapshot is active", async () => {

--- a/src/browser/server-context.ts
+++ b/src/browser/server-context.ts
@@ -129,6 +129,13 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
 
   const forProfile = (profileName?: string): ProfileContext => {
     const current = state();
+    if (!profileName) {
+      refreshResolvedBrowserConfigFromDisk({
+        current,
+        refreshConfigFromDisk,
+        mode: "cached",
+      });
+    }
     const name = profileName ?? current.resolved.defaultProfile;
     const profile = resolveBrowserProfileWithHotReload({
       current,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,6 +4,7 @@ export {
   clearRuntimeConfigSnapshot,
   createConfigIO,
   getRuntimeConfigSnapshot,
+  getRuntimeConfigSnapshotRefreshState,
   getRuntimeConfigSourceSnapshot,
   projectConfigOntoRuntimeSourceSnapshot,
   loadConfig,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,6 +4,7 @@ export {
   clearRuntimeConfigSnapshot,
   createConfigIO,
   getRuntimeConfigSnapshot,
+  getRuntimeConfigSnapshotFailedBrowserConfigJson,
   getRuntimeConfigSnapshotRefreshState,
   getRuntimeConfigSourceSnapshot,
   projectConfigOntoRuntimeSourceSnapshot,

--- a/src/config/io.runtime-snapshot-write.test.ts
+++ b/src/config/io.runtime-snapshot-write.test.ts
@@ -5,6 +5,8 @@ import { withTempHome } from "./home-env.test-harness.js";
 import {
   clearConfigCache,
   clearRuntimeConfigSnapshot,
+  createConfigIO,
+  getRuntimeConfigSnapshotFailedBrowserConfigJson,
   getRuntimeConfigSourceSnapshot,
   loadConfig,
   projectConfigOntoRuntimeSourceSnapshot,
@@ -12,6 +14,7 @@ import {
   setRuntimeConfigSnapshot,
   writeConfigFile,
 } from "./io.js";
+import { withEnvOverride } from "./test-helpers.js";
 import type { OpenClawConfig } from "./types.js";
 
 function createSourceConfig(): OpenClawConfig {
@@ -250,6 +253,70 @@ describe("runtime config snapshot writes", () => {
       } finally {
         resetRuntimeConfigState();
       }
+    });
+  });
+
+  it("stores failed browser config in the same resolved shape used by disk reads", async () => {
+    await withTempHome("openclaw-config-runtime-refresh-failed-browser-", async (home) => {
+      await withEnvOverride(
+        {
+          OPENCLAW_BROWSER_BIN: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        },
+        async () => {
+          const configPath = path.join(home, ".openclaw", "openclaw.json");
+          const sourceConfig: OpenClawConfig = {
+            env: {
+              vars: {
+                OPENCLAW_BROWSER_BIN:
+                  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+              },
+            },
+            browser: {
+              enabled: true,
+              executablePath: "${OPENCLAW_BROWSER_BIN}",
+              defaultProfile: "openclaw",
+              profiles: {
+                openclaw: { cdpPort: 18800, color: "#FF4500" },
+              },
+            },
+          };
+
+          await fs.mkdir(path.dirname(configPath), { recursive: true });
+          await fs.writeFile(configPath, `${JSON.stringify(sourceConfig, null, 2)}\n`, "utf8");
+
+          try {
+            const runtimeConfig = createConfigIO().loadConfig();
+            setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+            setRuntimeConfigSnapshotRefreshHandler({
+              refresh: async () => {
+                throw new Error("refresh failed");
+              },
+            });
+
+            await expect(
+              writeConfigFile({
+                ...runtimeConfig,
+                browser: {
+                  ...runtimeConfig.browser,
+                  headless: true,
+                },
+              }),
+            ).rejects.toThrow("refresh failed");
+
+            expect(getRuntimeConfigSnapshotFailedBrowserConfigJson()).toBe(
+              JSON.stringify(createConfigIO().loadConfig().browser ?? null),
+            );
+            expect(getRuntimeConfigSnapshotFailedBrowserConfigJson()).toContain(
+              "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            );
+            expect(getRuntimeConfigSnapshotFailedBrowserConfigJson()).not.toContain(
+              "${OPENCLAW_BROWSER_BIN}",
+            );
+          } finally {
+            resetRuntimeConfigState();
+          }
+        },
+      );
     });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1353,6 +1353,7 @@ let configCache: {
 let runtimeConfigSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSourceSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSnapshotRefreshHandler: RuntimeConfigSnapshotRefreshHandler | null = null;
+let runtimeConfigSnapshotRefreshState: "idle" | "pending" | "failed" = "idle";
 
 function resolveConfigCacheMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OPENCLAW_CONFIG_CACHE_MS?.trim();
@@ -1386,17 +1387,23 @@ export function setRuntimeConfigSnapshot(
 ): void {
   runtimeConfigSnapshot = config;
   runtimeConfigSourceSnapshot = sourceConfig ?? null;
+  runtimeConfigSnapshotRefreshState = "idle";
   clearConfigCache();
 }
 
 export function clearRuntimeConfigSnapshot(): void {
   runtimeConfigSnapshot = null;
   runtimeConfigSourceSnapshot = null;
+  runtimeConfigSnapshotRefreshState = "idle";
   clearConfigCache();
 }
 
 export function getRuntimeConfigSnapshot(): OpenClawConfig | null {
   return runtimeConfigSnapshot;
+}
+
+export function getRuntimeConfigSnapshotRefreshState(): "idle" | "pending" | "failed" {
+  return runtimeConfigSnapshotRefreshState;
 }
 
 export function getRuntimeConfigSourceSnapshot(): OpenClawConfig | null {
@@ -1459,6 +1466,9 @@ export function setRuntimeConfigSnapshotRefreshHandler(
   refreshHandler: RuntimeConfigSnapshotRefreshHandler | null,
 ): void {
   runtimeConfigSnapshotRefreshHandler = refreshHandler;
+  if (!refreshHandler) {
+    runtimeConfigSnapshotRefreshState = "idle";
+  }
 }
 
 export function loadConfig(): OpenClawConfig {
@@ -1523,12 +1533,15 @@ export async function writeConfigFile(
   // succeeds, so concurrent readers do not observe unresolved SecretRefs mid-refresh.
   const refreshHandler = runtimeConfigSnapshotRefreshHandler;
   if (refreshHandler) {
+    runtimeConfigSnapshotRefreshState = "pending";
     try {
       const refreshed = await refreshHandler.refresh({ sourceConfig: nextCfg });
       if (refreshed) {
         return;
       }
+      runtimeConfigSnapshotRefreshState = "idle";
     } catch (error) {
+      runtimeConfigSnapshotRefreshState = "failed";
       try {
         refreshHandler.clearOnRefreshFailure?.();
       } catch {
@@ -1550,6 +1563,7 @@ export async function writeConfigFile(
   }
   if (hadRuntimeSnapshot) {
     clearRuntimeConfigSnapshot();
+    runtimeConfigSnapshotRefreshState = "idle";
   }
   // When we had no runtime snapshot, keep callers reading from disk/cache so external/manual
   // edits to openclaw.json remain visible (no stale snapshot).

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1354,6 +1354,7 @@ let runtimeConfigSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSourceSnapshot: OpenClawConfig | null = null;
 let runtimeConfigSnapshotRefreshHandler: RuntimeConfigSnapshotRefreshHandler | null = null;
 let runtimeConfigSnapshotRefreshState: "idle" | "pending" | "failed" = "idle";
+let runtimeConfigSnapshotFailedBrowserConfigJson: string | null = null;
 
 function resolveConfigCacheMs(env: NodeJS.ProcessEnv): number {
   const raw = env.OPENCLAW_CONFIG_CACHE_MS?.trim();
@@ -1388,6 +1389,7 @@ export function setRuntimeConfigSnapshot(
   runtimeConfigSnapshot = config;
   runtimeConfigSourceSnapshot = sourceConfig ?? null;
   runtimeConfigSnapshotRefreshState = "idle";
+  runtimeConfigSnapshotFailedBrowserConfigJson = null;
   clearConfigCache();
 }
 
@@ -1395,6 +1397,7 @@ export function clearRuntimeConfigSnapshot(): void {
   runtimeConfigSnapshot = null;
   runtimeConfigSourceSnapshot = null;
   runtimeConfigSnapshotRefreshState = "idle";
+  runtimeConfigSnapshotFailedBrowserConfigJson = null;
   clearConfigCache();
 }
 
@@ -1404,6 +1407,10 @@ export function getRuntimeConfigSnapshot(): OpenClawConfig | null {
 
 export function getRuntimeConfigSnapshotRefreshState(): "idle" | "pending" | "failed" {
   return runtimeConfigSnapshotRefreshState;
+}
+
+export function getRuntimeConfigSnapshotFailedBrowserConfigJson(): string | null {
+  return runtimeConfigSnapshotFailedBrowserConfigJson;
 }
 
 export function getRuntimeConfigSourceSnapshot(): OpenClawConfig | null {
@@ -1468,6 +1475,7 @@ export function setRuntimeConfigSnapshotRefreshHandler(
   runtimeConfigSnapshotRefreshHandler = refreshHandler;
   if (!refreshHandler) {
     runtimeConfigSnapshotRefreshState = "idle";
+    runtimeConfigSnapshotFailedBrowserConfigJson = null;
   }
 }
 
@@ -1534,6 +1542,7 @@ export async function writeConfigFile(
   const refreshHandler = runtimeConfigSnapshotRefreshHandler;
   if (refreshHandler) {
     runtimeConfigSnapshotRefreshState = "pending";
+    runtimeConfigSnapshotFailedBrowserConfigJson = null;
     try {
       const refreshed = await refreshHandler.refresh({ sourceConfig: nextCfg });
       if (refreshed) {
@@ -1542,6 +1551,7 @@ export async function writeConfigFile(
       runtimeConfigSnapshotRefreshState = "idle";
     } catch (error) {
       runtimeConfigSnapshotRefreshState = "failed";
+      runtimeConfigSnapshotFailedBrowserConfigJson = JSON.stringify(nextCfg.browser ?? null);
       try {
         refreshHandler.clearOnRefreshFailure?.();
       } catch {
@@ -1564,6 +1574,7 @@ export async function writeConfigFile(
   if (hadRuntimeSnapshot) {
     clearRuntimeConfigSnapshot();
     runtimeConfigSnapshotRefreshState = "idle";
+    runtimeConfigSnapshotFailedBrowserConfigJson = null;
   }
   // When we had no runtime snapshot, keep callers reading from disk/cache so external/manual
   // edits to openclaw.json remain visible (no stale snapshot).

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1551,7 +1551,13 @@ export async function writeConfigFile(
       runtimeConfigSnapshotRefreshState = "idle";
     } catch (error) {
       runtimeConfigSnapshotRefreshState = "failed";
-      runtimeConfigSnapshotFailedBrowserConfigJson = JSON.stringify(nextCfg.browser ?? null);
+      try {
+        runtimeConfigSnapshotFailedBrowserConfigJson = JSON.stringify(
+          io.loadConfig().browser ?? null,
+        );
+      } catch {
+        runtimeConfigSnapshotFailedBrowserConfigJson = JSON.stringify(nextCfg.browser ?? null);
+      }
       try {
         refreshHandler.clearOnRefreshFailure?.();
       } catch {


### PR DESCRIPTION
## Summary

- Problem: browser route requests could keep reading a stale runtime config snapshot, so `browser status` showed default values and follow-up `start`/`open`/`navigate` calls could miss the configured browser settings.
- Why it matters: on headless Linux hosts this can turn a healthy running Chrome session into repeated `No supported browser found` failures on second and later browser actions.
- What changed: browser route hot-reload now reloads browser config directly from disk instead of preferring the process runtime snapshot, and regression coverage now locks in stale-snapshot refresh behavior.
- What did NOT change (scope boundary): this does not change CDP probing, executable detection, or Chrome MCP attach logic beyond making those paths see the latest browser config.

AI-assisted: yes
Latest green `main` base used for this branch: `b0ce53a79cf63834660270513e26d921899b4e5b`

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53004
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: browser route hot-reload preferred `getRuntimeConfigSnapshot()` over a fresh disk read, so long-lived browser service state could keep old browser settings even after `openclaw.json` changed or a newer on-disk config existed.
- Missing detection / guardrail: there was no regression test for a stale runtime snapshot coexisting with fresher browser config on disk.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue report #53004 narrowed the regression to the browser route/control path; I did not identify a single prior PR with a more specific introduction point.
- Why this regressed now: once the process held a stale runtime snapshot, request-time browser routes refreshed from that snapshot instead of disk and kept serving outdated browser settings.
- If unknown, what was ruled out: this change does not touch CDP readiness checks, Chrome executable lookup, or Chrome MCP session management.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/browser/server-context.hot-reload-profiles.test.ts`
- Scenario the test should lock in: a stale runtime snapshot must not override fresher on-disk browser config for browser route refresh, including `executablePath`, `headless`, `noSandbox`, `defaultProfile`, and updated profile ports.
- Why this is the smallest reliable guardrail: the bug lives in the synchronous config-refresh seam used by status/start/open/navigate routes, so a focused regression test on that seam catches the behavior without needing live Chrome.
- Existing test that already covers this (if any): the existing hot-reload profile tests already covered stale `loadConfig()` cache behavior but not stale runtime snapshot behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `browser status` now reflects the current on-disk browser config even when the browser control service process still holds an older runtime snapshot.
- Follow-up browser actions reuse the latest browser config instead of falling back to stale defaults.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS local dev host for regression tests; issue repro was reported on Ubuntu 25.10
- Runtime/container: Node.js workspace checkout
- Model/provider: N/A
- Integration/channel (if any): browser control routes / node-host browser proxy
- Relevant config (redacted): `browser.enabled=true`, custom `browser.executablePath`, `browser.headless=true`, `browser.noSandbox=true`, `browser.defaultProfile="openclaw"`

### Steps

1. Start with a browser service/runtime snapshot that still reflects older browser settings.
2. Update on-disk browser config to newer values and issue browser route refresh/status/start requests.
3. Verify the route context resolves browser config from disk and carries the new settings into route state.

### Expected

- Browser status and follow-up browser actions use the latest on-disk browser config.

### Actual

- Before this fix, browser route refresh could keep stale defaults from the runtime snapshot and later browser actions could fail with `No supported browser found`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran targeted regression tests for browser route hot-reload, existing-session basic status behavior, and node-host browser proxy behavior.
- Edge cases checked: stale runtime snapshot with fresher disk browser config; existing existing-session status route behavior still passes; browser proxy timeout/status tests still pass.
- What you did **not** verify: I did not run a manual live Chrome repro on Ubuntu in this environment, and I did not run the full `pnpm build && pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `412f0fd0f0253e9a11d8b47bcf01a1eebebc6bd2`
- Files/config to restore: `src/browser/resolved-config-refresh.ts`, `src/browser/server-context.hot-reload-profiles.test.ts`
- Known bad symptoms reviewers should watch for: browser routes ignoring new browser config written to disk; status showing default browser settings again.

## Risks and Mitigations

- Risk: browser route refresh now always trusts the latest on-disk config for browser settings, even if the broader runtime snapshot is older for other reasons.
  - Mitigation: this refresh path is browser-route-specific, keeps `evaluateEnabled` stable, and now has regression coverage for stale runtime snapshot behavior.
