### PR TITLE
fix(release): add build steps to publish job so Control UI assets ship in npm package

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -170,9 +170,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Build Control UI
-        run: pnpm ui:build
-
       - name: Verify release contents
         run: pnpm release:check
 

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -167,5 +167,14 @@ jobs:
 
           echo "Publishing openclaw@${PACKAGE_VERSION}"
 
+      - name: Build
+        run: pnpm build
+
+      - name: Build Control UI
+        run: pnpm ui:build
+
+      - name: Verify release contents
+        run: pnpm release:check
+
       - name: Publish
         run: bash scripts/openclaw-npm-publish.sh --publish


### PR DESCRIPTION
## Problem

After upgrading to v2026.3.22 via `npm install -g openclaw`, the Control UI / web dashboard returns:

> Control UI assets not found. Build them with \`pnpm ui:build\` (auto-installs UI deps), or run \`pnpm ui:dev\` during development.

The `dist/control-ui/` directory (containing `index.html`, CSS, and JS assets) is missing from the published npm tarball.

## Root Cause

The `publish_openclaw_npm` job in `openclaw-npm-release.yml` checks out on a **fresh runner** and runs `npm publish` directly — without any build step. The `preflight_openclaw_npm` job runs `pnpm build` and `pnpm release:check` (which includes `pnpm ui:build`), but those artifacts live on a different runner and do not carry over.

This likely worked before the Dashboard v2 rewrite (#41503) because `dist/control-ui/` was either committed to the repo or built as part of a different step that has since been removed.

## Fix

Add `pnpm build`, `pnpm ui:build`, and `pnpm release:check` to the `publish_openclaw_npm` job before `npm publish`, mirroring what the preflight job already validates.

## Verification

```bash
# v2026.3.13 tarball includes control-ui assets:
npm pack openclaw@2026.3.13 && tar tzf openclaw-2026.3.13.tgz | grep "dist/control-ui/"
# package/dist/control-ui/index.html, assets/*, etc.

# v2026.3.22 tarball is missing them:
npm pack openclaw@2026.3.22 && tar tzf openclaw-2026.3.22.tgz | grep "dist/control-ui/"
# (empty)
```

Fixes #53139