### PR TITLE
style: universalize rounded edges with shared radius tokens

### DIFF
--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -133,7 +133,7 @@
 .chat-divider__label {
   padding: 2px 10px;
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: rgba(255, 255, 255, 0.02);
 }
 
@@ -141,7 +141,7 @@
 .chat-avatar {
   width: 36px;
   height: 36px;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   background: var(--panel-strong);
   display: grid;
   place-items: center;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -59,7 +59,7 @@
   margin: 0 0 0 0;
   min-height: 0;
   /* Allow shrinking for flex scroll behavior */
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   background: transparent;
 }
 
@@ -121,7 +121,7 @@
   color: var(--text);
   background: var(--panel-strong);
   border: 1px solid var(--border);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   cursor: pointer;
   white-space: nowrap;
   z-index: 10;
@@ -154,7 +154,7 @@
   gap: 8px;
   padding: 7px 14px;
   margin: 0 auto 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid color-mix(in srgb, var(--ctx-color, #d97706) 35%, transparent);
   background: var(--ctx-bg, rgba(217, 119, 6, 0.12));
   color: var(--ctx-color, #d97706);
@@ -199,7 +199,7 @@
   gap: 8px;
   padding: 8px;
   background: var(--panel);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
   width: fit-content;
   max-width: 100%;
@@ -211,7 +211,7 @@
   position: relative;
   width: 80px;
   height: 80px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
   border: 1px solid var(--border);
   background: var(--bg);
@@ -285,7 +285,7 @@
 .chat-message-image {
   max-width: 300px;
   max-height: 200px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   object-fit: contain;
   cursor: pointer;
   transition: transform 150ms ease-out;
@@ -331,7 +331,7 @@
   min-height: 40px;
   max-height: 150px;
   padding: 9px 12px;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow-y: auto;
   resize: none;
   white-space: pre-wrap;
@@ -828,7 +828,7 @@
   font-size: 12px;
   padding: 4px 10px;
   background: rgba(255, 255, 255, 0.04);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--border);
 }
 
@@ -929,7 +929,7 @@
 .agent-chat__avatar--logo {
   width: 48px;
   height: 48px;
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: var(--panel-strong);
   border: 1px solid var(--border);
   display: grid;
@@ -959,7 +959,7 @@
   color: var(--muted);
   background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 100px;
+  border-radius: var(--radius-full);
   padding: 4px 12px;
 }
 
@@ -982,7 +982,7 @@
   font-family: var(--font-mono);
   background: var(--panel-strong);
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .agent-chat__suggestions {
@@ -997,7 +997,7 @@
 .agent-chat__suggestion {
   font-size: 13px;
   padding: 8px 16px;
-  border-radius: 100px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--border);
   background: var(--panel);
   color: var(--foreground);

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -96,7 +96,7 @@
 
 .sidebar-markdown pre {
   background: rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   padding: 12px;
   overflow-x: auto;
 }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -5,7 +5,7 @@
 .chat-thinking {
   margin-bottom: 10px;
   padding: 10px 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   border: 1px dashed rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.04);
   color: var(--muted);
@@ -72,14 +72,14 @@
 .chat-text :where(:not(pre) > code) {
   background: rgba(0, 0, 0, 0.15);
   padding: 0.15em 0.4em;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   overflow-wrap: normal;
   word-break: keep-all;
 }
 
 .chat-text :where(pre) {
   background: rgba(0, 0, 0, 0.15);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 10px 12px;
   overflow-x: auto;
 }
@@ -162,7 +162,7 @@
   .chat-text :where(pre) {
     padding: 8px 10px;
     font-size: 12px;
-    border-radius: 4px;
+    border-radius: var(--radius-sm);
   }
 
   .chat-text :where(.markdown-inline-image) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -588,7 +588,7 @@
   font-size: 11px;
   font-weight: 500;
   line-height: 1;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.15);
   color: inherit;
   opacity: 0.8;
@@ -1230,7 +1230,7 @@
   line-height: 1.2;
   padding: 6px 14px;
   margin-bottom: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--border);
   background: var(--panel-strong);
   color: var(--text);
@@ -1316,14 +1316,14 @@
 
 .code-block-wrapper {
   position: relative;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
   margin-top: 0.75em;
 }
 
 .code-block-wrapper pre {
   margin: 0;
-  border-radius: 0 0 6px 6px;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 
 .code-block-header {
@@ -2319,7 +2319,7 @@ td.data-table-key-col {
 .chat-new-messages {
   align-self: center;
   margin: 8px auto 0;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   padding: 6px 12px;
   font-size: 12px;
   line-height: 1;

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -588,7 +588,7 @@
 }
 
 .settings-slider__key-swatch--round {
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
 }
 
 .settings-slider__value {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -208,7 +208,7 @@
   min-height: 38px;
   padding: 0 14px;
   border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
   color: var(--muted);
   font-size: 13px;
@@ -256,7 +256,7 @@
   gap: 2px;
   padding: 3px;
   border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--bg-elevated) 78%, transparent);
 }
 
@@ -268,7 +268,7 @@
   justify-content: center;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: transparent;
   color: var(--muted);
   cursor: pointer;
@@ -389,7 +389,7 @@
   width: 32px;
   height: 32px;
   flex-shrink: 0;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   box-shadow: 0 8px 18px color-mix(in srgb, black 12%, transparent);
 }
 
@@ -440,7 +440,7 @@
   justify-content: center;
   background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--border-strong) 68%, transparent);
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   cursor: pointer;
   transition:
     background var(--duration-fast) ease,
