### PR TITLE
fix(cli): auto-select login-capable auth channels

### DIFF
--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -133,6 +133,7 @@ describe("channel-auth", () => {
         resolveAccount: vi.fn().mockReturnValue({ enabled: true }),
       },
     };
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {}, telegram: {} } });
     mocks.listChannelPlugins.mockReturnValue([telegramPlugin, plugin]);
 
     await runChannelLogin({}, runtime);

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -7,10 +7,10 @@ const mocks = vi.hoisted(() => ({
   getChannelPluginCatalogEntry: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
   getChannelPlugin: vi.fn(),
+  listChannelPlugins: vi.fn(),
   normalizeChannelId: vi.fn(),
   loadConfig: vi.fn(),
   writeConfigFile: vi.fn(),
-  resolveMessageChannelSelection: vi.fn(),
   setVerbose: vi.fn(),
   createClackPrompter: vi.fn(),
   ensureChannelSetupPluginInstalled: vi.fn(),
@@ -35,16 +35,13 @@ vi.mock("../channels/plugins/helpers.js", () => ({
 
 vi.mock("../channels/plugins/index.js", () => ({
   getChannelPlugin: mocks.getChannelPlugin,
+  listChannelPlugins: mocks.listChannelPlugins,
   normalizeChannelId: mocks.normalizeChannelId,
 }));
 
 vi.mock("../config/config.js", () => ({
   loadConfig: mocks.loadConfig,
   writeConfigFile: mocks.writeConfigFile,
-}));
-
-vi.mock("../infra/outbound/channel-selection.js", () => ({
-  resolveMessageChannelSelection: mocks.resolveMessageChannelSelection,
 }));
 
 vi.mock("../globals.js", () => ({
@@ -67,7 +64,10 @@ describe("channel-auth", () => {
     id: "whatsapp",
     auth: { login: mocks.login },
     gateway: { logoutAccount: mocks.logoutAccount },
-    config: { resolveAccount: mocks.resolveAccount },
+    config: {
+      listAccountIds: vi.fn().mockReturnValue(["default"]),
+      resolveAccount: mocks.resolveAccount,
+    },
   };
 
   beforeEach(() => {
@@ -75,18 +75,15 @@ describe("channel-auth", () => {
     mocks.normalizeChannelId.mockReturnValue("whatsapp");
     mocks.getChannelPlugin.mockReturnValue(plugin);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
-    mocks.loadConfig.mockReturnValue({ channels: {} });
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {} } });
     mocks.writeConfigFile.mockResolvedValue(undefined);
-    mocks.resolveMessageChannelSelection.mockResolvedValue({
-      channel: "whatsapp",
-      configured: ["whatsapp"],
-    });
+    mocks.listChannelPlugins.mockReturnValue([plugin]);
     mocks.resolveDefaultAgentId.mockReturnValue("main");
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
     mocks.resolveChannelDefaultAccountId.mockReturnValue("default-account");
     mocks.createClackPrompter.mockReturnValue({} as object);
     mocks.ensureChannelSetupPluginInstalled.mockResolvedValue({
-      cfg: { channels: {} },
+      cfg: { channels: { whatsapp: {} } },
       installed: true,
       pluginId: "whatsapp",
     });
@@ -106,7 +103,7 @@ describe("channel-auth", () => {
     expect(mocks.resolveChannelDefaultAccountId).not.toHaveBeenCalled();
     expect(mocks.login).toHaveBeenCalledWith(
       expect.objectContaining({
-        cfg: { channels: {} },
+        cfg: { channels: { whatsapp: {} } },
         accountId: "acct-1",
         runtime,
         verbose: true,
@@ -115,10 +112,9 @@ describe("channel-auth", () => {
     );
   });
 
-  it("auto-picks the single configured channel when opts are empty", async () => {
+  it("auto-picks the single configured channel that supports login when opts are empty", async () => {
     await runChannelLogin({}, runtime);
 
-    expect(mocks.resolveMessageChannelSelection).toHaveBeenCalledWith({ cfg: { channels: {} } });
     expect(mocks.normalizeChannelId).toHaveBeenCalledWith("whatsapp");
     expect(mocks.login).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -127,12 +123,48 @@ describe("channel-auth", () => {
     );
   });
 
-  it("propagates channel ambiguity when channel is omitted", async () => {
-    mocks.resolveMessageChannelSelection.mockRejectedValueOnce(
-      new Error("Channel is required when multiple channels are configured: telegram, slack"),
+  it("ignores configured channels that do not support login when channel is omitted", async () => {
+    const telegramPlugin = {
+      id: "telegram",
+      auth: {},
+      gateway: {},
+      config: {
+        listAccountIds: vi.fn().mockReturnValue(["default"]),
+        resolveAccount: vi.fn().mockReturnValue({ enabled: true }),
+      },
+    };
+    mocks.listChannelPlugins.mockReturnValue([telegramPlugin, plugin]);
+
+    await runChannelLogin({}, runtime);
+
+    expect(mocks.normalizeChannelId).toHaveBeenCalledWith("whatsapp");
+    expect(mocks.login).toHaveBeenCalled();
+  });
+
+  it("propagates auth-channel ambiguity when multiple configured channels support login", async () => {
+    const zaloPlugin = {
+      id: "zalouser",
+      auth: { login: vi.fn() },
+      gateway: {},
+      config: {
+        listAccountIds: vi.fn().mockReturnValue(["default"]),
+        resolveAccount: vi.fn().mockReturnValue({ enabled: true }),
+      },
+    };
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {}, zalouser: {} } });
+    mocks.listChannelPlugins.mockReturnValue([plugin, zaloPlugin]);
+    mocks.normalizeChannelId.mockImplementation((value) => value);
+    mocks.getChannelPlugin.mockImplementation((value) =>
+      value === "whatsapp"
+        ? plugin
+        : value === "zalouser"
+          ? (zaloPlugin as typeof plugin)
+          : undefined,
     );
 
-    await expect(runChannelLogin({}, runtime)).rejects.toThrow("Channel is required");
+    await expect(runChannelLogin({}, runtime)).rejects.toThrow(
+      "multiple configured channels support login: whatsapp, zalouser",
+    );
     expect(mocks.login).not.toHaveBeenCalled();
   });
 
@@ -199,16 +231,16 @@ describe("channel-auth", () => {
         workspaceDir: "/tmp/workspace",
       }),
     );
-    expect(mocks.writeConfigFile).toHaveBeenCalledWith({ channels: {} });
+    expect(mocks.writeConfigFile).toHaveBeenCalledWith({ channels: { whatsapp: {} } });
     expect(mocks.login).toHaveBeenCalled();
   });
 
   it("runs logout with resolved account and explicit account id", async () => {
     await runChannelLogout({ channel: "whatsapp", account: " acct-2 " }, runtime);
 
-    expect(mocks.resolveAccount).toHaveBeenCalledWith({ channels: {} }, "acct-2");
+    expect(mocks.resolveAccount).toHaveBeenCalledWith({ channels: { whatsapp: {} } }, "acct-2");
     expect(mocks.logoutAccount).toHaveBeenCalledWith({
-      cfg: { channels: {} },
+      cfg: { channels: { whatsapp: {} } },
       accountId: "acct-2",
       account: { id: "resolved-account" },
       runtime,

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -1,9 +1,12 @@
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
-import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
+import {
+  getChannelPlugin,
+  listChannelPlugins,
+  normalizeChannelId,
+} from "../channels/plugins/index.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
 import { loadConfig, writeConfigFile, type OpenClawConfig } from "../config/config.js";
 import { setVerbose } from "../globals.js";
-import { resolveMessageChannelSelection } from "../infra/outbound/channel-selection.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 
 type ChannelAuthOptions = {
@@ -14,6 +17,48 @@ type ChannelAuthOptions = {
 
 type ChannelPlugin = NonNullable<ReturnType<typeof getChannelPlugin>>;
 type ChannelAuthMode = "login" | "logout";
+
+function supportsChannelAuthMode(plugin: ChannelPlugin, mode: ChannelAuthMode): boolean {
+  return mode === "login" ? Boolean(plugin.auth?.login) : Boolean(plugin.gateway?.logoutAccount);
+}
+
+function isConfiguredAuthPlugin(plugin: ChannelPlugin, cfg: OpenClawConfig): boolean {
+  const channelCfg = cfg.channels?.[plugin.id as keyof NonNullable<typeof cfg.channels>];
+  if (!channelCfg || typeof channelCfg !== "object") {
+    return false;
+  }
+
+  for (const accountId of plugin.config.listAccountIds(cfg)) {
+    try {
+      const account = plugin.config.resolveAccount(cfg, accountId);
+      const enabled = plugin.config.isEnabled ? plugin.config.isEnabled(account, cfg) : true;
+      if (enabled) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+}
+
+function resolveConfiguredAuthChannelInput(cfg: OpenClawConfig, mode: ChannelAuthMode): string {
+  const configured = listChannelPlugins()
+    .filter((plugin): plugin is ChannelPlugin => supportsChannelAuthMode(plugin, mode))
+    .filter((plugin) => isConfiguredAuthPlugin(plugin, cfg))
+    .map((plugin) => plugin.id);
+
+  if (configured.length === 1) {
+    return configured[0];
+  }
+  if (configured.length === 0) {
+    throw new Error(`Channel is required (no configured channels support ${mode}).`);
+  }
+  throw new Error(
+    `Channel is required when multiple configured channels support ${mode}: ${configured.join(", ")}`,
+  );
+}
 
 async function resolveChannelPluginForMode(
   opts: ChannelAuthOptions,
@@ -28,9 +73,7 @@ async function resolveChannelPluginForMode(
   plugin: ChannelPlugin;
 }> {
   const explicitChannel = opts.channel?.trim();
-  const channelInput = explicitChannel
-    ? explicitChannel
-    : (await resolveMessageChannelSelection({ cfg })).channel;
+  const channelInput = explicitChannel || resolveConfiguredAuthChannelInput(cfg, mode);
   const channelId = normalizeChannelId(channelInput);
   if (!channelId) {
     throw new Error(`Unsupported channel: ${channelInput}`);
@@ -41,13 +84,10 @@ async function resolveChannelPluginForMode(
     runtime,
     channelId,
     allowInstall: true,
-    supports: (candidate) =>
-      mode === "login" ? Boolean(candidate.auth?.login) : Boolean(candidate.gateway?.logoutAccount),
+    supports: (candidate) => supportsChannelAuthMode(candidate, mode),
   });
   const plugin = resolved.plugin;
-  const supportsMode =
-    mode === "login" ? Boolean(plugin?.auth?.login) : Boolean(plugin?.gateway?.logoutAccount);
-  if (!supportsMode) {
+  if (!plugin || !supportsChannelAuthMode(plugin, mode)) {
     throw new Error(`Channel ${channelId} does not support ${mode}`);
   }
   return {
@@ -55,7 +95,7 @@ async function resolveChannelPluginForMode(
     configChanged: resolved.configChanged,
     channelInput,
     channelId,
-    plugin: plugin as ChannelPlugin,
+    plugin,
   };
 }
 

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -31,7 +31,11 @@ function isConfiguredAuthPlugin(plugin: ChannelPlugin, cfg: OpenClawConfig): boo
   for (const accountId of plugin.config.listAccountIds(cfg)) {
     try {
       const account = plugin.config.resolveAccount(cfg, accountId);
-      const enabled = plugin.config.isEnabled ? plugin.config.isEnabled(account, cfg) : true;
+      const enabled = plugin.config.isEnabled
+        ? plugin.config.isEnabled(account, cfg)
+        : account && typeof account === "object"
+          ? ((account as { enabled?: boolean }).enabled ?? true)
+          : true;
       if (enabled) {
         return true;
       }


### PR DESCRIPTION
## Summary
- stop `channels login/logout` from using the generic configured message-channel selector
- auto-pick a channel only when exactly one configured channel actually supports the requested auth flow
- add coverage for ignoring non-login channels and surfacing auth-channel ambiguity cleanly

## Problem
After `v2026.03.23`, some users with multiple configured channels can hit failures when running:

```bash
openclaw channels login --account default
```

Observed errors include:
- `whatsapp(default) isConfigured failed: ... missing light-runtime-api ...`
- `Channel is required (no configured channels detected)`

The underlying issue is that the auth flow was reusing the generic configured message-channel selector, which probes `isConfigured()` for outbound messaging. That is the wrong selector for login/logout flows.

## Solutions
### Immediate workaround
Pass the channel explicitly:

```bash
openclaw channels login --channel whatsapp --account default
```

<img width="881" height="158" alt="Screenshot 2026-03-23 at 7 47 05 PM" src="https://github.com/user-attachments/assets/f51cde2b-1451-48fd-8166-1abb1d8960e3" />

### Fix in this PR
This PR changes `channels login/logout` to:
- look only at channels that actually support the requested auth flow (`login` or `logout`)
- auto-select only when exactly one configured auth-capable channel exists
- return a clean ambiguity error when multiple auth-capable channels are configured

So the CLI no longer depends on generic outbound channel configuration to decide auth-channel selection.

## Why this resolves the regression
This avoids the brittle `isConfigured()` probe path during auth-channel auto-selection, which is what was surfacing plugin/runtime errors and leading to misleading channel-selection failures.

## Validation
- `pnpm vitest run src/cli/channel-auth.test.ts`
- `pnpm check`