### PR TITLE
release: upload macos preflight artifacts

### DIFF
--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -111,6 +111,9 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   the npm version is already published.
 - Validation-only runs may be dispatched from a branch when you are testing a
   workflow change before merge.
+- macOS preflight uploads the ad-hoc `.zip`, `.dmg`, and `.dSYM.zip` outputs as
+  workflow artifacts so maintainers can download and inspect the built package
+  before any real publish run.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
 - Real publish runs must be dispatched from `main`; branch-dispatched publish

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -111,9 +111,11 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   the npm version is already published.
 - Validation-only runs may be dispatched from a branch when you are testing a
   workflow change before merge.
-- macOS preflight uploads the ad-hoc `.zip`, `.dmg`, and `.dSYM.zip` outputs as
-  workflow artifacts so maintainers can download and inspect the built package
-  before any real publish run.
+- macOS release workflows run on GitHub's larger macOS runner and use a
+  SwiftPM cache because the Swift build/test/package path is CPU-heavy.
+- macOS preflight uploads the ad-hoc `.zip` output as a workflow artifact so
+  maintainers can download and inspect the built package before any real
+  publish run.
 - npm preflight and macOS preflight must both pass before any publish run
   starts.
 - Real publish runs must be dispatched from `main`; branch-dispatched publish

--- a/.agents/skills/openclaw-release-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-release-maintainer/SKILL.md
@@ -111,7 +111,7 @@ OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke
   the npm version is already published.
 - Validation-only runs may be dispatched from a branch when you are testing a
   workflow change before merge.
-- macOS release workflows run on GitHub's larger macOS runner and use a
+- macOS release workflows run on GitHub's xlarge macOS runner and use a
   SwiftPM cache because the Swift build/test/package path is CPU-heavy.
 - macOS preflight uploads the ad-hoc `.zip` output as a workflow artifact so
   maintainers can download and inspect the built package before any real

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -117,26 +117,30 @@ jobs:
           exit 1
 
       - name: Package macOS release with ad-hoc signing
+        id: package_preflight
         env:
-          APP_VERSION: ${{ steps.package_version.outputs.value }}
           BUNDLE_ID: ai.openclaw.mac
           BUILD_CONFIG: release
           CODESIGN_TIMESTAMP: "off"
           SIGN_IDENTITY: "-"
-          SKIP_NOTARIZE: "1"
-          SKIP_DMG: "1"
-          SKIP_DSYM: "1"
           SKIP_PNPM_INSTALL: "1"
           SKIP_TSC: "1"
           SKIP_UI_BUILD: "1"
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
-        run: scripts/package-mac-dist.sh
+        run: |
+          set -euo pipefail
+          scripts/package-mac-app.sh
+          VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" dist/OpenClaw.app/Contents/Info.plist)
+          ZIP_PATH="dist/OpenClaw-${VERSION}.zip"
+          rm -f "$ZIP_PATH"
+          ditto -c -k --sequesterRsrc --keepParent dist/OpenClaw.app "$ZIP_PATH"
+          echo "zip_path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Upload preflight macOS artifacts
         uses: actions/upload-artifact@v7
         with:
           name: macos-preflight-${{ inputs.tag }}
-          path: dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
+          path: ${{ steps.package_preflight.outputs.zip_path }}
           if-no-files-found: error
 
   validate_publish_dispatch_ref:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -132,6 +132,16 @@ jobs:
           SPARKLE_FEED_URL: ${{ env.SPARKLE_FEED_URL }}
         run: scripts/package-mac-dist.sh
 
+      - name: Upload preflight macOS artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-preflight-${{ inputs.tag }}
+          path: |
+            dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
+            dist/OpenClaw-${{ steps.package_version.outputs.value }}.dmg
+            dist/OpenClaw-${{ steps.package_version.outputs.value }}.dSYM.zip
+          if-no-files-found: error
+
   validate_publish_dispatch_ref:
     if: ${{ !inputs.preflight_only }}
     runs-on: ubuntu-latest

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -25,7 +25,9 @@ env:
 
 jobs:
   preflight_macos_release:
-    runs-on: macos-latest
+    # Use GitHub's larger macOS runner because release packaging is
+    # Swift-heavy and benefits more from extra CPU than the default image.
+    runs-on: macos-latest-large
     permissions:
       contents: read
     steps:
