### PR TITLE
fix(telegram): sequence stream.clear() after sendPayload() for media deliveries

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -717,6 +717,7 @@ export const dispatchTelegramMessage = async ({
                   logVerbose(
                     `telegram: media delivery failed (suppressed-reasoning path): ${String(mediaErr)}`,
                   );
+                  deliveryState.markNonSilentFailure();
                   const previewMsgId = answerLane.stream?.messageId();
                   if (typeof previewMsgId === "number") {
                     try {
@@ -756,6 +757,7 @@ export const dispatchTelegramMessage = async ({
                 await sendPayload(payload);
               } catch (mediaErr) {
                 logVerbose(`telegram: media delivery failed: ${String(mediaErr)}`);
+                deliveryState.markNonSilentFailure();
                 const previewMsgId = answerLane.stream?.messageId();
                 if (typeof previewMsgId === "number") {
                   try {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -273,6 +273,25 @@ export const dispatchTelegramMessage = async ({
   let splitReasoningOnNextStream = false;
   let skipNextAnswerMessageStartRotation = false;
   let draftLaneEventQueue = Promise.resolve();
+  /** Tracks in-flight fire-and-forget `deliver()` calls so cleanup can await them. */
+  let pendingDeliveryCount = 0;
+  let pendingDeliveryResolve: (() => void) | undefined;
+  const pendingDeliveriesDrained = () =>
+    pendingDeliveryCount === 0
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          pendingDeliveryResolve = resolve;
+        });
+  const trackPendingDelivery = () => {
+    pendingDeliveryCount++;
+    return () => {
+      pendingDeliveryCount--;
+      if (pendingDeliveryCount === 0 && pendingDeliveryResolve) {
+        pendingDeliveryResolve();
+        pendingDeliveryResolve = undefined;
+      }
+    };
+  };
   const reasoningStepState = createTelegramReasoningStepState();
   const enqueueDraftLaneEvent = (task: () => Promise<void>): Promise<void> => {
     const next = draftLaneEventQueue.then(task);
@@ -596,123 +615,170 @@ export const dispatchTelegramMessage = async ({
       dispatcherOptions: {
         ...replyPipeline,
         deliver: async (payload, info) => {
-          if (payload.isError === true) {
-            hadErrorReplyFailureOrSkip = true;
-          }
-          if (info.kind === "final") {
-            // Assistant callbacks are fire-and-forget; ensure queued boundary
-            // rotations/partials are applied before final delivery mapping.
-            await enqueueDraftLaneEvent(async () => {});
-          }
-          if (
-            shouldSuppressLocalTelegramExecApprovalPrompt({
-              cfg,
-              accountId: route.accountId,
-              payload,
-            })
-          ) {
-            queuedFinal = true;
-            return;
-          }
-          const previewButtons = (
-            payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
-          )?.buttons;
-          const split = splitTextIntoLaneSegments(payload.text);
-          const segments = split.segments;
-          const reply = resolveSendableOutboundReplyParts(payload);
-          const hasMedia = reply.hasMedia;
-
-          const flushBufferedFinalAnswer = async () => {
-            const buffered = reasoningStepState.takeBufferedFinalAnswer();
-            if (!buffered) {
+          const completePendingDelivery = trackPendingDelivery();
+          try {
+            if (payload.isError === true) {
+              hadErrorReplyFailureOrSkip = true;
+            }
+            if (info.kind === "final") {
+              // Assistant callbacks are fire-and-forget; ensure queued boundary
+              // rotations/partials are applied before final delivery mapping.
+              await enqueueDraftLaneEvent(async () => {});
+            }
+            if (
+              shouldSuppressLocalTelegramExecApprovalPrompt({
+                cfg,
+                accountId: route.accountId,
+                payload,
+              })
+            ) {
+              queuedFinal = true;
               return;
             }
-            const bufferedButtons = (
-              buffered.payload.channelData?.telegram as
-                | { buttons?: TelegramInlineButtons }
-                | undefined
+            const previewButtons = (
+              payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
             )?.buttons;
-            await deliverLaneText({
-              laneName: "answer",
-              text: buffered.text,
-              payload: buffered.payload,
-              infoKind: "final",
-              previewButtons: bufferedButtons,
-            });
-            reasoningStepState.resetForNextStep();
-          };
+            const split = splitTextIntoLaneSegments(payload.text);
+            const segments = split.segments;
+            const reply = resolveSendableOutboundReplyParts(payload);
+            const hasMedia = reply.hasMedia;
 
-          for (const segment of segments) {
-            if (
-              segment.lane === "answer" &&
-              info.kind === "final" &&
-              reasoningStepState.shouldBufferFinalAnswer()
-            ) {
-              reasoningStepState.bufferFinalAnswer({
-                payload,
-                text: segment.text,
+            const flushBufferedFinalAnswer = async () => {
+              const buffered = reasoningStepState.takeBufferedFinalAnswer();
+              if (!buffered) {
+                return;
+              }
+              const bufferedButtons = (
+                buffered.payload.channelData?.telegram as
+                  | { buttons?: TelegramInlineButtons }
+                  | undefined
+              )?.buttons;
+              await deliverLaneText({
+                laneName: "answer",
+                text: buffered.text,
+                payload: buffered.payload,
+                infoKind: "final",
+                previewButtons: bufferedButtons,
               });
-              continue;
+              reasoningStepState.resetForNextStep();
+            };
+
+            for (const segment of segments) {
+              if (
+                segment.lane === "answer" &&
+                info.kind === "final" &&
+                reasoningStepState.shouldBufferFinalAnswer()
+              ) {
+                reasoningStepState.bufferFinalAnswer({
+                  payload,
+                  text: segment.text,
+                });
+                continue;
+              }
+              if (segment.lane === "reasoning") {
+                reasoningStepState.noteReasoningHint();
+              }
+              const result = await deliverLaneText({
+                laneName: segment.lane,
+                text: segment.text,
+                payload,
+                infoKind: info.kind,
+                previewButtons,
+                allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
+              });
+              if (info.kind === "final") {
+                emitPreviewFinalizedHook(result);
+              }
+              if (segment.lane === "reasoning") {
+                if (result.kind !== "skipped") {
+                  reasoningStepState.noteReasoningDelivered();
+                  await flushBufferedFinalAnswer();
+                }
+                continue;
+              }
+              if (info.kind === "final") {
+                if (reasoningLane.hasStreamedMessage) {
+                  activePreviewLifecycleByLane.reasoning = "complete";
+                  retainPreviewOnCleanupByLane.reasoning = true;
+                }
+                reasoningStepState.resetForNextStep();
+              }
             }
-            if (segment.lane === "reasoning") {
-              reasoningStepState.noteReasoningHint();
+            if (segments.length > 0) {
+              return;
             }
-            const result = await deliverLaneText({
-              laneName: segment.lane,
-              text: segment.text,
-              payload,
-              infoKind: info.kind,
-              previewButtons,
-              allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
-            });
-            if (info.kind === "final") {
-              emitPreviewFinalizedHook(result);
-            }
-            if (segment.lane === "reasoning") {
-              if (result.kind !== "skipped") {
-                reasoningStepState.noteReasoningDelivered();
+            if (split.suppressedReasoningOnly) {
+              if (reply.hasMedia) {
+                const payloadWithoutSuppressedReasoning =
+                  typeof payload.text === "string" ? { ...payload, text: "" } : payload;
+                try {
+                  await sendPayload(payloadWithoutSuppressedReasoning);
+                } catch (mediaErr) {
+                  logVerbose(
+                    `telegram: media delivery failed (suppressed-reasoning path): ${String(mediaErr)}`,
+                  );
+                  const previewMsgId = answerLane.stream?.messageId();
+                  if (typeof previewMsgId === "number") {
+                    try {
+                      await (telegramDeps.editMessageTelegram ?? editMessageTelegram)(
+                        chatId,
+                        previewMsgId,
+                        "⚠️ Media delivery failed. Please try again.",
+                        { api: bot.api, cfg, accountId: route.accountId },
+                      );
+                    } catch {
+                      /* best-effort fallback */
+                    }
+                  }
+                  retainPreviewOnCleanupByLane.answer = true;
+                }
+              }
+              if (info.kind === "final") {
                 await flushBufferedFinalAnswer();
               }
-              continue;
+              return;
             }
+
             if (info.kind === "final") {
-              if (reasoningLane.hasStreamedMessage) {
-                activePreviewLifecycleByLane.reasoning = "complete";
-                retainPreviewOnCleanupByLane.reasoning = true;
-              }
+              await answerLane.stream?.stop();
+              await reasoningLane.stream?.stop();
               reasoningStepState.resetForNextStep();
             }
-          }
-          if (segments.length > 0) {
-            return;
-          }
-          if (split.suppressedReasoningOnly) {
+            const canSendAsIs = reply.hasMedia || reply.text.length > 0;
+            if (!canSendAsIs) {
+              if (info.kind === "final") {
+                await flushBufferedFinalAnswer();
+              }
+              return;
+            }
             if (reply.hasMedia) {
-              const payloadWithoutSuppressedReasoning =
-                typeof payload.text === "string" ? { ...payload, text: "" } : payload;
-              await sendPayload(payloadWithoutSuppressedReasoning);
+              try {
+                await sendPayload(payload);
+              } catch (mediaErr) {
+                logVerbose(`telegram: media delivery failed: ${String(mediaErr)}`);
+                const previewMsgId = answerLane.stream?.messageId();
+                if (typeof previewMsgId === "number") {
+                  try {
+                    await (telegramDeps.editMessageTelegram ?? editMessageTelegram)(
+                      chatId,
+                      previewMsgId,
+                      "⚠️ Media delivery failed. Please try again.",
+                      { api: bot.api, cfg, accountId: route.accountId },
+                    );
+                  } catch {
+                    /* best-effort fallback */
+                  }
+                }
+                retainPreviewOnCleanupByLane.answer = true;
+              }
+            } else {
+              await sendPayload(payload);
             }
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
             }
-            return;
-          }
-
-          if (info.kind === "final") {
-            await answerLane.stream?.stop();
-            await reasoningLane.stream?.stop();
-            reasoningStepState.resetForNextStep();
-          }
-          const canSendAsIs = reply.hasMedia || reply.text.length > 0;
-          if (!canSendAsIs) {
-            if (info.kind === "final") {
-              await flushBufferedFinalAnswer();
-            }
-            return;
-          }
-          await sendPayload(payload);
-          if (info.kind === "final") {
-            await flushBufferedFinalAnswer();
+          } finally {
+            completePendingDelivery();
           }
         },
         onSkip: (payload, info) => {
@@ -834,6 +900,10 @@ export const dispatchTelegramMessage = async ({
       }
       existing.shouldClear = existing.shouldClear && shouldClear;
     }
+    // Wait for any in-flight fire-and-forget deliver() calls to complete
+    // before clearing streams, so sendPayload() finishes before the preview
+    // message is deleted (#53124).
+    await pendingDeliveriesDrained();
     for (const [stream, cleanupState] of streamCleanupStates) {
       await stream.stop();
       if (cleanupState.shouldClear) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -732,6 +732,7 @@ export const dispatchTelegramMessage = async ({
                     }
                   }
                   retainPreviewOnCleanupByLane.answer = true;
+                  activePreviewLifecycleByLane.answer = "complete";
                 }
               }
               if (info.kind === "final") {


### PR DESCRIPTION
## Problem

When `hasMedia=true` in group chats, the Telegram streaming path had a race condition where `stream.clear()` could execute before `sendPayload()` resolved. This happened because:

1. The `deliver()` callback is fire-and-forget from the upstream dispatch pipeline
2. The `finally` block only awaited `draftLaneEventQueue` (which doesn't track `deliver()` calls)
3. `stream.clear()` ran while `sendPayload()` was still in-flight
4. **Result:** preview message deleted before media was delivered → users saw "deleted message"

## Fix

1. **Track in-flight deliveries:** Added `pendingDeliveriesDrained()` mechanism that tracks active `deliver()` calls via a counter + deferred promise. The `finally` cleanup block now awaits this before running `stream.clear()`.

2. **Error fallback for media failures:** When `sendPayload()` fails for media deliveries, instead of letting the error propagate (which would clear the preview), we now:
   - Edit the preview to show an error message
   - Set `retainPreviewOnCleanupByLane` so the error message persists

## Testing

All 1017 Telegram extension tests pass (83 test files).

Fix based on root cause analysis by @Hollychou924 in #53124.

Closes #53124