@@ -507,7 +507,7 @@
   min-height: 28px;
   background: transparent;
   border: none;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
   cursor: pointer;
   text-align: left;
@@ -558,7 +558,7 @@
   gap: 8px;
   min-height: 40px;
   padding: 0 9px;
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
   background: transparent;
   color: var(--muted);
@@ -653,7 +653,7 @@
   min-height: 44px;
   padding: 0;
   margin: 0 auto;
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   border-color: transparent;
   box-shadow: none;
 }
@@ -681,7 +681,7 @@
   top: 10px;
   bottom: 10px;
   width: 3px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--accent) 86%, transparent);
   box-shadow: 0 0 14px color-mix(in srgb, var(--accent) 34%, transparent);
 }
@@ -712,7 +712,7 @@
 .sidebar--collapsed .sidebar-brand__logo {
   width: 34px;
   height: 34px;
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   box-shadow:
     0 10px 20px color-mix(in srgb, black 20%, transparent),
     inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
@@ -734,7 +734,7 @@
   gap: 10px;
   min-height: 40px;
   padding: 0 12px;
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--bg-elevated) 72%, transparent);
   border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
 }
@@ -795,7 +795,7 @@
   min-height: 44px;
   padding: 0;
   justify-content: center;
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
 }
 
 .sidebar--collapsed .sidebar-version__status {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -77,7 +77,7 @@
     height: 38px;
     padding: 0;
     border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     background: color-mix(in srgb, var(--bg-elevated) 80%, transparent);
     color: var(--muted);
     box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
@@ -152,7 +152,7 @@
     min-height: 40px;
     padding: 0 12px;
     font-size: 13px;
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     white-space: nowrap;
     flex: 0 0 auto;
     width: auto;
@@ -164,7 +164,7 @@
     min-height: 44px;
     padding: 0;
     margin: 0 auto;
-    border-radius: 16px;
+    border-radius: var(--radius-lg);
   }
 
   .sidebar--collapsed .nav-item--active::before,
@@ -190,7 +190,7 @@
     top: 10px;
     bottom: 10px;
     width: 3px;
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     background: color-mix(in srgb, var(--accent) 86%, transparent);
     box-shadow: 0 0 14px color-mix(in srgb, var(--accent) 34%, transparent);
   }
@@ -261,7 +261,7 @@
     height: 38px;
     padding: 0;
     border: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
-    border-radius: 999px;
+    border-radius: var(--radius-full);
     background: color-mix(in srgb, var(--bg-elevated) 80%, transparent);
     color: var(--muted);
     box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
@@ -358,7 +358,7 @@
     z-index: 100;
     background: var(--card, #161b22);
     border: 1px solid var(--border, #30363d);
-    border-radius: 10px;
+    border-radius: var(--radius-md);
     padding: 8px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
     flex-direction: column;

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -104,7 +104,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: var(--accent-subtle);
   color: var(--accent);
   font-size: 12px;
@@ -120,7 +120,7 @@
   height: 12px;
   border: 2px solid currentcolor;
   border-right-color: transparent;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   animation: usage-spin 0.8s linear infinite;
 }
 
@@ -155,7 +155,7 @@
 
 .usage-skeleton-block {
   min-height: 96px;
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   background: linear-gradient(90deg, var(--bg-muted) 20%, var(--bg-hover) 50%, var(--bg-muted) 80%);
   background-size: 200% 100%;
@@ -199,7 +199,7 @@
 .usage-filters-inline input[type="text"] {
   min-height: 36px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text);
   font: inherit;
@@ -245,7 +245,7 @@
   gap: 6px;
   padding: 7px 11px;
   border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--border));
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--accent) 8%, var(--card));
   font-size: 12px;
   color: var(--text);
