### PR TITLE
fix(gateway): guard openrouter auto pricing recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/message tool: make Discord `components` and Slack `blocks` optional again so pin/unpin/react flows stop failing schema validation and Slack media sends are no longer forced into an invalid blocks-plus-media payload. Fixes #52970 and #52962. Thanks @vincentkoc.
 - Plugins/Feishu: route `message(..., media=...)` sends through the Feishu outbound media path so file and image attachments actually send instead of being silently dropped. Fixes #52962. Thanks @vincentkoc.
 - ClawHub/skills: resolve the local ClawHub auth token for gateway skill browsing and switch browse-all requests to search so ClawControl stops falling into unauthenticated 429s and empty authenticated skill lists. Fixes #52949. Thanks @vincentkoc.
+- Gateway/model pricing: stop `openrouter/auto` pricing refresh from recursing indefinitely during bootstrap, so OpenRouter auto routes can populate cached pricing and `usage.cost` again. Fixes #53035. Thanks @vincentkoc.
 
 ## 2026.3.22
 

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -201,4 +201,45 @@ describe("model-pricing-cache", () => {
       cacheWrite: 0,
     });
   });
+
+  it("does not recurse forever for native openrouter auto refs", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openrouter/auto" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const fetchImpl = withFetchPreconnect(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: "openrouter/auto",
+                pricing: {
+                  prompt: "0.000001",
+                  completion: "0.000002",
+                },
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+
+    await expect(refreshGatewayModelPricingCache({ config, fetchImpl })).resolves.toBeUndefined();
+    expect(
+      getCachedGatewayModelPricing({ provider: "openrouter", model: "openrouter/auto" }),
+    ).toEqual({
+      input: 1,
+      output: 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  });
 });

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -161,7 +161,14 @@ function canonicalizeOpenRouterLookupId(id: string): string {
   return `${provider}/${model}`;
 }
 
-function buildOpenRouterExactCandidates(ref: ModelRef): string[] {
+function buildOpenRouterExactCandidates(ref: ModelRef, seen = new Set<string>()): string[] {
+  const refKey = modelKey(ref.provider, ref.model);
+  if (seen.has(refKey)) {
+    return [];
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(refKey);
+
   const candidates = new Set<string>();
   const canonicalProvider = canonicalizeOpenRouterProvider(ref.provider);
   const canonicalFullId = canonicalizeOpenRouterLookupId(modelKey(canonicalProvider, ref.model));
@@ -181,7 +188,7 @@ function buildOpenRouterExactCandidates(ref: ModelRef): string[] {
   if (WRAPPER_PROVIDERS.has(ref.provider) && ref.model.includes("/")) {
     const nestedRef = parseModelRef(ref.model, DEFAULT_PROVIDER);
     if (nestedRef) {
-      for (const candidate of buildOpenRouterExactCandidates(nestedRef)) {
+      for (const candidate of buildOpenRouterExactCandidates(nestedRef, nextSeen)) {
         candidates.add(candidate);
       }
     }


### PR DESCRIPTION
## Summary
- guard OpenRouter exact-candidate expansion against fixed-point recursion
- add a regression test for native `openrouter/auto` pricing refresh
- add an Unreleased changelog fix entry

## Validation
- `pnpm test -- src/gateway/model-pricing-cache.test.ts`
- `pnpm build`

Fixes #53035
