### PR TITLE
fix(doctor): honor --fix in non-interactive mode

### DIFF
--- a/src/commands/doctor-gateway-daemon-flow.test.ts
+++ b/src/commands/doctor-gateway-daemon-flow.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDoctorPrompter } from "./doctor-prompter.js";
 
 const service = vi.hoisted(() => ({
   isLoaded: vi.fn(),
@@ -99,6 +100,7 @@ vi.mock("./health.js", () => ({
 describe("maybeRepairGatewayDaemon", () => {
   let maybeRepairGatewayDaemon: typeof import("./doctor-gateway-daemon-flow.js").maybeRepairGatewayDaemon;
   const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
 
   beforeAll(async () => {
     ({ maybeRepairGatewayDaemon } = await import("./doctor-gateway-daemon-flow.js"));
@@ -120,6 +122,11 @@ describe("maybeRepairGatewayDaemon", () => {
   afterEach(() => {
     if (originalPlatformDescriptor) {
       Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+    if (originalUpdateInProgress === undefined) {
+      delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+    } else {
+      process.env.OPENCLAW_UPDATE_IN_PROGRESS = originalUpdateInProgress;
     }
   });
 
@@ -190,5 +197,45 @@ describe("maybeRepairGatewayDaemon", () => {
     );
     expect(sleep).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
+  });
+
+  it("skips gateway install during non-interactive update repairs", async () => {
+    setPlatform("linux");
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    service.isLoaded.mockResolvedValue(false);
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { repair: true, nonInteractive: true },
+      }),
+      options: { deep: false, repair: true, nonInteractive: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+    });
+
+    expect(service.install).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("skips gateway restart during non-interactive update repairs", async () => {
+    setPlatform("linux");
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+
+    await maybeRepairGatewayDaemon({
+      cfg: { gateway: {} },
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      prompter: createDoctorPrompter({
+        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        options: { repair: true, nonInteractive: true },
+      }),
+      options: { deep: false, repair: true, nonInteractive: true },
+      gatewayDetailsMessage: "details",
+      healthOk: false,
+    });
+
+    expect(service.restart).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { createDoctorPrompter } from "./doctor-prompter.js";
 
 const fsMocks = vi.hoisted(() => ({
   realpath: vi.fn(),
@@ -97,6 +98,8 @@ import {
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
 
+const originalStdinIsTTY = process.stdin.isTTY;
+
 function makeDoctorIo() {
   return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 }
@@ -159,6 +162,13 @@ describe("maybeRepairGatewayServiceConfig", () => {
         typeof cfg.gateway?.auth?.token === "string" ? cfg.gateway.auth.token.trim() : undefined;
       const envToken = env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
       return { token: configToken || envToken };
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalStdinIsTTY,
+      configurable: true,
     });
   });
 
@@ -342,6 +352,57 @@ describe("maybeRepairGatewayServiceConfig", () => {
     });
 
     await runRepair({ gateway: {} });
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service entrypoint does not match the current install."),
+      "Gateway service config",
+    );
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+
+  it("repairs entrypoint mismatch in non-interactive fix mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    mocks.readCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/npm/node_modules/openclaw/dist/entry.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      workingDirectory: "/tmp",
+      environment: {},
+    });
+
+    await maybeRepairGatewayServiceConfig(
+      { gateway: {} },
+      "local",
+      makeDoctorIo(),
+      createDoctorPrompter({
+        runtime: makeDoctorIo(),
+        options: {
+          repair: true,
+          nonInteractive: true,
+        },
+      }),
+    );
 
     expect(mocks.note).toHaveBeenCalledWith(
       expect.stringContaining("Gateway service entrypoint does not match the current install."),

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -99,6 +99,7 @@ import {
 } from "./doctor-gateway-services.js";
 
 const originalStdinIsTTY = process.stdin.isTTY;
+const originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
 
 function makeDoctorIo() {
   return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
@@ -170,6 +171,11 @@ describe("maybeRepairGatewayServiceConfig", () => {
       value: originalStdinIsTTY,
       configurable: true,
     });
+    if (originalUpdateInProgress === undefined) {
+      delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+    } else {
+      process.env.OPENCLAW_UPDATE_IN_PROGRESS = originalUpdateInProgress;
+    }
   });
 
   it("treats gateway.auth.token as source of truth for service token repairs", async () => {
@@ -411,6 +417,58 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.install).toHaveBeenCalledTimes(1);
   });
 
+  it("skips service config reinstalls during non-interactive update repairs", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+    mocks.readCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/npm/node_modules/openclaw/dist/entry.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      environment: {},
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: true,
+      issues: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        "/Users/test/Library/npm/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      workingDirectory: "/tmp",
+      environment: {},
+    });
+
+    await maybeRepairGatewayServiceConfig(
+      { gateway: {} },
+      "local",
+      makeDoctorIo(),
+      createDoctorPrompter({
+        runtime: makeDoctorIo(),
+        options: {
+          repair: true,
+          nonInteractive: true,
+        },
+      }),
+    );
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Gateway service entrypoint does not match the current install."),
+      "Gateway service config",
+    );
+    expect(mocks.install).not.toHaveBeenCalled();
+  });
+
   it("treats SecretRef-managed gateway token as non-persisted service state", async () => {
     mocks.readCommand.mockResolvedValue({
       programArguments: gatewayProgramArguments,
@@ -497,6 +555,43 @@ describe("maybeRepairGatewayServiceConfig", () => {
           }),
         );
         expect(mocks.install).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  it("does not persist embedded service tokens during non-interactive update repairs", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+
+    await withEnvAsync(
+      {
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+      },
+      async () => {
+        setupGatewayTokenRepairScenario();
+
+        const cfg: OpenClawConfig = {
+          gateway: {},
+        };
+
+        await maybeRepairGatewayServiceConfig(
+          cfg,
+          "local",
+          makeDoctorIo(),
+          createDoctorPrompter({
+            runtime: makeDoctorIo(),
+            options: {
+              repair: true,
+              nonInteractive: true,
+            },
+          }),
+        );
+
+        expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+        expect(mocks.install).not.toHaveBeenCalled();
       },
     );
   });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -321,7 +321,7 @@ export async function maybeRepairGatewayServiceConfig(
         message: "Overwrite gateway service config with current defaults now?",
         initialValue: Boolean(prompter.shouldForce),
       })
-    : await prompter.confirmRepair({
+    : await prompter.confirmSkipInNonInteractive({
         message: "Update gateway service config to the recommended defaults now?",
         initialValue: true,
       });

--- a/src/commands/doctor-prompter.test.ts
+++ b/src/commands/doctor-prompter.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDoctorPrompter } from "./doctor-prompter.js";
+
+const confirmMock = vi.fn();
+const selectMock = vi.fn();
+
+vi.mock("@clack/prompts", () => ({
+  confirm: (options: unknown) => confirmMock(options),
+  select: (options: unknown) => selectMock(options),
+}));
+
+describe("createDoctorPrompter", () => {
+  const originalStdinIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: originalStdinIsTTY,
+      configurable: true,
+    });
+  });
+
+  it("auto-accepts repairs in non-interactive fix mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+
+    const prompter = createDoctorPrompter({
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      options: {
+        repair: true,
+        nonInteractive: true,
+      },
+    });
+
+    await expect(
+      prompter.confirm({
+        message: "Apply general repair?",
+        initialValue: false,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      prompter.confirmRepair({
+        message: "Repair gateway service config?",
+        initialValue: false,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      prompter.confirmSkipInNonInteractive({
+        message: "Repair launch agent bootstrap?",
+        initialValue: false,
+      }),
+    ).resolves.toBe(true);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("requires --force for aggressive repairs in non-interactive fix mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+
+    const prompter = createDoctorPrompter({
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      options: {
+        repair: true,
+        nonInteractive: true,
+      },
+    });
+
+    await expect(
+      prompter.confirmAggressive({
+        message: "Overwrite gateway service config?",
+        initialValue: true,
+      }),
+    ).resolves.toBe(false);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-accepts aggressive repairs only with --force in non-interactive fix mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+
+    const prompter = createDoctorPrompter({
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      options: {
+        repair: true,
+        force: true,
+        nonInteractive: true,
+      },
+    });
+
+    await expect(
+      prompter.confirmAggressive({
+        message: "Overwrite gateway service config?",
+        initialValue: false,
+      }),
+    ).resolves.toBe(true);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/doctor-prompter.test.ts
+++ b/src/commands/doctor-prompter.test.ts
@@ -11,6 +11,7 @@ vi.mock("@clack/prompts", () => ({
 
 describe("createDoctorPrompter", () => {
   const originalStdinIsTTY = process.stdin.isTTY;
+  const originalUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
 
   afterEach(() => {
     vi.resetAllMocks();
@@ -18,6 +19,11 @@ describe("createDoctorPrompter", () => {
       value: originalStdinIsTTY,
       configurable: true,
     });
+    if (originalUpdateInProgress === undefined) {
+      delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+    } else {
+      process.env.OPENCLAW_UPDATE_IN_PROGRESS = originalUpdateInProgress;
+    }
   });
 
   it("auto-accepts repairs in non-interactive fix mode", async () => {
@@ -80,6 +86,40 @@ describe("createDoctorPrompter", () => {
     await expect(
       prompter.confirmAggressive({
         message: "Overwrite gateway service config?",
+        initialValue: true,
+      }),
+    ).resolves.toBe(false);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps skip-in-non-interactive prompts disabled during update-mode repairs", async () => {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: false,
+      configurable: true,
+    });
+    process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+
+    const prompter = createDoctorPrompter({
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      options: {
+        repair: true,
+        nonInteractive: true,
+      },
+    });
+
+    await expect(
+      prompter.confirmRepair({
+        message: "Repair gateway service config?",
+        initialValue: false,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      prompter.confirmSkipInNonInteractive({
+        message: "Restart gateway service now?",
         initialValue: true,
       }),
     ).resolves.toBe(false);

--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -36,11 +36,11 @@ export function createDoctorPrompter(params: {
 
   const canPrompt = isTty && !yes && !nonInteractive;
   const confirmDefault = async (p: Parameters<typeof confirm>[0]) => {
-    if (nonInteractive) {
-      return false;
-    }
     if (shouldRepair) {
       return true;
+    }
+    if (nonInteractive) {
+      return false;
     }
     if (!canPrompt) {
       return Boolean(p.initialValue ?? false);
@@ -56,18 +56,13 @@ export function createDoctorPrompter(params: {
 
   return {
     confirm: confirmDefault,
-    confirmRepair: async (p) => {
-      if (nonInteractive) {
-        return false;
-      }
-      return confirmDefault(p);
-    },
+    confirmRepair: confirmDefault,
     confirmAggressive: async (p) => {
-      if (nonInteractive) {
-        return false;
-      }
       if (shouldRepair && shouldForce) {
         return true;
+      }
+      if (nonInteractive) {
+        return false;
       }
       if (shouldRepair && !shouldForce) {
         return false;
@@ -83,15 +78,7 @@ export function createDoctorPrompter(params: {
         params.runtime,
       );
     },
-    confirmSkipInNonInteractive: async (p) => {
-      if (nonInteractive) {
-        return false;
-      }
-      if (shouldRepair) {
-        return true;
-      }
-      return confirmDefault(p);
-    },
+    confirmSkipInNonInteractive: confirmDefault,
     select: async <T>(p: Parameters<typeof select>[0], fallback: T) => {
       if (!canPrompt || shouldRepair) {
         return fallback;

--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -1,4 +1,5 @@
 import { confirm, select } from "@clack/prompts";
+import { isTruthyEnvValue } from "../infra/env.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { stylePromptHint, stylePromptMessage } from "../terminal/prompt-style.js";
 import { guardCancel } from "./onboard-helpers.js";
@@ -33,6 +34,7 @@ export function createDoctorPrompter(params: {
   const shouldForce = params.options.force === true;
   const isTty = Boolean(process.stdin.isTTY);
   const nonInteractive = requestedNonInteractive || (!isTty && !yes);
+  const updateInProgress = isTruthyEnvValue(process.env.OPENCLAW_UPDATE_IN_PROGRESS);
 
   const canPrompt = isTty && !yes && !nonInteractive;
   const confirmDefault = async (p: Parameters<typeof confirm>[0]) => {
@@ -78,7 +80,12 @@ export function createDoctorPrompter(params: {
         params.runtime,
       );
     },
-    confirmSkipInNonInteractive: confirmDefault,
+    confirmSkipInNonInteractive: async (p) => {
+      if (updateInProgress && nonInteractive) {
+        return false;
+      }
+      return confirmDefault(p);
+    },
     select: async <T>(p: Parameters<typeof select>[0], fallback: T) => {
       if (!canPrompt || shouldRepair) {
         return fallback;

--- a/src/commands/doctor.e2e-harness.ts
+++ b/src/commands/doctor.e2e-harness.ts
@@ -93,6 +93,19 @@ export const findExtraGatewayServices = vi.fn().mockResolvedValue([]) as unknown
 export const renderGatewayServiceCleanupHints = vi
   .fn()
   .mockReturnValue(["cleanup"]) as unknown as MockFn;
+export const auditGatewayServiceConfig = vi
+  .fn()
+  .mockResolvedValue({ ok: true, issues: [] }) as unknown as MockFn;
+export const buildGatewayInstallPlan = vi.mocked(
+  vi.fn().mockResolvedValue({
+    programArguments: ["node", "cli", "gateway", "--port", "18789"],
+    workingDirectory: "/tmp",
+    environment: {},
+  }),
+) as unknown as MockFn;
+export const resolveGatewayAuthTokenForService = vi
+  .fn()
+  .mockResolvedValue({ token: undefined }) as unknown as MockFn;
 export const resolveGatewayProgramArguments = vi.fn().mockResolvedValue({
   programArguments: ["node", "cli", "gateway", "--port", "18789"],
 }) as unknown as MockFn;
@@ -101,6 +114,7 @@ export const serviceIsLoaded = vi.fn().mockResolvedValue(false) as unknown as Mo
 export const serviceStop = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
 export const serviceRestart = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
 export const serviceUninstall = vi.fn().mockResolvedValue(undefined) as unknown as MockFn;
+export const serviceReadCommand = vi.fn().mockResolvedValue(null) as unknown as MockFn;
 export const callGateway = vi
   .fn()
   .mockRejectedValue(new Error("gateway closed")) as unknown as MockFn;
@@ -207,8 +221,35 @@ vi.mock("../daemon/inspect.js", () => ({
   renderGatewayServiceCleanupHints,
 }));
 
+vi.mock("../daemon/service-audit.js", () => ({
+  auditGatewayServiceConfig,
+  needsNodeRuntimeMigration: vi.fn(() => false),
+  readEmbeddedGatewayToken: (
+    command: {
+      environment?: Record<string, string>;
+      environmentValueSources?: Record<string, "inline" | "file">;
+    } | null,
+  ) =>
+    command?.environmentValueSources?.OPENCLAW_GATEWAY_TOKEN === "file"
+      ? undefined
+      : command?.environment?.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined,
+  SERVICE_AUDIT_CODES: {
+    gatewayEntrypointMismatch: "gateway-entrypoint-mismatch",
+    gatewayTokenMismatch: "gateway-token-mismatch",
+  },
+}));
+
 vi.mock("../daemon/program-args.js", () => ({
   resolveGatewayProgramArguments,
+}));
+
+vi.mock("./daemon-install-helpers.js", () => ({
+  buildGatewayInstallPlan,
+  gatewayInstallErrorHint: vi.fn(() => "hint"),
+}));
+
+vi.mock("./doctor-gateway-auth-token.js", () => ({
+  resolveGatewayAuthTokenForService,
 }));
 
 vi.mock("../gateway/call.js", async (importOriginal) => {
@@ -250,7 +291,7 @@ vi.mock("../daemon/service.js", () => ({
     stop: serviceStop,
     restart: serviceRestart,
     isLoaded: serviceIsLoaded,
-    readCommand: vi.fn(),
+    readCommand: serviceReadCommand,
     readRuntime: vi.fn().mockResolvedValue({ status: "running" }),
   }),
 }));
@@ -390,6 +431,13 @@ beforeEach(() => {
   uninstallLegacyGatewayServices.mockReset().mockResolvedValue([]);
   findExtraGatewayServices.mockReset().mockResolvedValue([]);
   renderGatewayServiceCleanupHints.mockReset().mockReturnValue(["cleanup"]);
+  auditGatewayServiceConfig.mockReset().mockResolvedValue({ ok: true, issues: [] });
+  buildGatewayInstallPlan.mockReset().mockResolvedValue({
+    programArguments: ["node", "cli", "gateway", "--port", "18789"],
+    workingDirectory: "/tmp",
+    environment: {},
+  });
+  resolveGatewayAuthTokenForService.mockReset().mockResolvedValue({ token: undefined });
   resolveGatewayProgramArguments.mockReset().mockResolvedValue({
     programArguments: ["node", "cli", "gateway", "--port", "18789"],
   });
@@ -398,6 +446,7 @@ beforeEach(() => {
   serviceStop.mockReset().mockResolvedValue(undefined);
   serviceRestart.mockReset().mockResolvedValue(undefined);
   serviceUninstall.mockReset().mockResolvedValue(undefined);
+  serviceReadCommand.mockReset().mockResolvedValue(null);
   callGateway.mockReset().mockRejectedValue(new Error("gateway closed"));
   runStartupMatrixMigration.mockReset().mockResolvedValue(undefined);
 

--- a/src/commands/doctor.update-repair-no-restart.test.ts
+++ b/src/commands/doctor.update-repair-no-restart.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  confirm,
+  createDoctorRuntime,
+  mockDoctorConfigSnapshot,
+  serviceInstall,
+  serviceIsLoaded,
+  serviceRestart,
+} from "./doctor.e2e-harness.js";
+
+let doctorCommand: typeof import("./doctor.js").doctorCommand;
+let healthCommand: typeof import("./health.js").healthCommand;
+
+describe("doctor command update-mode repairs", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ doctorCommand } = await import("./doctor.js"));
+    ({ healthCommand } = await import("./health.js"));
+  });
+
+  it("skips gateway installs during non-interactive update repairs", async () => {
+    mockDoctorConfigSnapshot();
+
+    vi.mocked(healthCommand).mockRejectedValueOnce(new Error("gateway closed"));
+
+    serviceIsLoaded.mockResolvedValueOnce(false);
+    serviceInstall.mockClear();
+    serviceRestart.mockClear();
+    confirm.mockClear();
+
+    await doctorCommand(createDoctorRuntime(), { repair: true, nonInteractive: true });
+
+    expect(serviceInstall).not.toHaveBeenCalled();
+    expect(serviceRestart).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("skips gateway restarts during non-interactive update repairs", async () => {
+    mockDoctorConfigSnapshot();
+
+    vi.mocked(healthCommand).mockRejectedValueOnce(new Error("gateway closed"));
+
+    serviceIsLoaded.mockResolvedValueOnce(true);
+    serviceRestart.mockClear();
+    confirm.mockClear();
+
+    await doctorCommand(createDoctorRuntime(), { repair: true, nonInteractive: true });
+
+    expect(serviceRestart).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/doctor.update-repair-no-restart.test.ts
+++ b/src/commands/doctor.update-repair-no-restart.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  auditGatewayServiceConfig,
+  buildGatewayInstallPlan,
   confirm,
   createDoctorRuntime,
   mockDoctorConfigSnapshot,
+  serviceReadCommand,
   serviceInstall,
   serviceIsLoaded,
   serviceRestart,
+  writeConfigFile,
 } from "./doctor.e2e-harness.js";
 
 let doctorCommand: typeof import("./doctor.js").doctorCommand;
@@ -46,6 +50,46 @@ describe("doctor command update-mode repairs", () => {
 
     await doctorCommand(createDoctorRuntime(), { repair: true, nonInteractive: true });
 
+    expect(serviceRestart).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("skips gateway service-config reinstalls and token persistence during non-interactive update repairs", async () => {
+    mockDoctorConfigSnapshot({ config: { gateway: {} }, parsed: { gateway: {} } });
+
+    vi.mocked(healthCommand).mockRejectedValueOnce(new Error("gateway closed"));
+
+    serviceIsLoaded.mockResolvedValueOnce(false);
+    serviceReadCommand.mockResolvedValueOnce({
+      programArguments: ["node", "cli", "gateway", "--port", "18789"],
+      environment: {
+        OPENCLAW_GATEWAY_TOKEN: "stale-token",
+      },
+    });
+    auditGatewayServiceConfig.mockResolvedValueOnce({
+      ok: false,
+      issues: [
+        {
+          code: "gateway-token-mismatch",
+          message: "Gateway service OPENCLAW_GATEWAY_TOKEN does not match gateway.auth.token",
+          level: "recommended",
+        },
+      ],
+    });
+    buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: ["node", "cli", "gateway", "--port", "18789"],
+      workingDirectory: "/tmp",
+      environment: {},
+    });
+    serviceInstall.mockClear();
+    serviceRestart.mockClear();
+    writeConfigFile.mockClear();
+    confirm.mockClear();
+
+    await doctorCommand(createDoctorRuntime(), { repair: true, nonInteractive: true });
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(serviceInstall).not.toHaveBeenCalled();
     expect(serviceRestart).not.toHaveBeenCalled();
     expect(confirm).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- make doctor repair prompts honor `--fix` even when running in non-interactive mode
- keep aggressive rewrites gated behind `--force`
- add direct regression coverage for both the prompter contract and gateway service repair flow

## Why
Issue #53169 reports an upgrade path where a stale gateway service entrypoint (`entry.js` -> `index.js`) is detected by doctor but not repaired. The core regression here is that `createDoctorPrompter` returned `false` for `confirmRepair` / `confirmSkipInNonInteractive` whenever `nonInteractive` was set, even under explicit `--fix` mode. That lets doctor find the problem but skip the actual repair step.

## Validation
- `pnpm exec oxfmt --check src/commands/doctor-prompter.ts src/commands/doctor-prompter.test.ts src/commands/doctor-gateway-services.test.ts`
- `pnpm exec oxlint --type-aware src/commands/doctor-prompter.ts src/commands/doctor-prompter.test.ts src/commands/doctor-gateway-services.test.ts`
- `pnpm exec vitest --run src/commands/doctor-prompter.test.ts src/commands/doctor-gateway-services.test.ts`
- repeated the same focused validation a second time

Fixes #53169.
