### PR TITLE
fix(anthropic): split system prompt into static/dynamic blocks for stable cache prefix

### DIFF
--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -315,12 +315,12 @@ export function createAnthropicBetaHeadersWrapper(
 export function createAnthropicSystemPromptCacheSplitWrapper(
   baseStreamFn: StreamFn | undefined,
   delimiter: string,
+  splitAndCache = true,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    if (model.api !== "anthropic-messages") {
-      return underlying(model, context, options);
-    }
+    // The wrapper always runs to strip the delimiter. When splitAndCache is
+    // false, it only strips — no content block splitting or cache_control changes.
 
     const originalOnPayload = options?.onPayload;
     return underlying(model, context, {
@@ -329,10 +329,12 @@ export function createAnthropicSystemPromptCacheSplitWrapper(
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
 
-          // Anthropic Messages API: `system` can be a string or content block array.
-          // pi-ai with cacheRetention wraps it as a single-block array with cache_control.
+          // Strip or split the delimiter from the system prompt.
+          // When splitAndCache is true (Anthropic with caching enabled), split
+          // into two content blocks so the static prefix stays cached.
+          // When false, just strip the marker so it never reaches the model.
           const system = payloadObj.system;
-          if (Array.isArray(system)) {
+          if (splitAndCache && Array.isArray(system)) {
             const newBlocks: Array<Record<string, unknown>> = [];
             for (const block of system as Array<Record<string, unknown>>) {
               if (typeof block.text !== "string" || !block.text.includes(delimiter)) {
@@ -358,15 +360,14 @@ export function createAnthropicSystemPromptCacheSplitWrapper(
             }
             payloadObj.system = newBlocks;
           } else if (typeof system === "string" && system.includes(delimiter)) {
-            const idx = system.indexOf(delimiter);
-            const staticPart = system.slice(0, idx).trimEnd();
-            const dynamicPart = system.slice(idx + delimiter.length).trimStart();
-            payloadObj.system = [
-              ...(staticPart
-                ? [{ type: "text", text: staticPart, cache_control: { type: "ephemeral" } }]
-                : []),
-              ...(dynamicPart ? [{ type: "text", text: dynamicPart }] : []),
-            ];
+            payloadObj.system = system.replace(delimiter, "\n");
+          } else if (Array.isArray(system)) {
+            // Strip-only mode (no split): remove delimiter from text blocks
+            for (const block of system as Array<Record<string, unknown>>) {
+              if (typeof block.text === "string" && block.text.includes(delimiter)) {
+                block.text = block.text.replace(delimiter, "\n");
+              }
+            }
           }
         }
         return originalOnPayload?.(payload, model);

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -297,6 +297,84 @@ export function createAnthropicBetaHeadersWrapper(
   };
 }
 
+/**
+ * Split the system prompt at `SYSTEM_PROMPT_CACHE_BOUNDARY` into a static
+ * (cached) prefix and a dynamic (uncached) suffix. Anthropic's prompt cache is
+ * prefix-based — any change to the system content invalidates the cache for all
+ * content that follows. By isolating per-turn dynamic sections (group context,
+ * runtime info) into a separate content block without `cache_control`, the
+ * static prefix (tools, skills, memory, safety rules, project context) stays
+ * cached across turns.
+ *
+ * Without this, a single changing field (e.g. the model name after `/model`,
+ * or `extraSystemPrompt` with per-message metadata) causes a full ~60-150k
+ * token cache re-write on every API call.
+ *
+ * Related: openclaw/openclaw#49700, #18963, #19989
+ */
+export function createAnthropicSystemPromptCacheSplitWrapper(
+  baseStreamFn: StreamFn | undefined,
+  delimiter: string,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "anthropic-messages") {
+      return underlying(model, context, options);
+    }
+
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+
+          // Anthropic Messages API: `system` can be a string or content block array.
+          // pi-ai with cacheRetention wraps it as a single-block array with cache_control.
+          const system = payloadObj.system;
+          if (Array.isArray(system)) {
+            const newBlocks: Array<Record<string, unknown>> = [];
+            for (const block of system as Array<Record<string, unknown>>) {
+              if (typeof block.text !== "string" || !block.text.includes(delimiter)) {
+                newBlocks.push(block);
+                continue;
+              }
+              const idx = block.text.indexOf(delimiter);
+              const staticPart = block.text.slice(0, idx).trimEnd();
+              const dynamicPart = block.text.slice(idx + delimiter.length).trimStart();
+
+              // Static prefix: preserve any existing cache_control from pi-ai
+              if (staticPart) {
+                newBlocks.push({
+                  type: "text",
+                  text: staticPart,
+                  ...(block.cache_control ? { cache_control: block.cache_control } : {}),
+                });
+              }
+              // Dynamic suffix: no cache_control so it doesn't invalidate the prefix
+              if (dynamicPart) {
+                newBlocks.push({ type: "text", text: dynamicPart });
+              }
+            }
+            payloadObj.system = newBlocks;
+          } else if (typeof system === "string" && system.includes(delimiter)) {
+            const idx = system.indexOf(delimiter);
+            const staticPart = system.slice(0, idx).trimEnd();
+            const dynamicPart = system.slice(idx + delimiter.length).trimStart();
+            payloadObj.system = [
+              ...(staticPart
+                ? [{ type: "text", text: staticPart, cache_control: { type: "ephemeral" } }]
+                : []),
+              ...(dynamicPart ? [{ type: "text", text: dynamicPart }] : []),
+            ];
+          }
+        }
+        return originalOnPayload?.(payload, model);
+      },
+    });
+  };
+}
+
 export function createAnthropicToolPayloadCompatibilityWrapper(
   baseStreamFn: StreamFn | undefined,
   resolverOptions?: {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -9,6 +9,7 @@ import {
 } from "../../plugins/provider-runtime.js";
 import {
   createAnthropicBetaHeadersWrapper,
+  createAnthropicSystemPromptCacheSplitWrapper,
   createBedrockNoCacheWrapper,
   createAnthropicFastModeWrapper,
   createAnthropicToolPayloadCompatibilityWrapper,
@@ -17,6 +18,7 @@ import {
   resolveAnthropicBetas,
   resolveCacheRetention,
 } from "./anthropic-stream-wrappers.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../system-prompt.js";
 import { createGoogleThinkingPayloadWrapper } from "./google-stream-wrappers.js";
 import { log } from "./logger.js";
 import { createMinimaxFastModeWrapper } from "./minimax-stream-wrappers.js";
@@ -243,6 +245,16 @@ export function applyExtraParamsToAgent(
       `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
     );
     agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
+  }
+
+  // Split the system prompt into static (cached) and dynamic (uncached) blocks
+  // for Anthropic providers. This preserves cache hits across turns by keeping
+  // per-turn dynamic content (group context, runtime info) out of the cached prefix.
+  if (provider === "anthropic" || isAnthropicBedrockModel(provider, modelId)) {
+    agent.streamFn = createAnthropicSystemPromptCacheSplitWrapper(
+      agent.streamFn,
+      SYSTEM_PROMPT_CACHE_BOUNDARY,
+    );
   }
 
   if (shouldApplySiliconFlowThinkingOffCompat({ provider, modelId, thinkingLevel })) {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -7,6 +7,7 @@ import {
   prepareProviderExtraParams,
   wrapProviderStreamFn,
 } from "../../plugins/provider-runtime.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../system-prompt.js";
 import {
   createAnthropicBetaHeadersWrapper,
   createAnthropicSystemPromptCacheSplitWrapper,
@@ -18,7 +19,6 @@ import {
   resolveAnthropicBetas,
   resolveCacheRetention,
 } from "./anthropic-stream-wrappers.js";
-import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../system-prompt.js";
 import { createGoogleThinkingPayloadWrapper } from "./google-stream-wrappers.js";
 import { log } from "./logger.js";
 import { createMinimaxFastModeWrapper } from "./minimax-stream-wrappers.js";
@@ -247,13 +247,20 @@ export function applyExtraParamsToAgent(
     agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
   }
 
-  // Split the system prompt into static (cached) and dynamic (uncached) blocks
-  // for Anthropic providers. This preserves cache hits across turns by keeping
-  // per-turn dynamic content (group context, runtime info) out of the cached prefix.
-  if (provider === "anthropic" || isAnthropicBedrockModel(provider, modelId)) {
+  // Always strip the cache boundary delimiter from the system prompt so it never
+  // leaks to the model. For Anthropic providers with caching enabled, the wrapper
+  // also splits the prompt into static (cached) and dynamic (uncached) blocks.
+  {
+    const cacheRetentionForSplit = resolveCacheRetention(effectiveExtraParams, provider);
+    const shouldSplit =
+      cacheRetentionForSplit != null &&
+      cacheRetentionForSplit !== "none" &&
+      (provider === "anthropic" ||
+        (provider === "amazon-bedrock" && isAnthropicBedrockModel(modelId)));
     agent.streamFn = createAnthropicSystemPromptCacheSplitWrapper(
       agent.streamFn,
       SYSTEM_PROMPT_CACHE_BOUNDARY,
+      shouldSplit,
     );
   }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -16,6 +16,17 @@ import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
  * - "none": Just basic identity line, no sections
  */
 export type PromptMode = "full" | "minimal" | "none";
+
+/**
+ * Delimiter between the static (cacheable) and dynamic (per-turn) parts of the
+ * system prompt. Providers that support prefix-based prompt caching (Anthropic)
+ * can split on this marker and apply `cache_control` only to the static prefix,
+ * avoiding full cache invalidation when the dynamic suffix changes between turns.
+ *
+ * The delimiter is intentionally invisible to the model — it is stripped or used
+ * only at the transport layer.
+ */
+export const SYSTEM_PROMPT_CACHE_BOUNDARY = "\n<!-- OPENCLAW_CACHE_BOUNDARY -->\n";
 type OwnerIdDisplay = "raw" | "hash";
 
 function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
@@ -567,6 +578,11 @@ export function buildAgentSystemPrompt(params: {
     }),
     ...buildVoiceSection({ isMinimal, ttsHint: params.ttsHint }),
   ];
+
+  // --- Cache boundary: everything above is static per-session; everything below
+  // may change per-turn (group context, runtime info). Providers with prefix-based
+  // caching (Anthropic) split here so the static prefix stays cached.
+  lines.push(SYSTEM_PROMPT_CACHE_BOUNDARY);
 
   if (extraSystemPrompt) {
     // Use "Subagent Context" header for minimal mode (subagents), otherwise "Group Chat Context"

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -579,9 +579,11 @@ export function buildAgentSystemPrompt(params: {
     ...buildVoiceSection({ isMinimal, ttsHint: params.ttsHint }),
   ];
 
-  // --- Cache boundary: everything above is static per-session; everything below
-  // may change per-turn (group context, runtime info). Providers with prefix-based
-  // caching (Anthropic) split here so the static prefix stays cached.
+  // --- Cache boundary: everything above is stable per-session (tools, skills,
+  // memory, safety, project context, heartbeats). Everything below may change
+  // per-turn (group context, runtime info). The delimiter is stripped or used to
+  // split system content blocks at the transport layer — see
+  // createAnthropicSystemPromptCacheSplitWrapper.
   lines.push(SYSTEM_PROMPT_CACHE_BOUNDARY);
 
   if (extraSystemPrompt) {


### PR DESCRIPTION
## Summary

Split the monolithic system prompt into two Anthropic API content blocks — a **static prefix** (cached) and a **dynamic suffix** (uncached) — so the static prefix stays cached across turns instead of being re-written on every API call.

### Problem

`buildAgentSystemPrompt()` produces a single string containing both static sections (tools, skills, memory, safety rules, project context, heartbeats) and dynamic sections (`extraSystemPrompt` with per-message group context, `## Runtime` with model/capabilities). Anthropic's prompt cache is prefix-based: any byte change invalidates everything after it.

Measured on a real multi-tenant deployment (33 agents, 930 calls today):

| Metric | Value |
|--------|-------|
| Cache miss rate | **44%** |
| Avg cache write on miss | **63,333 tokens** |
| Cost per message (cache writes) | **$0.36** |
| Daily cache write cost (single agent) | **$74.30** (73% of total spend) |

### Fix

**Three files, 110 lines added, 0 removed:**

1. **`src/agents/system-prompt.ts`**: Export `SYSTEM_PROMPT_CACHE_BOUNDARY` delimiter constant. Insert it right before `extraSystemPrompt` — after all static per-session sections (tools, skills, memory, safety, project context, heartbeats, silent replies).

2. **`src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts`**: Add `createAnthropicSystemPromptCacheSplitWrapper(baseStreamFn, delimiter, splitAndCache)`:
   - When `splitAndCache=true`: splits system content at the delimiter into two blocks — static prefix keeps `cache_control` from pi-ai, dynamic suffix gets none.
   - When `splitAndCache=false`: strips the delimiter from the prompt so it never leaks to the model.
   - Handles both array (pi-ai with caching) and string (no caching) system content formats.

3. **`src/agents/pi-embedded-runner/extra-params.ts`**: Always apply the wrapper (to strip the delimiter), with `splitAndCache=true` only when `resolveCacheRetention()` returns a truthy non-`"none"` value AND the provider is `anthropic` or Bedrock Anthropic.

### Design decisions

- **Delimiter approach** (`<!-- OPENCLAW_CACHE_BOUNDARY -->`): Invisible to models, no interface change to `buildAgentSystemPrompt`'s return type. Follows the same `onPayload` wrapper pattern as `createOpenRouterSystemCacheWrapper`.
- **Boundary placement**: Before `extraSystemPrompt` (not before `## Runtime`). In group chats, `extraSystemPrompt` contains per-message sender metadata and group context that changes every turn. Placing the boundary before it keeps tools, skills, memory, project context, and heartbeats in the cached prefix.
- **Always-strip guarantee**: The wrapper always runs to remove the delimiter. The `splitAndCache` flag only controls whether it also splits into separate content blocks with differential `cache_control`. This prevents the delimiter from leaking to the model on any provider or cache configuration.
- **cacheRetention guard**: Cache-splitting is gated on `resolveCacheRetention()` returning a truthy non-`"none"` value. Sessions that opted out of caching via `cacheRetention: "none"` get strip-only behavior — no silent cache writes introduced.
- **Bedrock**: Uses `isAnthropicBedrockModel(modelId)` (not `provider`) to correctly detect Bedrock Anthropic models, matching the existing usage pattern at line 299.

### Scope

- [x] Gateway / orchestration

### Security impact

None — no new permissions, secrets, network calls, or execution surface changes.

### Test plan

- [ ] Consecutive DM messages on Anthropic — verify `cacheRead` dominates after first turn
- [ ] Group chat with `extraSystemPrompt` — verify static prefix stays cached
- [ ] `/model` switch mid-session — verify only dynamic block re-caches
- [ ] `cacheRetention: "none"` — verify delimiter stripped, no cache writes
- [ ] Non-Anthropic provider (OpenAI, Google) — verify delimiter stripped, no behavioral change
- [ ] Bedrock Anthropic model — verify wrapper splits correctly
- [ ] OpenRouter Anthropic — verify existing `createOpenRouterSystemCacheWrapper` unaffected
- [ ] Subagent (`promptMode: "minimal"`) — verify wrapper is no-op when delimiter absent

### Related

- Closes #49700
- Related: #18963, #19989, #20894, #43232
- Prior partial fix: #20597 (moved `message_id` — merged)

### AI-assisted

Developed with Claude Code. Cache analysis performed on real production data from a 33-tenant OpenClaw deployment.