### PR TITLE
fix(workspace): store workspace-state.json in workspace root, not .openclaw/ subdir

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -204,6 +204,10 @@ async function fileExists(filePath: string): Promise<boolean> {
 }
 
 function resolveWorkspaceStatePath(dir: string): string {
+  return path.join(dir, WORKSPACE_STATE_FILENAME);
+}
+
+function resolveLegacyWorkspaceStatePath(dir: string): string {
   return path.join(dir, WORKSPACE_STATE_DIRNAME, WORKSPACE_STATE_FILENAME);
 }
 
@@ -256,8 +260,13 @@ async function readWorkspaceSetupState(statePath: string): Promise<WorkspaceSetu
 }
 
 async function readWorkspaceSetupStateForDir(dir: string): Promise<WorkspaceSetupState> {
-  const statePath = resolveWorkspaceStatePath(resolveUserPath(dir));
-  return await readWorkspaceSetupState(statePath);
+  const resolved = resolveUserPath(dir);
+  const statePath = resolveWorkspaceStatePath(resolved);
+  const state = await readWorkspaceSetupState(statePath);
+  if (state.setupCompletedAt || state.bootstrapSeededAt) {
+    return state;
+  }
+  return await readWorkspaceSetupState(resolveLegacyWorkspaceStatePath(resolved));
 }
 
 export async function isWorkspaceSetupCompleted(dir: string): Promise<boolean> {
@@ -269,7 +278,6 @@ async function writeWorkspaceSetupState(
   statePath: string,
   state: WorkspaceSetupState,
 ): Promise<void> {
-  await fs.mkdir(path.dirname(statePath), { recursive: true });
   const payload = `${JSON.stringify(state, null, 2)}\n`;
   const tmpPath = `${statePath}.tmp-${process.pid}-${Date.now().toString(36)}`;
   try {
@@ -389,6 +397,9 @@ export async function ensureAgentWorkspace(params?: {
   await writeFileIfMissing(heartbeatPath, heartbeatTemplate);
 
   let state = await readWorkspaceSetupState(statePath);
+  if (!state.setupCompletedAt && !state.bootstrapSeededAt) {
+    state = await readWorkspaceSetupState(resolveLegacyWorkspaceStatePath(dir));
+  }
   let stateDirty = false;
   const markState = (next: Partial<WorkspaceSetupState>) => {
     state = { ...state, ...next };


### PR DESCRIPTION
## Summary
- Moves `workspace-state.json` from `<workspace>/.openclaw/workspace-state.json` to `<workspace>/workspace-state.json`
- Removes the requirement to create a dot-prefixed subdirectory inside the workspace
- Read falls back to the legacy `.openclaw/` path for existing workspaces
- Write always uses the new root path, no `mkdir` for `.openclaw/` subdir

## Why
Dot-prefixed directories fail on filesystems that reserve them — specifically [TigerFS](https://tigerfs.io/) FUSE mounts, where `.` prefixes are reserved for built-in operations (`.build/`, `.history/`, `.filter/`, etc.). This blocks using TigerFS-mounted PostgreSQL as a workspace backend.

Also addresses the nested `.openclaw/.openclaw/workspace/.openclaw/` path issue reported in #44783.

## Changes
1 file, 11 insertions, 3 deletions:
- `resolveWorkspaceStatePath()` → returns `dir/workspace-state.json` (was `dir/.openclaw/workspace-state.json`)
- New `resolveLegacyWorkspaceStatePath()` for backward-compatible reads
- `readWorkspaceSetupStateForDir()` tries new path first, falls back to legacy
- `writeWorkspaceSetupState()` removes `mkdir` for `.openclaw/` subdir (workspace root already exists)

## Testing
Existing workspace tests should pass. Legacy workspaces with `.openclaw/workspace-state.json` are read correctly via fallback.

Closes #44783
Related: #39446 (cloud storage sync issues with `.openclaw` directory)