### PR TITLE
Plugins: unify scoped web search credential wiring

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -1,9 +1,9 @@
 import { Type } from "@sinclair/typebox";
 import {
   buildSearchCacheKey,
+  createScopedPluginWebSearchCredentialAccessors,
   DEFAULT_SEARCH_COUNT,
   enablePluginInConfig,
-  getScopedCredentialValue,
   mergeScopedSearchConfig,
   normalizeToIsoDate,
   readCachedSearchPayload,
@@ -15,8 +15,6 @@ import {
   resolveSearchCacheTtlMs,
   resolveSearchTimeoutSeconds,
   resolveSiteName,
-  setProviderWebSearchPluginConfigValue,
-  setScopedCredentialValue,
   type SearchConfigRecord,
   type WebSearchProviderPlugin,
   type WebSearchProviderToolDefinition,
@@ -613,16 +611,7 @@ export function createExaWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://exa.ai/",
     docsUrl: "https://docs.openclaw.ai/tools/web",
     autoDetectOrder: 65,
-    credentialPath: "plugins.entries.exa.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.exa.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "exa"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "exa", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "exa")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "exa", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({ pluginId: "exa" }),
     applySelectionConfig: (config) => enablePluginInConfig(config, "exa").config,
     createTool: (ctx) =>
       createExaToolDefinition(

--- a/extensions/firecrawl/src/firecrawl-search-provider.ts
+++ b/extensions/firecrawl/src/firecrawl-search-provider.ts
@@ -1,10 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import {
+  createScopedPluginWebSearchCredentialAccessors,
   enablePluginInConfig,
-  getScopedCredentialValue,
-  resolveProviderWebSearchPluginConfig,
-  setScopedCredentialValue,
-  setProviderWebSearchPluginConfigValue,
   type WebSearchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { runFirecrawlSearch } from "./firecrawl-client.js";
@@ -34,16 +31,7 @@ export function createFirecrawlWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://www.firecrawl.dev/",
     docsUrl: "https://docs.openclaw.ai/tools/firecrawl",
     autoDetectOrder: 60,
-    credentialPath: "plugins.entries.firecrawl.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.firecrawl.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "firecrawl"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "firecrawl", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "firecrawl")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "firecrawl", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({ pluginId: "firecrawl" }),
     applySelectionConfig: (config) => enablePluginInConfig(config, "firecrawl").config,
     createTool: (ctx) => ({
       description:

--- a/extensions/google/src/gemini-web-search-provider.ts
+++ b/extensions/google/src/gemini-web-search-provider.ts
@@ -2,8 +2,8 @@ import { Type } from "@sinclair/typebox";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
+  createScopedPluginWebSearchCredentialAccessors,
   DEFAULT_SEARCH_COUNT,
-  getScopedCredentialValue,
   MAX_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
@@ -16,8 +16,6 @@ import {
   resolveSearchCacheTtlMs,
   resolveSearchCount,
   resolveSearchTimeoutSeconds,
-  setScopedCredentialValue,
-  setProviderWebSearchPluginConfigValue,
   type SearchConfigRecord,
   type WebSearchProviderPlugin,
   type WebSearchProviderToolDefinition,
@@ -252,16 +250,10 @@ export function createGeminiWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://aistudio.google.com/apikey",
     docsUrl: "https://docs.openclaw.ai/tools/web",
     autoDetectOrder: 20,
-    credentialPath: "plugins.entries.google.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.google.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "gemini"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "gemini", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "google")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "google", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({
+      pluginId: "google",
+      searchConfigKey: "gemini",
+    }),
     createTool: (ctx) =>
       createGeminiToolDefinition(
         mergeScopedSearchConfig(

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -2,8 +2,8 @@ import { Type } from "@sinclair/typebox";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
+  createScopedPluginWebSearchCredentialAccessors,
   DEFAULT_SEARCH_COUNT,
-  getScopedCredentialValue,
   MAX_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
@@ -15,8 +15,6 @@ import {
   resolveSearchCacheTtlMs,
   resolveSearchCount,
   resolveSearchTimeoutSeconds,
-  setScopedCredentialValue,
-  setProviderWebSearchPluginConfigValue,
   type SearchConfigRecord,
   type WebSearchProviderPlugin,
   type WebSearchProviderToolDefinition,
@@ -324,16 +322,10 @@ export function createKimiWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://platform.moonshot.cn/",
     docsUrl: "https://docs.openclaw.ai/tools/web",
     autoDetectOrder: 40,
-    credentialPath: "plugins.entries.moonshot.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.moonshot.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "kimi"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "kimi", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "moonshot")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "moonshot", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({
+      pluginId: "moonshot",
+      searchConfigKey: "kimi",
+    }),
     createTool: (ctx) =>
       createKimiToolDefinition(
         mergeScopedSearchConfig(

--- a/extensions/perplexity/src/perplexity-web-search-provider.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.ts
@@ -6,8 +6,8 @@ import {
 } from "openclaw/plugin-sdk/provider-web-search";
 import {
   buildSearchCacheKey,
+  createScopedPluginWebSearchCredentialAccessors,
   DEFAULT_SEARCH_COUNT,
-  getScopedCredentialValue,
   MAX_SEARCH_COUNT,
   isoToPerplexityDate,
   mergeScopedSearchConfig,
@@ -21,8 +21,6 @@ import {
   resolveSearchCount,
   resolveSearchTimeoutSeconds,
   resolveSiteName,
-  setScopedCredentialValue,
-  setProviderWebSearchPluginConfigValue,
   throwWebSearchApiError,
   type SearchConfigRecord,
   type WebSearchCredentialResolutionSource,
@@ -660,16 +658,7 @@ export function createPerplexityWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://www.perplexity.ai/settings/api",
     docsUrl: "https://docs.openclaw.ai/perplexity",
     autoDetectOrder: 50,
-    credentialPath: "plugins.entries.perplexity.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.perplexity.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "perplexity"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "perplexity", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "perplexity")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "perplexity", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({ pluginId: "perplexity" }),
     resolveRuntimeMetadata: (ctx) => ({
       perplexityTransport: resolveRuntimeTransport({
         searchConfig: mergeScopedSearchConfig(

--- a/extensions/tavily/src/tavily-search-provider.ts
+++ b/extensions/tavily/src/tavily-search-provider.ts
@@ -1,10 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import {
+  createScopedPluginWebSearchCredentialAccessors,
   enablePluginInConfig,
-  getScopedCredentialValue,
-  resolveProviderWebSearchPluginConfig,
-  setScopedCredentialValue,
-  setProviderWebSearchPluginConfigValue,
   type WebSearchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { runTavilySearch } from "./tavily-client.js";
@@ -34,16 +31,7 @@ export function createTavilyWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://tavily.com/",
     docsUrl: "https://docs.openclaw.ai/tools/tavily",
     autoDetectOrder: 70,
-    credentialPath: "plugins.entries.tavily.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.tavily.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "tavily"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "tavily", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "tavily")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "tavily", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({ pluginId: "tavily" }),
     applySelectionConfig: (config) => enablePluginInConfig(config, "tavily").config,
     createTool: (ctx) => ({
       description:

--- a/extensions/xai/src/grok-web-search-provider.ts
+++ b/extensions/xai/src/grok-web-search-provider.ts
@@ -2,8 +2,8 @@ import { Type } from "@sinclair/typebox";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
+  createScopedPluginWebSearchCredentialAccessors,
   DEFAULT_SEARCH_COUNT,
-  getScopedCredentialValue,
   MAX_SEARCH_COUNT,
   readCachedSearchPayload,
   readConfiguredSecretString,
@@ -15,8 +15,6 @@ import {
   resolveSearchCacheTtlMs,
   resolveSearchCount,
   resolveSearchTimeoutSeconds,
-  setScopedCredentialValue,
-  setProviderWebSearchPluginConfigValue,
   type SearchConfigRecord,
   type WebSearchProviderPlugin,
   type WebSearchProviderToolDefinition,
@@ -134,16 +132,10 @@ export function createGrokWebSearchProvider(): WebSearchProviderPlugin {
     signupUrl: "https://console.x.ai/",
     docsUrl: "https://docs.openclaw.ai/tools/web",
     autoDetectOrder: 30,
-    credentialPath: "plugins.entries.xai.config.webSearch.apiKey",
-    inactiveSecretPaths: ["plugins.entries.xai.config.webSearch.apiKey"],
-    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, "grok"),
-    setCredentialValue: (searchConfigTarget, value) =>
-      setScopedCredentialValue(searchConfigTarget, "grok", value),
-    getConfiguredCredentialValue: (config) =>
-      resolveProviderWebSearchPluginConfig(config, "xai")?.apiKey,
-    setConfiguredCredentialValue: (configTarget, value) => {
-      setProviderWebSearchPluginConfigValue(configTarget, "xai", "apiKey", value);
-    },
+    ...createScopedPluginWebSearchCredentialAccessors({
+      pluginId: "xai",
+      searchConfigKey: "grok",
+    }),
     createTool: (ctx) =>
       createGrokToolDefinition(
         mergeScopedSearchConfig(

--- a/src/agents/tools/web-search-provider-config.test.ts
+++ b/src/agents/tools/web-search-provider-config.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  createScopedPluginWebSearchCredentialAccessors,
+  type WebSearchConfig,
+} from "./web-search-provider-config.js";
+
+describe("createScopedPluginWebSearchCredentialAccessors", () => {
+  it("uses the plugin id as the default scoped config key", () => {
+    const accessors = createScopedPluginWebSearchCredentialAccessors({ pluginId: "perplexity" });
+    const searchConfigTarget: Record<string, unknown> = {};
+    const configTarget = {} as {
+      tools?: { web?: { search?: WebSearchConfig } };
+      plugins?: Record<string, unknown>;
+    };
+
+    accessors.setCredentialValue(searchConfigTarget, "pplx-test");
+    accessors.setConfiguredCredentialValue(configTarget, "pplx-configured");
+
+    expect(accessors.credentialPath).toBe("plugins.entries.perplexity.config.webSearch.apiKey");
+    expect(accessors.inactiveSecretPaths).toEqual([
+      "plugins.entries.perplexity.config.webSearch.apiKey",
+    ]);
+    expect(accessors.getCredentialValue(searchConfigTarget)).toBe("pplx-test");
+    expect(accessors.getConfiguredCredentialValue(configTarget)).toBe("pplx-configured");
+    expect(configTarget.plugins).toMatchObject({
+      entries: {
+        perplexity: {
+          enabled: true,
+          config: {
+            webSearch: {
+              apiKey: "pplx-configured",
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("supports distinct plugin and scoped config ids", () => {
+    const accessors = createScopedPluginWebSearchCredentialAccessors({
+      pluginId: "xai",
+      searchConfigKey: "grok",
+    });
+    const searchConfigTarget: Record<string, unknown> = {};
+    const configTarget = {} as {
+      tools?: { web?: { search?: WebSearchConfig } };
+      plugins?: Record<string, unknown>;
+    };
+
+    accessors.setCredentialValue(searchConfigTarget, "xai-scoped");
+    accessors.setConfiguredCredentialValue(configTarget, "xai-configured");
+
+    expect(searchConfigTarget).toEqual({
+      grok: {
+        apiKey: "xai-scoped",
+      },
+    });
+    expect(accessors.getConfiguredCredentialValue(configTarget)).toBe("xai-configured");
+    expect(configTarget.plugins).toMatchObject({
+      entries: {
+        xai: {
+          enabled: true,
+          config: {
+            webSearch: {
+              apiKey: "xai-configured",
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/src/agents/tools/web-search-provider-config.ts
+++ b/src/agents/tools/web-search-provider-config.ts
@@ -71,6 +71,38 @@ export function setScopedCredentialValue(
   (scoped as Record<string, unknown>).apiKey = value;
 }
 
+function buildPluginWebSearchCredentialPath(pluginId: string): string {
+  return `plugins.entries.${pluginId}.config.webSearch.apiKey`;
+}
+
+export function createScopedPluginWebSearchCredentialAccessors(params: {
+  pluginId: string;
+  searchConfigKey?: string;
+}): {
+  credentialPath: string;
+  inactiveSecretPaths: string[];
+  getCredentialValue: (searchConfig?: Record<string, unknown>) => unknown;
+  setCredentialValue: (searchConfigTarget: Record<string, unknown>, value: unknown) => void;
+  getConfiguredCredentialValue: (config?: OpenClawConfig) => unknown;
+  setConfiguredCredentialValue: (configTarget: OpenClawConfig, value: unknown) => void;
+} {
+  const credentialPath = buildPluginWebSearchCredentialPath(params.pluginId);
+  const searchConfigKey = params.searchConfigKey ?? params.pluginId;
+
+  return {
+    credentialPath,
+    inactiveSecretPaths: [credentialPath],
+    getCredentialValue: (searchConfig) => getScopedCredentialValue(searchConfig, searchConfigKey),
+    setCredentialValue: (searchConfigTarget, value) =>
+      setScopedCredentialValue(searchConfigTarget, searchConfigKey, value),
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, params.pluginId)?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, params.pluginId, "apiKey", value);
+    },
+  };
+}
+
 export function mergeScopedSearchConfig(
   searchConfig: Record<string, unknown> | undefined,
   key: string,

--- a/src/plugin-sdk/provider-web-search.ts
+++ b/src/plugin-sdk/provider-web-search.ts
@@ -29,6 +29,7 @@ export {
   writeCachedSearchPayload,
 } from "../agents/tools/web-search-provider-common.js";
 export {
+  createScopedPluginWebSearchCredentialAccessors,
   getScopedCredentialValue,
   getTopLevelCredentialValue,
   mergeScopedSearchConfig,


### PR DESCRIPTION
## Summary

AI-assisted PR.

- Problem: bundled scoped web-search providers repeated the same credential wiring around `credentialPath`, `inactiveSecretPaths`, scoped `get/set`, and configured plugin `get/set`.
- Why it matters: that duplication makes provider updates drift-prone, especially for alias pairs where `pluginId` and scoped search key differ (`google`/`gemini`, `moonshot`/`kimi`, `xai`/`grok`).
- What changed: added a small public helper, `createScopedPluginWebSearchCredentialAccessors`, and moved the bundled scoped providers to it.
- What did NOT change (scope boundary): no runtime behavior, provider ordering, network calls, auth resolution order, or top-level credential handling (for example Brave) changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

- Root cause:
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): bundled web search providers
- Relevant config (redacted): none

### Steps

1. Read the bundled scoped web-search providers and compare the credential blocks.
2. Add one helper that captures the shared scoped plugin credential wiring.
3. Move `exa`, `firecrawl`, `google/gemini`, `moonshot/kimi`, `perplexity`, `tavily`, and `xai/grok` to the helper.
4. Run targeted tests plus repo build/check lanes.

### Expected

- Providers keep the same credential paths and configured credential behavior.
- Alias providers still map plugin config and scoped search config correctly.
- Build, plugin-sdk API checks, and repo guardrails stay green.

### Actual

- Matched expected behavior.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

- `pnpm test -- src/agents/tools/web-search-provider-config.test.ts src/plugins/contracts/web-search-provider.contract.test.ts extensions/exa/src/exa-web-search-provider.test.ts extensions/firecrawl/src/firecrawl-search-provider.test.ts extensions/google/src/gemini-web-search-provider.test.ts extensions/moonshot/src/kimi-web-search-provider.test.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts extensions/tavily/src/tavily-search-provider.test.ts extensions/xai/src/grok-web-search-provider.test.ts`
- `pnpm plugin-sdk:api:check`
- `pnpm build`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: compared pre/post provider metadata wiring and added a helper test that covers same-id and alias-id cases.
- Edge cases checked: `pluginId !== searchConfigKey` for `google/gemini`, `moonshot/kimi`, and `xai/grok`.
- What you did **not** verify: live provider API calls and full onboarding flows.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR; providers fall back to the previous inline wiring.
- Files/config to restore: provider credential blocks plus `src/agents/tools/web-search-provider-config.ts`.
- Known bad symptoms reviewers should watch for: missing API key detection or wrong plugin/scoped key mapping for aliased providers.

## Risks and Mitigations

- Risk: helper accidentally conflates `pluginId` and scoped search key.
  - Mitigation: helper accepts separate `pluginId` and `searchConfigKey`, and the new test covers alias mappings explicitly.
- Risk: public plugin-sdk export changes could drift from generated surfaces.
  - Mitigation: `pnpm plugin-sdk:api:check`, `pnpm build`, and `pnpm check` all passed.
