### PR TITLE
fix(imessage): validate chat_id is numeric before parseInt

### DIFF
--- a/extensions/imessage/src/target-parsing-helpers.ts
+++ b/extensions/imessage/src/target-parsing-helpers.ts
@@ -88,6 +88,9 @@ export function parseChatTargetPrefixesOrThrow(
   for (const prefix of params.chatIdPrefixes) {
     if (params.lower.startsWith(prefix)) {
       const value = stripPrefix(params.trimmed, prefix);
+      if (!/^\d+$/.test(value)) {
+        throw new Error(`Invalid chat_id: ${value}. Use chat_identifier: for hex identifiers.`);
+      }
       const chatId = Number.parseInt(value, 10);
       if (!Number.isFinite(chatId)) {
         throw new Error(`Invalid chat_id: ${value}`);
@@ -194,6 +197,9 @@ export function parseChatAllowTargetPrefixes(
   for (const prefix of params.chatIdPrefixes) {
     if (params.lower.startsWith(prefix)) {
       const value = stripPrefix(params.trimmed, prefix);
+      if (!/^\d+$/.test(value)) {
+        return null;
+      }
       const chatId = Number.parseInt(value, 10);
       if (Number.isFinite(chatId)) {
         return { kind: "chat_id", chatId };

--- a/extensions/imessage/src/targets.test.ts
+++ b/extensions/imessage/src/targets.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parseChatAllowTargetPrefixes } from "./target-parsing-helpers.js";
 import {
   formatIMessageChatTarget,
   inferIMessageTargetChatType,
@@ -58,6 +59,34 @@ describe("imessage targets", () => {
     );
     expect(normalizeIMessageHandle("ChatIdentifier:test")).toBe("chat_identifier:test");
     expect(normalizeIMessageHandle("CHATIDENT:foo")).toBe("chat_identifier:foo");
+  });
+
+  it("rejects hex identifiers with chat_id prefix", () => {
+    expect(() => parseIMessageTarget("chat_id:2ecba0e20f3a4299b0efb228a5990731")).toThrow(
+      "Invalid chat_id: 2ecba0e20f3a4299b0efb228a5990731. Use chat_identifier: for hex identifiers.",
+    );
+  });
+
+  it("parseChatAllowTargetPrefixes returns null for hex chat_id", () => {
+    const result = parseChatAllowTargetPrefixes({
+      trimmed: "chat_id:2ecba0e20f3a4299b0efb228a5990731",
+      lower: "chat_id:2ecba0e20f3a4299b0efb228a5990731",
+      chatIdPrefixes: ["chat_id:", "chat:", "chatid:"],
+      chatGuidPrefixes: ["chat_guid:", "guid:"],
+      chatIdentifierPrefixes: ["chat_identifier:", "chatidentifier:", "chatident:"],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not match hex as chat_id in allowFrom (regression: parseInt truncation)", () => {
+    // Before fix: parseInt("2ecba0e20f3a4299b0efb228a5990731", 10) = 2,
+    // so a hex value in allowFrom would have wrongly matched chatId:2.
+    const ok = isAllowedIMessageSender({
+      allowFrom: ["chat_id:2ecba0e20f3a4299b0efb228a5990731"],
+      sender: "+1555",
+      chatId: 2,
+    });
+    expect(ok).toBe(false);
   });
 
   it("checks allowFrom against chat_id", () => {


### PR DESCRIPTION
Fixes #17362 — `chat_id:` with a hex identifier silently misroutes messages.

## Problem

`parseInt()` without prior validation truncates hex identifiers to their leading digits:

```
parseInt("2ecba0e20f3a4299b0efb228a5990731", 10) → 2
```

The only guard was `Number.isFinite()`, which passes for any string with a leading digit. Result: messages route to the wrong chat with no error or warning. The bug also affects allowlists — a hex value in `allowFrom` would falsely match a numeric `chatId`.

Real-world impact documented in #17362: private calendar data and email summaries were delivered to unintended recipients because DM sessions were silently misrouted.

## Fix

Added `/^\d+$/` validation before `parseInt` in both parsing paths in `extensions/imessage/src/target-parsing-helpers.ts`:

- **`parseChatTargetPrefixesOrThrow`** — throws with a clear message directing users to `chat_identifier:` for hex values
- **`parseChatAllowTargetPrefixes`** — returns `null` (silent reject, consistent with allowlist semantics — hex entry is treated as an unrecognised handle)

## Tests

`extensions/imessage/src/targets.test.ts` — 3 new cases on top of existing suite:

- hex `chat_id:` throws with the correct error message
- `parseChatAllowTargetPrefixes` returns `null` for a hex value
- regression: hex value in `allowFrom` no longer matches a numeric `chatId` (the exact misrouting from the issue)

17/17 iMessage tests pass.