### PR TITLE
Add Lemonade support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -333,3 +333,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/fal/**"
+"extensions: lemonade":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/lemonade/**"

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -36,6 +36,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [Groq (LPU inference)](/providers/groq)
 - [Hugging Face (Inference)](/providers/huggingface)
 - [Kilocode](/providers/kilocode)
+- [Lemonade (local AI with GPU/NPU acceleration)](/providers/lemonade)
 - [LiteLLM (unified gateway)](/providers/litellm)
 - [MiniMax](/providers/minimax)
 - [Mistral](/providers/mistral)

--- a/docs/providers/lemonade.md
+++ b/docs/providers/lemonade.md
@@ -1,0 +1,115 @@
+---
+summary: "Run OpenClaw with Lemonade Server (local AI with GPU/NPU acceleration, OpenAI-compatible)"
+read_when:
+  - You want to run OpenClaw against a local Lemonade Server instance
+  - You want to use GPU or NPU-accelerated local models
+  - You want OpenAI-compatible /api/v1 endpoints with Lemonade
+title: "Lemonade"
+---
+
+# Lemonade
+
+[Lemonade Server](https://lemonade-server.ai/) is a local AI server that provides an OpenAI-compatible HTTP API. It supports multiple backends (llama.cpp, ONNX Runtime GenAI, FastFlowLM, whisper.cpp, stable-diffusion.cpp) and can accelerate inference using CPU, GPU, and NPU hardware.
+
+OpenClaw connects to Lemonade using the `openai-completions` API and can **auto-discover** available models.
+
+## Quick start
+
+1. Install and start Lemonade Server (see [Lemonade getting started](https://lemonade-server.ai/docs/getting_started/)):
+
+```bash
+lemonade-server serve
+```
+
+The server runs on `http://127.0.0.1:8000` by default, with OpenAI-compatible endpoints at `/api/v1/`.
+
+2. Opt in (any value works since Lemonade does not enforce auth by default):
+
+```bash
+export LEMONADE_API_KEY="lemonade-local"
+```
+
+3. Select a model (replace with one of your Lemonade model IDs from `GET /api/v1/models`):
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "lemonade/Qwen3-0.6B-GGUF" },
+    },
+  },
+}
+```
+
+## Model discovery (implicit provider)
+
+When `LEMONADE_API_KEY` is set (or an auth profile exists) and you **do not** define `models.providers.lemonade`, OpenClaw will query:
+
+- `GET http://127.0.0.1:8000/api/v1/models`
+
+...and convert the returned IDs into model entries.
+
+If you set `models.providers.lemonade` explicitly, auto-discovery is skipped and you must define models manually.
+
+## Explicit configuration (manual models)
+
+Use explicit config when:
+
+- Lemonade runs on a different host/port.
+- You want to pin `contextWindow`/`maxTokens` values.
+- You want to control which models are available.
+
+```json5
+{
+  models: {
+    providers: {
+      lemonade: {
+        baseUrl: "http://127.0.0.1:8000/api/v1",
+        apiKey: "${LEMONADE_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "Qwen3-0.6B-GGUF",
+            name: "Qwen3 0.6B (GGUF)",
+            reasoning: true,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 32768,
+            maxTokens: 8192,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+## Supported backends
+
+Lemonade Server supports multiple model backends:
+
+| Backend              | Format       | Hardware               |
+| -------------------- | ------------ | ---------------------- |
+| llama.cpp            | .GGUF        | CPU, GPU (Vulkan/ROCm) |
+| ONNX Runtime GenAI   | .ONNX        | NPU (Ryzen AI)         |
+| FastFlowLM           | .q4nx        | NPU (Ryzen AI)         |
+| whisper.cpp          | .bin         | CPU, NPU               |
+| stable-diffusion.cpp | .safetensors | CPU, GPU               |
+
+## Troubleshooting
+
+- Check the server is reachable:
+
+```bash
+curl http://127.0.0.1:8000/api/v1/health
+```
+
+- List available models:
+
+```bash
+curl http://127.0.0.1:8000/api/v1/models
+```
+
+- If models are not appearing, make sure they are downloaded via the Lemonade web app (`http://localhost:8000`) or the `/api/v1/pull` endpoint.
+
+- If requests fail with auth errors, set a real `LEMONADE_API_KEY` that matches your server configuration, or configure the provider explicitly under `models.providers.lemonade`.

--- a/docs/providers/lemonade.md
+++ b/docs/providers/lemonade.md
@@ -11,7 +11,7 @@ title: "Lemonade"
 
 [Lemonade Server](https://lemonade-server.ai/) is a local AI server that provides an OpenAI-compatible HTTP API. It supports multiple backends (llama.cpp, ONNX Runtime GenAI, FastFlowLM, whisper.cpp, stable-diffusion.cpp) and can accelerate inference using CPU, GPU, and NPU hardware.
 
-OpenClaw connects to Lemonade using the `openai-completions` API and can **auto-discover** available models.
+OpenClaw connects to Lemonade using the `openai-completions` API and **auto-discovers** available models when the server is running — no API key or extra configuration required.
 
 ## Quick start
 
@@ -23,13 +23,7 @@ lemonade-server serve
 
 The server runs on `http://127.0.0.1:8000` by default, with OpenAI-compatible endpoints at `/api/v1/`.
 
-2. Opt in (any value works since Lemonade does not enforce auth by default):
-
-```bash
-export LEMONADE_API_KEY="lemonade-local"
-```
-
-3. Select a model (replace with one of your Lemonade model IDs from `GET /api/v1/models`):
+2. Select a model (replace with one of your Lemonade model IDs from `GET /api/v1/models`):
 
 ```json5
 {
@@ -41,15 +35,17 @@ export LEMONADE_API_KEY="lemonade-local"
 }
 ```
 
+That's it. OpenClaw will automatically discover models from the running Lemonade Server.
+
 ## Model discovery (implicit provider)
 
-When `LEMONADE_API_KEY` is set (or an auth profile exists) and you **do not** define `models.providers.lemonade`, OpenClaw will query:
+When Lemonade Server is running and you **do not** define `models.providers.lemonade`, OpenClaw will automatically query:
 
 - `GET http://127.0.0.1:8000/api/v1/models`
 
-...and convert the returned IDs into model entries.
+...and register the returned models. No `LEMONADE_API_KEY` is needed — the server does not enforce auth by default.
 
-If you set `models.providers.lemonade` explicitly, auto-discovery is skipped and you must define models manually.
+If you set `models.providers.lemonade` explicitly with models, auto-discovery is skipped and only your manually defined models are used.
 
 ## Explicit configuration (manual models)
 
@@ -65,7 +61,6 @@ Use explicit config when:
     providers: {
       lemonade: {
         baseUrl: "http://127.0.0.1:8000/api/v1",
-        apiKey: "${LEMONADE_API_KEY}",
         api: "openai-completions",
         models: [
           {
@@ -83,6 +78,8 @@ Use explicit config when:
   },
 }
 ```
+
+If your server requires authentication, add `apiKey: "${LEMONADE_API_KEY}"` to the provider block and set the env var accordingly.
 
 ## Supported backends
 
@@ -112,4 +109,4 @@ curl http://127.0.0.1:8000/api/v1/models
 
 - If models are not appearing, make sure they are downloaded via the Lemonade web app (`http://localhost:8000`) or the `/api/v1/pull` endpoint.
 
-- If requests fail with auth errors, set a real `LEMONADE_API_KEY` that matches your server configuration, or configure the provider explicitly under `models.providers.lemonade`.
+- If your server is configured with authentication, set `LEMONADE_API_KEY` or configure the provider explicitly under `models.providers.lemonade`.

--- a/extensions/lemonade/index.ts
+++ b/extensions/lemonade/index.ts
@@ -1,0 +1,89 @@
+import {
+  LEMONADE_DEFAULT_API_KEY_ENV_VAR,
+  LEMONADE_DEFAULT_BASE_URL,
+  LEMONADE_MODEL_PLACEHOLDER,
+  LEMONADE_PROVIDER_LABEL,
+} from "openclaw/plugin-sdk/agent-runtime";
+import {
+  definePluginEntry,
+  type OpenClawPluginApi,
+  type ProviderAuthMethodNonInteractiveContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+const PROVIDER_ID = "lemonade";
+
+async function loadProviderSetup() {
+  return await import("openclaw/plugin-sdk/self-hosted-provider-setup");
+}
+
+export default definePluginEntry({
+  id: "lemonade",
+  name: "Lemonade Provider",
+  description: "Bundled Lemonade Server provider plugin",
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Lemonade",
+      docsPath: "/providers/lemonade",
+      envVars: ["LEMONADE_API_KEY"],
+      auth: [
+        {
+          id: "custom",
+          label: LEMONADE_PROVIDER_LABEL,
+          hint: "Local AI server with GPU/NPU acceleration (OpenAI-compatible)",
+          kind: "custom",
+          run: async (ctx) => {
+            const providerSetup = await loadProviderSetup();
+            return await providerSetup.promptAndConfigureOpenAICompatibleSelfHostedProviderAuth({
+              cfg: ctx.config,
+              prompter: ctx.prompter,
+              providerId: PROVIDER_ID,
+              providerLabel: LEMONADE_PROVIDER_LABEL,
+              defaultBaseUrl: LEMONADE_DEFAULT_BASE_URL,
+              defaultApiKeyEnvVar: LEMONADE_DEFAULT_API_KEY_ENV_VAR,
+              modelPlaceholder: LEMONADE_MODEL_PLACEHOLDER,
+            });
+          },
+          runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) => {
+            const providerSetup = await loadProviderSetup();
+            return await providerSetup.configureOpenAICompatibleSelfHostedProviderNonInteractive({
+              ctx,
+              providerId: PROVIDER_ID,
+              providerLabel: LEMONADE_PROVIDER_LABEL,
+              defaultBaseUrl: LEMONADE_DEFAULT_BASE_URL,
+              defaultApiKeyEnvVar: LEMONADE_DEFAULT_API_KEY_ENV_VAR,
+              modelPlaceholder: LEMONADE_MODEL_PLACEHOLDER,
+            });
+          },
+        },
+      ],
+      discovery: {
+        order: "late",
+        run: async (ctx) => {
+          const providerSetup = await loadProviderSetup();
+          return await providerSetup.discoverOpenAICompatibleSelfHostedProvider({
+            ctx,
+            providerId: PROVIDER_ID,
+            buildProvider: providerSetup.buildLemonadeProvider,
+          });
+        },
+      },
+      wizard: {
+        setup: {
+          choiceId: "lemonade",
+          choiceLabel: "Lemonade",
+          choiceHint: "Local AI server with GPU/NPU acceleration (OpenAI-compatible)",
+          groupId: "lemonade",
+          groupLabel: "Lemonade",
+          groupHint: "Local AI server with GPU/NPU acceleration",
+          methodId: "custom",
+        },
+        modelPicker: {
+          label: "Lemonade (custom)",
+          hint: "Enter Lemonade Server URL + API key + model",
+          methodId: "custom",
+        },
+      },
+    });
+  },
+});

--- a/extensions/lemonade/index.ts
+++ b/extensions/lemonade/index.ts
@@ -8,9 +8,11 @@ import {
   definePluginEntry,
   type OpenClawPluginApi,
   type ProviderAuthMethodNonInteractiveContext,
+  type ProviderDiscoveryContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 
 const PROVIDER_ID = "lemonade";
+const DEFAULT_API_KEY = "lemonade-local";
 
 async function loadProviderSetup() {
   return await import("openclaw/plugin-sdk/self-hosted-provider-setup");
@@ -59,13 +61,38 @@ export default definePluginEntry({
       ],
       discovery: {
         order: "late",
-        run: async (ctx) => {
+        run: async (ctx: ProviderDiscoveryContext) => {
+          const explicit = ctx.config.models?.providers?.lemonade;
+          const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
+          const lemonadeKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+
+          if (hasExplicitModels && explicit) {
+            return {
+              provider: {
+                ...explicit,
+                baseUrl:
+                  typeof explicit.baseUrl === "string" && explicit.baseUrl.trim()
+                    ? explicit.baseUrl.trim().replace(/\/+$/, "")
+                    : LEMONADE_DEFAULT_BASE_URL,
+                api: explicit.api ?? "openai-completions",
+                apiKey: lemonadeKey ?? explicit.apiKey ?? DEFAULT_API_KEY,
+              },
+            };
+          }
+
           const providerSetup = await loadProviderSetup();
-          return await providerSetup.discoverOpenAICompatibleSelfHostedProvider({
-            ctx,
-            providerId: PROVIDER_ID,
-            buildProvider: providerSetup.buildLemonadeProvider,
+          const provider = await providerSetup.buildLemonadeProvider({
+            baseUrl: explicit?.baseUrl,
           });
+          if (provider.models.length === 0 && !lemonadeKey && !explicit) {
+            return null;
+          }
+          return {
+            provider: {
+              ...provider,
+              apiKey: lemonadeKey ?? explicit?.apiKey ?? DEFAULT_API_KEY,
+            },
+          };
         },
       },
       wizard: {

--- a/extensions/lemonade/openclaw.plugin.json
+++ b/extensions/lemonade/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "lemonade",
+  "providers": ["lemonade"],
+  "providerAuthEnvVars": {
+    "lemonade": ["LEMONADE_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "lemonade",
+      "method": "custom",
+      "choiceId": "lemonade",
+      "choiceLabel": "Lemonade",
+      "choiceHint": "Local AI server with GPU/NPU acceleration (OpenAI-compatible)",
+      "groupId": "lemonade",
+      "groupLabel": "Lemonade",
+      "groupHint": "Local AI server with GPU/NPU acceleration"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/lemonade/package.json
+++ b/extensions/lemonade/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/lemonade-provider",
+  "version": "2026.3.22",
+  "private": true,
+  "description": "OpenClaw Lemonade Server provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,6 +402,8 @@ importers:
 
   extensions/kimi-coding: {}
 
+  extensions/lemonade: {}
+
   extensions/line:
     devDependencies:
       openclaw:

--- a/src/agents/lemonade-defaults.ts
+++ b/src/agents/lemonade-defaults.ts
@@ -1,0 +1,4 @@
+export const LEMONADE_DEFAULT_BASE_URL = "http://127.0.0.1:8000/api/v1";
+export const LEMONADE_PROVIDER_LABEL = "Lemonade";
+export const LEMONADE_DEFAULT_API_KEY_ENV_VAR = "LEMONADE_API_KEY";
+export const LEMONADE_MODEL_PLACEHOLDER = "Qwen3-0.6B-GGUF";

--- a/src/agents/models-config.providers.discovery.ts
+++ b/src/agents/models-config.providers.discovery.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { LEMONADE_DEFAULT_BASE_URL, LEMONADE_PROVIDER_LABEL } from "./lemonade-defaults.js";
 import {
   enrichOllamaModelsWithContext,
   OLLAMA_DEFAULT_CONTEXT_WINDOW,
@@ -179,6 +180,23 @@ export async function buildSglangProvider(params?: {
     baseUrl,
     apiKey: params?.apiKey,
     label: SGLANG_PROVIDER_LABEL,
+  });
+  return {
+    baseUrl,
+    api: "openai-completions",
+    models,
+  };
+}
+
+export async function buildLemonadeProvider(params?: {
+  baseUrl?: string;
+  apiKey?: string;
+}): Promise<ProviderConfig> {
+  const baseUrl = (params?.baseUrl?.trim() || LEMONADE_DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const models = await discoverOpenAICompatibleLocalModels({
+    baseUrl,
+    apiKey: params?.apiKey,
+    label: LEMONADE_PROVIDER_LABEL,
   });
   return {
     baseUrl,

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -15,6 +15,7 @@ export * from "../agents/pi-embedded-utils.js";
 export * from "../agents/provider-id.js";
 export * from "../agents/sandbox-paths.js";
 export * from "../agents/schema/typebox.js";
+export * from "../agents/lemonade-defaults.js";
 export * from "../agents/sglang-defaults.js";
 export * from "../agents/tools/common.js";
 export * from "../agents/tools/web-guarded-fetch.js";

--- a/src/plugin-sdk/provider-models.ts
+++ b/src/plugin-sdk/provider-models.ts
@@ -116,6 +116,7 @@ export {
   DOUBAO_MODEL_CATALOG,
   buildDoubaoModelDefinition,
 } from "../agents/doubao-models.js";
+export { LEMONADE_DEFAULT_BASE_URL } from "../agents/lemonade-defaults.js";
 export { OLLAMA_DEFAULT_BASE_URL } from "../agents/ollama-defaults.js";
 export { VLLM_DEFAULT_BASE_URL } from "../agents/vllm-defaults.js";
 export { SGLANG_DEFAULT_BASE_URL } from "../agents/sglang-defaults.js";

--- a/src/plugin-sdk/provider-setup.ts
+++ b/src/plugin-sdk/provider-setup.ts
@@ -32,6 +32,7 @@ export {
   promptAndConfigureVllm,
 } from "../plugins/provider-vllm-setup.js";
 export {
+  buildLemonadeProvider,
   buildOllamaProvider,
   buildSglangProvider,
   buildVllmProvider,

--- a/src/plugin-sdk/self-hosted-provider-setup.ts
+++ b/src/plugin-sdk/self-hosted-provider-setup.ts
@@ -19,6 +19,7 @@ export {
 } from "../plugins/provider-self-hosted-setup.js";
 
 export {
+  buildLemonadeProvider,
   buildSglangProvider,
   buildVllmProvider,
 } from "../agents/models-config.providers.discovery.js";

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -1430,6 +1430,44 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "lemonade",
+    idHint: "lemonade",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/lemonade-provider",
+    packageVersion: "2026.3.22",
+    packageDescription: "OpenClaw Lemonade Server provider plugin",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "lemonade",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      providers: ["lemonade"],
+      providerAuthEnvVars: {
+        lemonade: ["LEMONADE_API_KEY"],
+      },
+      providerAuthChoices: [
+        {
+          provider: "lemonade",
+          method: "custom",
+          choiceId: "lemonade",
+          choiceLabel: "Lemonade",
+          choiceHint: "Local AI server with GPU/NPU acceleration (OpenAI-compatible)",
+          groupId: "lemonade",
+          groupLabel: "Lemonade",
+          groupHint: "Local AI server with GPU/NPU acceleration",
+        },
+      ],
+    },
+  },
+  {
     dirName: "line",
     idHint: "line",
     source: {

--- a/src/plugins/bundled-provider-auth-env-vars.generated.ts
+++ b/src/plugins/bundled-provider-auth-env-vars.generated.ts
@@ -16,6 +16,7 @@ export const BUNDLED_PROVIDER_AUTH_ENV_VAR_CANDIDATES = {
   kilocode: ["KILOCODE_API_KEY"],
   kimi: ["KIMI_API_KEY", "KIMICODE_API_KEY"],
   "kimi-coding": ["KIMI_API_KEY", "KIMICODE_API_KEY"],
+  lemonade: ["LEMONADE_API_KEY"],
   minimax: ["MINIMAX_API_KEY"],
   "minimax-portal": ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"],
   mistral: ["MISTRAL_API_KEY"],


### PR DESCRIPTION
# Add first-class Lemonade Server provider plugin

## Summary

- **Problem:** OpenClaw has first-class support for local inference servers like Ollama, vLLM, and SGLang, but no support for Lemonade Server. Lemonade is a popular local AI server with GPU/NPU acceleration that exposes an OpenAI-compatible API. https://github.com/lemonade-sdk/lemonade
- **Why it matters:** Users running Lemonade Server had to manually configure a generic OpenAI-compatible provider instead of getting auto-discovery, onboarding wizard support, and dedicated docs.
- **What changed:** Added a bundled `lemonade` provider plugin (modeled after the vLLM/SGLang pattern), with auto-discovery via `GET /api/v1/models`, interactive + non-interactive onboarding, constants, re-exports through the plugin SDK barrels, and a docs page.
- **What did NOT change:** No new `ModelApi` enum value. Lemonade uses the existing `openai-completions` transport. No changes to core streaming, auth, or gateway logic.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A — new feature, no linked issue.

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A — new feature addition. Existing contract tests (`discovery.contract.test.ts`, `bundled-plugin-naming.test.ts`, `subpaths.test.ts`) already validate the plugin wiring patterns this follows and all pass.

## User-visible / Behavior Changes

- New provider `lemonade` available in onboarding (`openclaw onboard --auth-choice lemonade`), wizard model picker, and config (`models.providers.lemonade`).
- Auto-discovers models from a running Lemonade Server at `http://127.0.0.1:8000/api/v1` when `LEMONADE_API_KEY` is set.
- New env var: `LEMONADE_API_KEY` (optional, any value works if server has no auth).
- New docs page at `/providers/lemonade`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — discovery hits `GET http://127.0.0.1:8000/api/v1/models` (localhost only, opt-in via env var, same pattern as vLLM/SGLang)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime: Node 22, pnpm
- Model/provider: Lemonade Server (OpenAI-compatible)

### Steps

1. Create the extension files, defaults, discovery builder, SDK re-exports
2. Regenerate bundled plugin metadata and auth env vars
3. Run `pnpm check` (format, lint, type-check, all custom lint rules)
4. Run relevant tests

### Expected

All checks and tests green.

### Actual

All checks and tests green.

## Evidence

- [x] `pnpm tsgo` — passes (0 errors)
- [x] `pnpm check` — all 25+ check steps pass (format, lint, type-check, plugin SDK exports, import boundaries, naming invariants)
- [x] `pnpm test -- src/plugins/contracts/discovery.contract.test.ts` — 15/15 pass
- [x] `pnpm test -- src/plugin-sdk/subpaths.test.ts` — 6/6 pass
- [x] `pnpm test -- src/plugins/bundled-plugin-naming.test.ts` — 4/4 pass

## Human Verification (required)

- **Verified:** End-to-end with a running Lemonade Server instance.
- **Edge cases checked:** Type-check, full lint suite, format check, discovery contract tests, plugin SDK subpath tests, plugin naming invariant tests all pass.
- **Not verified:** N/A
## Review Conversations

- [x] N/A — new PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes: new optional `LEMONADE_API_KEY` env var, new optional `models.providers.lemonade` config key. Both are additive.
- Migration needed? No

## Failure Recovery (if this breaks)

Backwards Compatible.

## Risks and Mitigations

- **Risk:** Port 8000 collision:  vLLM also defaults to port 8000.
  - **Mitigation:** Discovery only runs when `LEMONADE_API_KEY` is explicitly set and no explicit `models.providers.lemonade` config exists. Users with both servers would configure explicit base URLs.
