### PR TITLE
feat(whatsapp): support native @mentions in outbound group replies

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -6,7 +6,7 @@ import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/text-runtime";
-import { resolveJidToE164 } from "openclaw/plugin-sdk/text-runtime";
+import { jidToE164, normalizeE164, resolveJidToE164 } from "openclaw/plugin-sdk/text-runtime";
 import { readWebSelfIdentity } from "../auth-store.js";
 import { getPrimaryIdentityId, resolveComparableIdentity } from "../identity.js";
 import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
@@ -25,6 +25,7 @@ import {
 } from "./extract.js";
 import { attachEmitterListener, closeInboundMonitorSocket } from "./lifecycle.js";
 import { downloadInboundMedia } from "./media.js";
+import { extractOutboundMentions } from "./outbound-mentions.js";
 import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
@@ -134,7 +135,12 @@ export async function monitorWebInbox(options: {
   });
   const groupMetaCache = new Map<
     string,
-    { subject?: string; participants?: string[]; expires: number }
+    {
+      subject?: string;
+      participants?: string[];
+      participantJidMap?: Map<string, string>;
+      expires: number;
+    }
   >();
   const GROUP_META_TTL_MS = 5 * 60 * 1000; // 5 minutes
   const lidLookup = sock.signalRepository?.lidMapping;
