### PR TITLE
fix(whatsapp): skip fromMe messages in group auto-reply to prevent echo loops

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
@@ -1,158 +1,209 @@
-import { describe, expect, it, vi } from "vitest";
-import { createWebOnMessageHandler } from "./on-message.js";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 
-/**
- * Minimal stubs for the dependencies that `createWebOnMessageHandler` needs.
- * Only the fields exercised by the fromMe early-exit path are populated;
- * everything else is a no-op or empty object.
- */
-function stubParams(overrides?: { echoTrackerHas?: (key: string) => boolean }) {
-  const processed: Array<{ body: string; fromMe?: boolean }> = [];
-  const echoForgotten: string[] = [];
+// Mock all external dependencies so we can instantiate the real handler.
+vi.mock("openclaw/plugin-sdk/config-runtime", () => ({
+  loadConfig: vi.fn(() => ({
+    channels: { whatsapp: { enabled: true, groupPolicy: "allowlist", groups: {} } },
+    commands: {},
+    messages: {},
+    session: {},
+  })),
+}));
 
-  const echoTracker = {
-    rememberText: vi.fn(),
-    has: overrides?.echoTrackerHas ?? (() => false),
-    forget: (key: string) => echoForgotten.push(key),
-    buildCombinedKey: (p: { sessionKey: string; combinedBody: string }) =>
-      `combined:${p.sessionKey}:${p.combinedBody}`,
-  };
+vi.mock("openclaw/plugin-sdk/routing", () => ({
+  resolveAgentRoute: vi.fn(() => ({
+    agentId: "test-agent",
+    sessionKey: "agent:test-agent:main",
+    mainSessionKey: "agent:test-agent:main",
+    accountId: "default",
+  })),
+  buildGroupHistoryKey: vi.fn(() => "whatsapp:default:group:test-group"),
+}));
 
+vi.mock("openclaw/plugin-sdk/runtime-env", () => {
+  const verboseMessages: string[] = [];
   return {
-    processed,
-    echoForgotten,
-    echoTracker,
+    logVerbose: vi.fn((msg: string) => verboseMessages.push(msg)),
+    shouldLogVerbose: vi.fn(() => true),
+    getChildLogger: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    })),
+    __verboseMessages: verboseMessages,
   };
-}
+});
 
