### PR TITLE
fix(feishu): make message-tool card schema optional

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 
@@ -161,6 +162,16 @@ describe("feishuPlugin actions", () => {
     ]);
   });
 
+  it("keeps card optional in the message tool schema", () => {
+    const discovery = feishuPlugin.actions?.describeMessageTool?.({ cfg });
+    const schema = discovery?.schema;
+    if (!schema || Array.isArray(schema)) {
+      throw new Error("expected feishu message-tool schema");
+    }
+
+    expect(Type.Object(schema.properties).required).toBeUndefined();
+  });
+
   it("sends text messages", async () => {
     sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
 
@@ -235,6 +246,37 @@ describe("feishuPlugin actions", () => {
       replyToId: undefined,
     });
     expect(result?.details).toMatchObject({ messageId: "om_media" });
+  });
+
+  it("sends media-only payloads through the outbound adapter without card", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media_only",
+      details: { messageId: "om_media_only", chatId: "oc_group_1" },
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        media: "/tmp/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: ["/tmp"],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "",
+      mediaUrl: "/tmp/image.png",
+      accountId: undefined,
+      mediaLocalRoots: ["/tmp"],
+      replyToId: undefined,
+    });
+    expect(result?.details).toMatchObject({ messageId: "om_media_only" });
   });
 
   it("reads messages", async () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createMessageToolCardSchema } from "openclaw/plugin-sdk/channel-actions";
@@ -108,7 +109,7 @@ function describeFeishuMessageTool({
       schema: enabled
         ? {
             properties: {
-              card: createMessageToolCardSchema(),
+              card: Type.Optional(createMessageToolCardSchema()),
             },
           }
         : null,
@@ -136,7 +137,7 @@ function describeFeishuMessageTool({
     schema: enabled
       ? {
           properties: {
-            card: createMessageToolCardSchema(),
+            card: Type.Optional(createMessageToolCardSchema()),
           },
         }
       : null,


### PR DESCRIPTION
## Summary
- make the Feishu message-tool `card` schema optional so text-only sends stop failing validation
- restore media-only Feishu sends by keeping `media` valid without forcing an incompatible `card`
- add regression coverage for optional schema handling and media-only send dispatch

## Testing
- `./node_modules/.bin/vitest run --config vitest.extensions.config.ts extensions/feishu/src/channel.test.ts --maxWorkers=1`
- `./node_modules/.bin/vitest run --config vitest.extensions.config.ts extensions/feishu/src/outbound.test.ts --maxWorkers=1`

Base: latest passing `main` commit `50d996a6ec7c560fcce15ebf8a2ad6a3957842fb`

Fixes #53295
Fixes #53318