@@ -258,6 +258,7 @@
 .usage-pin-btn,
 .usage-export-button,
 .usage-action-btn,
+.toggle-btn,
 .session-copy-btn,
 .context-expand-btn,
 .session-close-btn {
@@ -276,6 +277,7 @@
 
 .usage-pin-btn,
 .usage-export-button,
+.toggle-btn,
 .context-expand-btn,
 .session-copy-btn {
   display: inline-flex;
@@ -284,7 +286,7 @@
   gap: 6px;
   min-height: 34px;
   padding: 8px 12px;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   font-size: 12px;
   font-weight: 600;
 }
@@ -292,6 +294,7 @@
 .usage-pin-btn:hover,
 .usage-export-button:hover,
 .usage-action-btn:hover,
+.toggle-btn:hover,
 .session-copy-btn:hover,
 .context-expand-btn:hover,
 .session-close-btn:hover {
@@ -372,7 +375,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   min-height: 34px;
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text);
   cursor: pointer;
@@ -396,7 +399,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   min-width: 20px;
   height: 20px;
   padding: 0 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: var(--accent-subtle);
   color: var(--accent);
   font-size: 11px;
@@ -411,7 +414,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   width: min(320px, calc(100vw - 48px));
   padding: 12px;
   border: 1px solid var(--border-strong);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: var(--popover);
   color: var(--popover-foreground);
   box-shadow: var(--shadow-lg);
@@ -434,7 +437,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   gap: 8px;
   align-items: center;
   padding: 8px 10px;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--bg-muted) 72%, transparent);
   font-size: 12px;
 }
@@ -448,7 +451,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   min-height: 36px;
   padding: 9px 10px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text);
   text-align: left;
@@ -483,7 +486,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   align-items: center;
   gap: 6px;
   padding: 8px 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
   background: color-mix(in srgb, var(--accent) 8%, var(--card));
   color: var(--text);
@@ -551,7 +554,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 .usage-empty-block {
   padding: 20px 14px;
   border: 1px dashed var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--bg-muted) 62%, transparent);
   text-align: center;
   color: var(--muted);
@@ -605,7 +608,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   grid-auto-rows: min-content;
   min-height: 132px;
   border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-  border-radius: 18px;
+  border-radius: var(--radius-xl);
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--card) 92%, var(--bg-elevated)) 0%,
@@ -698,7 +701,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   width: 18px;
   height: 18px;
   margin-left: 6px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg-muted) 82%, transparent);
   color: var(--muted);
@@ -720,7 +723,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   min-height: 168px;
   padding: 16px;
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--card) 82%, var(--bg-muted));
 }
 
@@ -819,7 +822,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .usage-daypart-cell,
 .usage-hour-cell {
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--accent) 14%, var(--border));
   background: color-mix(in srgb, var(--accent) 6%, transparent);
 }
@@ -948,7 +951,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   width: min(100%, var(--bar-max-width));
   min-height: 6px;
   border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
-  border-radius: 10px 10px 4px 4px;
+  border-radius: var(--radius-md) var(--radius-md) var(--radius-sm) var(--radius-sm);
   background: linear-gradient(
     180deg,
     color-mix(in srgb, var(--accent) 82%, white 6%),
@@ -990,7 +993,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   max-width: 220px;
   padding: 8px 10px;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-md);
   background: var(--popover);
   color: var(--popover-foreground);
   box-shadow: var(--shadow-md);
@@ -1013,7 +1016,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   width: 100%;
   min-height: 16px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--bg-muted) 82%, transparent);
   border: 1px solid var(--border);
 }
@@ -1049,7 +1052,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 .legend-dot {
   width: 10px;
   height: 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
 }
 
 .cost-segment.output,
@@ -1118,7 +1121,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   min-height: 34px;
   padding: 7px 10px;
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text);
 }
@@ -1149,7 +1152,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   gap: 12px;
   padding: 12px;
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--card) 86%, var(--bg-muted));
   cursor: pointer;
   transition:
@@ -1251,7 +1254,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   width: 34px;
   height: 34px;
   padding: 0;
