### PR TITLE
feat: broaden Ollama reasoning-model heuristics

### DIFF
--- a/src/agents/ollama-models.test.ts
+++ b/src/agents/ollama-models.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { jsonResponse, requestBodyText, requestUrl } from "../test-helpers/http.js";
 import {
   enrichOllamaModelsWithContext,
+  isReasoningModelHeuristic,
   resolveOllamaApiBase,
   type OllamaTagModel,
 } from "./ollama-models.js";
@@ -37,5 +38,16 @@ describe("ollama-models", () => {
       { name: "llama3:8b", contextWindow: 65536 },
       { name: "deepseek-r1:14b", contextWindow: undefined },
     ]);
+  });
+
+  it("marks newer reasoning model families as reasoning-capable", () => {
+    expect(isReasoningModelHeuristic("deepseek-r1:14b")).toBe(true);
+    expect(isReasoningModelHeuristic("qwen3:32b")).toBe(true);
+    expect(isReasoningModelHeuristic("qwq:latest")).toBe(true);
+    expect(isReasoningModelHeuristic("glm-5:latest")).toBe(true);
+    expect(isReasoningModelHeuristic("kimi-k2:latest")).toBe(true);
+    expect(isReasoningModelHeuristic("skywork-o1:latest")).toBe(true);
+    expect(isReasoningModelHeuristic("marco-o1:latest")).toBe(true);
+    expect(isReasoningModelHeuristic("llama3.3:70b")).toBe(false);
   });
 });

--- a/src/agents/ollama-models.test.ts
+++ b/src/agents/ollama-models.test.ts
@@ -45,6 +45,8 @@ describe("ollama-models", () => {
     expect(isReasoningModelHeuristic("qwen3:32b")).toBe(true);
     expect(isReasoningModelHeuristic("qwq:latest")).toBe(true);
     expect(isReasoningModelHeuristic("glm-5:latest")).toBe(true);
+    expect(isReasoningModelHeuristic("glm-50b:latest")).toBe(false);
+    expect(isReasoningModelHeuristic("glm-512k")).toBe(false);
     expect(isReasoningModelHeuristic("kimi-k2:latest")).toBe(true);
     expect(isReasoningModelHeuristic("skywork-o1:latest")).toBe(true);
     expect(isReasoningModelHeuristic("marco-o1:latest")).toBe(true);

--- a/src/agents/ollama-models.ts
+++ b/src/agents/ollama-models.ts
@@ -107,7 +107,9 @@ export async function enrichOllamaModelsWithContext(
  * reasoning capability contract during discovery.
  */
 export function isReasoningModelHeuristic(modelId: string): boolean {
-  return /r1|reasoning|think|reason|qwen3|qwq|glm-?5|kimi-?k2|marco-o|skywork-o/i.test(modelId);
+  return /r1|reasoning|think|reason|qwen3|qwq|glm-?5(?:[:\-_.]|$)|kimi-?k2|marco-o|skywork-o/i.test(
+    modelId,
+  );
 }
 
 /** Build a ModelDefinitionConfig for an Ollama model with default values. */

--- a/src/agents/ollama-models.ts
+++ b/src/agents/ollama-models.ts
@@ -100,9 +100,14 @@ export async function enrichOllamaModelsWithContext(
   return enriched;
 }
 
-/** Heuristic: treat models with "r1", "reasoning", or "think" in the name as reasoning models. */
+/**
+ * Heuristic: treat common open-source reasoning model families as reasoning-capable.
+ *
+ * This intentionally stays name-based because Ollama tags rarely expose a richer
+ * reasoning capability contract during discovery.
+ */
 export function isReasoningModelHeuristic(modelId: string): boolean {
-  return /r1|reasoning|think|reason/i.test(modelId);
+  return /r1|reasoning|think|reason|qwen3|qwq|glm-?5|kimi-?k2|marco-o|skywork-o/i.test(modelId);
 }
 
 /** Build a ModelDefinitionConfig for an Ollama model with default values. */


### PR DESCRIPTION
## Summary

This PR broadens the Ollama reasoning-model name heuristic used during local model discovery.

## What changes

`isReasoningModelHeuristic(...)` now treats these common local/open-source model families as reasoning-capable:

- `qwen3`
- `qwq`
- `glm-5`
- `kimi-k2`
- `skywork-o*`
- `marco-o*`

The existing `r1|reasoning|think|reason` matches remain in place.

## Why

Ollama discovery often has to infer capabilities from model IDs alone. The previous heuristic missed several common reasoning-capable local model families that operators actually deploy, which meant discovery could under-label them during local setup.

## Validation

Ran locally:

- `pnpm exec vitest run src/agents/ollama-models.test.ts`

Result:

- 1 test file passed
- 3 tests passed
