### PR TITLE
Raise chat.history text cap to avoid premature truncation

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -94,7 +94,7 @@ type ChatAbortRequester = {
   isAdmin: boolean;
 };
 
-const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
+const CHAT_HISTORY_TEXT_MAX_CHARS = 64_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
 let chatHistoryPlaceholderEmitCount = 0;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -96,7 +96,9 @@ type ChatAbortRequester = {
 
 const CHAT_HISTORY_TEXT_MAX_CHARS = 64_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
+const CHAT_HISTORY_TEXT_MAX_BYTES = CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES - 8 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const CHAT_HISTORY_TRUNCATED_SUFFIX = "\n...(truncated)...";
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
@@ -405,11 +407,45 @@ async function rewriteChatSendUserTurnMediaPaths(params: {
 }
 
 function truncateChatHistoryText(text: string): { text: string; truncated: boolean } {
-  if (text.length <= CHAT_HISTORY_TEXT_MAX_CHARS) {
+  if (
+    text.length <= CHAT_HISTORY_TEXT_MAX_CHARS &&
+    Buffer.byteLength(text, "utf8") <= CHAT_HISTORY_TEXT_MAX_BYTES
+  ) {
     return { text, truncated: false };
   }
+
+  let next = text;
+  let truncated = false;
+
+  if (next.length > CHAT_HISTORY_TEXT_MAX_CHARS) {
+    next = next.slice(0, CHAT_HISTORY_TEXT_MAX_CHARS);
+    truncated = true;
+  }
+
+  if (Buffer.byteLength(next, "utf8") > CHAT_HISTORY_TEXT_MAX_BYTES) {
+    const suffixBytes = Buffer.byteLength(CHAT_HISTORY_TRUNCATED_SUFFIX, "utf8");
+    const maxPrefixBytes = Math.max(0, CHAT_HISTORY_TEXT_MAX_BYTES - suffixBytes);
+    let low = 0;
+    let high = next.length;
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      const candidate = next.slice(0, mid);
+      if (Buffer.byteLength(candidate, "utf8") <= maxPrefixBytes) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+    next = next.slice(0, low);
+    truncated = true;
+  }
+
+  if (!truncated) {
+    return { text: next, truncated: false };
+  }
+
   return {
-    text: `${text.slice(0, CHAT_HISTORY_TEXT_MAX_CHARS)}\n...(truncated)...`,
+    text: `${next}${CHAT_HISTORY_TRUNCATED_SUFFIX}`,
     truncated: true,
   };
 }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -287,6 +287,40 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history preserves long assistant text that fits within the history byte budget", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const historyMaxBytes = 128 * 1024;
+      const sessionDir = await prepareMainHistoryHarness({
+        ws,
+        createSessionDir,
+        historyMaxBytes,
+      });
+
+      const longText = "L".repeat(50_000);
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            timestamp: Date.now(),
+            content: [{ type: "text", text: longText }],
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws);
+      expect(messages).toHaveLength(1);
+
+      const first = messages[0] as { content?: Array<{ text?: string }> };
+      expect(first.content?.[0]?.text).toBe(longText);
+
+      const serialized = JSON.stringify(messages);
+      const bytes = Buffer.byteLength(serialized, "utf8");
+      expect(bytes).toBeLessThanOrEqual(historyMaxBytes);
+      expect(serialized).not.toContain("...(truncated)...");
+      expect(serialized).not.toContain("[chat.history omitted: message too large]");
+    });
+  });
+
   test("chat.history preserves usage and cost metadata for assistant messages", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -321,6 +321,41 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history truncates UTF-8-heavy assistant text before oversized placeholder fallback", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      const historyMaxBytes = 128 * 1024;
+      const sessionDir = await prepareMainHistoryHarness({
+        ws,
+        createSessionDir,
+        historyMaxBytes,
+      });
+
+      const emojiText = "😀".repeat(40_000);
+      await writeMainSessionTranscript(sessionDir, [
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            timestamp: Date.now(),
+            content: [{ type: "text", text: emojiText }],
+          },
+        }),
+      ]);
+
+      const messages = await fetchHistoryMessages(ws);
+      expect(messages).toHaveLength(1);
+
+      const first = messages[0] as { content?: Array<{ text?: string }> };
+      const rendered = first.content?.[0]?.text ?? "";
+      expect(rendered).toContain("...(truncated)...");
+      expect(rendered).not.toContain("[chat.history omitted: message too large]");
+
+      const serialized = JSON.stringify(messages);
+      const bytes = Buffer.byteLength(serialized, "utf8");
+      expect(bytes).toBeLessThanOrEqual(historyMaxBytes);
+      expect(serialized).not.toContain("[chat.history omitted: message too large]");
+    });
+  });
+
   test("chat.history preserves usage and cost metadata for assistant messages", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);


### PR DESCRIPTION
## Summary

Raise the `chat.history` text cap from `12_000` to `64_000` and make truncation UTF-8 byte-aware so long assistant replies stay readable instead of being replaced by the oversized placeholder.

## What changed

- bumped `CHAT_HISTORY_TEXT_MAX_CHARS` in `src/gateway/server-methods/chat.ts` from `12_000` to `64_000`
- added a byte-aware fallback inside `truncateChatHistoryText()` so UTF-8-heavy text is truncated to a safe prefix before the `128 * 1024` single-message byte guard runs
- added a regression test for a 50k-character ASCII assistant reply that should be preserved intact
- added a regression test for an emoji-heavy assistant reply that should truncate visibly instead of collapsing to `[chat.history omitted: message too large]`

## Why

Before this change, `chat.history` truncated `content[].text`, `partialJson`, `arguments`, and `thinking` at 12k characters before the larger byte-budget logic ran.

Raising the char cap alone fixes premature truncation for long ASCII replies, but it leaves a second failure mode: long UTF-8-heavy text can bypass the char cap and then be replaced entirely by the oversized placeholder during the later byte-budget pass.

This update fixes both paths:

- long replies that still fit the budget remain visible
- byte-heavy replies are truncated to a readable prefix instead of being dropped completely

## Test

```bash
pnpm -C /tmp/openclaw-pr-53243 exec vitest run --config vitest.gateway.config.ts src/gateway/server.chat.gateway-server-chat-b.test.ts
```

Fixes #53242