### PR TITLE
tests: improve boundary audit coverage and safety

### DIFF
--- a/package.json
+++ b/package.json
@@ -586,6 +586,7 @@
     "android:test": "cd apps/android && ./gradlew :app:testPlayDebugUnitTest",
     "android:test:integration": "OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_ANDROID_NODE=1 vitest run --config vitest.live.config.ts src/gateway/android-node.capabilities.live.test.ts",
     "android:test:third-party": "cd apps/android && ./gradlew :app:testThirdPartyDebugUnitTest",
+    "audit:seams": "node scripts/audit-seams.mjs",
     "build": "pnpm canvas:a2ui:bundle && node scripts/tsdown-build.mjs && node scripts/runtime-postbuild.mjs && node scripts/build-stamp.mjs && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:docker": "node scripts/tsdown-build.mjs && node scripts/runtime-postbuild.mjs && node scripts/build-stamp.mjs && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/copy-export-html-templates.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-startup-metadata.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -8,11 +8,28 @@ import { optionalBundledClusterSet } from "./lib/optional-bundled-clusters.mjs";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const srcRoot = path.join(repoRoot, "src");
+const extensionsRoot = path.join(repoRoot, "extensions");
+const testRoot = path.join(repoRoot, "test");
 const workspacePackagePaths = ["ui/package.json"];
 const compareStrings = (left, right) => left.localeCompare(right);
+const HELP_TEXT = `Usage: node scripts/audit-seams.mjs [--help]
+
+Audit repo seam inventory and emit JSON to stdout.
+
+Sections:
+  duplicatedSeamFamilies       Plugin SDK seam families imported from multiple production files
+  overlapFiles                 Production files that touch multiple seam families
+  optionalClusterStaticLeaks   Optional extension/plugin clusters referenced from the static graph
+  missingPackages              Workspace packages whose deps are not mirrored at the root
+  seamTestInventory            High-signal seam candidates with nearby-test gap signals
+
+Notes:
+  - Output is JSON only.
+  - For clean redirected JSON through package scripts, prefer:
+      pnpm --silent audit:seams > seam-inventory.json
+`;
 
 async function collectWorkspacePackagePaths() {
-  const extensionsRoot = path.join(repoRoot, "extensions");
   const entries = await fs.readdir(extensionsRoot, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
@@ -59,6 +76,41 @@ async function walkCodeFiles(rootDir) {
       out.push(fullPath);
     }
   }
+  await walk(rootDir);
+  return out.toSorted((left, right) => normalizePath(left).localeCompare(normalizePath(right)));
+}
+
+async function walkAllCodeFiles(rootDir, options = {}) {
+  const out = [];
+  const includeTests = options.includeTests === true;
+
+  async function walk(dir) {
+    let entries = [];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === "dist" || entry.name === "node_modules") {
+        continue;
+      }
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !isCodeFile(entry.name)) {
+        continue;
+      }
+      const relativePath = normalizePath(fullPath);
+      if (!includeTests && !isProductionLikeFile(relativePath)) {
+        continue;
+      }
+      out.push(fullPath);
+    }
+  }
+
   await walk(rootDir);
   return out.toSorted((left, right) => normalizePath(left).localeCompare(normalizePath(right)));
 }
@@ -429,6 +481,156 @@ async function buildMissingPackages() {
   });
 }
 
