### PR TITLE
feat: add bundled OpenStream plugin for Ollama-heavy deployments

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -16,6 +16,7 @@ Related:
 - Bundle compatibility: [Plugin bundles](/plugins/bundles)
 - Plugin manifest + schema: [Plugin manifest](/plugins/manifest)
 - Security hardening: [Security](/gateway/security)
+- Example bundled plugin: [OpenStream](/plugins/openstream)
 
 ## Commands
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1062,6 +1062,7 @@
                 "group": "Plugins",
                 "pages": [
                   "tools/plugin",
+                  "plugins/openstream",
                   "plugins/community",
                   "plugins/bundles",
                   {

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -143,3 +143,4 @@ Low-effort wrappers, unclear ownership, or unmaintained packages may be declined
 - [Install and Configure Plugins](/tools/plugin) — how to install any plugin
 - [Building Plugins](/plugins/building-plugins) — create your own
 - [Plugin Manifest](/plugins/manifest) — manifest schema
+- [OpenStream](/plugins/openstream) — example bundled Ollama companion plugin

--- a/docs/plugins/openstream.md
+++ b/docs/plugins/openstream.md
@@ -1,0 +1,101 @@
+---
+summary: "OpenStream plugin: Ollama diagnostics, prompt guidance, and long-context / reasoning heuristics"
+read_when:
+  - You run OpenClaw on Ollama or other open-source local models
+  - You want stronger diagnostics before changing provider/runtime behavior
+  - You want an installable plugin surface for OpenStream-style guidance
+title: "OpenStream Plugin"
+---
+
+# OpenStream (plugin)
+
+OpenStream is a bundled OpenClaw companion plugin for Ollama-heavy deployments.
+
+It gives OpenClaw a stable, installable surface for:
+
+- Ollama diagnostics
+- long-context and reasoning-model heuristics
+- cached prompt guidance for open-source tool-calling behavior
+- generated config snippets for plugin mode and deeper runtime bridge mode
+
+## What it is not
+
+OpenStream does **not** claim to replace the deepest raw stream/parser path yet.
+
+Think of it as:
+
+- a plugin-native guidance and diagnosis layer now
+- a staging point for narrower runtime improvements later
+
+## Enable
+
+Bundled plugins ship with OpenClaw but start disabled:
+
+```bash
+openclaw plugins enable openstream
+openclaw plugins info openstream
+```
+
+## Use
+
+After enabling the plugin:
+
+```text
+/openstream doctor
+/openstream doctor qwen3:latest
+/openstream model deepseek-v3:671b
+/openstream sample-config
+```
+
+Agents can also call the `openstream_doctor` tool.
+
+## Config
+
+Set config under `plugins.entries.openstream.config`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      openstream: {
+        enabled: true,
+        config: {
+          promptGuidance: true,
+          streamingMode: "enhanced",
+          enableMegaContext: true,
+          maxContextWindow: 262144,
+          doctorDefaultProvider: "ollama",
+        },
+      },
+    },
+  },
+}
+```
+
+## Why use it
+
+Use OpenStream when you want a safer first step than patching provider internals directly.
+
+It is especially useful when:
+
+- a local open-source model emits markdown pseudo-tool calls
+- you are evaluating long-context model families and want better heuristics
+- you need a repeatable operator-facing doctor command before touching runtime code
+
+## Relationship to the built-in Ollama provider
+
+The built-in [Ollama provider](/providers/ollama) remains the actual provider/runtime path.
+
+OpenStream complements it by adding:
+
+- diagnostics
+- cached system guidance
+- model heuristics and config generation
+
+If you need deeper provider-stream behavior changes, keep those changes narrow and evidence-backed.
+
+## Related
+
+- [Ollama](/providers/ollama)
+- [Plugin SDK Overview](/plugins/sdk-overview)
+- [Building Plugins](/plugins/building-plugins)

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -105,6 +105,7 @@ and the [Plugin SDK Overview](/plugins/sdk-overview).
 
   <Accordion title="Other">
     - `copilot-proxy` — VS Code Copilot Proxy bridge (disabled by default)
+    - `openstream` — bundled Ollama companion plugin for diagnostics, prompt guidance, and long-context heuristics (disabled by default). Docs: [OpenStream](/plugins/openstream)
   </Accordion>
 </AccordionGroup>
 

--- a/extensions/openstream/README.md
+++ b/extensions/openstream/README.md
@@ -1,0 +1,61 @@
+# @openclaw/openstream
+
+Bundled Ollama companion plugin for **OpenClaw**.
+
+OpenStream gives OpenClaw operators and agents a stable install surface for:
+
+- Ollama-oriented diagnostics
+- long-context and reasoning-model heuristics
+- cached system-prompt guidance for open-source tool-calling behavior
+- generated sample config for plugin mode and runtime-bridge mode
+
+It does **not** claim to replace the deepest raw stream/parser path yet. Instead,
+it complements the built-in Ollama provider and narrows what still needs core
+changes or stronger provider hooks later.
+
+## What Agents Get
+
+When enabled, the plugin provides:
+
+- `/openstream` command
+- `openstream_doctor` tool
+- plugin-shipped `openstream` skill
+- stable `before_prompt_build` system guidance for Ollama/open-source models
+
+## Commands
+
+```text
+/openstream doctor [model]
+/openstream model <modelId>
+/openstream sample-config
+/openstream help
+```
+
+## Plugin Config
+
+Set config under `plugins.entries.openstream.config`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      openstream: {
+        enabled: true,
+        config: {
+          promptGuidance: true,
+          streamingMode: "enhanced",
+          enableMegaContext: true,
+          maxContextWindow: 262144,
+          doctorDefaultProvider: "ollama",
+        },
+      },
+    },
+  },
+}
+```
+
+## Notes
+
+- OpenStream is a **companion plugin**, not a replacement provider.
+- Use it when you want stronger diagnosis and installable guidance around Ollama.
+- Keep deeper provider-stream experimentation on a narrower core or provider-hook path.