-function makeMsg(overrides: Partial<{
-  body: string;
-  from: string;
-  to: string;
-  chatType: "direct" | "group";
-  fromMe: boolean;
-  conversationId: string;
-  accountId: string;
-  senderJid: string;
-  senderE164: string;
-  senderName: string;
-  selfJid: string;
-  selfE164: string;
-  chatId: string;
-  groupSubject: string;
-}> = {}) {
+vi.mock("openclaw/plugin-sdk/text-runtime", () => ({
+  normalizeE164: vi.fn((v: string) => v),
+  jidToE164: vi.fn((v: string) => v),
+}));
+
+vi.mock("./group-gating.js", () => ({
+  applyGroupGating: vi.fn(() => ({ shouldProcess: true })),
+}));
+
+vi.mock("./broadcast.js", () => ({
+  maybeBroadcastMessage: vi.fn(async () => false),
+}));
+
+vi.mock("./process-message.js", () => ({
+  processMessage: vi.fn(async () => true),
+}));
+
+vi.mock("./last-route.js", () => ({
+  updateLastRouteInBackground: vi.fn(),
+  trackBackgroundTask: vi.fn(),
+}));
+
+vi.mock("./peer.js", () => ({
+  resolvePeerId: vi.fn(() => "120363408809173967@g.us"),
+}));
+
+import { createWebOnMessageHandler } from "./on-message.js";
+import { processMessage } from "./process-message.js";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import type { WebInboundMsg } from "../types.js";
+
+function makeMsg(overrides: Partial<WebInboundMsg> = {}): WebInboundMsg {
   return {
     id: "msg-1",
-    body: overrides.body ?? "Hello from the group",
-    from: overrides.from ?? "120363408809173967@g.us",
-    to: overrides.to ?? "+971506443271",
-    conversationId: overrides.conversationId ?? overrides.from ?? "120363408809173967@g.us",
-    accountId: overrides.accountId ?? "default",
-    chatType: overrides.chatType ?? ("group" as const),
-    chatId: overrides.chatId ?? "120363408809173967@g.us",
-    fromMe: overrides.fromMe ?? false,
-    senderJid: overrides.senderJid ?? "215233729704@lid",
-    senderE164: overrides.senderE164 ?? "+923006761319",
-    senderName: overrides.senderName ?? "Test User",
-    selfJid: overrides.selfJid ?? "971506443271@s.whatsapp.net",
-    selfE164: overrides.selfE164 ?? "+971506443271",
-    groupSubject: overrides.groupSubject ?? "Test Group",
+    body: "Hello from the group",
+    from: "120363408809173967@g.us",
+    to: "+971506443271",
+    conversationId: "120363408809173967@g.us",
+    accountId: "default",
+    chatType: "group",
+    chatId: "120363408809173967@g.us",
+    fromMe: false,
+    senderJid: "215233729704@lid",
+    senderE164: "+923006761319",
+    senderName: "Test User",
+    selfJid: "971506443271@s.whatsapp.net",
+    selfE164: "+971506443271",
+    groupSubject: "Test Group",
     groupParticipants: [],
     mentionedJids: [],
     sendComposing: vi.fn().mockResolvedValue(undefined),
     reply: vi.fn().mockResolvedValue(undefined),
     sendMedia: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as WebInboundMsg;
+}
+
+function createHandler(overrides?: { echoTrackerHas?: (key: string) => boolean }) {
+  const echoTracker = {
+    rememberText: vi.fn(),
+    has: overrides?.echoTrackerHas ?? vi.fn(() => false),
+    forget: vi.fn(),
+    buildCombinedKey: vi.fn(
+      (p: { sessionKey: string; combinedBody: string }) =>
+        `combined:${p.sessionKey}:${p.combinedBody}`,
+    ),
   };
+
+  const handler = createWebOnMessageHandler({
+    cfg: {
+      channels: { whatsapp: { enabled: true, groupPolicy: "allowlist", groups: {} } },
+      commands: {},
+      messages: {},
+      session: {},
+    } as ReturnType<typeof import("openclaw/plugin-sdk/config-runtime").loadConfig>,
+    verbose: true,
+    connectionId: "test-conn",
+    maxMediaBytes: 20_971_520,
+    groupHistoryLimit: 20,
+    groupHistories: new Map(),
+    groupMemberNames: new Map(),
+    echoTracker,
+    backgroundTasks: new Set(),
+    replyResolver: vi.fn() as never,
+    replyLogger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as never,
+    baseMentionConfig: { requireMention: false },
+    account: { accountId: "default" },
+  });
+
+  return { handler, echoTracker };
 }
 
 describe("on-message fromMe echo protection", () => {
-  it("should skip fromMe messages in group chats", async () => {
-    const { echoTracker } = stubParams();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    // We can't easily construct the full handler without mocking
-    // the entire module graph, so we verify the logic inline:
+  it("skips fromMe messages in group chats and never calls processMessage", async () => {
+    const { handler, echoTracker } = createHandler();
     const msg = makeMsg({ fromMe: true, chatType: "group" });
 
-    // The core assertion: fromMe should be truthy
-    expect(msg.fromMe).toBe(true);
+    await handler(msg);
 
-    // When fromMe is true, the handler should return before reaching
-    // echoTracker or processMessage.  echoTracker.has should NOT be called.
-    const hasSpied = vi.fn().mockReturnValue(false);
-    const tracker = { ...echoTracker, has: hasSpied };
+    // processMessage should NOT have been called
+    expect(processMessage).not.toHaveBeenCalled();
 
-    // Simulate the guard logic from on-message.ts:
-    if (msg.fromMe) {
-      // This is the early exit path we added
-      expect(true).toBe(true); // reached the guard
-    } else {
-      // Should never reach here for fromMe messages
-      if (tracker.has(msg.body)) {
-        tracker.forget(msg.body);
-      }
-    }
+    // echoTracker.has should NOT have been called (fromMe exits before it)
+    expect(echoTracker.has).not.toHaveBeenCalled();
 
-    // echoTracker.has should NOT have been called because fromMe exited first
-    expect(hasSpied).not.toHaveBeenCalled();
+    // logVerbose should have logged the skip reason
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping auto-reply: fromMe message"),
+    );
   });
 
-  it("should NOT skip non-fromMe messages in group chats", () => {
+  it("processes non-fromMe messages from group members normally", async () => {
+    const { handler } = createHandler();
     const msg = makeMsg({ fromMe: false, chatType: "group" });
-    expect(msg.fromMe).toBe(false);
 
-    // This message should pass through the fromMe guard
-    let reachedEchoCheck = false;
-    if (msg.fromMe) {
-      // Should not enter here
-    } else {
-      reachedEchoCheck = true;
-    }
-    expect(reachedEchoCheck).toBe(true);
+    await handler(msg);
+
+    // processMessage SHOULD have been called
+    expect(processMessage).toHaveBeenCalled();
   });
 
-  it("should skip fromMe messages in direct chats too", () => {
-    const msg = makeMsg({ fromMe: true, chatType: "direct" });
-    expect(msg.fromMe).toBe(true);
+  it("skips fromMe messages in direct chats too", async () => {
+    const { handler } = createHandler();
+    const msg = makeMsg({
+      fromMe: true,
+      chatType: "direct",
+      from: "+923006761319",
+      to: "+971506443271",
+    });
 
-    // fromMe guard applies to all chat types
-    let skipped = false;
-    if (msg.fromMe) {
-      skipped = true;
-    }
-    expect(skipped).toBe(true);
+    await handler(msg);
+
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping auto-reply: fromMe message in direct"),
+    );
   });
 
-  it("should still use echo tracker as fallback when fromMe is false", () => {
+  it("still uses echo tracker as fallback when fromMe is false but text matches", async () => {
+    const echoHas = vi.fn(() => true);
+    const { handler, echoTracker } = createHandler({ echoTrackerHas: echoHas });
     const msg = makeMsg({ fromMe: false, body: "echoed text" });
-    const hasSpied = vi.fn().mockReturnValue(true);
-    const forgetSpied = vi.fn();
 
-    let skippedByFromMe = false;
-    let skippedByEcho = false;
+    await handler(msg);
 
-    if (msg.fromMe) {
-      skippedByFromMe = true;
-    } else if (hasSpied(msg.body)) {
-      skippedByEcho = true;
-      forgetSpied(msg.body);
-    }
-
-    expect(skippedByFromMe).toBe(false);
-    expect(skippedByEcho).toBe(true);
-    expect(hasSpied).toHaveBeenCalledWith("echoed text");
-    expect(forgetSpied).toHaveBeenCalledWith("echoed text");
+    // fromMe is false, so echo tracker should be checked
+    expect(echoHas).toHaveBeenCalledWith("echoed text");
+    // Echo was detected, so forget should be called
+    expect(echoTracker.forget).toHaveBeenCalledWith("echoed text");
+    // processMessage should NOT have been called (echo detected)
+    expect(processMessage).not.toHaveBeenCalled();
   });
 
-  it("should handle undefined fromMe as non-fromMe", () => {
-    const msg = makeMsg({});
-    // @ts-expect-error testing undefined case
-    msg.fromMe = undefined;
+  it("treats undefined fromMe as non-fromMe and processes the message", async () => {
+    const { handler } = createHandler();
+    const msg = makeMsg({ fromMe: undefined });
 
-    // undefined is falsy — should NOT trigger the guard
-    let skipped = false;
-    if (msg.fromMe) {
-      skipped = true;
-    }
-    expect(skipped).toBe(false);
+    await handler(msg);
+
+    // undefined is falsy — message should be processed
+    expect(processMessage).toHaveBeenCalled();
   });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
@@ -146,8 +146,9 @@ describe("on-message fromMe echo protection", () => {
     // processMessage should NOT have been called
     expect(processMessage).not.toHaveBeenCalled();
 
-    // echoTracker.has should NOT have been called (fromMe exits before it)
-    expect(echoTracker.has).not.toHaveBeenCalled();
+    // echoTracker.has IS called to consume any stale key, preventing
+    // false suppression of later real user messages with the same body
+    expect(echoTracker.has).toHaveBeenCalledWith("Hello from the group");
 
     // logVerbose should have logged the skip reason
     expect(logVerbose).toHaveBeenCalledWith(
@@ -213,6 +214,21 @@ describe("on-message fromMe echo protection", () => {
     expect(echoTracker.forget).toHaveBeenCalledWith("echoed text");
     // processMessage should NOT have been called (echo detected)
     expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it("consumes echo tracker key when skipping fromMe to avoid stale matches", async () => {
+    const echoHas = vi.fn(() => true);
+    const { handler, echoTracker } = createHandler({ echoTrackerHas: echoHas });
+    const msg = makeMsg({ fromMe: true, chatType: "group", body: "ok" });
+
+    await handler(msg);
+
+    // fromMe should skip the message
+    expect(processMessage).not.toHaveBeenCalled();
+    // But it should also consume the echo tracker key so "ok" from a real
+    // user later is not falsely dropped
+    expect(echoHas).toHaveBeenCalledWith("ok");
+    expect(echoTracker.forget).toHaveBeenCalledWith("ok");
   });
 
   it("treats undefined fromMe as non-fromMe and processes the message", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWebOnMessageHandler } from "./on-message.js";
+
+/**
+ * Minimal stubs for the dependencies that `createWebOnMessageHandler` needs.
+ * Only the fields exercised by the fromMe early-exit path are populated;
+ * everything else is a no-op or empty object.
+ */
+function stubParams(overrides?: { echoTrackerHas?: (key: string) => boolean }) {
+  const processed: Array<{ body: string; fromMe?: boolean }> = [];
+  const echoForgotten: string[] = [];
+
+  const echoTracker = {
+    rememberText: vi.fn(),
+    has: overrides?.echoTrackerHas ?? (() => false),
+    forget: (key: string) => echoForgotten.push(key),
+    buildCombinedKey: (p: { sessionKey: string; combinedBody: string }) =>
+      `combined:${p.sessionKey}:${p.combinedBody}`,
+  };
+
+  return {
+    processed,
+    echoForgotten,
+    echoTracker,
+  };
+}
+
+function makeMsg(overrides: Partial<{
+  body: string;
+  from: string;
+  to: string;
+  chatType: "direct" | "group";
+  fromMe: boolean;
+  conversationId: string;
+  accountId: string;
+  senderJid: string;
+  senderE164: string;
+  senderName: string;
+  selfJid: string;
+  selfE164: string;
+  chatId: string;
+  groupSubject: string;
+}> = {}) {
+  return {
+    id: "msg-1",
+    body: overrides.body ?? "Hello from the group",
+    from: overrides.from ?? "120363408809173967@g.us",
+    to: overrides.to ?? "+971506443271",
+    conversationId: overrides.conversationId ?? overrides.from ?? "120363408809173967@g.us",
+    accountId: overrides.accountId ?? "default",
+    chatType: overrides.chatType ?? ("group" as const),
+    chatId: overrides.chatId ?? "120363408809173967@g.us",
+    fromMe: overrides.fromMe ?? false,
+    senderJid: overrides.senderJid ?? "215233729704@lid",
+    senderE164: overrides.senderE164 ?? "+923006761319",
+    senderName: overrides.senderName ?? "Test User",
+    selfJid: overrides.selfJid ?? "971506443271@s.whatsapp.net",
+    selfE164: overrides.selfE164 ?? "+971506443271",
+    groupSubject: overrides.groupSubject ?? "Test Group",
+    groupParticipants: [],
+    mentionedJids: [],
+    sendComposing: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    sendMedia: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("on-message fromMe echo protection", () => {
+  it("should skip fromMe messages in group chats", async () => {
+    const { echoTracker } = stubParams();
+
+    // We can't easily construct the full handler without mocking
+    // the entire module graph, so we verify the logic inline:
+    const msg = makeMsg({ fromMe: true, chatType: "group" });
+
+    // The core assertion: fromMe should be truthy
+    expect(msg.fromMe).toBe(true);
+
+    // When fromMe is true, the handler should return before reaching
+    // echoTracker or processMessage.  echoTracker.has should NOT be called.
+    const hasSpied = vi.fn().mockReturnValue(false);
+    const tracker = { ...echoTracker, has: hasSpied };
+
+    // Simulate the guard logic from on-message.ts:
+    if (msg.fromMe) {
+      // This is the early exit path we added
+      expect(true).toBe(true); // reached the guard
+    } else {
+      // Should never reach here for fromMe messages
+      if (tracker.has(msg.body)) {
+        tracker.forget(msg.body);
+      }
+    }
+
+    // echoTracker.has should NOT have been called because fromMe exited first
+    expect(hasSpied).not.toHaveBeenCalled();
+  });
+
+  it("should NOT skip non-fromMe messages in group chats", () => {
+    const msg = makeMsg({ fromMe: false, chatType: "group" });
+    expect(msg.fromMe).toBe(false);
+
+    // This message should pass through the fromMe guard
+    let reachedEchoCheck = false;
+    if (msg.fromMe) {
+      // Should not enter here
+    } else {
+      reachedEchoCheck = true;
+    }
+    expect(reachedEchoCheck).toBe(true);
+  });
+
+  it("should skip fromMe messages in direct chats too", () => {
+    const msg = makeMsg({ fromMe: true, chatType: "direct" });
+    expect(msg.fromMe).toBe(true);
+
+    // fromMe guard applies to all chat types
+    let skipped = false;
+    if (msg.fromMe) {
+      skipped = true;
+    }
+    expect(skipped).toBe(true);
+  });
+
+  it("should still use echo tracker as fallback when fromMe is false", () => {
+    const msg = makeMsg({ fromMe: false, body: "echoed text" });
+    const hasSpied = vi.fn().mockReturnValue(true);
+    const forgetSpied = vi.fn();
+
+    let skippedByFromMe = false;
+    let skippedByEcho = false;
+
+    if (msg.fromMe) {
+      skippedByFromMe = true;
+    } else if (hasSpied(msg.body)) {
+      skippedByEcho = true;
+      forgetSpied(msg.body);
+    }
+
+    expect(skippedByFromMe).toBe(false);
+    expect(skippedByEcho).toBe(true);
+    expect(hasSpied).toHaveBeenCalledWith("echoed text");
+    expect(forgetSpied).toHaveBeenCalledWith("echoed text");
+  });
+
+  it("should handle undefined fromMe as non-fromMe", () => {
+    const msg = makeMsg({});
+    // @ts-expect-error testing undefined case
+    msg.fromMe = undefined;
+
+    // undefined is falsy — should NOT trigger the guard
+    let skipped = false;
+    if (msg.fromMe) {
+      skipped = true;
+    }
+    expect(skipped).toBe(false);
+  });
+});

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts
@@ -61,10 +61,10 @@ vi.mock("./peer.js", () => ({
   resolvePeerId: vi.fn(() => "120363408809173967@g.us"),
 }));
 
-import { createWebOnMessageHandler } from "./on-message.js";
-import { processMessage } from "./process-message.js";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { WebInboundMsg } from "../types.js";
+import { createWebOnMessageHandler } from "./on-message.js";
+import { processMessage } from "./process-message.js";
 
 function makeMsg(overrides: Partial<WebInboundMsg> = {}): WebInboundMsg {
   return {
@@ -165,13 +165,14 @@ describe("on-message fromMe echo protection", () => {
     expect(processMessage).toHaveBeenCalled();
   });
 
-  it("skips fromMe messages in direct chats too", async () => {
+  it("skips fromMe messages in direct chats when not same phone", async () => {
     const { handler } = createHandler();
     const msg = makeMsg({
       fromMe: true,
       chatType: "direct",
       from: "+923006761319",
       to: "+971506443271",
+      selfE164: "+971506443271",
     });
 
     await handler(msg);
@@ -180,6 +181,23 @@ describe("on-message fromMe echo protection", () => {
     expect(logVerbose).toHaveBeenCalledWith(
       expect.stringContaining("Skipping auto-reply: fromMe message in direct"),
     );
+  });
+
+  it("allows fromMe messages in same-phone self-chat DMs", async () => {
+    const { handler } = createHandler();
+    const msg = makeMsg({
+      fromMe: true,
+      chatType: "direct",
+      from: "+971506443271",
+      to: "+971506443271",
+      selfE164: "+971506443271",
+      conversationId: "+971506443271",
+    });
+
+    await handler(msg);
+
+    // Self-chat should be processed — user is messaging their own number
+    expect(processMessage).toHaveBeenCalled();
   });
 
   it("still uses echo tracker as fallback when fromMe is false but text matches", async () => {

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -95,10 +95,15 @@ export function createWebOnMessageHandler(params: {
     // unchecked, so the bot's replies would re-enter the auto-reply pipeline
     // whenever the text-based echo tracker failed to match (e.g. due to
     // minor formatting differences or Set eviction under load).
-    if (msg.fromMe) {
-      logVerbose(
-        `Skipping auto-reply: fromMe message in ${msg.chatType} chat ${conversationId}`,
-      );
+    //
+    // Same-phone (self-chat) DMs are exempted: when the user messages their
+    // own number, `fromMe` is true but the message is intentional input to
+    // the bot.  This mirrors `checkInboundAccessControl` which only rejects
+    // `isFromMe && !isSamePhone`.
+    const isSamePhone =
+      msg.selfE164 != null && normalizeE164(msg.from) === normalizeE164(msg.selfE164);
+    if (msg.fromMe && !isSamePhone) {
+      logVerbose(`Skipping auto-reply: fromMe message in ${msg.chatType} chat ${conversationId}`);
       return;
     }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -88,7 +88,24 @@ export function createWebOnMessageHandler(params: {
       logVerbose(`📱 Same-phone mode detected (from === to: ${msg.from})`);
     }
 
-    // Skip if this is a message we just sent (echo detection)
+    // Skip messages sent by the bot itself.  Baileys delivers the bot's own
+    // outbound messages back through the inbound event stream with
+    // `key.fromMe = true`.  In direct chats this is already handled by
+    // `checkInboundAccessControl`, but in groups the flag was previously
+    // unchecked, so the bot's replies would re-enter the auto-reply pipeline
+    // whenever the text-based echo tracker failed to match (e.g. due to
+    // minor formatting differences or Set eviction under load).
+    if (msg.fromMe) {
+      logVerbose(
+        `Skipping auto-reply: fromMe message in ${msg.chatType} chat ${conversationId}`,
+      );
+      return;
+    }
+
+    // Skip if this is a message we just sent (echo detection).
+    // This is a secondary safeguard; the `fromMe` check above is the
+    // authoritative gate.  The text-based tracker is kept for edge cases
+    // where Baileys does not set `fromMe` reliably (e.g. multi-device lag).
     if (params.echoTracker.has(msg.body)) {
       logVerbose("Skipping auto-reply: detected echo (message matches recently sent text)");
       params.echoTracker.forget(msg.body);

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -103,6 +103,12 @@ export function createWebOnMessageHandler(params: {
     const isSamePhone =
       msg.selfE164 != null && normalizeE164(msg.from) === normalizeE164(msg.selfE164);
     if (msg.fromMe && !isSamePhone) {
+      // Consume any matching echo-tracker key so it does not linger and
+      // falsely suppress a later *real* user message with the same body
+      // (e.g. common short replies like "ok" or "thanks").
+      if (params.echoTracker.has(msg.body)) {
+        params.echoTracker.forget(msg.body);
+      }
       logVerbose(`Skipping auto-reply: fromMe message in ${msg.chatType} chat ${conversationId}`);
       return;
     }


### PR DESCRIPTION
## Summary

Adds an early `msg.fromMe` guard in the WhatsApp auto-reply message handler to prevent the bot's own outbound messages from re-entering the auto-reply pipeline in group chats.

## Problem

In group chats, Baileys delivers the bot's own outbound messages back through the inbound event stream with `key.fromMe = true`. The existing echo protection relies on a text-matching `Set` (`echoTracker`) that remembers recently sent text and skips matching inbound messages. This fails when:

1. **Formatting differences** — WhatsApp/Baileys reformats the message slightly (whitespace normalization, link preview injection, Unicode changes)
2. **Set eviction** — The tracker is capped at 100 entries; under high message volume, older entries are evicted before the echo arrives
3. **Multi-device timing** — The echo arrives with enough delay that the Set entry was already consumed by a prior match

When the text-based tracker misses, the bot's own response re-enters the pipeline as a new inbound message → the agent responds to its own reply → creating a visible echo loop in the group chat.

**In direct chats**, `fromMe` is already checked by `checkInboundAccessControl` (which returns `allowed: false` when `isFromMe && !isSamePhone`), so the bug only manifests in **group chats**.

## Fix

Added `if (msg.fromMe) return` in `on-message.ts` right before the text-based echo check. This is the authoritative gate — any message Baileys marks as `fromMe` is unconditionally skipped. The existing `echoTracker` is retained as a secondary safeguard for edge cases where Baileys doesn't set `fromMe` reliably (e.g. multi-device lag or protocol quirks).

No type or data-flow changes needed — `fromMe` is already present on `WebInboundMessage` (types.ts:34) and populated from `msg.key?.fromMe` in the inbound monitor (monitor.ts:382).

## Reproduction

1. Connect a WhatsApp account to OpenClaw
2. Add the bot to a group chat with `requireMention: false`
3. Send a message from any group member
4. Observe the bot's reply being echoed back as a new inbound message, triggering another reply

After this fix, step 4 no longer occurs.

## Changes

- `extensions/whatsapp/src/auto-reply/monitor/on-message.ts` — Add `fromMe` early-exit guard before echo tracker check
- `extensions/whatsapp/src/auto-reply/monitor/on-message.fromme-echo.test.ts` — Unit tests for the fromMe guard logic

## Testing

- Verified the fix on a production OpenClaw instance with 6 WhatsApp groups (including bound agent groups with `requireMention: false`)
- Echo loop in affected group stopped immediately after applying the patch
- Non-fromMe messages from other group members continue to be processed normally
- Text-based echo tracker still functions as secondary safeguard