### PR TITLE
feishu: fix schema 2.0 card config - replace wide_screen_mode with enable_forward

### DIFF
--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -585,7 +585,7 @@ export function buildMarkdownCard(text: string): Record<string, unknown> {
   return {
     schema: "2.0",
     config: {
-      wide_screen_mode: true,
+      enable_forward: true,
     },
     body: {
       elements: [
@@ -632,7 +632,7 @@ export function buildStructuredCard(
   }
   const card: Record<string, unknown> = {
     schema: "2.0",
-    config: { wide_screen_mode: true },
+    config: { enable_forward: true },
     body: { elements },
   };
   if (options?.header) {


### PR DESCRIPTION
## Summary
Replace invalid `wide_screen_mode` with `enable_forward` in schema 2.0 Feishu card configs so cards deliver without error 230099.

## Changes
- `buildMarkdownCard`: replace `config: { wide_screen_mode: true }` with `config: { enable_forward: true }`
- `buildStructuredCard`: same replacement

## Root Cause
Feishu card schema 2.0 does not recognise `wide_screen_mode` (a schema 1.x-only field). Passing it causes the Feishu API to return HTTP 400 with error code 230099 `parse card json err` for every card delivery that goes through `sendMarkdownCardFeishu` or `sendStructuredCardFeishu`, including cron announcement delivery.

The correct schema 2.0 config field is `enable_forward`. The streaming card in the same extension already uses schema 2.0 without `wide_screen_mode`, confirming the intended pattern.

## Testing
- `pnpm test -- extensions/feishu/src/send.test.ts` - 10/10 passed
- `pnpm test -- extensions/feishu/src/send.reply-fallback.test.ts extensions/feishu/src/outbound.test.ts extensions/feishu/src/reply-dispatcher.test.ts` - 52/52 passed
- `npx oxfmt --check extensions/feishu/src/send.ts` - no format issues

Closes #53310