### PR TITLE
test(update-cli): make default git-dir assertion platform-aware

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1132,7 +1132,7 @@ describe("update-cli", () => {
   it("uses ~/openclaw as the default dev checkout directory", async () => {
     const homedirSpy = vi.spyOn(os, "homedir").mockReturnValue("/tmp/oc-home");
     await withEnvAsync({ OPENCLAW_GIT_DIR: undefined }, async () => {
-      expect(resolveGitInstallDir()).toBe("/tmp/oc-home/openclaw");
+      expect(resolveGitInstallDir()).toBe(path.join("/tmp/oc-home", "openclaw"));
     });
     homedirSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- make the default dev checkout path assertion use `path.join(...)`
- keep the fix test-only and platform-aware

## Why
`main` has been repeatedly failing on `checks-windows (node, test, 5, 6, pnpm test)` because `src/cli/update-cli.test.ts` expects a POSIX path literal even on Windows.

This patch is intentionally minimal and only fixes that expectation. It should help unblock many unrelated PRs that are currently red on the same Windows lane, so landing it sooner would reduce CI noise across the repo.