### PR TITLE
Fix workspace skill grouping in Control Panel

### DIFF
--- a/ui/src/ui/views/skills-grouping.ts
+++ b/ui/src/ui/views/skills-grouping.ts
@@ -21,9 +21,10 @@ export function groupSkills(skills: SkillStatusEntry[]): SkillGroup[] {
   const builtInGroup = SKILL_SOURCE_GROUPS.find((group) => group.id === "built-in");
   const other: SkillGroup = { id: "other", label: "Other Skills", skills: [] };
   for (const skill of skills) {
-    const match = skill.bundled
-      ? builtInGroup
-      : SKILL_SOURCE_GROUPS.find((group) => group.sources.includes(skill.source));
+    // The source determines where the skill lives; bundled is only a secondary badge.
+    const match =
+      SKILL_SOURCE_GROUPS.find((group) => group.sources.includes(skill.source)) ??
+      (skill.bundled ? builtInGroup : undefined);
     if (match) {
       groups.get(match.id)?.skills.push(skill);
     } else {

--- a/ui/src/ui/views/skills.browser.test.ts
+++ b/ui/src/ui/views/skills.browser.test.ts
@@ -1,0 +1,91 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import type { SkillStatusEntry, SkillStatusReport } from "../types.ts";
+import { renderSkills } from "./skills.ts";
+
+function makeSkill(overrides: Partial<SkillStatusEntry>): SkillStatusEntry {
+  return {
+    name: "sample-skill",
+    description: "Sample description",
+    source: "openclaw-workspace",
+    filePath: "/tmp/sample/SKILL.md",
+    baseDir: "/tmp/sample",
+    skillKey: "sample-skill",
+    bundled: false,
+    always: false,
+    disabled: false,
+    blockedByAllowlist: false,
+    eligible: true,
+    requirements: { bins: [], env: [], config: [], os: [] },
+    missing: { bins: [], env: [], config: [], os: [] },
+    configChecks: [],
+    install: [],
+    ...overrides,
+  };
+}
+
+function makeReport(skills: SkillStatusEntry[]): SkillStatusReport {
+  return {
+    workspaceDir: "/tmp/workspace",
+    managedSkillsDir: "/tmp/managed",
+    skills,
+  };
+}
+
+function makeProps(report: SkillStatusReport) {
+  return {
+    connected: true,
+    loading: false,
+    report,
+    error: null,
+    filter: "",
+    edits: {},
+    busyKey: null,
+    messages: {},
+    onFilterChange: () => undefined,
+    onRefresh: () => undefined,
+    onToggle: () => undefined,
+    onEdit: () => undefined,
+    onSaveKey: () => undefined,
+    onInstall: () => undefined,
+  };
+}
+
+describe("skills view (browser)", () => {
+  it("keeps workspace-installed skills in the workspace group even when bundled badge is set", async () => {
+    const container = document.createElement("div");
+    render(
+      renderSkills(
+        makeProps(
+          makeReport([
+            makeSkill({
+              name: "workspace-helper",
+              skillKey: "workspace-helper",
+              source: "openclaw-workspace",
+              bundled: true,
+            }),
+            makeSkill({
+              name: "bundled-helper",
+              skillKey: "bundled-helper",
+              source: "openclaw-bundled",
+              bundled: true,
+            }),
+          ]),
+        ),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const groups = [...container.querySelectorAll("details.agent-skills-group")].map((element) =>
+      (element.textContent ?? "").replace(/\s+/g, " ").trim(),
+    );
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toContain("Workspace Skills");
+    expect(groups[0]).toContain("workspace-helper");
+    expect(groups[0]).not.toContain("bundled-helper");
+    expect(groups[1]).toContain("Built-in Skills");
+    expect(groups[1]).toContain("bundled-helper");
+  });
+});


### PR DESCRIPTION
## Summary
- group skills in the Control Panel by `skill.source` before looking at the bundled badge
- keep workspace-installed skills in the Workspace Skills section even if they also report `bundled: true`
- add a browser regression test covering workspace and built-in skills side by side

## Testing
- corepack pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/views/skills.browser.test.ts
- corepack pnpm --dir ui build

Fixes #47139