### PR TITLE
fix(gateway): preserve scopes when dangerouslyDisableDeviceAuth bypasses device identity

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -543,6 +543,7 @@ export function attachGatewayWsMessageHandler(params: {
             !device &&
             (decision.kind !== "allow" ||
               (!preserveInsecureLocalControlUiScopes &&
+                !controlUiAuthPolicy.allowBypass &&
                 (authMethod === "token" || authMethod === "password" || trustedProxyAuthOk)))
           ) {
             clearUnboundScopes();


### PR DESCRIPTION
## Summary

- **Problem**: Control UI scopes silently cleared for `dangerouslyDisableDeviceAuth` deployments in v2026.3.22, causing `missing scope: operator.read` on all RPC calls
- **Why it matters**: Control UI is completely non-functional for localhost HTTP and reverse proxy (Cloudflare/nginx) deployments using token auth
- **What changed**: Add `!controlUiAuthPolicy.allowBypass` to the `clearUnboundScopes` condition so explicitly-bypassed connections retain their declared scopes
- **What did NOT change**: Non-Control-UI clients, device-authenticated connections, and non-bypass configurations are unaffected

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Auth / tokens

## Linked Issue

- Fixes #53077

## User-visible / Behavior Changes

Control UI with `dangerouslyDisableDeviceAuth: true` + token auth now works correctly behind reverse proxies and on localhost HTTP, matching pre-v2026.3.22 behavior.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — scopes are only preserved when the operator has explicitly opted out of device auth via `dangerouslyDisableDeviceAuth: true`

## Repro + Verification

### Environment

- OS: Linux (VPS behind Cloudflare + WSL2 localhost)
- Runtime: Node.js, OpenClaw 2026.3.22

### Steps

1. Configure `gateway.controlUi.dangerouslyDisableDeviceAuth: true` with token auth
2. Open Control UI via reverse proxy or localhost HTTP
3. Connect with gateway token

### Expected

Control UI loads, all RPC calls succeed.

### Actual (before fix)

All RPC calls fail: `GatewayRequestError: missing scope: operator.read`

## Evidence

- [x] Server logs confirming `missing scope` errors before fix
- [x] Server logs confirming successful connection after fix
- [x] Verified on both localhost HTTP (WSL2) and Cloudflare reverse proxy deployments

## Human Verification (required)

- Verified: localhost HTTP Control UI works after fix (WSL2)
- Verified: Cloudflare reverse proxy Control UI works after fix (bot.novax.fun)
- Verified: `controlUiAuthPolicy.allowBypass` is only true when `isControlUi && dangerouslyDisableDeviceAuth === true` (code inspection + existing tests)
- Not verified: device-authenticated Control UI paths (not affected by this change)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- Revert the single-line addition to restore v2026.3.22 behavior
- Watch for: Control UI scope errors returning after revert

## Risks and Mitigations

- Risk: `dangerouslyDisableDeviceAuth` connections retain self-declared scopes without device identity verification
- Mitigation: This is the explicit intent of the `dangerouslyDisableDeviceAuth` flag — the operator has consciously opted out of device identity enforcement. Token auth is still required. The `allowBypass` flag is gated on `isControlUi` at construction time, so non-Control-UI clients cannot exploit this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)