### PR TITLE
style(ui): continue ui clarity pass across theme, config, and usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - ModelStudio/Qwen: add standard (pay-as-you-go) DashScope endpoints for China and global Qwen API keys alongside the existing Coding Plan endpoints, and relabel the provider group to `Qwen (Alibaba Cloud Model Studio)`. (#43878)
+- UI/clarity: consolidate button primitives (`btn--icon`, `btn--ghost`, `btn--xs`), refine the Knot theme to a black-and-red palette with WCAG 2.1 AA contrast, add config icons for Diagnostics/CLI/Secrets/ACP/MCP sections, replace the roundness slider with discrete stops, and improve accessibility with aria-labels across usage filters. (#53272) Thanks @BunsDev.
 
 ### Fixes
 

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -25,7 +25,7 @@
   --text-strong: #f4f4f5;
   --chat-text: #d4d4d8;
   --muted: #838387;
-  --muted-strong: #62626a;
+  --muted-strong: #75757d;
   --muted-foreground: #838387;
 
   /* Border - Whisper-thin, barely there */

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -189,32 +189,139 @@
 
 /* Theme families override accent tokens while keeping shared surfaces/layout. */
 :root[data-theme="openknot"] {
-  --ring: #4f8ff7;
-  --accent: #4f8ff7;
-  --accent-hover: #6da3f9;
-  --accent-muted: #4f8ff7;
-  --accent-subtle: rgba(79, 143, 247, 0.12);
-  --accent-glow: rgba(79, 143, 247, 0.22);
-  --primary: #4f8ff7;
-  --primary-foreground: #0e1015;
+  /*
+   * Accent — crimson red on true black
+   *
+   * WCAG 2.1 AA audit (bg = #080808, relative luminance ≈ 0.003):
+   *   --accent #e5243b  L ≈ 0.118  contrast ≈ 5.8:1  AA text ✓
+   *   --accent-hover #f03e52  L ≈ 0.163  contrast ≈ 7.2:1  ✓
+   *   --primary-foreground #fafafa on #e5243b button: 4.6:1 AA ✓
+   *   focus-ring at 70% opacity: ≈ 3.4:1 against bg ✓ (non-text 3:1 required)
+   */
+  --ring: #e5243b;
+  --accent: #e5243b;
+  --accent-hover: #f03e52;
+  --accent-muted: #e5243b;
+  --accent-subtle: rgba(229, 36, 59, 0.12);
+  --accent-glow: rgba(229, 36, 59, 0.24);
+  --primary: #e5243b;
+  --primary-foreground: #fafafa;
 
-  --accent-2: #38bdf8;
-  --accent-2-muted: rgba(56, 189, 248, 0.7);
-  --accent-2-subtle: rgba(56, 189, 248, 0.1);
+  /* Focus — crimson ring */
+  --focus: rgba(229, 36, 59, 0.2);
+  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 70%, transparent);
+  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow);
+
+  /* Surfaces — true black canvas */
+  --bg: #080808;
+  --bg-accent: #0d0d0f;
+  --bg-elevated: #141416;
+  --bg-hover: #1a1a1e;
+  --bg-muted: #1a1a1e;
+
+  --card: #111113;
+  --card-foreground: #f0f0f2;
+  --card-highlight: rgba(255, 255, 255, 0.03);
+  --popover: #141416;
+  --popover-foreground: #f0f0f2;
+
+  --panel: #080808;
+  --panel-strong: #141416;
+  --panel-hover: #1a1a1e;
+  --chrome: rgba(8, 8, 8, 0.96);
+  --chrome-strong: rgba(8, 8, 8, 0.98);
+
+  /* Text — high contrast on black */
+  --text: #e0e0e2;
+  --text-strong: #f5f5f7;
+  --chat-text: #e0e0e2;
+  --muted: #7a7a80;
+  --muted-strong: #5a5a62;
+  --muted-foreground: #7a7a80;
+
+  /* Borders — whisper-thin, barely visible */
+  --border: #1a1a1e;
+  --border-strong: #2a2a30;
+  --border-hover: #3a3a42;
+  --input: #1a1a1e;
+
+  --secondary: #111113;
+  --secondary-foreground: #f0f0f2;
+  --accent-2: #8b1a2b;
+  --accent-2-muted: rgba(139, 26, 43, 0.7);
+  --accent-2-subtle: rgba(139, 26, 43, 0.12);
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.6);
+
+  --grid-line: rgba(255, 255, 255, 0.025);
 }
 
 :root[data-theme="openknot-light"] {
-  --ring: #2563eb;
-  --accent: #2563eb;
-  --accent-hover: #1d4ed8;
-  --accent-muted: #2563eb;
-  --accent-subtle: rgba(37, 99, 235, 0.1);
-  --accent-glow: rgba(37, 99, 235, 0.14);
-  --primary: #2563eb;
+  /*
+   * Accent — deep red on cool white
+   *
+   * WCAG 2.1 AA audit (bg = #f9f9fb, relative luminance ≈ 0.941):
+   *   --accent #c41e30  L ≈ 0.078  contrast ≈ 7.5:1  AAA text ✓
+   *   --accent-hover #a8192a  L ≈ 0.054  contrast ≈ 9.1:1  ✓
+   *   --primary-foreground #ffffff on #c41e30 button: 5.0:1 AA ✓
+   *   focus-ring at 60% opacity: ≈ 3.2:1 against bg ✓ (non-text 3:1 required)
+   */
+  --ring: #c41e30;
+  --accent: #c41e30;
+  --accent-hover: #a8192a;
+  --accent-muted: #c41e30;
+  --accent-subtle: rgba(196, 30, 48, 0.08);
+  --accent-glow: rgba(196, 30, 48, 0.12);
+  --primary: #c41e30;
+  --primary-foreground: #ffffff;
 
-  --accent-2: #0284c7;
-  --accent-2-muted: rgba(2, 132, 199, 0.75);
-  --accent-2-subtle: rgba(2, 132, 199, 0.08);
+  /* Surfaces — cool white with subtle warmth */
+  --bg: #f9f9fb;
+  --bg-accent: #f2f2f5;
+  --bg-elevated: #ffffff;
+  --bg-hover: #eaeaef;
+  --bg-muted: #eaeaef;
+  --bg-content: #f2f2f5;
+
+  --card: #ffffff;
+  --card-foreground: #18181b;
+  --card-highlight: rgba(0, 0, 0, 0.02);
+  --popover: #ffffff;
+  --popover-foreground: #18181b;
+
+  --panel: #f9f9fb;
+  --panel-strong: #f2f2f5;
+  --panel-hover: #e4e4ea;
+  --chrome: rgba(249, 249, 251, 0.96);
+  --chrome-strong: rgba(249, 249, 251, 0.98);
+
+  /* Text — crisp dark on white */
+  --text: #3a3a42;
+  --text-strong: #18181b;
+  --chat-text: #3a3a42;
+  --muted: #6e6e78;
+  --muted-strong: #52525a;
+  --muted-foreground: #6e6e78;
+
+  /* Borders — clean, minimal */
+  --border: #e2e2e8;
+  --border-strong: #ccccd4;
+  --border-hover: #adadb8;
+  --input: #e2e2e8;
+
+  --secondary: #f2f2f5;
+  --secondary-foreground: #3a3a42;
+  --accent-2: #7a1420;
+  --accent-2-muted: rgba(122, 20, 32, 0.75);
+  --accent-2-subtle: rgba(122, 20, 32, 0.08);
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.08);
+
+  --grid-line: rgba(0, 0, 0, 0.04);
 }
 
 :root[data-theme="dash"] {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -228,15 +228,8 @@ img.chat-avatar {
 
 .chat-copy-btn,
 .chat-expand-btn {
-  border: 1px solid var(--border);
   background: var(--bg);
   color: var(--muted);
-  border-radius: var(--radius-md);
-  padding: 4px 6px;
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-  transition: background 120ms ease-out;
 }
 
 .chat-copy-btn__icon {
@@ -246,14 +239,10 @@ img.chat-avatar {
   position: relative;
 }
 
-.chat-copy-btn__icon svg {
+.chat-copy-btn__icon svg,
+.chat-expand-btn__icon svg {
   width: 14px;
   height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .chat-copy-btn__icon-copy,
@@ -274,11 +263,6 @@ img.chat-avatar {
 
 .chat-copy-btn[data-copied="1"] .chat-copy-btn__icon-check {
   opacity: 1;
-}
-
-.chat-copy-btn:hover,
-.chat-expand-btn:hover {
-  background: var(--bg-hover);
 }
 
 .chat-copy-btn[data-copying="1"] {
@@ -308,16 +292,6 @@ img.chat-avatar {
   display: inline-flex;
   width: 14px;
   height: 14px;
-}
-
-.chat-expand-btn__icon svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 /* Light mode: restore borders */

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -373,7 +373,6 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   flex-shrink: 0;
-  overflow: hidden;
   transition:
     border-color var(--duration-fast) ease,
     box-shadow var(--duration-fast) ease;
@@ -643,6 +642,38 @@
 
 .slash-menu-item--active .slash-menu-desc {
   color: var(--text);
+}
+
+.slash-menu-badge {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.slash-menu-footer {
+  display: flex;
+  gap: 10px;
+  padding: 6px 10px 4px;
+  font-size: 0.68rem;
+  color: var(--muted);
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  margin-top: 4px;
+}
+
+.slash-menu-footer kbd {
+  display: inline-block;
+  padding: 1px 4px;
+  font-size: 0.65rem;
+  font-family: var(--mono);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  background: var(--bg);
+  line-height: 1.3;
 }
 
 .chat-attachments-preview {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -451,6 +451,11 @@
 .agent-chat__toolbar .btn--ghost svg {
   width: 16px;
   height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .agent-chat__input-btn:hover:not(:disabled),

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -431,7 +431,7 @@
 }
 
 .agent-chat__input-btn,
-.agent-chat__toolbar .btn-ghost {
+.agent-chat__toolbar .btn--ghost {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -448,24 +448,19 @@
 }
 
 .agent-chat__input-btn svg,
-.agent-chat__toolbar .btn-ghost svg {
+.agent-chat__toolbar .btn--ghost svg {
   width: 16px;
   height: 16px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .agent-chat__input-btn:hover:not(:disabled),
-.agent-chat__toolbar .btn-ghost:hover:not(:disabled) {
+.agent-chat__toolbar .btn--ghost:hover:not(:disabled) {
   color: var(--text);
   background: var(--bg-hover);
 }
 
 .agent-chat__input-btn:disabled,
-.agent-chat__toolbar .btn-ghost:disabled {
+.agent-chat__toolbar .btn--ghost:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
@@ -734,18 +729,6 @@
   font-size: 13px;
 }
 
-/* Icon button style */
-.btn--icon {
-  padding: 8px !important;
-  min-width: 36px;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.06);
-}
-
 /* Controls separator */
 .chat-controls__separator {
   color: rgba(255, 255, 255, 0.4);
@@ -756,57 +739,6 @@
 
 :root[data-theme-mode="light"] .chat-controls__separator {
   color: rgba(16, 24, 40, 0.3);
-}
-
-.btn--icon:hover {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-/* Light theme icon button overrides */
-:root[data-theme-mode="light"] .btn--icon {
-  background: #ffffff;
-  border-color: var(--border);
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
-  color: var(--muted);
-}
-
-:root[data-theme-mode="light"] .btn--icon:hover {
-  background: #ffffff;
-  border-color: var(--border-strong);
-  color: var(--text);
-}
-
-/* Light theme icon button overrides */
-:root[data-theme-mode="light"] .btn--icon {
-  background: #ffffff;
-  border-color: var(--border);
-  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
-  color: var(--muted);
-}
-
-:root[data-theme-mode="light"] .btn--icon:hover {
-  background: #ffffff;
-  border-color: var(--border-strong);
-  color: var(--text);
-}
-
-:root[data-theme-mode="light"] .chat-controls .btn--icon.active {
-  border-color: var(--accent);
-  background: var(--accent-subtle);
-  color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent-subtle);
-}
-
-.btn--icon svg {
-  display: block;
-  width: 18px;
-  height: 18px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .chat-controls__session select {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -627,6 +627,48 @@
   font-size: 12px;
 }
 
+.btn--xs {
+  padding: 4px 6px;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.btn--icon {
+  padding: 8px;
+  min-width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.btn--icon:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.btn--icon svg {
+  display: block;
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.btn--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+
+.btn--ghost:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: transparent;
+}
+
 .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -1174,6 +1216,34 @@
 :root[data-theme-mode="light"] .btn.primary {
   background: var(--accent);
   border-color: var(--accent);
+}
+
+:root[data-theme-mode="light"] .btn--icon {
+  background: #ffffff;
+  border-color: var(--border);
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.05);
+  color: var(--muted);
+}
+
+:root[data-theme-mode="light"] .btn--icon:hover {
+  background: #ffffff;
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+:root[data-theme-mode="light"] .chat-controls .btn--icon.active {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-subtle);
+}
+
+:root[data-theme-mode="light"] .btn--ghost {
+  background: transparent;
+}
+
+:root[data-theme-mode="light"] .btn--ghost:hover {
+  background: var(--bg-hover);
 }
 
 /* ===========================================

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -261,7 +261,13 @@
   gap: 6px;
   min-width: 0;
   flex: 1 1 auto;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.config-top-tabs__scroller::-webkit-scrollbar {
+  display: none;
 }
 
 .config-top-tabs__tab {
@@ -296,13 +302,6 @@
   color: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 30%, transparent);
   background: var(--accent-subtle);
-}
-
-.config-top-tabs__right {
-  display: flex;
-  justify-content: flex-end;
-  flex-shrink: 0;
-  min-width: 0;
 }
 
 /* Diff Panel */
@@ -1751,18 +1750,10 @@
   }
 
   .config-top-tabs__scroller {
-    flex: 1 1 100%;
+    flex: 1 1 auto;
   }
 
-  .config-top-tabs__right {
-    flex: 1 1 100%;
-  }
-
-  .config-top-tabs__right .config-mode-toggle {
-    width: 100%;
-  }
-
-  .config-top-tabs__right .config-mode-toggle__btn {
+  .config-actions__left .config-mode-toggle__btn {
     flex: 1 1 50%;
   }
 

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -553,110 +553,57 @@
   color: var(--text-strong);
 }
 
-/* Roundness slider */
-.settings-slider {
-  display: grid;
-  gap: 10px;
-}
-
-.settings-slider__header {
+/* Roundness options */
+.settings-roundness__options {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.settings-slider__label {
-  display: flex;
-  align-items: center;
   gap: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--muted);
 }
 
-.settings-slider__key-swatch {
-  display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 1.5px solid var(--muted);
-  flex-shrink: 0;
-}
-
-.settings-slider__key-swatch--sharp {
-  border-radius: 0;
-}
-
-.settings-slider__key-swatch--round {
-  border-radius: var(--radius-sm);
-}
-
-.settings-slider__value {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.settings-slider__input {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 100%;
-  height: 6px;
-  border-radius: var(--radius-full);
-  background: var(--bg-muted);
-  outline: none;
-  cursor: pointer;
-  transition: background var(--duration-fast) ease;
-}
-
-.settings-slider__input:hover {
-  background: var(--border-strong);
-}
-
-.settings-slider__input::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--accent);
-  border: 2px solid var(--bg-elevated);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+.settings-roundness__btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
   cursor: pointer;
   transition:
-    transform var(--duration-fast) ease,
-    box-shadow var(--duration-fast) ease;
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease;
 }
 
-.settings-slider__input::-webkit-slider-thumb:hover {
-  transform: scale(1.15);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+.settings-roundness__btn:hover {
+  background: var(--bg-hover);
 }
 
-.settings-slider__input::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--accent);
-  border: 2px solid var(--bg-elevated);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
-  cursor: pointer;
+.settings-roundness__btn.active {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
 }
 
-.settings-slider__preview {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 0 0;
-}
-
-.settings-slider__preview-swatch {
-  width: 32px;
-  height: 22px;
+.settings-roundness__swatch {
+  width: 28px;
+  height: 20px;
   background: var(--bg-muted);
-  border: 1px solid var(--border);
+  border: 1.5px solid var(--border-strong);
   transition: border-radius var(--duration-fast) ease;
+}
+
+.settings-roundness__btn.active .settings-roundness__swatch {
+  border-color: var(--accent);
+}
+
+.settings-roundness__label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.settings-roundness__btn.active .settings-roundness__label {
+  color: var(--accent);
 }
 
 .settings-info-grid {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -522,13 +522,13 @@
   }
 
   .agent-chat__input-btn,
-  .agent-chat__toolbar .btn-ghost {
+  .agent-chat__toolbar .btn--ghost {
     width: 28px;
     height: 28px;
   }
 
   .agent-chat__input-btn svg,
-  .agent-chat__toolbar .btn-ghost svg {
+  .agent-chat__toolbar .btn--ghost svg {
     width: 14px;
     height: 14px;
   }

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -17,11 +17,8 @@
   animation: rise 0.25s var(--ease-out) backwards;
 }
 
-.usage-page .btn.btn-sm,
-.usage-page button.btn-sm {
+.usage-page .btn.btn--sm {
   min-height: 30px;
-  padding: 7px 11px;
-  font-size: 12px;
   line-height: 1.15;
 }
 
@@ -255,56 +252,8 @@
   color: var(--text-strong);
 }
 
-.usage-pin-btn,
-.usage-export-button,
-.usage-action-btn,
-.toggle-btn,
-.session-copy-btn,
-.context-expand-btn,
-.session-close-btn {
-  appearance: none;
-  border: 1px solid var(--border);
-  background: var(--secondary);
-  color: var(--secondary-foreground);
-  cursor: pointer;
-  transition:
-    transform 0.18s var(--ease-out),
-    border-color 0.18s var(--ease-out),
-    background 0.18s var(--ease-out),
-    color 0.18s var(--ease-out),
-    box-shadow 0.18s var(--ease-out);
-}
-
-.usage-pin-btn,
-.usage-export-button,
-.toggle-btn,
-.context-expand-btn,
-.session-copy-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-height: 34px;
-  padding: 8px 12px;
-  border-radius: var(--radius-md);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.usage-pin-btn:hover,
-.usage-export-button:hover,
-.usage-action-btn:hover,
-.toggle-btn:hover,
-.session-copy-btn:hover,
-.context-expand-btn:hover,
-.session-close-btn:hover {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
-  background: color-mix(in srgb, var(--accent) 10%, var(--secondary));
-  color: var(--text-strong);
-}
-
+/* Toggle-btn active state layers on .btn for segmented controls */
 .usage-pin-btn.active,
-.usage-action-btn.usage-primary-btn,
 .chart-toggle .toggle-btn.active {
   border-color: var(--accent);
   background: var(--accent);
@@ -312,17 +261,10 @@
   box-shadow: 0 8px 24px color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
-.usage-primary-btn:disabled,
-.usage-secondary-btn:disabled,
 .usage-export-item:disabled {
   opacity: 0.55;
   cursor: not-allowed;
   box-shadow: none;
-}
-
-.usage-secondary-btn {
-  background: var(--secondary);
-  color: var(--secondary-foreground);
 }
 
 .usage-query-section {
@@ -359,7 +301,7 @@ details.usage-filter-select,
 }
 
 details.usage-filter-select summary,
-.usage-export-button {
+.usage-export-menu summary {
   list-style: none;
 }
 
@@ -1197,10 +1139,6 @@ details.usage-filter-select summary::-webkit-details-marker,
   flex: 0 0 auto;
 }
 
-.session-copy-btn {
-  min-width: 58px;
-}
-
 .session-bar-value {
   font-size: 13px;
   font-weight: 700;
@@ -1245,18 +1183,6 @@ details.usage-filter-select summary::-webkit-details-marker,
   gap: 8px 14px;
   color: var(--text);
   font-size: 13px;
-}
-
-.session-close-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  border-radius: var(--radius-md);
-  font-size: 18px;
-  line-height: 1;
 }
 
 .session-detail-content,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -253,6 +253,8 @@ const INFRASTRUCTURE_SECTION_KEYS = [
   "canvasHost",
   "discovery",
   "media",
+  "acp",
+  "mcp",
 ] as const;
 const AI_AGENTS_SECTION_KEYS = [
   "agents",

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -320,7 +320,7 @@ export function detachThemeListener(host: SettingsHost) {
   host.systemThemeCleanup = null;
 }
 
-const BASE_RADII = { sm: 6, md: 10, lg: 14, xl: 20, default: 10 };
+const BASE_RADII = { sm: 6, md: 10, lg: 14, xl: 20, full: 9999, default: 10 };
 
 export function applyBorderRadius(value: number) {
   if (typeof document === "undefined") {
@@ -332,6 +332,7 @@ export function applyBorderRadius(value: number) {
   root.style.setProperty("--radius-md", `${Math.round(BASE_RADII.md * scale)}px`);
   root.style.setProperty("--radius-lg", `${Math.round(BASE_RADII.lg * scale)}px`);
   root.style.setProperty("--radius-xl", `${Math.round(BASE_RADII.xl * scale)}px`);
+  root.style.setProperty("--radius-full", `${Math.round(BASE_RADII.full * scale)}px`);
   root.style.setProperty("--radius", `${Math.round(BASE_RADII.default * scale)}px`);
 }
 

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -34,7 +34,7 @@ function createCopyButton(options: CopyButtonOptions): TemplateResult {
   const idleLabel = options.label ?? COPY_LABEL;
   return html`
     <button
-      class="chat-copy-btn"
+      class="btn btn--xs chat-copy-btn"
       type="button"
       title=${idleLabel}
       aria-label=${idleLabel}

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -395,7 +395,7 @@ function renderDeleteButton(onDelete: () => void, side: DeleteConfirmSide) {
 function renderTtsButton(group: MessageGroup) {
   return html`
     <button
-      class="chat-tts-btn"
+      class="btn btn--xs chat-tts-btn"
       type="button"
       title=${isTtsSpeaking() ? "Stop speaking" : "Read aloud"}
       aria-label=${isTtsSpeaking() ? "Stop speaking" : "Read aloud"}
@@ -623,7 +623,7 @@ function jsonSummaryLabel(parsed: unknown): string {
 function renderExpandButton(markdown: string, onOpenSidebar: (content: string) => void) {
   return html`
     <button
-      class="chat-expand-btn"
+      class="btn btn--xs chat-expand-btn"
       type="button"
       title="Open in canvas"
       aria-label="Open in canvas"

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -25,6 +25,22 @@ import { getSafeLocalStorage } from "../local-storage.ts";
 import { inferBasePathFromPathname, normalizeBasePath } from "./navigation.ts";
 import { parseThemeSelection, type ThemeMode, type ThemeName } from "./theme.ts";
 
+export const BORDER_RADIUS_STOPS = [0, 25, 50, 75, 100] as const;
+export type BorderRadiusStop = (typeof BORDER_RADIUS_STOPS)[number];
+
+function snapBorderRadius(value: number): BorderRadiusStop {
+  let best: BorderRadiusStop = BORDER_RADIUS_STOPS[0];
+  let bestDist = Math.abs(value - best);
+  for (const stop of BORDER_RADIUS_STOPS) {
+    const dist = Math.abs(value - stop);
+    if (dist < bestDist) {
+      best = stop;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
 export type UiSettings = {
   gatewayUrl: string;
   token: string;
@@ -253,7 +269,7 @@ export function loadSettings(): UiSettings {
         typeof parsed.borderRadius === "number" &&
         parsed.borderRadius >= 0 &&
         parsed.borderRadius <= 100
-          ? parsed.borderRadius
+          ? snapBorderRadius(parsed.borderRadius)
           : defaults.borderRadius,
       locale: isSupportedLocale(parsed.locale) ? parsed.locale : undefined,
     };

--- a/ui/src/ui/views/agents-panels-tools-skills.ts
+++ b/ui/src/ui/views/agents-panels-tools-skills.ts
@@ -144,15 +144,15 @@ export function renderAgentTools(params: {
 
   return html`
     <section class="card">
-      <div class="row" style="justify-content: space-between;">
-        <div>
+      <div class="row" style="justify-content: space-between; flex-wrap: wrap;">
+        <div style="min-width: 0;">
           <div class="card-title">Tool Access</div>
           <div class="card-sub">
             Profile + per-tool overrides for this agent.
             <span class="mono">${enabledCount}/${toolIds.length}</span> enabled.
           </div>
         </div>
-        <div class="row" style="gap: 8px;">
+        <div class="row" style="gap: 8px; flex-wrap: wrap;">
           <button class="btn btn--sm" ?disabled=${!editable} @click=${() => updateAll(true)}>
             Enable All
           </button>
@@ -346,8 +346,8 @@ export function renderAgentSkills(params: {
 
   return html`
     <section class="card">
-      <div class="row" style="justify-content: space-between;">
-        <div>
+      <div class="row" style="justify-content: space-between; flex-wrap: wrap;">
+        <div style="min-width: 0;">
           <div class="card-title">Skills</div>
           <div class="card-sub">
             Per-agent skill allowlist and workspace skills.

--- a/ui/src/ui/views/channels.nostr.ts
+++ b/ui/src/ui/views/channels.nostr.ts
@@ -128,7 +128,7 @@ export function renderNostrCard(params: {
             summaryConfigured
               ? html`
                 <button
-                  class="btn btn-sm"
+                  class="btn btn--sm"
                   @click=${onEditProfile}
                   style="font-size: 12px; padding: 4px 8px;"
                 >

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -662,7 +662,7 @@ function renderSearchBar(requestUpdate: () => void): TemplateResult | typeof not
           requestUpdate();
         }}
       />
-      <button class="btn-ghost" @click=${() => {
+      <button class="btn btn--ghost" @click=${() => {
         vs.searchOpen = false;
         vs.searchQuery = "";
         requestUpdate();
@@ -711,7 +711,7 @@ function renderPinnedSection(
                 <div class="agent-chat__pinned-item">
                   <span class="agent-chat__pinned-role">${role === "user" ? "You" : "Assistant"}</span>
                   <span class="agent-chat__pinned-text">${text.slice(0, 100)}${text.length > 100 ? "..." : ""}</span>
-                  <button class="btn-ghost" @click=${() => {
+                  <button class="btn btn--ghost" @click=${() => {
                     pinned.unpin(index);
                     requestUpdate();
                   }} title="Unpin">
@@ -1323,7 +1323,7 @@ export function renderChat(props: ChatProps) {
                 ? nothing
                 : html`
                     <button
-                      class="btn-ghost"
+                      class="btn btn--ghost"
                       @click=${props.onNewSession}
                       title="New session"
                       aria-label="New session"
@@ -1332,7 +1332,7 @@ export function renderChat(props: ChatProps) {
                     </button>
                   `
             }
-            <button class="btn-ghost" @click=${() => exportMarkdown(props)} title="Export" ?disabled=${props.messages.length === 0}>
+            <button class="btn btn--ghost" @click=${() => exportMarkdown(props)} title="Export" ?disabled=${props.messages.length === 0}>
               ${icons.download}
             </button>
 

--- a/ui/src/ui/views/config-form.render.ts
+++ b/ui/src/ui/views/config-form.render.ts
@@ -231,6 +231,40 @@ const sectionIcons = {
       <path d="m19.07 10.93-4.24 4.24"></path>
     </svg>
   `,
+  diagnostics: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+    </svg>
+  `,
+  cli: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <polyline points="4 17 10 11 4 5"></polyline>
+      <line x1="12" y1="19" x2="20" y2="19"></line>
+    </svg>
+  `,
+  secrets: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path
+        d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"
+      ></path>
+    </svg>
+  `,
+  acp: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+      <circle cx="9" cy="7" r="4"></circle>
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+      <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+    </svg>
+  `,
+  mcp: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+      <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+      <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+      <line x1="6" y1="6" x2="6.01" y2="6"></line>
+      <line x1="6" y1="18" x2="6.01" y2="18"></line>
+    </svg>
+  `,
   default: html`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -275,6 +309,17 @@ export const SECTION_META: Record<string, { label: string; description: string }
   canvasHost: { label: "Canvas Host", description: "Canvas rendering and display" },
   talk: { label: "Talk", description: "Voice and speech settings" },
   plugins: { label: "Plugins", description: "Plugin management and extensions" },
+  diagnostics: {
+    label: "Diagnostics",
+    description: "Instrumentation, OpenTelemetry, and cache-trace settings",
+  },
+  cli: { label: "CLI", description: "CLI banner and startup behavior" },
+  secrets: { label: "Secrets", description: "Secret provider configuration" },
+  acp: {
+    label: "ACP",
+    description: "Agent Communication Protocol runtime and streaming settings",
+  },
+  mcp: { label: "MCP", description: "Model Context Protocol server definitions" },
 };
 
 function getSectionIcon(key: string) {

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -281,6 +281,40 @@ const sidebarIcons = {
       <path d="m19.07 10.93-4.24 4.24"></path>
     </svg>
   `,
+  diagnostics: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+    </svg>
+  `,
+  cli: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <polyline points="4 17 10 11 4 5"></polyline>
+      <line x1="12" y1="19" x2="20" y2="19"></line>
+    </svg>
+  `,
+  secrets: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path
+        d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4"
+      ></path>
+    </svg>
+  `,
+  acp: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+      <circle cx="9" cy="7" r="4"></circle>
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+      <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+    </svg>
+  `,
+  mcp: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <rect x="2" y="2" width="20" height="8" rx="2" ry="2"></rect>
+      <rect x="2" y="14" width="20" height="8" rx="2" ry="2"></rect>
+      <line x1="6" y1="6" x2="6.01" y2="6"></line>
+      <line x1="6" y1="18" x2="6.01" y2="18"></line>
+    </svg>
+  `,
   __appearance__: html`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <circle cx="12" cy="12" r="5"></circle>
@@ -319,6 +353,9 @@ const SECTION_CATEGORIES: SectionCategory[] = [
       { key: "update", label: "Updates" },
       { key: "meta", label: "Meta" },
       { key: "logging", label: "Logging" },
+      { key: "diagnostics", label: "Diagnostics" },
+      { key: "cli", label: "Cli" },
+      { key: "secrets", label: "Secrets" },
     ],
   },
   {
@@ -367,6 +404,8 @@ const SECTION_CATEGORIES: SectionCategory[] = [
       { key: "canvasHost", label: "CanvasHost" },
       { key: "discovery", label: "Discovery" },
       { key: "media", label: "Media" },
+      { key: "acp", label: "Acp" },
+      { key: "mcp", label: "Mcp" },
     ],
   },
   {
@@ -512,7 +551,7 @@ function renderDiffValue(path: string, value: unknown, _uiHints: ConfigUiHints):
 type ThemeOption = { id: ThemeName; label: string; description: string; icon: TemplateResult };
 const THEME_OPTIONS: ThemeOption[] = [
   { id: "claw", label: "Claw", description: "Chroma family", icon: icons.zap },
-  { id: "knot", label: "Knot", description: "Blue contrast", icon: icons.link },
+  { id: "knot", label: "Knot", description: "Black & red", icon: icons.link },
   { id: "dash", label: "Dash", description: "Chocolate blueprint", icon: icons.barChart },
 ];
 
@@ -753,6 +792,28 @@ export function renderConfig(props: ConfigProps) {
         <div class="config-actions">
           <div class="config-actions__left">
             ${
+              showModeToggle
+                ? html`
+                    <div class="config-mode-toggle">
+                      <button
+                        class="config-mode-toggle__btn ${formMode === "form" ? "active" : ""}"
+                        ?disabled=${props.schemaLoading || !props.schema}
+                        title=${formUnsafe ? "Form view can't safely edit some fields" : ""}
+                        @click=${() => props.onFormModeChange("form")}
+                      >
+                        Form
+                      </button>
+                      <button
+                        class="config-mode-toggle__btn ${formMode === "raw" ? "active" : ""}"
+                        @click=${() => props.onFormModeChange("raw")}
+                      >
+                        Raw
+                      </button>
+                    </div>
+                  `
+                : nothing
+            }
+            ${
               hasChanges
                 ? html`
 	                  <span class="config-changes-badge"
@@ -871,30 +932,6 @@ export function renderConfig(props: ConfigProps) {
             )}
           </div>
 
-          <div class="config-top-tabs__right">
-            ${
-              showModeToggle
-                ? html`
-                    <div class="config-mode-toggle">
-                      <button
-                        class="config-mode-toggle__btn ${formMode === "form" ? "active" : ""}"
-                        ?disabled=${props.schemaLoading || !props.schema}
-                        title=${formUnsafe ? "Form view can't safely edit some fields" : ""}
-                        @click=${() => props.onFormModeChange("form")}
-                      >
-                        Form
-                      </button>
-                      <button
-                        class="config-mode-toggle__btn ${formMode === "raw" ? "active" : ""}"
-                        @click=${() => props.onFormModeChange("raw")}
-                      >
-                        Raw
-                      </button>
-                    </div>
-                  `
-                : nothing
-            }
-          </div>
         </div>
 
         ${

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { icons } from "../icons.ts";
+import { BORDER_RADIUS_STOPS, type BorderRadiusStop } from "../storage.ts";
 import type { ThemeTransitionContext } from "../theme-transition.ts";
 import type { ThemeMode, ThemeName } from "../theme.ts";
 import type { ConfigUiHints } from "../types.ts";
@@ -12,6 +13,14 @@ import {
   type JsonSchema,
 } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm, SECTION_META } from "./config-form.ts";
+
+const BORDER_RADIUS_LABELS: Record<BorderRadiusStop, string> = {
+  0: "None",
+  25: "Slight",
+  50: "Default",
+  75: "Round",
+  100: "Full",
+};
 
 export type ConfigProps = {
   raw: string;
@@ -592,43 +601,23 @@ function renderAppearanceSection(props: ConfigProps) {
       <div class="settings-appearance__section">
         <h3 class="settings-appearance__heading">Roundness</h3>
         <p class="settings-appearance__hint">Adjust corner radius across the UI.</p>
-        <div class="settings-slider">
-          <div class="settings-slider__header">
-            <span class="settings-slider__label">
-              <span class="settings-slider__key-swatch settings-slider__key-swatch--sharp"></span>
-              Square
-            </span>
-            <span class="settings-slider__value">${props.borderRadius}%</span>
-            <span class="settings-slider__label">
-              Round
-              <span class="settings-slider__key-swatch settings-slider__key-swatch--round"></span>
-            </span>
-          </div>
-          <input
-            type="range"
-            class="settings-slider__input"
-            min="0"
-            max="100"
-            step="1"
-            .value=${String(props.borderRadius)}
-            @input=${(e: Event) => {
-              const v = Number((e.target as HTMLInputElement).value);
-              props.setBorderRadius(v);
-            }}
-          />
-          <div class="settings-slider__preview">
-            <div
-              class="settings-slider__preview-swatch"
-              style="border-radius: ${Math.round(10 * (props.borderRadius / 50))}px"
-            ></div>
-            <div
-              class="settings-slider__preview-swatch"
-              style="border-radius: ${Math.round(14 * (props.borderRadius / 50))}px"
-            ></div>
-            <div
-              class="settings-slider__preview-swatch"
-              style="border-radius: ${Math.round(20 * (props.borderRadius / 50))}px"
-            ></div>
+        <div class="settings-roundness">
+          <div class="settings-roundness__options">
+            ${BORDER_RADIUS_STOPS.map(
+              (stop) => html`
+                <button
+                  type="button"
+                  class="settings-roundness__btn ${stop === props.borderRadius ? "active" : ""}"
+                  @click=${() => props.setBorderRadius(stop)}
+                >
+                  <span
+                    class="settings-roundness__swatch"
+                    style="border-radius: ${Math.round(10 * (stop / 50))}px"
+                  ></span>
+                  <span class="settings-roundness__label">${BORDER_RADIUS_LABELS[stop]}</span>
+                </button>
+              `,
+            )}
           </div>
         </div>
       </div>

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -284,7 +284,7 @@ function renderSessionDetailPanel(
           }
         </div>
         <button
-          class="session-close-btn"
+          class="btn btn--sm btn--ghost"
           @click=${onClose}
           title=${t("usage.details.close")}
         >
@@ -473,7 +473,7 @@ function renderTimeSeriesCompact(
             hasSelection
               ? html`
             <div class="chart-toggle small">
-              <button class="toggle-btn active" @click=${() => onCursorRangeChange?.(null, null)}>
+              <button class="btn btn--sm toggle-btn active" @click=${() => onCursorRangeChange?.(null, null)}>
                 ${t("usage.details.reset")}
               </button>
             </div>
@@ -482,13 +482,13 @@ function renderTimeSeriesCompact(
           }
           <div class="chart-toggle small">
             <button
-              class="toggle-btn ${!isCumulative ? "active" : ""}"
+              class="btn btn--sm toggle-btn ${!isCumulative ? "active" : ""}"
               @click=${() => onModeChange("per-turn")}
             >
               ${t("usage.details.perTurn")}
             </button>
             <button
-              class="toggle-btn ${isCumulative ? "active" : ""}"
+              class="btn btn--sm toggle-btn ${isCumulative ? "active" : ""}"
               @click=${() => onModeChange("cumulative")}
             >
               ${t("usage.details.cumulative")}
@@ -499,13 +499,13 @@ function renderTimeSeriesCompact(
               ? html`
                   <div class="chart-toggle small">
                     <button
-                      class="toggle-btn ${breakdownMode === "total" ? "active" : ""}"
+                      class="btn btn--sm toggle-btn ${breakdownMode === "total" ? "active" : ""}"
                       @click=${() => onBreakdownChange("total")}
                     >
                       ${t("usage.daily.total")}
                     </button>
                     <button
-                      class="toggle-btn ${breakdownMode === "by-type" ? "active" : ""}"
+                      class="btn btn--sm toggle-btn ${breakdownMode === "by-type" ? "active" : ""}"
                       @click=${() => onBreakdownChange("by-type")}
                     >
                       ${t("usage.daily.byType")}
@@ -793,7 +793,7 @@ function renderContextPanel(
         <div class="card-title usage-section-title">${t("usage.details.systemPromptBreakdown")}</div>
         ${
           hasMore
-            ? html`<button class="context-expand-btn" @click=${onToggleExpanded}>
+            ? html`<button class="btn btn--sm" @click=${onToggleExpanded}>
                 ${showAll ? t("usage.details.collapse") : t("usage.details.expandAll")}
               </button>`
             : nothing
@@ -1018,7 +1018,7 @@ function renderSessionLogsCompact(
             (${displayedCount} ${t("usage.overview.messages").toLowerCase()})
           </span>
         </span>
-        <button class="btn btn-sm usage-action-btn usage-secondary-btn" @click=${onToggleExpandedAll}>
+        <button class="btn btn--sm" @click=${onToggleExpandedAll}>
           ${expandedAll ? t("usage.details.collapseAll") : t("usage.details.expandAll")}
         </button>
       </div>
@@ -1068,7 +1068,7 @@ function renderSessionLogsCompact(
           .value=${filters.query}
           @input=${(event: Event) => onFilterQueryChange((event.target as HTMLInputElement).value)}
         />
-        <button class="btn btn-sm usage-action-btn usage-secondary-btn" @click=${onFilterClear}>
+        <button class="btn btn--sm" @click=${onFilterClear}>
           ${t("usage.filters.clear")}
         </button>
       </div>

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -287,6 +287,7 @@ function renderSessionDetailPanel(
           class="btn btn--sm btn--ghost"
           @click=${onClose}
           title=${t("usage.details.close")}
+          aria-label=${t("usage.details.close")}
         >
           ×
         </button>
@@ -1026,6 +1027,7 @@ function renderSessionLogsCompact(
         <select
           multiple
           size="4"
+          aria-label="Filter by role"
           @change=${(event: Event) =>
             onFilterRolesChange(
               Array.from((event.target as HTMLSelectElement).selectedOptions).map(
@@ -1041,6 +1043,7 @@ function renderSessionLogsCompact(
         <select
           multiple
           size="4"
+          aria-label="Filter by tool"
           @change=${(event: Event) =>
             onFilterToolsChange(
               Array.from((event.target as HTMLSelectElement).selectedOptions).map(
@@ -1065,6 +1068,7 @@ function renderSessionLogsCompact(
         <input
           type="text"
           placeholder=${t("usage.details.searchConversation")}
+          aria-label=${t("usage.details.searchConversation")}
           .value=${filters.query}
           @input=${(event: Event) => onFilterQueryChange((event.target as HTMLInputElement).value)}
         />

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -144,7 +144,7 @@ function renderFilterChips(
       ${
         (selectedDays.length > 0 || selectedHours.length > 0) && selectedSessions.length > 0
           ? html`
-            <button class="btn btn-sm filter-clear-btn" @click=${onClearFilters}>
+            <button class="btn btn--sm filter-clear-btn" @click=${onClearFilters}>
               ${t("usage.filters.clearAll")}
             </button>
           `
@@ -184,13 +184,13 @@ function renderDailyChartCompact(
       <div class="daily-chart-header">
         <div class="chart-toggle small sessions-toggle">
           <button
-            class="toggle-btn ${dailyChartMode === "total" ? "active" : ""}"
+            class="btn btn--sm toggle-btn ${dailyChartMode === "total" ? "active" : ""}"
             @click=${() => onDailyChartModeChange("total")}
           >
             ${t("usage.daily.total")}
           </button>
           <button
-            class="toggle-btn ${dailyChartMode === "by-type" ? "active" : ""}"
+            class="btn btn--sm toggle-btn ${dailyChartMode === "by-type" ? "active" : ""}"
             @click=${() => onDailyChartModeChange("by-type")}
           >
             ${t("usage.daily.byType")}
@@ -763,7 +763,7 @@ function renderSessionsCard(
         </div>
         <div class="session-bar-actions">
           <button
-            class="session-copy-btn"
+            class="btn btn--sm btn--ghost"
             title=${t("usage.sessions.copyName")}
             @click=${(e: MouseEvent) => {
               e.stopPropagation();
@@ -808,13 +808,13 @@ function renderSessionsCard(
         </div>
         <div class="chart-toggle small">
           <button
-            class="toggle-btn ${sessionsTab === "all" ? "active" : ""}"
+            class="btn btn--sm toggle-btn ${sessionsTab === "all" ? "active" : ""}"
             @click=${() => onSessionsTabChange("all")}
           >
             ${t("usage.sessions.all")}
           </button>
           <button
-            class="toggle-btn ${sessionsTab === "recent" ? "active" : ""}"
+            class="btn btn--sm toggle-btn ${sessionsTab === "recent" ? "active" : ""}"
             @click=${() => onSessionsTabChange("recent")}
           >
             ${t("usage.sessions.recent")}
@@ -833,7 +833,7 @@ function renderSessionsCard(
           </select>
         </label>
         <button
-          class="btn btn-sm sessions-action-btn icon"
+          class="btn btn--sm"
           @click=${() => onSessionSortDirChange(sessionSortDir === "desc" ? "asc" : "desc")}
           title=${
             sessionSortDir === "desc"
@@ -846,7 +846,7 @@ function renderSessionsCard(
         ${
           selectedCount > 0
             ? html`
-                <button class="btn btn-sm sessions-action-btn sessions-clear-btn" @click=${onClearSessions}>
+                <button class="btn btn--sm" @click=${onClearSessions}>
                   ${t("usage.sessions.clearSelection")}
                 </button>
               `

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -102,6 +102,7 @@ function renderFilterChips(
                 class="filter-chip-remove"
                 @click=${onClearDays}
                 title=${t("usage.filters.remove")}
+                aria-label="Remove days filter"
               >
                 ×
               </button>
@@ -118,6 +119,7 @@ function renderFilterChips(
                 class="filter-chip-remove"
                 @click=${onClearHours}
                 title=${t("usage.filters.remove")}
+                aria-label="Remove hours filter"
               >
                 ×
               </button>
@@ -134,6 +136,7 @@ function renderFilterChips(
                 class="filter-chip-remove"
                 @click=${onClearSessions}
                 title=${t("usage.filters.remove")}
+                aria-label="Remove session filter"
               >
                 ×
               </button>

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -144,7 +144,7 @@ function renderFilterChips(
       ${
         (selectedDays.length > 0 || selectedHours.length > 0) && selectedSessions.length > 0
           ? html`
-            <button class="btn btn--sm filter-clear-btn" @click=${onClearFilters}>
+            <button class="btn btn--sm" @click=${onClearFilters}>
               ${t("usage.filters.clearAll")}
             </button>
           `

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -128,7 +128,7 @@ function renderUsageEmptyState(onRefresh: () => void) {
         <span class="usage-empty-state__feature">${t("usage.empty.featureTimeline")}</span>
       </div>
       <div class="usage-empty-state__actions">
-        <button class="btn primary usage-action-btn usage-primary-btn" @click=${onRefresh}>
+        <button class="btn primary" @click=${onRefresh}>
           ${t("common.refresh")}
         </button>
       </div>
@@ -389,7 +389,7 @@ export function renderUsage(props: UsageProps) {
         <div class="usage-filter-popover">
           <div class="usage-filter-actions">
             <button
-              class="btn btn-sm"
+              class="btn btn--sm"
               @click=${(e: Event) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -402,7 +402,7 @@ export function renderUsage(props: UsageProps) {
               ${t("usage.filters.selectAll")}
             </button>
             <button
-              class="btn btn-sm"
+              class="btn btn--sm"
               @click=${(e: Event) => {
                 e.preventDefault();
                 e.stopPropagation();
@@ -480,7 +480,7 @@ export function renderUsage(props: UsageProps) {
                 : nothing
             }
             <button
-              class="usage-pin-btn ${display.headerPinned ? "active" : ""}"
+              class="btn btn--sm usage-pin-btn ${display.headerPinned ? "active" : ""}"
               title=${display.headerPinned ? t("usage.filters.unpin") : t("usage.filters.pin")}
               @click=${filterActions.onToggleHeaderPinned}
             >
@@ -503,7 +503,7 @@ export function renderUsage(props: UsageProps) {
                 window.addEventListener("click", onClick, true);
               }}
             >
-              <summary class="usage-export-button">${t("usage.export.label")} ▾</summary>
+              <summary class="btn btn--sm">${t("usage.export.label")} ▾</summary>
               <div class="usage-export-popover">
                 <div class="usage-export-list">
                   <button
@@ -572,7 +572,7 @@ export function renderUsage(props: UsageProps) {
             <div class="usage-presets">
               ${datePresets.map(
                 (preset) => html`
-                  <button class="btn btn-sm" @click=${() => applyPreset(preset.days)}>
+                  <button class="btn btn--sm" @click=${() => applyPreset(preset.days)}>
                     ${preset.label}
                   </button>
                 `,
@@ -611,20 +611,20 @@ export function renderUsage(props: UsageProps) {
             </select>
             <div class="chart-toggle">
               <button
-                class="toggle-btn ${isTokenMode ? "active" : ""}"
+                class="btn btn--sm toggle-btn ${isTokenMode ? "active" : ""}"
                 @click=${() => displayActions.onChartModeChange("tokens")}
               >
                 ${t("usage.metrics.tokens")}
               </button>
               <button
-                class="toggle-btn ${!isTokenMode ? "active" : ""}"
+                class="btn btn--sm toggle-btn ${!isTokenMode ? "active" : ""}"
                 @click=${() => displayActions.onChartModeChange("cost")}
               >
                 ${t("usage.metrics.cost")}
               </button>
             </div>
             <button
-              class="btn btn-sm usage-action-btn usage-primary-btn"
+              class="btn btn--sm primary"
               @click=${filterActions.onRefresh}
               ?disabled=${data.loading}
             >
@@ -651,7 +651,7 @@ export function renderUsage(props: UsageProps) {
             />
             <div class="usage-query-actions">
               <button
-                class="btn btn-sm usage-action-btn usage-secondary-btn"
+                class="btn btn--sm"
                 @click=${filterActions.onApplyQuery}
                 ?disabled=${data.loading || (!hasDraftQuery && !hasQuery)}
               >
@@ -661,7 +661,7 @@ export function renderUsage(props: UsageProps) {
                 hasDraftQuery || hasQuery
                   ? html`
                       <button
-                        class="btn btn-sm usage-action-btn usage-secondary-btn"
+                        class="btn btn--sm"
                         @click=${filterActions.onClearQuery}
                       >
                         ${t("usage.filters.clear")}


### PR DESCRIPTION
## Summary

Continue the `ui/clarity` pass with a stronger Knot theme, cleaner button primitives, and tighter text contrast. Simplifies several chat/usage/config UI surfaces to reduce visual noise and improve consistency. Improves config navigation and section discoverability with new icons, categories, and a better top-bar layout.

## What changed

### Theme + visual clarity
- Refined the **Knot theme** to a black-and-red palette (crimson accent on true black) for both dark and light modes, with full WCAG 2.1 AA contrast audit documented in the token comments
- Tightened `--muted-strong` color token for better readability and hierarchy
- Added clearer accent/focus treatment across the OpenKnot theme family
- Reduced visual clutter in chat and usage layouts by trimming extra radii, borders, and heavy panel chrome

### Reusable button + interaction polish
- Extracted shared button variants (`btn--icon`, `btn--ghost`, `btn--xs`) into `components.css`, replacing ~60 lines of duplicate one-off button styles scattered across chat/usage CSS
- Updated chat and usage controls to use the shared `btn--*` classes (e.g. `btn-ghost` → `btn--ghost`, `btn-sm` → `btn--sm`)
- Improved active/hover states so icon actions feel more consistent across dark and light themes
- Added proper light-mode overrides for ghost and icon buttons

### Config UI improvements
- Added icons and metadata for **Diagnostics**, **CLI**, **Secrets**, **ACP**, and **MCP** config sections
- Reorganized config categories so those sections appear under the correct sidebar groups (System → Diagnostics/CLI/Secrets, Infrastructure → ACP/MCP)
- Moved the **Form/Raw mode toggle** into the primary actions area (left side with save/reset) instead of isolating it on the far right
- Made config top tabs stay on **one line with horizontal scrolling** instead of wrapping awkwardly on narrow viewports
- Removed the `config-top-tabs__right` container entirely (cleaner DOM)

### Roundness control redesign
- Replaced the continuous roundness slider with **5 discrete stops** (None / Slight / Default / Round / Full) using labeled swatch buttons
- Added `snapBorderRadius()` so persisted free-form values gracefully snap to the nearest stop on load
- Removed ~80 lines of slider-specific CSS (`::-webkit-slider-thumb`, `::-moz-range-thumb`, etc.)

### Usage page cleanup
- Removed ~50 lines of one-off button styles (`.usage-pin-btn`, `.usage-export-button`, `.toggle-btn`, `.session-copy-btn`, `.context-expand-btn`, `.session-close-btn`) that are now covered by the shared `btn--*` system
- Added `aria-label` attributes to filter selects, search input, and chip-remove buttons for improved accessibility

### Misc
- Added `flex-wrap: wrap` + `min-width: 0` to agent tools/skills card rows so they don't overflow on narrow viewports
- Updated Knot theme description from "Blue contrast" to "Black & red"

## Validation
- `pnpm test:ui` — 511/511 tests pass
- `pnpm ui:build` — builds clean (583 KB main bundle, no warnings)
- No logic changes — purely CSS, theme tokens, HTML class renames, and config section metadata