### PR TITLE
Doctor: prune stale plugin allowlist and entry refs

### DIFF
--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -13,6 +13,7 @@ import { scanEmptyAllowlistPolicyWarnings } from "./shared/empty-allowlist-scan.
 import { maybeRepairExecSafeBinProfiles } from "./shared/exec-safe-bins.js";
 import { maybeRepairLegacyToolsBySenderKeys } from "./shared/legacy-tools-by-sender.js";
 import { maybeRepairOpenPolicyAllowFrom } from "./shared/open-policy-allowfrom.js";
+import { maybeRepairStalePluginConfig } from "./shared/stale-plugin-config.js";
 
 export async function runDoctorRepairSequence(params: {
   state: DoctorConfigMutationState;
@@ -48,6 +49,7 @@ export async function runDoctorRepairSequence(params: {
   applyMutation(await maybeRepairTelegramAllowFromUsernames(state.candidate));
   applyMutation(maybeRepairDiscordNumericIds(state.candidate));
   applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));
+  applyMutation(maybeRepairStalePluginConfig(state.candidate, process.env));
   applyMutation(await maybeRepairAllowlistPolicyAllowFrom(state.candidate));
 
   const emptyAllowlistWarnings = scanEmptyAllowlistPolicyWarnings(state.candidate, {

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -1,7 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
+import * as manifestRegistry from "../../../plugins/manifest-registry.js";
 import { collectDoctorPreviewWarnings } from "./preview-warnings.js";
 
+function manifest(id: string): PluginManifestRecord {
+  return {
+    id,
+    channels: [],
+    providers: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: `/plugins/${id}`,
+    source: `/plugins/${id}`,
+    manifestPath: `/plugins/${id}/openclaw.plugin.json`,
+  };
+}
+
 describe("doctor preview warnings", () => {
+  beforeEach(() => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [manifest("discord")],
+      diagnostics: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("collects provider and shared preview warnings", () => {
     const warnings = collectDoctorPreviewWarnings({
       cfg: {
@@ -44,5 +71,53 @@ describe("doctor preview warnings", () => {
     ]);
     expect(warnings[0]).not.toContain("\u001B");
     expect(warnings[0]).not.toContain("\r");
+  });
+
+  it("includes stale plugin config warnings", () => {
+    const warnings = collectDoctorPreviewWarnings({
+      cfg: {
+        plugins: {
+          allow: ["acpx"],
+          entries: {
+            acpx: { enabled: true },
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining('plugins.allow: stale plugin reference "acpx"'),
+    ]);
+    expect(warnings[0]).toContain("plugins.entries.acpx");
+    expect(warnings[0]).toContain('Run "openclaw doctor --fix"');
+    expect(warnings[0]).not.toContain("Auto-removal is paused");
+  });
+
+  it("warns but skips auto-removal when plugin discovery has errors", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        { level: "error", message: "plugin path not found: /missing", source: "/missing" },
+      ],
+    });
+
+    const warnings = collectDoctorPreviewWarnings({
+      cfg: {
+        plugins: {
+          allow: ["acpx"],
+          entries: {
+            acpx: { enabled: true },
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining('plugins.allow: stale plugin reference "acpx"'),
+    ]);
+    expect(warnings[0]).toContain("Auto-removal is paused");
+    expect(warnings[0]).toContain('rerun "openclaw doctor --fix"');
   });
 });

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -24,6 +24,11 @@ import {
   collectOpenPolicyAllowFromWarnings,
   maybeRepairOpenPolicyAllowFrom,
 } from "./open-policy-allowfrom.js";
+import {
+  collectStalePluginConfigWarnings,
+  isStalePluginAutoRepairBlocked,
+  scanStalePluginConfig,
+} from "./stale-plugin-config.js";
 
 export function collectDoctorPreviewWarnings(params: {
   cfg: OpenClawConfig;
@@ -57,6 +62,17 @@ export function collectDoctorPreviewWarnings(params: {
       collectOpenPolicyAllowFromWarnings({
         changes: allowFromScan.changes,
         doctorFixCommand: params.doctorFixCommand,
+      }).join("\n"),
+    );
+  }
+
+  const stalePluginHits = scanStalePluginConfig(params.cfg, process.env);
+  if (stalePluginHits.length > 0) {
+    warnings.push(
+      collectStalePluginConfigWarnings({
+        hits: stalePluginHits,
+        doctorFixCommand: params.doctorFixCommand,
+        autoRepairBlocked: isStalePluginAutoRepairBlocked(params.cfg, process.env),
       }).join("\n"),
     );
   }

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import type { PluginManifestRecord } from "../../../plugins/manifest-registry.js";
+import * as manifestRegistry from "../../../plugins/manifest-registry.js";
+import {
+  collectStalePluginConfigWarnings,
+  maybeRepairStalePluginConfig,
+  scanStalePluginConfig,
+} from "./stale-plugin-config.js";
+
+function manifest(id: string): PluginManifestRecord {
+  return {
+    id,
+    channels: [],
+    providers: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: `/plugins/${id}`,
+    source: `/plugins/${id}`,
+    manifestPath: `/plugins/${id}/openclaw.plugin.json`,
+  };
+}
+
+describe("doctor stale plugin config helpers", () => {
+  beforeEach(() => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [manifest("discord"), manifest("voice-call"), manifest("openai")],
+      diagnostics: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("finds stale plugins.allow and plugins.entries refs", () => {
+    const hits = scanStalePluginConfig({
+      plugins: {
+        allow: ["discord", "acpx"],
+        entries: {
+          "voice-call": { enabled: true },
+          acpx: { enabled: true },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(hits).toEqual([
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.allow",
+        surface: "allow",
+      },
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.entries.acpx",
+        surface: "entries",
+      },
+    ]);
+  });
+
+  it("removes stale plugin ids from allow and entries without changing valid refs", () => {
+    const result = maybeRepairStalePluginConfig({
+      plugins: {
+        allow: ["discord", "acpx", "voice-call"],
+        entries: {
+          "voice-call": { enabled: true },
+          acpx: { enabled: true },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(result.changes).toEqual([
+      "- plugins.allow: removed 1 stale plugin id (acpx)",
+      "- plugins.entries: removed 1 stale plugin entry (acpx)",
+    ]);
+    expect(result.config.plugins?.allow).toEqual(["discord", "voice-call"]);
+    expect(result.config.plugins?.entries).toEqual({
+      "voice-call": { enabled: true },
+    });
+  });
+
+  it("formats stale plugin warnings with a doctor hint", () => {
+    const warnings = collectStalePluginConfigWarnings({
+      hits: [
+        {
+          pluginId: "acpx",
+          pathLabel: "plugins.allow",
+          surface: "allow",
+        },
+      ],
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining('plugins.allow: stale plugin reference "acpx"'),
+      expect.stringContaining('Run "openclaw doctor --fix"'),
+    ]);
+  });
+
+  it("does not auto-repair stale refs while plugin discovery has errors", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        { level: "error", message: "plugin path not found: /missing", source: "/missing" },
+      ],
+    });
+
+    const cfg = {
+      plugins: {
+        allow: ["acpx"],
+        entries: {
+          acpx: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const hits = scanStalePluginConfig(cfg);
+    expect(hits).toEqual([
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.allow",
+        surface: "allow",
+      },
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.entries.acpx",
+        surface: "entries",
+      },
+    ]);
+
+    const result = maybeRepairStalePluginConfig(cfg);
+    expect(result.changes).toEqual([]);
+    expect(result.config).toEqual(cfg);
+
+    const warnings = collectStalePluginConfigWarnings({
+      hits,
+      doctorFixCommand: "openclaw doctor --fix",
+      autoRepairBlocked: true,
+    });
+    expect(warnings[2]).toContain("Auto-removal is paused");
+  });
+
+  it("treats legacy plugin aliases as valid ids during scan and repair", () => {
+    const cfg = {
+      plugins: {
+        allow: ["openai-codex", "acpx"],
+        entries: {
+          "openai-codex": { enabled: true },
+          acpx: { enabled: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(scanStalePluginConfig(cfg)).toEqual([
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.allow",
+        surface: "allow",
+      },
+      {
+        pluginId: "acpx",
+        pathLabel: "plugins.entries.acpx",
+        surface: "entries",
+      },
+    ]);
+
+    const result = maybeRepairStalePluginConfig(cfg);
+    expect(result.config.plugins?.allow).toEqual(["openai-codex"]);
+    expect(result.config.plugins?.entries).toEqual({
+      "openai-codex": { enabled: true },
+    });
+  });
+});

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -1,0 +1,169 @@
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../../agents/agent-scope.js";
+import type { OpenClawConfig } from "../../../config/config.js";
+import { normalizePluginId } from "../../../plugins/config-state.js";
+import { loadPluginManifestRegistry } from "../../../plugins/manifest-registry.js";
+import { sanitizeForLog } from "../../../terminal/ansi.js";
+import { asObjectRecord } from "./object.js";
+
+type StalePluginSurface = "allow" | "entries";
+
+type StalePluginConfigHit = {
+  pluginId: string;
+  pathLabel: string;
+  surface: StalePluginSurface;
+};
+
+type StalePluginRegistryState = {
+  knownIds: Set<string>;
+  hasDiscoveryErrors: boolean;
+};
+
+function collectPluginRegistryState(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): StalePluginRegistryState {
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const registry = loadPluginManifestRegistry({
+    config: cfg,
+    workspaceDir: workspaceDir ?? undefined,
+    env,
+  });
+  return {
+    knownIds: new Set(registry.plugins.map((plugin) => plugin.id)),
+    hasDiscoveryErrors: registry.diagnostics.some((diag) => diag.level === "error"),
+  };
+}
+
+export function isStalePluginAutoRepairBlocked(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): boolean {
+  return collectPluginRegistryState(cfg, env).hasDiscoveryErrors;
+}
+
+export function scanStalePluginConfig(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): StalePluginConfigHit[] {
+  const plugins = asObjectRecord(cfg.plugins);
+  if (!plugins) {
+    return [];
+  }
+
+  const { knownIds } = collectPluginRegistryState(cfg, env);
+  const hits: StalePluginConfigHit[] = [];
+
+  const allow = Array.isArray(plugins.allow) ? plugins.allow : [];
+  for (const rawPluginId of allow) {
+    if (typeof rawPluginId !== "string") {
+      continue;
+    }
+    const pluginId = normalizePluginId(rawPluginId);
+    if (!pluginId || knownIds.has(pluginId)) {
+      continue;
+    }
+    hits.push({
+      pluginId: rawPluginId,
+      pathLabel: "plugins.allow",
+      surface: "allow",
+    });
+  }
+
+  const entries = asObjectRecord(plugins.entries);
+  if (!entries) {
+    return hits;
+  }
+  for (const rawPluginId of Object.keys(entries)) {
+    if (knownIds.has(normalizePluginId(rawPluginId))) {
+      continue;
+    }
+    hits.push({
+      pluginId: rawPluginId,
+      pathLabel: `plugins.entries.${rawPluginId}`,
+      surface: "entries",
+    });
+  }
+
+  return hits;
+}
+
+export function collectStalePluginConfigWarnings(params: {
+  hits: StalePluginConfigHit[];
+  doctorFixCommand: string;
+  autoRepairBlocked?: boolean;
+}): string[] {
+  if (params.hits.length === 0) {
+    return [];
+  }
+  const lines = params.hits.map(
+    (hit) => `- ${hit.pathLabel}: stale plugin reference "${hit.pluginId}" was found.`,
+  );
+  if (params.autoRepairBlocked) {
+    lines.push(
+      `- Auto-removal is paused because plugin discovery currently has errors. Fix plugin discovery first, then rerun "${params.doctorFixCommand}".`,
+    );
+  } else {
+    lines.push(
+      `- Run "${params.doctorFixCommand}" to remove stale plugins.allow and plugins.entries ids.`,
+    );
+  }
+  return lines.map((line) => sanitizeForLog(line));
+}
+
+export function maybeRepairStalePluginConfig(
+  cfg: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  if (isStalePluginAutoRepairBlocked(cfg, env)) {
+    return { config: cfg, changes: [] };
+  }
+
+  const hits = scanStalePluginConfig(cfg, env);
+  if (hits.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const nextPlugins = asObjectRecord(next.plugins);
+  if (!nextPlugins) {
+    return { config: cfg, changes: [] };
+  }
+
+  const allowIds = hits.filter((hit) => hit.surface === "allow").map((hit) => hit.pluginId);
+  if (allowIds.length > 0 && Array.isArray(nextPlugins.allow)) {
+    const staleAllowIds = new Set(allowIds.map((pluginId) => normalizePluginId(pluginId)));
+    nextPlugins.allow = nextPlugins.allow.filter(
+      (pluginId) => typeof pluginId !== "string" || !staleAllowIds.has(normalizePluginId(pluginId)),
+    );
+  }
+
+  const entryIds = hits.filter((hit) => hit.surface === "entries").map((hit) => hit.pluginId);
+  if (entryIds.length > 0) {
+    const entries = asObjectRecord(nextPlugins.entries);
+    if (entries) {
+      const staleEntryIds = new Set(entryIds.map((pluginId) => normalizePluginId(pluginId)));
+      for (const pluginId of Object.keys(entries)) {
+        if (staleEntryIds.has(normalizePluginId(pluginId))) {
+          delete entries[pluginId];
+        }
+      }
+    }
+  }
+
+  const changes: string[] = [];
+  if (allowIds.length > 0) {
+    changes.push(
+      `- plugins.allow: removed ${allowIds.length} stale plugin id${allowIds.length === 1 ? "" : "s"} (${allowIds.join(", ")})`,
+    );
+  }
+  if (entryIds.length > 0) {
+    changes.push(
+      `- plugins.entries: removed ${entryIds.length} stale plugin entr${entryIds.length === 1 ? "y" : "ies"} (${entryIds.join(", ")})`,
+    );
+  }
+
+  return { config: next, changes };
+}

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -72,7 +72,7 @@ const PLUGIN_ID_ALIASES: Readonly<Record<string, string>> = {
   "minimax-portal-auth": "minimax",
 };
 
-function normalizePluginId(id: string): string {
+export function normalizePluginId(id: string): string {
   const trimmed = id.trim();
   return PLUGIN_ID_ALIASES[trimmed] ?? trimmed;
 }


### PR DESCRIPTION
## Summary

  - Problem: `openclaw doctor --fix` did not remove stale plugin ids from `plugins.allow` or `plugins.entries`, even though those stale refs can be left behind after a plugin is removed.
  - Why it matters: users can get stuck with invalid or misleading plugin config after uninstall/removal, and doctor was not repairing the exact stale state it should clean up.
  - What changed: added a doctor helper that detects stale plugin refs against the current manifest registry, surfaces preview warnings, and removes stale ids from `plugins.allow` and
  `plugins.entries` during repair.
  - What did NOT change (scope boundary): no changes to `plugins.deny`, plugin slot validation, plugin loading rules, trust semantics, or general config validation behavior outside this
  stale-ref cleanup.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #53160
  - Related #
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: doctor’s repair sequence handled several config migrations/repairs, but it had no repair step for stale plugin refs even though config validation and warnings already recognized that stale plugin ids can exist.
  - Missing detection / guardrail: no doctor preview warning specifically called out stale `plugins.allow` / `plugins.entries` refs, and no repair-sequencing test covered stale plugin cleanup.
  - Prior context (`git blame`, prior PR, issue, or refactor if known): current validation logic already distinguishes stale plugin refs, but doctor repair sequencing in `src/commands/doctor/repair-sequencing.ts` never consumed that signal.
  - Why this regressed now: stricter plugin config handling made stale refs more user-visible, while doctor still lacked the corresponding auto-repair path.
  - If unknown, what was ruled out: ruled out a manifest-registry discovery failure on current `main`; the gap was in doctor repair wiring, not plugin discovery.

  ## Regression Test Plan (if applicable)

  For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `src/commands/doctor/shared/stale-plugin-config.test.ts` and `src/commands/doctor/repair-sequencing.test.ts`
  - Scenario the test should lock in: when config contains stale ids in `plugins.allow` and `plugins.entries`, preview warns about them and `openclaw doctor --fix` removes them while leaving
  valid plugin refs intact.
  - Why this is the smallest reliable guardrail: the behavior is pure config mutation based on manifest-registry ids, so focused doctor-helper and sequencing tests cover the failure mode directly without needing a full gateway run.
  - Existing test that already covers this (if any): none previously covered doctor cleanup for stale plugin refs.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  List user-visible changes (including defaults/config).
  If none, write `None`.

  - `openclaw doctor` now warns explicitly about stale plugin refs in `plugins.allow` and `plugins.entries`.
  - `openclaw doctor --fix` now removes those stale refs automatically.

  ## Security Impact (required)

  - New permissions/capabilities? (`Yes/No`) No
  - Secrets/tokens handling changed? (`Yes/No`) No
  - New/changed network calls? (`Yes/No`) No
  - Command/tool execution surface changed? (`Yes/No`) No
  - Data access scope changed? (`Yes/No`) No
  - If any `Yes`, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local Node/pnpm test run
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): config with `plugins.allow: ["acpx"]` and `plugins.entries.acpx` present while `acpx` is absent from discovered plugin manifests

  ### Steps

  1. Create config with a stale plugin id in `plugins.allow` and `plugins.entries`.
  2. Run `openclaw doctor` and observe preview warnings.
  3. Run `openclaw doctor --fix`.

  ### Expected

  - Doctor warns about stale plugin refs and `--fix` removes them from both surfaces.

  ### Actual

  - Before this change, doctor did not prune those stale refs.

  ## Evidence

  Attach at least one:

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: targeted tests for stale plugin scan/repair, preview warnings, and repair sequencing all pass.
  - Edge cases checked: valid plugin refs are preserved; both stale `plugins.allow` and stale `plugins.entries` refs are handled in the same repair flow.
  - What you did **not** verify: full manual CLI run against a live `~/.openclaw/openclaw.json`; broader `pnpm test` / `pnpm check` were not run.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (`Yes/No`) Yes
  - Config/env changes? (`Yes/No`) No
  - Migration needed? (`Yes/No`) No
  - If yes, exact upgrade steps: N/A

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: revert this PR or stop using `openclaw doctor --fix` for stale plugin cleanup.
  - Files/config to restore: restore removed ids in `plugins.allow` / `plugins.entries` if they were intentionally kept.
  - Known bad symptoms reviewers should watch for: doctor removing a valid plugin id that should still be recognized by manifest discovery.

  ## Risks and Mitigations

  List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: a plugin could be pruned if manifest discovery unexpectedly fails and makes a valid plugin look stale.
    - Mitigation: detection uses the same manifest-registry source doctor/config already relies on, preview warnings surface the exact ids before repair, and focused tests lock in that known plugin ids are preserved.
