### PR TITLE
feat: recover Ollama markdown tool calls

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -4,6 +4,7 @@ import {
   createOllamaStreamFn,
   convertToOllamaMessages,
   buildAssistantMessage,
+  extractMarkdownToolCalls,
   parseNdjsonStream,
   resolveOllamaBaseUrlForRun,
 } from "./ollama-stream.js";
@@ -312,6 +313,45 @@ describe("parseNdjsonStream", () => {
   });
 });
 
+describe("extractMarkdownToolCalls", () => {
+  it("extracts fenced json tool calls for registered tools", () => {
+    const toolCalls = extractMarkdownToolCalls(
+      [
+        "I can do that.",
+        "```json",
+        '{"name":"bash","arguments":{"command":"ls","thread":9223372036854775807}}',
+        "```",
+      ].join("\n"),
+      new Set(["bash"]),
+    );
+
+    expect(toolCalls).toEqual([
+      {
+        function: {
+          name: "bash",
+          arguments: {
+            command: "ls",
+            thread: "9223372036854775807",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("ignores fenced json blocks for tools that are not registered", () => {
+    const toolCalls = extractMarkdownToolCalls(
+      [
+        "```json",
+        '{"name":"dangerous_tool","arguments":{"command":"rm -rf /"}}',
+        "```",
+      ].join("\n"),
+      new Set(["bash"]),
+    );
+
+    expect(toolCalls).toEqual([]);
+  });
+});
+
 async function withMockNdjsonFetch(
   lines: string[],
   run: (fetchMock: ReturnType<typeof vi.fn>) => Promise<void>,
@@ -542,6 +582,55 @@ describe("createOllamaStreamFn", () => {
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
       ],
       [{ type: "text", text: "final answer" }],
+    );
+  });
+
+  it("recovers fenced json tool calls when Ollama emits markdown instead of native tool_calls", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"I can do that.\\n```json\\n{\\"name\\":\\"bash\\",\\"arguments\\":{\\"command\\":\\"ls -la\\"}}\\n```"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":4,"eval_count":2}',
+      ],
+      async () => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = await Promise.resolve(
+          streamFn(
+            {
+              id: "qwen3:32b",
+              api: "ollama",
+              provider: "custom-ollama",
+              contextWindow: 131072,
+            } as never,
+            {
+              messages: [{ role: "user", content: "list files" }],
+              tools: [
+                {
+                  name: "bash",
+                  description: "Run a shell command",
+                  parameters: { type: "object", properties: { command: { type: "string" } } },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        const events = await collectStreamEvents(stream);
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.reason).toBe("toolUse");
+        expect(doneEvent.message.content).toEqual([
+          { type: "text", text: "I can do that." },
+          expect.objectContaining({
+            type: "toolCall",
+            name: "bash",
+            arguments: { command: "ls -la" },
+          }),
+        ]);
+      },
     );
   });
 });

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -350,6 +350,59 @@ describe("extractMarkdownToolCalls", () => {
 
     expect(toolCalls).toEqual([]);
   });
+
+  it("keeps unregistered fenced json visible when a registered tool call is also extracted", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"First tool.\\n```json\\n{\\"name\\":\\"bash\\",\\"arguments\\":{\\"command\\":\\"ls -la\\"}}\\n```\\nSecond tool stays visible.\\n```json\\n{\\"name\\":\\"dangerous_tool\\",\\"arguments\\":{\\"command\\":\\"rm -rf /\\"}}\\n```"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":4,"eval_count":2}',
+      ],
+      async () => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = await Promise.resolve(
+          streamFn(
+            {
+              id: "qwen3:32b",
+              api: "ollama",
+              provider: "custom-ollama",
+              contextWindow: 131072,
+            } as never,
+            {
+              messages: [{ role: "user", content: "list files" }],
+              tools: [
+                {
+                  name: "bash",
+                  description: "Run a shell command",
+                  parameters: { type: "object", properties: { command: { type: "string" } } },
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+
+        const events = await collectStreamEvents(stream);
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.reason).toBe("toolUse");
+        expect(doneEvent.message.content).toEqual([
+          {
+            type: "text",
+            text:
+              'First tool.\n\nSecond tool stays visible.\n```json\n{"name":"dangerous_tool","arguments":{"command":"rm -rf /"}}\n```',
+          },
+          expect.objectContaining({
+            type: "toolCall",
+            name: "bash",
+            arguments: { command: "ls -la" },
+          }),
+        ]);
+      },
+    );
+  });
 });
 
 async function withMockNdjsonFetch(

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -198,10 +198,23 @@ function makeMarkdownToolCallRe(): RegExp {
   return /```(?:json)?\s*\n?\s*(\{(?:(?!```)[\s\S])*?"name"\s*:\s*"[^"]+"(?:(?!```)[\s\S])*?\})\s*\n?```/g;
 }
 
-function stripMarkdownToolCallBlocks(input: string): string {
+function stripMarkdownToolCallBlocks(input: string, allowedNames?: ReadonlySet<string>): string {
   return input
-    .replace(makeMarkdownToolCallRe(), "")
-    .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, "")
+    .replace(makeMarkdownToolCallRe(), (match, raw: string) => {
+      try {
+        const parsed = parseJsonPreservingUnsafeIntegers((raw ?? "").trim()) as Record<string, unknown>;
+        const name = typeof parsed.name === "string" ? parsed.name : undefined;
+        if (!name) {
+          return match;
+        }
+        if (allowedNames && !allowedNames.has(name)) {
+          return match;
+        }
+        return "";
+      } catch {
+        return match;
+      }
+    })
     .trim();
 }
 
