### PR TITLE
fix(agents): suppress heartbeat prompt for cron-triggered embedded runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/cron: suppress the default heartbeat system prompt for cron-triggered embedded runs even when they target non-cron session keys, so cron tasks stop reading `HEARTBEAT.md` and polluting unrelated threads. (#53152) Thanks @Protocol-zero-0.
+
 ## 2026.3.23
 
 ### Breaking

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -321,6 +321,8 @@ describe("shouldInjectHeartbeatPrompt", () => {
   it("injects the heartbeat prompt for default-agent non-cron runs", () => {
     expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: "user" })).toBe(true);
     expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: "heartbeat" })).toBe(true);
+    expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: "memory" })).toBe(true);
+    expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: undefined })).toBe(true);
   });
 
   it("suppresses the heartbeat prompt for cron-triggered runs", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -16,6 +16,7 @@ import {
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
   stripSessionsYieldArtifacts,
+  shouldInjectHeartbeatPrompt,
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
@@ -313,6 +314,21 @@ describe("resolvePromptModeForSession", () => {
     expect(resolvePromptModeForSession(undefined)).toBe("full");
     expect(resolvePromptModeForSession("agent:main")).toBe("full");
     expect(resolvePromptModeForSession("agent:main:thread:abc")).toBe("full");
+  });
+});
+
+describe("shouldInjectHeartbeatPrompt", () => {
+  it("injects the heartbeat prompt for default-agent non-cron runs", () => {
+    expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: "user" })).toBe(true);
+    expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: "heartbeat" })).toBe(true);
+  });
+
+  it("suppresses the heartbeat prompt for cron-triggered runs", () => {
+    expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: true, trigger: "cron" })).toBe(false);
+  });
+
+  it("suppresses the heartbeat prompt for non-default agents", () => {
+    expect(shouldInjectHeartbeatPrompt({ isDefaultAgent: false, trigger: "user" })).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1524,6 +1524,13 @@ export function resolvePromptModeForSession(sessionKey?: string): "minimal" | "f
   return isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey) ? "minimal" : "full";
 }
 
+export function shouldInjectHeartbeatPrompt(params: {
+  isDefaultAgent: boolean;
+  trigger?: string;
+}): boolean {
+  return params.isDefaultAgent && params.trigger !== "cron";
+}
+
 export function resolveAttemptFsWorkspaceOnly(params: {
   config?: OpenClawConfig;
   sessionAgentId: string;
@@ -1969,7 +1976,10 @@ export async function runEmbeddedAttempt(
     });
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
-    const heartbeatPrompt = isDefaultAgent
+    const heartbeatPrompt = shouldInjectHeartbeatPrompt({
+      isDefaultAgent,
+      trigger: params.trigger,
+    })
       ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
       : undefined;
 

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import {
   canResolveRegistryVersionForPackageTarget,
+  collectInstalledGlobalPackageErrors,
   cleanupGlobalRenameDirs,
   detectGlobalInstallManagerByPresence,
   detectGlobalInstallManagerForRoot,
@@ -184,5 +185,34 @@ describe("update global helpers", () => {
     });
     await expect(fs.stat(path.join(root, "openclaw"))).resolves.toBeDefined();
     await expect(fs.stat(path.join(root, ".openclaw-file"))).resolves.toBeDefined();
+  });
+
+  it("checks bundled runtime sidecars, including Matrix helper-api", async () => {
+    const packageRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-global-pkg-"));
+    const sidecars = [
+      "dist/extensions/whatsapp/light-runtime-api.js",
+      "dist/extensions/whatsapp/runtime-api.js",
+      "dist/extensions/matrix/helper-api.js",
+      "dist/extensions/matrix/runtime-api.js",
+      "dist/extensions/matrix/thread-bindings-runtime.js",
+      "dist/extensions/msteams/runtime-api.js",
+    ] as const;
+    await fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0" }),
+      "utf-8",
+    );
+    for (const relativePath of sidecars) {
+      const absolutePath = path.join(packageRoot, relativePath);
+      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fs.writeFile(absolutePath, "export {};\n", "utf-8");
+    }
+
+    await expect(collectInstalledGlobalPackageErrors({ packageRoot })).resolves.toEqual([]);
+
+    await fs.rm(path.join(packageRoot, "dist/extensions/matrix/helper-api.js"));
+    await expect(collectInstalledGlobalPackageErrors({ packageRoot })).resolves.toContain(
+      "missing bundled runtime sidecar dist/extensions/matrix/helper-api.js",
+    );
   });
 });

--- a/src/plugin-sdk/channel-import-guardrails.test.ts
+++ b/src/plugin-sdk/channel-import-guardrails.test.ts
@@ -11,6 +11,7 @@ const ALLOWED_EXTENSION_PUBLIC_SURFACES = new Set([
   "allow-from.js",
   "api.js",
   "auth-presence.js",
+  "helper-api.js",
   "index.js",
   "light-runtime-api.js",
   "login-qr-api.js",
@@ -22,6 +23,7 @@ const ALLOWED_EXTENSION_PUBLIC_SURFACES = new Set([
   "setup-api.js",
   "setup-entry.js",
   "timeouts.js",
+  "thread-bindings-runtime.js",
 ]);
 const GUARDED_CHANNEL_EXTENSIONS = new Set([
   "bluebubbles",


### PR DESCRIPTION
## Summary
- stop cron-triggered embedded runs from inheriting the default heartbeat prompt
- keep default-agent heartbeat prompt injection for non-cron triggers unchanged
- add regression coverage for cron vs non-cron prompt injection behavior

## Test plan
- [x] `pnpm test -- src/agents/pi-embedded-runner/run/attempt.test.ts`
- [ ] `pnpm check`

Fixes #53061

Made with [Cursor](https://cursor.com)