### PR TITLE
release: harden preflight workflows

### DIFF
--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -106,6 +106,9 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - The publish run must be started manually with `workflow_dispatch`.
 - Both release workflows accept `preflight_only=true` to run CI
   validation/build steps without entering the gated publish job.
+- `preflight_only=true` on the npm workflow is also the right way to validate an
+  existing tag after publish; it should keep running the build checks even when
+  the npm version is already published.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
 - The release workflows stay tag-based; rely on the documented release sequence

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -109,8 +109,12 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
 - `preflight_only=true` on the npm workflow is also the right way to validate an
   existing tag after publish; it should keep running the build checks even when
   the npm version is already published.
+- Validation-only runs may be dispatched from a branch when you are testing a
+  workflow change before merge.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
+- Real publish runs must be dispatched from `main`; branch-dispatched publish
+  attempts should fail before the protected environment is reached.
 - The release workflows stay tag-based; rely on the documented release sequence
   rather than workflow-level SHA pinning.
 - The `npm-release` environment must be approved by `@openclaw/openclaw-release-managers` before publish continues.

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -53,6 +53,12 @@ jobs:
           install-bun: "false"
           use-sticky-disk: "false"
 
+      - name: Select Xcode 26.1
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.1.app
+          xcodebuild -version
+          swift --version
+
       - name: Ensure matching GitHub release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -160,6 +166,12 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
           install-bun: "false"
           use-sticky-disk: "false"
+
+      - name: Select Xcode 26.1
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.1.app
+          xcodebuild -version
+          swift --version
 
       - name: Ensure matching GitHub release exists
         env:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -84,6 +84,8 @@ jobs:
         run: node scripts/ui.js build
 
       - name: Verify release contents
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         run: pnpm release:check
 
       - name: Swift build

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -95,10 +95,28 @@ jobs:
         run: pnpm release:check
 
       - name: Swift build
-        run: swift build --package-path apps/macos --configuration release
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if swift build --package-path apps/macos --configuration release; then
+              exit 0
+            fi
+            echo "swift build failed (attempt $attempt/3). Retrying…"
+            sleep $((attempt * 20))
+          done
+          exit 1
 
       - name: Swift test
-        run: swift test --package-path apps/macos --parallel
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if swift test --package-path apps/macos --parallel; then
+              exit 0
+            fi
+            echo "swift test failed (attempt $attempt/3). Retrying…"
+            sleep $((attempt * 20))
+          done
+          exit 1
 
       - name: Package macOS release with ad-hoc signing
         env:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -108,8 +108,24 @@ jobs:
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
         run: scripts/package-mac-dist.sh
 
+  validate_publish_dispatch_ref:
+    if: ${{ !inputs.preflight_only }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require main workflow ref for publish
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "Real publish runs must be dispatched from main. Use preflight_only=true for branch validation."
+            exit 1
+          fi
+
   publish_macos_release:
-    needs: [preflight_macos_release]
+    needs: [preflight_macos_release, validate_publish_dispatch_ref]
     if: ${{ !inputs.preflight_only }}
     runs-on: macos-latest
     environment: mac-release

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -66,11 +66,17 @@ jobs:
           pnpm release:openclaw:npm:check
 
       - name: Ensure version is not already published
+        env:
+          PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
         run: |
           set -euo pipefail
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
 
           if npm view "openclaw@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            if [[ "${PREFLIGHT_ONLY}" == "true" ]]; then
+              echo "openclaw@${PACKAGE_VERSION} is already published on npm; continuing because preflight_only=true."
+              exit 0
+            fi
             echo "openclaw@${PACKAGE_VERSION} is already published on npm."
             exit 1
           fi

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -92,9 +92,25 @@ jobs:
       - name: Verify release contents
         run: pnpm release:check
 
+  validate_publish_dispatch_ref:
+    if: ${{ !inputs.preflight_only }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Require main workflow ref for publish
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]]; then
+            echo "Real publish runs must be dispatched from main. Use preflight_only=true for branch validation."
+            exit 1
+          fi
+
   publish_openclaw_npm:
     # npm trusted publishing + provenance requires a GitHub-hosted runner.
-    needs: [preflight_openclaw_npm]
+    needs: [preflight_openclaw_npm, validate_publish_dispatch_ref]
     if: ${{ !inputs.preflight_only }}
     runs-on: ubuntu-latest
     environment: npm-release


### PR DESCRIPTION
## Summary
- let npm `preflight_only=true` keep validating an already-published tag
- raise Node heap for macOS `pnpm release:check` and gate real publish runs to workflows dispatched from `main`
- document that branch refs are for validation-only runs while real publish stays on `main`

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openclaw-npm-release.yml"); YAML.load_file(".github/workflows/macos-release.yml"); puts "yaml ok"'
- git diff --check
- scripts/committer "release: harden preflight-only workflows" .github/workflows/openclaw-npm-release.yml .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md
- scripts/committer "release: require main for publish runs" .github/workflows/openclaw-npm-release.yml .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md

## Follow-up
- matching maintainer docs PR: openclaw/maintainers#28