### PR TITLE
fix(cron): make --tz work with --at for one-shot jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Docs: https://docs.openclaw.ai
 - Agents/replay: canonicalize malformed assistant transcript content before session-history sanitization so legacy or corrupted assistant turns stop crashing Pi replay and subagent recovery paths.
 - Infra/exec trust: preserve shell-multiplexer wrapper binaries for policy checks without breaking approved-command reconstruction, so BusyBox/ToyBox allowlist and audit flows bind to the real wrapper while execution plans stay coherent. (#53134) Thanks @vincentkoc.
 - LINE/runtime-api: pre-export overlapping runtime symbols before the `line-runtime` star export so jiti no longer throws `TypeError: Cannot redefine property` on startup. (#53221) Thanks @Drickon.
+- CLI/cron: make `openclaw cron add|edit --at ... --tz <iana>` honor the requested local wall-clock time for offset-less one-shot datetimes, including DST boundaries, and keep `--tz` rejected for `--every`. (#53224) Thanks @RolfHegr.
+ - Infra/exec trust: preserve shell-multiplexer wrapper binaries for policy checks without breaking approved-command reconstruction, so BusyBox/ToyBox allowlist and audit flows bind to the real wrapper while execution plans stay coherent. (#53134) Thanks @vincentkoc.
+ - LINE/runtime-api: pre-export overlapping runtime symbols before the `line-runtime` star export so jiti no longer throws `TypeError: Cannot redefine property` on startup. (#53221) Thanks @Drickon.
+ - CLI/cron: make `openclaw cron add|edit --at ... --tz <iana>` honor the requested local wall-clock time for offset-less one-shot datetimes, including DST boundaries, and keep `--tz` rejected for `--every`. (#53224) Thanks @RolfHegr.
 
 ## 2026.3.23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,6 @@ Docs: https://docs.openclaw.ai
 - Infra/exec trust: preserve shell-multiplexer wrapper binaries for policy checks without breaking approved-command reconstruction, so BusyBox/ToyBox allowlist and audit flows bind to the real wrapper while execution plans stay coherent. (#53134) Thanks @vincentkoc.
 - LINE/runtime-api: pre-export overlapping runtime symbols before the `line-runtime` star export so jiti no longer throws `TypeError: Cannot redefine property` on startup. (#53221) Thanks @Drickon.
 - CLI/cron: make `openclaw cron add|edit --at ... --tz <iana>` honor the requested local wall-clock time for offset-less one-shot datetimes, including DST boundaries, and keep `--tz` rejected for `--every`. (#53224) Thanks @RolfHegr.
- - Infra/exec trust: preserve shell-multiplexer wrapper binaries for policy checks without breaking approved-command reconstruction, so BusyBox/ToyBox allowlist and audit flows bind to the real wrapper while execution plans stay coherent. (#53134) Thanks @vincentkoc.
- - LINE/runtime-api: pre-export overlapping runtime symbols before the `line-runtime` star export so jiti no longer throws `TypeError: Cannot redefine property` on startup. (#53221) Thanks @Drickon.
- - CLI/cron: make `openclaw cron add|edit --at ... --tz <iana>` honor the requested local wall-clock time for offset-less one-shot datetimes, including DST boundaries, and keep `--tz` rejected for `--every`. (#53224) Thanks @RolfHegr.
 
 ## 2026.3.23
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -363,7 +363,7 @@ Recurring job in a custom persistent session:
 Notes:
 
 - `schedule.kind`: `at` (`at`), `every` (`everyMs`), or `cron` (`expr`, optional `tz`).
-- `schedule.at` accepts ISO 8601 (timezone optional; treated as UTC when omitted).
+- `schedule.at` accepts ISO 8601. Tool/API values without a timezone are treated as UTC; the CLI also accepts `openclaw cron add|edit --at "<offset-less-iso>" --tz <iana>` for local wall-clock one-shots.
 - `everyMs` is milliseconds.
 - `sessionTarget`: `"main"`, `"isolated"`, `"current"`, or `"session:<custom-id>"`.
 - `"current"` is resolved to `"session:<sessionKey>"` at creation time.

--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -107,7 +107,7 @@ Quick rules:
 - `Config path not found: agents.defaults.userTimezone` means the key is unset; heartbeat falls back to host timezone (or `activeHours.timezone` if set).
 - Cron without `--tz` uses gateway host timezone.
 - Heartbeat `activeHours` uses configured timezone resolution (`user`, `local`, or explicit IANA tz).
-- ISO timestamps without timezone are treated as UTC for cron `at` schedules.
+- Cron `at` schedules treat ISO timestamps without timezone as UTC unless you used CLI `--at "<offset-less-iso>" --tz <iana>`.
 
 Common signatures:
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -21,6 +21,9 @@ output internal. `--deliver` remains as a deprecated alias for `--announce`.
 
 Note: one-shot (`--at`) jobs delete after success by default. Use `--keep-after-run` to keep them.
 
+Note: for one-shot CLI jobs, offset-less `--at` datetimes are treated as UTC unless you also pass
+`--tz <iana>`, which interprets that local wall-clock time in the given timezone.
+
 Note: recurring jobs now use exponential retry backoff after consecutive errors (30s → 1m → 5m → 15m → 60m), then return to normal schedule after the next successful run.
 
 Note: `openclaw cron run` now returns as soon as the manual run is queued for execution. Successful responses include `{ ok: true, enqueued: true, runId }`; use `openclaw cron runs --id <job-id>` to follow the eventual outcome.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -614,6 +614,50 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("applies --tz to --at for offset-less datetimes on cron add", async () => {
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "tz-at-test",
+      "--at",
+      "2026-03-23T23:00:00",
+      "--tz",
+      "Europe/Oslo",
+      "--session",
+      "isolated",
+      "--message",
+      "test",
+    ]);
+
+    const params = getGatewayCallParams<{ schedule: { kind: string; at: string } }>("cron.add");
+    // 2026-03-23 is CET (+01:00), so 23:00 Oslo = 22:00 UTC
+    expect(params.schedule.kind).toBe("at");
+    expect(params.schedule.at).toBe("2026-03-23T22:00:00.000Z");
+  });
+
+  it("does not apply --tz when --at already has an offset", async () => {
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "tz-at-offset-test",
+      "--at",
+      "2026-03-23T23:00:00+02:00",
+      "--tz",
+      "Europe/Oslo",
+      "--session",
+      "isolated",
+      "--message",
+      "test",
+    ]);
+
+    const params = getGatewayCallParams<{ schedule: { kind: string; at: string } }>("cron.add");
+    // Explicit +02:00 should be honored, not overridden by --tz
+    expect(params.schedule.kind).toBe("at");
+    expect(params.schedule.at).toBe("2026-03-23T21:00:00.000Z");
+  });
+
   it("sets explicit stagger for cron edit", async () => {
     await runCronCommand(["cron", "edit", "job-1", "--cron", "0 * * * *", "--stagger", "30s"]);
 

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -658,6 +658,27 @@ describe("cron cli", () => {
     expect(params.schedule.at).toBe("2026-03-23T21:00:00.000Z");
   });
 
+  it("applies --tz to --at correctly across DST boundaries on cron add", async () => {
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "tz-at-dst-test",
+      "--at",
+      "2026-03-29T01:30:00",
+      "--tz",
+      "Europe/Oslo",
+      "--session",
+      "isolated",
+      "--message",
+      "test",
+    ]);
+
+    const params = getGatewayCallParams<{ schedule: { kind: string; at: string } }>("cron.add");
+    expect(params.schedule.kind).toBe("at");
+    expect(params.schedule.at).toBe("2026-03-29T00:30:00.000Z");
+  });
+
   it("sets explicit stagger for cron edit", async () => {
     await runCronCommand(["cron", "edit", "job-1", "--cron", "0 * * * *", "--stagger", "30s"]);
 
@@ -683,6 +704,24 @@ describe("cron cli", () => {
 
   it("rejects --exact on edit when existing job is not cron", async () => {
     await expectCronEditWithScheduleLookupExit({ kind: "every", everyMs: 60_000 }, ["--exact"]);
+  });
+
+  it("applies --tz to --at for offset-less datetimes on cron edit", async () => {
+    const patch = await runCronEditAndGetPatch([
+      "--at",
+      "2026-03-23T23:00:00",
+      "--tz",
+      "Europe/Oslo",
+    ]);
+
+    expect(patch?.patch?.schedule).toEqual({
+      kind: "at",
+      at: "2026-03-23T22:00:00.000Z",
+    });
+  });
+
+  it("rejects --tz with --every on cron edit", async () => {
+    await expectCronCommandExit(["cron", "edit", "job-1", "--every", "10m", "--tz", "UTC"]);
   });
 
   it("patches failure alert settings on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -73,7 +73,10 @@ export function registerCronAddCommand(cron: Command) {
       .option("--session <target>", "Session target (main|isolated)")
       .option("--session-key <key>", "Session key for job routing (e.g. agent:my-agent:my-session)")
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)", "now")
-      .option("--at <when>", "Run once at time (ISO) or +duration (e.g. 20m)")
+      .option(
+        "--at <when>",
+        "Run once at time (ISO with offset, or +duration). Use --tz for offset-less datetimes",
+      )
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
       .option("--cron <expr>", "Cron expression (5-field or 6-field with seconds)")
       .option("--tz <iana>", "Timezone for cron expressions (IANA)", "")
@@ -119,7 +122,9 @@ export function registerCronAddCommand(cron: Command) {
               throw new Error("--stagger/--exact are only valid with --cron");
             }
             if (at) {
-              const atIso = parseAt(at);
+              const tzRaw =
+                typeof opts.tz === "string" && opts.tz.trim() ? opts.tz.trim() : undefined;
+              const atIso = parseAt(at, tzRaw);
               if (!atIso) {
                 throw new Error("Invalid --at; use ISO time or duration like 20m");
               }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -158,14 +158,13 @@ export function registerCronEditCommand(cron: Command) {
           if (scheduleChosen > 1) {
             throw new Error("Choose at most one schedule change");
           }
-          if (
-            (requestedStaggerMs !== undefined || typeof opts.tz === "string") &&
-            (opts.at || opts.every)
-          ) {
-            throw new Error("--stagger/--exact/--tz are only valid for cron schedules");
+          if (requestedStaggerMs !== undefined && (opts.at || opts.every)) {
+            throw new Error("--stagger/--exact are only valid for cron schedules");
           }
           if (opts.at) {
-            const atIso = parseAt(String(opts.at));
+            const tzRaw =
+              typeof opts.tz === "string" && opts.tz.trim() ? opts.tz.trim() : undefined;
+            const atIso = parseAt(String(opts.at), tzRaw);
             if (!atIso) {
               throw new Error("Invalid --at");
             }

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -158,6 +158,9 @@ export function registerCronEditCommand(cron: Command) {
           if (scheduleChosen > 1) {
             throw new Error("Choose at most one schedule change");
           }
+          if (typeof opts.tz === "string" && opts.every) {
+            throw new Error("--tz is only valid with --cron or offset-less --at");
+          }
           if (requestedStaggerMs !== undefined && (opts.at || opts.every)) {
             throw new Error("--stagger/--exact are only valid for cron schedules");
           }

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -89,6 +89,8 @@ export function parseCronStaggerMs(params: {
   return parsed;
 }
 
+const OFFSETLESS_ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?$/;
+
 /**
  * Parse a one-shot `--at` value into an ISO string (UTC).
  *
@@ -104,20 +106,10 @@ export function parseAt(input: string, tz?: string): string | null {
 
   // If a timezone is provided and the input looks like an offset-less ISO datetime,
   // resolve it in the given IANA timezone so users get the time they expect.
-  if (tz) {
-    const isoNoOffset = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?$/.test(raw);
-    if (isoNoOffset) {
-      try {
-        // Use Intl to find the UTC offset for the given tz at the specified local time.
-        // We first parse naively as UTC to get a rough Date, then compute the real offset.
-        const naiveMs = new Date(`${raw}Z`).getTime();
-        if (!Number.isNaN(naiveMs)) {
-          const offset = getTimezoneOffsetMs(naiveMs, tz);
-          return new Date(naiveMs - offset).toISOString();
-        }
-      } catch {
-        // Fall through to default parsing if tz is invalid
-      }
+  if (tz && OFFSETLESS_ISO_DATETIME_RE.test(raw)) {
+    const resolved = parseOffsetlessAtInTimezone(raw, tz);
+    if (resolved) {
+      return resolved;
     }
   }
 
@@ -130,6 +122,26 @@ export function parseAt(input: string, tz?: string): string | null {
     return new Date(Date.now() + dur).toISOString();
   }
   return null;
+}
+
+function parseOffsetlessAtInTimezone(raw: string, tz: string): string | null {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz }).format(new Date());
+
+    const naiveMs = new Date(`${raw}Z`).getTime();
+    if (Number.isNaN(naiveMs)) {
+      return null;
+    }
+
+    // Re-check the offset at the first candidate instant so DST boundaries
+    // land on the intended wall-clock time instead of drifting by one hour.
+    const firstOffsetMs = getTimezoneOffsetMs(naiveMs, tz);
+    const candidateMs = naiveMs - firstOffsetMs;
+    const finalOffsetMs = getTimezoneOffsetMs(candidateMs, tz);
+    return new Date(naiveMs - finalOffsetMs).toISOString();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -160,7 +172,7 @@ function getTimezoneOffsetMs(utcMs: number, tz: string): number {
     get("year"),
     get("month") - 1,
     get("day"),
-    get("hour") === 24 ? 0 : get("hour"),
+    get("hour"),
     get("minute"),
     get("second"),
   );

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -89,11 +89,38 @@ export function parseCronStaggerMs(params: {
   return parsed;
 }
 
-export function parseAt(input: string): string | null {
+/**
+ * Parse a one-shot `--at` value into an ISO string (UTC).
+ *
+ * When `tz` is provided and the input is an offset-less datetime
+ * (e.g. `2026-03-23T23:00:00`), the datetime is interpreted in
+ * that IANA timezone instead of UTC.
+ */
+export function parseAt(input: string, tz?: string): string | null {
   const raw = input.trim();
   if (!raw) {
     return null;
   }
+
+  // If a timezone is provided and the input looks like an offset-less ISO datetime,
+  // resolve it in the given IANA timezone so users get the time they expect.
+  if (tz) {
+    const isoNoOffset = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?$/.test(raw);
+    if (isoNoOffset) {
+      try {
+        // Use Intl to find the UTC offset for the given tz at the specified local time.
+        // We first parse naively as UTC to get a rough Date, then compute the real offset.
+        const naiveMs = new Date(`${raw}Z`).getTime();
+        if (!Number.isNaN(naiveMs)) {
+          const offset = getTimezoneOffsetMs(naiveMs, tz);
+          return new Date(naiveMs - offset).toISOString();
+        }
+      } catch {
+        // Fall through to default parsing if tz is invalid
+      }
+    }
+  }
+
   const absolute = parseAbsoluteTimeMs(raw);
   if (absolute !== null) {
     return new Date(absolute).toISOString();
@@ -103,6 +130,42 @@ export function parseAt(input: string): string | null {
     return new Date(Date.now() + dur).toISOString();
   }
   return null;
+}
+
+/**
+ * Get the UTC offset in milliseconds for a given IANA timezone at a given UTC instant.
+ * Positive means ahead of UTC (e.g. +3600000 for CET).
+ */
+function getTimezoneOffsetMs(utcMs: number, tz: string): number {
+  const d = new Date(utcMs);
+  // Format parts in the target timezone
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+
+  const get = (type: string) => {
+    const part = parts.find((p) => p.type === type);
+    return Number.parseInt(part?.value ?? "0", 10);
+  };
+
+  // Reconstruct the local time as if it were UTC
+  const localAsUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour") === 24 ? 0 : get("hour"),
+    get("minute"),
+    get("second"),
+  );
+
+  return localAsUtc - utcMs;
 }
 
 const CRON_ID_PAD = 36;


### PR DESCRIPTION
## Problem

`openclaw cron add --at '2026-03-23T23:00:00' --tz Europe/Oslo` schedules the job at 23:00 **UTC** instead of 23:00 Oslo time. The `--tz` flag is silently ignored for `--at` jobs, causing one-shot reminders to fire at the wrong time.

Fixes #53218

## Changes

- **`parseAt()`** now accepts an optional `tz` parameter. When provided and the input is an offset-less ISO datetime, it resolves the time in that IANA timezone using `Intl.DateTimeFormat`
- **`register.cron-add.ts`** passes `opts.tz` to `parseAt()`
- **`register.cron-edit.ts`** same, and relaxes the guard that previously blocked `--tz` with `--at`
- Updated `--at` help text to mention `--tz` support
- Datetimes with explicit offsets (e.g. `+01:00`, `Z`) are unaffected

## Tests

Added 2 tests:
1. Verifies `--tz Europe/Oslo` correctly interprets bare datetime as CET (23:00 Oslo → 22:00 UTC)
2. Verifies explicit offset in `--at` is not overridden by `--tz`

All 37 tests pass.