### PR TITLE
Discord: make components v2 cross-context containers configurable

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -11432,6 +11432,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.discord.accounts.*.useComponentsV2",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.discord.accounts.*.voice",
       "kind": "channel",
       "type": "object",
@@ -14473,6 +14483,16 @@
       ],
       "label": "Discord Component Accent Color",
       "help": "Accent color for Discord component containers (hex). Set per account via channels.discord.accounts.<id>.ui.components.accentColor.",
+      "hasChildren": false
+    },
+    {
+      "path": "channels.discord.useComponentsV2",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
       "hasChildren": false
     },
     {

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5628}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5630}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1015,6 +1015,7 @@
 {"recordType":"path","path":"channels.discord.accounts.*.ui","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.ui.components","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.ui.components.accentColor","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.discord.accounts.*.useComponentsV2","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.accounts.*.voice","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.voice.autoJoin","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.accounts.*.voice.autoJoin.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1281,6 +1282,7 @@
 {"recordType":"path","path":"channels.discord.ui","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.ui.components","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.ui.components.accentColor","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Discord Component Accent Color","help":"Accent color for Discord component containers (hex). Set per account via channels.discord.accounts.<id>.ui.components.accentColor.","hasChildren":false}
+{"recordType":"path","path":"channels.discord.useComponentsV2","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.discord.voice","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.discord.voice.autoJoin","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Discord Voice Auto-Join","help":"Voice channels to auto-join on startup (list of guildId/channelId entries).","hasChildren":true}
 {"recordType":"path","path":"channels.discord.voice.autoJoin.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -337,6 +337,8 @@ export type DiscordAccountConfig = {
   status?: "online" | "dnd" | "idle" | "invisible";
   /** Automatic runtime/quota presence signaling (status text + status mapping). */
   autoPresence?: DiscordAutoPresenceConfig;
+  /** Use Discord components v2 containers for cross-context messages. Default: true. */
+  useComponentsV2?: boolean;
   /** Activity type (0=Game, 1=Streaming, 2=Listening, 3=Watching, 4=Custom, 5=Competing). Defaults to 4 (Custom) when activity is set. */
   activityType?: 0 | 1 | 2 | 3 | 4 | 5;
   /** Streaming URL (Twitch/YouTube). Required when activityType=1. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -550,6 +550,7 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    useComponentsV2: z.boolean().optional(),
     ui: DiscordUiSchema,
     slashCommand: z
       .object({

--- a/src/infra/outbound/channel-adapters.test.ts
+++ b/src/infra/outbound/channel-adapters.test.ts
@@ -1,6 +1,7 @@
 import { Container, Separator, TextDisplay } from "@buape/carbon";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -80,5 +81,80 @@ describe("getChannelMessageAdapter", () => {
 
     expect(components).toHaveLength(1);
     expect(container?.components).toEqual([expect.any(TextDisplay)]);
+  });
+
+  describe("useComponentsV2 config", () => {
+    it("disables components v2 when useComponentsV2 is false at base channel level", () => {
+      const cfg: OpenClawConfig = {
+        channels: { discord: { useComponentsV2: false } },
+      };
+      const adapter = getChannelMessageAdapter("discord", cfg);
+      expect(adapter.supportsComponentsV2).toBe(false);
+      expect(adapter.buildCrossContextComponents).toBeUndefined();
+    });
+
+    it("keeps components v2 enabled when useComponentsV2 is true at base channel level", () => {
+      const cfg: OpenClawConfig = {
+        channels: { discord: { useComponentsV2: true } },
+      };
+      const adapter = getChannelMessageAdapter("discord", cfg);
+      expect(adapter.supportsComponentsV2).toBe(true);
+      expect(adapter.buildCrossContextComponents).toBeTypeOf("function");
+    });
+
+    it("defaults to components v2 enabled when useComponentsV2 is omitted", () => {
+      const cfg: OpenClawConfig = { channels: { discord: {} } };
+      const adapter = getChannelMessageAdapter("discord", cfg);
+      expect(adapter.supportsComponentsV2).toBe(true);
+    });
+
+    it("account-level useComponentsV2: false overrides base-level default", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          discord: {
+            accounts: { mybot: { useComponentsV2: false } },
+          },
+        },
+      };
+      const adapter = getChannelMessageAdapter("discord", cfg, "mybot");
+      expect(adapter.supportsComponentsV2).toBe(false);
+      expect(adapter.buildCrossContextComponents).toBeUndefined();
+    });
+
+    it("account-level useComponentsV2: true overrides base-level false", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          discord: {
+            useComponentsV2: false,
+            accounts: { mybot: { useComponentsV2: true } },
+          },
+        },
+      };
+      const adapter = getChannelMessageAdapter("discord", cfg, "mybot");
+      expect(adapter.supportsComponentsV2).toBe(true);
+      expect(adapter.buildCrossContextComponents).toBeTypeOf("function");
+    });
+
+    it("falls back to base-level config when account has no useComponentsV2 override", () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          discord: {
+            useComponentsV2: false,
+            accounts: { mybot: {} },
+          },
+        },
+      };
+      const adapter = getChannelMessageAdapter("discord", cfg, "mybot");
+      expect(adapter.supportsComponentsV2).toBe(false);
+    });
+
+    it("does not affect channels without a plugin buildCrossContextComponents", () => {
+      const cfg: OpenClawConfig = {
+        channels: { discord: { useComponentsV2: false } },
+      };
+      // Telegram plugin has no buildCrossContextComponents, so always returns default
+      const adapter = getChannelMessageAdapter("telegram", cfg);
+      expect(adapter.supportsComponentsV2).toBe(false);
+    });
   });
 });

--- a/src/infra/outbound/channel-adapters.ts
+++ b/src/infra/outbound/channel-adapters.ts
@@ -20,9 +20,49 @@ const DEFAULT_ADAPTER: ChannelMessageAdapter = {
   supportsComponentsV2: false,
 };
 
-export function getChannelMessageAdapter(channel: ChannelId): ChannelMessageAdapter {
+/**
+ * Resolve whether components v2 is enabled for the given channel, respecting
+ * account-level `useComponentsV2` overrides (account takes precedence over
+ * base channel config). Returns `true` when the field is absent (default).
+ */
+function resolveUseComponentsV2(
+  cfg: OpenClawConfig | undefined,
+  channel: ChannelId,
+  accountId?: string | null,
+): boolean {
+  if (!cfg) {
+    return true;
+  }
+  const channelCfg = cfg.channels?.[channel as string] as
+    | { useComponentsV2?: boolean; accounts?: Record<string, { useComponentsV2?: boolean }> }
+    | undefined;
+  if (!channelCfg) {
+    return true;
+  }
+  // Account-level override takes precedence
+  if (accountId) {
+    const accountCfg = channelCfg.accounts?.[accountId];
+    if (accountCfg && typeof accountCfg.useComponentsV2 === "boolean") {
+      return accountCfg.useComponentsV2;
+    }
+  }
+  // Fall back to base channel-level config
+  if (typeof channelCfg.useComponentsV2 === "boolean") {
+    return channelCfg.useComponentsV2;
+  }
+  return true;
+}
+
+export function getChannelMessageAdapter(
+  channel: ChannelId,
+  cfg?: OpenClawConfig,
+  accountId?: string | null,
+): ChannelMessageAdapter {
   const adapter = getChannelPlugin(channel)?.messaging?.buildCrossContextComponents;
   if (adapter) {
+    if (!resolveUseComponentsV2(cfg, channel, accountId)) {
+      return DEFAULT_ADAPTER;
+    }
     return {
       supportsComponentsV2: true,
       buildCrossContextComponents: adapter,

--- a/src/infra/outbound/outbound-policy.test.ts
+++ b/src/infra/outbound/outbound-policy.test.ts
@@ -11,28 +11,29 @@ let shouldApplyCrossContextMarker: typeof import("./outbound-policy.js").shouldA
 class TestDiscordUiContainer extends Container {}
 
 const mocks = vi.hoisted(() => ({
-  getChannelMessageAdapter: vi.fn((channel: string) =>
-    channel === "discord"
-      ? {
-          supportsComponentsV2: true,
-          buildCrossContextComponents: ({
-            originLabel,
-            message,
-          }: {
-            originLabel: string;
-            message: string;
-          }) => {
-            const trimmed = message.trim();
-            const components: Array<TextDisplay | Separator> = [];
-            if (trimmed) {
-              components.push(new TextDisplay(message));
-              components.push(new Separator({ divider: true, spacing: "small" }));
-            }
-            components.push(new TextDisplay(`*From ${originLabel}*`));
-            return [new TestDiscordUiContainer(components)];
-          },
-        }
-      : { supportsComponentsV2: false },
+  getChannelMessageAdapter: vi.fn(
+    (channel: string, _cfg?: OpenClawConfig, _accountId?: string | null) =>
+      channel === "discord"
+        ? {
+            supportsComponentsV2: true,
+            buildCrossContextComponents: ({
+              originLabel,
+              message,
+            }: {
+              originLabel: string;
+              message: string;
+            }) => {
+              const trimmed = message.trim();
+              const components: Array<TextDisplay | Separator> = [];
+              if (trimmed) {
+                components.push(new TextDisplay(message));
+                components.push(new Separator({ divider: true, spacing: "small" }));
+              }
+              components.push(new TextDisplay(`*From ${originLabel}*`));
+              return [new TestDiscordUiContainer(components)];
+            },
+          }
+        : { supportsComponentsV2: false },
   ),
   normalizeTargetForProvider: vi.fn((channel: string, raw: string) => {
     const trimmed = raw.trim();
@@ -189,5 +190,52 @@ describe("outbound policy helpers", () => {
     expect(shouldApplyCrossContextMarker("send")).toBe(true);
     expect(shouldApplyCrossContextMarker("thread-reply")).toBe(true);
     expect(shouldApplyCrossContextMarker("thread-create")).toBe(false);
+  });
+
+  it("falls back to text markers when useComponentsV2 is disabled via adapter", async () => {
+    // Override the mock so discord returns supportsComponentsV2: false
+    mocks.getChannelMessageAdapter.mockImplementation(() => ({
+      supportsComponentsV2: false,
+    }));
+
+    const cfg = {
+      channels: { discord: { useComponentsV2: false } },
+    } as OpenClawConfig;
+
+    const decoration = await buildCrossContextDecoration({
+      cfg,
+      channel: "discord",
+      target: "123",
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "discord" },
+    });
+
+    expect(decoration).not.toBeNull();
+    // No componentsBuilder since adapter says supportsComponentsV2: false
+    expect(decoration!.componentsBuilder).toBeUndefined();
+
+    const applied = applyCrossContextDecoration({
+      message: "hello",
+      decoration: decoration!,
+      preferComponents: true,
+    });
+    expect(applied.usedComponents).toBe(false);
+    expect(applied.message).toContain("[from ");
+    expect(applied.message).toContain("hello");
+  });
+
+  it("passes cfg and accountId to getChannelMessageAdapter", async () => {
+    const cfg = {
+      channels: { discord: {} },
+    } as OpenClawConfig;
+
+    await buildCrossContextDecoration({
+      cfg,
+      channel: "discord",
+      target: "123",
+      toolContext: { currentChannelId: "C12345678", currentChannelProvider: "discord" },
+      accountId: "mybot",
+    });
+
+    expect(mocks.getChannelMessageAdapter).toHaveBeenCalledWith("discord", cfg, "mybot");
   });
 });

--- a/src/infra/outbound/outbound-policy.ts
+++ b/src/infra/outbound/outbound-policy.ts
@@ -179,7 +179,7 @@ export async function buildCrossContextDecoration(params: {
   const prefix = prefixTemplate.replaceAll("{channel}", originLabel);
   const suffix = suffixTemplate.replaceAll("{channel}", originLabel);
 
-  const adapter = getChannelMessageAdapter(params.channel);
+  const adapter = getChannelMessageAdapter(params.channel, params.cfg, params.accountId);
   const componentsBuilder = adapter.supportsComponentsV2
     ? adapter.buildCrossContextComponents
       ? (message: string) =>


### PR DESCRIPTION
## Summary
- Add `useComponentsV2` boolean config field to `DiscordAccountConfig` (default: `true`, preserving existing behavior)
- When set to `false`, cross-context messages fall back to plain text prefix markers (`[from #channel]`) instead of Discord components v2 containers
- Supports both base-level (`channels.discord.useComponentsV2`) and per-account (`channels.discord.accounts.<id>.useComponentsV2`) configuration

Fixes the issue where components v2 containers render as quote-like blocks, which is undesirable for some users/models.

## Test plan
- [x] Unit tests for `channel-adapters.ts` (7 new cases: base disable, base enable, default, account override both ways, account fallback, no-op on non-component channels)
- [x] Unit tests for `outbound-policy.ts` (2 new cases: text marker fallback when disabled, cfg/accountId forwarding)
- [x] `pnpm check` passes (lint, format, type-check, boundary checks)
- [x] Deployed to pi02 with `useComponentsV2: false`, verified messages render as plain text on Discord