### PR TITLE
fix(matrix): resolve crypto bootstrap failure and multi-extension idHint warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web_search: localize the shared search cache to module scope so same-process global symbol lookups can no longer inspect or mutate cached web-search responses. Thanks @vincentkoc.
 - Agents/silent turns: fail closed on silent memory-flush runs so narrated `NO_REPLY` self-talk cannot stream or finalize into external replies even when block streaming is enabled. (#52593)
 - Browser/plugins: auto-enable the bundled browser plugin when browser config or browser tool policy already references it, and show a clearer CLI error when `plugins.allow` excludes `browser`.
+- Matrix/plugin loading: ship and source-load the crypto bootstrap runtime sidecar correctly so current `main` stops warning about failed Matrix bootstrap loads and `matrix/index` plugin-id mismatches on every invocation. (#53298) thanks @keithce.
 
 ## 2026.3.28
 

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -23,7 +23,8 @@
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./index.ts",
+      "./src/plugin-entry.runtime.ts"
     ],
     "setupEntry": "./setup-entry.ts",
     "channel": {

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -53,6 +53,7 @@ beforeEach(async () => {
   } = await import("./client/config.js"));
   credentialsReadModule = await import("./credentials-read.js");
   sdkModule = await import("./sdk.js");
+});
 
 vi.mock("matrix-js-sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("matrix-js-sdk")>();

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -53,6 +53,16 @@ beforeEach(async () => {
   } = await import("./client/config.js"));
   credentialsReadModule = await import("./credentials-read.js");
   sdkModule = await import("./sdk.js");
+
+vi.mock("matrix-js-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("matrix-js-sdk")>();
+  return {
+    ...actual,
+    createClient: vi.fn(() => ({
+      // Minimal stub — auth tests spy on MatrixClient.prototype.doRequest
+      // rather than exercising the underlying js-sdk client.
+    })),
+  };
 });
 
 describe("resolveMatrixConfig", () => {

--- a/extensions/matrix/src/plugin-entry.runtime.js
+++ b/extensions/matrix/src/plugin-entry.runtime.js
@@ -1,0 +1,12 @@
+// Thin ESM wrapper so native dynamic import() resolves in source-checkout mode
+// where jiti loads index.ts but import("./src/plugin-entry.runtime.js") uses
+// Node's native ESM loader which cannot resolve .ts files directly.
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const { createJiti } = require("jiti");
+const jiti = createJiti(import.meta.url, { interopDefault: true });
+const mod = jiti("./plugin-entry.runtime.ts");
+export const ensureMatrixCryptoRuntime = mod.ensureMatrixCryptoRuntime;
+export const handleVerifyRecoveryKey = mod.handleVerifyRecoveryKey;
+export const handleVerificationBootstrap = mod.handleVerificationBootstrap;
+export const handleVerificationStatus = mod.handleVerificationStatus;

--- a/extensions/matrix/src/plugin-entry.runtime.test.ts
+++ b/extensions/matrix/src/plugin-entry.runtime.test.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, it } from "vitest";
+
+it("loads the plugin-entry runtime wrapper through native ESM import", async () => {
+  const wrapperPath = path.join(
+    process.cwd(),
+    "extensions",
+    "matrix",
+    "src",
+    "plugin-entry.runtime.js",
+  );
+  const wrapperUrl = pathToFileURL(wrapperPath);
+  const mod = await import(wrapperUrl.href);
+
+  expect(mod).toMatchObject({
+    ensureMatrixCryptoRuntime: expect.any(Function),
+    handleVerifyRecoveryKey: expect.any(Function),
+    handleVerificationBootstrap: expect.any(Function),
+    handleVerificationStatus: expect.any(Function),
+  });
+}, 240_000);

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -638,6 +638,7 @@ describe("loadPluginManifestRegistry", () => {
     { name: "provider-style", manifestId: "openai", idHint: "openai-provider" },
     { name: "plugin-style", manifestId: "brave", idHint: "brave-plugin" },
     { name: "sandbox-style", manifestId: "openshell", idHint: "openshell-sandbox" },
+    { name: "multi-entry-style", manifestId: "matrix", idHint: "matrix/index" },
     {
       name: "media-understanding-style",
       manifestId: "groq",

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -195,6 +195,10 @@ function isCompatiblePluginIdHint(idHint: string | undefined, manifestId: string
   if (normalizedHint === manifestId) {
     return true;
   }
+  // Generated idHint for multi-extension plugins takes the form "id/entryBase".
+  if (normalizedHint.startsWith(`${manifestId}/`)) {
+    return true;
+  }
   return (
     normalizedHint === `${manifestId}-provider` ||
     normalizedHint === `${manifestId}-plugin` ||


### PR DESCRIPTION
## Summary

Fixes two issues with the Matrix plugin on current `main`:

- **Crypto bootstrap failure**: `Cannot read properties of undefined (reading 'ensureMatrixCryptoRuntime')` — reported on every CLI invocation
- **Spurious idHint warning**: `plugin id mismatch (manifest uses "matrix", entry hints "matrix/index")` — emitted after the build entry fix introduces a second extension entry

> **Note:** The LINE `TypeError: Cannot redefine property: isSenderAllowed` was already fixed by #53221 (merged). This PR no longer touches the LINE extension.

## Reproduction

```
$ openclaw models list

[plugins] matrix: failed loading crypto bootstrap runtime: Cannot read properties of undefined (reading 'ensureMatrixCryptoRuntime')
```

After the matrix `package.json` fix alone, a new warning appears on every invocation:
```
Config warnings:
- plugins.entries.matrix: plugin matrix: plugin id mismatch (manifest uses "matrix", entry hints "matrix/index")
```

## Root Cause & Fix

### Matrix: `plugin-entry.runtime.ts` not loadable in source-checkout mode

`extensions/matrix/index.ts` dynamically imports `./src/plugin-entry.runtime.js` at registration time for crypto bootstrap. Two issues:

1. **Build**: `src/plugin-entry.runtime.ts` was not listed in `openclaw.extensions` in `package.json`, so tsdown never compiled it to `dist/extensions/matrix/src/plugin-entry.runtime.js`.
2. **Source checkout**: The gateway resolves bundled plugins from the source `extensions/` tree (via `isSourceCheckoutRoot` in `src/plugins/bundled-dir.ts`). Native `import()` inside a jiti-loaded module uses Node's ESM loader, which cannot resolve `.js` → `.ts`. The `.js` file doesn't exist in the source tree — only `.ts` does.

**Fix:**
- Add `./src/plugin-entry.runtime.ts` to the `openclaw.extensions` array in `extensions/matrix/package.json` so it's compiled to dist for production builds
- Add a thin ESM `.js` wrapper at `extensions/matrix/src/plugin-entry.runtime.js` that uses jiti to load the `.ts` source, bridging the gap for source-checkout mode

### Multi-extension idHint format not recognised

Adding a second entry to `openclaw.extensions` causes `deriveIdHint` in the metadata generator to return `"matrix/index"` instead of `"matrix"`. `isCompatiblePluginIdHint` in `src/plugins/manifest-registry.ts` only accepts exact matches and four well-known suffixes — not the `{id}/{entryBase}` form.

**Fix:** Add a `startsWith(\`${manifestId}/\`)` check to `isCompatiblePluginIdHint` so multi-extension idHints are accepted.

## Files changed
- `extensions/matrix/package.json` — add build entry
- `extensions/matrix/src/plugin-entry.runtime.js` — new ESM wrapper for source-checkout mode
- `src/plugins/manifest-registry.ts` — accept multi-extension idHint format
- `src/plugins/bundled-plugin-metadata.generated.ts` — regenerated

## Test plan

- [ ] `pnpm build` succeeds
- [ ] `openclaw models list` shows no `matrix: failed loading crypto bootstrap runtime` errors
- [ ] `openclaw models list` shows no `plugin id mismatch` warnings
- [ ] `pnpm check` passes (pre-existing msteams/ui tsgo errors excluded)
- [ ] `pnpm test -- src/plugins/manifest-registry.test.ts --run` passes (26/26)
- [ ] `pnpm test -- extensions/matrix/src/matrix/client/file-sync-store.test.ts --run` passes (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)