### PR TITLE
Fix packaged Control UI asset lookup

### DIFF
--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -246,6 +246,17 @@ else
   echo "WARN: model catalog missing at $MODEL_CATALOG_SRC (continuing)" >&2
 fi
 
+echo "📦 Copying Control UI assets"
+CONTROL_UI_SRC="$ROOT_DIR/dist/control-ui"
+CONTROL_UI_DEST="$APP_ROOT/Contents/Resources/control-ui"
+if [ -d "$CONTROL_UI_SRC" ] && [ -f "$CONTROL_UI_SRC/index.html" ]; then
+  rm -rf "$CONTROL_UI_DEST"
+  cp -R "$CONTROL_UI_SRC" "$CONTROL_UI_DEST"
+else
+  echo "ERROR: Control UI assets missing at $CONTROL_UI_SRC. Run pnpm ui:build first." >&2
+  exit 1
+fi
+
 echo "📦 Copying OpenClawKit resources"
 OPENCLAWKIT_BUNDLE="$(build_path_for_arch "$PRIMARY_ARCH")/$BUILD_CONFIG/OpenClawKit_OpenClawKit.bundle"
 if [ -d "$OPENCLAWKIT_BUNDLE" ]; then

--- a/src/infra/control-ui-assets.test.ts
+++ b/src/infra/control-ui-assets.test.ts
@@ -214,6 +214,16 @@ describe("control UI assets helpers (fs-mocked)", () => {
     expect(resolveControlUiRootSync({ moduleUrl })).toBe(uiDir);
   });
 
+  it("prefers packaged app Control UI assets in Contents/Resources", () => {
+    const execPath = abs("fixtures/OpenClaw.app/Contents/MacOS/OpenClaw");
+    const bundledUiDir = abs("fixtures/OpenClaw.app/Contents/Resources/control-ui");
+    setFile(path.join(bundledUiDir, "index.html"), "<html></html>\n");
+
+    state.realpaths.set(execPath, execPath);
+
+    expect(resolveControlUiRootSync({ execPath })).toBe(bundledUiDir);
+  });
+
   it("resolves control-ui root for symlinked argv1 via realpath", () => {
     const pkgRoot = abs("fixtures/bun-global/openclaw");
     const wrapperArgv1 = abs("fixtures/bin/openclaw");

--- a/src/infra/control-ui-assets.ts
+++ b/src/infra/control-ui-assets.ts
@@ -215,7 +215,8 @@ export function resolveControlUiRootSync(opts: ControlUiRootResolveOptions = {})
     cwd,
   });
 
-  // Packaged app: control-ui lives alongside the executable.
+  // Packaged app: prefer bundled resources, then support legacy alongside-executable layout.
+  addCandidate(candidates, execDir ? path.join(execDir, "../Resources/control-ui") : null);
   addCandidate(candidates, execDir ? path.join(execDir, "control-ui") : null);
   if (moduleDir) {
     // dist/<bundle>.js -> dist/control-ui


### PR DESCRIPTION
## Summary
- copy built `dist/control-ui` assets into the mac app bundle resources during packaging
- teach packaged runtime lookup to prefer `Contents/Resources/control-ui`
- add a regression test covering packaged app resource resolution

## Why
Recent releases can report `Control UI assets not found` even when the repo/build flow generated the dashboard, because the packaged mac app was not reliably carrying or resolving those assets from the app bundle.

Latest main-branch preflight fix protects npm releases from empty dashboard tarballs. This PR addresses the packaged app/runtime side so the shipped app can actually find the Control UI assets.

## Validation
- `pnpm exec vitest run --config vitest.unit.config.ts src/infra/control-ui-assets.test.ts`
- `pnpm build`
- commit hook `pnpm check` passed
