### PR TITLE
fix: derive OPENCLAW_PLUGIN_API_VERSION from package version instead of hardcoded 1.2.0

### DIFF
--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -27,6 +27,8 @@ vi.mock("../infra/clawhub.js", async () => {
 });
 
 vi.mock("../version.js", () => ({
+  VERSION: "2026.3.22",
+  resolveUsableRuntimeVersion: (v: string | undefined) => (v && v !== "0.0.0" ? v : undefined),
   resolveRuntimeServiceVersion: (...args: unknown[]) => resolveRuntimeServiceVersionMock(...args),
 }));
 

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -13,10 +13,10 @@ import {
   type ClawHubPackageDetail,
   type ClawHubPackageFamily,
 } from "../infra/clawhub.js";
-import { VERSION, resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION, resolveUsableRuntimeVersion, resolveRuntimeServiceVersion } from "../version.js";
 import { installPluginFromArchive, type InstallPluginResult } from "./install.js";
 
-export const OPENCLAW_PLUGIN_API_VERSION = VERSION ?? resolveRuntimeServiceVersion();
+export const OPENCLAW_PLUGIN_API_VERSION = resolveUsableRuntimeVersion(VERSION) ?? resolveRuntimeServiceVersion();
 export const CLAWHUB_INSTALL_ERROR_CODE = {
   INVALID_SPEC: "invalid_spec",
   PACKAGE_NOT_FOUND: "package_not_found",

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -13,10 +13,10 @@ import {
   type ClawHubPackageDetail,
   type ClawHubPackageFamily,
 } from "../infra/clawhub.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { VERSION, resolveRuntimeServiceVersion } from "../version.js";
 import { installPluginFromArchive, type InstallPluginResult } from "./install.js";
 
-export const OPENCLAW_PLUGIN_API_VERSION = "1.2.0";
+export const OPENCLAW_PLUGIN_API_VERSION = VERSION ?? resolveRuntimeServiceVersion();
 export const CLAWHUB_INSTALL_ERROR_CODE = {
   INVALID_SPEC: "invalid_spec",
   PACKAGE_NOT_FOUND: "package_not_found",


### PR DESCRIPTION
## Problem

`OPENCLAW_PLUGIN_API_VERSION` in `src/plugins/clawhub.ts` is hardcoded to `"1.2.0"`. This means plugins that declare a `pluginApiRange` of `>=2026.3.22` (like `@openclaw/matrix`) cannot be installed, even when the runtime itself is at version `2026.3.22`.

```
Plugin "@openclaw/matrix" requires plugin API >=2026.3.22, but this OpenClaw runtime exposes 1.2.0.
```

## Fix

Replace the hardcoded `"1.2.0"` with the actual runtime version by using the existing `VERSION` constant from `../version.js` (the single source of truth for the OpenClaw version), with a fallback to `resolveRuntimeServiceVersion()`.

**Before:**
```typescript
import { resolveRuntimeServiceVersion } from "../version.js";
export const OPENCLAW_PLUGIN_API_VERSION = "1.2.0";
```

**After:**
```typescript
import { VERSION, resolveRuntimeServiceVersion } from "../version.js";
export const OPENCLAW_PLUGIN_API_VERSION = VERSION ?? resolveRuntimeServiceVersion();
```

The file already imported `resolveRuntimeServiceVersion` but wasn't using it. Now the plugin API version correctly reflects the runtime version (e.g. `2026.3.22`), allowing compatible plugins to install.

## Impact

- 1 file changed, 2 lines
- Fixes plugin installation for any plugin requiring a modern `pluginApiRange`
- No breaking changes — plugins that don't specify a range are unaffected