--- a/extensions/openstream/index.test.ts
+++ b/extensions/openstream/index.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/extensions/plugin-api.js";
+import type { OpenClawPluginApi, OpenClawPluginCommandDefinition } from "./runtime-api.js";
+import plugin from "./index.js";
+
+function createApi(params?: {
+  pluginConfig?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}) {
+  let command: OpenClawPluginCommandDefinition | undefined;
+  let tool: Parameters<OpenClawPluginApi["registerTool"]>[0] | undefined;
+  const on = vi.fn();
+  const registerCli = vi.fn();
+
+  const api = createTestPluginApi({
+    id: "openstream",
+    name: "OpenStream",
+    description: "OpenStream",
+    source: "test",
+    config: params?.config ?? {},
+    pluginConfig: params?.pluginConfig ?? {},
+    runtime: {
+      config: {
+        loadConfig: () => params?.config ?? {},
+      },
+    } as OpenClawPluginApi["runtime"],
+    registerCommand(nextCommand) {
+      command = nextCommand;
+    },
+    registerTool(nextTool) {
+      tool = nextTool;
+    },
+    registerCli,
+    on,
+  }) as OpenClawPluginApi;
+
+  plugin.register(api);
+  return { command, tool, on, registerCli };
+}
+
+describe("openstream plugin", () => {
+  it("registers command, tool, cli, and prompt guidance hook", async () => {
+    const { command, tool, on, registerCli } = createApi();
+
+    expect(command?.name).toBe("openstream");
+    expect(tool).toBeDefined();
+    expect(registerCli).toHaveBeenCalledTimes(1);
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(on.mock.calls[0]?.[0]).toBe("before_prompt_build");
+
+    const result = await on.mock.calls[0]?.[1]?.({}, {});
+    expect(result).toMatchObject({
+      prependSystemContext: expect.stringContaining("Prefer native tool calls"),
+    });
+  });
+
+  it("renders doctor output for configured ollama models", async () => {
+    const { command } = createApi({
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://127.0.0.1:11434/v1",
+              models: ["qwen3:latest", "deepseek-v3:671b"],
+            },
+          },
+        },
+      },
+    });
+
+    if (!command) {
+      throw new Error("openstream command was not registered");
+    }
+
+    const result = await command.handler({
+      channel: "test",
+      isAuthorizedSender: true,
+      commandBody: "/openstream doctor",
+      args: "doctor",
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://127.0.0.1:11434/v1",
+              models: ["qwen3:latest", "deepseek-v3:671b"],
+            },
+          },
+        },
+      },
+      requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
+      detachConversationBinding: async () => ({ removed: false }),
+      getCurrentConversationBinding: async () => null,
+    });
+
+    const text = String(result?.text ?? "");
+    expect(text).toContain("OpenStream doctor");
+    expect(text).toContain("qwen3:latest");
+    expect(text).toContain("deepseek-v3:671b");
+    expect(text).toContain("prompt guidance: enabled");
+  });
+
+  it("returns model hint usage guidance when no model id is provided", async () => {
+    const { command } = createApi();
+
+    if (!command) {
+      throw new Error("openstream command was not registered");
+    }
+
+    const result = await command.handler({
+      channel: "test",
+      isAuthorizedSender: true,
+      commandBody: "/openstream model",
+      args: "model",
+      config: {},
+      requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
+      detachConversationBinding: async () => ({ removed: false }),
+      getCurrentConversationBinding: async () => null,
+    });
+
+    expect(String(result?.text ?? "")).toContain("Usage: /openstream model <modelId>");
+  });
+});

--- a/extensions/openstream/index.test.ts
+++ b/extensions/openstream/index.test.ts
@@ -119,4 +119,51 @@ describe("openstream plugin", () => {
 
     expect(String(result?.text ?? "")).toContain("Usage: /openstream model <modelId>");
   });
+
+  it("recommends enabling prompt guidance only when it is disabled", async () => {
+    const { command } = createApi({
+      pluginConfig: {
+        promptGuidance: false,
+      },
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://127.0.0.1:11434",
+              models: ["deepseek-v3:671b"],
+            },
+          },
+        },
+      },
+    });
+
+    if (!command) {
+      throw new Error("openstream command was not registered");
+    }
+
+    const result = await command.handler({
+      channel: "test",
+      isAuthorizedSender: true,
+      commandBody: "/openstream doctor",
+      args: "doctor",
+      config: {
+        models: {
+          providers: {
+            ollama: {
+              baseUrl: "http://127.0.0.1:11434",
+              models: ["deepseek-v3:671b"],
+            },
+          },
+        },
+      },
+      requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
+      detachConversationBinding: async () => ({ removed: false }),
+      getCurrentConversationBinding: async () => null,
+    });
+
+    const text = String(result?.text ?? "");
+    expect(text).toContain("Enable plugin prompt guidance");
+    expect(text).toContain("context=131072");
+    expect(text).not.toContain("context=2097152");
+  });
 });

