### PR TITLE
fix(ui): resolve model provider from catalog instead of stale session default

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -536,9 +536,19 @@ function resolveModelOverrideValue(state: AppViewState): string {
     return "";
   }
   // No local override recorded yet — fall back to server data.
-  // Include provider prefix so the value matches option keys (provider/model).
+  // Use the bare model name and resolve provider from the catalog rather than
+  // trusting the session's modelProvider, which may be the session default and
+  // not the model's actual provider (e.g. "zai" for a "deepseek-chat" model).
   const activeRow = resolveActiveSessionRow(state);
   if (activeRow && typeof activeRow.model === "string" && activeRow.model.trim()) {
+    const rawOverride = createChatModelOverride(activeRow.model.trim());
+    if (rawOverride) {
+      const normalized = normalizeChatModelOverrideValue(rawOverride, state.chatModelCatalog ?? []);
+      if (normalized) {
+        return normalized;
+      }
+    }
+    // Fallback: use server-provided provider if catalog lookup fails.
     return resolveServerChatModelValue(activeRow.model, activeRow.modelProvider);
   }
   return "";
@@ -546,7 +556,18 @@ function resolveModelOverrideValue(state: AppViewState): string {
 
 function resolveDefaultModelValue(state: AppViewState): string {
   const defaults = state.sessionsResult?.defaults;
-  return resolveServerChatModelValue(defaults?.model, defaults?.modelProvider);
+  const model = defaults?.model;
+  if (typeof model !== "string" || !model.trim()) {
+    return "";
+  }
+  const rawOverride = createChatModelOverride(model.trim());
+  if (rawOverride) {
+    const normalized = normalizeChatModelOverrideValue(rawOverride, state.chatModelCatalog ?? []);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return resolveServerChatModelValue(model, defaults?.modelProvider);
 }
 
 function buildChatModelOptions(

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -16,7 +16,7 @@ import {
   isSubagentSessionKey,
   parseAgentSessionKey,
 } from "../../../../src/routing/session-key.js";
-import { createChatModelOverride, resolveServerChatModelValue } from "../chat-model-ref.ts";
+import { createChatModelOverride, normalizeChatModelOverrideValue, resolveServerChatModelValue } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import type {
   AgentsListResult,
@@ -155,10 +155,12 @@ async function executeModel(
       key: sessionKey,
       model: args.trim(),
     });
-    const resolvedValue = resolveServerChatModelValue(
-      patched.resolved?.model ?? args.trim(),
-      patched.resolved?.modelProvider,
-    );
+    const patchedModel = patched.resolved?.model ?? args.trim();
+    const rawOverride = createChatModelOverride(patchedModel.trim());
+    const resolvedValue = rawOverride
+      ? (normalizeChatModelOverrideValue(rawOverride, state.chatModelCatalog ?? []) ||
+         resolveServerChatModelValue(patchedModel, patched.resolved?.modelProvider))
+      : resolveServerChatModelValue(patchedModel, patched.resolved?.modelProvider);
     return {
       content: `Model set to \`${args.trim()}\`.`,
       action: "refresh",


### PR DESCRIPTION
lobster-biscuit

Closes #53031
Also fixes #52173, #52482, #51306, #51334, #51139, #51608, #50585, #51809, #51824

## Problem

When switching models in the Control UI, the model picker sends the **wrong provider prefix**. For example, selecting DeepSeek from a session running on ZAI produces `zai/deepseek-chat` instead of `deepseek/deepseek-chat` — causing "model not allowed" errors.

This is the root cause behind 9+ independent bug reports across different provider combinations (ZAI/DeepSeek, Ollama/Moonshot, MiniMax/Kimi, etc.).

## Root cause

Three call sites use `resolveServerChatModelValue(model, modelProvider)` which blindly prepends the session's current provider to the bare model name:

1. `ui/src/ui/app-render.helpers.ts:542` — active session model display
2. `ui/src/ui/app-render.helpers.ts:549` — default model display
3. `ui/src/ui/chat/slash-command-executor.ts:158` — /model slash command

The `modelProvider` from the server reflects the **previous** model's provider, not the newly selected model's provider.

## User impact

Every user who switches between models from different providers in the Control UI gets "model not allowed" errors. Affects all multi-provider setups.

## Fix

For bare model names (no `/`), create a raw `ChatModelOverride` and resolve the correct provider through `normalizeChatModelOverrideValue()`, which looks up the model in the catalog and returns the catalog's provider. Falls back to server-provided provider only if catalog lookup fails.

All 3 call sites are fixed. 2 files, +30/-7.

## How to verify

1. Configure 2+ providers (e.g. ZAI + DeepSeek)
2. Start a session with one provider's model
3. Switch to another provider's model via UI dropdown
4. Before: "model not allowed". After: switches correctly.

## Tests

`chat-model-ref.test.ts` covers `normalizeChatModelOverrideValue` catalog lookup. The fix routes through this existing tested path. No new test needed — the functions are correct, only the call sites were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)