### PR TITLE
test(extensions): lock bundled runtime API coverage

### DIFF
--- a/src/plugins/copy-bundled-plugin-metadata.test.ts
+++ b/src/plugins/copy-bundled-plugin-metadata.test.ts
@@ -84,6 +84,73 @@ describe("copyBundledPluginMetadata", () => {
     expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);
   });
 
+  it("keeps bundled package metadata scoped to declared plugin entry points when runtime helpers exist", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-runtime-metadata-");
+    const pluginDir = path.join(repoRoot, "extensions", "whatsapp");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "runtime-api.ts"),
+      "export const heavy = true;\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "light-runtime-api.ts"),
+      "export const light = true;\n",
+      "utf8",
+    );
+    writeJson(path.join(pluginDir, "openclaw.plugin.json"), {
+      id: "whatsapp",
+      configSchema: { type: "object" },
+    });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "@openclaw/whatsapp",
+      openclaw: { extensions: ["./index.ts"], setupEntry: "./setup-entry.ts" },
+    });
+
+    copyBundledPluginMetadata({ repoRoot });
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "dist", "extensions", "whatsapp", "package.json"),
+        "utf8",
+      ),
+    ) as { openclaw?: { extensions?: string[]; setupEntry?: string } };
+
+    expect(packageJson.openclaw?.extensions).toEqual(["./index.js"]);
+    expect(packageJson.openclaw?.setupEntry).toBe("./setup-entry.js");
+  });
+
+  it("handles malformed extension metadata without throwing while leaving extension discovery metadata unset", () => {
+    const repoRoot = makeRepoRoot("openclaw-bundled-plugin-malformed-runtime-metadata-");
+    const pluginDir = path.join(repoRoot, "extensions", "telegram");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "runtime-api.ts"),
+      "export const runtime = true;\n",
+      "utf8",
+    );
+    writeJson(path.join(pluginDir, "openclaw.plugin.json"), {
+      id: "telegram",
+      configSchema: { type: "object" },
+    });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "@openclaw/telegram",
+      openclaw: { extensions: null, setupEntry: "./setup-entry.ts" },
+    });
+
+    expect(() => copyBundledPluginMetadata({ repoRoot })).not.toThrow();
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(
+        path.join(repoRoot, "dist", "extensions", "telegram", "package.json"),
+        "utf8",
+      ),
+    ) as { openclaw?: { extensions?: string[]; setupEntry?: string } };
+
+    expect(packageJson.openclaw?.extensions).toBeUndefined();
+    expect(packageJson.openclaw?.setupEntry).toBe("./setup-entry.js");
+  });
+
   it("relocates node_modules-backed skill paths into bundled-skills and rewrites the manifest", () => {
     const repoRoot = makeRepoRoot("openclaw-bundled-plugin-node-modules-");
     const pluginDir = path.join(repoRoot, "extensions", "tlon");

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { listBundledPluginPackArtifacts } from "../scripts/lib/bundled-plugin-build-entries.mjs";
+import {
+  listBundledPluginBuildEntries,
+  listBundledPluginPackArtifacts,
+} from "../scripts/lib/bundled-plugin-build-entries.mjs";
 import { listPluginSdkDistArtifacts } from "../scripts/lib/plugin-sdk-entries.mjs";
 import {
   collectAppcastSparkleVersionErrors,
@@ -18,6 +21,7 @@ function makePackResult(filename: string, unpackedSize: number) {
 }
 
 const requiredPluginSdkPackPaths = [...listPluginSdkDistArtifacts(), "dist/plugin-sdk/compat.js"];
+const bundledPluginBuildEntries = listBundledPluginBuildEntries();
 const requiredBundledPluginPackPaths = listBundledPluginPackArtifacts();
 
 describe("collectAppcastSparkleVersionErrors", () => {
@@ -122,6 +126,24 @@ describe("collectForbiddenPackPaths", () => {
 });
 
 describe("collectMissingPackPaths", () => {
+  it("adds implicit runtime API build entries and pack artifacts for bundled channel plugins", () => {
+    expect(bundledPluginBuildEntries).toMatchObject({
+      "extensions/discord/runtime-api": "extensions/discord/runtime-api.ts",
+      "extensions/telegram/runtime-api": "extensions/telegram/runtime-api.ts",
+      "extensions/whatsapp/light-runtime-api": "extensions/whatsapp/light-runtime-api.ts",
+      "extensions/whatsapp/runtime-api": "extensions/whatsapp/runtime-api.ts",
+    });
+
+    expect(requiredBundledPluginPackPaths).toEqual(
+      expect.arrayContaining([
+        "dist/extensions/discord/runtime-api.js",
+        "dist/extensions/telegram/runtime-api.js",
+        "dist/extensions/whatsapp/light-runtime-api.js",
+        "dist/extensions/whatsapp/runtime-api.js",
+      ]),
+    );
+  });
+
   it("requires the shipped channel catalog, control ui, and optional bundled metadata", () => {
     const missing = collectMissingPackPaths([
       "dist/index.js",
@@ -137,13 +159,8 @@ describe("collectMissingPackPaths", () => {
       expect.arrayContaining([
         "dist/channel-catalog.json",
         "dist/control-ui/index.html",
-        "dist/extensions/matrix/helper-api.js",
-        "dist/extensions/matrix/runtime-api.js",
-        "dist/extensions/matrix/thread-bindings-runtime.js",
         "dist/extensions/matrix/openclaw.plugin.json",
         "dist/extensions/matrix/package.json",
-        "dist/extensions/whatsapp/light-runtime-api.js",
-        "dist/extensions/whatsapp/runtime-api.js",
         "dist/extensions/whatsapp/openclaw.plugin.json",
         "dist/extensions/whatsapp/package.json",
       ]),
@@ -163,18 +180,6 @@ describe("collectMissingPackPaths", () => {
         "dist/channel-catalog.json",
       ]),
     ).toEqual([]);
-  });
-
-  it("requires bundled plugin runtime sidecars that dynamic plugin boundaries resolve at runtime", () => {
-    expect(requiredBundledPluginPackPaths).toEqual(
-      expect.arrayContaining([
-        "dist/extensions/matrix/helper-api.js",
-        "dist/extensions/matrix/runtime-api.js",
-        "dist/extensions/matrix/thread-bindings-runtime.js",
-        "dist/extensions/whatsapp/light-runtime-api.js",
-        "dist/extensions/whatsapp/runtime-api.js",
-      ]),
-    );
   });
 });
 

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   listBundledPluginBuildEntries,
@@ -128,10 +129,14 @@ describe("collectForbiddenPackPaths", () => {
 describe("collectMissingPackPaths", () => {
   it("adds implicit runtime API build entries and pack artifacts for bundled channel plugins", () => {
     expect(bundledPluginBuildEntries).toMatchObject({
-      "extensions/discord/runtime-api": "extensions/discord/runtime-api.ts",
-      "extensions/telegram/runtime-api": "extensions/telegram/runtime-api.ts",
-      "extensions/whatsapp/light-runtime-api": "extensions/whatsapp/light-runtime-api.ts",
-      "extensions/whatsapp/runtime-api": "extensions/whatsapp/runtime-api.ts",
+      "extensions/discord/runtime-api": path.join("extensions", "discord", "runtime-api.ts"),
+      "extensions/telegram/runtime-api": path.join("extensions", "telegram", "runtime-api.ts"),
+      "extensions/whatsapp/light-runtime-api": path.join(
+        "extensions",
+        "whatsapp",
+        "light-runtime-api.ts",
+      ),
+      "extensions/whatsapp/runtime-api": path.join("extensions", "whatsapp", "runtime-api.ts"),
     });
 
     expect(requiredBundledPluginPackPaths).toEqual(


### PR DESCRIPTION
## Summary
- add regression coverage that locks bundled `runtime-api` / `light-runtime-api` build entries and packed dist artifacts for bundled channel plugins
- prove bundled `package.json` metadata stays scoped to declared plugin entry points even when runtime helper modules exist on disk
- cover malformed `openclaw.extensions` metadata without throwing during bundled metadata generation

## Context
Current `main` already carries the runtime-helper shipping behavior through the newer top-level public-surface discovery path. I refreshed this PR onto current `main` and deliberately narrowed it to the regression coverage that proves that behavior stays intact, rather than reintroducing the older implementation path from the original branch.

## Validation
- `pnpm exec oxlint --type-aware src/plugins/copy-bundled-plugin-metadata.test.ts test/release-check.test.ts`
- `pnpm exec vitest --run src/plugins/copy-bundled-plugin-metadata.test.ts test/release-check.test.ts`
- repeated the same targeted gate a second time with no code changes in between
- `pnpm build:strict-smoke`
- direct artifact proof after the build:
  - `dist/extensions/discord/runtime-api.js`
  - `dist/extensions/telegram/runtime-api.js`
  - `dist/extensions/whatsapp/runtime-api.js`
  - `dist/extensions/whatsapp/light-runtime-api.js`
