### PR TITLE
fix(slack): preserve raw ampersands in outbound mrkdwn

### DIFF
--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -27,6 +27,11 @@ describe("markdownToSlackMrkdwn", () => {
       ["does not duplicate bare URLs", "see https://example.com", "see https://example.com"],
       ["escapes angle brackets but preserves ampersands", "a & b < c > d", "a & b &lt; c &gt; d"],
       [
+        "preserves HTML-escaped Slack tokens as literal text",
+        "&lt;@U123&gt; &amp; &lt;https://example.com|docs&gt;",
+        "&amp;lt;@U123&amp;gt; &amp;amp; &amp;lt;https://example.com|docs&amp;gt;",
+      ],
+      [
         "preserves Slack angle-bracket markup (mentions/links)",
         "hi <@U123> see <https://example.com|docs> and <!here>",
         "hi <@U123> see <https://example.com|docs> and <!here>",
@@ -80,5 +85,11 @@ describe("normalizeSlackOutboundText", () => {
 
   it("preserves raw ampersands in outbound text", () => {
     expect(normalizeSlackOutboundText("R&D < Q&A >")).toBe("R&D &lt; Q&A &gt;");
+  });
+
+  it("keeps escaped entities literal in outbound text", () => {
+    expect(normalizeSlackOutboundText("&lt;!here&gt; &amp; status")).toBe(
+      "&amp;lt;!here&amp;gt; &amp;amp; status",
+    );
   });
 });

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -25,7 +25,7 @@ describe("markdownToSlackMrkdwn", () => {
         "see <https://example.com|docs>",
       ],
       ["does not duplicate bare URLs", "see https://example.com", "see https://example.com"],
-      ["escapes unsafe characters", "a & b < c > d", "a &amp; b &lt; c &gt; d"],
+      ["escapes angle brackets but preserves ampersands", "a & b < c > d", "a & b &lt; c &gt; d"],
       [
         "preserves Slack angle-bracket markup (mentions/links)",
         "hi <@U123> see <https://example.com|docs> and <!here>",
@@ -76,5 +76,9 @@ describe("escapeSlackMrkdwn", () => {
 describe("normalizeSlackOutboundText", () => {
   it("normalizes markdown for outbound send/update paths", () => {
     expect(normalizeSlackOutboundText(" **bold** ")).toBe("*bold*");
+  });
+
+  it("preserves raw ampersands in outbound text", () => {
+    expect(normalizeSlackOutboundText("R&D < Q&A >")).toBe("R&D &lt; Q&A &gt;");
   });
 });

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -6,10 +6,21 @@ import {
 } from "openclaw/plugin-sdk/text-runtime";
 import { renderMarkdownWithMarkers } from "openclaw/plugin-sdk/text-runtime";
 
-// Escape special characters for Slack mrkdwn format.
-// Preserve Slack's angle-bracket tokens so mentions and links stay intact.
+const SLACK_HTML_ENTITY_RE = /&(?:[a-zA-Z][a-zA-Z0-9]+|#\d+|#x[0-9A-Fa-f]+);/g;
+const SLACK_LITERAL_ENTITY_RE = /&(?:amp|lt|gt|#0*38|#0*60|#0*62|#x0*26|#x0*3[cC]|#x0*3[eE]);/g;
+
+// Escape angle brackets for outbound Slack mrkdwn.
+// Preserve bare '&' to avoid double-encoding plain text, but re-escape
+// entity-looking sequences so Slack does not decode them into live tokens.
 function escapeSlackMrkdwnSegment(text: string): string {
-  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text
+    .replace(SLACK_HTML_ENTITY_RE, (entity) => `&amp;${entity.slice(1)}`)
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function protectSlackLiteralEntitiesBeforeParse(text: string): string {
+  return text.replace(SLACK_LITERAL_ENTITY_RE, (entity) => `&amp;${entity.slice(1)}`);
 }
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
@@ -35,7 +46,7 @@ function escapeSlackMrkdwnContent(text: string): string {
   if (!text) {
     return "";
   }
-  if (!text.includes("<") && !text.includes(">")) {
+  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }
 
@@ -63,7 +74,7 @@ function escapeSlackMrkdwnText(text: string): string {
   if (!text) {
     return "";
   }
-  if (!text.includes("<") && !text.includes(">")) {
+  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
     return text;
   }
 
@@ -122,7 +133,7 @@ export function markdownToSlackMrkdwn(
   markdown: string,
   options: SlackMarkdownOptions = {},
 ): string {
-  const ir = markdownToIR(markdown ?? "", {
+  const ir = markdownToIR(protectSlackLiteralEntitiesBeforeParse(markdown ?? ""), {
     linkify: false,
     autolink: false,
     headingStyle: "bold",
@@ -141,7 +152,7 @@ export function markdownToSlackMrkdwnChunks(
   limit: number,
   options: SlackMarkdownOptions = {},
 ): string[] {
-  const ir = markdownToIR(markdown ?? "", {
+  const ir = markdownToIR(protectSlackLiteralEntitiesBeforeParse(markdown ?? ""), {
     linkify: false,
     autolink: false,
     headingStyle: "bold",

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -9,7 +9,7 @@ import { renderMarkdownWithMarkers } from "openclaw/plugin-sdk/text-runtime";
 // Escape special characters for Slack mrkdwn format.
 // Preserve Slack's angle-bracket tokens so mentions and links stay intact.
 function escapeSlackMrkdwnSegment(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 const SLACK_ANGLE_TOKEN_RE = /<[^>\n]+>/g;
@@ -35,7 +35,7 @@ function escapeSlackMrkdwnContent(text: string): string {
   if (!text) {
     return "";
   }
-  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
+  if (!text.includes("<") && !text.includes(">")) {
     return text;
   }
 
@@ -63,7 +63,7 @@ function escapeSlackMrkdwnText(text: string): string {
   if (!text) {
     return "";
   }
-  if (!text.includes("&") && !text.includes("<") && !text.includes(">")) {
+  if (!text.includes("<") && !text.includes(">")) {
     return text;
   }
 

--- a/extensions/slack/src/monitor/provider.auth-errors.test.ts
+++ b/extensions/slack/src/monitor/provider.auth-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isNonRecoverableSlackAuthError } from "./provider.js";
+import { isNonRecoverableSlackAuthError } from "./reconnect-policy.js";
 
 describe("isNonRecoverableSlackAuthError", () => {
   it.each([

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -48,6 +48,21 @@ describe("sendMessageSlack NO_REPLY guard", () => {
     expect(client.chat.postMessage).toHaveBeenCalled();
     expect(result.messageId).toBe("171234.567");
   });
+
+  it("preserves ampersands in plain outbound text", async () => {
+    const client = createSlackSendTestClient();
+    await sendMessageSlack("channel:C123", "R&D <plan>", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: "R&D &lt;plan&gt;",
+      }),
+    );
+  });
 });
 
 describe("sendMessageSlack blocks", () => {

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -48,21 +48,6 @@ describe("sendMessageSlack NO_REPLY guard", () => {
     expect(client.chat.postMessage).toHaveBeenCalled();
     expect(result.messageId).toBe("171234.567");
   });
-
-  it("preserves ampersands in plain outbound text", async () => {
-    const client = createSlackSendTestClient();
-    await sendMessageSlack("channel:C123", "R&D <plan>", {
-      token: "xoxb-test",
-      client,
-    });
-
-    expect(client.chat.postMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        channel: "C123",
-        text: "R&D &lt;plan&gt;",
-      }),
-    );
-  });
 });
 
 describe("sendMessageSlack blocks", () => {
@@ -186,5 +171,37 @@ describe("sendMessageSlack blocks", () => {
       }),
     ).rejects.toThrow(/non-empty string type/i);
     expect(client.chat.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendMessageSlack plain text", () => {
+  it("preserves ampersands in plain outbound text", async () => {
+    const client = createSlackSendTestClient();
+    await sendMessageSlack("channel:C123", "R&D <plan>", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: "R&D &lt;plan&gt;",
+      }),
+    );
+  });
+
+  it("keeps escaped Slack entities literal in plain outbound text", async () => {
+    const client = createSlackSendTestClient();
+    await sendMessageSlack("channel:C123", "&lt;!here&gt; &amp; status", {
+      token: "xoxb-test",
+      client,
+    });
+
+    expect(client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "C123",
+        text: "&amp;lt;!here&amp;gt; &amp;amp; status",
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- stop pre-escaping plain `&` characters in Slack outbound mrkdwn text
- keep angle-bracket escaping unchanged so Slack link and mention syntax stays safe
- add formatting and send-path regression coverage for raw ampersands

## Test plan
- [x] `pnpm test -- extensions/slack/src/format.test.ts extensions/slack/src/send.blocks.test.ts`
- [ ] `pnpm check`

Fixes #53056

Made with [Cursor](https://cursor.com)