### PR TITLE
fix(discord): return explicit auth replies for native commands

### DIFF
--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -6,6 +6,13 @@ import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandHandlerResult, HandleCommandsParams } from "./commands-types.js";
 
+function buildNativeCommandGateReply(text: string): CommandHandlerResult {
+  return {
+    shouldContinue: false,
+    reply: { text },
+  };
+}
+
 export function rejectUnauthorizedCommand(
   params: HandleCommandsParams,
   commandLabel: string,
@@ -16,6 +23,9 @@ export function rejectUnauthorizedCommand(
   logVerbose(
     `Ignoring ${commandLabel} from unauthorized sender: ${redactIdentifier(params.command.senderId)}`,
   );
+  if (params.ctx.CommandSource === "native") {
+    return buildNativeCommandGateReply("You are not authorized to use this command.");
+  }
   return { shouldContinue: false };
 }
 
@@ -29,6 +39,9 @@ export function rejectNonOwnerCommand(
   logVerbose(
     `Ignoring ${commandLabel} from non-owner sender: ${redactIdentifier(params.command.senderId)}`,
   );
+  if (params.ctx.CommandSource === "native") {
+    return buildNativeCommandGateReply("You are not authorized to use this command.");
+  }
   return { shouldContinue: false };
 }
 

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -818,6 +818,48 @@ describe("handleCommands owner gating for privileged show commands", () => {
       testCase.assert(result);
     }
   });
+
+  it("returns an explicit unauthorized reply for native privileged commands", async () => {
+    const configParams = buildParams(
+      "/config show",
+      {
+        commands: { config: true, text: true },
+        channels: { discord: { dm: { enabled: true, policy: "open" } } },
+      } as OpenClawConfig,
+      {
+        Provider: "discord",
+        Surface: "discord",
+        CommandSource: "native",
+      },
+    );
+    configParams.command.senderIsOwner = false;
+
+    const configResult = await handleCommands(configParams);
+    expect(configResult).toEqual({
+      shouldContinue: false,
+      reply: { text: "You are not authorized to use this command." },
+    });
+
+    const pluginParams = buildParams(
+      "/plugins list",
+      {
+        commands: { plugins: true, text: true },
+        channels: { discord: { dm: { enabled: true, policy: "open" } } },
+      } as OpenClawConfig,
+      {
+        Provider: "discord",
+        Surface: "discord",
+        CommandSource: "native",
+      },
+    );
+    pluginParams.command.senderIsOwner = false;
+
+    const pluginResult = await handleCommands(pluginParams);
+    expect(pluginResult).toEqual({
+      shouldContinue: false,
+      reply: { text: "You are not authorized to use this command." },
+    });
+  });
 });
 
 describe("handleCommands /config configWrites gating", () => {


### PR DESCRIPTION
## Summary

- Problem: privileged Discord native commands could return no reply payload when auth gates rejected the sender.
- Why it matters: Discord then fell through to a misleading generic completion instead of telling the user the command was unauthorized.
- What changed: native command auth gates now return an explicit `You are not authorized to use this command.` reply, and regression coverage locks that behavior in for privileged native commands.
- What did NOT change (scope boundary): this does not change owner resolution or local config; it only fixes the native no-reply fallback path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #53041
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `rejectUnauthorizedCommand()` and `rejectNonOwnerCommand()` returned `shouldContinue: false` with no reply payload. In Discord native command flows, that empty result fell through to the generic interaction fallback instead of an explicit auth failure.
- Missing detection / guardrail: there was no native-command regression test asserting that privileged command auth failures must still emit a reply.
- Prior context (`git blame`, prior PR, issue, or refactor if known): current Discord native command handling closes empty interactions with a generic fallback in `extensions/discord/src/monitor/native-command.ts`.
- Why this regressed now: unknown.
- If unknown, what was ruled out: this was not caused by Carbon reconcile or by `/status`; local real-DM verification showed `/status` already worked and `/plugins` was the reproducible path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands.test.ts`
- Scenario the test should lock in: privileged native `/config show` and `/plugins list` requests from non-owners return an explicit unauthorized reply instead of silently stopping.
- Why this is the smallest reliable guardrail: the bug lives in the shared command gate contract, so a command-layer test catches it without needing a full Discord harness.
- Existing test that already covers this (if any): `src/auto-reply/reply/commands-plugins.test.ts` still covers plugin command behavior separately.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord native privileged commands now reply `You are not authorized to use this command.` instead of falling through to the generic empty-interaction fallback.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 local gateway + Discord DM
- Model/provider: `anthropic/claude-sonnet-4-6`
- Integration/channel (if any): Discord native slash commands
- Relevant config (redacted): `commands.plugins: true`; Discord DM with Clover

### Steps

1. Use a Discord DM with Clover where the sender is not treated as owner.
2. Run `/plugins list` as a native slash command.
3. Observe the reply payload.

### Expected

- The command should respond with an explicit unauthorized message.

### Actual

- Before this change, the auth gate returned no reply payload and Discord fell through to a misleading generic completion.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced `/plugins list` returning the wrong Discord fallback before the fix in the compiled native command path; after the fix it returned `You are not authorized to use this command.`; later verified live in a real Clover DM that `/plugins` produced a proper auth reply instead of a generic completion.
- Edge cases checked: `/status` still worked; `/acp doctor` did not reproduce the bad behavior; text-command behavior remained unchanged.
- What you did **not** verify: full Discord client matrix beyond the local DM flow.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/command-gates.ts`, `src/auto-reply/reply/commands.test.ts`
- Known bad symptoms reviewers should watch for: privileged native commands unexpectedly replying when they should stay silent on non-Discord surfaces.

## Risks and Mitigations

- Risk: changing shared auth gates could alter non-native command behavior.
  - Mitigation: the new reply payload is gated on `CommandSource === "native"`, and text-command behavior remains covered separately.
