### PR TITLE
fix(ollama): send think=false for thinking models when thinking is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/inbound claims: pass full inbound attachment arrays through `inbound_claim` hook metadata while keeping the legacy singular media attachment fields for compatibility. (#55452) Thanks @huntharo.
 - Plugins/Matrix: preserve sender filenames for inbound media by forwarding `originalFilename` to `saveMediaBuffer`. (#55692) thanks @esrehmki.
 - Matrix/mentions: recognize `matrix.to` mentions whose visible label uses the bot's room display name, so `requireMention: true` rooms respond correctly in modern Matrix clients. (#55393) thanks @nickludlam.
+- Ollama/thinking off: route `thinkingLevel=off` through the live Ollama extension request path so thinking-capable Ollama models now receive top-level `think: false` instead of silently generating hidden reasoning tokens. (#53200) Thanks @BruceMacD.
 
 ## 2026.3.24
 

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -257,6 +257,7 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  think?: boolean;
 }
 
 interface OllamaChatMessage {
@@ -652,6 +653,14 @@ export function createOllamaStreamFn(
           ollamaOptions.num_predict = options.maxTokens;
         }
 
+        const body: OllamaChatRequest = {
+          model: model.id,
+          messages: ollamaMessages,
+          stream: true,
+          ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
+          options: ollamaOptions,
+        };
+        options?.onPayload?.(body, model);
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
           ...defaultHeaders,
@@ -667,13 +676,7 @@ export function createOllamaStreamFn(
         const response = await fetch(chatUrl, {
           method: "POST",
           headers,
-          body: JSON.stringify({
-            model: model.id,
-            messages: ollamaMessages,
-            stream: true,
-            ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
-            options: ollamaOptions,
-          } satisfies OllamaChatRequest),
+          body: JSON.stringify(body),
           signal: options?.signal,
         });
 

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -7,6 +7,7 @@ import {
   parseNdjsonStream,
   resolveOllamaBaseUrlForRun,
 } from "../plugin-sdk/ollama.js";
+import { applyExtraParamsToAgent } from "./pi-embedded-runner/extra-params.js";
 
 describe("convertToOllamaMessages", () => {
   it("converts user text messages", () => {
@@ -642,6 +643,53 @@ describe("createOllamaStreamFn", () => {
         };
         expect(requestBody.options.num_ctx).toBe(131072);
         expect(requestBody.options.num_predict).toBe(123);
+      },
+    );
+  });
+
+  it("serializes top-level think=false when thinking is off", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const agent = {
+          streamFn: createOllamaStreamFn("http://ollama-host:11434"),
+        };
+        applyExtraParamsToAgent(agent, undefined, "ollama", "qwen3.5:9b", undefined, "off");
+
+        const stream = await Promise.resolve(
+          agent.streamFn?.(
+            {
+              id: "qwen3.5:9b",
+              api: "ollama",
+              provider: "ollama",
+              contextWindow: 131072,
+            } as never,
+            {
+              messages: [{ role: "user", content: "hello" }],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        if (!stream) {
+          throw new Error("Expected Ollama streamFn");
+        }
+
+        await collectStreamEvents(stream);
+
+        const [, requestInit] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+        if (typeof requestInit.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(requestInit.body) as {
+          think?: boolean;
+          options?: { think?: boolean };
+        };
+        expect(requestBody.think).toBe(false);
+        expect(requestBody.options?.think).toBeUndefined();
       },
     );
   });

--- a/src/agents/pi-embedded-runner/extra-params.ollama.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ollama.test.ts
@@ -1,0 +1,83 @@
+import type { Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { runExtraParamsCase } from "./extra-params.test-support.js";
+
+vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@mariozechner/pi-ai")>();
+  return {
+    ...original,
+    streamSimple: vi.fn(() => ({
+      push: vi.fn(),
+      result: vi.fn(),
+    })),
+  };
+});
+
+describe("extra-params: Ollama thinking payload compatibility", () => {
+  it("injects top-level think=false when thinkingLevel is off", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "ollama",
+      applyModelId: "qwen3.5:9b",
+      model: {
+        api: "ollama",
+        provider: "ollama",
+        id: "qwen3.5:9b",
+      } as unknown as Model<"openai-completions">,
+      thinkingLevel: "off",
+      payload: {
+        model: "qwen3.5:9b",
+        messages: [],
+        stream: true,
+        options: {
+          num_ctx: 65536,
+        },
+      },
+    }).payload as Record<string, unknown>;
+
+    // think must be top-level, not nested under options
+    expect(payload.think).toBe(false);
+    expect((payload.options as Record<string, unknown>).think).toBeUndefined();
+  });
+
+  it("does not inject think=false for non-ollama models", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5.4",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-5.4",
+      } as unknown as Model<"openai-completions">,
+      thinkingLevel: "off",
+      payload: {
+        model: "gpt-5.4",
+        messages: [],
+      },
+    }).payload as Record<string, unknown>;
+
+    expect(payload.think).toBeUndefined();
+  });
+
+  it("does not inject think=false when thinkingLevel is not off", () => {
+    const payload = runExtraParamsCase({
+      applyProvider: "ollama",
+      applyModelId: "qwen3.5:9b",
+      model: {
+        api: "ollama",
+        provider: "ollama",
+        id: "qwen3.5:9b",
+      } as unknown as Model<"openai-completions">,
+      thinkingLevel: "high",
+      payload: {
+        model: "qwen3.5:9b",
+        messages: [],
+        stream: true,
+        options: {
+          num_ctx: 65536,
+        },
+      },
+    }).payload as Record<string, unknown>;
+
+    expect(payload.think).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.test-support.ts
+++ b/src/agents/pi-embedded-runner/extra-params.test-support.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import type { ThinkLevel } from "../../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 
@@ -19,7 +20,7 @@ type RunExtraParamsCaseParams<
   model: Model<TApi>;
   options?: SimpleStreamOptions;
   payload: TPayload;
-  thinkingLevel?: "minimal" | "low" | "medium" | "high";
+  thinkingLevel?: ThinkLevel;
 };
 
 export function runExtraParamsCase<

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -357,6 +357,10 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createSiliconFlowThinkingWrapper(agent.streamFn);
   }
 
