### PR TITLE
docs: expand Ollama and local model tool-calling guidance

### DIFF
--- a/docs/gateway/local-models.md
+++ b/docs/gateway/local-models.md
@@ -150,3 +150,24 @@ Keep `models.mode: "merge"` so hosted models stay available as fallbacks.
 - LM Studio model unloaded? Reload; cold start is a common “hanging” cause.
 - Context errors? Lower `contextWindow` or raise your server limit.
 - Safety: local models skip provider-side filters; keep agents narrow and compaction on to limit prompt injection blast radius.
+
+### Tool-calling triage for local stacks
+
+When a local model looks "close" to tool calling but still fails, the failure mode usually tells you where to look:
+
+- raw JSON or fenced ` ```json ` blocks in the assistant reply:
+  the model is trying to express a tool call in text instead of structured output
+- no tool call and no JSON at all:
+  the model likely ignored the tool schema or ran out of context budget
+- good behavior through the native provider but bad behavior through `/v1`:
+  the OpenAI-compatible proxy surface is the likely regression point
+
+Fastest debugging order:
+
+1. try the provider's native tool-calling surface when available
+2. retest with one tool instead of many
+3. shorten the system prompt
+4. retest on a larger checkpoint or less aggressive quantization
+5. only then tune `contextWindow` / `maxTokens`
+
+For Ollama specifically, start with [Ollama](/providers/ollama) and avoid the `/v1` URL unless you really need an OpenAI-compatible proxy layer.

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -345,6 +345,65 @@ ps aux | grep ollama
 ollama serve
 ```
 
+### Model prints raw JSON or fenced code blocks instead of running tools
+
+If you see responses like:
+
+```text
+~~~json
+{"name":"bash","arguments":{"command":"ls -la"}}
+~~~
+```
+
+or plain-text tool JSON in the chat, check these first:
+
+1. Confirm you are using the **native Ollama API** URL with no `/v1` suffix.
+2. Confirm the provider entry uses `api: "ollama"` instead of `openai-completions`.
+3. Retest with a model family that is known to behave better for tool calling.
+4. Reduce the prompt and tool list temporarily to rule out context pressure.
+
+Recommended checks:
+
+```bash
+openclaw models list
+curl http://127.0.0.1:11434/api/tags
+```
+
+Then inspect your config and make sure the Ollama provider looks like:
+
+```json5
+{
+  models: {
+    providers: {
+      ollama: {
+        baseUrl: "http://127.0.0.1:11434",
+        api: "ollama",
+      },
+    },
+  },
+}
+```
+
+If you intentionally use `http://host:11434/v1`, OpenClaw is talking to the OpenAI-compatible surface instead of native Ollama. That mode is fine for some proxy setups, but tool calling is less reliable there.
+
+### Tool calling works on one model but not another
+
+OpenClaw can send the same tool schema to different Ollama-hosted models and still get very different behavior back.
+
+When comparing local models, check:
+
+- whether the model actually emits native `tool_calls`
+- whether the model writes markdown or pseudo-JSON before the tool call
+- whether the model has enough context window for your system prompt and tool schema
+- whether the model is a small / heavily quantized variant that is brittle under long prompts
+
+Practical operator advice:
+
+- prefer the native Ollama API over OpenAI-compatible mode when you care about tool use
+- prefer larger or less aggressively quantized checkpoints for multi-tool agents
+- keep explicit `contextWindow` values realistic if you override model metadata manually
+- validate new local model families with a simple one-tool prompt before using them in a larger agent stack
+
 ## See Also
 
 - [Model Providers](/concepts/model-providers) - Overview of all providers


### PR DESCRIPTION
## Summary

This PR expands the operator-facing docs for Ollama and local-model deployments with a focused troubleshooting path for tool-calling failures.

## What this adds

- `docs/providers/ollama.md`
  - new troubleshooting guidance for raw JSON / fenced code blocks appearing instead of tool execution
  - clearer native-vs-`/v1` diagnosis steps
  - model-family / context-budget triage guidance
- `docs/gateway/local-models.md`
  - new local-model tool-calling triage section
  - practical debugging order for native endpoints, prompt size, checkpoint size, and context tuning

## Why

OpenClaw operators often hit the same local-model failure modes:

- raw JSON tool-call text appears in the assistant output
- the same tool schema works on one model family but fails on another
- behavior regresses when a stack uses an OpenAI-compatible proxy layer instead of the provider's native endpoint

This PR turns that operational knowledge into first-class docs so users can debug local model stacks faster.