--- a/extensions/openstream/index.ts
+++ b/extensions/openstream/index.ts
@@ -1,0 +1,203 @@
+import { definePluginEntry, type OpenClawPluginApi } from "./runtime-api.js";
+import {
+  openstreamPluginConfigSchema,
+  resolveOpenStreamPluginConfig,
+} from "./src/config.js";
+import {
+  buildOpenStreamDoctorReport,
+  buildSuggestedPluginConfig,
+  buildSuggestedRuntimeConfig,
+  formatDoctorReport,
+} from "./src/doctor.js";
+import { OPENSTREAM_AGENT_GUIDANCE } from "./src/guidance.js";
+import { buildModelHint } from "./src/heuristics.js";
+
+type DoctorAction = "doctor" | "sample_config" | "model_hint";
+
+function renderJson(payload: unknown): string {
+  return JSON.stringify(payload, null, 2);
+}
+
+function formatHelp(): string {
+  return [
+    "OpenStream commands:",
+    "",
+    "/openstream doctor [model]",
+    "/openstream model <modelId>",
+    "/openstream sample-config",
+    "/openstream help",
+    "",
+    "Use this plugin when you want Ollama-focused diagnostics, heuristic recommendations, or plugin/core bridge setup guidance.",
+  ].join("\n");
+}
+
+function parseCommandArgs(rawArgs: string | undefined): { action: DoctorAction | "help"; rest: string } {
+  const args = (rawArgs ?? "").trim();
+  if (!args) {
+    return { action: "doctor", rest: "" };
+  }
+  const [first, ...rest] = args.split(/\s+/);
+  const action = first.toLowerCase();
+  if (action === "doctor" || action === "sample-config") {
+    return {
+      action: action === "sample-config" ? "sample_config" : "doctor",
+      rest: rest.join(" ").trim(),
+    };
+  }
+  if (action === "model" || action === "hint" || action === "heuristics") {
+    return { action: "model_hint", rest: rest.join(" ").trim() };
+  }
+  if (action === "help" || action === "status") {
+    return { action: action === "status" ? "doctor" : "help", rest: rest.join(" ").trim() };
+  }
+  return { action: "doctor", rest: args };
+}
+
+function makeToolResponse(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: renderJson(payload) }],
+    details: payload,
+  };
+}
+
+function resolveHostConfig(api: OpenClawPluginApi) {
+  return api.runtime.config.loadConfig();
+}
+
+export default definePluginEntry({
+  id: "openstream",
+  name: "OpenStream",
+  description:
+    "Ollama companion plugin with diagnostics, prompt guidance, and heuristic recommendations.",
+  configSchema: openstreamPluginConfigSchema,
+  register(api: OpenClawPluginApi) {
+    const pluginConfig = resolveOpenStreamPluginConfig(api.pluginConfig);
+
+    api.registerCommand({
+      name: "openstream",
+      description: "Inspect OpenStream plugin state and generate Ollama-oriented setup guidance.",
+      acceptsArgs: true,
+      handler: async (ctx) => {
+        const parsed = parseCommandArgs(ctx.args);
+        const hostConfig = ctx.config ?? resolveHostConfig(api);
+        if (parsed.action === "help") {
+          return { text: formatHelp() };
+        }
+        if (parsed.action === "sample_config") {
+          return {
+            text:
+              "Plugin config:\n```json\n" +
+              `${renderJson(buildSuggestedPluginConfig(pluginConfig))}\n` +
+              "```\n\nRuntime bridge config:\n```json\n" +
+              `${renderJson(buildSuggestedRuntimeConfig(pluginConfig))}\n` +
+              "```",
+          };
+        }
+        if (parsed.action === "model_hint") {
+          if (!parsed.rest) {
+            return { text: "Usage: /openstream model <modelId>" };
+          }
+          return {
+            text: `\`\`\`json\n${renderJson(buildModelHint(parsed.rest, pluginConfig))}\n\`\`\``,
+          };
+        }
+        const report = buildOpenStreamDoctorReport({
+          hostConfig,
+          pluginConfig,
+          ...(parsed.rest ? { targetModelId: parsed.rest } : {}),
+        });
+        return { text: formatDoctorReport(report) };
+      },
+    });
+
+    api.registerCli(
+      ({ program }) => {
+        const cmd = program.command("openstream").description("OpenStream plugin diagnostics");
+        cmd
+          .command("doctor")
+          .argument("[model]", "Optional model id to evaluate")
+          .action((model?: string) => {
+            const report = buildOpenStreamDoctorReport({
+              hostConfig: resolveHostConfig(api),
+              pluginConfig,
+              ...(model ? { targetModelId: model } : {}),
+            });
+            console.log(formatDoctorReport(report));
+          });
+        cmd
+          .command("model")
+          .argument("<model>", "Model id to evaluate")
+          .action((model: string) => {
+            console.log(renderJson(buildModelHint(model, pluginConfig)));
+          });
+        cmd.command("sample-config").action(() => {
+          console.log(renderJson(buildSuggestedPluginConfig(pluginConfig)));
+          console.log("");
+          console.log(renderJson(buildSuggestedRuntimeConfig(pluginConfig)));
+        });
+      },
+      { commands: ["openstream"] },
+    );
+
+    api.registerTool({
+      name: "openstream_doctor",
+      label: "OpenStream Doctor",
+      description:
+        "Inspect Ollama/OpenStream setup, generate plugin or runtime-bridge config, and explain model heuristics.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          action: {
+            type: "string",
+            enum: ["doctor", "sample_config", "model_hint"],
+          },
+          model: {
+            type: "string",
+            description: "Optional model id for targeted heuristics.",
+          },
+        },
+      },
+      async execute(_toolCallId, params) {
+        const action =
+          params &&
+          typeof params === "object" &&
+          typeof (params as Record<string, unknown>).action === "string"
+            ? ((params as Record<string, unknown>).action as DoctorAction)
+            : "doctor";
+        const model =
+          params &&
+          typeof params === "object" &&
+          typeof (params as Record<string, unknown>).model === "string"
+            ? ((params as Record<string, unknown>).model as string)
+            : undefined;
+
+        if (action === "sample_config") {
+          return makeToolResponse({
+            pluginConfig: buildSuggestedPluginConfig(pluginConfig),
+            runtimeBridgeConfig: buildSuggestedRuntimeConfig(pluginConfig),
+          });
+        }
+        if (action === "model_hint") {
+          if (!model) {
+            throw new Error("model is required when action=model_hint");
+          }
+          return makeToolResponse(buildModelHint(model, pluginConfig));
+        }
+        return makeToolResponse(
+          buildOpenStreamDoctorReport({
+            hostConfig: resolveHostConfig(api),
+            pluginConfig,
+            ...(model ? { targetModelId: model } : {}),
+          }),
+        );
+      },
+    });
+
+    if (pluginConfig.promptGuidance) {
+      api.on("before_prompt_build", async () => ({
+        prependSystemContext: OPENSTREAM_AGENT_GUIDANCE,
+      }));
+    }
+  },
+});

