### PR TITLE
fix(macos): strip "OpenClaw " prefix before parsing gateway version

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -317,8 +317,13 @@ enum GatewayEnvironment {
                     bin=\(binary, privacy: .public)
                     """)
             }
-            let raw = String(data: data, encoding: .utf8)?
+            var raw = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
+            // `openclaw --version` outputs "OpenClaw 2026.x.y"; strip the product prefix
+            // so Semver.parse receives only the version token.
+            if let r = raw, r.lowercased().hasPrefix("openclaw ") {
+                raw = String(r.dropFirst("openclaw ".count))
+            }
             return Semver.parse(raw)
         } catch {
             let elapsedMs = Int(Date().timeIntervalSince(start) * 1000)

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -19,6 +19,9 @@ struct GatewayEnvironmentTests {
         #expect(Semver.parse("invalid") == nil)
         #expect(Semver.parse("1.2") == nil)
         #expect(Semver.parse("1.2.x") == nil)
+        // Product-prefixed output from `openclaw --version` should NOT parse as semver
+        // (the prefix must be stripped by the caller, not the parser).
+        #expect(Semver.parse("OpenClaw 2026.3.23-1") == nil)
     }
 
     @Test func `semver compatibility requires same major and not older`() {


### PR DESCRIPTION
## Problem

`readGatewayVersion()` passes the raw output of `openclaw --version` directly to `Semver.parse()`. Since the CLI outputs `"OpenClaw 2026.x.y-z"` (with a product name prefix), `Semver.parse()` fails to extract the version and returns `nil`.

When the CLI version is `nil`, the app falls back to `readLocalGatewayVersion()`, which reads `package.json` from a local source checkout discovered via the hardcoded `~/Projects/openclaw` fallback path. If that checkout is outdated, the app incorrectly reports a version mismatch — even though the installed CLI is up to date.

## Root Cause

Two issues combine:

1. **Missing prefix strip**: `readGatewayVersion()` does not strip the `"OpenClaw "` prefix before parsing, so `Semver.parse("OpenClaw 2026.3.23-1")` returns `nil`.
2. **Silent fallback**: When the global CLI version is unreadable, the code silently falls back to a local `package.json` instead of reporting the parse failure.

## Fix

Strip the `"OpenClaw "` (case-insensitive) prefix in `readGatewayVersion()` before calling `Semver.parse()`.

Added a test case confirming that `Semver.parse()` itself correctly rejects prefixed strings (the stripping responsibility belongs to the caller).

## Repro

1. Install `openclaw` globally (e.g. `2026.3.23-1`)
2. Have a local clone at `~/projects/openclaw` with an older `package.json` version
3. Open OpenClaw.app → "Gateway version 2026.3.13 is incompatible with app 2026.3.23"