### PR TITLE
fix(mistral): repair max-token defaults and doctor migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Anthropic: preserve latest assistant thinking and redacted-thinking block ordering during transcript image sanitization so follow-up turns do not trip Anthropic's unmodified-thinking validation. (#52961) Thanks @vincentkoc.
 - Voice-call/Plivo: stabilize Plivo v2 replay keys so webhook retries and replay protection stop colliding on valid follow-up deliveries.
 - Release/install: keep previously released bundled plugins and Control UI assets in published openclaw npm installs, and fail release checks when those shipped artifacts are missing. Thanks @vincentkoc.
+- Mistral/models: lower bundled Mistral max-token defaults to safe output budgets and teach `openclaw doctor --fix` to repair old persisted Mistral provider configs that still carry context-sized output limits, avoiding deterministic Mistral 422 rejects on fresh and existing setups. Fixes #52599. Thanks @vincentkoc.
 
 ## 2026.3.22
 

--- a/extensions/mistral/model-definitions.test.ts
+++ b/extensions/mistral/model-definitions.test.ts
@@ -39,13 +39,13 @@ describe("mistral model definitions", () => {
           reasoning: true,
           input: ["text"],
           contextWindow: 128000,
-          maxTokens: 128000,
+          maxTokens: 40000,
         }),
         expect.objectContaining({
           id: "pixtral-large-latest",
           input: ["text", "image"],
           contextWindow: 128000,
-          maxTokens: 128000,
+          maxTokens: 32768,
         }),
       ]),
     );

--- a/extensions/mistral/model-definitions.ts
+++ b/extensions/mistral/model-definitions.ts
@@ -4,7 +4,7 @@ export const MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 export const MISTRAL_DEFAULT_MODEL_ID = "mistral-large-latest";
 export const MISTRAL_DEFAULT_MODEL_REF = `mistral/${MISTRAL_DEFAULT_MODEL_ID}`;
 export const MISTRAL_DEFAULT_CONTEXT_WINDOW = 262144;