--- a/extensions/openstream/openclaw.plugin.json
+++ b/extensions/openstream/openclaw.plugin.json
@@ -1,0 +1,36 @@
+{
+  "id": "openstream",
+  "name": "OpenStream",
+  "description": "Ollama companion plugin with diagnostics, prompt guidance, and heuristic recommendations for OpenClaw.",
+  "skills": ["./skills"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "promptGuidance": {
+        "type": "boolean",
+        "description": "When true, inject stable Ollama/open-source model guidance into system prompt space."
+      },
+      "streamingMode": {
+        "type": "string",
+        "enum": ["standard", "enhanced", "ultra"],
+        "description": "Preferred OpenStream streaming preset used by diagnostics and sample config output."
+      },
+      "enableMegaContext": {
+        "type": "boolean",
+        "description": "Whether diagnostics should recommend 2M-context behavior when model families support it."
+      },
+      "maxContextWindow": {
+        "type": "integer",
+        "minimum": 32768,
+        "maximum": 2097152,
+        "description": "Maximum context window OpenStream should recommend in generated config snippets."
+      },
+      "doctorDefaultProvider": {
+        "type": "string",
+        "enum": ["ollama", "openstream"],
+        "description": "Preferred provider label shown by doctor/sample-config output."
+      }
+    }
+  }
+}

--- a/extensions/openstream/package.json
+++ b/extensions/openstream/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/openstream",
+  "version": "2026.3.24",
+  "private": true,
+  "description": "OpenClaw Ollama companion plugin with diagnostics, prompt guidance, and heuristic recommendations.",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/openstream/runtime-api.ts
+++ b/extensions/openstream/runtime-api.ts
@@ -1,0 +1,2 @@
+export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";

