### PR TITLE
Infra: preserve shell multiplexer wrapper path for trust checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Docs/Feishu: replace `botName` with `name` in the channel config examples so the docs match the strict account schema for per-account display names. (#52753) Thanks @haroldfabla2-hue.
 - Doctor/plugins: make `openclaw doctor --fix` remove stale `plugins.allow` and `plugins.entries` refs left behind after plugin removal. Thanks @sallyom
 - Agents/replay: canonicalize malformed assistant transcript content before session-history sanitization so legacy or corrupted assistant turns stop crashing Pi replay and subagent recovery paths.
+- Infra/exec trust: preserve shell-multiplexer wrapper binaries for policy checks without breaking approved-command reconstruction, so BusyBox/ToyBox allowlist and audit flows bind to the real wrapper while execution plans stay coherent. (#53134) Thanks @vincentkoc.
 
 ## 2026.3.23
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -8,6 +8,7 @@ import {
   recordAllowlistUse,
   requiresExecApproval,
   resolveAllowAlwaysPatterns,
+  resolvePolicyAllowlistCandidatePath,
 } from "../infra/exec-approvals.js";
 import {
   describeInterpreterInlineEval,
@@ -184,7 +185,10 @@ export async function processGatewayAllowlist(
           agentId: params.agentId,
           sessionKey: params.sessionKey,
         }),
-        resolvedPath: allowlistEval.segments[0]?.resolution?.resolvedPath,
+        resolvedPath: resolvePolicyAllowlistCandidatePath(
+          allowlistEval.segments[0]?.resolution ?? null,
+          params.workdir,
+        ),
         ...buildExecApprovalTurnSourceContext(params),
       });
     const {
@@ -200,7 +204,10 @@ export async function processGatewayAllowlist(
       ...requestArgs,
       register: registerGatewayApproval,
     });
