### PR TITLE
fix(openai-codex): bootstrap proxy on oauth refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/auto-reply: preserve same-chat inbound debounce order without stranding stale busy-session followups, and keep same-key overflow turns ordered when tracked debounce keys are saturated. (#52998) Thanks @osolmaz.
 - ClawHub/macOS: read the local ClawHub login from the macOS Application Support path and still honor XDG config on macOS, so skill browsing uses the logged-in token on both default and XDG-style setups. Fixes #52949. Thanks @scoootscooob.
 - Discord/commands: return an explicit unauthorized reply for privileged native slash commands instead of falling through to Discord's misleading generic completion when auth gates reject the sender. Fixes #53041. Thanks @scoootscooob.
+- Models/OpenAI Codex OAuth: bootstrap the env-configured HTTP/HTTPS proxy dispatcher on the stored-credential refresh path before token renewal runs, so expired Codex OAuth profiles can refresh successfully in proxy-required environments instead of locking users out after the first token expiry.
 
 ## 2026.3.22
 

--- a/extensions/openai/openai-codex-provider.runtime.test.ts
+++ b/extensions/openai/openai-codex-provider.runtime.test.ts
@@ -45,7 +45,7 @@ describe("openai-codex-provider.runtime", () => {
     expect(mocks.ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
     expect(mocks.getOAuthApiKey).toHaveBeenCalledOnce();
     expect(mocks.ensureGlobalUndiciEnvProxyDispatcher.mock.invocationCallOrder[0]).toBeLessThan(
-      mocks.getOAuthApiKey.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      mocks.getOAuthApiKey.mock.invocationCallOrder[0],
     );
   });
 });

--- a/extensions/openai/openai-codex-provider.runtime.test.ts
+++ b/extensions/openai/openai-codex-provider.runtime.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureGlobalUndiciEnvProxyDispatcher: vi.fn(),
+  getOAuthApiKey: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
+  ensureGlobalUndiciEnvProxyDispatcher: mocks.ensureGlobalUndiciEnvProxyDispatcher,
+}));
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: mocks.getOAuthApiKey,
+}));
+
+import { getOAuthApiKey } from "./openai-codex-provider.runtime.js";
+
+describe("openai-codex-provider.runtime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("bootstraps the env proxy dispatcher before refreshing oauth credentials", async () => {
+    const refreshed = {
+      newCredentials: {
+        access: "next-access",
+        refresh: "next-refresh",
+        expires: Date.now() + 60_000,
+      },
+    };
+    mocks.getOAuthApiKey.mockResolvedValue(refreshed);
+
+    await expect(
+      getOAuthApiKey("openai-codex", {
+        "openai-codex": {
+          provider: "openai-codex",
+          type: "oauth",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now(),
+        },
+      }),
+    ).resolves.toBe(refreshed);
+
+    expect(mocks.ensureGlobalUndiciEnvProxyDispatcher).toHaveBeenCalledOnce();
+    expect(mocks.getOAuthApiKey).toHaveBeenCalledOnce();
+    expect(mocks.ensureGlobalUndiciEnvProxyDispatcher.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.getOAuthApiKey.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+});

--- a/extensions/openai/openai-codex-provider.runtime.ts
+++ b/extensions/openai/openai-codex-provider.runtime.ts
@@ -1,1 +1,9 @@
-export { getOAuthApiKey } from "@mariozechner/pi-ai/oauth";
+import { getOAuthApiKey as getOAuthApiKeyFromPi } from "@mariozechner/pi-ai/oauth";
+import { ensureGlobalUndiciEnvProxyDispatcher } from "openclaw/plugin-sdk/infra-runtime";
+
+export async function getOAuthApiKey(
+  ...args: Parameters<typeof getOAuthApiKeyFromPi>
+): Promise<Awaited<ReturnType<typeof getOAuthApiKeyFromPi>>> {
+  ensureGlobalUndiciEnvProxyDispatcher();
+  return await getOAuthApiKeyFromPi(...args);
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the interactive OpenAI Codex OAuth login path now boots the env proxy dispatcher, but the stored-credential refresh path still called `getOAuthApiKey()` without that bootstrap.
- Why it matters: in proxy-required environments, sign-in can succeed and later token refresh can still fail after the first access-token expiry, locking users out again.
- What changed: wrap `extensions/openai/openai-codex-provider.runtime.ts` so it calls `ensureGlobalUndiciEnvProxyDispatcher()` before delegating to Pi's `getOAuthApiKey()`, add a focused regression test for call ordering, and add an `Unreleased` changelog entry.
- What did NOT change (scope boundary): this does not change the Pi OAuth implementation itself, the interactive login flow, or add a live proxy integration harness.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #52228
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the OpenAI Codex refresh path used a separate runtime shim that re-exported `getOAuthApiKey()` directly, so it bypassed the env-proxy bootstrap added to the interactive login path.
- Missing detection / guardrail: there was no test asserting that the refresh/runtime path bootstraps the global undici env-proxy dispatcher before invoking Pi OAuth.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the earlier proxy fix landed in #52228 for the interactive sign-in flow; this follow-up covers the stored-credential refresh path that remained outside that fix.
- Why this regressed now: the login path and refresh path were fixed at different seams, and only the login seam received proxy bootstrap initialization.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openai/openai-codex-provider.runtime.test.ts`
- Scenario the test should lock in: the runtime refresh shim bootstraps `ensureGlobalUndiciEnvProxyDispatcher()` before calling `getOAuthApiKey()`.
- Why this is the smallest reliable guardrail: the bug is in the wrapper seam itself, so a focused unit test catches missing bootstrap without requiring live OAuth or proxy infrastructure.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Users with expired OpenAI Codex OAuth profiles in proxy-required environments can refresh tokens through the stored-credential path instead of being forced back into a broken locked-out state after the first token expiry.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: OpenAI Codex OAuth
- Integration/channel (if any): none
- Relevant config (redacted): affected environments set `HTTP_PROXY` and/or `HTTPS_PROXY`

### Steps

1. Start from an OpenAI Codex OAuth profile whose stored access token is expired.
2. Run the stored-credential refresh path so `extensions/openai/openai-codex-provider.runtime.ts` calls into Pi OAuth for renewal.
3. Observe whether the refresh path bootstraps the env-proxy dispatcher before the outbound token-refresh request.

### Expected

- The refresh path initializes the env-configured proxy dispatcher before `getOAuthApiKey()` performs network work.

### Actual

- Before this change, the runtime shim re-exported `getOAuthApiKey()` directly and skipped proxy bootstrap.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before: no test covered this refresh shim behavior.
After: `pnpm exec vitest run extensions/openai/openai-codex-provider.runtime.test.ts extensions/openai/openai-provider.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed the runtime shim now boots `ensureGlobalUndiciEnvProxyDispatcher()` before delegating to Pi OAuth, and verified the focused OpenAI extension tests pass locally.
- Edge cases checked: ensured the diff is limited to the runtime shim, one focused unit test, and the changelog entry.
- What you did **not** verify: I did not run a live end-to-end expired-token refresh against a real proxy-configured environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous one-line runtime re-export.
- Files/config to restore: `extensions/openai/openai-codex-provider.runtime.ts`, `extensions/openai/openai-codex-provider.runtime.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: refresh-time OAuth failures, missing proxy behavior in proxy-required environments, or unexpected runtime import issues around the new wrapper.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the unit test locks in ordering at the wrapper seam but not full live proxy refresh behavior.
  - Mitigation: keep scope narrow and follow up with an integration-style proxy refresh test if this area regresses again.