@@ -170,18 +176,27 @@ export async function monitorWebInbox(options: {
     }
     try {
       const meta = await sock.groupMetadata(jid);
+      const participantJidMap = new Map<string, string>();
       const participants =
         (
           await Promise.all(
             meta.participants?.map(async (p) => {
               const mapped = await resolveInboundJid(p.id);
-              return mapped ?? p.id;
+              const resolved = mapped ?? p.id;
+              // Map normalized display number → original JID so outbound mentions
+              // use the correct JID type (phone @s.whatsapp.net vs LID @lid).
+              const normalized = normalizeE164(resolved);
+              if (normalized) {
+                participantJidMap.set(normalized, p.id);
+              }
+              return resolved;
             }) ?? [],
           )
         ).filter(Boolean) ?? [];
       const entry = {
         subject: meta.subject,
         participants,
+        participantJidMap,
         expires: Date.now() + GROUP_META_TTL_MS,
       };
       groupMetaCache.set(jid, entry);
@@ -374,6 +389,9 @@ export async function monitorWebInbox(options: {
     enriched: EnrichedInboundMessage,
   ) => {
     const chatJid = inbound.remoteJid;
+    // Retrieve the participant JID map from the cached group metadata so
+    // outbound @mentions resolve to the correct JID type (phone vs LID).
+    const groupJidMap = inbound.group ? groupMetaCache.get(chatJid)?.participantJidMap : undefined;
     const sendComposing = async () => {
       try {
         await sock.sendPresenceUpdate("composing", chatJid);
@@ -382,10 +400,20 @@ export async function monitorWebInbox(options: {
       }
     };
     const reply = async (text: string) => {
-      await sendTrackedMessage(chatJid, { text });
+      const mentions = inbound.access.isSelfChat ? [] : extractOutboundMentions(text, groupJidMap);
+      await sendTrackedMessage(chatJid, {
+        text,
+        ...(mentions.length > 0 ? { mentions } : {}),
+      });
     };
     const sendMedia = async (payload: AnyMessageContent) => {
-      await sendTrackedMessage(chatJid, payload);
+      const caption = "caption" in payload ? (payload as { caption?: string }).caption : undefined;
+      const mentions =
+        caption && !inbound.access.isSelfChat ? extractOutboundMentions(caption, groupJidMap) : [];
+      await sendTrackedMessage(
+        chatJid,
+        mentions.length > 0 ? ({ ...payload, mentions } as AnyMessageContent) : payload,
+      );
     };
     const timestamp = inbound.messageTimestampMs;
     const mentionedJids = extractMentionedJids(msg.message as proto.IMessage | undefined);

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -185,7 +185,9 @@ export async function monitorWebInbox(options: {
               const resolved = mapped ?? p.id;
               // Map normalized display number → original JID so outbound mentions
               // use the correct JID type (phone @s.whatsapp.net vs LID @lid).
-              const normalized = normalizeE164(resolved);
+              // Strip device suffix before normalizing so LID JIDs like
+              // "123456:1@hosted.lid" don't merge the device digit into the number.
+              const normalized = normalizeE164(resolved.replace(/:[\d]+@/, "@"));
               if (normalized) {
                 participantJidMap.set(normalized, p.id);
               }

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -189,6 +189,13 @@ export async function monitorWebInbox(options: {
               if (normalized) {
                 participantJidMap.set(normalized, p.id);
               }
+              // Also map the raw JID digits so the agent can mention using
+              // either the resolved phone or the raw LID number it sees in
+              // inbound message bodies (e.g. "@101653353078797").
+              const rawDigits = p.id.replace(/:.*/, "").replace(/@.*/, "");
+              if (rawDigits && rawDigits !== normalized?.replace(/^\+/, "")) {
+                participantJidMap.set(`+${rawDigits}`, p.id);
+              }
               return resolved;
             }) ?? [],
           )

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -398,9 +398,12 @@ export async function monitorWebInbox(options: {
     enriched: EnrichedInboundMessage,
   ) => {
     const chatJid = inbound.remoteJid;
-    // Retrieve the participant JID map from the cached group metadata so
-    // outbound @mentions resolve to the correct JID type (phone vs LID).
-    const groupJidMap = inbound.group ? groupMetaCache.get(chatJid)?.participantJidMap : undefined;
+    // Retrieve the participant JID map via getGroupMeta() (which checks
+    // expiry and refreshes when stale) so outbound @mentions resolve to
+    // the correct JID type (phone vs LID).
+    const groupJidMap = inbound.group
+      ? (await getGroupMeta(chatJid))?.participantJidMap
+      : undefined;
     const sendComposing = async () => {
       try {
         await sock.sendPresenceUpdate("composing", chatJid);

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -412,20 +412,31 @@ export async function monitorWebInbox(options: {
       }
     };
     const reply = async (text: string) => {
-      const mentions = inbound.access.isSelfChat ? [] : extractOutboundMentions(text, groupJidMap);
+      const { jids: mentions, text: updatedText } = inbound.access.isSelfChat
+        ? { jids: [], text }
+        : extractOutboundMentions(text, groupJidMap);
       await sendTrackedMessage(chatJid, {
-        text,
+        text: updatedText,
         ...(mentions.length > 0 ? { mentions } : {}),
       });
     };
     const sendMedia = async (payload: AnyMessageContent) => {
       const caption = "caption" in payload ? (payload as { caption?: string }).caption : undefined;
-      const mentions =
-        caption && !inbound.access.isSelfChat ? extractOutboundMentions(caption, groupJidMap) : [];
-      await sendTrackedMessage(
-        chatJid,
-        mentions.length > 0 ? ({ ...payload, mentions } as AnyMessageContent) : payload,
-      );
+      if (caption && !inbound.access.isSelfChat) {
+        const { jids: mentions, text: updatedCaption } = extractOutboundMentions(
+          caption,
+          groupJidMap,
+        );
+        if (mentions.length > 0) {
+          await sendTrackedMessage(chatJid, {
+            ...payload,
+            caption: updatedCaption,
+            mentions,
+          } as AnyMessageContent);
+          return;
+        }
+      }
+      await sendTrackedMessage(chatJid, payload);
     };
     const timestamp = inbound.messageTimestampMs;
     const mentionedJids = extractMentionedJids(msg.message as proto.IMessage | undefined);

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -137,6 +137,15 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("(@+1234567890)")).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
+  it("matches colon-terminated mentions", () => {
+    expect(extractOutboundMentions("@+1234567890: please check")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+    expect(extractOutboundMentions("@1234567890: what do you think?")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+  });
+
   describe("with participantJidMap", () => {
     it("uses original JID from map for phone-based participants", () => {
       const jidMap = new Map([["+1234567890", "1234567890:0@s.whatsapp.net"]]);

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -90,6 +90,14 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("x`y`@1234567890")).toEqual([]);
   });
 
+  it("skips mentions inside multi-backtick code spans", () => {
+    expect(extractOutboundMentions("`` @+1234567890 ``")).toEqual([]);
+    expect(extractOutboundMentions("```@+1234567890```")).toEqual([]);
+    expect(extractOutboundMentions("`` @+1234567890 `` but @+9876543210 outside")).toEqual([
+      "9876543210@s.whatsapp.net",
+    ]);
+  });
+
   it("matches mention followed by punctuation", () => {
     expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
       "1234567890@s.whatsapp.net",

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -98,11 +98,20 @@ describe("extractOutboundMentions", () => {
     ]);
   });
 
+  it("ignores dotted suffixes like filenames and domains", () => {
+    expect(extractOutboundMentions("@1234567.json")).toEqual([]);
+    expect(extractOutboundMentions("@1234567.com")).toEqual([]);
+    expect(extractOutboundMentions("@1234567.89")).toEqual([]);
+  });
+
+  it("still matches mention followed by sentence-ending period", () => {
+    expect(extractOutboundMentions("ask @+1234567890.")).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
   it("matches mention followed by punctuation", () => {
     expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("ask @+1234567890.")).toEqual(["1234567890@s.whatsapp.net"]);
     expect(extractOutboundMentions("(@+1234567890)")).toEqual(["1234567890@s.whatsapp.net"]);
   });
 

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -113,6 +113,14 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("ask @+1234567890.")).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
+  it("matches mention preceded by punctuation (comma, period, exclamation)", () => {
+    expect(extractOutboundMentions("Great,@+1234567890 please review")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+    expect(extractOutboundMentions("Done!@+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("see:@+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
   it("matches mention followed by punctuation", () => {
     expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
       "1234567890@s.whatsapp.net",

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -58,6 +58,11 @@ describe("extractOutboundMentions", () => {
     ]);
   });
 
+  it("ignores email-like patterns where @ is not at token start", () => {
+    expect(extractOutboundMentions("contact@1234567890 for info")).toEqual([]);
+    expect(extractOutboundMentions("user@+9876543210")).toEqual([]);
+  });
+
   describe("with participantJidMap", () => {
     it("uses original JID from map for phone-based participants", () => {
       const jidMap = new Map([["+1234567890", "1234567890:0@s.whatsapp.net"]]);

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -68,11 +68,21 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("@1234567890abc")).toEqual([]);
   });
 
+  it("ignores tokens with underscore, dash, or slash suffix", () => {
+    expect(extractOutboundMentions("@1234567_user")).toEqual([]);
+    expect(extractOutboundMentions("@1234567-foo")).toEqual([]);
+    expect(extractOutboundMentions("@1234567/bar")).toEqual([]);
+  });
+
   it("skips mentions inside backtick code spans", () => {
     expect(extractOutboundMentions("see `@+1234567890` for details")).toEqual([]);
     expect(
       extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside"),
     ).toEqual(["9876543210@s.whatsapp.net"]);
+  });
+
+  it("does not create false mention when code span removal merges tokens", () => {
+    expect(extractOutboundMentions("x`y`@1234567890")).toEqual([]);
   });
 
   it("matches mention followed by punctuation", () => {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -74,6 +74,11 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("@1234567/bar")).toEqual([]);
   });
 
+  it("ignores tokens with non-ASCII letter suffix", () => {
+    expect(extractOutboundMentions("@1234567中文")).toEqual([]);
+    expect(extractOutboundMentions("@1234567é")).toEqual([]);
+  });
+
   it("skips mentions inside backtick code spans", () => {
     expect(extractOutboundMentions("see `@+1234567890` for details")).toEqual([]);
     expect(

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -79,6 +79,11 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("@1234567é")).toEqual([]);
   });
 
+  it("ignores tokens with non-ASCII digit suffix (Arabic-Indic, fullwidth)", () => {
+    expect(extractOutboundMentions("@1234567\u0661")).toEqual([]); // Arabic-Indic ١
+    expect(extractOutboundMentions("@1234567\uFF12")).toEqual([]); // Fullwidth ２
+  });
+
   it("skips mentions inside backtick code spans", () => {
     expect(extractOutboundMentions("see `@+1234567890` for details")).toEqual([]);
     expect(extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside")).toEqual([

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -63,6 +63,30 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("user@+9876543210")).toEqual([]);
   });
 
+  it("ignores pasted JID-like tokens with trailing non-boundary chars", () => {
+    expect(extractOutboundMentions("@123456789012345:1@lid")).toEqual([]);
+    expect(extractOutboundMentions("@1234567890abc")).toEqual([]);
+  });
+
+  it("skips mentions inside backtick code spans", () => {
+    expect(extractOutboundMentions("see `@+1234567890` for details")).toEqual([]);
+    expect(
+      extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside"),
+    ).toEqual(["9876543210@s.whatsapp.net"]);
+  });
+
+  it("matches mention followed by punctuation", () => {
+    expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+    expect(extractOutboundMentions("ask @+1234567890.")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+    expect(extractOutboundMentions("(@+1234567890)")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+  });
+
   describe("with participantJidMap", () => {
     it("uses original JID from map for phone-based participants", () => {
       const jidMap = new Map([["+1234567890", "1234567890:0@s.whatsapp.net"]]);

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -81,9 +81,9 @@ describe("extractOutboundMentions", () => {
 
   it("skips mentions inside backtick code spans", () => {
     expect(extractOutboundMentions("see `@+1234567890` for details")).toEqual([]);
-    expect(
-      extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside"),
-    ).toEqual(["9876543210@s.whatsapp.net"]);
+    expect(extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside")).toEqual([
+      "9876543210@s.whatsapp.net",
+    ]);
   });
 
   it("does not create false mention when code span removal merges tokens", () => {
@@ -94,12 +94,8 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("ask @+1234567890.")).toEqual([
-      "1234567890@s.whatsapp.net",
-    ]);
-    expect(extractOutboundMentions("(@+1234567890)")).toEqual([
-      "1234567890@s.whatsapp.net",
-    ]);
+    expect(extractOutboundMentions("ask @+1234567890.")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("(@+1234567890)")).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   describe("with participantJidMap", () => {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { extractOutboundMentions } from "./outbound-mentions.js";
+
+describe("extractOutboundMentions", () => {
+  it("returns empty array for text with no mentions", () => {
+    expect(extractOutboundMentions("Hello world")).toEqual([]);
+  });
+
+  it("extracts single mention with plus prefix", () => {
+    expect(extractOutboundMentions("Hey @+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("extracts single mention without plus prefix", () => {
+    expect(extractOutboundMentions("Hey @1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("extracts multiple mentions", () => {
+    const result = extractOutboundMentions("Hey @+1234567890 and @+9876543210!");
+    expect(result).toEqual(["1234567890@s.whatsapp.net", "9876543210@s.whatsapp.net"]);
+  });
+
+  it("deduplicates repeated mentions", () => {
+    const result = extractOutboundMentions("@+1234567890 and @+1234567890 again");
+    expect(result).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("deduplicates same number with and without plus", () => {
+    const result = extractOutboundMentions("@+1234567890 and @1234567890");
+    expect(result).toEqual(["1234567890@s.whatsapp.net"]);
+  });
+
+  it("ignores too-short digit sequences (< 7 digits)", () => {
+    expect(extractOutboundMentions("@123456")).toEqual([]);
+    expect(extractOutboundMentions("@12345")).toEqual([]);
+  });
+
+  it("accepts 7-digit numbers", () => {
+    expect(extractOutboundMentions("@1234567")).toEqual(["1234567@s.whatsapp.net"]);
+  });
+
+  it("accepts 15-digit numbers (E.164 max)", () => {
+    expect(extractOutboundMentions("@123456789012345")).toEqual(["123456789012345@s.whatsapp.net"]);
+  });
+
+  it("accepts LID-length numbers (up to 25 digits)", () => {
+    expect(extractOutboundMentions("@1234567890123456789")).toEqual([
+      "1234567890123456789@s.whatsapp.net",
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(extractOutboundMentions("")).toEqual([]);
+  });
+
+  it("handles mention embedded in sentence", () => {
+    expect(extractOutboundMentions("Check with @+85291234567 about the plan")).toEqual([
+      "85291234567@s.whatsapp.net",
+    ]);
+  });
+
+  describe("with participantJidMap", () => {
+    it("uses original JID from map for phone-based participants", () => {
+      const jidMap = new Map([["+1234567890", "1234567890:0@s.whatsapp.net"]]);
+      expect(extractOutboundMentions("Hey @+1234567890", jidMap)).toEqual([
+        "1234567890:0@s.whatsapp.net",
+      ]);
+    });
+
+    it("uses original LID JID from map instead of defaulting to @s.whatsapp.net", () => {
+      const jidMap = new Map([["+1234567890123456789", "1234567890123456789:0@lid"]]);
+      expect(extractOutboundMentions("Hey @+1234567890123456789", jidMap)).toEqual([
+        "1234567890123456789:0@lid",
+      ]);
+    });
+
+    it("falls back to @s.whatsapp.net when number not in map", () => {
+      const jidMap = new Map([["+9999999999", "9999999999@s.whatsapp.net"]]);
+      expect(extractOutboundMentions("Hey @+1234567890", jidMap)).toEqual([
+        "1234567890@s.whatsapp.net",
+      ]);
+    });
+
+    it("handles mix of mapped and unmapped mentions", () => {
+      const jidMap = new Map([
+        ["+1234567890", "1234567890@s.whatsapp.net"],
+        ["+9876543210123456789", "9876543210123456789:0@lid"],
+      ]);
+      const result = extractOutboundMentions(
+        "Hey @+1234567890 and @+9876543210123456789 and @+5555555555",
+        jidMap,
+      );
+      expect(result).toEqual([
+        "1234567890@s.whatsapp.net",
+        "9876543210123456789:0@lid",
+        "5555555555@s.whatsapp.net",
+      ]);
+    });
+
+    it("resolves LID mention correctly with hosted.lid suffix", () => {
+      const jidMap = new Map([["+12345678901234567890", "12345678901234567890:1@hosted.lid"]]);
+      expect(extractOutboundMentions("@+12345678901234567890", jidMap)).toEqual([
+        "12345678901234567890:1@hosted.lid",
+      ]);
+    });
+  });
+});

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -121,7 +121,9 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("Great,@+1234567890 please review").jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("Done!@+1234567890").jids).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("Done!@+1234567890").jids).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
     expect(extractOutboundMentions("see:@+1234567890").jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -121,6 +121,15 @@ describe("extractOutboundMentions", () => {
     expect(extractOutboundMentions("see:@+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
+  it("matches mention inside quotes", () => {
+    expect(extractOutboundMentions('"@+1234567890" please review')).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+    expect(extractOutboundMentions("'@1234567890' is the contact")).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
+  });
+
   it("matches mention followed by punctuation", () => {
     expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
       "1234567890@s.whatsapp.net",

--- a/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.test.ts
@@ -3,145 +3,149 @@ import { extractOutboundMentions } from "./outbound-mentions.js";
 
 describe("extractOutboundMentions", () => {
   it("returns empty array for text with no mentions", () => {
-    expect(extractOutboundMentions("Hello world")).toEqual([]);
+    expect(extractOutboundMentions("Hello world").jids).toEqual([]);
   });
 
   it("extracts single mention with plus prefix", () => {
-    expect(extractOutboundMentions("Hey @+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("Hey @+1234567890").jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   it("extracts single mention without plus prefix", () => {
-    expect(extractOutboundMentions("Hey @1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("Hey @1234567890").jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   it("extracts multiple mentions", () => {
     const result = extractOutboundMentions("Hey @+1234567890 and @+9876543210!");
-    expect(result).toEqual(["1234567890@s.whatsapp.net", "9876543210@s.whatsapp.net"]);
+    expect(result.jids).toEqual(["1234567890@s.whatsapp.net", "9876543210@s.whatsapp.net"]);
   });
 
   it("deduplicates repeated mentions", () => {
     const result = extractOutboundMentions("@+1234567890 and @+1234567890 again");
-    expect(result).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(result.jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   it("deduplicates same number with and without plus", () => {
     const result = extractOutboundMentions("@+1234567890 and @1234567890");
-    expect(result).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(result.jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   it("ignores too-short digit sequences (< 7 digits)", () => {
-    expect(extractOutboundMentions("@123456")).toEqual([]);
-    expect(extractOutboundMentions("@12345")).toEqual([]);
+    expect(extractOutboundMentions("@123456").jids).toEqual([]);
+    expect(extractOutboundMentions("@12345").jids).toEqual([]);
   });
 
   it("accepts 7-digit numbers", () => {
-    expect(extractOutboundMentions("@1234567")).toEqual(["1234567@s.whatsapp.net"]);
+    expect(extractOutboundMentions("@1234567").jids).toEqual(["1234567@s.whatsapp.net"]);
   });
 
   it("accepts 15-digit numbers (E.164 max)", () => {
-    expect(extractOutboundMentions("@123456789012345")).toEqual(["123456789012345@s.whatsapp.net"]);
+    expect(extractOutboundMentions("@123456789012345").jids).toEqual([
+      "123456789012345@s.whatsapp.net",
+    ]);
   });
 
   it("accepts LID-length numbers (up to 25 digits)", () => {
-    expect(extractOutboundMentions("@1234567890123456789")).toEqual([
+    expect(extractOutboundMentions("@1234567890123456789").jids).toEqual([
       "1234567890123456789@s.whatsapp.net",
     ]);
   });
 
   it("returns empty array for empty string", () => {
-    expect(extractOutboundMentions("")).toEqual([]);
+    expect(extractOutboundMentions("").jids).toEqual([]);
   });
 
   it("handles mention embedded in sentence", () => {
-    expect(extractOutboundMentions("Check with @+85291234567 about the plan")).toEqual([
+    expect(extractOutboundMentions("Check with @+85291234567 about the plan").jids).toEqual([
       "85291234567@s.whatsapp.net",
     ]);
   });
 
   it("ignores email-like patterns where @ is not at token start", () => {
-    expect(extractOutboundMentions("contact@1234567890 for info")).toEqual([]);
-    expect(extractOutboundMentions("user@+9876543210")).toEqual([]);
+    expect(extractOutboundMentions("contact@1234567890 for info").jids).toEqual([]);
+    expect(extractOutboundMentions("user@+9876543210").jids).toEqual([]);
   });
 
   it("ignores pasted JID-like tokens with trailing non-boundary chars", () => {
-    expect(extractOutboundMentions("@123456789012345:1@lid")).toEqual([]);
-    expect(extractOutboundMentions("@1234567890abc")).toEqual([]);
+    expect(extractOutboundMentions("@123456789012345:1@lid").jids).toEqual([]);
+    expect(extractOutboundMentions("@1234567890abc").jids).toEqual([]);
   });
 
   it("ignores tokens with underscore, dash, or slash suffix", () => {
-    expect(extractOutboundMentions("@1234567_user")).toEqual([]);
-    expect(extractOutboundMentions("@1234567-foo")).toEqual([]);
-    expect(extractOutboundMentions("@1234567/bar")).toEqual([]);
+    expect(extractOutboundMentions("@1234567_user").jids).toEqual([]);
+    expect(extractOutboundMentions("@1234567-foo").jids).toEqual([]);
+    expect(extractOutboundMentions("@1234567/bar").jids).toEqual([]);
   });
 
   it("ignores tokens with non-ASCII letter suffix", () => {
-    expect(extractOutboundMentions("@1234567中文")).toEqual([]);
-    expect(extractOutboundMentions("@1234567é")).toEqual([]);
+    expect(extractOutboundMentions("@1234567中文").jids).toEqual([]);
+    expect(extractOutboundMentions("@1234567é").jids).toEqual([]);
   });
 
   it("ignores tokens with non-ASCII digit suffix (Arabic-Indic, fullwidth)", () => {
-    expect(extractOutboundMentions("@1234567\u0661")).toEqual([]); // Arabic-Indic ١
-    expect(extractOutboundMentions("@1234567\uFF12")).toEqual([]); // Fullwidth ２
+    expect(extractOutboundMentions("@1234567\u0661").jids).toEqual([]); // Arabic-Indic ١
+    expect(extractOutboundMentions("@1234567\uFF12").jids).toEqual([]); // Fullwidth ２
   });
 
   it("skips mentions inside backtick code spans", () => {
-    expect(extractOutboundMentions("see `@+1234567890` for details")).toEqual([]);
-    expect(extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside")).toEqual([
-      "9876543210@s.whatsapp.net",
-    ]);
+    expect(extractOutboundMentions("see `@+1234567890` for details").jids).toEqual([]);
+    expect(
+      extractOutboundMentions("code `@+1234567890` but also @+9876543210 outside").jids,
+    ).toEqual(["9876543210@s.whatsapp.net"]);
   });
 
   it("does not create false mention when code span removal merges tokens", () => {
-    expect(extractOutboundMentions("x`y`@1234567890")).toEqual([]);
+    expect(extractOutboundMentions("x`y`@1234567890").jids).toEqual([]);
   });
 
   it("skips mentions inside multi-backtick code spans", () => {
-    expect(extractOutboundMentions("`` @+1234567890 ``")).toEqual([]);
-    expect(extractOutboundMentions("```@+1234567890```")).toEqual([]);
-    expect(extractOutboundMentions("`` @+1234567890 `` but @+9876543210 outside")).toEqual([
+    expect(extractOutboundMentions("`` @+1234567890 ``").jids).toEqual([]);
+    expect(extractOutboundMentions("```@+1234567890```").jids).toEqual([]);
+    expect(extractOutboundMentions("`` @+1234567890 `` but @+9876543210 outside").jids).toEqual([
       "9876543210@s.whatsapp.net",
     ]);
   });
 
   it("ignores dotted suffixes like filenames and domains", () => {
-    expect(extractOutboundMentions("@1234567.json")).toEqual([]);
-    expect(extractOutboundMentions("@1234567.com")).toEqual([]);
-    expect(extractOutboundMentions("@1234567.89")).toEqual([]);
+    expect(extractOutboundMentions("@1234567.json").jids).toEqual([]);
+    expect(extractOutboundMentions("@1234567.com").jids).toEqual([]);
+    expect(extractOutboundMentions("@1234567.89").jids).toEqual([]);
   });
 
   it("still matches mention followed by sentence-ending period", () => {
-    expect(extractOutboundMentions("ask @+1234567890.")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("ask @+1234567890.").jids).toEqual([
+      "1234567890@s.whatsapp.net",
+    ]);
   });
 
   it("matches mention preceded by punctuation (comma, period, exclamation)", () => {
-    expect(extractOutboundMentions("Great,@+1234567890 please review")).toEqual([
+    expect(extractOutboundMentions("Great,@+1234567890 please review").jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("Done!@+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
-    expect(extractOutboundMentions("see:@+1234567890")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("Done!@+1234567890").jids).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("see:@+1234567890").jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   it("matches mention inside quotes", () => {
-    expect(extractOutboundMentions('"@+1234567890" please review')).toEqual([
+    expect(extractOutboundMentions('"@+1234567890" please review').jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("'@1234567890' is the contact")).toEqual([
+    expect(extractOutboundMentions("'@1234567890' is the contact").jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
   });
 
   it("matches mention followed by punctuation", () => {
-    expect(extractOutboundMentions("hey @+1234567890, what's up?")).toEqual([
+    expect(extractOutboundMentions("hey @+1234567890, what's up?").jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("(@+1234567890)")).toEqual(["1234567890@s.whatsapp.net"]);
+    expect(extractOutboundMentions("(@+1234567890)").jids).toEqual(["1234567890@s.whatsapp.net"]);
   });
 
   it("matches colon-terminated mentions", () => {
-    expect(extractOutboundMentions("@+1234567890: please check")).toEqual([
+    expect(extractOutboundMentions("@+1234567890: please check").jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
-    expect(extractOutboundMentions("@1234567890: what do you think?")).toEqual([
+    expect(extractOutboundMentions("@1234567890: what do you think?").jids).toEqual([
       "1234567890@s.whatsapp.net",
     ]);
   });
@@ -149,21 +153,21 @@ describe("extractOutboundMentions", () => {
   describe("with participantJidMap", () => {
     it("uses original JID from map for phone-based participants", () => {
       const jidMap = new Map([["+1234567890", "1234567890:0@s.whatsapp.net"]]);
-      expect(extractOutboundMentions("Hey @+1234567890", jidMap)).toEqual([
+      expect(extractOutboundMentions("Hey @+1234567890", jidMap).jids).toEqual([
         "1234567890:0@s.whatsapp.net",
       ]);
     });
 
     it("uses original LID JID from map instead of defaulting to @s.whatsapp.net", () => {
       const jidMap = new Map([["+1234567890123456789", "1234567890123456789:0@lid"]]);
-      expect(extractOutboundMentions("Hey @+1234567890123456789", jidMap)).toEqual([
+      expect(extractOutboundMentions("Hey @+1234567890123456789", jidMap).jids).toEqual([
         "1234567890123456789:0@lid",
       ]);
     });
 
     it("falls back to @s.whatsapp.net when number not in map", () => {
       const jidMap = new Map([["+9999999999", "9999999999@s.whatsapp.net"]]);
-      expect(extractOutboundMentions("Hey @+1234567890", jidMap)).toEqual([
+      expect(extractOutboundMentions("Hey @+1234567890", jidMap).jids).toEqual([
         "1234567890@s.whatsapp.net",
       ]);
     });
@@ -177,7 +181,7 @@ describe("extractOutboundMentions", () => {
         "Hey @+1234567890 and @+9876543210123456789 and @+5555555555",
         jidMap,
       );
-      expect(result).toEqual([
+      expect(result.jids).toEqual([
         "1234567890@s.whatsapp.net",
         "9876543210123456789:0@lid",
         "5555555555@s.whatsapp.net",
@@ -186,7 +190,7 @@ describe("extractOutboundMentions", () => {
 
     it("resolves LID mention correctly with hosted.lid suffix", () => {
       const jidMap = new Map([["+12345678901234567890", "12345678901234567890:1@hosted.lid"]]);
-      expect(extractOutboundMentions("@+12345678901234567890", jidMap)).toEqual([
+      expect(extractOutboundMentions("@+12345678901234567890", jidMap).jids).toEqual([
         "12345678901234567890:1@hosted.lid",
       ]);
     });

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -22,7 +22,7 @@ export function extractOutboundMentions(
   // underscores (a non-boundary char) so that adjacent tokens don't merge
   // into false mentions and content inside code spans is never matched.
   const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
-  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}_\-/])(?!\.[\p{L}\d])/gu;
+  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -5,6 +5,11 @@
  * E.164 phone numbers and WhatsApp LID identifiers) and returns a deduplicated
  * array of JIDs suitable for Baileys' `mentions` field.
  *
+ * Requires both a leading token boundary (whitespace or start-of-string) and a
+ * trailing token boundary (whitespace, punctuation, or end-of-string) to avoid
+ * false positives on pasted JIDs like `@123456:1@lid` or `@1234567890abc`.
+ * Tokens inside backtick code spans are skipped.
+ *
  * When a `participantJidMap` is provided (mapping normalized "+digits" to the
  * participant's original JID), the original JID is used — this ensures LID
  * participants get `<lid>@lid` instead of the incorrect `<lid>@s.whatsapp.net`.
@@ -13,10 +18,12 @@ export function extractOutboundMentions(
   text: string,
   participantJidMap?: Map<string, string>,
 ): string[] {
-  const pattern = /(?<![^\s])@\+?(\d{7,25})/g;
+  // Strip inline code spans (`...`) to avoid matching pasted JIDs in technical messages.
+  const cleaned = text.replace(/`[^`]*`/g, "");
+  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@a-zA-Z])/g;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
-  while ((match = pattern.exec(text)) !== null) {
+  while ((match = pattern.exec(cleaned)) !== null) {
     const digits = match[1]!;
     const normalized = `+${digits}`;
     const originalJid = participantJidMap?.get(normalized);

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -22,7 +22,7 @@ export function extractOutboundMentions(
   // underscores (a non-boundary char) so that adjacent tokens don't merge
   // into false mentions and content inside code spans is never matched.
   const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
-  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
+  const pattern = /(?<=^|[\s({\[<,.!?:;>])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -22,7 +22,7 @@ export function extractOutboundMentions(
   // underscores (a non-boundary char) so that adjacent tokens don't merge
   // into false mentions and content inside code spans is never matched.
   const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
-  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}_\-/])/gu;
+  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}_\-/])(?!\.[\p{L}\d])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -23,7 +23,7 @@ export function extractOutboundMentions(
   // into false mentions and content inside code spans is never matched.
   const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
   const pattern =
-    /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
+    /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])(?!:\d)/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -22,7 +22,7 @@ export function extractOutboundMentions(
   // adjacent tokens don't merge into false mentions and content inside code
   // spans is never matched.
   const cleaned = text.replace(/`[^`]*`/g, (m) => "_".repeat(m.length));
-  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@a-zA-Z_\-/])/g;
+  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}_\-/])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -38,8 +38,10 @@ export function extractOutboundMentions(
   const pattern =
     /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])(?!:\d)/gu;
   const jids = new Set<string>();
-  // Track text replacements: original token → replacement token
-  const replacements: Array<{ from: string; to: string }> = [];
+  // Track text replacements by position (offset in `cleaned`, which has same
+  // length as `text`). Position-based replacement avoids accidentally rewriting
+  // tokens inside code spans that happen to share the same text.
+  const replacements: Array<{ start: number; end: number; to: string }> = [];
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {
     const fullToken = match[0]!; // e.g. "@+85251159218"
@@ -50,20 +52,26 @@ export function extractOutboundMentions(
       // LID participant: use LID JID and rewrite text token to match.
       // Baileys 7 rc9 uses "@lid" suffix; future versions may use "@hosted.lid".
       jids.add(originalJid);
-      const lidDigits = originalJid.replace(/@.*/, "");
+      // Strip device suffix (e.g. "123456:1@lid" → "123456") before building
+      // the replacement token — the `:N` qualifier is protocol-internal.
+      const lidDigits = originalJid.replace(/:[\d]+@/, "@").replace(/@.*/, "");
       const newToken = `@${lidDigits}`;
       if (fullToken !== newToken) {
-        replacements.push({ from: fullToken, to: newToken });
+        replacements.push({
+          start: match.index,
+          end: match.index + fullToken.length,
+          to: newToken,
+        });
       }
     } else {
       // Phone participant or no map: use phone JID
       jids.add(originalJid ?? `${digits}@s.whatsapp.net`);
     }
   }
-  // Apply text replacements
+  // Apply text replacements in reverse order so earlier offsets stay valid
   let updatedText = text;
-  for (const { from, to } of replacements) {
-    updatedText = updatedText.replaceAll(from, to);
+  for (const r of replacements.sort((a, b) => b.start - a.start)) {
+    updatedText = updatedText.slice(0, r.start) + r.to + updatedText.slice(r.end);
   }
   return { jids: Array.from(jids), text: updatedText };
 }

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -1,0 +1,26 @@
+/**
+ * Extract native WhatsApp mention JIDs from outbound message text.
+ *
+ * Scans for `@+<digits>` or `@<digits>` patterns (7–25 digits, covers both
+ * E.164 phone numbers and WhatsApp LID identifiers) and returns a deduplicated
+ * array of JIDs suitable for Baileys' `mentions` field.
+ *
+ * When a `participantJidMap` is provided (mapping normalized "+digits" to the
+ * participant's original JID), the original JID is used — this ensures LID
+ * participants get `<lid>@lid` instead of the incorrect `<lid>@s.whatsapp.net`.
+ */
+export function extractOutboundMentions(
+  text: string,
+  participantJidMap?: Map<string, string>,
+): string[] {
+  const pattern = /@\+?(\d{7,25})/g;
+  const jids = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    const digits = match[1]!;
+    const normalized = `+${digits}`;
+    const originalJid = participantJidMap?.get(normalized);
+    jids.add(originalJid ?? `${digits}@s.whatsapp.net`);
+  }
+  return Array.from(jids);
+}

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -18,10 +18,10 @@ export function extractOutboundMentions(
   text: string,
   participantJidMap?: Map<string, string>,
 ): string[] {
-  // Replace inline code spans with underscores (a non-boundary char) so that
-  // adjacent tokens don't merge into false mentions and content inside code
-  // spans is never matched.
-  const cleaned = text.replace(/`[^`]*`/g, (m) => "_".repeat(m.length));
+  // Replace inline code spans (single, double, and triple backtick) with
+  // underscores (a non-boundary char) so that adjacent tokens don't merge
+  // into false mentions and content inside code spans is never matched.
+  const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
   const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@\p{L}_\-/])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -18,9 +18,11 @@ export function extractOutboundMentions(
   text: string,
   participantJidMap?: Map<string, string>,
 ): string[] {
-  // Strip inline code spans (`...`) to avoid matching pasted JIDs in technical messages.
-  const cleaned = text.replace(/`[^`]*`/g, "");
-  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@a-zA-Z])/g;
+  // Replace inline code spans with underscores (a non-boundary char) so that
+  // adjacent tokens don't merge into false mentions and content inside code
+  // spans is never matched.
+  const cleaned = text.replace(/`[^`]*`/g, (m) => "_".repeat(m.length));
+  const pattern = /(?<=^|[\s({\[<])@\+?(\d{7,25})(?![:\d@a-zA-Z_\-/])/g;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -13,7 +13,7 @@ export function extractOutboundMentions(
   text: string,
   participantJidMap?: Map<string, string>,
 ): string[] {
-  const pattern = /@\+?(\d{7,25})/g;
+  const pattern = /(?<![^\s])@\+?(\d{7,25})/g;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(text)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -22,7 +22,8 @@ export function extractOutboundMentions(
   // underscores (a non-boundary char) so that adjacent tokens don't merge
   // into false mentions and content inside code spans is never matched.
   const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
-  const pattern = /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
+  const pattern =
+    /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -22,7 +22,7 @@ export function extractOutboundMentions(
   // underscores (a non-boundary char) so that adjacent tokens don't merge
   // into false mentions and content inside code spans is never matched.
   const cleaned = text.replace(/(`{1,3})[\s\S]*?\1/g, (m) => "_".repeat(m.length));
-  const pattern = /(?<=^|[\s({\[<,.!?:;>])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
+  const pattern = /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![:\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])/gu;
   const jids = new Set<string>();
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -46,8 +46,9 @@ export function extractOutboundMentions(
     const digits = match[1]!; // e.g. "85251159218"
     const normalized = `+${digits}`;
     const originalJid = participantJidMap?.get(normalized);
-    if (originalJid && originalJid.endsWith("@lid")) {
-      // LID participant: use LID JID and rewrite text token to match
+    if (originalJid && (originalJid.endsWith("@lid") || originalJid.includes("@lid"))) {
+      // LID participant: use LID JID and rewrite text token to match.
+      // Baileys 7 rc9 uses "@lid" suffix; future versions may use "@hosted.lid".
       jids.add(originalJid);
       const lidDigits = originalJid.replace(/@.*/, "");
       const newToken = `@${lidDigits}`;
@@ -62,7 +63,7 @@ export function extractOutboundMentions(
   // Apply text replacements
   let updatedText = text;
   for (const { from, to } of replacements) {
-    updatedText = updatedText.replace(from, to);
+    updatedText = updatedText.replaceAll(from, to);
   }
   return { jids: Array.from(jids), text: updatedText };
 }

--- a/extensions/whatsapp/src/inbound/outbound-mentions.ts
+++ b/extensions/whatsapp/src/inbound/outbound-mentions.ts
@@ -1,23 +1,36 @@
 /**
+ * Result of outbound mention extraction, containing both the JIDs for Baileys'
+ * `mentions` field and an updated text where phone-number tokens have been
+ * replaced with the corresponding LID numbers when necessary.
+ */
+export interface OutboundMentionResult {
+  /** JIDs suitable for Baileys' `mentions` field */
+  jids: string[];
+  /** Updated text with phone tokens replaced to match the mention JIDs */
+  text: string;
+}
+
+/**
  * Extract native WhatsApp mention JIDs from outbound message text.
  *
  * Scans for `@+<digits>` or `@<digits>` patterns (7–25 digits, covers both
  * E.164 phone numbers and WhatsApp LID identifiers) and returns a deduplicated
  * array of JIDs suitable for Baileys' `mentions` field.
  *
+ * When a `participantJidMap` is provided and a match resolves to a LID JID,
+ * the text token is rewritten (e.g. `@+85251159218` → `@60065218322686`) so
+ * the mention number in the text matches the JID — WhatsApp requires this for
+ * mentions to render as clickable.
+ *
  * Requires both a leading token boundary (whitespace or start-of-string) and a
  * trailing token boundary (whitespace, punctuation, or end-of-string) to avoid
  * false positives on pasted JIDs like `@123456:1@lid` or `@1234567890abc`.
  * Tokens inside backtick code spans are skipped.
- *
- * When a `participantJidMap` is provided (mapping normalized "+digits" to the
- * participant's original JID), the original JID is used — this ensures LID
- * participants get `<lid>@lid` instead of the incorrect `<lid>@s.whatsapp.net`.
  */
 export function extractOutboundMentions(
   text: string,
   participantJidMap?: Map<string, string>,
-): string[] {
+): OutboundMentionResult {
   // Replace inline code spans (single, double, and triple backtick) with
   // underscores (a non-boundary char) so that adjacent tokens don't merge
   // into false mentions and content inside code spans is never matched.
@@ -25,12 +38,31 @@ export function extractOutboundMentions(
   const pattern =
     /(?<=^|[\s({\[<,.!?:;>"'])@\+?(\d{7,25})(?![\d@\p{L}\p{N}_\-/])(?!\.[\p{L}\d])(?!:\d)/gu;
   const jids = new Set<string>();
+  // Track text replacements: original token → replacement token
+  const replacements: Array<{ from: string; to: string }> = [];
   let match: RegExpExecArray | null;
   while ((match = pattern.exec(cleaned)) !== null) {
-    const digits = match[1]!;
+    const fullToken = match[0]!; // e.g. "@+85251159218"
+    const digits = match[1]!; // e.g. "85251159218"
     const normalized = `+${digits}`;
     const originalJid = participantJidMap?.get(normalized);
-    jids.add(originalJid ?? `${digits}@s.whatsapp.net`);
+    if (originalJid && originalJid.endsWith("@lid")) {
+      // LID participant: use LID JID and rewrite text token to match
+      jids.add(originalJid);
+      const lidDigits = originalJid.replace(/@.*/, "");
+      const newToken = `@${lidDigits}`;
+      if (fullToken !== newToken) {
+        replacements.push({ from: fullToken, to: newToken });
+      }
+    } else {
+      // Phone participant or no map: use phone JID
+      jids.add(originalJid ?? `${digits}@s.whatsapp.net`);
+    }
   }
-  return Array.from(jids);
+  // Apply text replacements
+  let updatedText = text;
+  for (const { from, to } of replacements) {
+    updatedText = updatedText.replace(from, to);
+  }
+  return { jids: Array.from(jids), text: updatedText };
 }

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -18,6 +18,10 @@ function resolveOutboundMessageId(result: unknown): string {
     : "unknown";
 }
 
+// Known limitation: this helper has no access to the per-group participantJidMap
+// that monitor.ts builds for auto-reply closures. Mentions through this path
+// (CLI `message send`, message tool, sendApi IPC) default to @s.whatsapp.net,
+// which is incorrect for LID-based participants. The auto-reply path is unaffected.
 function mentionsSpread(text: string | undefined): { mentions: string[] } | Record<string, never> {
   if (!text) return {};
   const mentions = extractOutboundMentions(text);

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -2,6 +2,7 @@ import type { AnyMessageContent, WAPresence } from "@whiskeysockets/baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { toWhatsappJid } from "openclaw/plugin-sdk/text-runtime";
 import type { ActiveWebSendOptions } from "../active-listener.js";
+import { extractOutboundMentions } from "./outbound-mentions.js";
 
 function recordWhatsAppOutbound(accountId: string) {
   recordChannelActivity({
@@ -15,6 +16,12 @@ function resolveOutboundMessageId(result: unknown): string {
   return typeof result === "object" && result && "key" in result
     ? String((result as { key?: { id?: string } }).key?.id ?? "unknown")
     : "unknown";
+}
+
+function mentionsSpread(text: string | undefined): { mentions: string[] } | Record<string, never> {
+  if (!text) return {};
+  const mentions = extractOutboundMentions(text);
+  return mentions.length > 0 ? { mentions } : {};
 }
 
 export function createWebSendApi(params: {
@@ -40,6 +47,7 @@ export function createWebSendApi(params: {
             image: mediaBuffer,
             caption: text || undefined,
             mimetype: mediaType,
+            ...mentionsSpread(text),
           };
         } else if (mediaType.startsWith("audio/")) {
           payload = { audio: mediaBuffer, ptt: true, mimetype: mediaType };
@@ -50,6 +58,7 @@ export function createWebSendApi(params: {
             caption: text || undefined,
             mimetype: mediaType,
             ...(gifPlayback ? { gifPlayback: true } : {}),
+            ...mentionsSpread(text),
           };
         } else {
           const fileName = sendOptions?.fileName?.trim() || "file";
@@ -61,7 +70,7 @@ export function createWebSendApi(params: {
           };
         }
       } else {
-        payload = { text };
+        payload = { text, ...mentionsSpread(text) };
       }
       const result = await params.sock.sendMessage(jid, payload);
       const accountId = sendOptions?.accountId ?? params.defaultAccountId;

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -67,6 +67,7 @@ export function createWebSendApi(params: {
             fileName,
             caption: text || undefined,
             mimetype: mediaType,
+            ...mentionsSpread(text),
           };
         }
       } else {

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -24,7 +24,7 @@ function resolveOutboundMessageId(result: unknown): string {
 // which is incorrect for LID-based participants. The auto-reply path is unaffected.
 function mentionsSpread(text: string | undefined): { mentions: string[] } | Record<string, never> {
   if (!text) return {};
-  const mentions = extractOutboundMentions(text);
+  const { jids: mentions } = extractOutboundMentions(text);
   return mentions.length > 0 ? { mentions } : {};
 }
 

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -162,6 +162,12 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
   }
   if (members) {
     lines.push(`Participants: ${members}.`);
+    const rawProvider = params.sessionCtx.Provider?.trim().toLowerCase();
+    if (rawProvider === "whatsapp") {
+      lines.push(
+        "To @mention a participant, write @<their phone number> in your reply (e.g. @+1234567890). This sends a native mention notification.",
+      );
+    }
   }
   lines.push(
     "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group — just reply normally.",

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -162,8 +162,8 @@ export function buildGroupChatContext(params: { sessionCtx: TemplateContext }): 
   }
   if (members) {
     lines.push(`Participants: ${members}.`);
-    const rawProvider = params.sessionCtx.Provider?.trim().toLowerCase();
-    if (rawProvider === "whatsapp") {
+    const providerId = resolveDockChannelId(params.sessionCtx.Provider?.trim());
+    if (providerId === "whatsapp") {
       lines.push(
         "To @mention a participant, write @<their phone number> in your reply (e.g. @+1234567890). This sends a native mention notification.",
       );


### PR DESCRIPTION
## Summary

- Problem: WhatsApp group replies from the agent never trigger native @mention push notifications, even when the agent references another participant by name/number.
- Why it matters: In busy WhatsApp groups, members miss replies directed at them because there's no notification highlight — the message looks like any other group message.
- What changed: Extract `@+<phone>` / `@<digits>` patterns from agent text/captions, resolve them to correct Baileys JIDs (including LID), and populate the `mentions` field so WhatsApp delivers native mention notifications.
- What did NOT change (scope boundary): Inbound mention handling, group metadata fetching logic (only added JID map population on top), non-WhatsApp channels.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #51059
- Supersedes #53009 (removed unrelated context-pruning commit)
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- Target test or file: `extensions/whatsapp/src/inbound/outbound-mentions.test.ts`
- Scenario the test should lock in: Mention extraction with word boundaries, code span skipping, Unicode-aware boundaries, LID JID map resolution, deduplication
- 25 unit tests covering normal mentions, edge cases (email-like, pasted JIDs, code spans, dotted suffixes, non-ASCII digits/letters, punctuation boundaries), and participantJidMap resolution

## User-visible / Behavior Changes

- In WhatsApp groups, when the agent mentions a participant using `@+<phone>` syntax, the mentioned user now receives a native WhatsApp mention notification (bold highlight + push notification).
- System prompt in WhatsApp group chats now includes a hint instructing the agent to use `@<phone>` to mention participants.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (uses existing `sock.sendMessage` with added `mentions` field)
- Command/tool execution surface changed? No
- Data access scope changed? No (group metadata was already fetched; we now build a JID map from it)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Integration/channel: WhatsApp (web provider via Baileys)

### Steps

1. Connect WhatsApp to openclaw gateway
2. In a WhatsApp group with the bot, send a message that triggers an agent reply mentioning another participant
3. Observe the reply in WhatsApp

### Expected

- The mentioned participant sees a native WhatsApp @mention notification

### Actual (before this PR)

- The reply is plain text with no mention metadata — no notification highlight

## Evidence

- [x] Failing test/log before + passing after
- [x] Screenshot/recording — Manual testing in WhatsApp group confirmed native mention notifications

## Human Verification (required)

- Verified scenarios: Agent reply with single mention, multiple mentions, LID participant mention, CLI `message send` with mention
- Edge cases checked: Code spans not triggering mentions, email-like patterns rejected, pasted JIDs rejected, Unicode boundaries
- What you did **not** verify: Cross-platform mention rendering (only tested on iOS/macOS WhatsApp)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; mentions field simply won't be populated, falling back to plain text (no mention notifications)
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Incorrect user being mentioned (wrong JID resolution), mention appearing as plain text in WhatsApp (Baileys API change)

## Risks and Mitigations

- Risk: Stale `participantJidMap` after group membership changes could resolve to wrong JID
  - Mitigation: Map is refreshed via `getGroupMeta()` on each inbound message (5min TTL cache). Window of staleness is seconds between message receipt and reply.
- Risk: CLI `message send` path has no JID map (uses `@s.whatsapp.net` fallback)
  - Mitigation: Documented as known limitation. Works for phone-based participants; LID participants won't get native notification via CLI path.