-    const resolvedPath = allowlistEval.segments[0]?.resolution?.resolvedPath;
+    const resolvedPath = resolvePolicyAllowlistCandidatePath(
+      allowlistEval.segments[0]?.resolution ?? null,
+      params.workdir,
+    );
     const effectiveTimeout =
       typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec;
     const followupTarget = buildExecApprovalFollowupTarget({
@@ -337,7 +344,12 @@ export async function processGatewayAllowlist(
     throw new Error("exec denied: allowlist miss");
   }
 
-  recordMatchedAllowlistUse(allowlistEval.segments[0]?.resolution?.resolvedPath);
+  recordMatchedAllowlistUse(
+    resolvePolicyAllowlistCandidatePath(
+      allowlistEval.segments[0]?.resolution ?? null,
+      params.workdir,
+    ),
+  );
 
   return { execCommandOverride: enforcedCommand };
 }

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -5,6 +5,7 @@ import {
   matchAllowlist,
   resolveAllowlistCandidatePath,
   resolveCommandResolutionFromArgv,
+  resolvePolicyAllowlistCandidatePath,
   splitCommandChain,
   type ExecCommandAnalysis,
   type CommandResolution,
@@ -221,11 +222,12 @@ function evaluateSegments(
         : segment.argv;
     const allowlistSegment =
       effectiveArgv === segment.argv ? segment : { ...segment, argv: effectiveArgv };
-    const candidatePath = resolveAllowlistCandidatePath(segment.resolution, params.cwd);
+    const executableResolution = segment.resolution?.policyResolution ?? segment.resolution;
+    const candidatePath = resolvePolicyAllowlistCandidatePath(segment.resolution, params.cwd);
     const candidateResolution =
-      candidatePath && segment.resolution
-        ? { ...segment.resolution, resolvedPath: candidatePath }
-        : segment.resolution;
+      candidatePath && executableResolution
+        ? { ...executableResolution, resolvedPath: candidatePath }
+        : executableResolution;
     const executableMatch = matchAllowlist(params.allowlist, candidateResolution);
     const inlineCommand = extractShellWrapperInlineCommand(allowlistSegment.argv);
     const shellPositionalArgvCandidatePath = resolveShellWrapperPositionalArgvCandidatePath({

--- a/src/infra/exec-approvals-analysis.test.ts
+++ b/src/infra/exec-approvals-analysis.test.ts
@@ -7,6 +7,7 @@ import {
   analyzeShellCommand,
   buildEnforcedShellCommand,
   buildSafeBinsShellCommand,
+  resolvePlannedSegmentArgv,
 } from "./exec-approvals-analysis.js";
 import { makePathEnv, makeTempDir } from "./exec-approvals-test-helpers.js";
 import type { ExecAllowlistEntry } from "./exec-approvals.js";
@@ -69,6 +70,31 @@ describe("exec approvals shell analysis", () => {
       expect(res.ok).toBe(true);
       expect(res.command).toMatch(/'(?:[^']*\/)?rg' '-n' 'needle'/);
       expect(res.command).not.toContain("'env'");
+    });
+
+    it("keeps shell multiplexer rebuilds as coherent execution argv", () => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const dir = makeTempDir();
+      const busybox = path.join(dir, "busybox");
+      fs.writeFileSync(busybox, "");
+      fs.chmodSync(busybox, 0o755);
+
+      const analysis = analyzeArgvCommand({
+        argv: [busybox, "sh", "-lc", "echo hi"],
+        cwd: dir,
+        env: { PATH: `/bin:/usr/bin${path.delimiter}${process.env.PATH ?? ""}` },
+      });
+      expect(analysis.ok).toBe(true);
+      const segment = analysis.segments[0];
+      if (!segment) {
+        throw new Error("expected first segment");
+      }
+
+      const planned = resolvePlannedSegmentArgv(segment);
+      expect(planned).toEqual([segment.resolution?.resolvedPath, "-lc", "echo hi"]);
+      expect(planned?.[0]).not.toBe(busybox);
     });
   });
 

--- a/src/infra/exec-approvals-analysis.ts
+++ b/src/infra/exec-approvals-analysis.ts
@@ -11,7 +11,9 @@ export {
   resolveAllowlistCandidatePath,
   resolveCommandResolution,
   resolveCommandResolutionFromArgv,
+  resolvePolicyAllowlistCandidatePath,
   type CommandResolution,
+  type ExecutableResolution,
   type ExecArgvToken,
 } from "./exec-command-resolution.js";
 

--- a/src/infra/exec-command-resolution.test.ts
+++ b/src/infra/exec-command-resolution.test.ts
@@ -154,7 +154,7 @@ describe("exec-command-resolution", () => {
     expect(timeResolution?.executableName).toBe(fixture.exeName);
   });
 
-  it("unwraps shell multiplexers before resolving the effective executable", () => {
+  it("keeps shell multiplexer wrappers as the trusted executable target", () => {
     if (process.platform === "win32") {
       return;
     }
@@ -164,9 +164,43 @@ describe("exec-command-resolution", () => {
     fs.chmodSync(busybox, 0o755);
 
     const resolution = resolveCommandResolutionFromArgv([busybox, "sh", "-lc", "echo hi"]);
-    expect(resolution?.rawExecutable).toBe("sh");
+    expect(resolution?.rawExecutable).toBe(busybox);
+    expect(resolution?.effectiveArgv).toEqual(["sh", "-lc", "echo hi"]);
     expect(resolution?.wrapperChain).toEqual(["busybox"]);
-    expect(resolution?.executableName.toLowerCase()).toContain("sh");
+    expect(resolution?.resolvedPath).toBe(busybox);
+    expect(resolution?.executableName.toLowerCase()).toContain("busybox");
+  });
+
+  it("does not satisfy inner-shell allowlists when invoked through busybox wrappers", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const busybox = path.join(dir, "busybox");
+    fs.writeFileSync(busybox, "");
+    fs.chmodSync(busybox, 0o755);
+
+    const shellResolution = resolveCommandResolutionFromArgv(["sh", "-lc", "echo hi"]);
+    expect(shellResolution?.resolvedPath).toBeTruthy();
+
+    const wrappedResolution = resolveCommandResolutionFromArgv([busybox, "sh", "-lc", "echo hi"]);
+    const evalResult = evaluateExecAllowlist({
+      analysis: {
+        ok: true,
+        segments: [
+          {
+            raw: `${busybox} sh -lc echo hi`,
+            argv: [busybox, "sh", "-lc", "echo hi"],
+            resolution: wrappedResolution,
+          },
+        ],
+      },
+      allowlist: [{ pattern: shellResolution?.resolvedPath ?? "" }],
+      safeBins: normalizeSafeBins([]),
+      cwd: dir,
+    });
+
+    expect(evalResult.allowlistSatisfied).toBe(false);
   });
 
   it("blocks semantic env wrappers, env -S, and deep transparent-wrapper chains", () => {

--- a/src/infra/exec-command-resolution.test.ts
+++ b/src/infra/exec-command-resolution.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAllowlistCandidatePath,
   resolveCommandResolution,
   resolveCommandResolutionFromArgv,
+  resolvePolicyAllowlistCandidatePath,
 } from "./exec-approvals.js";
 
 function buildNestedEnvShellCommand(params: {
@@ -154,7 +155,7 @@ describe("exec-command-resolution", () => {
     expect(timeResolution?.executableName).toBe(fixture.exeName);
   });
 
-  it("keeps shell multiplexer wrappers as the trusted executable target", () => {
+  it("keeps shell multiplexer wrappers as a separate policy target", () => {
     if (process.platform === "win32") {
       return;
     }
@@ -164,11 +165,13 @@ describe("exec-command-resolution", () => {
     fs.chmodSync(busybox, 0o755);
 
     const resolution = resolveCommandResolutionFromArgv([busybox, "sh", "-lc", "echo hi"]);
-    expect(resolution?.rawExecutable).toBe(busybox);
+    expect(resolution?.rawExecutable).toBe("sh");
     expect(resolution?.effectiveArgv).toEqual(["sh", "-lc", "echo hi"]);
     expect(resolution?.wrapperChain).toEqual(["busybox"]);
-    expect(resolution?.resolvedPath).toBe(busybox);
-    expect(resolution?.executableName.toLowerCase()).toContain("busybox");
+    expect(resolution?.policyResolution?.rawExecutable).toBe(busybox);
+    expect(resolution?.policyResolution?.resolvedPath).toBe(busybox);
+    expect(resolvePolicyAllowlistCandidatePath(resolution ?? null, dir)).toBe(busybox);
+    expect(resolution?.executableName.toLowerCase()).toContain("sh");
   });
 
   it("does not satisfy inner-shell allowlists when invoked through busybox wrappers", () => {

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -98,7 +98,8 @@ export function resolveCommandResolutionFromArgv(
 ): CommandResolution | null {
   const plan = resolveExecWrapperTrustPlan(argv);
   const effectiveArgv = plan.argv;
-  const rawExecutable = effectiveArgv[0]?.trim();
+  const policyArgv = plan.policyArgv;
+  const rawExecutable = policyArgv[0]?.trim();
   if (!rawExecutable) {
     return null;
   }

--- a/src/infra/exec-command-resolution.ts
+++ b/src/infra/exec-command-resolution.ts
@@ -6,15 +6,19 @@ import { resolveExecWrapperTrustPlan } from "./exec-wrapper-trust-plan.js";
 import { resolveExecutablePath as resolveExecutableCandidatePath } from "./executable-path.js";
 import { expandHomePrefix } from "./home-dir.js";
 
-export type CommandResolution = {
+export type ExecutableResolution = {
   rawExecutable: string;
   resolvedPath?: string;
   resolvedRealPath?: string;
   executableName: string;
+};
+
+export type CommandResolution = ExecutableResolution & {
   effectiveArgv?: string[];
   wrapperChain?: string[];
   policyBlocked?: boolean;
   blockedWrapper?: string;
+  policyResolution?: ExecutableResolution;
 };
 
 function parseFirstToken(command: string): string | null {
@@ -45,8 +49,30 @@ function tryResolveRealpath(filePath: string | undefined): string | undefined {
   }
 }
 
+function buildExecutableResolution(
+  rawExecutable: string,
+  params: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  },
+): ExecutableResolution {
+  const resolvedPath = resolveExecutableCandidatePath(rawExecutable, {
+    cwd: params.cwd,
+    env: params.env,
+  });
+  const resolvedRealPath = tryResolveRealpath(resolvedPath);
+  const executableName = resolvedPath ? path.basename(resolvedPath) : rawExecutable;
+  return {
+    rawExecutable,
+    resolvedPath,
+    resolvedRealPath,
+    executableName,
+  };
+}
+
 function buildCommandResolution(params: {
   rawExecutable: string;
+  policyRawExecutable?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   effectiveArgv: string[];
@@ -54,21 +80,18 @@ function buildCommandResolution(params: {
   policyBlocked: boolean;
   blockedWrapper?: string;
 }): CommandResolution {
-  const resolvedPath = resolveExecutableCandidatePath(params.rawExecutable, {
-    cwd: params.cwd,
-    env: params.env,
-  });
-  const resolvedRealPath = tryResolveRealpath(resolvedPath);
-  const executableName = resolvedPath ? path.basename(resolvedPath) : params.rawExecutable;
+  const resolution = buildExecutableResolution(params.rawExecutable, params);
+  const policyResolution =
+    params.policyRawExecutable && params.policyRawExecutable !== params.rawExecutable
+      ? buildExecutableResolution(params.policyRawExecutable, params)
+      : undefined;
   return {
-    rawExecutable: params.rawExecutable,
-    resolvedPath,
-    resolvedRealPath,
-    executableName,
+    ...resolution,
     effectiveArgv: params.effectiveArgv,
     wrapperChain: params.wrapperChain,
     policyBlocked: params.policyBlocked,
     blockedWrapper: params.blockedWrapper,
+    policyResolution,
   };
 }
 
@@ -98,13 +121,13 @@ export function resolveCommandResolutionFromArgv(
 ): CommandResolution | null {
   const plan = resolveExecWrapperTrustPlan(argv);
   const effectiveArgv = plan.argv;
-  const policyArgv = plan.policyArgv;
-  const rawExecutable = policyArgv[0]?.trim();
+  const rawExecutable = effectiveArgv[0]?.trim();
   if (!rawExecutable) {
     return null;
   }
   return buildCommandResolution({
     rawExecutable,
+    policyRawExecutable: plan.policyArgv[0]?.trim(),
     effectiveArgv,
     wrapperChain: plan.wrapperChain,
     policyBlocked: plan.policyBlocked,
@@ -116,6 +139,13 @@ export function resolveCommandResolutionFromArgv(
 
 export function resolveAllowlistCandidatePath(
   resolution: CommandResolution | null,
+  cwd?: string,
+): string | undefined {
+  return resolveExecutableCandidatePathFromResolution(resolution, cwd);
+}
+
+function resolveExecutableCandidatePathFromResolution(
+  resolution: ExecutableResolution | null | undefined,
   cwd?: string,
 ): string | undefined {
   if (!resolution) {
@@ -139,9 +169,19 @@ export function resolveAllowlistCandidatePath(
   return path.resolve(base, expanded);
 }
 
+export function resolvePolicyAllowlistCandidatePath(
+  resolution: CommandResolution | null,
+  cwd?: string,
+): string | undefined {
+  return resolveExecutableCandidatePathFromResolution(
+    resolution?.policyResolution ?? resolution,
+    cwd,
+  );
+}
+
 export function matchAllowlist(
   entries: ExecAllowlistEntry[],
-  resolution: CommandResolution | null,
+  resolution: ExecutableResolution | null,
 ): ExecAllowlistEntry | null {
   if (!entries.length) {
     return null;

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -10,6 +10,7 @@ describe("resolveExecWrapperTrustPlan", () => {
       resolveExecWrapperTrustPlan(["/usr/bin/time", "-p", "busybox", "sh", "-lc", "echo hi"]),
     ).toEqual({
       argv: ["sh", "-lc", "echo hi"],
+      policyArgv: ["busybox", "sh", "-lc", "echo hi"],
       wrapperChain: ["time", "busybox"],
       policyBlocked: false,
       shellWrapperExecutable: true,
@@ -20,6 +21,7 @@ describe("resolveExecWrapperTrustPlan", () => {
   test("fails closed for unsupported shell multiplexer applets", () => {
     expect(resolveExecWrapperTrustPlan(["busybox", "sed", "-n", "1p"])).toEqual({
       argv: ["busybox", "sed", "-n", "1p"],
+      policyArgv: ["busybox", "sed", "-n", "1p"],
       wrapperChain: [],
       policyBlocked: true,
       blockedWrapper: "busybox",
@@ -33,6 +35,7 @@ describe("resolveExecWrapperTrustPlan", () => {
       resolveExecWrapperTrustPlan(["nohup", "timeout", "5s", "busybox", "sh", "-lc", "echo hi"], 2),
     ).toEqual({
       argv: ["busybox", "sh", "-lc", "echo hi"],
+      policyArgv: ["busybox", "sh", "-lc", "echo hi"],
       wrapperChain: ["nohup", "timeout"],
       policyBlocked: true,
       blockedWrapper: "busybox",

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -43,4 +43,29 @@ describe("resolveExecWrapperTrustPlan", () => {
       shellInlineCommand: null,
     });
   });
+
+  test("keeps the blocked dispatch argv as the policy target after transparent unwraps", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    expect(
+      resolveExecWrapperTrustPlan([
+        "/usr/bin/time",
+        "-p",
+        "/usr/bin/env",
+        "FOO=bar",
+        "sh",
+        "-lc",
+        "echo hi",
+      ]),
+    ).toEqual({
+      argv: ["/usr/bin/env", "FOO=bar", "sh", "-lc", "echo hi"],
+      policyArgv: ["/usr/bin/env", "FOO=bar", "sh", "-lc", "echo hi"],
+      wrapperChain: [],
+      policyBlocked: true,
+      blockedWrapper: "env",
+      shellWrapperExecutable: false,
+      shellInlineCommand: null,
+    });
+  });
 });

--- a/src/infra/exec-wrapper-trust-plan.ts
+++ b/src/infra/exec-wrapper-trust-plan.ts
@@ -11,6 +11,7 @@ import {
 
 export type ExecWrapperTrustPlan = {
   argv: string[];
+  policyArgv: string[];
   wrapperChain: string[];
   policyBlocked: boolean;
   blockedWrapper?: string;
@@ -20,11 +21,13 @@ export type ExecWrapperTrustPlan = {
 
 function blockedExecWrapperTrustPlan(params: {
   argv: string[];
+  policyArgv?: string[];
   wrapperChain: string[];
   blockedWrapper: string;
 }): ExecWrapperTrustPlan {
   return {
     argv: params.argv,
+    policyArgv: params.policyArgv ?? params.argv,
     wrapperChain: params.wrapperChain,
     policyBlocked: true,
     blockedWrapper: params.blockedWrapper,
@@ -35,6 +38,7 @@ function blockedExecWrapperTrustPlan(params: {
 
 function finalizeExecWrapperTrustPlan(
   argv: string[],
+  policyArgv: string[],
   wrapperChain: string[],
   policyBlocked: boolean,
   blockedWrapper?: string,
@@ -44,6 +48,7 @@ function finalizeExecWrapperTrustPlan(
     !policyBlocked && rawExecutable.length > 0 && isShellWrapperExecutable(rawExecutable);
   return {
     argv,
+    policyArgv,
     wrapperChain,
     policyBlocked,
     blockedWrapper,
@@ -57,12 +62,15 @@ export function resolveExecWrapperTrustPlan(
   maxDepth = MAX_DISPATCH_WRAPPER_DEPTH,
 ): ExecWrapperTrustPlan {
   let current = argv;
+  let policyArgv = argv;
+  let sawShellMultiplexer = false;
   const wrapperChain: string[] = [];
   for (let depth = 0; depth < maxDepth; depth += 1) {
     const dispatchPlan = resolveDispatchWrapperTrustPlan(current, maxDepth - wrapperChain.length);
     if (dispatchPlan.policyBlocked) {
       return blockedExecWrapperTrustPlan({
         argv: dispatchPlan.argv,
+        policyArgv,
         wrapperChain,
         blockedWrapper: dispatchPlan.blockedWrapper ?? current[0] ?? "unknown",
       });
@@ -70,6 +78,9 @@ export function resolveExecWrapperTrustPlan(
     if (dispatchPlan.wrappers.length > 0) {
       wrapperChain.push(...dispatchPlan.wrappers);
       current = dispatchPlan.argv;
+      if (!sawShellMultiplexer) {
+        policyArgv = current;
+      }
       if (wrapperChain.length >= maxDepth) {
         break;
       }
@@ -80,12 +91,18 @@ export function resolveExecWrapperTrustPlan(
     if (shellMultiplexerUnwrap.kind === "blocked") {
       return blockedExecWrapperTrustPlan({
         argv: current,
+        policyArgv,
         wrapperChain,
         blockedWrapper: shellMultiplexerUnwrap.wrapper,
       });
     }
     if (shellMultiplexerUnwrap.kind === "unwrapped") {
       wrapperChain.push(shellMultiplexerUnwrap.wrapper);
+      if (!sawShellMultiplexer) {
+        // Preserve the real executable target for trust checks.
+        policyArgv = current;
+        sawShellMultiplexer = true;
+      }
       current = shellMultiplexerUnwrap.argv;
       if (wrapperChain.length >= maxDepth) {
         break;
@@ -101,6 +118,7 @@ export function resolveExecWrapperTrustPlan(
     if (dispatchOverflow.kind === "blocked" || dispatchOverflow.kind === "unwrapped") {
       return blockedExecWrapperTrustPlan({
         argv: current,
+        policyArgv,
         wrapperChain,
         blockedWrapper: dispatchOverflow.wrapper,
       });
@@ -112,11 +130,12 @@ export function resolveExecWrapperTrustPlan(
     ) {
       return blockedExecWrapperTrustPlan({
         argv: current,
+        policyArgv,
         wrapperChain,
         blockedWrapper: shellMultiplexerOverflow.wrapper,
       });
     }
   }
 
-  return finalizeExecWrapperTrustPlan(current, wrapperChain, false);
+  return finalizeExecWrapperTrustPlan(current, policyArgv, wrapperChain, false);
 }

--- a/src/infra/exec-wrapper-trust-plan.ts
+++ b/src/infra/exec-wrapper-trust-plan.ts
@@ -70,7 +70,7 @@ export function resolveExecWrapperTrustPlan(
     if (dispatchPlan.policyBlocked) {
       return blockedExecWrapperTrustPlan({
         argv: dispatchPlan.argv,
-        policyArgv,
+        policyArgv: dispatchPlan.argv,
         wrapperChain,
         blockedWrapper: dispatchPlan.blockedWrapper ?? current[0] ?? "unknown",
       });

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -7,6 +7,7 @@ import {
   recordAllowlistUse,
   resolveAllowAlwaysPatterns,
   resolveExecApprovals,
+  resolvePolicyAllowlistCandidatePath,
   type ExecAllowlistEntry,
   type ExecAsk,
   type ExecCommandSegment,
@@ -575,7 +576,7 @@ async function executeSystemRunPhase(
         phase.agentId,
         match,
         phase.commandText,
-        phase.segments[0]?.resolution?.resolvedPath,
+        resolvePolicyAllowlistCandidatePath(phase.segments[0]?.resolution ?? null, phase.cwd),
       );
     }
   }


### PR DESCRIPTION
### Motivation
- Resolves a high-severity bypass where busybox/toybox unwrapping caused policy checks to trust the inner applet (`sh`) instead of the real wrapper binary, allowing allowlist/safe-bin bypass. 
- Preserve the original executed wrapper as the policy/trust target while keeping the unwrapped argv for payload inspection and analysis.

### Description
- Added `policyArgv` to `ExecWrapperTrustPlan` and populate it so policy decisions can reference the pre-unwrapped executable (file: `src/infra/exec-wrapper-trust-plan.ts`).
- Preserve the wrapper executable for trust checks by recording `policyArgv` before performing shell-multiplexer unwrapping and dispatch-wrapper resolution changes.
- Updated `resolveCommandResolutionFromArgv` to derive the resolution `rawExecutable` from `plan.policyArgv[0]` while still returning `plan.argv` as the `effectiveArgv` used for analysis (file: `src/infra/exec-command-resolution.ts`).
- Added/adjusted tests to assert the new semantics and a regression that verifies a `busybox`-wrapped shell invocation does not satisfy an inner-shell allowlist (files: `src/infra/exec-wrapper-trust-plan.test.ts`, `src/infra/exec-command-resolution.test.ts`).

### Testing
- Ran unit tests for the modified area with `pnpm test -- src/infra/exec-wrapper-trust-plan.test.ts src/infra/exec-command-resolution.test.ts` and all tests passed.
- Ran repository checks with `pnpm check` which completed successfully (format/lint/type checks passed).
- Attempted `pnpm build` which failed in this environment during staged bundled runtime dependency installation for `discord` (`npm install failed`), unrelated to the semantic changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e611589c83208d1ca5dc0de6f0d9)