-  border-radius: 10px;
+  border-radius: var(--radius-md);
   font-size: 18px;
   line-height: 1;
 }
@@ -1280,7 +1283,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 .session-logs-compact {
   padding: 14px;
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--card) 88%, var(--bg-muted));
 }
 
@@ -1351,7 +1354,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   display: flex;
   min-height: 18px;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg-muted) 82%, transparent);
 }
@@ -1367,7 +1370,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   gap: 10px;
   padding: 14px;
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: var(--bg);
 }
 
@@ -1422,7 +1425,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   gap: 8px;
   padding: 12px;
   border: 1px solid var(--border);
-  border-radius: 14px;
+  border-radius: var(--radius-lg);
   background: var(--bg);
 }
 
@@ -1476,7 +1479,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   display: inline-flex;
   align-items: center;
   padding: 6px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--accent) 8%, var(--card));
   border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
   font-size: 11px;
@@ -1551,7 +1554,7 @@ details.usage-filter-select summary::-webkit-details-marker,
     align-items: flex-start;
     padding: 12px 14px;
     border: 1px solid color-mix(in srgb, var(--danger) 16%, var(--border));
-    border-radius: 14px;
+    border-radius: var(--radius-lg);
     background: color-mix(in srgb, var(--danger) 5%, var(--bg-muted));
     flex-direction: column;
     gap: 4px;

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -119,7 +119,7 @@ function renderCronFilterIcon(hiddenCount: number) {
               right: -6px;
               background: var(--color-accent, #6366f1);
               color: #fff;
-              border-radius: 999px;
+              border-radius: var(--radius-full);
               font-size: 9px;
               line-height: 1;
               padding: 1px 3px;

--- a/ui/src/ui/views/channels.nostr-profile-form.ts
+++ b/ui/src/ui/views/channels.nostr-profile-form.ts
@@ -101,7 +101,7 @@ export function renderNostrProfileForm(params: {
             placeholder=${placeholder ?? ""}
             maxlength=${maxLength ?? 2000}
             rows="3"
-            style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: 4px; resize: vertical; font-family: inherit;"
+            style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: var(--radius-sm); resize: vertical; font-family: inherit;"
             @input=${(e: InputEvent) => {
               const target = e.target as HTMLTextAreaElement;
               callbacks.onFieldChange(field, target.value);
@@ -125,7 +125,7 @@ export function renderNostrProfileForm(params: {
           .value=${value}
           placeholder=${placeholder ?? ""}
           maxlength=${maxLength ?? 256}
-          style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: 4px;"
+          style="width: 100%; padding: 8px; border: 1px solid var(--border-color); border-radius: var(--radius-sm);"
           @input=${(e: InputEvent) => {
             const target = e.target as HTMLInputElement;
             callbacks.onFieldChange(field, target.value);
@@ -164,7 +164,7 @@ export function renderNostrProfileForm(params: {
   };
 
   return html`
-    <div class="nostr-profile-form" style="padding: 16px; background: var(--bg-secondary); border-radius: 8px; margin-top: 12px;">
+    <div class="nostr-profile-form" style="padding: 16px; background: var(--bg-secondary); border-radius: var(--radius-md); margin-top: 12px;">
       <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
         <div style="font-weight: 600; font-size: 16px;">Edit Profile</div>
         <div style="font-size: 12px; color: var(--text-muted);">Account: ${accountId}</div>

--- a/ui/src/ui/views/channels.nostr.ts
+++ b/ui/src/ui/views/channels.nostr.ts
@@ -121,7 +121,7 @@ export function renderNostrCard(params: {
     const hasAnyProfileData = name || displayName || about || picture || nip05;
 
     return html`
-      <div style="margin-top: 16px; padding: 12px; background: var(--bg-secondary); border-radius: 8px;">
+      <div style="margin-top: 16px; padding: 12px; background: var(--bg-secondary); border-radius: var(--radius-md);">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px;">
           <div style="font-weight: 500;">Profile</div>
           ${


### PR DESCRIPTION
## Summary
- replace hard-coded `border-radius` values with shared CSS radius variables across the UI
- apply the radius token cleanup across chat, layout, components, config, usage, and related view styling
- make rounded-edge treatment more consistent and easier to tune universally from the design tokens

## Notes
This is the rounded edges universalization update: a UI clarity pass that standardizes corners on shared radius tokens like `--radius-sm`, `--radius-md`, `--radius-lg`, and `--radius-full` instead of one-off literal values.