### PR TITLE
fix(gateway): rate-limit map pruning + CSP img-src hardening

### DIFF
--- a/src/gateway/control-plane-rate-limit.ts
+++ b/src/gateway/control-plane-rate-limit.ts
@@ -10,6 +10,26 @@ type Bucket = {
 
 const controlPlaneBuckets = new Map<string, Bucket>();
 
+// ---------------------------------------------------------------------------
+// Periodic pruning – prevents unbounded Map growth from stale client keys.
+// ---------------------------------------------------------------------------
+
+const CONTROL_PLANE_PRUNE_INTERVAL_MS = 120_000; // every 2 minutes
+
+function pruneControlPlaneBuckets(nowMs?: number): void {
+  const now = nowMs ?? Date.now();
+  for (const [key, bucket] of controlPlaneBuckets) {
+    if (now - bucket.windowStartMs >= CONTROL_PLANE_RATE_LIMIT_WINDOW_MS) {
+      controlPlaneBuckets.delete(key);
+    }
+  }
+}
+
+const _pruneTimer = setInterval(() => pruneControlPlaneBuckets(), CONTROL_PLANE_PRUNE_INTERVAL_MS);
+if (_pruneTimer?.unref) {
+  _pruneTimer.unref();
+}
+
 function normalizePart(value: unknown, fallback: string): string {
   if (typeof value !== "string") {
     return fallback;
@@ -82,5 +102,9 @@ export function consumeControlPlaneWriteBudget(params: {
 export const __testing = {
   resetControlPlaneRateLimitState() {
     controlPlaneBuckets.clear();
+  },
+  pruneControlPlaneBuckets,
+  get bucketCount() {
+    return controlPlaneBuckets.size;
   },
 };

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -1,5 +1,7 @@
 export function buildControlUiCspHeader(): string {
   // Control UI: block framing, block inline scripts, keep styles permissive
+  // img-src restricted to 'self' + data: only (no blanket https:) to prevent
+  // data exfiltration via attacker-controlled image URLs (audit finding M-2).
   // (UI uses a lot of inline style attributes in templates).
   // Keep Google Fonts origins explicit in CSP for deployments that load
   // external Google Fonts stylesheets/font files.
@@ -10,7 +12,7 @@ export function buildControlUiCspHeader(): string {
     "frame-ancestors 'none'",
     "script-src 'self'",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src 'self' data: https:",
+    "img-src 'self' data:",
     "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");


### PR DESCRIPTION
## Summary

Two small security/reliability fixes discovered during a local audit:

### 1. Prune control-plane rate-limit map (M-1)
`controlPlaneBuckets` Map grows unbounded as clients connect and disconnect. Under sustained load or long uptimes this leads to memory exhaustion.

**Fix:** Add periodic pruning (every 2 min) that removes entries whose window has expired. Timer is `.unref()`'d so it doesn't keep the process alive.

### 2. Tighten CSP img-src (M-2)
The Control UI CSP header includes `img-src 'self' data: https:` — the blanket `https:` allows loading images from any HTTPS origin, which could be exploited to exfiltrate data via crafted image URLs.

**Fix:** Remove `https:` from img-src, restricting to `'self' data:` only.

### Testing
- Rate-limit pruning: exports `__testing.pruneControlPlaneBuckets` and `__testing.bucketCount` for unit test coverage.
- CSP change: verified Control UI still renders correctly (all images are self-hosted or data: URIs).