### PR TITLE
refactor(gateway): unify config-derived cache invalidation on hot reload

### DIFF
--- a/src/agents/config-derived-caches.test.ts
+++ b/src/agents/config-derived-caches.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  invalidateConfigDerivedCaches,
+  registerConfigDerivedCache,
+  resetConfigDerivedCacheRegistryForTest,
+} from "./config-derived-caches.js";
+
+describe("config-derived-caches", () => {
+  beforeEach(() => {
+    resetConfigDerivedCacheRegistryForTest();
+  });
+
+  afterEach(() => {
+    resetConfigDerivedCacheRegistryForTest();
+  });
+
+  it("invalidates caches whose prefix matches a changed path", () => {
+    const modelInvalidate = vi.fn();
+    const cronInvalidate = vi.fn();
+
+    registerConfigDerivedCache({
+      name: "models",
+      prefixes: ["models"],
+      invalidate: modelInvalidate,
+    });
+    registerConfigDerivedCache({
+      name: "cron",
+      prefixes: ["cron"],
+      invalidate: cronInvalidate,
+    });
+
+    const invalidated = invalidateConfigDerivedCaches(["models.providers.openai.models"]);
+
+    expect(modelInvalidate).toHaveBeenCalledOnce();
+    expect(cronInvalidate).not.toHaveBeenCalled();
+    expect(invalidated).toEqual(["models"]);
+  });
+
+  it("invalidates caches with exact path match", () => {
+    const invalidate = vi.fn();
+    registerConfigDerivedCache({
+      name: "test",
+      prefixes: ["models"],
+      invalidate,
+    });
+
+    invalidateConfigDerivedCaches(["models"]);
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+
+  it("does not invalidate when prefix does not match", () => {
+    const invalidate = vi.fn();
+    registerConfigDerivedCache({
+      name: "test",
+      prefixes: ["models"],
+      invalidate,
+    });
+
+    invalidateConfigDerivedCaches(["cron.schedule"]);
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it("invalidates caches with empty prefixes on any change", () => {
+    const invalidate = vi.fn();
+    registerConfigDerivedCache({
+      name: "catch-all",
+      prefixes: [],
+      invalidate,
+    });
+
+    const invalidated = invalidateConfigDerivedCaches(["anything.at.all"]);
+
+    expect(invalidate).toHaveBeenCalledOnce();
+    expect(invalidated).toEqual(["catch-all"]);
+  });
+
+  it("invalidates multiple caches that share the same prefix", () => {
+    const inv1 = vi.fn();
+    const inv2 = vi.fn();
+
+    registerConfigDerivedCache({
+      name: "cache-a",
+      prefixes: ["models"],
+      invalidate: inv1,
+    });
+    registerConfigDerivedCache({
+      name: "cache-b",
+      prefixes: ["models"],
+      invalidate: inv2,
+    });
+
+    const invalidated = invalidateConfigDerivedCaches(["models.providers.xai"]);
+
+    expect(inv1).toHaveBeenCalledOnce();
+    expect(inv2).toHaveBeenCalledOnce();
+    expect(invalidated).toEqual(["cache-a", "cache-b"]);
+  });
+
+  it("does not match paths that merely share a common prefix substring", () => {
+    const invalidate = vi.fn();
+    registerConfigDerivedCache({
+      name: "test",
+      prefixes: ["model"],
+      invalidate,
+    });
+
+    // "models.providers" starts with "model" but is NOT "model" or "model.*"
+    invalidateConfigDerivedCaches(["models.providers"]);
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when no caches are invalidated", () => {
+    registerConfigDerivedCache({
+      name: "test",
+      prefixes: ["models"],
+      invalidate: vi.fn(),
+    });
+
+    const invalidated = invalidateConfigDerivedCaches(["cron.schedule"]);
+    expect(invalidated).toEqual([]);
+  });
+
+  it("handles cache with multiple prefixes", () => {
+    const invalidate = vi.fn();
+    registerConfigDerivedCache({
+      name: "multi",
+      prefixes: ["models", "auth"],
+      invalidate,
+    });
+
+    invalidateConfigDerivedCaches(["auth.provider"]);
+    expect(invalidate).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/config-derived-caches.ts
+++ b/src/agents/config-derived-caches.ts
@@ -1,0 +1,61 @@
+// Config-derived cache invalidation registry
+//
+// Caches that hold state derived from openclaw.json (model catalog, context
+// windows, models.json fingerprints, …) must be invalidated when the
+// underlying config changes. This module provides a lightweight registry so
+// the hot-reload handler can clear them in one call instead of enumerating
+// each cache individually.
+//
+// Process-lifetime caches (code-module imports, ONNX models) and
+// request-scoped caches (loadConfig 200ms TTL) are NOT registered here —
+// they have different invalidation semantics.
+
+type ConfigDerivedCacheEntry = {
+  /** Human-readable name for logging / debugging. */
+  name: string;
+  /**
+   * Config path prefixes this cache depends on.
+   * An empty array means "invalidate on any config change".
+   */
+  prefixes: string[];
+  /** Clear the cached state so the next access rebuilds it from config. */
+  invalidate: () => void;
+};
+
+const registry: ConfigDerivedCacheEntry[] = [];
+
+/**
+ * Register a cache that is derived from config and must be invalidated
+ * when the corresponding config paths change during hot reload.
+ */
+export function registerConfigDerivedCache(entry: ConfigDerivedCacheEntry): void {
+  registry.push(entry);
+}
+
+/**
+ * Invalidate all registered caches whose declared prefixes overlap with the
+ * changed config paths.  Called by the gateway hot-reload handler.
+ *
+ * Returns the names of the caches that were actually invalidated (useful for
+ * logging).
+ */
+export function invalidateConfigDerivedCaches(changedPaths: string[]): string[] {
+  const invalidated: string[] = [];
+  for (const entry of registry) {
+    const shouldInvalidate =
+      entry.prefixes.length === 0 ||
+      entry.prefixes.some((prefix) =>
+        changedPaths.some((cp) => cp === prefix || cp.startsWith(prefix + ".")),
+      );
+    if (shouldInvalidate) {
+      entry.invalidate();
+      invalidated.push(entry.name);
+    }
+  }
+  return invalidated;
+}
+
+/** Test-only: remove all registered caches so tests start with a clean slate. */
+export function resetConfigDerivedCacheRegistryForTest(): void {
+  registry.length = 0;
+}

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
 import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { registerConfigDerivedCache } from "./config-derived-caches.js";
 import { lookupCachedContextTokens, MODEL_CONTEXT_TOKEN_CACHE } from "./context-cache.js";
 import { normalizeProviderId } from "./model-selection.js";
 
@@ -84,6 +85,18 @@ let configuredConfig: OpenClawConfig | undefined;
 let configLoadFailures = 0;
 let nextConfigLoadAttemptAtMs = 0;
 let modelsConfigRuntimePromise: Promise<typeof import("./models-config.runtime.js")> | undefined;
+
+registerConfigDerivedCache({
+  name: "contextWindowCache",
+  prefixes: ["models"],
+  invalidate: () => {
+    MODEL_CONTEXT_TOKEN_CACHE.clear();
+    loadPromise = null;
+    configuredConfig = undefined;
+    configLoadFailures = 0;
+    nextConfigLoadAttemptAtMs = 0;
+  },
+});
 
 function loadModelsConfigRuntime() {
   modelsConfigRuntimePromise ??= import("./models-config.runtime.js");

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -2,6 +2,7 @@ import { type OpenClawConfig, loadConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { augmentModelCatalogWithProviderPlugins } from "../plugins/provider-runtime.runtime.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { registerConfigDerivedCache } from "./config-derived-caches.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 
 const log = createSubsystemLogger("model-catalog");
@@ -33,6 +34,15 @@ let hasLoggedModelCatalogError = false;
 const defaultImportPiSdk = () => import("./pi-model-discovery-runtime.js");
 let importPiSdk = defaultImportPiSdk;
 let modelSuppressionPromise: Promise<typeof import("./model-suppression.runtime.js")> | undefined;
+
+registerConfigDerivedCache({
+  name: "modelCatalog",
+  prefixes: ["models"],
+  invalidate: () => {
+    modelCatalogPromise = null;
+    hasLoggedModelCatalogError = false;
+  },
+});
 
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["deepseek", "kilocode"]);
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -8,6 +8,7 @@ import {
 } from "../config/config.js";
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { registerConfigDerivedCache } from "./config-derived-caches.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 
 const MODELS_JSON_WRITE_LOCKS = new Map<string, Promise<void>>();
@@ -15,6 +16,14 @@ const MODELS_JSON_READY_CACHE = new Map<
   string,
   Promise<{ fingerprint: string; result: { agentDir: string; wrote: boolean } }>
 >();
+
+registerConfigDerivedCache({
+  name: "modelsJsonReady",
+  prefixes: ["models"],
+  invalidate: () => {
+    MODELS_JSON_READY_CACHE.clear();
+  },
+});
 
 async function readFileMtimeMs(pathname: string): Promise<number | null> {
   try {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,3 +1,4 @@
+import { invalidateConfigDerivedCaches } from "../agents/config-derived-caches.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.js";
@@ -78,6 +79,11 @@ export function createGatewayReloadHandlers(params: {
     }
 
     resetDirectoryCache();
+
+    const invalidated = invalidateConfigDerivedCaches(plan.changedPaths);
+    if (invalidated.length > 0) {
+      params.logReload.info(`invalidated config-derived caches: ${invalidated.join(", ")}`);
+    }
 
     if (plan.restartCron) {
       state.cronState.cron.stop();


### PR DESCRIPTION
## Summary

- **Problem**: module-scoped caches for model catalog, models.json fingerprints, and context windows use the same `let promise = null` pattern as process-lifetime code-module caches — but unlike code modules, they hold state derived from `openclaw.json` that must refresh on config changes. Hot reload missed them because they weren't recognized as a distinct category.
- **Solution**: introduce a lightweight registry (`config-derived-caches.ts`) that lets each config-derived cache declare which config prefixes it depends on. The reload handler calls `invalidateConfigDerivedCaches(changedPaths)` once — no per-cache if-statements needed.
- **Scope boundary**: process-lifetime caches (40+ lazy `import()` calls) and request-scoped caches (`loadConfig()` 200ms TTL) are NOT touched. Only the 3 caches that actually hold config-derived state are migrated.

## The three cache categories

| Category | Lifetime | Example | Invalidation | Touched? |
|----------|----------|---------|--------------|----------|
| Process | Never | `import("./xxx.runtime.js")` | Not needed | No |
| **Config-derived** | **Config change** | **modelCatalog, contextWindow, modelsJson** | **Registry → hot reload** | **Yes** |
| Request | 200ms TTL | `loadConfig()` | Auto-expire | No |

## Changes

| File | What |
|------|------|
| `src/agents/config-derived-caches.ts` | New — registry + `invalidateConfigDerivedCaches()` (~60 lines) |
| `src/agents/config-derived-caches.test.ts` | New — 8 tests covering prefix matching, exact match, no-match, catch-all, multi-prefix |
| `src/agents/model-catalog.ts` | +10 lines — register `modelCatalog` (prefixes: `["models"]`) |
| `src/agents/models-config.ts` | +9 lines — register `modelsJsonReady` (prefixes: `["models"]`) |
| `src/agents/context.ts` | +13 lines — register `contextWindowCache` (prefixes: `["models"]`) |
| `src/gateway/server-reload-handlers.ts` | +6 lines — single `invalidateConfigDerivedCaches()` call after `resetDirectoryCache()` |

## Why this approach over per-cache if-statements

Three competing PRs (#49586, #49600, #49795) each add an if-statement for model catalog only. But context window cache and models.json fingerprint cache have the same stale-after-reload problem — they just haven't been reported yet. This PR fixes all three and ensures future config-derived caches only need a `registerConfigDerivedCache()` call; the reload handler needs no changes.

## Test plan

- [x] 8 new unit tests for registry (prefix matching, exact match, no-match, catch-all, multi-prefix, substring safety)
- [x] Existing `config-reload.test.ts` — 22 tests pass
- [x] Existing `model-catalog.test.ts` — passes
- [x] TypeScript check passes (no new errors introduced)
- [ ] CI

Closes #49568
Supersedes #49586, #49795, #49600

🤖 Generated with [Claude Code](https://claude.com/claude-code)