+function stemFromRelativePath(relativePath) {
+  return relativePath.replace(/\.(m|c)?[jt]sx?$/, "");
+}
+
+function describeSeamKinds(relativePath, source) {
+  const seamKinds = [];
+  if (
+    relativePath.startsWith("src/agents/tools/") &&
+    /details\s*:\s*{[\s\S]*\bmedia\b\s*:/.test(source)
+  ) {
+    seamKinds.push("tool-result-media");
+  }
+  if (
+    /reply-delivery|reply-delivery\.ts|reply\/.*delivery|outbound\/deliver|outbound\/message/.test(
+      relativePath,
+    ) &&
+    /\bmediaUrl\b|\bmediaUrls\b|resolveSendableOutboundReplyParts/.test(source)
+  ) {
+    seamKinds.push("reply-delivery-media");
+  }
+  if (
+    relativePath.startsWith("extensions/") &&
+    /(outbound-adapter|reply-delivery|send|delivery|messenger)\.ts$/.test(relativePath) &&
+    /\bmediaUrl\b|\bmediaUrls\b|filename|audioAsVoice/.test(source)
+  ) {
+    seamKinds.push("channel-media-adapter");
+  }
+  if (
+    /blockStreamingEnabled|directlySentBlockKeys|resolveSendableOutboundReplyParts/.test(source) &&
+    /\bmediaUrl\b|\bmediaUrls\b/.test(source)
+  ) {
+    seamKinds.push("streaming-media-handoff");
+  }
+  return [...new Set(seamKinds)].toSorted(compareStrings);
+}
+
+function buildTestIndex(testFiles) {
+  return testFiles.map((filePath) => {
+    const relativePath = normalizePath(filePath);
+    const stem = stemFromRelativePath(relativePath)
+      .replace(/\.test$/, "")
+      .replace(/\.spec$/, "");
+    const baseName = path.basename(stem);
+    return {
+      filePath,
+      relativePath,
+      stem,
+      baseName,
+    };
+  });
+}
+
+function findRelatedTests(relativePath, testIndex, source) {
+  const stem = stemFromRelativePath(relativePath);
+  const baseName = path.basename(stem);
+  const dirName = path.dirname(relativePath);
+  const normalizedDir = dirName.split(path.sep).join("/");
+  const pathSuffix = `${normalizedDir}/${baseName}`;
+
+  const matches = testIndex.filter((entry) => {
+    if (entry.stem === stem) {
+      return true;
+    }
+    if (entry.relativePath.includes(pathSuffix)) {
+      return true;
+    }
+    const entryDir = path.dirname(entry.relativePath).split(path.sep).join("/");
+    if (entryDir === normalizedDir && entry.baseName.includes(baseName)) {
+      return true;
+    }
+    return (
+      baseName.length >= 12 && source.includes(baseName) && entry.relativePath.includes(baseName)
+    );
+  });
+
+  return [...new Set(matches.map((entry) => entry.relativePath))].toSorted(compareStrings);
+}
+
+function determineSeamTestStatus(seamKinds, relatedTests) {
+  if (relatedTests.length === 0) {
+    return {
+      status: "gap",
+      reason: "No nearby test file references this seam candidate.",
+    };
+  }
+  if (
+    seamKinds.includes("reply-delivery-media") ||
+    seamKinds.includes("streaming-media-handoff") ||
+    seamKinds.includes("tool-result-media")
+  ) {
+    return {
+      status: "partial",
+      reason:
+        "Nearby tests exist, but this inventory does not prove cross-layer seam coverage end to end.",
+    };
+  }
+  return {
+    status: "covered-nearby",
+    reason: "Nearby test files exist for this seam candidate.",
+  };
+}
+
+async function buildSeamTestInventory() {
+  const productionFiles = [
+    ...(await walkCodeFiles(srcRoot)),
+    ...(await walkCodeFiles(extensionsRoot)),
+  ].toSorted((left, right) => normalizePath(left).localeCompare(normalizePath(right)));
+  const testFiles = [
+    ...(await walkAllCodeFiles(srcRoot, { includeTests: true })),
+    ...(await walkAllCodeFiles(extensionsRoot, { includeTests: true })),
+    ...(await walkAllCodeFiles(testRoot, { includeTests: true })),
+  ]
+    .filter((filePath) => /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(filePath))
+    .toSorted((left, right) => normalizePath(left).localeCompare(normalizePath(right)));
+  const testIndex = buildTestIndex(testFiles);
+  const inventory = [];
+
+  for (const filePath of productionFiles) {
+    const relativePath = normalizePath(filePath);
+    const source = await fs.readFile(filePath, "utf8");
+    const seamKinds = describeSeamKinds(relativePath, source);
+    if (seamKinds.length === 0) {
+      continue;
+    }
+    const relatedTests = findRelatedTests(relativePath, testIndex, source);
+    const status = determineSeamTestStatus(seamKinds, relatedTests);
+    inventory.push({
+      file: relativePath,
+      seamKinds,
+      relatedTests,
+      status: status.status,
+      reason: status.reason,
+    });
+  }
+
+  return inventory.toSorted((left, right) => {
+    return (
+      left.status.localeCompare(right.status) ||
+      left.file.localeCompare(right.file) ||
+      left.seamKinds.join(",").localeCompare(right.seamKinds.join(","))
+    );
+  });
+}
+
+const args = new Set(process.argv.slice(2));
+if (args.has("--help") || args.has("-h")) {
+  process.stdout.write(`${HELP_TEXT}\n`);
+  process.exit(0);
+}
+
 await collectWorkspacePackagePaths();
 const inventory = await collectCorePluginSdkImports();
 const optionalClusterStaticLeaks = await collectOptionalClusterStaticLeaks();
@@ -437,6 +639,7 @@ const result = {
   overlapFiles: buildOverlapFiles(inventory),
   optionalClusterStaticLeaks: buildOptionalClusterStaticLeaks(optionalClusterStaticLeaks),
   missingPackages: await buildMissingPackages(),
+  seamTestInventory: await buildSeamTestInventory(),
 };
 
 process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -46,11 +46,17 @@ function isCodeFile(fileName) {
   return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(fileName);
 }
 
-function isProductionLikeFile(relativePath) {
+function isTestLikePath(relativePath) {
   return (
-    !/(^|\/)(__tests__|fixtures)\//.test(relativePath) &&
-    !/\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(relativePath)
+    /(^|\/)(__tests__|fixtures|test-utils|test-fixtures)\//.test(relativePath) ||
+    /(?:^|\/)[^/]*(?:[.-](?:test|spec))(?:[.-][^/]+)?\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(
+      relativePath,
+    )
   );
+}
+
+function isProductionLikeFile(relativePath) {
+  return !isTestLikePath(relativePath);
 }
 
 async function walkCodeFiles(rootDir) {
@@ -533,6 +539,21 @@ function buildTestIndex(testFiles) {
   });
 }
 
+function matchQualityRank(quality) {
+  switch (quality) {
+    case "exact-stem":
+      return 0;
+    case "path-nearby":
+      return 1;
+    case "dir-basename":
+      return 2;
+    case "source-echo":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
 function findRelatedTests(relativePath, testIndex, source) {
   const stem = stemFromRelativePath(relativePath);
   const baseName = path.basename(stem);
@@ -540,32 +561,48 @@ function findRelatedTests(relativePath, testIndex, source) {
   const normalizedDir = dirName.split(path.sep).join("/");
   const pathSuffix = `${normalizedDir}/${baseName}`;
 
-  const matches = testIndex.filter((entry) => {
+  const matches = testIndex.flatMap((entry) => {
     if (entry.stem === stem) {
-      return true;
+      return [{ file: entry.relativePath, matchQuality: "exact-stem" }];
     }
     if (entry.relativePath.includes(pathSuffix)) {
-      return true;
+      return [{ file: entry.relativePath, matchQuality: "path-nearby" }];
     }
     const entryDir = path.dirname(entry.relativePath).split(path.sep).join("/");
     if (entryDir === normalizedDir && entry.baseName.includes(baseName)) {
-      return true;
+      return [{ file: entry.relativePath, matchQuality: "dir-basename" }];
     }
-    return (
-      baseName.length >= 12 && source.includes(baseName) && entry.relativePath.includes(baseName)
-    );
+    if (baseName.length >= 12 && source.includes(baseName) && entry.relativePath.includes(baseName)) {
+      return [{ file: entry.relativePath, matchQuality: "source-echo" }];
+    }
+    return [];
   });
 
-  return [...new Set(matches.map((entry) => entry.relativePath))].toSorted(compareStrings);
+  const byFile = new Map();
+  for (const match of matches) {
+    const existing = byFile.get(match.file);
+    if (!existing || matchQualityRank(match.matchQuality) < matchQualityRank(existing.matchQuality)) {
+      byFile.set(match.file, match);
+    }
+  }
+
+  return [...byFile.values()].toSorted((left, right) => {
+    return (
+      matchQualityRank(left.matchQuality) - matchQualityRank(right.matchQuality) ||
+      left.file.localeCompare(right.file)
+    );
+  });
 }
 
-function determineSeamTestStatus(seamKinds, relatedTests) {
-  if (relatedTests.length === 0) {
+function determineSeamTestStatus(seamKinds, relatedTestMatches) {
+  if (relatedTestMatches.length === 0) {
     return {
       status: "gap",
       reason: "No nearby test file references this seam candidate.",
     };
   }
+
+  const bestMatch = relatedTestMatches[0]?.matchQuality ?? "unknown";
   if (
     seamKinds.includes("reply-delivery-media") ||
     seamKinds.includes("streaming-media-handoff") ||
@@ -574,12 +611,13 @@ function determineSeamTestStatus(seamKinds, relatedTests) {
     return {
       status: "partial",
       reason:
-        "Nearby tests exist, but this inventory does not prove cross-layer seam coverage end to end.",
+        `Nearby tests exist (best match: ${bestMatch}), but this inventory does not prove cross-layer seam coverage end to end.`,
     };
   }
   return {
-    status: "covered-nearby",
-    reason: "Nearby test files exist for this seam candidate.",
+    status: "heuristic-nearby",
+    reason:
+      `Nearby tests exist (best match: ${bestMatch}), but this remains a filename/path heuristic rather than proof of seam assertions.`,
   };
 }
 
@@ -605,12 +643,13 @@ async function buildSeamTestInventory() {
     if (seamKinds.length === 0) {
       continue;
     }
-    const relatedTests = findRelatedTests(relativePath, testIndex, source);
-    const status = determineSeamTestStatus(seamKinds, relatedTests);
+    const relatedTestMatches = findRelatedTests(relativePath, testIndex, source);
+    const status = determineSeamTestStatus(seamKinds, relatedTestMatches);
     inventory.push({
       file: relativePath,
       seamKinds,
-      relatedTests,
+      relatedTests: relatedTestMatches.map((entry) => entry.file),
+      relatedTestMatches,
       status: status.status,
       reason: status.reason,
     });

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -311,14 +311,21 @@ function buildDuplicatedSeamFamilies(inventory) {
         return [
           family,
           {
-            count: entries.length,
+            count: files.length,
+            importCount: entries.length,
             files,
             imports: entries,
           },
         ];
       })
       .filter(([, value]) => value.files.length > 1)
-      .toSorted((left, right) => right[1].count - left[1].count || left[0].localeCompare(right[0])),
+      .toSorted((left, right) => {
+        return (
+          right[1].count - left[1].count ||
+          right[1].importCount - left[1].importCount ||
+          left[0].localeCompare(right[0])
+        );
+      }),
   );
 
   return duplicated;
@@ -396,6 +403,13 @@ function packageClusterMeta(relativePackagePath) {
 }
 
 function classifyMissingPackageCluster(params) {
+  if (params.hasStaticLeak) {
+    return {
+      decision: "required",
+      reason:
+        "Cluster already appears in the static graph in this audit run, so treating it as optional would be misleading.",
+    };
+  }
   if (optionalBundledClusterSet.has(params.cluster)) {
     if (params.cluster === "ui") {
       return {
@@ -424,7 +438,7 @@ function classifyMissingPackageCluster(params) {
   };
 }
 
-async function buildMissingPackages() {
+async function buildMissingPackages(params = {}) {
   const rootPackage = JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8"));
   const rootDeps = new Set([
     ...Object.keys(rootPackage.dependencies ?? {}),
@@ -467,6 +481,7 @@ async function buildMissingPackages() {
     const classification = classifyMissingPackageCluster({
       cluster: meta.cluster,
       pluginSdkEntries,
+      hasStaticLeak: params.staticLeakClusters?.has(meta.cluster) === true,
     });
     output.push({
       cluster: meta.cluster,
@@ -539,13 +554,20 @@ function buildTestIndex(testFiles) {
   });
 }
 
+function splitNameTokens(name) {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
 function matchQualityRank(quality) {
   switch (quality) {
     case "exact-stem":
       return 0;
     case "path-nearby":
       return 1;
-    case "dir-basename":
+    case "dir-token":
       return 2;
     case "source-echo":
       return 3;
@@ -559,20 +581,29 @@ function findRelatedTests(relativePath, testIndex, source) {
   const baseName = path.basename(stem);
   const dirName = path.dirname(relativePath);
   const normalizedDir = dirName.split(path.sep).join("/");
-  const pathSuffix = `${normalizedDir}/${baseName}`;
+  const baseTokens = new Set(splitNameTokens(baseName).filter((token) => token.length >= 7));
 
   const matches = testIndex.flatMap((entry) => {
     if (entry.stem === stem) {
       return [{ file: entry.relativePath, matchQuality: "exact-stem" }];
     }
-    if (entry.relativePath.includes(pathSuffix)) {
+    if (entry.stem.startsWith(`${stem}.`)) {
       return [{ file: entry.relativePath, matchQuality: "path-nearby" }];
     }
     const entryDir = path.dirname(entry.relativePath).split(path.sep).join("/");
-    if (entryDir === normalizedDir && entry.baseName.includes(baseName)) {
-      return [{ file: entry.relativePath, matchQuality: "dir-basename" }];
+    if (entryDir === normalizedDir && baseTokens.size > 0) {
+      const entryTokens = splitNameTokens(entry.baseName);
+      const sharedToken = entryTokens.find((token) => baseTokens.has(token));
+      if (sharedToken) {
+        return [{ file: entry.relativePath, matchQuality: "dir-token" }];
+      }
     }
-    if (baseName.length >= 12 && source.includes(baseName) && entry.relativePath.includes(baseName)) {
+    if (
+      baseName.length >= 12 &&
+      source.includes(baseName) &&
+      entryDir === normalizedDir &&
+      (entry.baseName === baseName || entry.baseName.startsWith(`${baseName}.`))
+    ) {
       return [{ file: entry.relativePath, matchQuality: "source-echo" }];
     }
     return [];
@@ -673,11 +704,12 @@ if (args.has("--help") || args.has("-h")) {
 await collectWorkspacePackagePaths();
 const inventory = await collectCorePluginSdkImports();
 const optionalClusterStaticLeaks = await collectOptionalClusterStaticLeaks();
+const staticLeakClusters = new Set(optionalClusterStaticLeaks.map((entry) => entry.cluster));
 const result = {
   duplicatedSeamFamilies: buildDuplicatedSeamFamilies(inventory),
   overlapFiles: buildOverlapFiles(inventory),
   optionalClusterStaticLeaks: buildOptionalClusterStaticLeaks(optionalClusterStaticLeaks),
-  missingPackages: await buildMissingPackages(),
+  missingPackages: await buildMissingPackages({ staticLeakClusters }),
   seamTestInventory: await buildSeamTestInventory(),
 };
 

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -607,7 +607,10 @@ function findRelatedTests(relativePath, testIndex) {
   const byFile = new Map();
   for (const match of matches) {
     const existing = byFile.get(match.file);
-    if (!existing || matchQualityRank(match.matchQuality) < matchQualityRank(existing.matchQuality)) {
+    if (
+      !existing ||
+      matchQualityRank(match.matchQuality) < matchQualityRank(existing.matchQuality)
+    ) {
       byFile.set(match.file, match);
     }
   }
@@ -636,14 +639,12 @@ function determineSeamTestStatus(seamKinds, relatedTestMatches) {
   ) {
     return {
       status: "partial",
-      reason:
-        `Nearby tests exist (best match: ${bestMatch}), but this inventory does not prove cross-layer seam coverage end to end.`,
+      reason: `Nearby tests exist (best match: ${bestMatch}), but this inventory does not prove cross-layer seam coverage end to end.`,
     };
   }
   return {
     status: "heuristic-nearby",
-    reason:
-      `Nearby tests exist (best match: ${bestMatch}), but this remains a filename/path heuristic rather than proof of seam assertions.`,
+    reason: `Nearby tests exist (best match: ${bestMatch}), but this remains a filename/path heuristic rather than proof of seam assertions.`,
   };
 }
 

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -526,7 +526,7 @@ function describeSeamKinds(relativePath, source) {
   }
   if (
     relativePath.startsWith("extensions/") &&
-    /(outbound-adapter|reply-delivery|send|delivery|messenger|channel(?:\.runtime)?)\.ts$/.test(
+    /(outbound|outbound-adapter|reply-delivery|send|delivery|messenger|channel(?:\.runtime)?)\.ts$/.test(
       relativePath,
     ) &&
     (/sendMedia\b/.test(source) || /\bmediaUrl\b|\bmediaUrls\b|filename|audioAsVoice/.test(source))
@@ -543,20 +543,24 @@ function describeSeamKinds(relativePath, source) {
   return [...new Set(seamKinds)].toSorted(compareStrings);
 }
 
-function buildTestIndex(testFiles) {
-  return testFiles.map((filePath) => {
-    const relativePath = normalizePath(filePath);
-    const stem = stemFromRelativePath(relativePath)
-      .replace(/\.test$/, "")
-      .replace(/\.spec$/, "");
-    const baseName = path.basename(stem);
-    return {
-      filePath,
-      relativePath,
-      stem,
-      baseName,
-    };
-  });
+async function buildTestIndex(testFiles) {
+  return Promise.all(
+    testFiles.map(async (filePath) => {
+      const relativePath = normalizePath(filePath);
+      const stem = stemFromRelativePath(relativePath)
+        .replace(/\.test$/, "")
+        .replace(/\.spec$/, "");
+      const baseName = path.basename(stem);
+      const source = await fs.readFile(filePath, "utf8");
+      return {
+        filePath,
+        relativePath,
+        stem,
+        baseName,
+        source,
+      };
+    }),
+  );
 }
 
 function splitNameTokens(name) {
@@ -566,16 +570,22 @@ function splitNameTokens(name) {
     .filter(Boolean);
 }
 
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function matchQualityRank(quality) {
   switch (quality) {
     case "exact-stem":
       return 0;
     case "path-nearby":
       return 1;
-    case "dir-token":
+    case "direct-import":
       return 2;
-    default:
+    case "dir-token":
       return 3;
+    default:
+      return 4;
   }
 }
 
@@ -594,6 +604,18 @@ function findRelatedTests(relativePath, testIndex) {
       return [{ file: entry.relativePath, matchQuality: "path-nearby" }];
     }
     const entryDir = path.dirname(entry.relativePath).split(path.sep).join("/");
+    const importPath =
+      path.posix.relative(entryDir, stem) === path.basename(stem)
+        ? `./${path.basename(stem)}`
+        : path.posix.relative(entryDir, stem).startsWith(".")
+          ? path.posix.relative(entryDir, stem)
+          : `./${path.posix.relative(entryDir, stem)}`;
+    const directImportPattern = new RegExp(
+      `["'\`]${escapeForRegExp(importPath)}(?:\\.[^"'\\\`]+)?["'\`]`,
+    );
+    if (directImportPattern.test(entry.source)) {
+      return [{ file: entry.relativePath, matchQuality: "direct-import" }];
+    }
     if (entryDir === normalizedDir && baseTokens.size > 0) {
       const entryTokens = splitNameTokens(entry.baseName);
       const sharedToken = entryTokens.find((token) => baseTokens.has(token));
@@ -660,7 +682,7 @@ async function buildSeamTestInventory() {
   ]
     .filter((filePath) => /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/.test(filePath))
     .toSorted((left, right) => normalizePath(left).localeCompare(normalizePath(right)));
-  const testIndex = buildTestIndex(testFiles);
+  const testIndex = await buildTestIndex(testFiles);
   const inventory = [];
 
   for (const filePath of productionFiles) {

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -508,6 +508,10 @@ function stemFromRelativePath(relativePath) {
 
 function describeSeamKinds(relativePath, source) {
   const seamKinds = [];
+  const isReplyDeliveryPath =
+    /reply-delivery|reply-delivery\.ts|reply\/.*delivery|outbound\/deliver|outbound\/message/.test(
+      relativePath,
+    );
   if (
     relativePath.startsWith("src/agents/tools/") &&
     /details\s*:\s*{[\s\S]*\bmedia\b\s*:/.test(source)
@@ -515,22 +519,23 @@ function describeSeamKinds(relativePath, source) {
     seamKinds.push("tool-result-media");
   }
   if (
-    /reply-delivery|reply-delivery\.ts|reply\/.*delivery|outbound\/deliver|outbound\/message/.test(
-      relativePath,
-    ) &&
+    isReplyDeliveryPath &&
     /\bmediaUrl\b|\bmediaUrls\b|resolveSendableOutboundReplyParts/.test(source)
   ) {
     seamKinds.push("reply-delivery-media");
   }
   if (
     relativePath.startsWith("extensions/") &&
-    /(outbound-adapter|reply-delivery|send|delivery|messenger)\.ts$/.test(relativePath) &&
-    /\bmediaUrl\b|\bmediaUrls\b|filename|audioAsVoice/.test(source)
+    /(outbound-adapter|reply-delivery|send|delivery|messenger|channel(?:\.runtime)?)\.ts$/.test(
+      relativePath,
+    ) &&
+    (/sendMedia\b/.test(source) || /\bmediaUrl\b|\bmediaUrls\b|filename|audioAsVoice/.test(source))
   ) {
     seamKinds.push("channel-media-adapter");
   }
   if (
-    /blockStreamingEnabled|directlySentBlockKeys|resolveSendableOutboundReplyParts/.test(source) &&
+    isReplyDeliveryPath &&
+    /blockStreamingEnabled|directlySentBlockKeys/.test(source) &&
     /\bmediaUrl\b|\bmediaUrls\b/.test(source)
   ) {
     seamKinds.push("streaming-media-handoff");
@@ -569,14 +574,12 @@ function matchQualityRank(quality) {
       return 1;
     case "dir-token":
       return 2;
-    case "source-echo":
-      return 3;
     default:
-      return 4;
+      return 3;
   }
 }
 
-function findRelatedTests(relativePath, testIndex, source) {
+function findRelatedTests(relativePath, testIndex) {
   const stem = stemFromRelativePath(relativePath);
   const baseName = path.basename(stem);
   const dirName = path.dirname(relativePath);
@@ -597,14 +600,6 @@ function findRelatedTests(relativePath, testIndex, source) {
       if (sharedToken) {
         return [{ file: entry.relativePath, matchQuality: "dir-token" }];
       }
-    }
-    if (
-      baseName.length >= 12 &&
-      source.includes(baseName) &&
-      entryDir === normalizedDir &&
-      (entry.baseName === baseName || entry.baseName.startsWith(`${baseName}.`))
-    ) {
-      return [{ file: entry.relativePath, matchQuality: "source-echo" }];
     }
     return [];
   });
@@ -674,7 +669,7 @@ async function buildSeamTestInventory() {
     if (seamKinds.length === 0) {
       continue;
     }
-    const relatedTestMatches = findRelatedTests(relativePath, testIndex, source);
+    const relatedTestMatches = findRelatedTests(relativePath, testIndex);
     const status = determineSeamTestStatus(seamKinds, relatedTestMatches);
     inventory.push({
       file: relativePath,

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -11,6 +11,7 @@ const srcRoot = path.join(repoRoot, "src");
 const extensionsRoot = path.join(repoRoot, "extensions");
 const testRoot = path.join(repoRoot, "test");
 const workspacePackagePaths = ["ui/package.json"];
+const MAX_SCAN_BYTES = 2 * 1024 * 1024;
 const compareStrings = (left, right) => left.localeCompare(right);
 const HELP_TEXT = `Usage: node scripts/audit-seams.mjs [--help]
 
@@ -40,6 +41,30 @@ async function collectWorkspacePackagePaths() {
 
 function normalizePath(filePath) {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+async function readScannableText(filePath, maxBytes = MAX_SCAN_BYTES) {
+  const stat = await fs.stat(filePath);
+  if (stat.size <= maxBytes) {
+    return fs.readFile(filePath, "utf8");
+  }
+  const handle = await fs.open(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
+
+function redactNpmSpec(npmSpec) {
+  if (typeof npmSpec !== "string") {
+    return npmSpec ?? null;
+  }
+  return npmSpec
+    .replace(/(https?:\/\/)([^/\s:@]+):([^/\s@]+)@/gi, "$1***:***@")
+    .replace(/(https?:\/\/)([^/\s:@]+)@/gi, "$1***@");
 }
 
 function isCodeFile(fileName) {
@@ -489,7 +514,7 @@ async function buildMissingPackages(params = {}) {
       decisionReason: classification.reason,
       packageName: pkg.name ?? meta.packageName,
       packagePath: relativePackagePath,
-      npmSpec: pkg.openclaw?.install?.npmSpec ?? null,
+      npmSpec: redactNpmSpec(pkg.openclaw?.install?.npmSpec),
       private: pkg.private === true,
       pluginSdkReachability:
         pluginSdkEntries.length > 0 ? { staticEntryPoints: pluginSdkEntries } : undefined,
@@ -509,11 +534,19 @@ function stemFromRelativePath(relativePath) {
 function describeSeamKinds(relativePath, source) {
   const seamKinds = [];
   const isReplyDeliveryPath =
-    /reply-delivery|reply-delivery\.ts|reply\/.*delivery|outbound\/deliver|outbound\/message/.test(
+    /reply-delivery|reply-dispatcher|reply\/.*delivery|monitor\/(?:replies|deliver)|outbound\/deliver|outbound\/message/.test(
       relativePath,
     );
+  const isChannelMediaAdapterPath =
+    (relativePath.startsWith("extensions/") &&
+      /(outbound|outbound-adapter|reply-delivery|send|delivery|messenger|channel(?:\.runtime)?)\.ts$/.test(
+        relativePath,
+      )) ||
+    /^src\/channels\/plugins\/outbound\/[^/]+\.ts$/.test(relativePath);
   if (
     relativePath.startsWith("src/agents/tools/") &&
+    source.includes("details") &&
+    source.includes("media") &&
     /details\s*:\s*{[\s\S]*\bmedia\b\s*:/.test(source)
   ) {
     seamKinds.push("tool-result-media");
@@ -525,10 +558,7 @@ function describeSeamKinds(relativePath, source) {
     seamKinds.push("reply-delivery-media");
   }
   if (
-    relativePath.startsWith("extensions/") &&
-    /(outbound|outbound-adapter|reply-delivery|send|delivery|messenger|channel(?:\.runtime)?)\.ts$/.test(
-      relativePath,
-    ) &&
+    isChannelMediaAdapterPath &&
     (/sendMedia\b/.test(source) || /\bmediaUrl\b|\bmediaUrls\b|filename|audioAsVoice/.test(source))
   ) {
     seamKinds.push("channel-media-adapter");
@@ -551,7 +581,7 @@ async function buildTestIndex(testFiles) {
         .replace(/\.test$/, "")
         .replace(/\.spec$/, "");
       const baseName = path.basename(stem);
-      const source = await fs.readFile(filePath, "utf8");
+      const source = await readScannableText(filePath);
       return {
         filePath,
         relativePath,
@@ -687,7 +717,7 @@ async function buildSeamTestInventory() {
 
   for (const filePath of productionFiles) {
     const relativePath = normalizePath(filePath);
-    const source = await fs.readFile(filePath, "utf8");
+    const source = await readScannableText(filePath);
     const seamKinds = describeSeamKinds(relativePath, source);
     if (seamKinds.length === 0) {
       continue;

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -534,7 +534,7 @@ function stemFromRelativePath(relativePath) {
 function describeSeamKinds(relativePath, source) {
   const seamKinds = [];
   const isReplyDeliveryPath =
-    /reply-delivery|reply-dispatcher|reply\/.*delivery|monitor\/(?:replies|deliver)|outbound\/deliver|outbound\/message/.test(
+    /reply-delivery|reply-dispatcher|deliver-reply|reply\/.*delivery|monitor\/(?:replies|deliver)|outbound\/deliver|outbound\/message/.test(
       relativePath,
     );
   const isChannelMediaAdapterPath =
@@ -604,6 +604,18 @@ function escapeForRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function hasExecutableImportReference(source, importPath) {
+  const escapedImportPath = escapeForRegExp(importPath);
+  const suffix = String.raw`(?:\.[^"'\\\`]+)?`;
+  const patterns = [
+    new RegExp(String.raw`\bfrom\s*["'\`]${escapedImportPath}${suffix}["'\`]`),
+    new RegExp(String.raw`\bimport\s*["'\`]${escapedImportPath}${suffix}["'\`]`),
+    new RegExp(String.raw`\brequire\s*\(\s*["'\`]${escapedImportPath}${suffix}["'\`]\s*\)`),
+    new RegExp(String.raw`\bimport\s*\(\s*["'\`]${escapedImportPath}${suffix}["'\`]\s*\)`),
+  ];
+  return patterns.some((pattern) => pattern.test(source));
+}
+
 function matchQualityRank(quality) {
   switch (quality) {
     case "exact-stem":
@@ -640,10 +652,7 @@ function findRelatedTests(relativePath, testIndex) {
         : path.posix.relative(entryDir, stem).startsWith(".")
           ? path.posix.relative(entryDir, stem)
           : `./${path.posix.relative(entryDir, stem)}`;
-    const directImportPattern = new RegExp(
-      `["'\`]${escapeForRegExp(importPath)}(?:\\.[^"'\\\`]+)?["'\`]`,
-    );
-    if (directImportPattern.test(entry.source)) {
+    if (hasExecutableImportReference(entry.source, importPath)) {
       return [{ file: entry.relativePath, matchQuality: "direct-import" }];
     }
     if (entryDir === normalizedDir && baseTokens.size > 0) {

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -616,6 +616,16 @@ function hasExecutableImportReference(source, importPath) {
   return patterns.some((pattern) => pattern.test(source));
 }
 
+function hasModuleMockReference(source, importPath) {
+  const escapedImportPath = escapeForRegExp(importPath);
+  const suffix = String.raw`(?:\.[^"'\\\`]+)?`;
+  const patterns = [
+    new RegExp(String.raw`\bvi\.mock\s*\(\s*["'\`]${escapedImportPath}${suffix}["'\`]`),
+    new RegExp(String.raw`\bjest\.mock\s*\(\s*["'\`]${escapedImportPath}${suffix}["'\`]`),
+  ];
+  return patterns.some((pattern) => pattern.test(source));
+}
+
 function matchQualityRank(quality) {
   switch (quality) {
     case "exact-stem":
@@ -652,7 +662,10 @@ function findRelatedTests(relativePath, testIndex) {
         : path.posix.relative(entryDir, stem).startsWith(".")
           ? path.posix.relative(entryDir, stem)
           : `./${path.posix.relative(entryDir, stem)}`;
-    if (hasExecutableImportReference(entry.source, importPath)) {
+    if (
+      hasExecutableImportReference(entry.source, importPath) &&
+      !hasModuleMockReference(entry.source, importPath)
+    ) {
       return [{ file: entry.relativePath, matchQuality: "direct-import" }];
     }
     if (entryDir === normalizedDir && baseTokens.size > 0) {

--- a/scripts/audit-seams.mjs
+++ b/scripts/audit-seams.mjs
@@ -534,7 +534,7 @@ function stemFromRelativePath(relativePath) {
 function describeSeamKinds(relativePath, source) {
   const seamKinds = [];
   const isReplyDeliveryPath =
-    /reply-delivery|reply-dispatcher|deliver-reply|reply\/.*delivery|monitor\/(?:replies|deliver)|outbound\/deliver|outbound\/message/.test(
+    /reply-delivery|reply-dispatcher|deliver-reply|reply\/.*delivery|monitor\/(?:replies|deliver|native-command)|outbound\/deliver|outbound\/message/.test(
       relativePath,
     );
   const isChannelMediaAdapterPath =


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the boundary audit tool undercounted real reply/media boundary files and sometimes overstated nearby test coverage with overly broad heuristics.
- Why it matters: this inventory is meant to seed and ratchet boundary-level test work, so false gaps and false coverage both make it less useful.
- What changed: renamed and expanded the audit script, added boundary test inventory output, widened matcher coverage for real reply/outbound handlers, tightened nearby-test matching, added scan guardrails, and redacted credential-bearing `npmSpec` output.
- What did NOT change (scope boundary): this PR does not check in a baseline snapshot or add the future diff/ratchet test yet.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the audit started with filename/path heuristics that were too narrow for some real boundary files and too permissive for some nearby-test matches.
- Missing detection / guardrail: there was no checked-in baseline yet, so inventory drift and heuristic overreach were only caught by review.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this PR grew out of investigating a media reply regression where the missing test layer was a boundary-level handoff between tool output, reply delivery, and channel send.
- Why this regressed now: the initial inventory implementation was intentionally heuristic and then had to be tightened against real repo examples surfaced by bot review.
- If unknown, what was ruled out: not a production runtime behavior regression; this is isolated to developer tooling/inventory semantics.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: follow-up baseline/assertion coverage for `scripts/audit-seams.mjs` output.
- Scenario the test should lock in: real boundary files stay inventoried, mock-only references do not count as nearby coverage, and output stays redacted/safe by default.
- Why this is the smallest reliable guardrail: the behavior is about cross-file inventory semantics, not a single helper in isolation.
- Existing test that already covers this (if any): none yet.
- If no new test is added, why not: this PR stabilizes the tool first; baseline/rachet enforcement is intended as the next step once output shape is settled.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `pnpm audit:seams` now reports a broader and more accurate boundary-test inventory.
- The JSON output redacts credential-bearing `npmSpec` URL forms.
- Large files are scan-bounded for the heuristic inventory pass.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: `npmSpec` values are now redacted before being emitted to stdout, reducing the chance of leaking credential-bearing package specs into CI logs.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm 10
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default repo config

### Steps

1. Run `pnpm --silent audit:seams` on the branch.
2. Inspect representative entries for reply handlers, outbound helpers, and nearby-test matches.
3. Run formatting check for `scripts/audit-seams.mjs`.

### Expected

- Real boundary files are present in inventory.
- Mock-only references do not count as nearby coverage.
- Output is formatted and `npmSpec` does not leak credential-bearing URL forms.

### Actual

- Verified locally on the rebased PR head.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: exact inventory entries for `extensions/whatsapp/src/auto-reply/deliver-reply.ts`, `extensions/feishu/src/reply-dispatcher.ts`, `extensions/slack/src/monitor/replies.ts`, `extensions/imessage/src/monitor/deliver.ts`, `src/channels/plugins/outbound/direct-text-media.ts`, and `extensions/signal/src/send.ts`.
- Edge cases checked: direct-import tests still count; `vi.mock(...)` references no longer count as nearby coverage; credential-bearing `npmSpec` URL forms are redacted; scan reads are bounded.
- What you did **not** verify: no checked-in baseline snapshot/test yet; no attempt to exhaustively validate every inventory entry in the repo by hand.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the script/package-command changes or stop using `pnpm audit:seams` until fixed.
- Files/config to restore: `scripts/audit-seams.mjs`, `package.json`
- Known bad symptoms reviewers should watch for: missing obvious boundary files, false nearby coverage from mocks, or unredacted credential-bearing package specs in JSON output.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: heuristics still miss some repo-specific boundary shapes.
  - Mitigation: the tool now covers the concrete misses raised in review, and the next step is a checked-in baseline/ratchet test.
- Risk: output changes may shift future inventory counts.
  - Mitigation: this PR intentionally stabilizes semantics before adding a baseline snapshot.
