### PR TITLE
fix(build): auto-discover extension runtime-api entry points

### DIFF
--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -13,7 +13,7 @@ function readBundledPluginPackageJson(packageJsonPath) {
   }
 }
 
-function collectPluginSourceEntries(packageJson) {
+function collectPluginSourceEntries(packageJson, pluginDir) {
   let packageEntries = Array.isArray(packageJson?.openclaw?.extensions)
     ? packageJson.openclaw.extensions.filter(
         (entry) => typeof entry === "string" && entry.trim().length > 0,
@@ -26,6 +26,19 @@ function collectPluginSourceEntries(packageJson) {
       : undefined;
   if (setupEntry) {
     packageEntries = Array.from(new Set([...packageEntries, setupEntry]));
+  }
+  // Auto-discover runtime API entry points that the core boundary modules
+  // load dynamically via jiti.  Without these the plugin fails at runtime
+  // even though index.js loads fine.
+  if (pluginDir) {
+    for (const file of fs.readdirSync(pluginDir)) {
+      if (file.endsWith("-runtime-api.ts") || file === "runtime-api.ts") {
+        const entry = `./${file}`;
+        if (!packageEntries.includes(entry)) {
+          packageEntries.push(entry);
+        }
+      }
+    }
   }
   return packageEntries.length > 0 ? packageEntries : ["./index.ts"];
 }
@@ -57,7 +70,7 @@ export function collectBundledPluginBuildEntries(params = {}) {
       id: dirent.name,
       hasPackageJson: packageJson !== null,
       packageJson,
-      sourceEntries: collectPluginSourceEntries(packageJson),
+      sourceEntries: collectPluginSourceEntries(packageJson, pluginDir),
     });
   }
 


### PR DESCRIPTION
## Summary

The build script (`bundled-plugin-build-entries.mjs`) only compiles files listed in each extension's `openclaw.extensions` array plus `setupEntry`. However, core boundary modules (e.g. `runtime-whatsapp-boundary.ts`) dynamically load `light-runtime-api.js` and `runtime-api.js` via jiti at runtime. Since these files were never listed in `openclaw.extensions`, they were not compiled into `dist/extensions/<plugin>/`, causing runtime failures on v2026.3.22+:

```
Error: WhatsApp plugin runtime is unavailable: missing light-runtime-api for plugin 'whatsapp'
```

## Root Cause

`collectPluginSourceEntries()` reads only two sources for build entries:
1. `packageJson.openclaw.extensions` (e.g. `["./index.ts"]`)
2. `packageJson.openclaw.setupEntry` (e.g. `"./setup-entry.ts"`)

But `resolveWhatsAppRuntimeModulePath()` in `runtime-whatsapp-boundary.ts` expects `light-runtime-api.js` and `runtime-api.js` to exist as separate compiled files at runtime (loaded via jiti). These were never declared as build entries.

This affects **all 28 extensions** that have `runtime-api.ts` or `*-runtime-api.ts` files, though WhatsApp was the most visible because its boundary module is loaded eagerly during gateway startup.

## Fix

Add auto-discovery of `*-runtime-api.ts` and `runtime-api.ts` files in each extension directory during build entry collection. This ensures dynamically loaded runtime APIs are always compiled without requiring each extension to manually declare them.

Changes: `scripts/lib/bundled-plugin-build-entries.mjs` — 1 file, +15 −2 lines.

## Verification

Built before and after the fix:

**Before:**
```
$ ls dist/extensions/whatsapp/
index.js  setup-entry.js
```

**After:**
```
$ ls dist/extensions/whatsapp/
action-runtime-api.js  index.js  light-runtime-api.js  runtime-api.js  setup-entry.js
```

All 28 affected extensions now have their `runtime-api.js` compiled.

## Affected Versions
- v2026.3.22
- v2026.3.23

## Workaround
Downgrade to v2026.3.13 where WhatsApp was still part of the main bundle.

Fixes #53046