### PR TITLE
fix(doctor): repair stale bundled plugin paths

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -256,6 +256,76 @@ describe("doctor config flow", () => {
     });
   });
 
+  it("repairs stale bundled plugin install paths on doctor --fix", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      const bundledRoot = path.join(home, "pkg", "dist", "extensions");
+      const bundledPluginPath = path.join(bundledRoot, "acpx");
+      const stalePath = path.join(home, "pkg", "extensions", "acpx");
+
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.mkdir(bundledRoot, { recursive: true });
+      await fs.cp(path.join(process.cwd(), "extensions", "acpx"), bundledPluginPath, {
+        recursive: true,
+      });
+      const canonicalBundledPluginPath = await fs.realpath(bundledPluginPath);
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            plugins: {
+              load: { paths: [stalePath] },
+              installs: {
+                acpx: {
+                  source: "path",
+                  spec: "acpx",
+                  sourcePath: stalePath,
+                  installPath: stalePath,
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+
+      const previousBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+      const previousDisableCache = process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE;
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledRoot;
+      process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE = "1";
+
+      try {
+        const result = await loadAndMaybeMigrateDoctorConfig({
+          options: { nonInteractive: true, repair: true },
+          confirm: async () => false,
+        });
+
+        expect(result.sourceConfigValid).toBe(false);
+        expect(result.cfg.plugins?.load?.paths).toEqual([canonicalBundledPluginPath]);
+        expect(result.cfg.plugins?.installs?.acpx).toMatchObject({
+          source: "path",
+          spec: "acpx",
+          sourcePath: canonicalBundledPluginPath,
+          installPath: canonicalBundledPluginPath,
+        });
+      } finally {
+        if (previousBundledDir === undefined) {
+          delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+        } else {
+          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = previousBundledDir;
+        }
+        if (previousDisableCache === undefined) {
+          delete process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE;
+        } else {
+          process.env.OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE = previousDisableCache;
+        }
+      }
+    });
+  });
+
   it("migrates legacy browser extension profiles to existing-session on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -71,4 +71,69 @@ describe("doctor repair sequencing", () => {
     expect(result.warningNotes[0]).not.toContain("\u001B");
     expect(result.warningNotes[0]).not.toContain("\r");
   });