--- a/extensions/openstream/runtime-api.ts
+++ b/extensions/openstream/runtime-api.ts
@@ -1,2 +1,2 @@
 export { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-export type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+export type { OpenClawPluginApi, OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";

--- a/extensions/openstream/skills/openstream/SKILL.md
+++ b/extensions/openstream/skills/openstream/SKILL.md
@@ -1,0 +1,31 @@
+# OpenStream
+
+Use this skill when OpenClaw is running on Ollama or another open-source model path and you need stronger diagnostics, safer tool-call behavior guidance, or context-window recommendations.
+
+## What This Plugin Helps With
+
+- diagnose whether the current OpenClaw config is ready for OpenStream-style Ollama tuning
+- recommend a plugin config and runtime bridge config
+- explain which models look like reasoning or long-context families
+- keep stable system guidance cached through the OpenClaw plugin hook surface
+
+## Preferred Entry Points
+
+- `/openstream doctor`
+- `/openstream model <modelId>`
+- `/openstream sample-config`
+- `openstream_doctor` tool
+
+## Guidance
+
+When Ollama tool-calling or long-context behavior looks brittle:
+
+1. Run `/openstream doctor` first.
+2. If a specific model is involved, run `/openstream model <modelId>`.
+3. Use the generated plugin config immediately.
+4. Treat the generated runtime bridge config as the path for deeper stream/parser changes until OpenClaw exposes richer provider hooks.
+
+## Important Limit
+
+This plugin does not claim to replace the full OpenStream runtime patch yet.
+It is the bundled plugin surface that complements the built-in Ollama provider.

--- a/extensions/openstream/src/config.ts
+++ b/extensions/openstream/src/config.ts
@@ -1,0 +1,156 @@
+export type StreamingMode = "standard" | "enhanced" | "ultra";
+export type DoctorDefaultProvider = "ollama" | "openstream";
+
+export type OpenStreamPluginConfig = {
+  promptGuidance?: boolean;
+  streamingMode?: StreamingMode;
+  enableMegaContext?: boolean;
+  maxContextWindow?: number;
+  doctorDefaultProvider?: DoctorDefaultProvider;
+};
+
+export type ResolvedOpenStreamPluginConfig = Required<OpenStreamPluginConfig>;
+
+export const DEFAULT_OPENSTREAM_PLUGIN_CONFIG: ResolvedOpenStreamPluginConfig = {
+  promptGuidance: true,
+  streamingMode: "enhanced",
+  enableMegaContext: true,
+  maxContextWindow: 262144,
+  doctorDefaultProvider: "ollama",
+};
+
+const ALLOWED_STREAMING_MODES = new Set<StreamingMode>(["standard", "enhanced", "ultra"]);
+const ALLOWED_DOCTOR_PROVIDERS = new Set<DoctorDefaultProvider>(["ollama", "openstream"]);
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
+}
+
+function asStreamingMode(value: unknown): StreamingMode | undefined {
+  return typeof value === "string" && ALLOWED_STREAMING_MODES.has(value as StreamingMode)
+    ? (value as StreamingMode)
+    : undefined;
+}
+
+function asDoctorDefaultProvider(value: unknown): DoctorDefaultProvider | undefined {
+  return typeof value === "string" && ALLOWED_DOCTOR_PROVIDERS.has(value as DoctorDefaultProvider)
+    ? (value as DoctorDefaultProvider)
+    : undefined;
+}
+
+export function resolveOpenStreamPluginConfig(raw: unknown): ResolvedOpenStreamPluginConfig {
+  const cfg = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const maxContextWindow = asInteger(cfg.maxContextWindow);
+  return {
+    promptGuidance:
+      asBoolean(cfg.promptGuidance) ?? DEFAULT_OPENSTREAM_PLUGIN_CONFIG.promptGuidance,
+    streamingMode:
+      asStreamingMode(cfg.streamingMode) ?? DEFAULT_OPENSTREAM_PLUGIN_CONFIG.streamingMode,
+    enableMegaContext:
+      asBoolean(cfg.enableMegaContext) ?? DEFAULT_OPENSTREAM_PLUGIN_CONFIG.enableMegaContext,
+    maxContextWindow:
+      maxContextWindow && maxContextWindow >= 32768 && maxContextWindow <= 2097152
+        ? maxContextWindow
+        : DEFAULT_OPENSTREAM_PLUGIN_CONFIG.maxContextWindow,
+    doctorDefaultProvider:
+      asDoctorDefaultProvider(cfg.doctorDefaultProvider) ??
+      DEFAULT_OPENSTREAM_PLUGIN_CONFIG.doctorDefaultProvider,
+  };
+}
+
+export const openstreamPluginConfigSchema = {
+  validate(value: unknown) {
+    if (value == null) {
+      return { ok: true as const, value: DEFAULT_OPENSTREAM_PLUGIN_CONFIG };
+    }
+    if (typeof value !== "object" || Array.isArray(value)) {
+      return { ok: false as const, errors: ["openstream config must be an object"] };
+    }
+    const cfg = value as Record<string, unknown>;
+    const errors: string[] = [];
+    const allowed = new Set([
+      "promptGuidance",
+      "streamingMode",
+      "enableMegaContext",
+      "maxContextWindow",
+      "doctorDefaultProvider",
+    ]);
+    for (const key of Object.keys(cfg)) {
+      if (!allowed.has(key)) {
+        errors.push(`unsupported key: ${key}`);
+      }
+    }
+    if (cfg.promptGuidance != null && typeof cfg.promptGuidance !== "boolean") {
+      errors.push("promptGuidance must be a boolean");
+    }
+    if (cfg.enableMegaContext != null && typeof cfg.enableMegaContext !== "boolean") {
+      errors.push("enableMegaContext must be a boolean");
+    }
+    if (
+      cfg.streamingMode != null &&
+      (typeof cfg.streamingMode !== "string" ||
+        !ALLOWED_STREAMING_MODES.has(cfg.streamingMode as StreamingMode))
+    ) {
+      errors.push("streamingMode must be one of: standard, enhanced, ultra");
+    }
+    if (
+      cfg.doctorDefaultProvider != null &&
+      (typeof cfg.doctorDefaultProvider !== "string" ||
+        !ALLOWED_DOCTOR_PROVIDERS.has(cfg.doctorDefaultProvider as DoctorDefaultProvider))
+    ) {
+      errors.push("doctorDefaultProvider must be one of: ollama, openstream");
+    }
+    if (cfg.maxContextWindow != null) {
+      const maxContextWindow = asInteger(cfg.maxContextWindow);
+      if (
+        maxContextWindow === undefined ||
+        maxContextWindow < 32768 ||
+        maxContextWindow > 2097152
+      ) {
+        errors.push("maxContextWindow must be an integer between 32768 and 2097152");
+      }
+    }
+    return errors.length > 0
+      ? { ok: false as const, errors }
+      : { ok: true as const, value: resolveOpenStreamPluginConfig(cfg) };
+  },
+  jsonSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      promptGuidance: { type: "boolean" },
+      streamingMode: { type: "string", enum: ["standard", "enhanced", "ultra"] },
+      enableMegaContext: { type: "boolean" },
+      maxContextWindow: { type: "integer", minimum: 32768, maximum: 2097152 },
+      doctorDefaultProvider: { type: "string", enum: ["ollama", "openstream"] },
+    },
+  },
+  uiHints: {
+    promptGuidance: {
+      label: "Prompt guidance",
+      help: "Inject cached Ollama/tool-call recovery guidance into system prompt space.",
+    },
+    streamingMode: {
+      label: "Streaming mode",
+      help: "Doctor/sample-config preset that matches the intended OpenStream runtime behavior.",
+    },
+    enableMegaContext: {
+      label: "Mega context",
+      help: "Prefer larger context recommendations for model families that advertise long context.",
+    },
+    maxContextWindow: {
+      label: "Max context window",
+      help: "Upper bound used in generated recommendations and plugin guidance.",
+      advanced: true,
+    },
+    doctorDefaultProvider: {
+      label: "Default provider label",
+      help: "Whether sample snippets default to the built-in Ollama provider or a future overlay provider.",
+      advanced: true,
+    },
+  },
+};

--- a/extensions/openstream/src/doctor.ts
+++ b/extensions/openstream/src/doctor.ts
@@ -160,7 +160,7 @@ export function buildOpenStreamDoctorReport(params: {
     );
   }
 
