### PR TITLE
fix: relay ACP parent completions reliably

### DIFF
--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -1,52 +1,69 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as sessionMeta from "../acp/runtime/session-meta.js";
+import * as sessionPaths from "../config/sessions/paths.js";
+import * as gatewayCall from "../gateway/call.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import * as heartbeatWake from "../infra/heartbeat-wake.js";
+import * as systemEvents from "../infra/system-events.js";
 import {
   resolveAcpSpawnStreamLogPath,
   startAcpSpawnParentStreamRelay,
 } from "./acp-spawn-parent-stream.js";
-
-const enqueueSystemEventMock = vi.fn();
-const requestHeartbeatNowMock = vi.fn();
-const readAcpSessionEntryMock = vi.fn();
-const resolveSessionFilePathMock = vi.fn();
-const resolveSessionFilePathOptionsMock = vi.fn();
-
-vi.mock("../infra/system-events.js", () => ({
-  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
-}));
-
-vi.mock("../infra/heartbeat-wake.js", () => ({
-  requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
-}));
-
-vi.mock("../acp/runtime/session-meta.js", () => ({
-  readAcpSessionEntry: (...args: unknown[]) => readAcpSessionEntryMock(...args),
-}));
-
-vi.mock("../config/sessions/paths.js", () => ({
-  resolveSessionFilePath: (...args: unknown[]) => resolveSessionFilePathMock(...args),
-  resolveSessionFilePathOptions: (...args: unknown[]) => resolveSessionFilePathOptionsMock(...args),
-}));
-
-function collectedTexts() {
-  return enqueueSystemEventMock.mock.calls.map((call) => String(call[0] ?? ""));
-}
+import * as subagentAnnounce from "./subagent-announce.js";
+import * as subagentRegistry from "./subagent-registry.js";
 
 describe("startAcpSpawnParentStreamRelay", () => {
+  let enqueueSystemEventSpy: ReturnType<typeof vi.spyOn>;
+  let requestHeartbeatNowSpy: ReturnType<typeof vi.spyOn>;
+  let readAcpSessionEntrySpy: ReturnType<typeof vi.spyOn>;
+  let resolveSessionFilePathSpy: ReturnType<typeof vi.spyOn>;
+  let resolveSessionFilePathOptionsSpy: ReturnType<typeof vi.spyOn>;
+  let callGatewaySpy: ReturnType<typeof vi.spyOn>;
+  let readSubagentOutputSpy: ReturnType<typeof vi.spyOn>;
+  let completeSubagentRunSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
-    enqueueSystemEventMock.mockClear();
-    requestHeartbeatNowMock.mockClear();
-    readAcpSessionEntryMock.mockReset();
-    resolveSessionFilePathMock.mockReset();
-    resolveSessionFilePathOptionsMock.mockReset();
-    resolveSessionFilePathOptionsMock.mockImplementation((value: unknown) => value);
+    enqueueSystemEventSpy = vi
+      .spyOn(systemEvents, "enqueueSystemEvent")
+      .mockImplementation(() => false);
+    requestHeartbeatNowSpy = vi
+      .spyOn(heartbeatWake, "requestHeartbeatNow")
+      .mockImplementation(() => {});
+    readAcpSessionEntrySpy = vi
+      .spyOn(sessionMeta, "readAcpSessionEntry")
+      .mockReturnValue(undefined as never);
+    resolveSessionFilePathSpy = vi
+      .spyOn(sessionPaths, "resolveSessionFilePath")
+      .mockReturnValue("");
+    resolveSessionFilePathOptionsSpy = vi
+      .spyOn(sessionPaths, "resolveSessionFilePathOptions")
+      .mockImplementation((value: unknown) => value as never);
+    callGatewaySpy = vi.spyOn(gatewayCall, "callGateway").mockResolvedValue(undefined as never);
+    readSubagentOutputSpy = vi
+      .spyOn(subagentAnnounce, "readSubagentOutput")
+      .mockResolvedValue(undefined);
+    completeSubagentRunSpy = vi
+      .spyOn(subagentRegistry, "completeSubagentRun")
+      .mockResolvedValue(undefined as never);
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-04T01:00:00.000Z"));
   });
 
   afterEach(() => {
+    enqueueSystemEventSpy.mockRestore();
+    requestHeartbeatNowSpy.mockRestore();
+    readAcpSessionEntrySpy.mockRestore();
+    resolveSessionFilePathSpy.mockRestore();
+    resolveSessionFilePathOptionsSpy.mockRestore();
+    callGatewaySpy.mockRestore();
+    readSubagentOutputSpy.mockRestore();
+    completeSubagentRunSpy.mockRestore();
     vi.useRealTimers();
   });