+
+  it("repairs stale bundled plugin path references before later config repairs", async () => {
+    const stalePath = "/pkg/extensions/acpx";
+    const nextPath = "/pkg/dist/extensions/acpx";
+
+    const result = await runDoctorRepairSequence({
+      state: {
+        cfg: {
+          plugins: {
+            load: { paths: [stalePath] },
+            installs: {
+              acpx: {
+                source: "path",
+                spec: "acpx",
+                sourcePath: stalePath,
+                installPath: stalePath,
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        candidate: {
+          plugins: {
+            load: { paths: [stalePath] },
+            installs: {
+              acpx: {
+                source: "path",
+                spec: "acpx",
+                sourcePath: stalePath,
+                installPath: stalePath,
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        pendingChanges: false,
+        fixHints: [],
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+      bundledPluginPathOptions: {
+        bundledSources: new Map([
+          [
+            "acpx",
+            {
+              pluginId: "acpx",
+              localPath: nextPath,
+            },
+          ],
+        ]),
+        pathExists: (candidatePath) => candidatePath === nextPath,
+      },
+    });
+
+    expect(result.state.pendingChanges).toBe(true);
+    expect(result.state.candidate.plugins?.load?.paths).toEqual([nextPath]);
+    expect(result.state.candidate.plugins?.installs?.acpx).toMatchObject({
+      source: "path",
+      spec: "acpx",
+      sourcePath: nextPath,
+      installPath: nextPath,
+    });
+    expect(result.changeNotes).toEqual([
+      expect.stringContaining("plugins.installs.acpx.sourcePath"),
+    ]);
+    expect(result.changeNotes[0]).toContain("plugins.installs.acpx.installPath");
+    expect(result.changeNotes[0]).toContain("plugins.load.paths[0]");
+  });
 });

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -6,6 +6,10 @@ import {
 } from "./providers/telegram.js";
 import { maybeRepairAllowlistPolicyAllowFrom } from "./shared/allowlist-policy-repair.js";
 import {
+  type BundledPluginInstallPathOptions,
+  maybeRepairBundledPluginInstallPaths,
+} from "./shared/bundled-plugin-install-paths.js";
+import {
   applyDoctorConfigMutation,
   type DoctorConfigMutationState,
 } from "./shared/config-mutation-state.js";
@@ -18,6 +22,7 @@ import { maybeRepairStalePluginConfig } from "./shared/stale-plugin-config.js";
 export async function runDoctorRepairSequence(params: {
   state: DoctorConfigMutationState;
   doctorFixCommand: string;
+  bundledPluginPathOptions?: BundledPluginInstallPathOptions;
 }): Promise<{
   state: DoctorConfigMutationState;
   changeNotes: string[];
@@ -46,6 +51,9 @@ export async function runDoctorRepairSequence(params: {
     }
   };
 
+  applyMutation(
+    maybeRepairBundledPluginInstallPaths(state.candidate, params.bundledPluginPathOptions),
+  );
   applyMutation(await maybeRepairTelegramAllowFromUsernames(state.candidate));
   applyMutation(maybeRepairDiscordNumericIds(state.candidate));
   applyMutation(maybeRepairOpenPolicyAllowFrom(state.candidate));

--- a/src/commands/doctor/shared/bundled-plugin-install-paths.test.ts
+++ b/src/commands/doctor/shared/bundled-plugin-install-paths.test.ts
@@ -131,6 +131,85 @@ describe("doctor bundled plugin install path repair", () => {
     expect(hits).toEqual([]);
   });
 
+  it("repairs only install fields that were flagged as stale", () => {
+    const stalePath = "/pkg/extensions/acpx";
+    const customInstallPath = "/custom/missing/acpx";
+    const nextPath = "/pkg/dist/extensions/acpx";
+
+    const hits = scanBundledPluginInstallPathRepairs(
+      {
+        plugins: {
+          installs: {
+            acpx: {
+              source: "path",
+              spec: "acpx",
+              sourcePath: stalePath,
+              installPath: customInstallPath,
+            },
+          },
+        },
+      },
+      {
+        bundledSources: new Map([
+          [
+            "acpx",
+            {
+              pluginId: "acpx",
+              localPath: nextPath,
+            },
+          ],
+        ]),
+        pathExists: (candidatePath) => candidatePath === nextPath,
+      },
+    );
+
+    expect(hits).toEqual([
+      {
+        pluginId: "acpx",
+        nextPath,
+        installFieldHits: [{ field: "sourcePath", previousPath: stalePath }],
+        loadPathHits: [],
+      },
+    ]);
+
+    const repaired = maybeRepairBundledPluginInstallPaths(
+      {
+        plugins: {
+          installs: {
+            acpx: {
+              source: "path",
+              spec: "acpx",
+              sourcePath: stalePath,
+              installPath: customInstallPath,
+            },
+          },
+        },
+      },
+      {
+        bundledSources: new Map([
+          [
+            "acpx",
+            {
+              pluginId: "acpx",
+              localPath: nextPath,
+            },
+          ],
+        ]),
+        pathExists: (candidatePath) => candidatePath === nextPath,
+      },
+    );
+
+    expect(repaired.config.plugins?.installs?.acpx).toMatchObject({
+      source: "path",
+      spec: "acpx",
+      sourcePath: nextPath,
+      installPath: customInstallPath,
+    });
+    expect(repaired.changes).toEqual([
+      `- plugins.installs.acpx.sourcePath: updated stale bundled path from ${stalePath} -> ${nextPath}`,
+    ]);
+  });
+
   it("repairs stale bundled paths when config and discovery use symlinked package roots", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-paths-"));
     const realPkgRoot = path.join(tempRoot, "real", "pkg");

--- a/src/commands/doctor/shared/bundled-plugin-install-paths.test.ts
+++ b/src/commands/doctor/shared/bundled-plugin-install-paths.test.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  collectBundledPluginInstallPathWarnings,
+  maybeRepairBundledPluginInstallPaths,
+  scanBundledPluginInstallPathRepairs,
+} from "./bundled-plugin-install-paths.js";
+
+describe("doctor bundled plugin install path repair", () => {
+  it("repairs stale bundled install records and load paths", () => {
+    const stalePath = "/pkg/extensions/acpx";
+    const nextPath = "/pkg/dist/extensions/acpx";
+    const bundledSources = new Map([
+      [
+        "acpx",
+        {
+          pluginId: "acpx",
+          localPath: nextPath,
+        },
+      ],
+    ]);
+
+    const hits = scanBundledPluginInstallPathRepairs(
+      {
+        plugins: {
+          load: { paths: [stalePath] },
+          installs: {
+            acpx: {
+              source: "path",
+              spec: "acpx",
+              sourcePath: stalePath,
+              installPath: stalePath,
+            },
+          },
+        },
+      },
+      {
+        bundledSources,
+        pathExists: (candidatePath) => candidatePath === nextPath,
+      },
+    );
+
+    expect(hits).toEqual([
+      {
+        pluginId: "acpx",
+        nextPath,
+        installFieldHits: [
+          { field: "sourcePath", previousPath: stalePath },
+          { field: "installPath", previousPath: stalePath },
+        ],
+        loadPathHits: [{ index: 0, previousPath: stalePath }],
+      },
+    ]);
+
+    const repaired = maybeRepairBundledPluginInstallPaths(
+      {
+        plugins: {
+          load: { paths: [stalePath] },
+          installs: {
+            acpx: {
+              source: "path",
+              spec: "acpx",
+              sourcePath: stalePath,
+              installPath: stalePath,
+            },
+          },
+        },
+      },
+      {
+        bundledSources,
+        pathExists: (candidatePath) => candidatePath === nextPath,
+      },
+    );
+
+    expect(repaired.config.plugins?.load?.paths).toEqual([nextPath]);
+    expect(repaired.config.plugins?.installs?.acpx).toMatchObject({
+      source: "path",
+      spec: "acpx",
+      sourcePath: nextPath,
+      installPath: nextPath,
+    });
+    expect(repaired.changes).toEqual([
+      `- plugins.installs.acpx.sourcePath: updated stale bundled path from ${stalePath} -> ${nextPath}`,
+      `- plugins.installs.acpx.installPath: updated stale bundled path from ${stalePath} -> ${nextPath}`,
+      `- plugins.load.paths[0]: updated stale bundled path from ${stalePath} -> ${nextPath}`,
+    ]);
+
+    const warnings = collectBundledPluginInstallPathWarnings({
+      hits,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+    expect(warnings).toEqual([
+      expect.stringContaining(`Bundled plugin "acpx" now resolves to ${nextPath}`),
+    ]);
+    expect(warnings[0]).toContain(`plugins.installs.acpx.sourcePath: ${stalePath}`);
+    expect(warnings[0]).toContain(`plugins.load.paths[0]: ${stalePath}`);
+    expect(warnings[0]).toContain('Run "openclaw doctor --fix"');
+  });
+
+  it("does not rewrite missing custom paths outside the current package root", () => {
+    const hits = scanBundledPluginInstallPathRepairs(
+      {
+        plugins: {
+          load: { paths: ["/workspace/custom-plugins/acpx"] },
+          installs: {
+            acpx: {
+              source: "path",
+              spec: "acpx",
+              sourcePath: "/workspace/custom-plugins/acpx",
+              installPath: "/workspace/custom-plugins/acpx",
+            },
+          },
+        },
+      },
+      {
+        bundledSources: new Map([
+          [
+            "acpx",
+            {
+              pluginId: "acpx",
+              localPath: "/pkg/dist/extensions/acpx",
+            },
+          ],
+        ]),
+        pathExists: () => false,
+      },
+    );
+
+    expect(hits).toEqual([]);
+  });
+
+  it("repairs stale bundled paths when config and discovery use symlinked package roots", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-paths-"));
+    const realPkgRoot = path.join(tempRoot, "real", "pkg");
+    const aliasRoot = path.join(tempRoot, "alias");
+    const bundledPath = path.join(realPkgRoot, "dist", "extensions", "acpx");
+    const stalePath = path.join(aliasRoot, "pkg", "extensions", "acpx");
+
+    fs.mkdirSync(path.dirname(bundledPath), { recursive: true });
+    fs.symlinkSync(path.join(tempRoot, "real"), aliasRoot, "dir");
+    fs.mkdirSync(path.dirname(stalePath), { recursive: true });
+
+    try {
+      const hits = scanBundledPluginInstallPathRepairs(
+        {
+          plugins: {
+            load: { paths: [stalePath] },
+            installs: {
+              acpx: {
+                source: "path",
+                spec: "acpx",
+                sourcePath: stalePath,
+                installPath: stalePath,
+              },
+            },
+          },
+        },
+        {
+          bundledSources: new Map([
+            [
+              "acpx",
+              {
+                pluginId: "acpx",
+                localPath: bundledPath,
+              },
+            ],
+          ]),
+          pathExists: (candidatePath) => candidatePath === bundledPath,
+        },
+      );
+
+      expect(hits).toEqual([
+        {
+          pluginId: "acpx",
+          nextPath: bundledPath,
+          installFieldHits: [
+            { field: "sourcePath", previousPath: stalePath },
+            { field: "installPath", previousPath: stalePath },
+          ],
+          loadPathHits: [{ index: 0, previousPath: stalePath }],
+        },
+      ]);
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/doctor/shared/bundled-plugin-install-paths.ts
+++ b/src/commands/doctor/shared/bundled-plugin-install-paths.ts
@@ -262,7 +262,8 @@ export function maybeRepairBundledPluginInstallPaths(
       continue;
     }
 
-    for (const field of ["sourcePath", "installPath"] as const) {
+    for (const fieldHit of hit.installFieldHits) {
+      const field = fieldHit.field;
       const previousPath = typeof install[field] === "string" ? install[field] : "(unset)";
       if (pathsEqual(previousPath, hit.nextPath, env)) {
         continue;

--- a/src/commands/doctor/shared/bundled-plugin-install-paths.ts
+++ b/src/commands/doctor/shared/bundled-plugin-install-paths.ts
@@ -1,0 +1,299 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  type BundledPluginSource,
+  resolveBundledPluginSources,
+} from "../../../plugins/bundled-sources.js";
+import { sanitizeForLog } from "../../../terminal/ansi.js";
+import { resolveUserPath } from "../../../utils.js";
+
+type InstallPathField = "sourcePath" | "installPath";
+
+type InstallFieldHit = {
+  field: InstallPathField;
+  previousPath: string;
+};
+
+type LoadPathHit = {
+  index: number;
+  previousPath: string;
+};
+
+export type BundledPluginInstallPathOptions = {
+  env?: NodeJS.ProcessEnv;
+  bundledSources?: ReadonlyMap<string, BundledPluginSource>;
+  pathExists?: (absolutePath: string) => boolean;
+};
+
+export type BundledPluginInstallPathRepairHit = {
+  pluginId: string;
+  nextPath: string;
+  installFieldHits: InstallFieldHit[];
+  loadPathHits: LoadPathHit[];
+};
+
+function resolveFsPath(value: string, env: NodeJS.ProcessEnv = process.env): string {
+  return path.resolve(resolveUserPath(value, env));
+}
+
+function resolveExistingRealPath(value: string): string | null {
+  try {
+    if (!fs.existsSync(value)) {
+      return null;
+    }
+    return fs.realpathSync.native?.(value) ?? fs.realpathSync(value);
+  } catch {
+    return null;
+  }
+}
+
+function pathsEqual(
+  left: string | undefined,
+  right: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!left || !right) {
+    return false;
+  }
+  const resolvedLeft = resolveFsPath(left, env);
+  const resolvedRight = resolveFsPath(right, env);
+  if (resolvedLeft === resolvedRight) {
+    return true;
+  }
+  const leftRealPath = resolveExistingRealPath(resolvedLeft);
+  const rightRealPath = resolveExistingRealPath(resolvedRight);
+  return Boolean(leftRealPath && rightRealPath && leftRealPath === rightRealPath);
+}
+
+function derivePackagePluginPathInfo(
+  pluginPath: string,
+  env: NodeJS.ProcessEnv = process.env,
+): { packageRoot: string; relativePath: string } | null {
+  const resolvedPluginPath = resolveFsPath(pluginPath, env);
+  const pluginLeaf = path.basename(resolvedPluginPath);
+  const extensionsDir = path.dirname(resolvedPluginPath);
+  if (path.basename(extensionsDir) !== "extensions") {
+    return null;
+  }
+  const layoutRoot = path.dirname(extensionsDir);
+  const layoutName = path.basename(layoutRoot);
+  if (layoutName === "dist" || layoutName === "dist-runtime") {
+    return {
+      packageRoot: path.dirname(layoutRoot),
+      relativePath: path.join(layoutName, "extensions", pluginLeaf),
+    };
+  }
+  return {
+    packageRoot: layoutRoot,
+    relativePath: path.join("extensions", pluginLeaf),
+  };
+}
+
+function isBundledRelativePluginPath(relativePath: string, bundledLeaf: string): boolean {
+  const normalized = path.normalize(relativePath);
+  return [
+    path.join("extensions", bundledLeaf),
+    path.join("dist", "extensions", bundledLeaf),
+    path.join("dist-runtime", "extensions", bundledLeaf),
+  ].includes(normalized);
+}
+
+function isStaleBundledPluginPath(params: {
+  candidatePath: string;
+  bundledPath: string;
+  env: NodeJS.ProcessEnv;
+  pathExists: (absolutePath: string) => boolean;
+}): boolean {
+  if (pathsEqual(params.candidatePath, params.bundledPath, params.env)) {
+    return false;
+  }
+
+  const resolvedCandidatePath = resolveFsPath(params.candidatePath, params.env);
+  if (params.pathExists(resolvedCandidatePath)) {
+    return false;
+  }
+
+  const bundledPathInfo = derivePackagePluginPathInfo(params.bundledPath, params.env);
+  const candidatePathInfo = derivePackagePluginPathInfo(params.candidatePath, params.env);
+  if (!bundledPathInfo || !candidatePathInfo) {
+    return false;
+  }
+  if (!pathsEqual(candidatePathInfo.packageRoot, bundledPathInfo.packageRoot, params.env)) {
+    return false;
+  }
+
+  const bundledLeaf = path.basename(resolveFsPath(params.bundledPath, params.env));
+  return isBundledRelativePluginPath(candidatePathInfo.relativePath, bundledLeaf);
+}
+
+function dedupePathEntries(paths: string[], env: NodeJS.ProcessEnv = process.env): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const entry of paths) {
+    const normalized = resolveFsPath(entry, env);
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    deduped.push(entry);
+  }
+  return deduped;
+}
+
+export function scanBundledPluginInstallPathRepairs(
+  cfg: OpenClawConfig,
+  options: BundledPluginInstallPathOptions = {},
+): BundledPluginInstallPathRepairHit[] {
+  const env = options.env ?? process.env;
+  const bundledSources =
+    options.bundledSources ?? resolveBundledPluginSources({ env: options.env ?? process.env });
+  const pathExists = options.pathExists ?? fs.existsSync;
+  const installs = cfg.plugins?.installs ?? {};
+  const loadPaths = cfg.plugins?.load?.paths ?? [];
+  const hits: BundledPluginInstallPathRepairHit[] = [];
+
+  for (const [pluginId, install] of Object.entries(installs)) {
+    if (!install || install.source !== "path") {
+      continue;
+    }
+
+    const bundledSource = bundledSources.get(pluginId);
+    if (!bundledSource) {
+      continue;
+    }
+
+    const installFieldHits: InstallFieldHit[] = [];
+    for (const field of ["sourcePath", "installPath"] as const) {
+      const currentPath = typeof install[field] === "string" ? install[field].trim() : "";
+      if (!currentPath) {
+        continue;
+      }
+      if (
+        isStaleBundledPluginPath({
+          candidatePath: currentPath,
+          bundledPath: bundledSource.localPath,
+          env,
+          pathExists,
+        })
+      ) {
+        installFieldHits.push({ field, previousPath: currentPath });
+      }
+    }
+
+    const loadPathHits: LoadPathHit[] = [];
+    for (const [index, loadPath] of loadPaths.entries()) {
+      if (typeof loadPath !== "string" || !loadPath.trim()) {
+        continue;
+      }
+      if (
+        isStaleBundledPluginPath({
+          candidatePath: loadPath,
+          bundledPath: bundledSource.localPath,
+          env,
+          pathExists,
+        })
+      ) {
+        loadPathHits.push({ index, previousPath: loadPath });
+      }
+    }
+
+    if (installFieldHits.length === 0 && loadPathHits.length === 0) {
+      continue;
+    }
+
+    hits.push({
+      pluginId,
+      nextPath: bundledSource.localPath,
+      installFieldHits,
+      loadPathHits,
+    });
+  }
+
+  return hits;
+}
+
+export function collectBundledPluginInstallPathWarnings(params: {
+  hits: BundledPluginInstallPathRepairHit[];
+  doctorFixCommand: string;
+}): string[] {
+  if (params.hits.length === 0) {
+    return [];
+  }
+
+  return params.hits.map((hit) =>
+    [
+      `- Bundled plugin "${hit.pluginId}" now resolves to ${hit.nextPath}, but config still points at stale path references.`,
+      ...hit.installFieldHits.map(
+        (fieldHit) =>
+          `- plugins.installs.${hit.pluginId}.${fieldHit.field}: ${fieldHit.previousPath}`,
+      ),
+      ...hit.loadPathHits.map(
+        (loadPathHit) => `- plugins.load.paths[${loadPathHit.index}]: ${loadPathHit.previousPath}`,
+      ),
+      `- Run "${params.doctorFixCommand}" to update stale bundled plugin path references.`,
+    ]
+      .map((line) => sanitizeForLog(line))
+      .join("\n"),
+  );
+}
+
+export function maybeRepairBundledPluginInstallPaths(
+  cfg: OpenClawConfig,
+  options: BundledPluginInstallPathOptions = {},
+): {
+  config: OpenClawConfig;
+  changes: string[];
+} {
+  const env = options.env ?? process.env;
+  const hits = scanBundledPluginInstallPathRepairs(cfg, options);
+  if (hits.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+
+  const next = structuredClone(cfg);
+  const changes: string[] = [];
+  const nextLoadPaths = [...(next.plugins?.load?.paths ?? [])];
+  let loadPathsChanged = false;
+
+  for (const hit of hits) {
+    const install = next.plugins?.installs?.[hit.pluginId];
+    if (!install || install.source !== "path") {
+      continue;
+    }
+
+    for (const field of ["sourcePath", "installPath"] as const) {
+      const previousPath = typeof install[field] === "string" ? install[field] : "(unset)";
+      if (pathsEqual(previousPath, hit.nextPath, env)) {
+        continue;
+      }
+      install[field] = hit.nextPath;
+      changes.push(
+        `- plugins.installs.${hit.pluginId}.${field}: updated stale bundled path from ${previousPath} -> ${hit.nextPath}`,
+      );
+    }
+
+    for (const loadPathHit of hit.loadPathHits) {
+      if (pathsEqual(nextLoadPaths[loadPathHit.index], hit.nextPath, env)) {
+        continue;
+      }
+      nextLoadPaths[loadPathHit.index] = hit.nextPath;
+      loadPathsChanged = true;
+      changes.push(
+        `- plugins.load.paths[${loadPathHit.index}]: updated stale bundled path from ${loadPathHit.previousPath} -> ${hit.nextPath}`,
+      );
+    }
+  }
+
+  if (loadPathsChanged) {
+    next.plugins = {
+      ...next.plugins,
+      load: {
+        ...next.plugins?.load,
+        paths: dedupePathEntries(nextLoadPaths, env),
+      },
+    };
+  }
+
+  return changes.length === 0 ? { config: cfg, changes: [] } : { config: next, changes };
+}

--- a/src/commands/doctor/shared/preview-warnings.test.ts
+++ b/src/commands/doctor/shared/preview-warnings.test.ts
@@ -120,4 +120,44 @@ describe("doctor preview warnings", () => {
     expect(warnings[0]).toContain("Auto-removal is paused");
     expect(warnings[0]).toContain('rerun "openclaw doctor --fix"');
   });
+
+  it("warns about stale bundled plugin path references", () => {
+    const stalePath = "/pkg/extensions/acpx";
+    const nextPath = "/pkg/dist/extensions/acpx";
+    const warnings = collectDoctorPreviewWarnings({
+      cfg: {
+        plugins: {
+          load: { paths: [stalePath] },
+          installs: {
+            acpx: {
+              source: "path",
+              spec: "acpx",
+              sourcePath: stalePath,
+              installPath: stalePath,
+            },
+          },
+        },
+      },
+      doctorFixCommand: "openclaw doctor --fix",
+      bundledPluginPathOptions: {
+        bundledSources: new Map([
+          [
+            "acpx",
+            {
+              pluginId: "acpx",
+              localPath: nextPath,
+            },
+          ],
+        ]),
+        pathExists: (candidatePath) => candidatePath === nextPath,
+      },
+    });
+
+    expect(warnings).toEqual([
+      expect.stringContaining(`Bundled plugin "acpx" now resolves to ${nextPath}`),
+    ]);
+    expect(warnings[0]).toContain(`plugins.installs.acpx.sourcePath: ${stalePath}`);
+    expect(warnings[0]).toContain(`plugins.load.paths[0]: ${stalePath}`);
+    expect(warnings[0]).toContain('Run "openclaw doctor --fix"');
+  });
 });

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -9,6 +9,11 @@ import {
   collectTelegramEmptyAllowlistExtraWarnings,
   scanTelegramAllowFromUsernameEntries,
 } from "../providers/telegram.js";
+import {
+  type BundledPluginInstallPathOptions,
+  collectBundledPluginInstallPathWarnings,
+  scanBundledPluginInstallPathRepairs,
+} from "./bundled-plugin-install-paths.js";
 import { scanEmptyAllowlistPolicyWarnings } from "./empty-allowlist-scan.js";
 import {
   collectExecSafeBinCoverageWarnings,
@@ -33,6 +38,7 @@ import {
 export function collectDoctorPreviewWarnings(params: {
   cfg: OpenClawConfig;
   doctorFixCommand: string;
+  bundledPluginPathOptions?: BundledPluginInstallPathOptions;
 }): string[] {
   const warnings: string[] = [];
 
@@ -108,6 +114,19 @@ export function collectDoctorPreviewWarnings(params: {
   const safeBinTrustedDirHints = scanExecSafeBinTrustedDirHints(params.cfg);
   if (safeBinTrustedDirHints.length > 0) {
     warnings.push(collectExecSafeBinTrustedDirHintWarnings(safeBinTrustedDirHints).join("\n"));
+  }
+
+  const staleBundledPluginPaths = scanBundledPluginInstallPathRepairs(
+    params.cfg,
+    params.bundledPluginPathOptions,
+  );
+  if (staleBundledPluginPaths.length > 0) {
+    warnings.push(
+      ...collectBundledPluginInstallPathWarnings({
+        hits: staleBundledPluginPaths,
+        doctorFixCommand: params.doctorFixCommand,
+      }),
+    );
   }
 
   return warnings;


### PR DESCRIPTION
## Summary
- repair stale bundled plugin install references during `openclaw doctor --fix`
- preview the stale bundled-path drift before repair
- cover the direct repair path, preview path, invalid-config doctor flow, and symlinked package-root case

## Root cause
Bundled plugin installs are persisted as path installs. After an npm/global layout shift from `extensions/<plugin>` to `dist/extensions/<plugin>`, doctor could detect an invalid config but still left the stale bundled path references untouched. The repair logic also needed to treat equivalent package roots such as `/var/...` and `/private/var/...` as the same package root on macOS temp paths.

## Validation
- `pnpm exec oxfmt --check src/commands/doctor/shared/bundled-plugin-install-paths.ts src/commands/doctor/shared/bundled-plugin-install-paths.test.ts src/commands/doctor/shared/preview-warnings.ts src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor/repair-sequencing.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor-config-flow.test.ts`
- `pnpm exec oxlint --type-aware src/commands/doctor/shared/bundled-plugin-install-paths.ts src/commands/doctor/shared/bundled-plugin-install-paths.test.ts src/commands/doctor/shared/preview-warnings.ts src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor/repair-sequencing.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor-config-flow.test.ts`
- `pnpm exec vitest --run src/commands/doctor/shared/bundled-plugin-install-paths.test.ts src/commands/doctor/shared/preview-warnings.test.ts src/commands/doctor/repair-sequencing.test.ts src/commands/doctor-config-flow.test.ts`
- repo `check` hook on commit (`pnpm check`) passed cleanly aside from the existing local `~/.openclaw/openclaw.json` schema warning emitted by `check:base-config-schema`

## Real proof
Using a temp `HOME`, a copied bundled `extensions/acpx` tree under `pkg/dist/extensions/acpx`, and a config that still pointed both `plugins.load.paths[0]` and `plugins.installs.acpx.{sourcePath,installPath}` at the stale `pkg/extensions/acpx`, running:

- `node scripts/run-node.mjs doctor --fix --non-interactive`

rewrote all three persisted paths to the canonical bundled path on disk and wrote the config backup successfully.

Closes #53273.
