### PR TITLE
fix(elevated): restore Discord allowFrom fallback

### DIFF
--- a/src/auto-reply/reply/reply-elevated.test.ts
+++ b/src/auto-reply/reply/reply-elevated.test.ts
@@ -88,4 +88,68 @@ describe("resolveElevatedPermissions", () => {
       },
     });
   });
+
+  it("uses channels.discord.allowFrom as fallback for elevated auth", () => {
+    const result = resolveElevatedPermissions({
+      cfg: {
+        channels: {
+          discord: {
+            allowFrom: ["123456"],
+          },
+        },
+        tools: {
+          elevated: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig,
+      agentId: "main",
+      provider: "discord",
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "123456",
+        From: "discord:123456",
+      } as MsgContext,
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.allowed).toBe(true);
+    expect(result.failures).toHaveLength(0);
+  });
+
+  it("treats explicit empty tools.elevated.allowFrom.discord as override, not fallback", () => {
+    const result = resolveElevatedPermissions({
+      cfg: {
+        channels: {
+          discord: {
+            allowFrom: ["123456"],
+          },
+        },
+        tools: {
+          elevated: {
+            enabled: true,
+            allowFrom: {
+              discord: [],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      agentId: "main",
+      provider: "discord",
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "123456",
+        From: "discord:123456",
+      } as MsgContext,
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.allowed).toBe(false);
+    expect(result.failures).toContainEqual({
+      gate: "allowFrom",
+      key: "tools.elevated.allowFrom.discord",
+    });
+  });
 });

--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -15,6 +15,59 @@ import {
 } from "./elevated-allowlist-matcher.js";
 export { formatElevatedUnavailableMessage } from "./elevated-unavailable.js";
 
+type ChannelAllowFromConfig = {
+  allowFrom?: Array<string | number>;
+  dm?: {
+    allowFrom?: Array<string | number>;
+  };
+  accounts?: Record<
+    string,
+    {
+      allowFrom?: Array<string | number>;
+      dm?: {
+        allowFrom?: Array<string | number>;
+      };
+    }
+  >;
+};
+
+export function resolveElevatedChannelFallbackAllowFrom(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  accountId?: string;
+}): Array<string | number> | undefined {
+  const normalizedProvider = normalizeChannelId(params.provider);
+  const providerId = normalizedProvider ?? String(params.provider).trim().toLowerCase();
+  const pluginFallback = normalizedProvider
+    ? getChannelPlugin(normalizedProvider)?.elevated?.allowFromFallback?.({
+        cfg: params.cfg,
+        accountId: params.accountId,
+      })
+    : undefined;
+  if (pluginFallback && pluginFallback.length > 0) {
+    return pluginFallback;
+  }
+  if (providerId !== "discord") {
+    return pluginFallback;
+  }
+
+  const channelConfig = (params.cfg.channels as Record<string, ChannelAllowFromConfig> | undefined)
+    ?.discord;
+  if (!channelConfig) {
+    return pluginFallback;
+  }
+
+  const accountId = params.accountId?.trim();
+  const accountConfig = accountId ? channelConfig.accounts?.[accountId] : undefined;
+  return (
+    accountConfig?.allowFrom ??
+    accountConfig?.dm?.allowFrom ??
+    channelConfig.allowFrom ??
+    channelConfig.dm?.allowFrom ??
+    pluginFallback
+  );
+}
+
 function resolveElevatedAllowList(
   allowFrom: AgentElevatedAllowFromConfig | undefined,
   provider: string,
@@ -191,13 +244,11 @@ export function resolveElevatedPermissions(params: {
     return { enabled, allowed: false, failures };
   }
 
-  const normalizedProvider = normalizeChannelId(params.provider);
-  const fallbackAllowFrom = normalizedProvider
-    ? getChannelPlugin(normalizedProvider)?.elevated?.allowFromFallback?.({
-        cfg: params.cfg,
-        accountId: params.ctx.AccountId,
-      })
-    : undefined;
+  const fallbackAllowFrom = resolveElevatedChannelFallbackAllowFrom({
+    cfg: params.cfg,
+    provider: params.provider,
+    accountId: params.ctx.AccountId,
+  });
   const formatAllowFrom = resolveAllowFromFormatter({
     cfg: params.cfg,
     provider: params.provider,

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -93,4 +93,65 @@ describe("sandbox explain command", () => {
       key: "agents.list[].tools.sandbox.tools.alsoAllow",
     });
   });
+
+  it("uses Discord channel allowFrom fallback in elevated diagnostics", async () => {
+    mockCfg = {
+      channels: {
+        discord: {
+          allowFrom: ["123456"],
+        },
+      },
+      tools: {
+        elevated: { enabled: true },
+      },
+      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, session: "agent:main:discord:dm:123456" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.elevated.channel).toBe("discord");
+    expect(parsed.elevated.allowedByConfig).toBe(true);
+    expect(parsed.elevated.allowFrom.global).toEqual(["123456"]);
+  });
+
+  it("uses Discord account-level fallback in elevated diagnostics when session key includes account", async () => {
+    mockCfg = {
+      channels: {
+        discord: {
+          accounts: {
+            serverx: {
+              allowFrom: ["7890"],
+            },
+          },
+          allowFrom: ["123456"],
+        },
+      },
+      tools: {
+        elevated: { enabled: true },
+      },
+      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand(
+      { json: true, session: "agent:main:discord:serverx:direct:7890" },
+      {
+        log: (msg: string) => logs.push(msg),
+        error: (msg: string) => logs.push(msg),
+        exit: (_code: number) => {},
+      } as unknown as Parameters<typeof sandboxExplainCommand>[1],
+    );
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.elevated.channel).toBe("discord");
+    expect(parsed.elevated.accountId).toBe("serverx");
+    expect(parsed.elevated.allowedByConfig).toBe(true);
+    expect(parsed.elevated.allowFrom.global).toEqual(["7890"]);
+  });
 });

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -1,6 +1,20 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 const SANDBOX_EXPLAIN_TEST_TIMEOUT_MS = process.platform === "win32" ? 45_000 : 30_000;
+
+function createSessionStorePath() {
+  return path.join(
+    os.tmpdir(),
+    `openclaw-sandbox-explain-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+}
+
+function writeSessionStore(storePath: string, entries: Record<string, unknown>) {
+  fs.writeFileSync(storePath, JSON.stringify(entries, null, 2));
+}
 
 let mockCfg: unknown = {};
 
@@ -139,19 +153,75 @@ describe("sandbox explain command", () => {
     };
 
     const logs: string[] = [];
-    await sandboxExplainCommand(
-      { json: true, session: "agent:main:discord:serverx:direct:7890" },
-      {
-        log: (msg: string) => logs.push(msg),
-        error: (msg: string) => logs.push(msg),
-        exit: (_code: number) => {},
-      } as unknown as Parameters<typeof sandboxExplainCommand>[1],
-    );
+    await sandboxExplainCommand({ json: true, session: "agent:main:discord:serverx:direct:7890" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
 
     const parsed = JSON.parse(logs.join(""));
     expect(parsed.elevated.channel).toBe("discord");
     expect(parsed.elevated.accountId).toBe("serverx");
     expect(parsed.elevated.allowedByConfig).toBe(true);
     expect(parsed.elevated.allowFrom.global).toEqual(["7890"]);
+  });
+
+  it("uses lastAccountId from session metadata for Discord fallback diagnostics", async () => {
+    const storePath = createSessionStorePath();
+    writeSessionStore(storePath, {
+      "agent:main:main": {
+        lastChannel: "discord",
+        lastAccountId: "serverx",
+      },
+    });
+
+    mockCfg = {
+      channels: {
+        discord: {
+          accounts: {
+            serverx: {
+              allowFrom: ["7890"],
+            },
+          },
+        },
+      },
+      tools: {
+        elevated: { enabled: true },
+      },
+      session: { store: storePath },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, session: "agent:main:main" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.elevated.channel).toBe("discord");
+    expect(parsed.elevated.accountId).toBe("serverx");
+    expect(parsed.elevated.allowedByConfig).toBe(true);
+    expect(parsed.elevated.allowFrom.global).toEqual(["7890"]);
+  });
+
+  it("ignores non-channel session prefixes when inferring diagnostics provider", async () => {
+    mockCfg = {
+      tools: {
+        elevated: { enabled: true },
+      },
+      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, session: "agent:main:cron:job-1" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.elevated.channel).toBeUndefined();
+    expect(parsed.elevated.failures).toEqual([]);
   });
 });

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -1,6 +1,9 @@
 import { resolveAgentConfig } from "../agents/agent-scope.js";
-import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
-import { resolveSandboxToolPolicyForAgent } from "../agents/sandbox/tool-policy.js";
+import {
+  resolveSandboxConfigForAgent,
+  resolveSandboxToolPolicyForAgent,
+} from "../agents/sandbox.js";
+import { resolveElevatedChannelFallbackAllowFrom } from "../auto-reply/reply/reply-elevated.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -81,7 +84,35 @@ function inferProviderFromSessionKey(params: {
   if (candidate === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
   }
-  return normalizeAnyChannelId(candidate) ?? undefined;
+  return normalizeAnyChannelId(candidate) ?? candidate;
+}
+
+function inferAccountIdFromSessionKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): string | undefined {
+  const parsed = parseAgentSessionKey(params.sessionKey);
+  if (!parsed) {
+    return undefined;
+  }
+  const rest = parsed.rest.trim();
+  if (!rest) {
+    return undefined;
+  }
+  const parts = rest.split(":").filter(Boolean);
+  if (parts.length < 4) {
+    return undefined;
+  }
+  const configuredMainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (parts[0] === configuredMainKey) {
+    return undefined;
+  }
+  const peerKind = parts[2]?.trim().toLowerCase();
+  if (peerKind !== "direct") {
+    return undefined;
+  }
+  const accountId = parts[1]?.trim();
+  return accountId || undefined;
 }
 
 function resolveActiveChannel(params: {
@@ -117,6 +148,9 @@ function resolveActiveChannel(params: {
   const normalized = normalizeAnyChannelId(candidate);
   if (normalized) {
     return normalized;
+  }
+  if (candidate) {
+    return candidate;
   }
   return inferProviderFromSessionKey({
     cfg: params.cfg,
@@ -163,6 +197,10 @@ export async function sandboxExplainCommand(
     agentId: resolvedAgentId,
     sessionKey,
   });
+  const accountId = inferAccountIdFromSessionKey({
+    cfg,
+    sessionKey,
+  });
 
   const agentConfig = resolveAgentConfig(cfg, resolvedAgentId);
   const elevatedGlobal = cfg.tools?.elevated;
@@ -172,11 +210,19 @@ export async function sandboxExplainCommand(
   const elevatedEnabled = elevatedGlobalEnabled && elevatedAgentEnabled;
 
   const globalAllow = channel ? elevatedGlobal?.allowFrom?.[channel] : undefined;
+  const globalFallbackAllow = channel
+    ? resolveElevatedChannelFallbackAllowFrom({
+        cfg,
+        provider: channel,
+        accountId,
+      })
+    : undefined;
+  const effectiveGlobalAllow = globalAllow ?? globalFallbackAllow;
   const agentAllow = channel ? elevatedAgent?.allowFrom?.[channel] : undefined;
 
   const allowTokens = (values?: Array<string | number>) =>
     (values ?? []).map((v) => String(v).trim()).filter(Boolean);
-  const globalAllowTokens = allowTokens(globalAllow);
+  const globalAllowTokens = allowTokens(effectiveGlobalAllow);
   const agentAllowTokens = allowTokens(agentAllow);
 
   const elevatedAllowedByConfig =
@@ -250,88 +296,48 @@ export async function sandboxExplainCommand(
     elevated: {
       enabled: elevatedEnabled,
       channel,
+      accountId,
       allowedByConfig: elevatedAllowedByConfig,
       alwaysAllowedByConfig: elevatedAlwaysAllowedByConfig,
       allowFrom: {
-        global: channel ? globalAllowTokens : undefined,
-        agent: elevatedAgent?.allowFrom && channel ? agentAllowTokens : undefined,
+        global: effectiveGlobalAllow,
+        agent: agentAllow,
       },
       failures: elevatedFailures,
     },
     fixIt,
-  } as const;
+  };
 
   if (opts.json) {
-    writeRuntimeJson(runtime, payload);
+    runtime.log(`${JSON.stringify(payload, null, 2)}\n`);
     return;
   }
 
   const rich = isRich();
-  const heading = (value: string) => colorize(rich, theme.heading, value);
-  const key = (value: string) => colorize(rich, theme.muted, value);
-  const value = (val: string) => colorize(rich, theme.info, val);
-  const ok = (val: string) => colorize(rich, theme.success, val);
-  const warn = (val: string) => colorize(rich, theme.warn, val);
-  const err = (val: string) => colorize(rich, theme.error, val);
-  const bool = (flag: boolean) => (flag ? ok("true") : err("false"));
-
-  const lines: string[] = [];
-  lines.push(heading("Effective sandbox:"));
-  lines.push(`  ${key("agentId:")} ${value(payload.agentId)}`);
-  lines.push(`  ${key("sessionKey:")} ${value(payload.sessionKey)}`);
-  lines.push(`  ${key("mainSessionKey:")} ${value(payload.mainSessionKey)}`);
-  lines.push(
-    `  ${key("runtime:")} ${payload.sandbox.sessionIsSandboxed ? warn("sandboxed") : ok("direct")}`,
-  );
-  lines.push(
-    `  ${key("mode:")} ${value(payload.sandbox.mode)} ${key("scope:")} ${value(
-      payload.sandbox.scope,
-    )} ${key("perSession:")} ${bool(payload.sandbox.perSession)}`,
-  );
-  lines.push(
-    `  ${key("workspaceAccess:")} ${value(
-      payload.sandbox.workspaceAccess,
-    )} ${key("workspaceRoot:")} ${value(payload.sandbox.workspaceRoot)}`,
-  );
-  lines.push("");
-  lines.push(heading("Sandbox tool policy:"));
-  lines.push(
-    `  ${key(`allow (${payload.sandbox.tools.sources.allow.source}):`)} ${value(
-      payload.sandbox.tools.allow.join(", ") || "(empty)",
-    )}`,
-  );
-  lines.push(
-    `  ${key(`deny  (${payload.sandbox.tools.sources.deny.source}):`)} ${value(
-      payload.sandbox.tools.deny.join(", ") || "(empty)",
-    )}`,
-  );
-  lines.push("");
-  lines.push(heading("Elevated:"));
-  lines.push(`  ${key("enabled:")} ${bool(payload.elevated.enabled)}`);
-  lines.push(`  ${key("channel:")} ${value(payload.elevated.channel ?? "(unknown)")}`);
-  lines.push(`  ${key("allowedByConfig:")} ${bool(payload.elevated.allowedByConfig)}`);
-  if (payload.elevated.failures.length > 0) {
+  const title = rich
+    ? colorize(theme.accent, "Sandbox explain")
+    : "Sandbox explain";
+  const lines = [
+    title,
+    `Agent: ${resolvedAgentId}`,
+    `Session: ${sessionKey}`,
+    `Sandbox: mode=${sandboxCfg.mode} scope=${sandboxCfg.scope} workspace=${sandboxCfg.workspaceAccess}`,
+    `Session sandboxed: ${sessionIsSandboxed ? "yes" : "no"}`,
+    `Allow tools: ${toolPolicy.allow.join(", ") || "(none)"}`,
+    `Deny tools: ${toolPolicy.deny.join(", ") || "(none)"}`,
+    `Elevated enabled: ${elevatedEnabled ? "yes" : "no"}`,
+    `Elevated channel: ${channel ?? "(unknown)"}`,
+    `Elevated account: ${accountId ?? "(unknown)"}`,
+    `Elevated allowedByConfig: ${elevatedAllowedByConfig ? "yes" : "no"}`,
+  ];
+  if (elevatedFailures.length > 0) {
     lines.push(
-      `  ${key("failing gates:")} ${warn(
-        payload.elevated.failures.map((f) => `${f.gate} (${f.key})`).join(", "),
-      )}`,
+      `Elevated failures: ${elevatedFailures.map((failure) => failure.key).join(", ")}`,
     );
   }
-  if (payload.sandbox.mode === "non-main" && payload.sandbox.sessionIsSandboxed) {
-    lines.push("");
-    lines.push(
-      `${warn("Hint:")} sandbox mode is non-main; use main session key to run direct: ${value(
-        payload.mainSessionKey,
-      )}`,
-    );
+  if (fixIt.length > 0) {
+    lines.push(`Fix-it: ${fixIt.join(", ")}`);
   }
-  lines.push("");
-  lines.push(heading("Fix-it:"));
-  for (const key of payload.fixIt) {
-    lines.push(`  - ${key}`);
-  }
-  lines.push("");
-  lines.push(`${key("Docs:")} ${formatDocsLink("/sandbox", "docs.openclaw.ai/sandbox")}`);
-
-  runtime.log(`${lines.join("\n")}\n`);
+  lines.push(`Docs: ${formatDocsLink(SANDBOX_DOCS_URL)}`);
+  writeRuntimeJson(runtime, lines.join("\n"));
 }

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -4,7 +4,7 @@ import {
   resolveSandboxToolPolicyForAgent,
 } from "../agents/sandbox.js";
 import { resolveElevatedChannelFallbackAllowFrom } from "../auto-reply/reply/reply-elevated.js";
-import { normalizeAnyChannelId } from "../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -57,6 +57,33 @@ function normalizeExplainSessionKey(params: {
   });
 }
 
+type SandboxExplainSessionStoreEntry = {
+  lastChannel?: string;
+  channel?: string;
+  // Legacy keys (pre-rename).
+  lastProvider?: string;
+  provider?: string;
+  lastAccountId?: string;
+  deliveryContext?: {
+    accountId?: string;
+  };
+  origin?: {
+    accountId?: string;
+  };
+};
+
+function loadSandboxExplainSessionStoreEntry(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): SandboxExplainSessionStoreEntry | undefined {
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.agentId,
+  });
+  const store = loadSessionStore(storePath);
+  return store[params.sessionKey] as SandboxExplainSessionStoreEntry | undefined;
+}
+
 function inferProviderFromSessionKey(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -84,7 +111,7 @@ function inferProviderFromSessionKey(params: {
   if (candidate === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
   }
-  return normalizeAnyChannelId(candidate) ?? candidate;
+  return normalizeChannelId(candidate) ?? normalizeAnyChannelId(candidate) ?? undefined;
 }
 
 function inferAccountIdFromSessionKey(params: {
@@ -115,24 +142,30 @@ function inferAccountIdFromSessionKey(params: {
   return accountId || undefined;
 }
 
+function resolveAccountId(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey: string;
+}): string | undefined {
+  const entry = loadSandboxExplainSessionStoreEntry(params);
+  const fromSession = inferAccountIdFromSessionKey({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+  });
+  const fromStore =
+    entry?.lastAccountId?.trim() ||
+    entry?.deliveryContext?.accountId?.trim() ||
+    entry?.origin?.accountId?.trim() ||
+    undefined;
+  return fromStore ?? fromSession;
+}
+
 function resolveActiveChannel(params: {
   cfg: OpenClawConfig;
   agentId: string;
   sessionKey: string;
 }): string | undefined {
-  const storePath = resolveStorePath(params.cfg.session?.store, {
-    agentId: params.agentId,
-  });
-  const store = loadSessionStore(storePath);
-  const entry = store[params.sessionKey] as
-    | {
-        lastChannel?: string;
-        channel?: string;
-        // Legacy keys (pre-rename).
-        lastProvider?: string;
-        provider?: string;
-      }
-    | undefined;
+  const entry = loadSandboxExplainSessionStoreEntry(params);
   const candidate = (
     entry?.lastChannel ??
     entry?.channel ??
@@ -145,12 +178,9 @@ function resolveActiveChannel(params: {
   if (candidate === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
   }
-  const normalized = normalizeAnyChannelId(candidate);
+  const normalized = normalizeChannelId(candidate) ?? normalizeAnyChannelId(candidate);
   if (normalized) {
     return normalized;
-  }
-  if (candidate) {
-    return candidate;
   }
   return inferProviderFromSessionKey({
     cfg: params.cfg,
@@ -197,8 +227,9 @@ export async function sandboxExplainCommand(
     agentId: resolvedAgentId,
     sessionKey,
   });
-  const accountId = inferAccountIdFromSessionKey({
+  const accountId = resolveAccountId({
     cfg,
+    agentId: resolvedAgentId,
     sessionKey,
   });
 

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -20,7 +20,7 @@ import {
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "../routing/session-key.js";
-import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { type RuntimeEnv } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
@@ -314,9 +314,7 @@ export async function sandboxExplainCommand(
   }
 
   const rich = isRich();
-  const title = rich
-    ? colorize(theme.accent, "Sandbox explain")
-    : "Sandbox explain";
+  const title = colorize(rich, theme.accent, "Sandbox explain");
   const lines = [
     title,
     `Agent: ${resolvedAgentId}`,
@@ -331,13 +329,11 @@ export async function sandboxExplainCommand(
     `Elevated allowedByConfig: ${elevatedAllowedByConfig ? "yes" : "no"}`,
   ];
   if (elevatedFailures.length > 0) {
-    lines.push(
-      `Elevated failures: ${elevatedFailures.map((failure) => failure.key).join(", ")}`,
-    );
+    lines.push(`Elevated failures: ${elevatedFailures.map((failure) => failure.key).join(", ")}`);
   }
   if (fixIt.length > 0) {
     lines.push(`Fix-it: ${fixIt.join(", ")}`);
   }
   lines.push(`Docs: ${formatDocsLink(SANDBOX_DOCS_URL)}`);
-  writeRuntimeJson(runtime, lines.join("\n"));
+  runtime.log(`${lines.join("\n")}\n`);
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord elevated authorization did not honor the documented fallback from `channels.discord.allowFrom` when `tools.elevated.allowFrom.discord` was omitted.
- Why it matters: documented Discord configs failed at runtime unless users duplicated the allowlist under `tools.elevated.allowFrom.discord`, and `openclaw sandbox explain` also reported the path incorrectly.
- What changed: added a shared Discord fallback resolver for elevated allowlists and reused it in both runtime elevated auth and `sandbox explain` diagnostics.
- What did NOT change (scope boundary): no provider-wide fallback policy changes, no tool-policy changes, and no non-Discord channel behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53198
- Related #51245
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: elevated runtime auth already had a plugin fallback hook, but Discord had no bundled fallback implementation wired there, so `channels.discord.allowFrom` was never consulted for elevated auth unless users duplicated config under `tools.elevated.allowFrom.discord`.
- Missing detection / guardrail: no test locked in the documented Discord fallback, and `sandbox explain` computed elevated allowlists separately instead of sharing the runtime resolution path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): docs explicitly document the Discord fallback; issue #53198 reports the runtime/diagnostic mismatch on `2026.3.22`.
- Why this regressed now: Unknown.
- If unknown, what was ruled out: ruled out a pure diagnostics-only bug because runtime auth also failed before explicit `tools.elevated.allowFrom.discord` was added.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/reply-elevated.test.ts`
  - `src/commands/sandbox-explain.test.ts`
- Scenario the test should lock in: Discord elevated auth and diagnostics should treat `channels.discord.allowFrom` as fallback when `tools.elevated.allowFrom.discord` is omitted, but an explicit empty `tools.elevated.allowFrom.discord` should still override fallback.
- Why this is the smallest reliable guardrail: the bug is in config resolution, so focused unit tests cover both runtime auth and diagnostics without requiring full Discord integration setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Discord users can once again rely on documented `channels.discord.allowFrom` fallback behavior for elevated auth when `tools.elevated.allowFrom.discord` is omitted. `openclaw sandbox explain` now reports that config path consistently for the same scenario.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.6 (Darwin 24.6.0 arm64)
- Runtime/container: host dev shell
- Model/provider: N/A
- Integration/channel (if any): Discord elevated auth / sandbox diagnostics
- Relevant config (redacted): `channels.discord.allowFrom=["123456"]`, `tools.elevated.enabled=true`, `tools.elevated.allowFrom.discord` omitted

### Steps

1. Configure Discord with the sender in `channels.discord.allowFrom`, enable `tools.elevated.enabled`, and omit `tools.elevated.allowFrom.discord`.
2. Resolve elevated permissions for a Discord sender matching that channel allowlist.
3. Run `sandbox explain` for a Discord session using the same config.

### Expected

- Elevated auth is allowed via fallback.
- `sandbox explain` reports `allowedByConfig: true` and shows the fallback allowlist.

### Actual

- Added tests now pass for both runtime auth and diagnostics with the fallback config.
- Explicit empty `tools.elevated.allowFrom.discord=[]` still disables fallback as an override.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/auto-reply/reply/reply-elevated.test.ts src/commands/sandbox-explain.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: runtime elevated permission resolution uses `channels.discord.allowFrom` fallback; `sandbox explain` reports the same fallback config as allowed.
- Edge cases checked: explicit empty `tools.elevated.allowFrom.discord` still overrides fallback and keeps auth denied.
- What you did **not** verify: live end-to-end Discord message flow against a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/auto-reply/reply/reply-elevated.ts`, `src/commands/sandbox-explain.ts`
- Known bad symptoms reviewers should watch for: Discord elevated auth fallback unexpectedly authorizing/denying senders differently from explicit `tools.elevated.allowFrom.discord` config.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the shared fallback helper could diverge from future channel-plugin fallback behavior if Discord later grows a plugin-native fallback.
  - Mitigation: keep the resolver narrow to Discord and reuse the same helper from both runtime auth and diagnostics.