+
+  function collectedTexts() {
+    return enqueueSystemEventSpy.mock.calls.map((call) => String(call[0] ?? ""));
+  }
 
   it("relays assistant progress and completion to the parent session", () => {
     const relay = startAcpSpawnParentStreamRelay({
@@ -78,10 +95,10 @@ describe("startAcpSpawnParentStreamRelay", () => {
     });
 
     const texts = collectedTexts();
-    expect(texts.some((text) => text.includes("Started codex session"))).toBe(true);
-    expect(texts.some((text) => text.includes("codex: hello from child"))).toBe(true);
-    expect(texts.some((text) => text.includes("codex run completed in 2s"))).toBe(true);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith(
+    expect(texts.some((text: string) => text.includes("Started codex session"))).toBe(true);
+    expect(texts.some((text: string) => text.includes("codex: hello from child"))).toBe(true);
+    expect(texts.some((text: string) => text.includes("codex run completed in 2s"))).toBe(true);
+    expect(requestHeartbeatNowSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         reason: "acp:spawn:stream",
         sessionKey: "agent:main:main",
@@ -90,7 +107,7 @@ describe("startAcpSpawnParentStreamRelay", () => {
     relay.dispose();
   });
 
-  it("emits a no-output notice and a resumed notice when output returns", () => {
+  it("emits a no-output notice and a resumed notice when output returns", async () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-2",
       parentSessionKey: "agent:main:main",
@@ -101,10 +118,10 @@ describe("startAcpSpawnParentStreamRelay", () => {
       noOutputPollMs: 250,
     });
 
-    vi.advanceTimersByTime(1_500);
-    expect(collectedTexts().some((text) => text.includes("has produced no output for 1s"))).toBe(
-      true,
-    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(
+      collectedTexts().some((text: string) => text.includes("has produced no output for 1s")),
+    ).toBe(true);
 
     emitAgentEvent({
       runId: "run-2",
@@ -116,8 +133,8 @@ describe("startAcpSpawnParentStreamRelay", () => {
     vi.advanceTimersByTime(5);
 
     const texts = collectedTexts();
-    expect(texts.some((text) => text.includes("resumed output."))).toBe(true);
-    expect(texts.some((text) => text.includes("codex: resumed output"))).toBe(true);
+    expect(texts.some((text: string) => text.includes("resumed output."))).toBe(true);
+    expect(texts.some((text: string) => text.includes("codex: resumed output"))).toBe(true);
 
     emitAgentEvent({
       runId: "run-2",
@@ -127,11 +144,11 @@ describe("startAcpSpawnParentStreamRelay", () => {
         error: "boom",
       },
     });
-    expect(collectedTexts().some((text) => text.includes("run failed: boom"))).toBe(true);
+    expect(collectedTexts().some((text: string) => text.includes("run failed: boom"))).toBe(true);
     relay.dispose();
   });
 
-  it("auto-disposes stale relays after max lifetime timeout", () => {
+  it("auto-disposes stale relays after max lifetime timeout", async () => {
     const relay = startAcpSpawnParentStreamRelay({
       runId: "run-3",
       parentSessionKey: "agent:main:main",
@@ -142,12 +159,12 @@ describe("startAcpSpawnParentStreamRelay", () => {
       maxRelayLifetimeMs: 1_000,
     });
 
-    vi.advanceTimersByTime(1_001);
-    expect(collectedTexts().some((text) => text.includes("stream relay timed out after 1s"))).toBe(
-      true,
-    );
+    await vi.advanceTimersByTimeAsync(1_001);
+    expect(
+      collectedTexts().some((text: string) => text.includes("stream relay timed out after 1s")),
+    ).toBe(true);
 
-    const before = enqueueSystemEventMock.mock.calls.length;
+    const before = enqueueSystemEventSpy.mock.calls.length;
     emitAgentEvent({
       runId: "run-3",
       stream: "assistant",
@@ -157,7 +174,7 @@ describe("startAcpSpawnParentStreamRelay", () => {
     });
     vi.advanceTimersByTime(5);
 
-    expect(enqueueSystemEventMock.mock.calls).toHaveLength(before);
+    expect(enqueueSystemEventSpy.mock.calls).toHaveLength(before);
     relay.dispose();
   });
 
@@ -170,11 +187,15 @@ describe("startAcpSpawnParentStreamRelay", () => {
       emitStartNotice: false,
     });
 
-    expect(collectedTexts().some((text) => text.includes("Started codex session"))).toBe(false);
+    expect(collectedTexts().some((text: string) => text.includes("Started codex session"))).toBe(
+      false,
+    );
 
     relay.notifyStarted();
 
-    expect(collectedTexts().some((text) => text.includes("Started codex session"))).toBe(true);
+    expect(collectedTexts().some((text: string) => text.includes("Started codex session"))).toBe(
+      true,
+    );
     relay.dispose();
   });
 
@@ -205,31 +226,29 @@ describe("startAcpSpawnParentStreamRelay", () => {
     vi.advanceTimersByTime(15);
 
     const texts = collectedTexts();
-    expect(texts.some((text) => text.includes("codex: hello world"))).toBe(true);
+    expect(texts.some((text: string) => text.includes("codex: hello world"))).toBe(true);
     relay.dispose();
   });
 
   it("resolves ACP spawn stream log path from session metadata", () => {
-    readAcpSessionEntryMock.mockReturnValue({
+    readAcpSessionEntrySpy.mockReturnValue({
       storePath: "/tmp/openclaw/agents/codex/sessions/sessions.json",
       entry: {
         sessionId: "sess-123",
         sessionFile: "/tmp/openclaw/agents/codex/sessions/sess-123.jsonl",
       },
     });
-    resolveSessionFilePathMock.mockReturnValue(
-      "/tmp/openclaw/agents/codex/sessions/sess-123.jsonl",
-    );
+    resolveSessionFilePathSpy.mockReturnValue("/tmp/openclaw/agents/codex/sessions/sess-123.jsonl");
 
     const resolved = resolveAcpSpawnStreamLogPath({
       childSessionKey: "agent:codex:acp:child-1",
     });
 
     expect(resolved).toBe("/tmp/openclaw/agents/codex/sessions/sess-123.acp-stream.jsonl");
-    expect(readAcpSessionEntryMock).toHaveBeenCalledWith({
+    expect(readAcpSessionEntrySpy).toHaveBeenCalledWith({
       sessionKey: "agent:codex:acp:child-1",
     });
-    expect(resolveSessionFilePathMock).toHaveBeenCalledWith(
+    expect(resolveSessionFilePathSpy).toHaveBeenCalledWith(
       "sess-123",
       expect.objectContaining({
         sessionId: "sess-123",
@@ -238,5 +257,45 @@ describe("startAcpSpawnParentStreamRelay", () => {
         storePath: "/tmp/openclaw/agents/codex/sessions/sessions.json",
       }),
     );
+  });
+
+  it("probes for completed relay before emitting stall warning", async () => {
+    callGatewaySpy.mockResolvedValue({ status: "ok", endedAt: Date.now() } as never);
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-6",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-6",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 1_000,
+      noOutputPollMs: 250,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    const texts = collectedTexts();
+    expect(texts.some((text: string) => text.includes("has produced no output"))).toBe(false);
+    expect(texts.some((text: string) => text.includes("run completed"))).toBe(true);
+    relay.dispose();
+  });
+
+  it("uses transcript fallback before emitting stall warning", async () => {
+    readSubagentOutputSpy.mockResolvedValue("transcript result");
+
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-7",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-7",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 1_000,
+      noOutputPollMs: 250,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    const texts = collectedTexts();
+    expect(texts.some((text: string) => text.includes("has produced no output"))).toBe(false);
+    expect(texts.some((text: string) => text.includes("run completed"))).toBe(true);
+    relay.dispose();
   });
 });

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -61,8 +61,10 @@ describe("startAcpSpawnParentStreamRelay", () => {
     vi.useRealTimers();
   });
 
-  function collectedTexts() {
-    return enqueueSystemEventSpy.mock.calls.map((call) => String(call[0] ?? ""));
+  function collectedTexts(): string[] {
+    return enqueueSystemEventSpy.mock.calls.map((call: [string, ...unknown[]]) =>
+      String(call[0] ?? ""),
+    );
   }
 
   it("relays assistant progress and completion to the parent session", () => {

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -2,7 +2,13 @@ import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
+import {
+  completeSubagentRun,
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+} from "./subagent-registry.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
@@ -246,6 +252,77 @@ export function startAcpSpawnParentStreamRelay(params: {
     flushTimer.unref?.();
   };
 
+  const finalizeCompletedRelay = async (wait: {
+    status?: string;
+    error?: string;
+    startedAt?: number;
+    endedAt?: number;
+  }): Promise<boolean> => {
+    const startedAt = toFiniteNumber(wait.startedAt);
+    const endedAt = toFiniteNumber(wait.endedAt) ?? Date.now();
+    flushPending();
+    if (wait.status === "error") {
+      const errorText = toTrimmedString(wait.error);
+      if (errorText) {
+        emit(`${relayLabel} run failed: ${errorText}`, `${contextPrefix}:error`);
+      } else {
+        emit(`${relayLabel} run failed.`, `${contextPrefix}:error`);
+      }
+      await completeSubagentRun({
+        runId,
+        endedAt,
+        outcome: { status: "error", error: errorText },
+        reason: SUBAGENT_ENDED_REASON_ERROR,
+        sendFarewell: true,
+        triggerCleanup: true,
+      });
+      dispose();
+      return true;
+    }
+    const durationMs =
+      startedAt != null && endedAt >= startedAt ? endedAt - startedAt : undefined;
+    if (durationMs != null) {
+      emit(
+        `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
+        `${contextPrefix}:done`,
+      );
+    } else {
+      emit(`${relayLabel} run completed.`, `${contextPrefix}:done`);
+    }
+    await completeSubagentRun({
+      runId,
+      endedAt,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      sendFarewell: true,
+      triggerCleanup: true,
+    });
+    dispose();
+    return true;
+  };
+
+  const probeForCompletedRelay = async (timeoutMs = 1): Promise<boolean> => {
+    try {
+      const wait = await callGateway<{
+        status?: string;
+        error?: string;
+        startedAt?: number;
+        endedAt?: number;
+      }>({
+        method: "agent.wait",
+        params: {
+          runId,
+          timeoutMs: Math.max(1, Math.floor(timeoutMs)),
+        },
+        timeoutMs: Math.max(1_500, Math.floor(timeoutMs) + 1_000),
+      });
+      if (wait?.status === "ok" || wait?.status === "error") {
+        return await finalizeCompletedRelay(wait);
+      }
+    } catch {}
+    return false;
+  };
+
   const noOutputWatcherTimer = setInterval(() => {
     if (disposed || noOutputNoticeMs <= 0) {
       return;
@@ -256,11 +333,16 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (Date.now() - lastProgressAt < noOutputNoticeMs) {
       return;
     }
-    stallNotified = true;
-    emit(
-      `${relayLabel} has produced no output for ${Math.round(noOutputNoticeMs / 1000)}s. It may be waiting for interactive input.`,
-      `${contextPrefix}:stall`,
-    );
+    void probeForCompletedRelay().then((completed) => {
+      if (disposed || completed || stallNotified) {
+        return;
+      }
+      stallNotified = true;
+      emit(
+        `${relayLabel} has produced no output for ${Math.round(noOutputNoticeMs / 1000)}s. It may be waiting for interactive input.`,
+        `${contextPrefix}:stall`,
+      );
+    });
   }, noOutputPollMs);
   noOutputWatcherTimer.unref?.();
 
@@ -268,11 +350,16 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (disposed) {
       return;
     }
-    emit(
-      `${relayLabel} stream relay timed out after ${Math.max(1, Math.round(maxRelayLifetimeMs / 1000))}s without completion.`,
-      `${contextPrefix}:timeout`,
-    );
-    dispose();
+    void probeForCompletedRelay(250).then((completed) => {
+      if (disposed || completed) {
+        return;
+      }
+      emit(
+        `${relayLabel} stream relay timed out after ${Math.max(1, Math.round(maxRelayLifetimeMs / 1000))}s without completion.`,
+        `${contextPrefix}:timeout`,
+      );
+      dispose();
+    });
   }, maxRelayLifetimeMs);
   relayLifetimeTimer.unref?.();
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -319,7 +319,9 @@ export function startAcpSpawnParentStreamRelay(params: {
       if (wait?.status === "ok" || wait?.status === "error") {
         return await finalizeCompletedRelay(wait);
       }
-    } catch {}
+    } catch (err) {
+      logEvent("probe_error", { error: String(err) });
+    }
     return false;
   };
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -4,14 +4,15 @@ import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
 import { callGateway } from "../gateway/call.js";
 import { onAgentEvent } from "../infra/agent-events.js";
-import {
-  completeSubagentRun,
-  SUBAGENT_ENDED_REASON_COMPLETE,
-  SUBAGENT_ENDED_REASON_ERROR,
-} from "./subagent-registry.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { readSubagentOutput } from "./subagent-announce.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+} from "./subagent-lifecycle-events.js";
+import { completeSubagentRun } from "./subagent-registry.js";
 
 const DEFAULT_STREAM_FLUSH_MS = 2_500;
 const DEFAULT_NO_OUTPUT_NOTICE_MS = 60_000;
@@ -279,8 +280,7 @@ export function startAcpSpawnParentStreamRelay(params: {
       dispose();
       return true;
     }
-    const durationMs =
-      startedAt != null && endedAt >= startedAt ? endedAt - startedAt : undefined;
+    const durationMs = startedAt != null && endedAt >= startedAt ? endedAt - startedAt : undefined;
     if (durationMs != null) {
       emit(
         `${relayLabel} run completed in ${Math.max(1, Math.round(durationMs / 1000))}s.`,
@@ -333,8 +333,18 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (Date.now() - lastProgressAt < noOutputNoticeMs) {
       return;
     }
-    void probeForCompletedRelay().then((completed) => {
+    void probeForCompletedRelay().then(async (completed) => {
       if (disposed || completed || stallNotified) {
+        return;
+      }
+      try {
+        const childOutput = await readSubagentOutput(params.childSessionKey);
+        if (childOutput?.trim()) {
+          await finalizeCompletedRelay({ status: "ok" });
+          return;
+        }
+      } catch {}
+      if (disposed) {
         return;
       }
       stallNotified = true;
@@ -350,8 +360,18 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (disposed) {
       return;
     }
-    void probeForCompletedRelay(250).then((completed) => {
+    void probeForCompletedRelay(250).then(async (completed) => {
       if (disposed || completed) {
+        return;
+      }
+      try {
+        const childOutput = await readSubagentOutput(params.childSessionKey);
+        if (childOutput?.trim()) {
+          await finalizeCompletedRelay({ status: "ok" });
+          return;
+        }
+      } catch {}
+      if (disposed) {
         return;
       }
       emit(

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -27,6 +27,7 @@ import { loadConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadSessionStore, resolveStorePath, type SessionEntry } from "../config/sessions.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
 import { callGateway } from "../gateway/call.js";
 import { areHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
@@ -54,8 +55,8 @@ import {
 } from "./acp-spawn-parent-stream.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 import { registerSubagentRun } from "./subagent-registry.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
@@ -793,6 +794,7 @@ export async function spawnAcpDirect(
   let binding: SessionBindingRecord | null = null;
   let sessionCreated = false;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  let initializedMeta: SessionAcpMeta | undefined;
   try {
     await callGateway({
       method: "sessions.patch",
@@ -813,6 +815,7 @@ export async function spawnAcpDirect(
       cwd: params.cwd,
     });
     initializedRuntime = initializedSession.runtimeCloseHandle;
+    initializedMeta = initializedSession.initialized.meta;
 
     if (preparedBinding) {
       ({ binding } = await bindPreparedAcpThread({
@@ -918,12 +921,12 @@ export async function spawnAcpDirect(
         childSessionKey: sessionKey,
         controllerSessionKey: requesterInternalKey,
         requesterSessionKey: requesterInternalKey,
-        requesterOrigin,
+        requesterOrigin: requesterState.origin,
         requesterDisplayKey: parentSessionKey,
         task: params.task,
         cleanup: "keep",
         label: params.label || undefined,
-        workspaceDir: resolveAcpSessionCwd(initialized.meta) || params.cwd || undefined,
+        workspaceDir: resolveAcpSessionCwd(initializedMeta) || params.cwd || undefined,
         runTimeoutSeconds: 0,
         expectsCompletionMessage: true,
         spawnMode,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -931,7 +931,9 @@ export async function spawnAcpDirect(
         expectsCompletionMessage: true,
         spawnMode,
       });
-    } catch {}
+    } catch (err) {
+      log.warn("registerSubagentRun failed for run %s: %s", childRunId, err);
+    }
     parentRelay?.notifyStarted();
     return {
       status: "accepted",

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -932,7 +932,7 @@ export async function spawnAcpDirect(
         spawnMode,
       });
     } catch (err) {
-      log.warn("registerSubagentRun failed for run %s: %s", childRunId, err);
+      log.warn("registerSubagentRun failed", { runId: childRunId, err: String(err) });
     }
     parentRelay?.notifyStarted();
     return {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -55,6 +55,7 @@ import {
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+import { registerSubagentRun } from "./subagent-registry.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
 
@@ -911,6 +912,23 @@ export async function spawnAcpDirect(
         emitStartNotice: false,
       });
     }
+    try {
+      registerSubagentRun({
+        runId: childRunId,
+        childSessionKey: sessionKey,
+        controllerSessionKey: requesterInternalKey,
+        requesterSessionKey: requesterInternalKey,
+        requesterOrigin,
+        requesterDisplayKey: parentSessionKey,
+        task: params.task,
+        cleanup: "keep",
+        label: params.label || undefined,
+        workspaceDir: resolveAcpSessionCwd(initialized.meta) || params.cwd || undefined,
+        runTimeoutSeconds: 0,
+        expectsCompletionMessage: true,
+        spawnMode,
+      });
+    } catch {}
     parentRelay?.notifyStarted();
     return {
       status: "accepted",

--- a/src/agents/subagent-announce.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce.capture-completion-reply.test.ts
@@ -1,18 +1,14 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import * as gatewayCall from "../gateway/call.js";
+import * as sessionUtils from "../gateway/session-utils.js";
 
 const chatHistoryMock = vi.fn<(sessionKey: string) => Promise<{ messages?: Array<unknown> }>>(
   async (_sessionKey: string) => ({ messages: [] }),
 );
 
-vi.mock("../gateway/call.js", () => ({
-  callGateway: vi.fn(async (request: unknown) => {
-    const typed = request as { method?: string; params?: { sessionKey?: string } };
-    if (typed.method === "chat.history") {
-      return await chatHistoryMock(typed.params?.sessionKey ?? "");
-    }
-    return {};
-  }),
-}));
+const callGatewayMock = vi.spyOn(gatewayCall, "callGateway");
+const loadSessionEntryMock = vi.spyOn(sessionUtils, "loadSessionEntry");
+const readSessionMessagesMock = vi.spyOn(sessionUtils, "readSessionMessages");
 
 describe("captureSubagentCompletionReply", () => {
   let previousFastTestEnv: string | undefined;
@@ -34,6 +30,17 @@ describe("captureSubagentCompletionReply", () => {
 
   beforeEach(() => {
     chatHistoryMock.mockReset().mockResolvedValue({ messages: [] });
+    callGatewayMock.mockReset().mockImplementation(async (request: unknown) => {
+      const typed = request as { method?: string; params?: { sessionKey?: string } };
+      if (typed.method === "chat.history") {
+        return await chatHistoryMock(typed.params?.sessionKey ?? "");
+      }
+      return {};
+    });
+    loadSessionEntryMock.mockReset().mockImplementation(() => {
+      throw new Error("no session entry");
+    });
+    readSessionMessagesMock.mockReset().mockReturnValue([]);
   });
 
   it("returns immediate assistant output from history without polling", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -394,7 +394,7 @@ function readSubagentOutputFromTranscript(
     if (!sessionId) {
       return undefined;
     }
-    const messages = readSessionMessages(sessionId, storePath, entry.sessionFile);
+    const messages = readSessionMessages(sessionId, storePath, entry?.sessionFile);
     const selected = selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
     return selected?.trim() ? selected : undefined;
   } catch {
@@ -402,7 +402,7 @@ function readSubagentOutputFromTranscript(
   }
 }
 
-async function readSubagentOutput(
+export async function readSubagentOutput(
   sessionKey: string,
   outcome?: SubagentRunOutcome,
 ): Promise<string | undefined> {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -9,6 +9,7 @@ import {
   resolveStorePath,
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
+import { loadSessionEntry, readSessionMessages } from "../gateway/session-utils.js";
 import { createBoundDeliveryRouter } from "../infra/outbound/bound-delivery-router.js";
 import { resolveConversationIdFromTargets } from "../infra/outbound/conversation-id.js";
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
@@ -383,21 +384,46 @@ function selectSubagentOutputText(
   return snapshot.latestRawText;
 }
 
+function readSubagentOutputFromTranscript(
+  sessionKey: string,
+  outcome?: SubagentRunOutcome,
+): string | undefined {
+  try {
+    const { storePath, entry } = loadSessionEntry(sessionKey);
+    const sessionId = entry?.sessionId?.trim();
+    if (!sessionId) {
+      return undefined;
+    }
+    const messages = readSessionMessages(sessionId, storePath, entry.sessionFile);
+    const selected = selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
+    return selected?.trim() ? selected : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function readSubagentOutput(
   sessionKey: string,
   outcome?: SubagentRunOutcome,
 ): Promise<string | undefined> {
-  const history = await callGateway<{ messages?: Array<unknown> }>({
-    method: "chat.history",
-    params: { sessionKey, limit: 100 },
-  });
-  const messages = Array.isArray(history?.messages) ? history.messages : [];
-  const selected = selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
-  if (selected?.trim()) {
-    return selected;
-  }
-  const latestAssistant = await readLatestAssistantReply({ sessionKey, limit: 100 });
-  return latestAssistant?.trim() ? latestAssistant : undefined;
+  try {
+    const history = await callGateway<{ messages?: Array<unknown> }>({
+      method: "chat.history",
+      params: { sessionKey, limit: 100 },
+    });
+    const messages = Array.isArray(history?.messages) ? history.messages : [];
+    const selected = selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
+    if (selected?.trim()) {
+      return selected;
+    }
+  } catch {}
+  try {
+    const latestAssistant = await readLatestAssistantReply({ sessionKey, limit: 100 });
+    if (latestAssistant?.trim()) {
+      return latestAssistant;
+    }
+  } catch {}
+  return readSubagentOutputFromTranscript(sessionKey, outcome);
 }
 
 async function readLatestSubagentOutputWithRetry(params: {

--- a/src/agents/subagent-registry.idempotent-complete.test.ts
+++ b/src/agents/subagent-registry.idempotent-complete.test.ts
@@ -48,6 +48,7 @@ const emitSessionLifecycleEventMock = vi.fn();
 
 vi.mock("./subagent-announce.js", () => ({
   runSubagentAnnounceFlow: announceSpy,
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
 }));
 
 vi.mock("../plugins/hook-runner-global.js", () => ({
@@ -89,7 +90,33 @@ describe("completeSubagentRun idempotency", () => {
     });
   };
 
-  it("second call is a no-op for an already-ended run", async () => {
+  it("first completion runs full finalization even when endedAt is pre-set", async () => {
+    registerRun("run-idem-0");
+
+    // Simulate what waitForSubagentCompletion does: set endedAt on the entry
+    // BEFORE calling completeSubagentRun.
+    const runs0 = mod.listSubagentRunsForRequester("agent:main:main");
+    const preEntry = runs0.find((r) => r.runId === "run-idem-0");
+    expect(preEntry).toBeDefined();
+    preEntry!.endedAt = 500;
+
+    await mod.completeSubagentRun({
+      runId: "run-idem-0",
+      endedAt: 500,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const afterEntry = runs0.find((r) => r.runId === "run-idem-0");
+    // completionFinalized proves the full finalization path ran.
+    expect(afterEntry?.completionFinalized).toBe(true);
+    expect(afterEntry?.endedAt).toBe(500);
+    expect(afterEntry?.outcome).toEqual({ status: "ok" });
+    expect(afterEntry?.endedReason).toBe(SUBAGENT_ENDED_REASON_COMPLETE);
+  });
+
+  it("second call is a no-op for a finalized run", async () => {
     registerRun("run-idem-1");
 
     // First completion should succeed.
@@ -104,6 +131,7 @@ describe("completeSubagentRun idempotency", () => {
     const runs1 = mod.listSubagentRunsForRequester("agent:main:main");
     const entry1 = runs1.find((r) => r.runId === "run-idem-1");
     expect(entry1?.endedAt).toBe(1000);
+    expect(entry1?.completionFinalized).toBe(true);
 
     emitSessionLifecycleEventMock.mockClear();
 
@@ -131,7 +159,7 @@ describe("completeSubagentRun idempotency", () => {
     await mod.completeSubagentRun({
       runId: "run-idem-2",
       endedAt: 1000,
-      outcome: { status: "killed" },
+      outcome: { status: "error", error: "killed" },
       reason: SUBAGENT_ENDED_REASON_KILLED,
       triggerCleanup: false,
     });

--- a/src/agents/subagent-registry.idempotent-complete.test.ts
+++ b/src/agents/subagent-registry.idempotent-complete.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_KILLED,
+} from "./subagent-lifecycle-events.js";
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async () => ({})),
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: vi.fn(() => () => {}),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+  })),
+}));
+
+vi.mock("../config/sessions.js", () => {
+  const sessionStore = new Proxy<Record<string, { sessionId: string; updatedAt: number }>>(
+    {},
+    {
+      get(target, prop, receiver) {
+        if (typeof prop !== "string" || prop in target) {
+          return Reflect.get(target, prop, receiver);
+        }
+        return { sessionId: `sess-${prop}`, updatedAt: 1 };
+      },
+    },
+  );
+
+  return {
+    loadSessionStore: vi.fn(() => sessionStore),
+    resolveAgentIdFromSessionKey: (key: string) => {
+      const match = key.match(/^agent:([^:]+)/);
+      return match?.[1] ?? "main";
+    },
+    resolveMainSessionKey: () => "agent:main:main",
+    resolveStorePath: () => "/tmp/test-store",
+    updateSessionStore: vi.fn(),
+  };
+});
+
+const announceSpy = vi.fn(async () => true);
+const emitSessionLifecycleEventMock = vi.fn();
+
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: announceSpy,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => ({
+    hasHooks: () => false,
+    runSubagentEnded: vi.fn(async () => {}),
+  })),
+}));
+
+vi.mock("../sessions/session-lifecycle-events.js", () => ({
+  emitSessionLifecycleEvent: emitSessionLifecycleEventMock,
+}));
+
+vi.mock("./subagent-registry.store.js", () => ({
+  loadSubagentRegistryFromDisk: vi.fn(() => new Map()),
+  saveSubagentRegistryToDisk: vi.fn(() => {}),
+}));
+
+describe("completeSubagentRun idempotency", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeAll(async () => {
+    mod = await import("./subagent-registry.js");
+  });
+
+  afterEach(() => {
+    emitSessionLifecycleEventMock.mockClear();
+    announceSpy.mockClear();
+  });
+
+  const registerRun = (runId: string) => {
+    mod.registerSubagentRun({
+      runId,
+      childSessionKey: `agent:main:subagent:${runId}`,
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "test task",
+      cleanup: "keep",
+    });
+  };
+
+  it("second call is a no-op for an already-ended run", async () => {
+    registerRun("run-idem-1");
+
+    // First completion should succeed.
+    await mod.completeSubagentRun({
+      runId: "run-idem-1",
+      endedAt: 1000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const runs1 = mod.listSubagentRunsForRequester("agent:main:main");
+    const entry1 = runs1.find((r) => r.runId === "run-idem-1");
+    expect(entry1?.endedAt).toBe(1000);
+
+    emitSessionLifecycleEventMock.mockClear();
+
+    // Second completion with a different endedAt should be ignored.
+    await mod.completeSubagentRun({
+      runId: "run-idem-1",
+      endedAt: 2000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const runs2 = mod.listSubagentRunsForRequester("agent:main:main");
+    const entry2 = runs2.find((r) => r.runId === "run-idem-1");
+    // endedAt should NOT have been mutated by the second call.
+    expect(entry2?.endedAt).toBe(1000);
+    // No lifecycle event emitted on duplicate.
+    expect(emitSessionLifecycleEventMock).not.toHaveBeenCalled();
+  });
+
+  it("allows recovery path when reason=complete after kill with cleanup handled", async () => {
+    registerRun("run-idem-2");
+
+    // Simulate an earlier kill completion.
+    await mod.completeSubagentRun({
+      runId: "run-idem-2",
+      endedAt: 1000,
+      outcome: { status: "killed" },
+      reason: SUBAGENT_ENDED_REASON_KILLED,
+      triggerCleanup: false,
+    });
+
+    // Mark cleanup as handled (simulating what the kill path does).
+    const runs = mod.listSubagentRunsForRequester("agent:main:main");
+    const entry = runs.find((r) => r.runId === "run-idem-2");
+    expect(entry).toBeDefined();
+    // Directly set the fields the recovery path checks.
+    entry!.suppressAnnounceReason = "killed";
+    entry!.cleanupHandled = true;
+
+    emitSessionLifecycleEventMock.mockClear();
+
+    // A late lifecycle completion should be allowed through the recovery path.
+    await mod.completeSubagentRun({
+      runId: "run-idem-2",
+      endedAt: 3000,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+      triggerCleanup: false,
+    });
+
+    const runsAfter = mod.listSubagentRunsForRequester("agent:main:main");
+    const entryAfter = runsAfter.find((r) => r.runId === "run-idem-2");
+    // Recovery path should update endedAt and clear suppressAnnounceReason.
+    expect(entryAfter?.endedAt).toBe(3000);
+    expect(entryAfter?.suppressAnnounceReason).toBeUndefined();
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -545,9 +545,11 @@ export async function completeSubagentRun(params: {
     entry.suppressAnnounceReason === "killed" &&
     (entry.cleanupHandled || typeof entry.cleanupCompletedAt === "number");
 
-  // Idempotency: if the run already ended, bail out to avoid mutating endedAt
-  // a second time or re-triggering farewell/cleanup side-effects.
-  if (typeof entry.endedAt === "number" && !isRecoveryFromKill) {
+  // Idempotency: bail only if completeSubagentRun already ran its full
+  // finalization path. Using entry.completionFinalized (not entry.endedAt)
+  // so that the normal first call from waitForSubagentCompletion — which
+  // populates endedAt before calling us — still executes cleanup/announce.
+  if (entry.completionFinalized && !isRecoveryFromKill) {
     return;
   }
 
@@ -556,6 +558,7 @@ export async function completeSubagentRun(params: {
     entry.suppressAnnounceReason = undefined;
     entry.cleanupHandled = false;
     entry.cleanupCompletedAt = undefined;
+    entry.completionFinalized = false;
     mutated = true;
   }
 
@@ -576,6 +579,9 @@ export async function completeSubagentRun(params: {
   if (await freezeRunResultAtCompletion(entry)) {
     mutated = true;
   }
+
+  // Mark finalization complete so duplicate calls are no-ops.
+  entry.completionFinalized = true;
 
   if (mutated) {
     persistSubagentRuns();
@@ -1312,6 +1318,7 @@ export function replaceSubagentRunAfterSteer(params: {
     accumulatedRuntimeMs,
     endedAt: undefined,
     endedReason: undefined,
+    completionFinalized: false,
     endedHookEmittedAt: undefined,
     wakeOnDescendantSettle: undefined,
     outcome: undefined,

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -523,7 +523,7 @@ async function refreshFrozenResultFromSession(sessionKey: string): Promise<boole
   return changed;
 }
 
-async function completeSubagentRun(params: {
+export async function completeSubagentRun(params: {
   runId: string;
   endedAt?: number;
   outcome: SubagentRunOutcome;

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -538,14 +538,21 @@ export async function completeSubagentRun(params: {
     return;
   }
 
-  let mutated = false;
   // If a late lifecycle completion arrives after an earlier kill marker, allow
   // completion cleanup/announce to run instead of staying permanently suppressed.
-  if (
+  const isRecoveryFromKill =
     params.reason === SUBAGENT_ENDED_REASON_COMPLETE &&
     entry.suppressAnnounceReason === "killed" &&
-    (entry.cleanupHandled || typeof entry.cleanupCompletedAt === "number")
-  ) {
+    (entry.cleanupHandled || typeof entry.cleanupCompletedAt === "number");
+
+  // Idempotency: if the run already ended, bail out to avoid mutating endedAt
+  // a second time or re-triggering farewell/cleanup side-effects.
+  if (typeof entry.endedAt === "number" && !isRecoveryFromKill) {
+    return;
+  }
+
+  let mutated = false;
+  if (isRecoveryFromKill) {
     entry.suppressAnnounceReason = undefined;
     entry.cleanupHandled = false;
     entry.cleanupCompletedAt = undefined;

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -55,6 +55,8 @@ export type SubagentRunRecord = {
   fallbackFrozenResultText?: string | null;
   /** Timestamp when fallbackFrozenResultText was preserved. */
   fallbackFrozenResultCapturedAt?: number;
+  /** Set once completeSubagentRun has executed its full finalization path. */
+  completionFinalized?: boolean;
   /** Set after the subagent_ended hook has been emitted successfully once. */
   endedHookEmittedAt?: number;
   attachmentsDir?: string;

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1,39 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as acpSpawn from "../acp-spawn.js";
+import * as subagentSpawn from "../subagent-spawn.js";
+import { createSessionsSpawnTool } from "./sessions-spawn-tool.js";
 
-const hoisted = vi.hoisted(() => {
-  const spawnSubagentDirectMock = vi.fn();
-  const spawnAcpDirectMock = vi.fn();
-  return {
-    spawnSubagentDirectMock,
-    spawnAcpDirectMock,
-  };
-});
-
-vi.mock("../subagent-spawn.js", () => ({
-  SUBAGENT_SPAWN_MODES: ["run", "session"],
-  spawnSubagentDirect: (...args: unknown[]) => hoisted.spawnSubagentDirectMock(...args),
-}));
-
-vi.mock("../acp-spawn.js", () => ({
-  ACP_SPAWN_MODES: ["run", "session"],
-  ACP_SPAWN_STREAM_TARGETS: ["parent"],
-  spawnAcpDirect: (...args: unknown[]) => hoisted.spawnAcpDirectMock(...args),
-}));
-
-const { createSessionsSpawnTool } = await import("./sessions-spawn-tool.js");
+const spawnSubagentDirectMock = vi.spyOn(subagentSpawn, "spawnSubagentDirect");
+const spawnAcpDirectMock = vi.spyOn(acpSpawn, "spawnAcpDirect");
 
 describe("sessions_spawn tool", () => {
   beforeEach(() => {
-    hoisted.spawnSubagentDirectMock.mockReset().mockResolvedValue({
+    spawnSubagentDirectMock.mockReset().mockResolvedValue({
       status: "accepted",
       childSessionKey: "agent:main:subagent:1",
       runId: "run-subagent",
-    });
-    hoisted.spawnAcpDirectMock.mockReset().mockResolvedValue({
+    } as never);
+    spawnAcpDirectMock.mockReset().mockResolvedValue({
       status: "accepted",
       childSessionKey: "agent:codex:acp:1",
       runId: "run-acp",
-    });
+    } as never);
   });
 
   it("uses subagent runtime by default", async () => {
@@ -61,7 +45,7 @@ describe("sessions_spawn tool", () => {
       childSessionKey: "agent:main:subagent:1",
       runId: "run-subagent",
     });
-    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+    expect(spawnSubagentDirectMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: "build feature",
         agentId: "main",
@@ -76,7 +60,7 @@ describe("sessions_spawn tool", () => {
         agentSessionKey: "agent:main:main",
       }),
     );
-    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
   it("passes inherited workspaceDir from tool context, not from tool args", async () => {
@@ -90,7 +74,7 @@ describe("sessions_spawn tool", () => {
       workspaceDir: "/tmp/attempted-override",
     });
 
-    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+    expect(spawnSubagentDirectMock).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({
         workspaceDir: "/parent/workspace",
@@ -122,7 +106,7 @@ describe("sessions_spawn tool", () => {
       childSessionKey: "agent:codex:acp:1",
       runId: "run-acp",
     });
-    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+    expect(spawnAcpDirectMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: "investigate the failing CI run",
         agentId: "codex",
@@ -135,7 +119,7 @@ describe("sessions_spawn tool", () => {
         agentSessionKey: "agent:main:main",
       }),
     );
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("forwards ACP sandbox options and requester sandbox context", async () => {
@@ -151,7 +135,7 @@ describe("sessions_spawn tool", () => {
       sandbox: "require",
     });
 
-    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+    expect(spawnAcpDirectMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: "investigate",
         sandbox: "require",
@@ -175,7 +159,7 @@ describe("sessions_spawn tool", () => {
       resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
     });
 
-    expect(hoisted.spawnAcpDirectMock).toHaveBeenCalledWith(
+    expect(spawnAcpDirectMock).toHaveBeenCalledWith(
       expect.objectContaining({
         task: "resume prior work",
         agentId: "codex",
@@ -196,8 +180,8 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(JSON.stringify(result)).toContain("resumeSessionId is only supported for runtime=acp");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
   it("rejects attachments for ACP runtime", async () => {
@@ -220,8 +204,8 @@ describe("sessions_spawn tool", () => {
     });
     const details = result.details as { error?: string };
     expect(details.error).toContain("attachments are currently unsupported for runtime=acp");
-    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it('rejects streamTo when runtime is not "acp"', async () => {
@@ -240,8 +224,8 @@ describe("sessions_spawn tool", () => {
     });
     const details = result.details as { error?: string };
     expect(details.error).toContain("streamTo is only supported for runtime=acp");
-    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {


### PR DESCRIPTION
## Summary
- probe ACP parent relays for completed runs before emitting stall/timeout warnings
- fall back to child transcript reads when completion output is missing from projected history
- register `streamTo:"parent"` ACP runs so the normal subagent completion announce path can deliver final results

## Root cause
`streamTo:"parent"` ACP runs started the parent relay and returned without registering a subagent run. That meant the completion/announce cleanup path had no run record to resolve against, so successful child transcripts could finish without ever relaying the final user-facing completion. Separately, the parent relay could emit a false stall warning when projected assistant/lifecycle events were silent even though the child had already completed.

## Verification
- verified locally on the installed OpenClaw package with live Telegram -> OpenClaw -> Claude ACP runs
- successful runs no longer show the false 60s stall warning
- parent streams now emit terminal completion events
- final completion is delivered back to chat
- `git diff --check` passes in this source clone

## Notes
I could not run the repo test suite in this clone because the local environment here does not have the project toolchain installed (`pnpm`/repo dependencies unavailable in-path for test execution).