+  if (thinkingLevel === "off") {
+    agent.streamFn = createOllamaThinkingOffWrapper(agent.streamFn);
+  }
+
   agent.streamFn = createAnthropicToolPayloadCompatibilityWrapper(agent.streamFn, {
     config: cfg,
     workspaceDir,
@@ -454,4 +458,23 @@ export function applyExtraParamsToAgent(
   }
 
   return { effectiveExtraParams };
+}
+
+function createOllamaThinkingOffWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "ollama") {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload, payloadModel) => {
+        if (payload && typeof payload === "object") {
+          (payload as Record<string, unknown>).think = false;
+        }
+        return originalOnPayload?.(payload, payloadModel);
+      },
+    });
+  };
 }


### PR DESCRIPTION
## Summary

- **Problem:** When `thinkingLevel` is `off`, OpenClaw never sends `think: false` in the Ollama `/api/chat` request body. Ollama defaults to `think: true` for thinking-capable models, so they continue generating thinking tokens that the response parser discards. This wastes tokens and in the case of some models which behave badly it may produce empty responses.
- **Why it matters:** All thinking-capable Ollama models (qwen3.5, kimi-k2.5, glm-5, etc.) would continue to think silently when thinking was off, delaying response.
- **What changed:** (1) Wire `onPayload` into `createOllamaStreamFn` so payload wrappers can mutate the request body before serialization. (2) Add an Ollama-specific wrapper in `extra-params.ts` that sets top-level `think: false` when `thinkingLevel === "off"`. (3) Regression tests covering the payload injection, non-Ollama passthrough, and non-off passthrough. (4) Widen test-support `thinkingLevel` type to use the canonical `ThinkLevel` union.
- **What did NOT change (scope boundary):** Response-side parsing (`buildAssistantMessage`) is untouched. No changes to other providers. No new files beyond the test.

**Note:** @SnowSky1 has been added as a collaborator. This builds on their work in #50741 but aims to be as minimal as possible. Their PR had a bug where `think` was nested under `options` instead of being set as a top-level request body field where Ollama expects it.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #46680
- Closes #50702
- Closes #50712
- Related #50741
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** The Ollama stream path (`createOllamaStreamFn`) never called `onPayload`, so payload wrappers had no way to mutate the request body. Additionally, no wrapper existed to map `thinkingLevel=off` to Ollama's native `think: false` parameter. Other thinking-aware providers (SiliconFlow, Moonshot, Google) have a dedicated wrapper already.
- **Prior context:** The Ollama native stream path was added in #11828. Provider-specific thinking wrappers were added incrementally for SiliconFlow, Moonshot/Kimi, and Google, but Ollama was never wired up.
- **If unknown, what was ruled out:** N/A, root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/pi-embedded-runner/extra-params.ollama.test.ts`
- **Scenario the test should lock in:** When `thinkingLevel=off` and `model.api=ollama`, the request payload must have top-level `think: false`. Non-Ollama models and non-off thinking levels must not be affected.
- **Why this is the smallest reliable guardrail:** The test exercises the wrapper through `applyExtraParamsToAgent` and asserts the final payload shape.
- **Existing test that already covers this (if any):** None.

## User-visible / Behavior Changes

Ollama thinking-capable models now return actual content immediately when thinking is set to off. No config changes needed.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same Ollama `/api/chat` endpoint, one additional field in body)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, Ollama 0.18.0+
- Model/provider: `qwen3.5:cloud` via Ollama
- Integration/channel (if any): N/A
- Relevant config (redacted): `thinking: "off"`

### Steps

1. Run Ollama with a thinking-capable model (e.g. `qwen3.5:cloud`)
2. Set thinking to off (`/think off`)
3. Send a message

### Expected

- Model returns response without thinking, user sees response

### Actual (before fix)

- Model does think, but this is not clear to the user

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- **Verified scenarios:** Confirmed via debug logging in an ollama server that `think: false` is received only when `think` is off. Ran `pnpm test`. Typecheck and all lint/format checks green.
- **Edge cases checked:** Non-Ollama models unaffected (test). Thinking levels other than off unaffected (end-to-end). 
- **What you did not verify:** 

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- **How to disable/revert this change quickly:** Revert the single commit; the wrapper is guarded by `model.api !== "ollama"` so only Ollama is affected.
- **Files/config to restore:** `src/agents/ollama-stream.ts`, `src/agents/pi-embedded-runner/extra-params.ts`
- **Known bad symptoms reviewers should watch for:**

## Risks and Mitigations

- **Risk:** Older Ollama versions (pre-0.18.0) may not recognize the `think` field.
  - **Mitigation:** Ollama ignores unknown top-level fields; verified no error on older versions. The field is only injected when `thinkingLevel=off`, which is already a no-op for non-thinking models.
