### PR TITLE
fix(line): pre-export clashing symbols to prevent jiti TypeError on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Doctor/plugins: make `openclaw doctor --fix` remove stale `plugins.allow` and `plugins.entries` refs left behind after plugin removal. Thanks @sallyom
 - Agents/replay: canonicalize malformed assistant transcript content before session-history sanitization so legacy or corrupted assistant turns stop crashing Pi replay and subagent recovery paths.
 - Infra/exec trust: preserve shell-multiplexer wrapper binaries for policy checks without breaking approved-command reconstruction, so BusyBox/ToyBox allowlist and audit flows bind to the real wrapper while execution plans stay coherent. (#53134) Thanks @vincentkoc.
+- LINE/runtime-api: pre-export overlapping runtime symbols before the `line-runtime` star export so jiti no longer throws `TypeError: Cannot redefine property` on startup. (#53221) Thanks @Drickon.
 
 ## 2026.3.23
 

--- a/extensions/line/index.test.ts
+++ b/extensions/line/index.test.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { createJiti } from "jiti";
+import { describe, expect, it } from "vitest";
+
+describe("line runtime api", () => {
+  it("loads through Jiti without duplicate export errors", () => {
+    const runtimeApiPath = path.join(process.cwd(), "extensions", "line", "runtime-api.ts");
+    const jiti = createJiti(import.meta.url, {
+      fsCache: false,
+      moduleCache: false,
+      tryNative: false,
+    });
+
+    expect(jiti(runtimeApiPath)).toMatchObject({
+      buildTemplateMessageFromPayload: expect.any(Function),
+      downloadLineMedia: expect.any(Function),
+      isSenderAllowed: expect.any(Function),
+      probeLineBot: expect.any(Function),
+      pushMessageLine: expect.any(Function),
+    });
+  }, 240_000);
+});

--- a/extensions/line/index.test.ts
+++ b/extensions/line/index.test.ts
@@ -1,24 +1,63 @@
+import { execFileSync } from "node:child_process";
 import path from "node:path";
-import { createJiti } from "jiti";
 import { describe, expect, it } from "vitest";
 
 describe("line runtime api", () => {
   it("loads through Jiti without duplicate export errors", () => {
-    const runtimeApiPath = path.join(process.cwd(), "extensions", "line", "runtime-api.ts");
-    const jiti = createJiti(path.join(process.cwd(), "openclaw.mjs"), {
-      interopDefault: true,
-      fsCache: false,
-      moduleCache: false,
-      tryNative: false,
-      extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
-    });
+    const root = process.cwd();
+    const runtimeApiPath = path.join(root, "extensions", "line", "runtime-api.ts");
+    const pluginSdkSubpaths = [
+      "core",
+      "channel-config-schema",
+      "reply-runtime",
+      "testing",
+      "channel-contract",
+      "setup",
+      "status-helpers",
+      "line-runtime",
+    ];
+    const script = `
+import path from "node:path";
+import { createJiti } from "jiti";
 
-    expect(jiti(runtimeApiPath)).toMatchObject({
-      buildTemplateMessageFromPayload: expect.any(Function),
-      downloadLineMedia: expect.any(Function),
-      isSenderAllowed: expect.any(Function),
-      probeLineBot: expect.any(Function),
-      pushMessageLine: expect.any(Function),
+const root = ${JSON.stringify(root)};
+const runtimeApiPath = ${JSON.stringify(runtimeApiPath)};
+const alias = Object.fromEntries(
+  ${JSON.stringify(pluginSdkSubpaths)}.map((name) => [
+    "openclaw/plugin-sdk/" + name,
+    path.join(root, "dist", "plugin-sdk", name + ".js"),
+  ]),
+);
+const jiti = createJiti(path.join(root, "openclaw.mjs"), {
+  interopDefault: true,
+  tryNative: false,
+  fsCache: false,
+  moduleCache: false,
+  extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
+  alias,
+});
+const mod = jiti(runtimeApiPath);
+console.log(
+  JSON.stringify({
+    buildTemplateMessageFromPayload: typeof mod.buildTemplateMessageFromPayload,
+    downloadLineMedia: typeof mod.downloadLineMedia,
+    isSenderAllowed: typeof mod.isSenderAllowed,
+    probeLineBot: typeof mod.probeLineBot,
+    pushMessageLine: typeof mod.pushMessageLine,
+  }),
+);
+`;
+
+    const raw = execFileSync(process.execPath, ["--input-type=module", "--eval", script], {
+      cwd: root,
+      encoding: "utf-8",
+    });
+    expect(JSON.parse(raw)).toEqual({
+      buildTemplateMessageFromPayload: "function",
+      downloadLineMedia: "function",
+      isSenderAllowed: "function",
+      probeLineBot: "function",
+      pushMessageLine: "function",
     });
   }, 240_000);
 });

--- a/extensions/line/index.test.ts
+++ b/extensions/line/index.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from "vitest";
 describe("line runtime api", () => {
   it("loads through Jiti without duplicate export errors", () => {
     const runtimeApiPath = path.join(process.cwd(), "extensions", "line", "runtime-api.ts");
-    const jiti = createJiti(import.meta.url, {
+    const jiti = createJiti(path.join(process.cwd(), "openclaw.mjs"), {
+      interopDefault: true,
       fsCache: false,
       moduleCache: false,
       tryNative: false,
+      extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     });
 
     expect(jiti(runtimeApiPath)).toMatchObject({

--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -23,6 +23,34 @@ export {
   setSetupChannelEnabled,
   splitSetupEntries,
 } from "openclaw/plugin-sdk/setup";
+// Pre-export all symbols that src/plugin-sdk/line-runtime.ts re-exports from this
+// extension's source files. These named exports register the symbols in jiti's
+// _exportNames map at transform time. The star re-export below then skips them
+// via the hasOwnProperty guard, preventing a second Object.defineProperty call
+// with configurable:false that would throw TypeError: Cannot redefine property.
+//
+// If src/plugin-sdk/line-runtime.ts gains new re-exports from extension source
+// files, add matching named exports here to keep the two files in sync.
+// See: src/plugin-sdk/line-runtime.ts for the authoritative list.
+export {
+  firstDefined,
+  isSenderAllowed,
+  normalizeAllowFrom,
+  normalizeDmAllowFromWithStore,
+} from "./src/bot-access.js";
+export { downloadLineMedia } from "./src/download.js";
+export { probeLineBot } from "./src/probe.js";
+export { buildTemplateMessageFromPayload } from "./src/template-messages.js";
+export {
+  createQuickReplyItems,
+  pushFlexMessage,
+  pushLocationMessage,
+  pushMessageLine,
+  pushMessagesLine,
+  pushTemplateMessage,
+  pushTextMessageWithQuickReplies,
+  sendMessageLine,
+} from "./src/send.js";
 export * from "openclaw/plugin-sdk/line-runtime";
 
 export * from "./src/accounts.js";


### PR DESCRIPTION
## Problem

`extensions/line/runtime-api.ts` crashes on startup with:

    TypeError: Cannot redefine property: isSenderAllowed

## Root cause

`src/plugin-sdk/line-runtime.ts` re-exports 15 symbols directly from this
extension's source files (bot-access, download, probe, send, template-messages).
`runtime-api.ts` also star-exports those same source files. When jiti
CJS-transforms the barrel, both star-exports call `Object.defineProperty`
for the same property with `configurable: false`. The second call throws.

## Why reordering `export *` does not fix it

jiti's `_exportNames` dedup guard only fires for symbols registered by
named exports. `export *` never populates `_exportNames`, so the guard
never fires regardless of which star-export comes first.

## Fix

Named pre-exports for all 15 symbols that `line-runtime.ts` re-exports
from this extension. Named exports register in `_exportNames` at AST
transform time; the `export * from "openclaw/plugin-sdk/line-runtime"`
star-export then skips them via the `hasOwnProperty` guard.

A comment in the file cross-references `src/plugin-sdk/line-runtime.ts`
as the authoritative list, so future additions stay in sync.

## Related

Same root cause as #50868, #52780, #52891. Same fix pattern as #50919
(which correctly diagnosed the mechanism for Matrix). The Matrix barrel
has since been updated on `main`; this applies the complete fix to LINE.