### PR TITLE
fix(msteams): throttle typing indicator to prevent 429 rate limit spiral

### DIFF
--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -51,26 +51,49 @@ export function createMSTeamsReplyDispatcher(params: {
    * First tries the live turn context (cheapest path).  When the context has
    * been revoked (debounced messages) we fall back to proactive messaging via
    * the stored conversation reference so the user still sees the "…" bubble.
+   *
+   * Throttled to at most once every 3 seconds and suppressed after a 429 for
+   * 30 seconds to avoid hitting Teams API rate limits during long agent runs.
    */
+  let lastTypingSentAt = 0;
+  let typingSuppressedUntil = 0;
+  let typingStopped = false;
+  const TYPING_MIN_INTERVAL_MS = 3_000;
+  const TYPING_BACKOFF_MS = 30_000;
+
   const sendTypingIndicator = async () => {
-    await withRevokedProxyFallback({
-      run: async () => {
-        await params.context.sendActivity({ type: "typing" });
-      },
-      onRevoked: async () => {
-        const baseRef = buildConversationReference(params.conversationRef);
-        await params.adapter.continueConversation(
-          params.appId,
-          { ...baseRef, activityId: undefined },
-          async (ctx) => {
-            await ctx.sendActivity({ type: "typing" });
-          },
-        );
-      },
-      onRevokedLog: () => {
-        params.log.debug?.("turn context revoked, sending typing via proactive messaging");
-      },
-    });
+    if (typingStopped) return;
+    const now = Date.now();
+    if (now < typingSuppressedUntil) return;
+    if (now - lastTypingSentAt < TYPING_MIN_INTERVAL_MS) return;
+    lastTypingSentAt = now;
+
+    try {
+      await withRevokedProxyFallback({
+        run: async () => {
+          await params.context.sendActivity({ type: "typing" });
+        },
+        onRevoked: async () => {
+          const baseRef = buildConversationReference(params.conversationRef);
+          await params.adapter.continueConversation(
+            params.appId,
+            { ...baseRef, activityId: undefined },
+            async (ctx) => {
+              await ctx.sendActivity({ type: "typing" });
+            },
+          );
+        },
+        onRevokedLog: () => {
+          params.log.debug?.("turn context revoked, sending typing via proactive messaging");
+        },
+      });
+    } catch (err: unknown) {
+      const errStr = String(err);
+      if (errStr.includes("429") || errStr.includes("quota exceeded")) {
+        typingSuppressedUntil = Date.now() + TYPING_BACKOFF_MS;
+        params.log.debug?.(`msteams typing suppressed for ${TYPING_BACKOFF_MS}ms after 429`);
+      }
+    }
   };
 
   const { onModelSelected, typingCallbacks, ...replyPipeline } = createChannelReplyPipeline({
@@ -206,6 +229,7 @@ export function createMSTeamsReplyDispatcher(params: {
   // Wrap markDispatchIdle to flush all accumulated messages before signalling idle.
   // Returns a promise so callers (e.g. onSettled) can await completion.
   const markDispatchIdle = (): Promise<void> => {
+    typingStopped = true;
     return flushPendingMessages()
       .catch((err) => {
         const errMsg = formatUnknownError(err);

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -92,6 +92,8 @@ export function createMSTeamsReplyDispatcher(params: {
       if (errStr.includes("429") || errStr.includes("quota exceeded")) {
         typingSuppressedUntil = Date.now() + TYPING_BACKOFF_MS;
         params.log.debug?.(`msteams typing suppressed for ${TYPING_BACKOFF_MS}ms after 429`);
+      } else {
+        throw err;
       }
     }
   };


### PR DESCRIPTION
During long-running agent sessions (browser automation, complex tool chains), the MS Teams typing indicator fires in a tight loop without any throttle. This quickly hits Teams' API rate limit (HTTP 429 "API calls quota exceeded"), then falls back to proactive messaging which also loops, creating an escalating spiral that blocks message delivery.

## Changes

- **Throttle:** typing indicator fires at most once every 3 seconds
- **429 backoff:** after a 429 error, typing is suppressed for 30 seconds instead of retrying immediately
- **Stop flag:** `typingStopped` is set when `markDispatchIdle()` is called, preventing typing from continuing after the response is sent

## Testing

Tested on a live Gumroad Teams workspace:
- Long-running agent tasks no longer cause 429 spirals
- Typing indicator shows during processing and stops after response
- Messages deliver successfully
- No typing indicator lingering after response is sent

Fixes #53184