### PR TITLE
fix(slack): remove double HTML encoding for ampersand

### DIFF
--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -25,7 +25,7 @@ describe("markdownToSlackMrkdwn", () => {
         "see <https://example.com|docs>",
       ],
       ["does not duplicate bare URLs", "see https://example.com", "see https://example.com"],
-      ["escapes unsafe characters", "a & b < c > d", "a &amp; b &lt; c &gt; d"],
+      ["escapes unsafe characters", "a & b < c > d", "a & b &lt; c &gt; d"],
       [
         "preserves Slack angle-bracket markup (mentions/links)",
         "hi <@U123> see <https://example.com|docs> and <!here>",
@@ -69,7 +69,7 @@ describe("escapeSlackMrkdwn", () => {
   });
 
   it("escapes slack and mrkdwn control characters", () => {
-    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode\\_\\*\\`\\~&lt;&amp;&gt;\\\\");
+    expect(escapeSlackMrkdwn("mode_*`~<&>\\")).toBe("mode\\_\\*\\`\\~&lt;&&gt;\\\\");
   });
 });
 

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -8,8 +8,10 @@ import { renderMarkdownWithMarkers } from "openclaw/plugin-sdk/text-runtime";
 
 // Escape special characters for Slack mrkdwn format.
 // Preserve Slack's angle-bracket tokens so mentions and links stay intact.
+// NOTE: We do NOT escape & because Slack's API handles entity encoding automatically.
+// Pre-escaping & causes double-encoding (& → &amp; → &#38;).
 function escapeSlackMrkdwnSegment(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -809,7 +809,7 @@ describe("registerSlackInteractionEvents", () => {
             elements: [
               {
                 type: "mrkdwn",
-                text: ":white_check_mark: *Canary\\_\\*\\`\\~&lt;&amp;&gt;* selected by <@U556>",
+                text: ":white_check_mark: *Canary\\_\\*\\`\\~&lt;&&gt;* selected by <@U556>",
               },
             ],
           },

--- a/extensions/slack/src/monitor/mrkdwn.ts
+++ b/extensions/slack/src/monitor/mrkdwn.ts
@@ -1,7 +1,8 @@
 export function escapeSlackMrkdwn(value: string): string {
+  // NOTE: We do NOT escape & because Slack's API handles entity encoding automatically.
+  // Pre-escaping & causes double-encoding (& → &amp; → &#38;).
   return value
     .replaceAll("\\", "\\\\")
-    .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;")
     .replace(/([*_`~])/g, "\\$1");

--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -549,7 +549,7 @@ describe("Slack native command argument menus", () => {
       | { confirm?: { text?: { text?: string } } }
       | undefined;
     expect(element?.confirm?.text?.text).toContain(
-      "Run */unsafeconfirm* with *mode\\_\\*\\`\\~&lt;&amp;&gt;* set to this value?",
+      "Run */unsafeconfirm* with *mode\\_\\*\\`\\~&lt;&&gt;* set to this value?",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes #53056

Slack's API already handles entity encoding for ampersands. Pre-escaping `&` to `&amp;` causes double-encoding, resulting in `&#38;` being displayed instead of `&` in Slack messages.

## Root Cause

The `escapeSlackMrkdwnSegment()` and `escapeSlackMrkdwn()` functions were pre-escaping `&` to `&amp;`, but Slack's API also performs this encoding, leading to double-encoding.

## Changes

- Remove `&` escaping in `escapeSlackMrkdwnSegment()` in `format.ts`
- Remove `&` escaping in `escapeSlackMrkdwn()` in `monitor/mrkdwn.ts`
- Update related tests to reflect the new behavior

## Testing

All existing tests pass with the updated expectations.