### PR TITLE
fix(memory): bootstrap lancedb runtime on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 - ClawHub/macOS: read the local ClawHub login from the macOS Application Support path and still honor XDG config on macOS, so skill browsing uses the logged-in token on both default and XDG-style setups. Fixes #52949. Thanks @scoootscooob.
 - Discord/commands: return an explicit unauthorized reply for privileged native slash commands instead of falling through to Discord's misleading generic completion when auth gates reject the sender. Fixes #53041. Thanks @scoootscooob.
 - Models/OpenAI Codex OAuth: bootstrap the env-configured HTTP/HTTPS proxy dispatcher on the stored-credential refresh path before token renewal runs, so expired Codex OAuth profiles can refresh successfully in proxy-required environments instead of locking users out after the first token expiry.
+- Plugins/memory-lancedb: bootstrap LanceDB into plugin runtime state on first use when the bundled npm install does not already have it, so `plugins.slots.memory="memory-lancedb"` works again after global npm installs without moving LanceDB into OpenClaw core dependencies. Fixes #26100.
 
 ## 2026.3.22
 

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -148,14 +148,7 @@ describe("memory plugin e2e", () => {
     const toArray = vi.fn(async () => []);
     const limit = vi.fn(() => ({ toArray }));
     const vectorSearch = vi.fn(() => ({ limit }));
-
-    vi.resetModules();
-    vi.doMock("openai", () => ({
-      default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
-      },
-    }));
-    vi.doMock("@lancedb/lancedb", () => ({
+    const loadLanceDbModule = vi.fn(async () => ({
       connect: vi.fn(async () => ({
         tableNames: vi.fn(async () => ["memories"]),
         openTable: vi.fn(async () => ({
@@ -165,6 +158,16 @@ describe("memory plugin e2e", () => {
           delete: vi.fn(async () => undefined),
         })),
       })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("./lancedb-runtime.js", () => ({
+      loadLanceDbModule,
     }));
 
     try {
@@ -214,6 +217,7 @@ describe("memory plugin e2e", () => {
       }
       await recallTool.execute("test-call-dims", { query: "hello dimensions" });
 
+      expect(loadLanceDbModule).toHaveBeenCalledTimes(1);
       expect(embeddingsCreate).toHaveBeenCalledWith({
         model: "text-embedding-3-small",
         input: "hello dimensions",
@@ -221,7 +225,7 @@ describe("memory plugin e2e", () => {
       });
     } finally {
       vi.doUnmock("openai");
-      vi.doUnmock("@lancedb/lancedb");
+      vi.doUnmock("./lancedb-runtime.js");
       vi.resetModules();
     }
   });

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -18,23 +18,11 @@ import {
   memoryConfigSchema,
   vectorDimsForModel,
 } from "./config.js";
+import { loadLanceDbModule } from "./lancedb-runtime.js";
 
 // ============================================================================
 // Types
 // ============================================================================
-
-let lancedbImportPromise: Promise<typeof import("@lancedb/lancedb")> | null = null;
-const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> => {
-  if (!lancedbImportPromise) {
-    lancedbImportPromise = import("@lancedb/lancedb");
-  }
-  try {
-    return await lancedbImportPromise;
-  } catch (err) {
-    // Common on macOS today: upstream package may not ship darwin native bindings.
-    throw new Error(`memory-lancedb: failed to load LanceDB. ${String(err)}`, { cause: err });
-  }
-};
 
 type MemoryEntry = {
   id: string;
@@ -79,7 +67,7 @@ class MemoryDB {
   }
 
   private async doInitialize(): Promise<void> {
-    const lancedb = await loadLanceDB();
+    const lancedb = await loadLanceDbModule();
     this.db = await lancedb.connect(this.dbPath);
     const tables = await this.db.tableNames();
 

--- a/extensions/memory-lancedb/lancedb-runtime.test.ts
+++ b/extensions/memory-lancedb/lancedb-runtime.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLanceDbRuntimeLoader, type LanceDbRuntimeLogger } from "./lancedb-runtime.js";
+
+const TEST_RUNTIME_MANIFEST = {
+  name: "openclaw-memory-lancedb-runtime",
+  private: true as const,
+  type: "module" as const,
+  dependencies: {
+    "@lancedb/lancedb": "^0.27.1",
+  },
+};
+
+type LanceDbModule = typeof import("@lancedb/lancedb");
+type RuntimeManifest = {
+  name: string;
+  private: true;
+  type: "module";
+  dependencies: Record<string, string>;
+};
+
+function createMockModule(): LanceDbModule {
+  return {
+    connect: vi.fn(),
+  } as unknown as LanceDbModule;
+}
+
+function createLoader(
+  overrides: {
+    env?: NodeJS.ProcessEnv;
+    importBundled?: () => Promise<LanceDbModule>;
+    importResolved?: (resolvedPath: string) => Promise<LanceDbModule>;
+    resolveRuntimeEntry?: (params: {
+      runtimeDir: string;
+      manifest: RuntimeManifest;
+    }) => string | null;
+    installRuntime?: (params: {
+      runtimeDir: string;
+      manifest: RuntimeManifest;
+      env: NodeJS.ProcessEnv;
+      logger?: LanceDbRuntimeLogger;
+    }) => Promise<string>;
+  } = {},
+) {
+  return createLanceDbRuntimeLoader({
+    env: overrides.env ?? ({} as NodeJS.ProcessEnv),
+    resolveStateDir: () => "/tmp/openclaw-state",
+    runtimeManifest: TEST_RUNTIME_MANIFEST,
+    importBundled:
+      overrides.importBundled ??
+      (async () => {
+        throw new Error("Cannot find package '@lancedb/lancedb'");
+      }),
+    importResolved: overrides.importResolved ?? (async () => createMockModule()),
+    resolveRuntimeEntry: overrides.resolveRuntimeEntry ?? (() => null),
+    installRuntime:
+      overrides.installRuntime ??
+      (async ({ runtimeDir }: { runtimeDir: string }) =>
+        `${runtimeDir}/node_modules/@lancedb/lancedb/index.js`),
+  });
+}
+
+describe("lancedb runtime loader", () => {
+  it("uses the bundled module when it is already available", async () => {
+    const bundledModule = createMockModule();
+    const importBundled = vi.fn(async () => bundledModule);
+    const importResolved = vi.fn(async () => createMockModule());
+    const resolveRuntimeEntry = vi.fn(() => null);
+    const installRuntime = vi.fn(async () => "/tmp/openclaw-state/plugin-runtimes/lancedb.js");
+    const loader = createLoader({
+      importBundled,
+      importResolved,
+      resolveRuntimeEntry,
+      installRuntime,
+    });
+
+    await expect(loader.load()).resolves.toBe(bundledModule);
+
+    expect(resolveRuntimeEntry).not.toHaveBeenCalled();
+    expect(installRuntime).not.toHaveBeenCalled();
+    expect(importResolved).not.toHaveBeenCalled();
+  });
+
+  it("reuses an existing user runtime install before attempting a reinstall", async () => {
+    const runtimeModule = createMockModule();
+    const importResolved = vi.fn(async () => runtimeModule);
+    const resolveRuntimeEntry = vi.fn(
+      () => "/tmp/openclaw-state/plugin-runtimes/memory-lancedb/runtime-entry.js",
+    );
+    const installRuntime = vi.fn(
+      async () => "/tmp/openclaw-state/plugin-runtimes/memory-lancedb/runtime-entry.js",
+    );
+    const loader = createLoader({
+      importResolved,
+      resolveRuntimeEntry,
+      installRuntime,
+    });
+
+    await expect(loader.load()).resolves.toBe(runtimeModule);
+
+    expect(resolveRuntimeEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeDir: "/tmp/openclaw-state/plugin-runtimes/memory-lancedb/lancedb",
+      }),
+    );
+    expect(installRuntime).not.toHaveBeenCalled();
+  });
+
+  it("installs LanceDB into user state when the bundled runtime is unavailable", async () => {
+    const runtimeModule = createMockModule();
+    const logger: LanceDbRuntimeLogger = {
+      warn: vi.fn(),
+      info: vi.fn(),
+    };
+    const importResolved = vi.fn(async () => runtimeModule);
+    const resolveRuntimeEntry = vi.fn(() => null);
+    const installRuntime = vi.fn(
+      async ({ runtimeDir }: { runtimeDir: string }) =>
+        `${runtimeDir}/node_modules/@lancedb/lancedb/index.js`,
+    );
+    const loader = createLoader({
+      importResolved,
+      resolveRuntimeEntry,
+      installRuntime,
+    });
+
+    await expect(loader.load(logger)).resolves.toBe(runtimeModule);
+
+    expect(installRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeDir: "/tmp/openclaw-state/plugin-runtimes/memory-lancedb/lancedb",
+        manifest: TEST_RUNTIME_MANIFEST,
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "installing runtime deps under /tmp/openclaw-state/plugin-runtimes/memory-lancedb/lancedb",
+      ),
+    );
+  });
+
+  it("fails fast in nix mode instead of attempting auto-install", async () => {
+    const installRuntime = vi.fn(
+      async ({ runtimeDir }: { runtimeDir: string }) =>
+        `${runtimeDir}/node_modules/@lancedb/lancedb/index.js`,
+    );
+    const loader = createLoader({
+      env: { OPENCLAW_NIX_MODE: "1" } as NodeJS.ProcessEnv,
+      installRuntime,
+    });
+
+    await expect(loader.load()).rejects.toThrow(
+      "memory-lancedb: failed to load LanceDB and Nix mode disables auto-install.",
+    );
+    expect(installRuntime).not.toHaveBeenCalled();
+  });
+
+  it("clears the cached failure so later calls can retry the install", async () => {
+    const runtimeModule = createMockModule();
+    const installRuntime = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(
+        "/tmp/openclaw-state/plugin-runtimes/memory-lancedb/lancedb/node_modules/@lancedb/lancedb/index.js",
+      );
+    const importResolved = vi.fn(async () => runtimeModule);
+    const loader = createLoader({
+      installRuntime,
+      importResolved,
+    });
+
+    await expect(loader.load()).rejects.toThrow("network down");
+    await expect(loader.load()).resolves.toBe(runtimeModule);
+
+    expect(installRuntime).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/memory-lancedb/lancedb-runtime.ts
+++ b/extensions/memory-lancedb/lancedb-runtime.ts
@@ -1,0 +1,266 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { resolveStateDir } from "./api.js";
+
+type LanceDbModule = typeof import("@lancedb/lancedb");
+
+export type LanceDbRuntimeLogger = {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+};
+
+type RuntimeManifest = {
+  name: string;
+  private: true;
+  type: "module";
+  dependencies: Record<string, string>;
+};
+
+type LanceDbRuntimeLoaderDeps = {
+  env: NodeJS.ProcessEnv;
+  resolveStateDir: (env?: NodeJS.ProcessEnv, homedir?: () => string) => string;
+  runtimeManifest: RuntimeManifest;
+  importBundled: () => Promise<LanceDbModule>;
+  importResolved: (resolvedPath: string) => Promise<LanceDbModule>;
+  resolveRuntimeEntry: (params: { runtimeDir: string; manifest: RuntimeManifest }) => string | null;
+  installRuntime: (params: {
+    runtimeDir: string;
+    manifest: RuntimeManifest;
+    env: NodeJS.ProcessEnv;
+    logger?: LanceDbRuntimeLogger;
+  }) => Promise<string>;
+};
+
+const MEMORY_LANCEDB_RUNTIME_MANIFEST: RuntimeManifest = (() => {
+  const packageJson = JSON.parse(
+    fs.readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+  ) as {
+    dependencies?: Record<string, string>;
+  };
+  const lanceDbSpec = packageJson.dependencies?.["@lancedb/lancedb"];
+  if (!lanceDbSpec) {
+    throw new Error('memory-lancedb package.json is missing "@lancedb/lancedb"');
+  }
+  return {
+    name: "openclaw-memory-lancedb-runtime",
+    private: true,
+    type: "module",
+    dependencies: {
+      "@lancedb/lancedb": lanceDbSpec,
+    },
+  };
+})();
+
+function resolveRuntimeDir(stateDir: string): string {
+  return path.join(stateDir, "plugin-runtimes", "memory-lancedb", "lancedb");
+}
+
+function readRuntimeManifest(filePath: string): RuntimeManifest | null {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as RuntimeManifest;
+  } catch {
+    return null;
+  }
+}
+
+function manifestsMatch(actual: RuntimeManifest | null, expected: RuntimeManifest): boolean {
+  if (!actual) {
+    return false;
+  }
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function defaultResolveRuntimeEntry(params: {
+  runtimeDir: string;
+  manifest: RuntimeManifest;
+}): string | null {
+  const runtimePackagePath = path.join(params.runtimeDir, "package.json");
+  if (!manifestsMatch(readRuntimeManifest(runtimePackagePath), params.manifest)) {
+    return null;
+  }
+  try {
+    const runtimeRequire = createRequire(runtimePackagePath);
+    return runtimeRequire.resolve("@lancedb/lancedb");
+  } catch {
+    return null;
+  }
+}
+
+function collectSpawnOutput(params: {
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): Promise<{ code: number | null; stdout: string; stderr: string; error?: Error }> {
+  return new Promise((resolve) => {
+    const child = spawn(params.command, params.args, {
+      cwd: params.cwd,
+      env: params.env,
+      shell: process.platform === "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      resolve({ code: null, stdout, stderr, error });
+    });
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function defaultInstallRuntime(params: {
+  runtimeDir: string;
+  manifest: RuntimeManifest;
+  env: NodeJS.ProcessEnv;
+  logger?: LanceDbRuntimeLogger;
+}): Promise<string> {
+  const runtimePackagePath = path.join(params.runtimeDir, "package.json");
+  const currentManifest = readRuntimeManifest(runtimePackagePath);
+  if (!manifestsMatch(currentManifest, params.manifest)) {
+    await fs.promises.rm(path.join(params.runtimeDir, "node_modules"), {
+      recursive: true,
+      force: true,
+    });
+    await fs.promises.rm(path.join(params.runtimeDir, "package-lock.json"), { force: true });
+  }
+
+  await fs.promises.mkdir(params.runtimeDir, { recursive: true });
+  await fs.promises.writeFile(
+    runtimePackagePath,
+    `${JSON.stringify(params.manifest, null, 2)}\n`,
+    "utf8",
+  );
+
+  const install = await collectSpawnOutput({
+    command: "npm",
+    args: ["install", "--omit=dev", "--silent", "--ignore-scripts", "--package-lock=false"],
+    cwd: params.runtimeDir,
+    env: params.env,
+  });
+  if (install.error) {
+    const spawnError = install.error as NodeJS.ErrnoException;
+    throw new Error(
+      spawnError.code === "ENOENT"
+        ? "npm is required to install the LanceDB runtime but was not found on PATH"
+        : install.error.message,
+    );
+  }
+  if ((install.code ?? 0) !== 0) {
+    const detail = install.stderr.trim() || install.stdout.trim();
+    throw new Error(detail || `npm exited with code ${install.code ?? "unknown"}`);
+  }
+
+  const resolved = defaultResolveRuntimeEntry({
+    runtimeDir: params.runtimeDir,
+    manifest: params.manifest,
+  });
+  if (!resolved) {
+    throw new Error("installed LanceDB runtime is missing the @lancedb/lancedb entry");
+  }
+  params.logger?.info?.(`memory-lancedb: installed LanceDB runtime under ${params.runtimeDir}`);
+  return resolved;
+}
+
+function defaultImportResolved(resolvedPath: string): Promise<LanceDbModule> {
+  return import(pathToFileURL(resolvedPath).href);
+}
+
+function buildLoadFailureMessage(prefix: string, error: unknown): string {
+  return `memory-lancedb: ${prefix}. ${String(error)}`;
+}
+
+export function createLanceDbRuntimeLoader(overrides: Partial<LanceDbRuntimeLoaderDeps> = {}): {
+  load: (logger?: LanceDbRuntimeLogger) => Promise<LanceDbModule>;
+} {
+  const deps: LanceDbRuntimeLoaderDeps = {
+    env: overrides.env ?? process.env,
+    resolveStateDir: overrides.resolveStateDir ?? resolveStateDir,
+    runtimeManifest: overrides.runtimeManifest ?? MEMORY_LANCEDB_RUNTIME_MANIFEST,
+    importBundled: overrides.importBundled ?? (() => import("@lancedb/lancedb")),
+    importResolved: overrides.importResolved ?? defaultImportResolved,
+    resolveRuntimeEntry: overrides.resolveRuntimeEntry ?? defaultResolveRuntimeEntry,
+    installRuntime: overrides.installRuntime ?? defaultInstallRuntime,
+  };
+
+  let loadPromise: Promise<LanceDbModule> | null = null;
+
+  return {
+    async load(logger?: LanceDbRuntimeLogger): Promise<LanceDbModule> {
+      if (!loadPromise) {
+        loadPromise = (async () => {
+          try {
+            return await deps.importBundled();
+          } catch (bundledError) {
+            const runtimeDir = resolveRuntimeDir(
+              deps.resolveStateDir(deps.env, () =>
+                deps.env.HOME?.trim() ? deps.env.HOME : os.homedir(),
+              ),
+            );
+            const existingRuntime = deps.resolveRuntimeEntry({
+              runtimeDir,
+              manifest: deps.runtimeManifest,
+            });
+            if (existingRuntime) {
+              try {
+                return await deps.importResolved(existingRuntime);
+              } catch {
+                // Reinstall below when the cached runtime is incomplete or stale.
+              }
+            }
+            if (deps.env.OPENCLAW_NIX_MODE === "1") {
+              throw new Error(
+                buildLoadFailureMessage(
+                  "failed to load LanceDB and Nix mode disables auto-install",
+                  bundledError,
+                ),
+                { cause: bundledError },
+              );
+            }
+            logger?.warn?.(
+              `memory-lancedb: bundled LanceDB runtime unavailable (${String(bundledError)}); installing runtime deps under ${runtimeDir}`,
+            );
+            const installedEntry = await deps.installRuntime({
+              runtimeDir,
+              manifest: deps.runtimeManifest,
+              env: deps.env,
+              logger,
+            });
+            try {
+              return await deps.importResolved(installedEntry);
+            } catch (runtimeError) {
+              throw new Error(
+                buildLoadFailureMessage(
+                  "failed to load LanceDB after installing runtime deps",
+                  runtimeError,
+                ),
+                { cause: runtimeError },
+              );
+            }
+          }
+        })().catch((error) => {
+          loadPromise = null;
+          throw error;
+        });
+      }
+      return await loadPromise;
+    },
+  };
+}
+
+const defaultLoader = createLanceDbRuntimeLoader();
+
+export async function loadLanceDbModule(logger?: LanceDbRuntimeLogger): Promise<LanceDbModule> {
+  return await defaultLoader.load(logger);
+}

--- a/src/plugin-sdk/memory-lancedb.ts
+++ b/src/plugin-sdk/memory-lancedb.ts
@@ -2,4 +2,5 @@
 // Keep this list additive and scoped to symbols used under extensions/memory-lancedb.
 
 export { definePluginEntry } from "./plugin-entry.js";
+export { resolveStateDir } from "./state-paths.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";


### PR DESCRIPTION
## Summary
- bootstrap `memory-lancedb` into user-state runtime on first use when packaged installs do not already include LanceDB
- keep `@lancedb/lancedb` plugin-local instead of moving it into OpenClaw core dependencies
- add loader and regression coverage for bundled load, cached runtime reuse, retry-after-failure, and Nix-mode fail-fast behavior

## Verification
- `pnpm test -- extensions/memory-lancedb/index.test.ts extensions/memory-lancedb/lancedb-runtime.test.ts src/plugins/bundled-runtime-deps.test.ts src/config/config.plugin-validation.test.ts`
- `pnpm build`
- `pnpm check`
- isolated packaged-install repro: installed tarball into a temp prefix, ran from `/tmp` with isolated `HOME` + `OPENCLAW_STATE_DIR`, confirmed `plugins list --json` resolved `memory-lancedb` from installed `dist/extensions`, and verified `openclaw ltm list` created `plugin-runtimes/memory-lancedb/lancedb` with `@lancedb/lancedb` and `apache-arrow`

Closes #26100