### PR TITLE
test: add Ollama stream replay fixtures

### DIFF
--- a/src/agents/ollama-stream.fixture-replay.test.ts
+++ b/src/agents/ollama-stream.fixture-replay.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { extractMarkdownToolCalls } from "./ollama-stream.js";
+
+type ReplayFixture = {
+  name: string;
+  content: string;
+  allowedTools: string[];
+  expectedToolCalls: Array<{
+    function: {
+      name: string;
+      arguments: Record<string, unknown>;
+    };
+  }>;
+};
+
+const fixturePath = resolve(process.cwd(), "test/fixtures/ollama-markdown-toolcall-replay.json");
+const fixtures = JSON.parse(readFileSync(fixturePath, "utf8")) as ReplayFixture[];
+
+describe("ollama markdown tool-call replay fixtures", () => {
+  for (const fixture of fixtures) {
+    it(fixture.name, () => {
+      expect(extractMarkdownToolCalls(fixture.content, new Set(fixture.allowedTools))).toEqual(
+        fixture.expectedToolCalls,
+      );
+    });
+  }
+});

--- a/test/fixtures/ollama-markdown-toolcall-replay.json
+++ b/test/fixtures/ollama-markdown-toolcall-replay.json
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "registered fenced json tool call is promoted",
+    "content": "I can do that.\n```json\n{\"name\":\"bash\",\"arguments\":{\"command\":\"ls -la\"}}\n```",
+    "allowedTools": ["bash"],
+    "expectedToolCalls": [
+      {
+        "function": {
+          "name": "bash",
+          "arguments": {
+            "command": "ls -la"
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "unregistered fenced json tool call is ignored",
+    "content": "```json\n{\"name\":\"dangerous_tool\",\"arguments\":{\"command\":\"rm -rf /\"}}\n```",
+    "allowedTools": ["bash"],
+    "expectedToolCalls": []
+  },
+  {
+    "name": "unsafe integer arguments are preserved as strings",
+    "content": "```json\n{\"name\":\"bash\",\"arguments\":{\"thread\":9223372036854775807,\"command\":\"ls\"}}\n```",
+    "allowedTools": ["bash"],
+    "expectedToolCalls": [
+      {
+        "function": {
+          "name": "bash",
+          "arguments": {
+            "thread": "9223372036854775807",
+            "command": "ls"
+          }
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

This PR adds fixture-driven replay coverage for a few high-value Ollama stream behaviors.

## What this adds

- `test/fixtures/ollama-markdown-toolcall-replay.json`
  - sample cases for registered/unregistered markdown tool calls
  - unsafe integer argument preservation
- `src/agents/ollama-stream.fixture-replay.test.ts`
  - fixture-driven assertions wired against `extractMarkdownToolCalls(...)`

## Why

The Ollama stream adapter now has a few subtle behaviors that are easy to regress:

- only promote markdown tool calls for registered tools
- preserve oversized integer literals as strings
- keep local-model parsing rules easy to extend with new fixtures

This PR creates a lightweight replay fixture path so future Ollama/operator regressions can be captured by adding JSON samples rather than hand-writing every case from scratch.

## Validation

Ran locally:

- `pnpm exec vitest run src/agents/ollama-stream.fixture-replay.test.ts src/agents/ollama-stream.test.ts`

Result:

- 2 test files passed
- 37 tests passed