-export const MISTRAL_DEFAULT_MAX_TOKENS = 262144;
+export const MISTRAL_DEFAULT_MAX_TOKENS = 16384;
 export const MISTRAL_DEFAULT_COST = {
   input: 0.5,
   output: 1.5,
@@ -29,7 +29,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text"],
     cost: { input: 0.4, output: 2, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,
-    maxTokens: 262144,
+    maxTokens: 32768,
   },
   {
     id: "magistral-small",
@@ -38,7 +38,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text"],
     cost: { input: 0.5, output: 1.5, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
-    maxTokens: 128000,
+    maxTokens: 40000,
   },
   {
     id: "mistral-large-latest",
@@ -56,7 +56,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text", "image"],
     cost: { input: 0.4, output: 2, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,
-    maxTokens: 262144,
+    maxTokens: 8192,
   },
   {
     id: "mistral-small-latest",
@@ -74,7 +74,7 @@ const MISTRAL_MODEL_CATALOG = [
     input: ["text", "image"],
     cost: { input: 2, output: 6, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 128000,
-    maxTokens: 128000,
+    maxTokens: 32768,
   },
 ] as const satisfies readonly ModelDefinitionConfig[];
 

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -669,4 +669,52 @@ describe("normalizeCompatibilityConfigValues", () => {
       "Merged tools.media.models[0].deepgram → tools.media.models[0].providerOptions.deepgram (filled missing canonical fields from legacy).",
     ]);
   });
+
+  it("normalizes persisted mistral model maxTokens that matched the old context-sized defaults", () => {
+    const res = normalizeCompatibilityConfigValues({
+      models: {
+        providers: {
+          mistral: {
+            baseUrl: "https://api.mistral.ai/v1",
+            api: "openai-completions",
+            models: [
+              {
+                id: "mistral-large-latest",
+                name: "Mistral Large",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 262144,
+                maxTokens: 262144,
+              },
+              {
+                id: "magistral-small",
+                name: "Magistral Small",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128000,
+                maxTokens: 128000,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(res.config.models?.providers?.mistral?.models).toEqual([
+      expect.objectContaining({
+        id: "mistral-large-latest",
+        maxTokens: 16384,
+      }),
+      expect.objectContaining({
+        id: "magistral-small",
+        maxTokens: 40000,
+      }),
+    ]);
+    expect(res.changes).toEqual([
+      "Normalized models.providers.mistral.models[0].maxTokens (262144 → 16384) to avoid Mistral context-window rejects.",
+      "Normalized models.providers.mistral.models[1].maxTokens (128000 → 40000) to avoid Mistral context-window rejects.",
+    ]);
+  });
 });

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -1,5 +1,7 @@
+import { normalizeProviderId } from "../agents/model-selection.js";
 import { shouldMoveSingleAccountChannelKey } from "../channels/plugins/setup-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveNormalizedProviderModelMaxTokens } from "../config/defaults.js";
 import {
   formatSlackStreamingBooleanMigrationMessage,
   formatSlackStreamModeMigrationMessage,
@@ -809,11 +811,91 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
     };
   };
 
+  const normalizeLegacyMistralModelMaxTokens = () => {
+    const rawProviders = next.models?.providers;
+    if (!isRecord(rawProviders)) {
+      return;
+    }
+
+    let providersChanged = false;
+    const nextProviders = { ...rawProviders };
+    for (const [providerId, rawProvider] of Object.entries(rawProviders)) {
+      if (normalizeProviderId(providerId) !== "mistral" || !isRecord(rawProvider)) {
+        continue;
+      }
+      const rawModels = rawProvider.models;
+      if (!Array.isArray(rawModels)) {
+        continue;
+      }
+
+      let modelsChanged = false;
+      const nextModels = rawModels.map((model, index) => {
+        if (!isRecord(model)) {
+          return model;
+        }
+        const modelId = typeof model.id === "string" ? model.id.trim() : "";
+        const contextWindow =
+          typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow)
+            ? model.contextWindow
+            : null;
+        const maxTokens =
+          typeof model.maxTokens === "number" && Number.isFinite(model.maxTokens)
+            ? model.maxTokens
+            : null;
+        if (!modelId || contextWindow === null || maxTokens === null) {
+          return model;
+        }
+
+        const normalizedMaxTokens = resolveNormalizedProviderModelMaxTokens({
+          providerId,
+          modelId,
+          contextWindow,
+          rawMaxTokens: maxTokens,
+        });
+        if (normalizedMaxTokens === maxTokens) {
+          return model;
+        }
+
+        modelsChanged = true;
+        changes.push(
+          `Normalized models.providers.${providerId}.models[${index}].maxTokens (${maxTokens} → ${normalizedMaxTokens}) to avoid Mistral context-window rejects.`,
+        );
+        return {
+          ...model,
+          maxTokens: normalizedMaxTokens,
+        };
+      });
+
+      if (!modelsChanged) {
+        continue;
+      }
+
+      nextProviders[providerId] = {
+        ...rawProvider,
+        models: nextModels,
+      };
+      providersChanged = true;
+    }
+
+    if (!providersChanged) {
+      return;
+    }
+
+    next = {
+      ...next,
+      models: {
+        ...next.models,
+        providers: nextProviders as NonNullable<OpenClawConfig["models"]>["providers"],
+      },
+    };
+  };
+
   normalizeBrowserSsrFPolicyAlias();
   normalizeLegacyNanoBananaSkill();
   normalizeLegacyTalkConfig();
   normalizeLegacyCrossContextMessageConfig();
   normalizeLegacyMediaProviderOptions();
+  normalizeLegacyMistralModelMaxTokens();
 
   const legacyAckReaction = cfg.messages?.ackReaction?.trim();
   const hasWhatsAppConfig = cfg.channels?.whatsapp !== undefined;

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -7,6 +7,7 @@ import {
   applyMinimaxApiConfig,
   applyMinimaxApiProviderConfig,
 } from "../../extensions/minimax/onboard.js";
+import { buildMistralModelDefinition as buildBundledMistralModelDefinition } from "../../extensions/mistral/model-definitions.js";
 import {
   applyMistralConfig,
   applyMistralProviderConfig,
@@ -50,6 +51,7 @@ import {
 } from "../plugins/provider-auth-storage.js";
 import {
   MISTRAL_DEFAULT_MODEL_REF,
+  buildMistralModelDefinition as buildCoreMistralModelDefinition,
   ZAI_CODING_CN_BASE_URL,
   ZAI_GLOBAL_BASE_URL,
 } from "../plugins/provider-model-definitions.js";
@@ -659,7 +661,18 @@ describe("applyMistralProviderConfig", () => {
       (model) => model.id === "mistral-large-latest",
     );
     expect(mistralDefault?.contextWindow).toBe(262144);
-    expect(mistralDefault?.maxTokens).toBe(262144);
+    expect(mistralDefault?.maxTokens).toBe(16384);
+  });
+
+  it("keeps the core and bundled mistral defaults aligned", () => {
+    const bundled = buildBundledMistralModelDefinition();
+    const core = buildCoreMistralModelDefinition();
+
+    expect(core).toMatchObject({
+      id: bundled.id,
+      contextWindow: bundled.contextWindow,
+      maxTokens: bundled.maxTokens,
+    });
   });
 });
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -41,6 +41,13 @@ const DEFAULT_MODEL_COST: ModelDefinitionConfig["cost"] = {
 };
 const DEFAULT_MODEL_INPUT: ModelDefinitionConfig["input"] = ["text"];
 const DEFAULT_MODEL_MAX_TOKENS = 8192;
+const MISTRAL_SAFE_MAX_TOKENS_BY_MODEL = {
+  "devstral-medium-latest": 32_768,
+  "magistral-small": 40_000,
+  "mistral-large-latest": 16_384,
+  "mistral-medium-2508": 8_192,
+  "pixtral-large-latest": 32_768,
+} as const;
 
 type ModelDefinitionLike = Partial<ModelDefinitionConfig> &
   Pick<ModelDefinitionConfig, "id" | "name">;
@@ -69,6 +76,24 @@ function resolveModelCost(
     cacheWrite:
       typeof raw?.cacheWrite === "number" ? raw.cacheWrite : DEFAULT_MODEL_COST.cacheWrite,
   };
+}
+
+export function resolveNormalizedProviderModelMaxTokens(params: {
+  providerId: string;
+  modelId: string;
+  contextWindow: number;
+  rawMaxTokens: number;
+}): number {
+  const clamped = Math.min(params.rawMaxTokens, params.contextWindow);
+  if (normalizeProviderId(params.providerId) !== "mistral" || clamped < params.contextWindow) {
+    return clamped;
+  }
+
+  const safeMaxTokens =
+    MISTRAL_SAFE_MAX_TOKENS_BY_MODEL[
+      params.modelId as keyof typeof MISTRAL_SAFE_MAX_TOKENS_BY_MODEL
+    ] ?? DEFAULT_MODEL_MAX_TOKENS;
+  return Math.min(safeMaxTokens, params.contextWindow);
 }
 
 function resolveAnthropicDefaultAuthMode(cfg: OpenClawConfig): AnthropicAuthDefaultsMode | null {
@@ -263,7 +288,12 @@ export function applyModelDefaults(cfg: OpenClawConfig): OpenClawConfig {
 
         const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
         const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
-        const maxTokens = Math.min(rawMaxTokens, contextWindow);
+        const maxTokens = resolveNormalizedProviderModelMaxTokens({
+          providerId,
+          modelId: raw.id,
+          contextWindow,
+          rawMaxTokens,
+        });
         if (raw.maxTokens !== maxTokens) {
           modelMutated = true;
         }

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -46,6 +46,7 @@ const MISTRAL_SAFE_MAX_TOKENS_BY_MODEL = {
   "magistral-small": 40_000,
   "mistral-large-latest": 16_384,
   "mistral-medium-2508": 8_192,
+  "mistral-small-latest": 16_384,
   "pixtral-large-latest": 32_768,
 } as const;
 

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -29,6 +29,35 @@ describe("applyModelDefaults", () => {
     } satisfies OpenClawConfig;
   }
 
+  function buildMistralProviderConfig(overrides?: {
+    modelId?: string;
+    contextWindow?: number;
+    maxTokens?: number;
+  }) {
+    return {
+      models: {
+        providers: {
+          mistral: {
+            baseUrl: "https://api.mistral.ai/v1",
+            apiKey: "sk-mistral", // pragma: allowlist secret
+            api: "openai-completions",
+            models: [
+              {
+                id: overrides?.modelId ?? "mistral-large-latest",
+                name: "Mistral",
+                reasoning: false,
+                input: ["text", "image"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: overrides?.contextWindow ?? 262_144,
+                maxTokens: overrides?.maxTokens ?? 262_144,
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+  }
+
   it("adds default aliases when models are present", () => {
     const cfg = {
       agents: {
@@ -107,6 +136,16 @@ describe("applyModelDefaults", () => {
 
     expect(model?.contextWindow).toBe(32768);
     expect(model?.maxTokens).toBe(32768);
+  });
+
+  it("normalizes stale mistral maxTokens that matched the full context window", () => {
+    const cfg = buildMistralProviderConfig();
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.mistral?.models?.[0];
+
+    expect(model?.contextWindow).toBe(262144);
+    expect(model?.maxTokens).toBe(16384);
   });
 
   it("defaults anthropic provider and model api to anthropic-messages", () => {

--- a/src/plugins/provider-model-definitions.ts
+++ b/src/plugins/provider-model-definitions.ts
@@ -27,7 +27,7 @@ const MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 const MISTRAL_DEFAULT_MODEL_ID = "mistral-large-latest";
 const MISTRAL_DEFAULT_MODEL_REF = `mistral/${MISTRAL_DEFAULT_MODEL_ID}`;
 const MISTRAL_DEFAULT_CONTEXT_WINDOW = 262144;
-const MISTRAL_DEFAULT_MAX_TOKENS = 262144;
+const MISTRAL_DEFAULT_MAX_TOKENS = 16384;
 const MISTRAL_DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 
 const MODELSTUDIO_CN_BASE_URL = "https://coding.dashscope.aliyuncs.com/v1";


### PR DESCRIPTION
## Summary

- Problem: built-in Mistral defaults seeded `maxTokens` equal to full context for several models, which can deterministically trigger Mistral 422 rejects on normal prompts.
- Why it matters: the bad values were duplicated in both the bundled Mistral plugin catalog and the core provider-onboarding defaults, and persisted once written into user config.
- What changed: lowered bundled/core Mistral output defaults, taught config normalization and `openclaw doctor --fix` to repair stale persisted Mistral provider model entries, and added regression coverage to keep the core and bundled defaults aligned.
- What did NOT change (scope boundary): this does not change user-overridden Mistral model settings that are already below the safe thresholds, and it does not add a new command path beyond existing doctor/config normalization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52599
- Related #53006
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: OpenClaw shipped context-sized `maxTokens` defaults for Mistral models even though Mistral treats `max_tokens` as output budget, not total context.
- Missing detection / guardrail: the bundled plugin catalog and the core provider-onboarding seed path drifted independently, and we had no repair pass for already-persisted provider model values.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `#53006` identified the extension-side catalog fix but missed the duplicate core seed path and the persisted-config repair path.
- Why this regressed now: any onboarding or provider reconfiguration that wrote the old Mistral defaults preserved them indefinitely in config.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/mistral/model-definitions.test.ts`
  - `src/commands/onboard-auth.test.ts`
  - `src/config/model-alias-defaults.test.ts`
  - `src/commands/doctor-legacy-config.migrations.test.ts`
- Scenario the test should lock in: bundled catalog defaults, core provider seed defaults, config normalization, and doctor migration all converge on the same safe Mistral max-token values.
- Why this is the smallest reliable guardrail: the bug existed in both fresh-onboarding and already-persisted config paths; these tests cover both without requiring live Mistral credentials.
- Existing test that already covers this (if any): onboarding/provider tests existed, but they only covered the stale `262144` defaults.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Fresh Mistral onboarding now seeds safer default `maxTokens` values.
- Existing configs with stale context-sized Mistral `maxTokens` are repaired by config normalization and `openclaw doctor --fix`.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24.13.0 via `NODENV_VERSION=24.13.0`
- Model/provider: Mistral provider defaults/config repair
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Seed or onboard Mistral with the old default provider model definitions.
2. Observe `maxTokens` equal to the full model context window.
3. Run provider default application or `openclaw doctor --fix`.

### Expected

- Mistral models use safe output-token defaults instead of context-sized output budgets.
- Persisted stale Mistral provider configs get normalized.

### Actual

- Before this patch, fresh and persisted Mistral defaults could retain `262144` / `128000` output budgets and trigger deterministic 422 rejects.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - scoped test suite passed for Mistral catalog, onboarding, config normalization, and doctor migration
  - `pnpm build` passed
- Edge cases checked:
  - non-Mistral provider max-token clamping still behaves normally
  - core and bundled Mistral defaults stay aligned
  - persisted Mistral configs below the repaired thresholds are left alone
- What you did **not** verify:
  - live Mistral API request/response on a real key in this branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (Yes)
- If yes, exact upgrade steps:
  - upgrade to this build
  - run `openclaw doctor --fix` to rewrite stale persisted Mistral provider model defaults

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or manually override Mistral provider model `maxTokens` in config.
- Files/config to restore: `extensions/mistral/model-definitions.ts`, `src/plugins/provider-model-definitions.ts`, `src/config/defaults.ts`, `src/commands/doctor-legacy-config.ts`
- Known bad symptoms reviewers should watch for: Mistral onboarding still writing `262144` / `128000`, or doctor not updating persisted Mistral provider model entries.

## Risks and Mitigations

- Risk: exact Mistral per-model output ceilings are inconsistently documented publicly.
  - Mitigation: used conservative safe defaults, verified against public Mistral docs plus secondary public registries, and added repair logic only for stale context-sized values.