-  if (params.pluginConfig.promptGuidance) {
+  if (!params.pluginConfig.promptGuidance) {
     recommendations.push(
       "Enable plugin prompt guidance so OpenClaw can keep cached Ollama/tool-call recovery guidance out of user space.",
     );

--- a/extensions/openstream/src/doctor.ts
+++ b/extensions/openstream/src/doctor.ts
@@ -1,0 +1,235 @@
+import type { ResolvedOpenStreamPluginConfig } from "./config.js";
+import { buildModelHint, type OpenStreamModelHint } from "./heuristics.js";
+
+type OpenClawConfigLike = Record<string, unknown>;
+
+export type OpenStreamDoctorReport = {
+  pluginId: "openstream";
+  mode: "plugin-companion";
+  providerDefault: string;
+  promptGuidanceEnabled: boolean;
+  coreBridgeStillNeeded: boolean;
+  ollamaConfigured: boolean;
+  baseUrl?: string;
+  configuredModels: string[];
+  modelHints: OpenStreamModelHint[];
+  recommendations: string[];
+  suggestedPluginConfig: Record<string, unknown>;
+  suggestedRuntimeConfig: Record<string, unknown>;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+export function extractConfiguredModelIds(hostConfig: unknown): string[] {
+  const cfg = asRecord(hostConfig);
+  if (!cfg) {
+    return [];
+  }
+  const models = asRecord(cfg.models);
+  const providers = asRecord(models?.providers);
+  const ollama = asRecord(providers?.ollama);
+  const configuredModels = Array.isArray(ollama?.models) ? ollama?.models : [];
+  const result: string[] = [];
+  for (const entry of configuredModels) {
+    if (typeof entry === "string" && entry.trim()) {
+      result.push(entry.trim());
+      continue;
+    }
+    const record = asRecord(entry);
+    const id = asString(record?.id) ?? asString(record?.name);
+    if (id) {
+      result.push(id);
+    }
+  }
+  const defaults = asRecord(cfg.defaults);
+  const defaultModels = asRecord(defaults?.models);
+  for (const key of ["ollama", "openstream", "chat", "default"]) {
+    const modelId = asString(defaultModels?.[key]);
+    if (modelId) {
+      result.push(modelId);
+    }
+  }
+  return uniqueStrings(result);
+}
+
+export function detectOllamaBaseUrl(hostConfig: unknown): string | undefined {
+  const cfg = asRecord(hostConfig);
+  const models = asRecord(cfg?.models);
+  const providers = asRecord(models?.providers);
+  const ollama = asRecord(providers?.ollama);
+  return asString(ollama?.baseUrl);
+}
+
+export function isOllamaConfigured(hostConfig: unknown): boolean {
+  return Boolean(detectOllamaBaseUrl(hostConfig) || extractConfiguredModelIds(hostConfig).length > 0);
+}
+
+export function buildSuggestedPluginConfig(
+  pluginConfig: ResolvedOpenStreamPluginConfig,
+): Record<string, unknown> {
+  return {
+    plugins: {
+      entries: {
+        openstream: {
+          enabled: true,
+          config: {
+            promptGuidance: pluginConfig.promptGuidance,
+            streamingMode: pluginConfig.streamingMode,
+            enableMegaContext: pluginConfig.enableMegaContext,
+            maxContextWindow: pluginConfig.maxContextWindow,
+            doctorDefaultProvider: pluginConfig.doctorDefaultProvider,
+          },
+        },
+      },
+    },
+  };
+}
+
+export function buildSuggestedRuntimeConfig(
+  pluginConfig: ResolvedOpenStreamPluginConfig,
+): Record<string, unknown> {
+  return {
+    streaming: {
+      mode: pluginConfig.streamingMode,
+      bufferSize:
+        pluginConfig.streamingMode === "ultra"
+          ? 4096
+          : pluginConfig.streamingMode === "enhanced"
+            ? 2048
+            : 1024,
+      throttleDelay:
+        pluginConfig.streamingMode === "ultra"
+          ? 1
+          : pluginConfig.streamingMode === "enhanced"
+            ? 5
+            : 10,
+      enableThinkingOutput: pluginConfig.streamingMode === "ultra",
+      streamInterval:
+        pluginConfig.streamingMode === "ultra"
+          ? 10
+          : pluginConfig.streamingMode === "enhanced"
+            ? 25
+            : 50,
+    },
+    context: {
+      enableMegaContext: pluginConfig.enableMegaContext,
+      maxContextWindow: pluginConfig.maxContextWindow,
+      autoDetectContext: true,
+    },
+  };
+}
+
+export function buildOpenStreamDoctorReport(params: {
+  hostConfig: unknown;
+  pluginConfig: ResolvedOpenStreamPluginConfig;
+  targetModelId?: string;
+}): OpenStreamDoctorReport {
+  const configuredModels = extractConfiguredModelIds(params.hostConfig);
+  const targetModels = uniqueStrings([
+    ...(params.targetModelId ? [params.targetModelId] : []),
+    ...configuredModels,
+  ]).slice(0, 8);
+  const modelHints = targetModels.map((modelId) => buildModelHint(modelId, params.pluginConfig));
+  const baseUrl = detectOllamaBaseUrl(params.hostConfig);
+  const ollamaConfigured = isOllamaConfigured(params.hostConfig);
+  const recommendations: string[] = [];
+
+  if (!ollamaConfigured) {
+    recommendations.push(
+      "Configure models.providers.ollama with a reachable baseUrl before expecting OpenStream runtime guidance to matter.",
+    );
+  } else if (baseUrl && !baseUrl.includes("/v1")) {
+    recommendations.push(
+      "Ollama baseUrl looks native already; keep it stable and avoid mixing OpenAI-compatible and native endpoints in the same provider block.",
+    );
+  } else if (baseUrl) {
+    recommendations.push(
+      "Base URL appears OpenAI-compatible; if native Ollama discovery behaves oddly, validate the corresponding native /api endpoint too.",
+    );
+  }
+
+  if (params.pluginConfig.promptGuidance) {
+    recommendations.push(
+      "Enable plugin prompt guidance so OpenClaw can keep cached Ollama/tool-call recovery guidance out of user space.",
+    );
+  }
+
+  if (modelHints.some((hint) => hint.estimatedContextWindow === undefined)) {
+    recommendations.push(
+      "Some configured models do not match strong OpenStream heuristics yet; keep runtime benchmarks and replay fixtures before widening defaults.",
+    );
+  }
+
+  if (modelHints.some((hint) => hint.estimatedContextWindow === 2097152)) {
+    recommendations.push(
+      "Mega-context families are present; keep summarization checkpoints and memory pressure testing in the validation loop.",
+    );
+  }
+
+  recommendations.push(
+    "Use OpenStream for diagnostics, prompt guidance, and safe config generation now; keep raw stream parsing and payload repair on a narrower core or provider-hook path until the runtime surface grows.",
+  );
+
+  return {
+    pluginId: "openstream",
+    mode: "plugin-companion",
+    providerDefault: params.pluginConfig.doctorDefaultProvider,
+    promptGuidanceEnabled: params.pluginConfig.promptGuidance,
+    coreBridgeStillNeeded: true,
+    ollamaConfigured,
+    ...(baseUrl ? { baseUrl } : {}),
+    configuredModels,
+    modelHints,
+    recommendations,
+    suggestedPluginConfig: buildSuggestedPluginConfig(params.pluginConfig),
+    suggestedRuntimeConfig: buildSuggestedRuntimeConfig(params.pluginConfig),
+  };
+}
+
+export function formatDoctorReport(report: OpenStreamDoctorReport): string {
+  const lines: string[] = [];
+  lines.push("OpenStream doctor");
+  lines.push("");
+  lines.push(`- mode: ${report.mode}`);
+  lines.push(`- provider default: ${report.providerDefault}`);
+  lines.push(`- prompt guidance: ${report.promptGuidanceEnabled ? "enabled" : "disabled"}`);
+  lines.push(`- core bridge still needed: ${report.coreBridgeStillNeeded ? "yes" : "no"}`);
+  lines.push(`- ollama configured: ${report.ollamaConfigured ? "yes" : "no"}`);
+  if (report.baseUrl) {
+    lines.push(`- baseUrl: ${report.baseUrl}`);
+  }
+  lines.push(
+    `- configured models: ${
+      report.configuredModels.length > 0 ? report.configuredModels.join(", ") : "(none detected)"
+    }`,
+  );
+  if (report.modelHints.length > 0) {
+    lines.push("");
+    lines.push("Model hints:");
+    for (const hint of report.modelHints) {
+      lines.push(
+        `- ${hint.modelId}: reasoning=${hint.reasoning ? "yes" : "no"}, context=${
+          hint.estimatedContextWindow ?? "unknown"
+        }, maxTokens=${hint.recommendedMaxTokens}, mode=${hint.recommendedStreamingMode}`,
+      );
+    }
+  }
+  lines.push("");
+  lines.push("Recommendations:");
+  for (const recommendation of report.recommendations) {
+    lines.push(`- ${recommendation}`);
+  }
+  return lines.join("\n");
+}

--- a/extensions/openstream/src/guidance.ts
+++ b/extensions/openstream/src/guidance.ts
@@ -1,0 +1,11 @@
+export const OPENSTREAM_AGENT_GUIDANCE = [
+  "## OpenStream Ollama Guidance",
+  "If the active provider or model is Ollama or another open-source tool-calling model:",
+  "- Prefer native tool calls over fenced JSON or markdown pseudo-tool output.",
+  "- Do not wrap tool arguments in triple backticks.",
+  "- Keep tool arguments minimal, schema-valid, and free of explanatory prose.",
+  "- If a tool call fails, retry once with a smaller argument payload instead of emitting another pseudo-tool block.",
+  "- For long-context models, keep intermediate summaries stable so later turns can recover state cleanly.",
+  "- If tool-calling or context behavior looks brittle, ask the operator to run /openstream doctor or the openstream_doctor tool.",
+  "",
+].join("\n");

--- a/extensions/openstream/src/heuristics.ts
+++ b/extensions/openstream/src/heuristics.ts
@@ -35,7 +35,11 @@ export function estimateContextWindow(modelId: string): number | undefined {
     return name.includes("128k") ? 131072 : OLLAMA_EXTENDED_CONTEXT_WINDOW;
   }
   if (name.includes("deepseek") && name.includes("v3")) {
-    return OLLAMA_MEGA_CONTEXT_WINDOW;
+    if (name.includes("2m")) return OLLAMA_MEGA_CONTEXT_WINDOW;
+    if (name.includes("1m")) return 1048576;
+    if (name.includes("256k")) return OLLAMA_EXTENDED_CONTEXT_WINDOW;
+    if (name.includes("128k")) return 131072;
+    return 131072;
   }
   if (name.includes("kimi") && (name.includes("k2") || name.includes("2.5"))) {
     return OLLAMA_MEGA_CONTEXT_WINDOW;

--- a/extensions/openstream/src/heuristics.ts
+++ b/extensions/openstream/src/heuristics.ts
@@ -1,0 +1,122 @@
+import type { ResolvedOpenStreamPluginConfig, StreamingMode } from "./config.js";
+
+export const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
+export const OLLAMA_EXTENDED_CONTEXT_WINDOW = 262144;
+export const OLLAMA_MEGA_CONTEXT_WINDOW = 2097152;
+export const OLLAMA_DEFAULT_MAX_TOKENS = 8192;
+export const OLLAMA_EXTENDED_MAX_TOKENS = 32768;
+
+export type OpenStreamModelHint = {
+  modelId: string;
+  reasoning: boolean;
+  estimatedContextWindow?: number;
+  recommendedMaxTokens: number;
+  recommendedStreamingMode: StreamingMode;
+  notes: string[];
+};
+
+export function isReasoningModelHeuristic(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  return /r1|reasoning|think|reason|qwen3|qwq|glm-?5|kimi-?k2|marco-o|skywork-o|llama.*reason|yi.*1\.5/i.test(
+    id,
+  );
+}
+
+export function estimateContextWindow(modelId: string): number | undefined {
+  const name = modelId.toLowerCase();
+  if (name.includes("qwen3") || name.includes("qwen-3")) {
+    if (name.includes("2m")) return OLLAMA_MEGA_CONTEXT_WINDOW;
+    if (name.includes("1m")) return 1048576;
+    if (name.includes("256k")) return OLLAMA_EXTENDED_CONTEXT_WINDOW;
+    if (name.includes("128k")) return 131072;
+    return OLLAMA_EXTENDED_CONTEXT_WINDOW;
+  }
+  if (name.includes("glm") && (name.includes("5") || name.includes("4"))) {
+    return name.includes("128k") ? 131072 : OLLAMA_EXTENDED_CONTEXT_WINDOW;
+  }
+  if (name.includes("deepseek") && name.includes("v3")) {
+    return OLLAMA_MEGA_CONTEXT_WINDOW;
+  }
+  if (name.includes("kimi") && (name.includes("k2") || name.includes("2.5"))) {
+    return OLLAMA_MEGA_CONTEXT_WINDOW;
+  }
+  if ((name.includes("llama3") || name.includes("llama-3")) && name.includes("405b")) {
+    return OLLAMA_MEGA_CONTEXT_WINDOW;
+  }
+  if ((name.includes("llama3") || name.includes("llama-3")) && name.includes("70b")) {
+    return OLLAMA_EXTENDED_CONTEXT_WINDOW;
+  }
+  if ((name.includes("code") || name.includes("coder")) && name.includes("34b")) {
+    return OLLAMA_EXTENDED_CONTEXT_WINDOW;
+  }
+  if (name.includes("128k")) return 131072;
+  if (name.includes("256k")) return OLLAMA_EXTENDED_CONTEXT_WINDOW;
+  return undefined;
+}
+
+export function recommendMaxTokens(contextWindow?: number): number {
+  if (!contextWindow) {
+    return OLLAMA_DEFAULT_MAX_TOKENS;
+  }
+  if (contextWindow >= OLLAMA_MEGA_CONTEXT_WINDOW) {
+    return OLLAMA_EXTENDED_MAX_TOKENS;
+  }
+  if (contextWindow >= OLLAMA_EXTENDED_CONTEXT_WINDOW) {
+    return Math.min(OLLAMA_EXTENDED_MAX_TOKENS, Math.floor(contextWindow * 0.25));
+  }
+  return OLLAMA_DEFAULT_MAX_TOKENS;
+}
+
+export function recommendStreamingMode(params: {
+  modelId: string;
+  pluginConfig: ResolvedOpenStreamPluginConfig;
+  contextWindow?: number;
+  reasoning?: boolean;
+}): StreamingMode {
+  if (params.pluginConfig.streamingMode === "ultra") {
+    return "ultra";
+  }
+  if (params.reasoning || (params.contextWindow ?? 0) >= OLLAMA_EXTENDED_CONTEXT_WINDOW) {
+    return "enhanced";
+  }
+  const id = params.modelId.toLowerCase();
+  if (id.includes("qwen3") || id.includes("kimi") || id.includes("deepseek")) {
+    return "enhanced";
+  }
+  return params.pluginConfig.streamingMode;
+}
+
+export function buildModelHint(
+  modelId: string,
+  pluginConfig: ResolvedOpenStreamPluginConfig,
+): OpenStreamModelHint {
+  const reasoning = isReasoningModelHeuristic(modelId);
+  const estimatedContextWindow = estimateContextWindow(modelId);
+  const recommendedStreamingMode = recommendStreamingMode({
+    modelId,
+    pluginConfig,
+    contextWindow: estimatedContextWindow,
+    reasoning,
+  });
+  const notes: string[] = [];
+  if (reasoning) {
+    notes.push("Model name matches OpenStream reasoning-model heuristic.");
+  }
+  if (estimatedContextWindow && estimatedContextWindow >= OLLAMA_EXTENDED_CONTEXT_WINDOW) {
+    notes.push("Long-context family detected; keep summaries and checkpoints stable during long runs.");
+  }
+  if (estimatedContextWindow === OLLAMA_MEGA_CONTEXT_WINDOW && pluginConfig.enableMegaContext) {
+    notes.push("Mega-context recommendation is enabled for this plugin configuration.");
+  }
+  if (notes.length === 0) {
+    notes.push("No strong heuristic match found; keep OpenClaw defaults unless runtime evidence shows otherwise.");
+  }
+  return {
+    modelId,
+    reasoning,
+    estimatedContextWindow,
+    recommendedMaxTokens: recommendMaxTokens(estimatedContextWindow),
+    recommendedStreamingMode,
+    notes,
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds **OpenStream** as a bundled OpenClaw plugin for Ollama-heavy deployments.

The goal is to upstream the highest-leverage, lowest-risk slice first:

- an installable plugin surface instead of patch-only guidance
- operator-facing diagnostics for Ollama setups
- model heuristics for reasoning / long-context open-source models
- cached prompt guidance for markdown / pseudo tool-call behavior
- generated config snippets for plugin mode and deeper runtime bridge mode

## What this includes

- new bundled plugin under `extensions/openstream`
- `/openstream` command
- `openstream_doctor` tool
- `before_prompt_build` prompt-guidance hook
- config schema + doctor report generation
- bundled skill docs and user-facing plugin docs
- navigation/docs links for the new plugin page
- targeted tests for plugin registration and doctor output

## Why this shape

OpenStream started as a downstream patch-oriented repo.

For upstreaming, this PR intentionally stops at the plugin-native layer first. That keeps the initial review surface narrower and makes the capability installable, documented, and testable inside OpenClaw without claiming to replace the deepest raw provider/parser path yet.

In other words, this is a **companion plugin now** and a staging point for narrower runtime improvements later.

## Not included in this PR

- deep provider stream/parser replacement
- broad core runtime rewrites
- claims that OpenStream fully supersedes the built-in Ollama provider

The built-in Ollama provider remains the runtime/provider path. OpenStream complements it with diagnostics, heuristics, and guidance.

## Validation

Ran locally:

- `pnpm exec vitest run extensions/openstream/index.test.ts extensions/ollama/index.test.ts`

Results:

- 2 test files passed
- 5 tests passed

I also attempted a full `pnpm install --frozen-lockfile`, but the workspace hit an unrelated `sharp` native build failure during install on my machine. The targeted vitest path still ran successfully after dependency resolution, and the new plugin tests passed.

## Follow-ups

If this direction looks good, the next upstreamable steps would be:

1. move the highest-value recovery logic into narrower provider/runtime hooks
2. add replay fixtures / before-after transcripts for malformed tool-call recovery
3. keep runtime-facing changes evidence-backed and much smaller than the original downstream patch surface