@@ -58,6 +60,14 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.1.app
           xcodebuild -version
           swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swiftpm-release-${{ hashFiles('apps/macos/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-release-
 
       - name: Ensure matching GitHub release exists
         env:
@@ -94,18 +104,6 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
         run: pnpm release:check
 
-      - name: Swift build
-        run: |
-          set -euo pipefail
-          for attempt in 1 2 3; do
-            if swift build --package-path apps/macos --configuration release; then
-              exit 0
-            fi
-            echo "swift build failed (attempt $attempt/3). Retrying…"
-            sleep $((attempt * 20))
-          done
-          exit 1
-
       - name: Swift test
         run: |
           set -euo pipefail
@@ -126,6 +124,8 @@ jobs:
           CODESIGN_TIMESTAMP: "off"
           SIGN_IDENTITY: "-"
           SKIP_NOTARIZE: "1"
+          SKIP_DMG: "1"
+          SKIP_DSYM: "1"
           SKIP_PNPM_INSTALL: "1"
           SKIP_TSC: "1"
           SKIP_UI_BUILD: "1"
@@ -136,10 +136,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: macos-preflight-${{ inputs.tag }}
-          path: |
-            dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
-            dist/OpenClaw-${{ steps.package_version.outputs.value }}.dmg
-            dist/OpenClaw-${{ steps.package_version.outputs.value }}.dSYM.zip
+          path: dist/OpenClaw-${{ steps.package_version.outputs.value }}.zip
           if-no-files-found: error
 
   validate_publish_dispatch_ref:
@@ -161,7 +158,7 @@ jobs:
   publish_macos_release:
     needs: [preflight_macos_release, validate_publish_dispatch_ref]
     if: ${{ !inputs.preflight_only }}
-    runs-on: macos-latest
+    runs-on: macos-latest-large
     environment: mac-release
     concurrency:
       # Stable releases all derive the same shared appcast.xml; serialize those
@@ -200,6 +197,14 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_26.1.app
           xcodebuild -version
           swift --version
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-swiftpm-release-${{ hashFiles('apps/macos/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-release-
 
       - name: Ensure matching GitHub release exists
         env:

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -25,9 +25,9 @@ env:
 
 jobs:
   preflight_macos_release:
-    # Use GitHub's larger macOS runner because release packaging is
-    # Swift-heavy and benefits more from extra CPU than the default image.
-    runs-on: macos-latest-large
+    # Use GitHub's xlarge macOS runner because release packaging is
+    # Swift-heavy and benefits from the faster hosted hardware tier.
+    runs-on: macos-latest-xlarge
     permissions:
       contents: read
     steps:
@@ -158,7 +158,7 @@ jobs:
   publish_macos_release:
     needs: [preflight_macos_release, validate_publish_dispatch_ref]
     if: ${{ !inputs.preflight_only }}
-    runs-on: macos-latest-large
+    runs-on: macos-latest-xlarge
     environment: mac-release
     concurrency:
       # Stable releases all derive the same shared appcast.xml; serialize those

--- a/scripts/package-mac-dist.sh
+++ b/scripts/package-mac-dist.sh
@@ -36,6 +36,7 @@ DSYM_ZIP="$ROOT_DIR/dist/OpenClaw-$VERSION.dSYM.zip"
 SKIP_NOTARIZE="${SKIP_NOTARIZE:-0}"
 NOTARIZE=1
 SKIP_DSYM="${SKIP_DSYM:-0}"
+SKIP_DMG="${SKIP_DMG:-0}"
 
 if [[ "$SKIP_NOTARIZE" == "1" ]]; then
   NOTARIZE=0
@@ -53,15 +54,19 @@ echo "📦 Zip: $ZIP"
 rm -f "$ZIP"
 ditto -c -k --sequesterRsrc --keepParent "$APP" "$ZIP"
 
-echo "💿 DMG: $DMG"
-"$ROOT_DIR/scripts/create-dmg.sh" "$APP" "$DMG"
+if [[ "$SKIP_DMG" != "1" ]]; then
+  echo "💿 DMG: $DMG"
+  "$ROOT_DIR/scripts/create-dmg.sh" "$APP" "$DMG"
 
-if [[ "$NOTARIZE" == "1" ]]; then
-  if [[ -n "${SIGN_IDENTITY:-}" ]]; then
-    echo "🔏 Signing DMG: $DMG"
-    /usr/bin/codesign --force --sign "$SIGN_IDENTITY" --timestamp "$DMG"
+  if [[ "$NOTARIZE" == "1" ]]; then
+    if [[ -n "${SIGN_IDENTITY:-}" ]]; then
+      echo "🔏 Signing DMG: $DMG"
+      /usr/bin/codesign --force --sign "$SIGN_IDENTITY" --timestamp "$DMG"
+    fi
+    "$ROOT_DIR/scripts/notarize-mac-artifact.sh" "$DMG"
   fi
-  "$ROOT_DIR/scripts/notarize-mac-artifact.sh" "$DMG"
+else
+  echo "💿 Skipping DMG (SKIP_DMG=1)"
 fi
 
 if [[ "$SKIP_DSYM" != "1" ]]; then


### PR DESCRIPTION
## Summary
- upload the macOS preflight-built zip as a workflow artifact
- run the macOS release workflow on GitHub's larger macOS runner with a SwiftPM cache
- speed up preflight by skipping the standalone Swift release build and by skipping DMG/dSYM work in the validation-only package step

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/macos-release.yml"); puts "yaml ok"'
- bash -n scripts/package-mac-dist.sh
- git diff --check
- scripts/committer "release: upload macos preflight artifacts" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md
- scripts/committer "release: speed up macos preflight" .github/workflows/macos-release.yml .agents/skills/openclaw-release-maintainer/SKILL.md scripts/package-mac-dist.sh

## Follow-up
- matching maintainer docs PR: openclaw/maintainers#29