### PR TITLE
Plugins: prefer current loader root for sdk aliases

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -725,7 +725,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
   const getJiti = (modulePath: string) => {
     const tryNative = shouldPreferNativeJiti(modulePath);
-    const aliasMap = buildPluginLoaderAliasMap(modulePath);
+    const aliasMap = buildPluginLoaderAliasMap(modulePath, { moduleUrl: import.meta.url });
     const cacheKey = JSON.stringify({
       tryNative,
       aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),

--- a/src/plugins/runtime/runtime-matrix-boundary.ts
+++ b/src/plugins/runtime/runtime-matrix-boundary.ts
@@ -73,10 +73,11 @@ function getJiti(modulePath: string) {
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
     modulePath,
+    moduleUrl: import.meta.url,
   });
   const aliasMap = {
     ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-    ...resolvePluginSdkScopedAliasMap({ modulePath }),
+    ...resolvePluginSdkScopedAliasMap({ modulePath, moduleUrl: import.meta.url }),
   };
   const loader = createJiti(import.meta.url, {
     ...buildPluginLoaderJitiOptions(aliasMap),

--- a/src/plugins/runtime/runtime-whatsapp-boundary.ts
+++ b/src/plugins/runtime/runtime-whatsapp-boundary.ts
@@ -94,11 +94,12 @@ function getJiti(modulePath: string) {
   const pluginSdkAlias = resolvePluginSdkAliasFile({
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
-    modulePath: modulePath,
+    modulePath,
+    moduleUrl: import.meta.url,
   });
   const aliasMap = {
     ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-    ...resolvePluginSdkScopedAliasMap({ modulePath }),
+    ...resolvePluginSdkScopedAliasMap({ modulePath, moduleUrl: import.meta.url }),
   };
   const loader = createJiti(import.meta.url, {
     ...buildPluginLoaderJitiOptions(aliasMap),

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -461,6 +461,135 @@ describe("plugin sdk alias helpers", () => {
     );
   });
 
+  it("prefers the current loader module root over cwd fallback for local plugins", async () => {
+    const wrongRoot = createPluginSdkAliasFixture({
+      srcFile: "plugin-entry.ts",
+      distFile: "plugin-entry.js",
+      srcBody: "export const definePluginEntry = () => 'wrong-root';\n",
+      distBody: "export const definePluginEntry = () => 'wrong-root';\n",
+      packageExports: {
+        "./plugin-sdk/plugin-entry": { default: "./dist/plugin-sdk/plugin-entry.js" },
+      },
+    });
+    const correctRoot = createPluginSdkAliasFixture({
+      srcFile: "plugin-entry.ts",
+      distFile: "plugin-entry.js",
+      srcBody: "export const definePluginEntry = () => 'correct-root';\n",
+      distBody: "export const definePluginEntry = () => 'correct-root';\n",
+      packageExports: {
+        "./plugin-sdk/plugin-entry": { default: "./dist/plugin-sdk/plugin-entry.js" },
+      },
+    });
+    const wrongRootAlias = path.join(wrongRoot.root, "src", "plugin-sdk", "root-alias.cjs");
+    const correctRootAlias = path.join(correctRoot.root, "src", "plugin-sdk", "root-alias.cjs");
+    fs.writeFileSync(wrongRootAlias, "module.exports = {};\n", "utf-8");
+    fs.writeFileSync(
+      path.join(wrongRoot.root, "dist", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    fs.writeFileSync(correctRootAlias, "module.exports = {};\n", "utf-8");
+    fs.writeFileSync(
+      path.join(correctRoot.root, "dist", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+
+    const localPluginEntry = path.join(makeTempDir(), "extensions", "demo-plugin", "index.ts");
+    mkdirSafe(path.dirname(localPluginEntry));
+    fs.writeFileSync(
+      localPluginEntry,
+      `import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export const loadedEntry = definePluginEntry();
+`,
+      "utf-8",
+    );
+
+    const withoutModuleHint = withCwd(wrongRoot.root, () =>
+      withEnv({ NODE_ENV: undefined }, () => buildPluginLoaderAliasMap(localPluginEntry)),
+    );
+    expect(fs.realpathSync(withoutModuleHint["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(wrongRootAlias),
+    );
+
+    const withModuleHint = withCwd(wrongRoot.root, () =>
+      withEnv({ NODE_ENV: undefined }, () =>
+        buildPluginLoaderAliasMap(localPluginEntry, {
+          moduleUrl: pathToFileURL(path.join(correctRoot.root, "src", "plugins", "loader.ts")).href,
+        }),
+      ),
+    );
+    expect(fs.realpathSync(withModuleHint["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(correctRootAlias),
+    );
+    expect(fs.realpathSync(withModuleHint["openclaw/plugin-sdk/plugin-entry"] ?? "")).toBe(
+      fs.realpathSync(path.join(correctRoot.root, "src", "plugin-sdk", "plugin-entry.ts")),
+    );
+
+    const createJiti = await getCreateJiti();
+    const jiti = createJiti(import.meta.url, {
+      ...buildPluginLoaderJitiOptions(withModuleHint),
+      tryNative: false,
+    });
+    expect(jiti(localPluginEntry)).toMatchObject({
+      loadedEntry: "correct-root",
+    });
+  }, 240_000);
+
+  it("prefers the current loader module root even when the plugin lives under another OpenClaw root", () => {
+    const wrongRoot = createPluginSdkAliasFixture({
+      srcFile: "plugin-entry.ts",
+      distFile: "plugin-entry.js",
+      srcBody: "export const definePluginEntry = () => 'wrong-root';\n",
+      distBody: "export const definePluginEntry = () => 'wrong-root';\n",
+      packageExports: {
+        "./plugin-sdk/plugin-entry": { default: "./dist/plugin-sdk/plugin-entry.js" },
+      },
+    });
+    const correctRoot = createPluginSdkAliasFixture({
+      srcFile: "plugin-entry.ts",
+      distFile: "plugin-entry.js",
+      srcBody: "export const definePluginEntry = () => 'correct-root';\n",
+      distBody: "export const definePluginEntry = () => 'correct-root';\n",
+      packageExports: {
+        "./plugin-sdk/plugin-entry": { default: "./dist/plugin-sdk/plugin-entry.js" },
+      },
+    });
+    fs.writeFileSync(
+      path.join(wrongRoot.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(correctRoot.root, "src", "plugin-sdk", "root-alias.cjs"),
+      "module.exports = {};\n",
+      "utf-8",
+    );
+    const foreignPluginEntry = path.join(
+      wrongRoot.root,
+      "extensions",
+      "foreign-plugin",
+      "index.ts",
+    );
+    mkdirSafe(path.dirname(foreignPluginEntry));
+    fs.writeFileSync(foreignPluginEntry, 'export const plugin = "foreign";\n', "utf-8");
+
+    const aliasMap = withCwd(wrongRoot.root, () =>
+      withEnv({ NODE_ENV: undefined }, () =>
+        buildPluginLoaderAliasMap(foreignPluginEntry, {
+          moduleUrl: pathToFileURL(path.join(correctRoot.root, "src", "plugins", "loader.ts")).href,
+        }),
+      ),
+    );
+    expect(fs.realpathSync(aliasMap["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(path.join(correctRoot.root, "src", "plugin-sdk", "root-alias.cjs")),
+    );
+    expect(fs.realpathSync(aliasMap["openclaw/plugin-sdk/plugin-entry"] ?? "")).toBe(
+      fs.realpathSync(path.join(correctRoot.root, "src", "plugin-sdk", "plugin-entry.ts")),
+    );
+  });
+
   it("does not resolve plugin-sdk alias files from cwd fallback when package root is not an OpenClaw root", () => {
     const fixture = createPluginSdkAliasFixture({
       srcFile: "channel-runtime.ts",
@@ -544,6 +673,53 @@ export const syntheticRuntimeMarker = {
       syntheticRuntimeMarker: {
         resolveOutboundSendDep: expect.any(Function),
       },
+    });
+  }, 240_000);
+
+  it("loads a local TypeScript plugin that imports plugin-sdk/plugin-entry", async () => {
+    const fixture = createPluginSdkAliasFixture({
+      srcFile: "plugin-entry.ts",
+      distFile: "plugin-entry.js",
+      srcBody: "export const definePluginEntry = () => 'source-plugin-entry';\n",
+      distBody: "export const definePluginEntry = () => 'dist-plugin-entry';\n",
+      packageExports: {
+        "./plugin-sdk/plugin-entry": { default: "./dist/plugin-sdk/plugin-entry.js" },
+      },
+    });
+    const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
+    const distRootAlias = path.join(fixture.root, "dist", "plugin-sdk", "root-alias.cjs");
+    fs.writeFileSync(sourceRootAlias, "module.exports = {};\n", "utf-8");
+    fs.writeFileSync(distRootAlias, "module.exports = {};\n", "utf-8");
+
+    const localPluginEntry = path.join(fixture.root, "extensions", "demo-plugin", "index.ts");
+    mkdirSafe(path.dirname(localPluginEntry));
+    fs.writeFileSync(
+      localPluginEntry,
+      `import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export const loadedEntry = definePluginEntry();
+`,
+      "utf-8",
+    );
+
+    const aliasMap = withEnv({ NODE_ENV: undefined }, () =>
+      buildPluginLoaderAliasMap(localPluginEntry),
+    );
+    expect(fs.realpathSync(aliasMap["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(sourceRootAlias),
+    );
+    expect(fs.realpathSync(aliasMap["openclaw/plugin-sdk/plugin-entry"] ?? "")).toBe(
+      fs.realpathSync(path.join(fixture.root, "src", "plugin-sdk", "plugin-entry.ts")),
+    );
+
+    const createJiti = await getCreateJiti();
+    const jiti = createJiti(import.meta.url, {
+      ...buildPluginLoaderJitiOptions(aliasMap),
+      tryNative: false,
+    });
+
+    expect(jiti(localPluginEntry)).toMatchObject({
+      loadedEntry: "source-plugin-entry",
     });
   }, 240_000);
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -120,8 +120,8 @@ function resolveLoaderPluginSdkPackageRoot(
         })
       : null;
   return (
-    fromCwd ??
     fromExplicitHints ??
+    fromCwd ??
     findNearestPluginSdkPackageRoot(path.dirname(params.modulePath)) ??
     (params.cwd ? findNearestPluginSdkPackageRoot(params.cwd) : null) ??
     findNearestPluginSdkPackageRoot(process.cwd())
@@ -207,9 +207,14 @@ export function resolvePluginSdkAliasFile(params: {
 const cachedPluginSdkExportedSubpaths = new Map<string, string[]>();
 const cachedPluginSdkScopedAliasMaps = new Map<string, Record<string, string>>();
 
-export function listPluginSdkExportedSubpaths(params: { modulePath?: string } = {}): string[] {
-  const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
-  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath });
+export function listPluginSdkExportedSubpaths(params: LoaderModuleResolveParams = {}): string[] {
+  const modulePath = resolveLoaderModulePath(params);
+  const packageRoot = resolveLoaderPluginSdkPackageRoot({
+    modulePath,
+    argv1: params.argv1,
+    cwd: params.cwd,
+    moduleUrl: params.moduleUrl,
+  });
   if (!packageRoot) {
     return [];
   }
@@ -223,10 +228,15 @@ export function listPluginSdkExportedSubpaths(params: { modulePath?: string } = 
 }
 
 export function resolvePluginSdkScopedAliasMap(
-  params: { modulePath?: string } = {},
+  params: LoaderModuleResolveParams = {},
 ): Record<string, string> {
-  const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
-  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath });
+  const modulePath = resolveLoaderModulePath(params);
+  const packageRoot = resolveLoaderPluginSdkPackageRoot({
+    modulePath,
+    argv1: params.argv1,
+    cwd: params.cwd,
+    moduleUrl: params.moduleUrl,
+  });
   if (!packageRoot) {
     return {};
   }
@@ -240,7 +250,12 @@ export function resolvePluginSdkScopedAliasMap(
     return cached;
   }
   const aliasMap: Record<string, string> = {};
-  for (const subpath of listPluginSdkExportedSubpaths({ modulePath })) {
+  for (const subpath of listPluginSdkExportedSubpaths({
+    modulePath,
+    argv1: params.argv1,
+    cwd: params.cwd,
+    moduleUrl: params.moduleUrl,
+  })) {
     const candidateMap = {
       src: path.join(packageRoot, "src", "plugin-sdk", `${subpath}.ts`),
       dist: path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`),
@@ -285,17 +300,21 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
   return null;
 }
 
-export function buildPluginLoaderAliasMap(modulePath: string): Record<string, string> {
+export function buildPluginLoaderAliasMap(
+  modulePath: string,
+  params: Omit<LoaderModuleResolveParams, "modulePath"> = {},
+): Record<string, string> {
+  const loaderParams = { ...params, modulePath };
   const pluginSdkAlias = resolvePluginSdkAliasFile({
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
-    modulePath,
+    ...loaderParams,
   });
-  const extensionApiAlias = resolveExtensionApiAlias({ modulePath });
+  const extensionApiAlias = resolveExtensionApiAlias(loaderParams);
   return {
     ...(extensionApiAlias ? { "openclaw/extension-api": extensionApiAlias } : {}),
     ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-    ...resolvePluginSdkScopedAliasMap({ modulePath }),
+    ...resolvePluginSdkScopedAliasMap(loaderParams),
   };
 }
 


### PR DESCRIPTION
## Summary

- Problem: local TS plugins can resolve SDK aliases from the wrong OpenClaw install root when alias fallback depends on `process.cwd()` instead of the currently running loader module.
- Why it matters: if multiple installs or mismatched working directories are present, `openclaw/plugin-sdk/*` imports can point at the wrong package tree and fail to load.
- What changed: threaded `moduleUrl` hints through plugin SDK alias resolution and passed the current loader/runtime module URL from the plugin loader plus the Matrix/WhatsApp runtime boundaries.
- What did NOT change (scope boundary): no plugin manifest or Jiti dependency changes; this stays inside alias-root selection.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53002
- Related #53047
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: local plugin alias resolution could fall back to `process.cwd()` and choose a different OpenClaw package root than the one that is actually executing the loader.
- Missing detection / guardrail: there was no regression test covering multiple candidate OpenClaw roots for a local TS plugin load.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #53002 reports the failure against a global npm install where the observed failing path did not match the install path described in the issue, which points to root-selection drift.
- Why this regressed now: the loader path already had `cwd`/package-root fallback logic, but it did not consistently anchor resolution to the currently running loader/runtime module.
- If unknown, what was ruled out: a minimal repro against current `main` and an unpacked `openclaw@2026.3.22` tarball worked when the package root was unambiguous, which ruled out a simple `plugin-entry` alias omission.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/sdk-alias.test.ts`
- Scenario the test should lock in: when `cwd` points at one valid OpenClaw root but the current loader module belongs to another, local TS plugin SDK aliases should follow the loader module root.
- Why this is the smallest reliable guardrail: it exercises the real alias builder and Jiti load path without requiring a full gateway restart or multiple real global installs.
- Existing test that already covers this (if any): existing tests covered alias candidate order and scoped alias loading, but not cross-root selection.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Local TS plugins now resolve `openclaw/plugin-sdk/*` against the currently running OpenClaw install even if `process.cwd()` points at another valid OpenClaw root.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3 (local dev machine)
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): plugin loader / Jiti alias boundary
- Relevant config (redacted): N/A

### Steps

1. Create two valid fixture OpenClaw roots with different `plugin-entry` exports.
2. Set `process.cwd()` to the wrong root and load a local TS plugin outside both roots.
3. Build aliases using the current loader module URL and load the plugin through Jiti.

### Expected

- The local plugin resolves SDK aliases from the current loader module root, not the unrelated `cwd` fallback root.

### Actual

- Verified locally after the fix: the plugin resolves from the intended loader root and loads successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm exec vitest run src/plugins/sdk-alias.test.ts src/plugin-sdk/root-alias.test.ts`.
- Edge cases checked: verified the old fallback still uses `cwd` when no module hint is provided, and verified the new module hint overrides that fallback for local plugin loading.
- What you did **not** verify: I did not run a full `openclaw gateway restart` against a real global multi-install machine.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/plugins/sdk-alias.ts`, `src/plugins/loader.ts`, `src/plugins/runtime/runtime-matrix-boundary.ts`, `src/plugins/runtime/runtime-whatsapp-boundary.ts`, `src/plugins/sdk-alias.test.ts`
- Known bad symptoms reviewers should watch for: local plugins resolve SDK aliases from the wrong install root or Jiti-based plugin loads regress.

## Risks and Mitigations

- Risk: other call sites might still rely on `cwd` fallback if they do not pass a module hint.
  - Mitigation: this PR updates the main plugin loader and the Jiti-based Matrix/WhatsApp runtime boundaries, which are the user-facing entry points for this regression.
