### PR TITLE
docs: clarify OpenClaw CLI subcommand usage

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -50,6 +50,24 @@ OpenClaw has three layers that work together:
 
 ## Built-in tools
 
+These tools ship with OpenClaw and are available without installing any plugins.
+
+> **Tool names are not shell commands.** Names like `sessions_list`,
+> `sessions_spawn`, and `agents_list` are tool identifiers that the agent can
+> call through the OpenClaw runtime. In a terminal, use subcommands of the
+> `openclaw` binary instead of dropping the prefix.
+>
+> Examples:
+>
+> - ❌ `sessions_list`
+> - ✅ `openclaw sessions list`
+> - ❌ `agents_list`
+> - ✅ `openclaw agents list`
+>
+> If you are in a shell, start from `openclaw --help` and then drill into the
+> relevant command group such as `openclaw sessions --help` or
+> `openclaw agents --help`.
+
 These tools ship with OpenClaw and are available without installing any plugins:
 
 | Tool                         | What it does                                             | Page                              |


### PR DESCRIPTION
## Summary
- clarify that tool names like `sessions_list` and `agents_list` are not shell commands
- add terminal examples showing the correct `openclaw sessions list` and `openclaw agents list` forms
- point readers to `openclaw --help` and per-command help for discovery

Closes #53253.
