### PR TITLE
fix(ui): infer mounted base path for dashboard logo

### DIFF
--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   agentLogoUrl,
   resolveConfiguredCronModelSuggestions,
@@ -102,21 +102,25 @@ describe("sortLocaleStrings", () => {
 });
 
 describe("agentLogoUrl", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("keeps base-mounted control UI logo paths absolute to the mount", () => {
     expect(agentLogoUrl("/ui")).toBe("/ui/favicon.svg");
     expect(agentLogoUrl("/apps/openclaw/")).toBe("/apps/openclaw/favicon.svg");
   });
 
   it("infers the mounted base path before bootstrap finishes", () => {
-    window.history.replaceState({}, "", "/openclaw");
+    vi.stubGlobal("window", { location: { pathname: "/openclaw" } });
     expect(agentLogoUrl("")).toBe("/openclaw/favicon.svg");
 
-    window.history.replaceState({}, "", "/apps/openclaw/cron");
+    vi.stubGlobal("window", { location: { pathname: "/apps/openclaw/cron" } });
     expect(agentLogoUrl("")).toBe("/apps/openclaw/favicon.svg");
   });
 
   it("uses a route-relative fallback when there is no mounted base path", () => {
-    window.history.replaceState({}, "", "/chat");
+    vi.stubGlobal("window", { location: { pathname: "/chat" } });
     expect(agentLogoUrl("")).toBe("favicon.svg");
   });
 });

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -107,7 +107,16 @@ describe("agentLogoUrl", () => {
     expect(agentLogoUrl("/apps/openclaw/")).toBe("/apps/openclaw/favicon.svg");
   });
 
-  it("uses a route-relative fallback before basePath bootstrap finishes", () => {
+  it("infers the mounted base path before bootstrap finishes", () => {
+    window.history.replaceState({}, "", "/openclaw");
+    expect(agentLogoUrl("")).toBe("/openclaw/favicon.svg");
+
+    window.history.replaceState({}, "", "/apps/openclaw/cron");
+    expect(agentLogoUrl("")).toBe("/apps/openclaw/favicon.svg");
+  });
+
+  it("uses a route-relative fallback when there is no mounted base path", () => {
+    window.history.replaceState({}, "", "/chat");
     expect(agentLogoUrl("")).toBe("favicon.svg");
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -4,6 +4,7 @@ import {
   normalizeToolName,
   resolveToolProfilePolicy,
 } from "../../../../src/agents/tool-policy-shared.js";
+import { inferBasePathFromPathname, normalizeBasePath } from "../navigation.ts";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -217,8 +218,17 @@ export function resolveAgentAvatarUrl(
 }
 
 export function agentLogoUrl(basePath: string): string {
-  const base = basePath?.trim() ? basePath.replace(/\/$/, "") : "";
-  return base ? `${base}/favicon.svg` : "favicon.svg";
+  const explicitBase = normalizeBasePath(basePath ?? "");
+  if (explicitBase) {
+    return `${explicitBase}/favicon.svg`;
+  }
+  if (typeof window !== "undefined") {
+    const inferredBase = inferBasePathFromPathname(window.location?.pathname ?? "");
+    if (inferredBase) {
+      return `${inferredBase}/favicon.svg`;
+    }
+  }
+  return "favicon.svg";
 }
 
 function isLikelyEmoji(value: string) {


### PR DESCRIPTION
## Summary

- fix the connect/dashboard logo fallback when the Control UI is mounted under a base path like `/openclaw`
- infer the mounted base path from `window.location.pathname` before the bootstrap config has populated `state.basePath`
- add regression coverage for both inferred mounted paths and the direct-tab no-base fallback

## Problem

The login/connect view renders before the Control UI base-path bootstrap finishes. In that window, the logo fallback used a route-relative `favicon.svg` URL. When the dashboard was mounted under a path like `/openclaw`, that could resolve to the wrong location and show a broken image.

## Scope

- UI helper only
- no protocol, gateway, or runtime behavior changes

## Verification

- `pnpm --dir ui test -- src/ui/views/agents-utils.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/views/agents-utils.ts ui/src/ui/views/agents-utils.test.ts`

Closes #53172