### PR TITLE
test(auth): align device scope expectations

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -294,7 +294,11 @@ describe("device pairing tokens", () => {
     const paired = await getPairedDevice("device-1", baseDir);
     expect(paired?.scopes).toEqual(["operator.admin"]);
     expect(paired?.approvedScopes).toEqual(["operator.admin"]);
-    expect(paired?.tokens?.operator?.scopes).toEqual(["operator.admin"]);
+    expect(paired?.tokens?.operator?.scopes).toEqual([
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+    ]);
   });
 
   test("rejects scope escalation when rotating a token and leaves state unchanged", async () => {

--- a/src/shared/device-auth-store.test.ts
+++ b/src/shared/device-auth-store.test.ts
@@ -186,7 +186,7 @@ describe("device-auth-store", () => {
     expect(entry).toEqual({
       token: "new-token",
       role: "operator",
-      scopes: ["operator.write"],
+      scopes: ["operator.read", "operator.write"],
       updatedAtMs: 2222,
     });
     expect(readStore()).toEqual({


### PR DESCRIPTION
## Summary

- Problem: current `main` has stale device-auth test expectations that no longer match normalized operator scope behavior.
- Why it matters: these unrelated red tests block merge verification for focused PRs like #45489.
- What changed: updated two test assertions to match the current scope normalization contract for `operator.write` and `operator.admin`.
- What did NOT change (scope boundary): no production logic, runtime behavior, or auth/token semantics changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #45489
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: tests still expected narrower operator scope sets even though runtime normalization expands `operator.write` to include `operator.read` and `operator.admin` to include both.
- Missing detection / guardrail: these assertions were not updated when the normalized scope contract became the runtime source of truth.
- Prior context (`git blame`, prior PR, issue, or refactor if known): surfaced while trying to merge #45489 after rebasing onto current `main`.
- Why this regressed now: rebased PR verification hit unrelated baseline tests on current `main`.
- If unknown, what was ruled out: ruled out regressions in the Slack/session code from #45489 because these failures reproduce on a fresh branch from current `main`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/shared/device-auth-store.test.ts`, `src/infra/device-pairing.test.ts`
- Scenario the test should lock in: normalized operator scopes are reflected in stored token scopes and repaired pairing tokens.
- Why this is the smallest reliable guardrail: the behavior is fully encoded in these unit-level auth scope helpers and pairing/token flows.
- Existing test that already covers this (if any): surrounding device auth normalization tests cover related operator scope expansion.
- If no new test is added, why not: existing tests were corrected rather than expanded because the failure was stale expected output.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Check out current `main`.
2. Run `pnpm test -- src/shared/device-auth-store.test.ts src/infra/device-pairing.test.ts`.
3. Observe the stale expectations fail, then rerun after this patch.

### Expected

- Tests should reflect the current normalized operator scope behavior.

### Actual

- `src/shared/device-auth-store.test.ts` expected `operator.write` without the implied `operator.read` scope.
- `src/infra/device-pairing.test.ts` expected `operator.admin` without the implied `operator.read` / `operator.write` scopes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced both failing tests on fresh `origin/main`, updated expectations, reran the same targeted test command successfully.
- Edge cases checked: verified both the direct store path and repair approval path.
- What you did **not** verify: full `pnpm test` matrix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/shared/device-auth-store.test.ts`, `src/infra/device-pairing.test.ts`
- Known bad symptoms reviewers should watch for: none beyond these two tests reverting to red.

## Risks and Mitigations

- Risk: the assertions could still be too specific if scope normalization changes again.
  - Mitigation: they now match the current normalization rules used by production code.