@@ -584,7 +597,10 @@ export function createOllamaStreamFn(
           const markdownToolCalls = extractMarkdownToolCalls(accumulatedContent, allowedNames);
           if (markdownToolCalls.length > 0) {
             accumulatedToolCalls.push(...markdownToolCalls);
-            finalResponse.message.content = stripMarkdownToolCallBlocks(accumulatedContent);
+            finalResponse.message.content = stripMarkdownToolCallBlocks(
+              accumulatedContent,
+              allowedNames,
+            );
             finalResponse.message.tool_calls = accumulatedToolCalls;
           }
         }

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -194,6 +194,61 @@ function parseJsonPreservingUnsafeIntegers(input: string): unknown {
   return JSON.parse(quoteUnsafeIntegerLiterals(input)) as unknown;
 }
 
+function makeMarkdownToolCallRe(): RegExp {
+  return /```(?:json)?\s*\n?\s*(\{(?:(?!```)[\s\S])*?"name"\s*:\s*"[^"]+"(?:(?!```)[\s\S])*?\})\s*\n?```/g;
+}
+
+function stripMarkdownToolCallBlocks(input: string): string {
+  return input
+    .replace(makeMarkdownToolCallRe(), "")
+    .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, "")
+    .trim();
+}
+
+export function extractMarkdownToolCalls(
+  input: string,
+  allowedNames?: ReadonlySet<string>,
+): OllamaToolCall[] {
+  const result: OllamaToolCall[] = [];
+  const re = makeMarkdownToolCallRe();
+
+  for (const match of input.matchAll(re)) {
+    const raw = (match[1] ?? match[0] ?? "").trim();
+    if (!raw) {
+      continue;
+    }
+    try {
+      const parsed = parseJsonPreservingUnsafeIntegers(raw) as Record<string, unknown>;
+      const name = typeof parsed.name === "string" ? parsed.name : undefined;
+      if (!name) {
+        continue;
+      }
+      if (allowedNames && !allowedNames.has(name)) {
+        log.debug(`Skipping markdown tool call for unregistered tool '${name}'`);
+        continue;
+      }
+      const args =
+        parsed.arguments != null && typeof parsed.arguments === "object" && !Array.isArray(parsed.arguments)
+          ? (parsed.arguments as Record<string, unknown>)
+          : parsed.parameters != null &&
+              typeof parsed.parameters === "object" &&
+              !Array.isArray(parsed.parameters)
+            ? (parsed.parameters as Record<string, unknown>)
+            : {};
+      result.push({
+        function: {
+          name,
+          arguments: args,
+        },
+      });
+    } catch {
+      log.warn(`Skipping malformed markdown tool call: ${raw.slice(0, 120)}`);
+    }
+  }
+
+  return result;
+}
+
 // ── Ollama /api/chat response types ─────────────────────────────────────────
 
 interface OllamaChatResponse {
@@ -524,6 +579,14 @@ export function createOllamaStreamFn(
         finalResponse.message.content = accumulatedContent;
         if (accumulatedToolCalls.length > 0) {
           finalResponse.message.tool_calls = accumulatedToolCalls;
+        } else if (accumulatedContent && ollamaTools.length > 0) {
+          const allowedNames = new Set(ollamaTools.map((tool) => tool.function.name));
+          const markdownToolCalls = extractMarkdownToolCalls(accumulatedContent, allowedNames);
+          if (markdownToolCalls.length > 0) {
+            accumulatedToolCalls.push(...markdownToolCalls);
+            finalResponse.message.content = stripMarkdownToolCallBlocks(accumulatedContent);
+            finalResponse.message.tool_calls = accumulatedToolCalls;
+          }
         }
 
         const assistantMessage = buildAssistantMessage(finalResponse, {


### PR DESCRIPTION
## Summary

This PR teaches the built-in Ollama stream adapter to recover fenced JSON tool calls when a local model emits markdown instead of native `tool_calls`.

## Why

Some open-source models behind Ollama do not reliably emit structured `tool_calls` even when tool definitions are present. A common fallback pattern is a fenced JSON block such as:

```json
{"name":"bash","arguments":{"command":"ls -la"}}
```

Today OpenClaw surfaces that raw JSON as visible assistant text and loses the tool execution opportunity.

## What this changes

- adds `extractMarkdownToolCalls(...)` to `src/agents/ollama-stream.ts`
- only promotes fenced JSON blocks when the extracted `name` matches a registered tool
- preserves unsafe integer argument values as exact strings, matching the existing NDJSON parser behavior
- strips recovered fenced tool-call JSON from the visible assistant text before finalizing the message
- leaves native Ollama `tool_calls` behavior unchanged

## Validation

Ran locally:

- `pnpm exec vitest run src/agents/ollama-stream.test.ts`

Result:

- 1 test file passed
- 34 tests passed

## Tests added

- extracts fenced JSON tool calls for registered tools
- ignores fenced JSON blocks for unregistered tools
- recovers a fenced JSON tool call during `createOllamaStreamFn(...)` end-to-end stream assembly
