### PR TITLE
feat(discord): extract embed fields and footer for agent visibility

### DIFF
--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -106,7 +106,12 @@ function expectAttachmentImageFallback(params: { result: unknown; attachment: { 
 
 function asForwardedSnapshotMessage(params: {
   content: string;
-  embeds: Array<{ title?: string; description?: string }>;
+  embeds: Array<{
+    title?: string;
+    description?: string;
+    fields?: Array<{ name: string; value: string }>;
+    footer?: { text: string };
+  }>;
 }) {
   return asMessage({
     content: "",
@@ -650,6 +655,88 @@ describe("resolveDiscordMessageText", () => {
     );
 
     expect(text).toBe("hello from content");
+  });
+
+  it("extracts embed fields when content is empty", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [
+          {
+            fields: [
+              { name: "Status", value: "Online" },
+              { name: "Uptime", value: "3h" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe("Status: Online\nUptime: 3h");
+  });
+
+  it("extracts embed footer when content is empty", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [{ title: "Alert", footer: { text: "Generated at 12:00" } }],
+      }),
+    );
+
+    expect(text).toBe("Alert\nGenerated at 12:00");
+  });
+
+  it("extracts title, description, fields, and footer together", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [
+          {
+            title: "System Status",
+            description: "All systems operational",
+            fields: [
+              { name: "CPU", value: "45%" },
+              { name: "RAM", value: "2.1GB" },
+            ],
+            footer: { text: "Last checked: now" },
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe(
+      "System Status\nAll systems operational\nCPU: 45%\nRAM: 2.1GB\nLast checked: now",
+    );
+  });
+
+  it("joins multiple embeds with separator", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [{ title: "Embed One" }, { title: "Embed Two", description: "Details" }],
+      }),
+    );
+
+    expect(text).toBe("Embed One\n---\nEmbed Two\nDetails");
+  });
+
+  it("skips fields with whitespace-only name or value", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        embeds: [
+          {
+            title: "Test",
+            fields: [
+              { name: "  ", value: "val" },
+              { name: "Real", value: "data" },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(text).toBe("Test\nReal: data");
   });
 
   it("joins forwarded snapshot embed title and description when content is empty", () => {

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -729,6 +729,7 @@ describe("resolveDiscordMessageText", () => {
             title: "Test",
             fields: [
               { name: "  ", value: "val" },
+              { name: "Real", value: "   " },
               { name: "Real", value: "data" },
             ],
           },

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -80,9 +80,16 @@ type DiscordSnapshotAuthor = {
   name?: string | null;
 };
 
+export type DiscordEmbedLike = {
+  title?: string | null;
+  description?: string | null;
+  fields?: Array<{ name: string; value: string }> | null;
+  footer?: { text?: string | null } | null;
+};
+
 type DiscordSnapshotMessage = {
   content?: string | null;
-  embeds?: Array<{ description?: string | null; title?: string | null }> | null;
+  embeds?: Array<DiscordEmbedLike> | null;
   attachments?: APIAttachment[] | null;
   stickers?: APIStickerItem[] | null;
   sticker_items?: APIStickerItem[] | null;
@@ -490,25 +497,36 @@ function buildDiscordMediaPlaceholder(params: {
   return attachmentText || stickerText || "";
 }
 
-export function resolveDiscordEmbedText(
-  embed?: { title?: string | null; description?: string | null } | null,
-): string {
-  const title = embed?.title?.trim() || "";
-  const description = embed?.description?.trim() || "";
-  if (title && description) {
-    return `${title}\n${description}`;
+export function resolveDiscordEmbedText(embed?: DiscordEmbedLike | null): string {
+  if (!embed) {
+    return "";
   }
-  return title || description || "";
+  const parts: string[] = [];
+  if (embed.title?.trim()) {
+    parts.push(embed.title.trim());
+  }
+  if (embed.description?.trim()) {
+    parts.push(embed.description.trim());
+  }
+  for (const f of embed.fields ?? []) {
+    if (f.name?.trim() && f.value?.trim()) {
+      parts.push(`${f.name.trim()}: ${f.value.trim()}`);
+    }
+  }
+  if (embed.footer?.text?.trim()) {
+    parts.push(embed.footer.text.trim());
+  }
+  return parts.join("\n");
 }
 
 export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
 ): string {
-  const embedText = resolveDiscordEmbedText(
-    (message.embeds?.[0] as { title?: string | null; description?: string | null } | undefined) ??
-      null,
-  );
+  const embedText = (message.embeds ?? [])
+    .map((e) => resolveDiscordEmbedText(e))
+    .filter(Boolean)
+    .join("\n---\n");
   const rawText =
     message.content?.trim() ||
     buildDiscordMediaPlaceholder({
@@ -596,7 +614,10 @@ function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): st
     attachments: snapshot.attachments ?? undefined,
     stickers: resolveDiscordSnapshotStickers(snapshot),
   });
-  const embedText = resolveDiscordEmbedText(snapshot.embeds?.[0]);
+  const embedText = (snapshot.embeds ?? [])
+    .map((e) => resolveDiscordEmbedText(e))
+    .filter(Boolean)
+    .join("\n---\n");
   return content || attachmentText || embedText || "";
 }
 

--- a/extensions/discord/src/monitor/threading.ts
+++ b/extensions/discord/src/monitor/threading.ts
@@ -8,6 +8,7 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-runtime";
 import type { DiscordChannelConfigResolved } from "./allow-list.js";
 import type { DiscordMessageEvent } from "./listeners.js";
 import {
+  type DiscordEmbedLike,
   resolveDiscordChannelInfo,
   resolveDiscordEmbedText,
   resolveDiscordMessageChannelId,
@@ -188,7 +189,7 @@ export async function resolveDiscordThreadStarter(params: {
       Routes.channelMessage(messageChannelId, params.channel.id),
     )) as {
       content?: string | null;
-      embeds?: Array<{ title?: string | null; description?: string | null }>;
+      embeds?: Array<DiscordEmbedLike>;
       member?: { nick?: string | null; displayName?: string | null };
       author?: {
         id?: string | null;
@@ -201,7 +202,10 @@ export async function resolveDiscordThreadStarter(params: {
       return null;
     }
     const content = starter.content?.trim() ?? "";
-    const embedText = resolveDiscordEmbedText(starter.embeds?.[0]);
+    const embedText = (starter.embeds ?? [])
+      .map((e) => resolveDiscordEmbedText(e))
+      .filter(Boolean)
+      .join("\n---\n");
     const text = content || embedText;
     if (!text) {
       return null;


### PR DESCRIPTION
## Summary

- Expand `resolveDiscordEmbedText` to extract **title, description, fields, and footer** (previously only title and description)
- Iterate **all embeds** in a message, not just `embeds[0]`, at all three call sites
- Export `DiscordEmbedLike` type for cross-file reuse

## Motivation

Many Discord bot messages use embeds for structured content — status dashboards, alerts, monitoring cards, cross-agent communication. When `message.content` is empty and data lives in embed fields/footer, agents currently see nothing. This is especially impactful in multi-agent setups where bots communicate primarily through rich embeds.

## Changes

**`extensions/discord/src/monitor/message-utils.ts`:**
- New exported `DiscordEmbedLike` type with `title`, `description`, `fields`, and `footer`
- `resolveDiscordEmbedText()` rewritten to extract all embed parts, joining fields as `Name: Value`
- `resolveDiscordMessageText()` and `resolveDiscordSnapshotMessageText()` iterate all embeds with `---` separator

**`extensions/discord/src/monitor/threading.ts`:**
- Thread starter embed extraction updated to use `DiscordEmbedLike` and iterate all embeds

**`extensions/discord/src/monitor/message-utils.test.ts`:**
- 5 new test cases: fields-only, footer with title, combined (title+description+fields+footer), multiple embeds with separator, whitespace-only field filtering

## Design decisions

- **Fallback chain unchanged:** embed text is only used when `message.content` is empty — no change for messages that already have text content
- **Fields formatted as `Name: Value`:** simple, readable, no parsing overhead for agents
- **`---` separator between embeds:** distinguishes multi-embed boundaries
- **Whitespace-only fields skipped:** prevents blank entries from cluttering agent context
- **`author.name` not included:** intentionally left for a follow-up — keeps this PR minimal

## Known limitation

When a message has both text content AND embeds, only the content is shown (embed text is fallback-only). This is existing behavior and intentional — changing it would require a larger design discussion about how to present both without context bloat.

## Test plan

- [x] All 34 tests pass (29 existing + 5 new)
- [x] `tsgo --noEmit` clean
- [x] Full pre-commit check suite passed (format, lint, type-check, boundaries, imports)
- [x] Live-tested on production gateway: Watson confirmed title, description, all fields, and footer visible in agent context from embed-only messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)