### PR TITLE
Prompt: reuse injected bootstrap context to save tokens and startup time

### DIFF
--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -50,6 +50,28 @@ describe("buildBootstrapInjectionStats", () => {
       truncated: true,
     });
   });
+
+  it("preserves explicit truncation markers even when injected content is longer than raw", () => {
+    const bootstrapFiles: WorkspaceBootstrapFile[] = [
+      {
+        name: "AGENTS.md",
+        path: "/tmp/AGENTS.md",
+        content: "tiny",
+        missing: false,
+      },
+    ];
+    const injectedFiles = [{ path: "/tmp/AGENTS.md", content: "tiny but marked", truncated: true }];
+    const stats = buildBootstrapInjectionStats({
+      bootstrapFiles,
+      injectedFiles,
+    });
+    expect(stats[0]).toMatchObject({
+      name: "AGENTS.md",
+      rawChars: 4,
+      injectedChars: 15,
+      truncated: true,
+    });
+  });
 });
 
 describe("analyzeBootstrapBudget", () => {

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -125,31 +125,33 @@ export function buildBootstrapInjectionStats(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   injectedFiles: EmbeddedContextFile[];
 }): BootstrapInjectionStat[] {
-  const injectedByPath = new Map<string, string>();
-  const injectedByBaseName = new Map<string, string>();
+  const injectedByPath = new Map<string, EmbeddedContextFile>();
+  const injectedByBaseName = new Map<string, EmbeddedContextFile>();
   for (const file of params.injectedFiles) {
     const pathValue = typeof file.path === "string" ? file.path.trim() : "";
     if (!pathValue) {
       continue;
     }
     if (!injectedByPath.has(pathValue)) {
-      injectedByPath.set(pathValue, file.content);
+      injectedByPath.set(pathValue, file);
     }
     const normalizedPath = pathValue.replace(/\\/g, "/");
     const baseName = path.posix.basename(normalizedPath);
     if (!injectedByBaseName.has(baseName)) {
-      injectedByBaseName.set(baseName, file.content);
+      injectedByBaseName.set(baseName, file);
     }
   }
   return params.bootstrapFiles.map((file) => {
     const pathValue = typeof file.path === "string" ? file.path.trim() : "";
     const rawChars = file.missing ? 0 : (file.content ?? "").trimEnd().length;
-    const injected =
+    const injectedEntry =
       (pathValue ? injectedByPath.get(pathValue) : undefined) ??
       injectedByPath.get(file.name) ??
       injectedByBaseName.get(file.name);
+    const injected = injectedEntry?.content;
     const injectedChars = injected ? injected.length : 0;
-    const truncated = !file.missing && injectedChars < rawChars;
+    const truncated =
+      !file.missing && (injectedEntry?.truncated === true || injectedChars < rawChars);
     return {
       name: file.name,
       path: pathValue || file.name,

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -251,6 +251,9 @@ export function buildBootstrapContextFiles(
     result.push({
       path: pathValue,
       content: contentWithinBudget,
+      ...(trimmed.truncated || contentWithinBudget.length < trimmed.content.length
+        ? { truncated: true }
+        : {}),
     });
   }
   return result;

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,4 +1,4 @@
-export type EmbeddedContextFile = { path: string; content: string };
+export type EmbeddedContextFile = { path: string; content: string; truncated?: boolean };
 
 export type FailoverReason =
   | "auth"

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -735,8 +735,12 @@ export async function runReplyAgent(params: {
 
       // Inject post-compaction workspace context for the next agent turn
       if (sessionKey) {
-        const workspaceDir = process.cwd();
-        readPostCompactionContext(workspaceDir, cfg)
+        const workspaceDir = followupRun.run.workspaceDir;
+        readPostCompactionContext(workspaceDir, cfg, undefined, {
+          sessionKey,
+          sessionId: followupRun.run.sessionId,
+          agentId: resolveAgentIdFromSessionKey(sessionKey),
+        })
           .then((contextContent) => {
             if (contextContent) {
               enqueueSystemEvent(contextContent, { sessionKey });

--- a/src/auto-reply/reply/bootstrap-prompt-hooks.ts
+++ b/src/auto-reply/reply/bootstrap-prompt-hooks.ts
@@ -1,0 +1,45 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildWorkspaceHookSnapshot } from "../../hooks/workspace.js";
+
+function resolveConfiguredBootstrapExtraFilesPatterns(cfg?: OpenClawConfig): string[] {
+  const entry = cfg?.hooks?.internal?.entries?.["bootstrap-extra-files"];
+  if (!entry || typeof entry !== "object") {
+    return [];
+  }
+
+  const values = [
+    ...(Array.isArray(entry.paths) ? entry.paths : []),
+    ...(Array.isArray(entry.patterns) ? entry.patterns : []),
+    ...(Array.isArray(entry.files) ? entry.files : []),
+  ];
+  return values.map((value) => (typeof value === "string" ? value.trim() : "")).filter(Boolean);
+}
+
+export function hasPromptAffectingBootstrapHooks(params: {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+}): boolean {
+  if (!params.cfg?.hooks?.internal?.enabled) {
+    return false;
+  }
+
+  const snapshot = buildWorkspaceHookSnapshot(params.workspaceDir, {
+    config: params.cfg,
+  });
+  return snapshot.hooks.some((hook, index) => {
+    if (!hook.events.includes("agent:bootstrap")) {
+      return false;
+    }
+
+    const resolvedHook = snapshot.resolvedHooks?.[index];
+    // The bundled extra-files hook is default-on, but without configured patterns
+    // it exits immediately and does not change bootstrap context.
+    if (
+      resolvedHook?.source === "openclaw-bundled" &&
+      resolvedHook.name === "bootstrap-extra-files"
+    ) {
+      return resolveConfiguredBootstrapExtraFilesPatterns(params.cfg).length > 0;
+    }
+    return true;
+  });
+}

--- a/src/auto-reply/reply/bootstrap-prompt-hooks.ts
+++ b/src/auto-reply/reply/bootstrap-prompt-hooks.ts
@@ -23,6 +23,16 @@ export function hasPromptAffectingBootstrapHooks(params: {
     return false;
   }
 
+  const legacyHandlers = params.cfg.hooks.internal.handlers ?? [];
+  if (
+    legacyHandlers.some((handler) => {
+      const event = handler.event.trim();
+      return event === "agent" || event === "agent:bootstrap";
+    })
+  ) {
+    return true;
+  }
+
   const snapshot = buildWorkspaceHookSnapshot(params.workspaceDir, {
     config: params.cfg,
   });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -38,7 +38,7 @@ import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue/settings.js";
 import type { RouteReplyParams } from "./route-reply.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import { buildBareSessionResetPromptForRun } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -314,7 +314,15 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
+  const baseBodyFinal = isBareSessionReset
+    ? await buildBareSessionResetPromptForRun({
+        workspaceDir,
+        cfg,
+        sessionKey,
+        sessionId,
+        agentId,
+      })
+    : baseBody;
   const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -448,6 +448,21 @@ Read WORKFLOW.md on startup.
       expect(result).not.toContain("injected sections below instead of rereading AGENTS.md");
     });
 
+    it("falls back to reread guidance when hook discovery fails", async () => {
+      const content = `## Session Startup\n\nDo startup.\n`;
+      fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+      vi.spyOn(bootstrapPromptHooks, "hasPromptAffectingBootstrapHooks").mockImplementation(() => {
+        throw new Error("boom");
+      });
+
+      const result = await readPostCompactionContext(tmpDir);
+
+      expect(result).not.toBeNull();
+      expect(result).toContain("Bootstrap inspection was unavailable");
+      expect(result).toContain("reread AGENTS.md before responding to the user");
+      expect(result).not.toContain("injected sections below instead of rereading AGENTS.md");
+    });
+
     it("falls back to legacy sections when defaults are explicitly configured", async () => {
       // Older AGENTS.md templates use "Every Session" / "Safety" instead of
       // "Session Startup" / "Red Lines". Explicitly setting the defaults should

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -1,13 +1,16 @@
 import fs from "node:fs";
 import path from "node:path";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as bootstrapFiles from "../../agents/bootstrap-files.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as bootstrapPromptHooks from "./bootstrap-prompt-hooks.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
 
 describe("readPostCompactionContext", () => {
   const tmpDir = path.join("/tmp", "test-post-compaction-" + Date.now());
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     fs.mkdirSync(tmpDir, { recursive: true });
   });
 
@@ -118,6 +121,8 @@ Ignore this.
     const result = await readPostCompactionContext(tmpDir);
     expect(result).not.toBeNull();
     expect(result).toContain("[truncated]");
+    expect(result).toContain("The injected sections below are truncated");
+    expect(result).toContain("reread AGENTS.md only if you need omitted content");
   });
 
   it("matches section names case-insensitively", async () => {
@@ -355,6 +360,92 @@ Read WORKFLOW.md on startup.
       const result = await readPostCompactionContext(tmpDir);
       expect(result).not.toBeNull();
       expect(result).toContain("Run your Session Startup sequence");
+      expect(result).toContain("injected sections below instead of rereading AGENTS.md");
+      expect(result).not.toContain("The injected sections below are truncated");
+      expect(result).not.toContain("new-prompt.mjs");
+    });
+
+    it("mentions rereading AGENTS.md only when the injected default sections are truncated", async () => {
+      const content = `## Session Startup\n\n${"A".repeat(4000)}\n`;
+      fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+      const result = await readPostCompactionContext(tmpDir);
+      expect(result).not.toBeNull();
+      expect(result).toContain("Run your Session Startup sequence");
+      expect(result).toContain("The injected sections below are truncated");
+      expect(result).toContain("reread AGENTS.md only if you need omitted content");
+    });
+
+    it("mentions rereading AGENTS.md when normal bootstrap injection truncates AGENTS.md", async () => {
+      const content =
+        "## Session Startup\n\nDo startup.\n\n## Red Lines\n\nDo not break.\n\n## Other\n\n" +
+        "A".repeat(500);
+      fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+      const cfg = {
+        agents: {
+          defaults: {
+            bootstrapMaxChars: 120,
+          },
+        },
+      } as OpenClawConfig;
+      const result = await readPostCompactionContext(tmpDir, cfg);
+      expect(result).not.toBeNull();
+      expect(result).toContain("Run your Session Startup sequence");
+      expect(result).toContain("Your normal injected AGENTS.md context may be partial");
+      expect(result).not.toContain("The injected sections below are truncated");
+    });
+
+    it("avoids bootstrap inspection and falls back to reread guidance when hooks may customize AGENTS", async () => {
+      const content = `## Session Startup\n\nDo startup.\n`;
+      fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+      const hookSpy = vi
+        .spyOn(bootstrapPromptHooks, "hasPromptAffectingBootstrapHooks")
+        .mockReturnValue(true);
+      const resolveSpy = vi.spyOn(bootstrapFiles, "resolveBootstrapContextForRun");
+
+      const result = await readPostCompactionContext(tmpDir);
+
+      expect(result).not.toBeNull();
+      expect(result).toContain("Bootstrap hooks may customize your runtime AGENTS.md context");
+      expect(result).toContain("reread AGENTS.md before responding to the user");
+      expect(result).not.toContain("injected sections below instead of rereading AGENTS.md");
+      expect(hookSpy).toHaveBeenCalled();
+      expect(resolveSpy).not.toHaveBeenCalled();
+    });
+
+    it("uses reference labeling for custom sections when bootstrap hooks may customize AGENTS", async () => {
+      const content = `## Boot Sequence\n\nCustom boot.\n`;
+      fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+      vi.spyOn(bootstrapPromptHooks, "hasPromptAffectingBootstrapHooks").mockReturnValue(true);
+      const cfg = {
+        agents: {
+          defaults: {
+            compaction: { postCompactionSections: ["Boot Sequence"] },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = await readPostCompactionContext(tmpDir, cfg);
+
+      expect(result).not.toBeNull();
+      expect(result).toContain("Reference sections from AGENTS.md (Boot Sequence):");
+      expect(result).not.toContain("Injected sections from AGENTS.md");
+      expect(result).toContain("Bootstrap hooks may customize your runtime AGENTS.md context");
+    });
+
+    it("falls back to reread guidance when bootstrap inspection fails", async () => {
+      const content = `## Session Startup\n\nDo startup.\n`;
+      fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+      vi.spyOn(bootstrapPromptHooks, "hasPromptAffectingBootstrapHooks").mockReturnValue(false);
+      vi.spyOn(bootstrapFiles, "resolveBootstrapContextForRun").mockRejectedValueOnce(
+        new Error("boom"),
+      );
+
+      const result = await readPostCompactionContext(tmpDir);
+
+      expect(result).not.toBeNull();
+      expect(result).toContain("Bootstrap inspection was unavailable");
+      expect(result).toContain("reread AGENTS.md before responding to the user");
+      expect(result).not.toContain("injected sections below instead of rereading AGENTS.md");
     });
 
     it("falls back to legacy sections when defaults are explicitly configured", async () => {

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -73,11 +73,11 @@ async function resolvePostCompactionBootstrapState(params: {
   sessionId?: string;
   agentId?: string;
 }): Promise<PostCompactionBootstrapState> {
-  if (hasPromptAffectingBootstrapHooks({ workspaceDir: params.workspaceDir, cfg: params.cfg })) {
-    return "customized";
-  }
-
   try {
+    if (hasPromptAffectingBootstrapHooks({ workspaceDir: params.workspaceDir, cfg: params.cfg })) {
+      return "customized";
+    }
+
     const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir: params.workspaceDir,
       config: params.cfg,

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -1,13 +1,25 @@
 import fs from "node:fs";
 import path from "node:path";
+import {
+  analyzeBootstrapBudget,
+  buildBootstrapInjectionStats,
+} from "../../agents/bootstrap-budget.js";
+import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { resolveUserTimezone } from "../../agents/date-time.js";
+import {
+  resolveBootstrapMaxChars,
+  resolveBootstrapTotalMaxChars,
+} from "../../agents/pi-embedded-helpers.js";
+import { DEFAULT_AGENTS_FILENAME } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
+import { hasPromptAffectingBootstrapHooks } from "./bootstrap-prompt-hooks.js";
 
 const MAX_CONTEXT_CHARS = 3000;
 const DEFAULT_POST_COMPACTION_SECTIONS = ["Session Startup", "Red Lines"];
 const LEGACY_POST_COMPACTION_SECTIONS = ["Every Session", "Safety"];
+type PostCompactionBootstrapState = "full" | "partial" | "customized" | "unknown";
 
 // Compare configured section names as a case-insensitive set so deployments can
 // pin the documented defaults in any order without changing fallback semantics.
@@ -54,6 +66,43 @@ function formatDateStamp(nowMs: number, timezone: string): string {
   return new Date(nowMs).toISOString().slice(0, 10);
 }
 
+async function resolvePostCompactionBootstrapState(params: {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+}): Promise<PostCompactionBootstrapState> {
+  if (hasPromptAffectingBootstrapHooks({ workspaceDir: params.workspaceDir, cfg: params.cfg })) {
+    return "customized";
+  }
+
+  try {
+    const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
+      workspaceDir: params.workspaceDir,
+      config: params.cfg,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+    });
+    const analysis = analyzeBootstrapBudget({
+      files: buildBootstrapInjectionStats({
+        bootstrapFiles,
+        injectedFiles: contextFiles,
+      }),
+      bootstrapMaxChars: resolveBootstrapMaxChars(params.cfg),
+      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.cfg),
+    });
+    return analysis.files.some(
+      (file) => file.name === DEFAULT_AGENTS_FILENAME && !file.missing && file.truncated,
+    )
+      ? "partial"
+      : "full";
+  } catch {
+    return "unknown";
+  }
+}
+
 /**
  * Read critical sections from workspace AGENTS.md for post-compaction injection.
  * Returns formatted system event text, or null if no AGENTS.md or no relevant sections.
@@ -64,6 +113,7 @@ export async function readPostCompactionContext(
   workspaceDir: string,
   cfg?: OpenClawConfig,
   nowMs?: number,
+  opts?: { sessionKey?: string; sessionId?: string; agentId?: string },
 ): Promise<string | null> {
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
 
@@ -123,26 +173,71 @@ export async function readPostCompactionContext(
     // Always append the real runtime timestamp — AGENTS.md content may itself contain
     // "Current time:" as user-authored text, so we must not gate on that substring.
     const { timeLine } = resolveCronStyleNow(cfg ?? {}, resolvedNowMs);
+    const bootstrapState = await resolvePostCompactionBootstrapState({
+      workspaceDir,
+      cfg,
+      sessionKey: opts?.sessionKey,
+      sessionId: opts?.sessionId,
+      agentId: opts?.agentId,
+    });
 
     const combined = sections.join("\n\n").replaceAll("YYYY-MM-DD", dateStamp);
-    const safeContent =
-      combined.length > MAX_CONTEXT_CHARS
-        ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
-        : combined;
+    const excerptTruncated = combined.length > MAX_CONTEXT_CHARS;
+    const safeContent = excerptTruncated
+      ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
+      : combined;
 
     // When using the default section set, use precise prose that names the
     // "Session Startup" sequence explicitly. When custom sections are configured,
     // use generic prose — referencing a hardcoded "Session Startup" sequence
     // would be misleading for deployments that use different section names.
     const prose = isDefaultSections
-      ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-        "Run your Session Startup sequence — read the required files before responding to the user."
-      : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
-        `Re-read the sections injected below (${displayNames.join(", ")}) and follow your configured startup procedure before responding to the user.`;
+      ? bootstrapState === "customized"
+        ? excerptTruncated
+          ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+            "The AGENTS.md sections below are truncated and bootstrap hooks may customize your runtime AGENTS.md context, so reread AGENTS.md before responding to the user."
+          : "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+            "The AGENTS.md sections below are a refresher only. Bootstrap hooks may customize your runtime AGENTS.md context, so reread AGENTS.md before responding to the user."
+        : bootstrapState === "unknown"
+          ? excerptTruncated
+            ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+              "The AGENTS.md sections below are truncated and bootstrap inspection was unavailable, so reread AGENTS.md before responding to the user."
+            : "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+              "The AGENTS.md sections below are a refresher only. Bootstrap inspection was unavailable, so reread AGENTS.md before responding to the user."
+          : excerptTruncated
+            ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+              "Run your Session Startup sequence using the injected sections below first. The injected sections below are truncated, so reread AGENTS.md only if you need omitted content before responding to the user."
+            : bootstrapState === "partial"
+              ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+                "Run your Session Startup sequence using the injected sections below first. Your normal injected AGENTS.md context may be partial, so reread AGENTS.md only if you need omitted content before responding to the user."
+              : "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
+                "Run your Session Startup sequence using the injected sections below instead of rereading AGENTS.md before responding to the user."
+      : bootstrapState === "customized"
+        ? excerptTruncated
+          ? `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+            `The configured AGENTS.md sections below (${displayNames.join(", ")}) are truncated and bootstrap hooks may customize your runtime AGENTS.md context, so reread AGENTS.md before responding to the user.`
+          : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+            `The configured AGENTS.md sections below (${displayNames.join(", ")}) are a refresher only. Bootstrap hooks may customize your runtime AGENTS.md context, so reread AGENTS.md before responding to the user.`
+        : bootstrapState === "unknown"
+          ? excerptTruncated
+            ? `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+              `The configured AGENTS.md sections below (${displayNames.join(", ")}) are truncated and bootstrap inspection was unavailable, so reread AGENTS.md before responding to the user.`
+            : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+              `The configured AGENTS.md sections below (${displayNames.join(", ")}) are a refresher only. Bootstrap inspection was unavailable, so reread AGENTS.md before responding to the user.`
+          : excerptTruncated
+            ? `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+              `The configured AGENTS.md sections below (${displayNames.join(", ")}) are truncated. Use them first, then reread AGENTS.md only if you need omitted content before responding to the user.`
+            : bootstrapState === "partial"
+              ? `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+                `Use the configured AGENTS.md sections below (${displayNames.join(", ")}) first. Your normal injected AGENTS.md context may be partial, so reread AGENTS.md only if you need omitted content before responding to the user.`
+              : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
+                `The configured AGENTS.md sections below (${displayNames.join(", ")}) are injected in full. Use them directly and follow your configured startup procedure before responding to the user.`;
 
     const sectionLabel = isDefaultSections
       ? "Critical rules from AGENTS.md:"
-      : `Injected sections from AGENTS.md (${displayNames.join(", ")}):`;
+      : bootstrapState === "full" || bootstrapState === "partial"
+        ? `Injected sections from AGENTS.md (${displayNames.join(", ")}):`
+        : `Reference sections from AGENTS.md (${displayNames.join(", ")}):`;
 
     return (
       "[Post-compaction context refresh]\n\n" +

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -191,6 +191,23 @@ describe("buildBareSessionResetPromptForRun", () => {
     ).toBe(true);
   });
 
+  it("treats legacy bootstrap handlers as prompt-affecting", () => {
+    expect(
+      hasPromptAffectingBootstrapHooks({
+        workspaceDir: "/tmp/workspace",
+        cfg: {
+          hooks: {
+            internal: {
+              enabled: true,
+              handlers: [{ event: "agent:bootstrap", module: "hooks/bootstrap.ts" }],
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+    expect(hoisted.buildWorkspaceHookSnapshot).not.toHaveBeenCalled();
+  });
+
   it("skips preflight bootstrap resolution when another bootstrap hook is active", async () => {
     hoisted.buildWorkspaceHookSnapshot.mockReturnValueOnce({
       hooks: [{ name: "custom-bootstrap", events: ["agent:bootstrap"] }],

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,12 +1,78 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
+import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+const hoisted = vi.hoisted(() => ({
+  resolveBootstrapContextForRun: vi.fn(),
+  buildWorkspaceHookSnapshot: vi.fn(),
+}));
+
+vi.mock("../../agents/bootstrap-files.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/bootstrap-files.js")>(
+    "../../agents/bootstrap-files.js",
+  );
+  return {
+    ...actual,
+    resolveBootstrapContextForRun: hoisted.resolveBootstrapContextForRun,
+  };
+});
+
+vi.mock("../../hooks/workspace.js", async () => {
+  const actual = await vi.importActual<typeof import("../../hooks/workspace.js")>(
+    "../../hooks/workspace.js",
+  );
+  return {
+    ...actual,
+    buildWorkspaceHookSnapshot: hoisted.buildWorkspaceHookSnapshot,
+  };
+});
+
+import { hasPromptAffectingBootstrapHooks } from "./bootstrap-prompt-hooks.js";
+import {
+  buildBareSessionResetPrompt,
+  buildBareSessionResetPromptForRun,
+  resolveBareSessionResetPromptMode,
+} from "./session-reset-prompt.js";
+
+function makeBootstrapFile(
+  overrides: Partial<WorkspaceBootstrapFile> = {},
+): WorkspaceBootstrapFile {
+  return {
+    name: "AGENTS.md",
+    path: "/tmp/AGENTS.md",
+    content: "## Session Startup\n\nRead AGENTS.md.",
+    missing: false,
+    ...overrides,
+  };
+}
+
+function makeInjectedFile(
+  content: string,
+  overrides: Partial<EmbeddedContextFile> = {},
+): EmbeddedContextFile {
+  return {
+    path: "/tmp/AGENTS.md",
+    content,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  hoisted.resolveBootstrapContextForRun.mockReset();
+  hoisted.buildWorkspaceHookSnapshot.mockReset();
+  hoisted.buildWorkspaceHookSnapshot.mockReturnValue({
+    hooks: [],
+    resolvedHooks: [],
+  });
+});
 
 describe("buildBareSessionResetPrompt", () => {
-  it("includes the core session startup instruction", () => {
+  it("keeps the sync fallback generic when bootstrap state is unavailable", () => {
     const prompt = buildBareSessionResetPrompt();
     expect(prompt).toContain("Run your Session Startup sequence");
-    expect(prompt).toContain("read the required files before responding to the user");
+    expect(prompt).toContain("Read the required bootstrap/reference files before responding");
+    expect(prompt).not.toContain("Use injected workspace bootstrap/reference files already");
+    expect(prompt).not.toContain("new-prompt.mjs");
   });
 
   it("appends current time line so agents know the date", () => {
@@ -31,5 +97,128 @@ describe("buildBareSessionResetPrompt", () => {
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(undefined, nowMs);
     expect(prompt).toContain("Current time:");
+  });
+});
+
+describe("resolveBareSessionResetPromptMode", () => {
+  it("uses generic mode when there is no usable injected bootstrap content", () => {
+    expect(
+      resolveBareSessionResetPromptMode({
+        bootstrapFiles: [makeBootstrapFile({ missing: true, content: undefined })],
+        injectedFiles: [makeInjectedFile("[MISSING] Expected at: /tmp/AGENTS.md")],
+      }),
+    ).toBe("generic");
+  });
+
+  it("uses injected mode when bootstrap content is fully injected", () => {
+    const content = "## Session Startup\n\nRead AGENTS.md.";
+    expect(
+      resolveBareSessionResetPromptMode({
+        bootstrapFiles: [makeBootstrapFile({ content })],
+        injectedFiles: [makeInjectedFile(content)],
+      }),
+    ).toBe("injected");
+  });
+
+  it("uses truncated mode when bootstrap content is only partially injected", () => {
+    const content = "## Session Startup\n\n" + "A".repeat(200);
+    expect(
+      resolveBareSessionResetPromptMode({
+        bootstrapFiles: [makeBootstrapFile({ content })],
+        injectedFiles: [makeInjectedFile(content.slice(0, 40))],
+      }),
+    ).toBe("truncated");
+  });
+
+  it("uses truncated mode when injected content carries a truncation marker", () => {
+    const content = "tiny";
+    expect(
+      resolveBareSessionResetPromptMode({
+        bootstrapFiles: [makeBootstrapFile({ content })],
+        injectedFiles: [makeInjectedFile("tiny with marker", { truncated: true })],
+      }),
+    ).toBe("truncated");
+  });
+});
+
+describe("buildBareSessionResetPromptForRun", () => {
+  it("treats unconfigured bundled bootstrap-extra-files as non-blocking", () => {
+    hoisted.buildWorkspaceHookSnapshot.mockReturnValueOnce({
+      hooks: [{ name: "bootstrap-extra-files", events: ["agent:bootstrap"] }],
+      resolvedHooks: [
+        {
+          name: "bootstrap-extra-files",
+          source: "openclaw-bundled",
+        },
+      ],
+    });
+
+    expect(
+      hasPromptAffectingBootstrapHooks({
+        workspaceDir: "/tmp/workspace",
+        cfg: { hooks: { internal: { enabled: true } } },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats configured bundled bootstrap-extra-files as prompt-affecting", () => {
+    hoisted.buildWorkspaceHookSnapshot.mockReturnValueOnce({
+      hooks: [{ name: "bootstrap-extra-files", events: ["agent:bootstrap"] }],
+      resolvedHooks: [
+        {
+          name: "bootstrap-extra-files",
+          source: "openclaw-bundled",
+        },
+      ],
+    });
+
+    expect(
+      hasPromptAffectingBootstrapHooks({
+        workspaceDir: "/tmp/workspace",
+        cfg: {
+          hooks: {
+            internal: {
+              enabled: true,
+              entries: {
+                "bootstrap-extra-files": {
+                  paths: ["packages/*/AGENTS.md"],
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("skips preflight bootstrap resolution when another bootstrap hook is active", async () => {
+    hoisted.buildWorkspaceHookSnapshot.mockReturnValueOnce({
+      hooks: [{ name: "custom-bootstrap", events: ["agent:bootstrap"] }],
+      resolvedHooks: [
+        {
+          name: "custom-bootstrap",
+          source: "openclaw-managed",
+        },
+      ],
+    });
+
+    const prompt = await buildBareSessionResetPromptForRun({
+      workspaceDir: "/tmp/workspace",
+      cfg: { hooks: { internal: { enabled: true } } },
+    });
+
+    expect(prompt).toContain("Read the required bootstrap/reference files before responding");
+    expect(hoisted.resolveBootstrapContextForRun).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the generic prompt when bootstrap resolution fails", async () => {
+    hoisted.resolveBootstrapContextForRun.mockRejectedValueOnce(new Error("boom"));
+
+    const prompt = await buildBareSessionResetPromptForRun({
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(prompt).toContain("Read the required bootstrap/reference files before responding");
+    expect(prompt).not.toContain("Use injected workspace bootstrap/reference files already");
   });
 });

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,8 +1,64 @@
+import {
+  analyzeBootstrapBudget,
+  buildBootstrapInjectionStats,
+} from "../../agents/bootstrap-budget.js";
+import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
+import {
+  resolveBootstrapMaxChars,
+  resolveBootstrapTotalMaxChars,
+  type EmbeddedContextFile,
+} from "../../agents/pi-embedded-helpers.js";
+import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { hasPromptAffectingBootstrapHooks } from "./bootstrap-prompt-hooks.js";
 
-const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Run your Session Startup sequence - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+const BARE_SESSION_RESET_PROMPT_PREFIX =
+  "A new session was started via /new or /reset. Run your Session Startup sequence.";
+const BARE_SESSION_RESET_PROMPT_SUFFIX =
+  "Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+
+export type BareSessionResetPromptMode = "generic" | "injected" | "truncated";
+
+const BARE_SESSION_RESET_PROMPT_GUIDANCE: Record<BareSessionResetPromptMode, string> = {
+  generic: "Read the required bootstrap/reference files before responding.",
+  injected:
+    "Use injected workspace bootstrap/reference files already in context instead of rereading them. " +
+    "Only read another required bootstrap/reference file if you need one that was not injected into context.",
+  truncated:
+    "Use injected workspace bootstrap/reference files already in context first. " +
+    "If a required bootstrap/reference file was truncated or omitted from the injected context, reread just that file before responding.",
+};
+
+function buildBareSessionResetPromptText(mode: BareSessionResetPromptMode): string {
+  return [
+    BARE_SESSION_RESET_PROMPT_PREFIX,
+    BARE_SESSION_RESET_PROMPT_GUIDANCE[mode],
+    BARE_SESSION_RESET_PROMPT_SUFFIX,
+  ].join(" ");
+}
+
+export function resolveBareSessionResetPromptMode(params: {
+  cfg?: OpenClawConfig;
+  bootstrapFiles: WorkspaceBootstrapFile[];
+  injectedFiles: EmbeddedContextFile[];
+}): BareSessionResetPromptMode {
+  const analysis = analyzeBootstrapBudget({
+    files: buildBootstrapInjectionStats({
+      bootstrapFiles: params.bootstrapFiles,
+      injectedFiles: params.injectedFiles,
+    }),
+    bootstrapMaxChars: resolveBootstrapMaxChars(params.cfg),
+    bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.cfg),
+  });
+  const hasUsableInjectedContent = analysis.files.some(
+    (file) => !file.missing && file.injectedChars > 0,
+  );
+  if (!hasUsableInjectedContent) {
+    return "generic";
+  }
+  return analysis.hasTruncation ? "truncated" : "injected";
+}
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents
@@ -11,11 +67,46 @@ const BARE_SESSION_RESET_PROMPT_BASE =
  */
 export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number): string {
   return appendCronStyleCurrentTimeLine(
-    BARE_SESSION_RESET_PROMPT_BASE,
+    buildBareSessionResetPromptText("generic"),
     cfg ?? {},
     nowMs ?? Date.now(),
   );
 }
 
+export async function buildBareSessionResetPromptForRun(params: {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  nowMs?: number;
+}): Promise<string> {
+  try {
+    if (hasPromptAffectingBootstrapHooks({ workspaceDir: params.workspaceDir, cfg: params.cfg })) {
+      return buildBareSessionResetPrompt(params.cfg, params.nowMs);
+    }
+
+    const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
+      workspaceDir: params.workspaceDir,
+      config: params.cfg,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+    });
+    const mode = resolveBareSessionResetPromptMode({
+      cfg: params.cfg,
+      bootstrapFiles,
+      injectedFiles: contextFiles,
+    });
+    return appendCronStyleCurrentTimeLine(
+      buildBareSessionResetPromptText(mode),
+      params.cfg ?? {},
+      params.nowMs ?? Date.now(),
+    );
+  } catch {
+    return buildBareSessionResetPrompt(params.cfg, params.nowMs);
+  }
+}
+
 /** @deprecated Use buildBareSessionResetPrompt(cfg) instead */
-export const BARE_SESSION_RESET_PROMPT = BARE_SESSION_RESET_PROMPT_BASE;
+export const BARE_SESSION_RESET_PROMPT = buildBareSessionResetPromptText("generic");

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -59,6 +59,8 @@ vi.mock("../../config/config.js", async () => {
 
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: () => ["main"],
+  resolveSessionAgentIds: () => ({ defaultAgentId: "main", sessionAgentId: "main" }),
+  resolveAgentWorkspaceDir: () => "/tmp/openclaw-test-workspace",
 }));
 
 vi.mock("../../infra/agent-events.js", () => ({
@@ -817,6 +819,148 @@ describe("gateway agent handler", () => {
     expect(call?.message).toContain("Current time:");
     expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
     expect(call?.sessionId).toBe("reset-session-id");
+  });
+
+  it("preserves spawned workspace inheritance across bare /reset", async () => {
+    mockSessionResetSuccess({ reason: "reset" });
+    let mainSessionLoadCount = 0;
+    mocks.loadSessionEntry.mockImplementation((key: string) => {
+      if (key === "agent:main:subagent:parent") {
+        return {
+          cfg: {},
+          storePath: "/tmp/sessions.json",
+          entry: {
+            sessionId: "parent-session-id",
+            updatedAt: Date.now(),
+          },
+          canonicalKey: key,
+        };
+      }
+      if (key === "agent:main:main") {
+        mainSessionLoadCount += 1;
+        return {
+          cfg: {},
+          storePath: "/tmp/sessions.json",
+          entry:
+            mainSessionLoadCount === 1
+              ? {
+                  sessionId: "existing-session-id",
+                  updatedAt: Date.now(),
+                  spawnedBy: "agent:main:subagent:parent",
+                  spawnedWorkspaceDir: "/tmp/inherited",
+                  spawnDepth: 1,
+                }
+              : {
+                  sessionId: "reset-session-id",
+                  updatedAt: Date.now(),
+                },
+          canonicalKey: key,
+        };
+      }
+      throw new Error(`unexpected session key: ${key}`);
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          sessionId: "reset-session-id",
+        }),
+      };
+      return await updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "/reset",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-idem-reset-inherited-workspace",
+      },
+      {
+        reqId: "4bare-reset",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const call = mocks.agentCommand.mock.calls.at(-1)?.[0] as { workspaceDir?: string };
+    expect(call.workspaceDir).toBe("/tmp/inherited");
+  });
+
+  it("preserves stricter subagent role limits across bare /reset", async () => {
+    mockSessionResetSuccess({ reason: "reset" });
+    let mainSessionLoadCount = 0;
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.loadSessionEntry.mockImplementation((key: string) => {
+      if (key === "agent:main:subagent:parent") {
+        return {
+          cfg: {},
+          storePath: "/tmp/sessions.json",
+          entry: {
+            sessionId: "parent-session-id",
+            updatedAt: Date.now(),
+          },
+          canonicalKey: key,
+        };
+      }
+      if (key === "agent:main:main") {
+        mainSessionLoadCount += 1;
+        return {
+          cfg: {},
+          storePath: "/tmp/sessions.json",
+          entry:
+            mainSessionLoadCount === 1
+              ? {
+                  sessionId: "existing-session-id",
+                  updatedAt: Date.now(),
+                  spawnedBy: "agent:main:subagent:parent",
+                  spawnedWorkspaceDir: "/tmp/inherited",
+                  spawnDepth: 1,
+                  subagentRole: "leaf",
+                  subagentControlScope: "none",
+                }
+              : {
+                  sessionId: "reset-session-id",
+                  updatedAt: Date.now(),
+                },
+          canonicalKey: key,
+        };
+      }
+      throw new Error(`unexpected session key: ${key}`);
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          sessionId: "reset-session-id",
+        }),
+      };
+      const result = await updater(store);
+      capturedEntry = store["agent:main:main"] as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "/reset",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-idem-reset-preserve-subagent-role",
+      },
+      {
+        reqId: "4bare-reset-subagent-role",
+        client: { connect: { scopes: ["operator.admin"] } } as AgentHandlerArgs["client"],
+      },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    expect(capturedEntry?.subagentRole).toBe("leaf");
+    expect(capturedEntry?.subagentControlScope).toBe("none");
+    expect(capturedEntry?.spawnDepth).toBe(1);
   });
 
   it("uses /reset suffix as the post-reset message and still injects timestamp", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,11 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { listAgentIds } from "../../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveSessionAgentIds,
+} from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
-import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import { buildBareSessionResetPromptForRun } from "../../auto-reply/reply/session-reset-prompt.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -380,6 +384,17 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedSessionKey = requestedSessionKey;
     let isNewSession = false;
     let skipTimestampInjection = false;
+    let requestedSessionLoad: ReturnType<typeof loadSessionEntry> | undefined;
+    let preservedResetSpawnedMetadata:
+      | Pick<
+          SessionEntry,
+          | "spawnedBy"
+          | "spawnedWorkspaceDir"
+          | "spawnDepth"
+          | "subagentRole"
+          | "subagentControlScope"
+        >
+      | undefined;
 
     const resetCommandMatch = message.match(RESET_COMMAND_RE);
     if (resetCommandMatch && requestedSessionKey) {
@@ -390,6 +405,16 @@ export const agentHandlers: GatewayRequestHandlers = {
           errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${ADMIN_SCOPE}`),
         );
         return;
+      }
+      const preResetEntry = loadSessionEntry(requestedSessionKey)?.entry;
+      if (preResetEntry) {
+        preservedResetSpawnedMetadata = {
+          spawnedBy: preResetEntry.spawnedBy,
+          spawnedWorkspaceDir: preResetEntry.spawnedWorkspaceDir,
+          spawnDepth: preResetEntry.spawnDepth,
+          subagentRole: preResetEntry.subagentRole,
+          subagentControlScope: preResetEntry.subagentControlScope,
+        };
       }
       const resetReason = resetCommandMatch[1]?.toLowerCase() === "new" ? "new" : "reset";
       const resetResult = await runSessionResetFromAgent({
@@ -410,7 +435,31 @@ export const agentHandlers: GatewayRequestHandlers = {
         // reset first, then run a fresh-session greeting prompt in-place.
         // Date is embedded in the prompt so agents read the correct daily
         // memory files; skip further timestamp injection to avoid duplication.
-        message = buildBareSessionResetPrompt(cfg);
+        requestedSessionLoad = loadSessionEntry(requestedSessionKey);
+        const {
+          cfg: resetCfg,
+          entry: resetEntry,
+          canonicalKey: resetSessionKey,
+        } = requestedSessionLoad;
+        const { sessionAgentId } = resolveSessionAgentIds({
+          sessionKey: resetSessionKey,
+          config: resetCfg,
+        });
+        const resetSpawnedBy = resetEntry?.spawnedBy ?? preservedResetSpawnedMetadata?.spawnedBy;
+        const resetSpawnedWorkspaceDir =
+          resetEntry?.spawnedWorkspaceDir ?? preservedResetSpawnedMetadata?.spawnedWorkspaceDir;
+        const resetWorkspaceDir =
+          resolveIngressWorkspaceOverrideForSpawnedRun({
+            spawnedBy: resetSpawnedBy,
+            workspaceDir: resetSpawnedWorkspaceDir,
+          }) ?? resolveAgentWorkspaceDir(resetCfg, sessionAgentId);
+        message = await buildBareSessionResetPromptForRun({
+          workspaceDir: resetWorkspaceDir,
+          cfg: resetCfg,
+          sessionKey: resetSessionKey,
+          sessionId: resolvedSessionId,
+          agentId: sessionAgentId,
+        });
         skipTimestampInjection = true;
       }
     }
@@ -424,14 +473,23 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     if (requestedSessionKey) {
-      const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(requestedSessionKey);
+      const { cfg, storePath, entry, canonicalKey } =
+        requestedSessionLoad ?? loadSessionEntry(requestedSessionKey);
       cfgForAgent = cfg;
       isNewSession = !entry;
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
       const labelValue = request.label?.trim() || entry?.label;
       const sessionAgent = resolveAgentIdFromSessionKey(canonicalKey);
-      spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, entry?.spawnedBy);
+      const effectiveSpawnedBy = entry?.spawnedBy ?? preservedResetSpawnedMetadata?.spawnedBy;
+      const effectiveSpawnedWorkspaceDir =
+        entry?.spawnedWorkspaceDir ?? preservedResetSpawnedMetadata?.spawnedWorkspaceDir;
+      const effectiveSpawnDepth = entry?.spawnDepth ?? preservedResetSpawnedMetadata?.spawnDepth;
+      const effectiveSubagentRole =
+        entry?.subagentRole ?? preservedResetSpawnedMetadata?.subagentRole;
+      const effectiveSubagentControlScope =
+        entry?.subagentControlScope ?? preservedResetSpawnedMetadata?.subagentControlScope;
+      spawnedByValue = canonicalizeSpawnedByForAgent(cfg, sessionAgent, effectiveSpawnedBy);
       let inheritedGroup:
         | { groupId?: string; groupChannel?: string; groupSpace?: string }
         | undefined;
@@ -469,8 +527,10 @@ export const agentHandlers: GatewayRequestHandlers = {
         providerOverride: entry?.providerOverride,
         label: labelValue,
         spawnedBy: spawnedByValue,
-        spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
-        spawnDepth: entry?.spawnDepth,
+        spawnedWorkspaceDir: effectiveSpawnedWorkspaceDir,
+        spawnDepth: effectiveSpawnDepth,
+        subagentRole: effectiveSubagentRole,
+        subagentControlScope: effectiveSubagentControlScope,
         channel: entry?.channel ?? request.channel?.trim(),
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,


### PR DESCRIPTION
## Summary

Reduce unnecessary startup overhead on `/new`, `/reset`, and post-compaction turns by telling the agent to reuse injected bootstrap context when it is already present.

This avoids redundant file rereads in the common case, which saves:
- context window
- prompt/input tokens
- latency
- tool/file-read work

The reread path is still preserved when injected bootstrap content is truncated or omitted.

## What changed

- Bare `/new` and `/reset` prompts now inspect actual bootstrap injection state before rendering.
- Bare reset prompts choose between three modes:
  - generic: no usable injected bootstrap content
  - injected: bootstrap content is already injected in full
  - truncated: injected bootstrap content was truncated or omitted
- Post-compaction guidance now only tells the agent to reread `AGENTS.md` when the injected sections are actually truncated.
- The reset prompt template was condensed so only the mode-specific guidance varies.

## Why

The main benefit is avoiding redundant startup work.

OpenClaw already injects bootstrap/reference content into agent context. If the prompt still tells the agent to go reread those same files, we pay for the same information twice:
- extra prompt/context budget
- extra input tokens
- extra startup latency
- extra tool calls or file reads
- more chances for the model to spend effort re-establishing context it already has

This change makes the prompt match reality:
- if bootstrap content is already injected, use it directly
- if injected content is truncated or omitted, reread only what is needed
- if no usable injected bootstrap context exists, fall back to the generic startup instruction

That means the common path is cheaper and faster, while the incomplete-context path still stays correct.

## Testing

- `pnpm test -- src/auto-reply/reply/session-reset-prompt.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts`
- `pnpm test -- src/auto-reply/reply/post-compaction-context.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts src/auto-reply/reply.triggers.trigger-handling.test-harness.ts`
- `pnpm build`
- `pnpm check`
