### PR TITLE
fix: /new command should reset session instead of spawning subagent (#53335)

### DIFF
--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -239,6 +239,25 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
         },
       };
     }
+    // For /new command without ACP binding, trigger session reset and stop
+    // This prevents spawning a subagent when user just wants to clear context
+    if (commandAction === "new") {
+      await emitResetCommandHooks({
+        action: commandAction,
+        ctx: params.ctx,
+        cfg: params.cfg,
+        command: params.command,
+        sessionKey: params.sessionKey,
+        sessionEntry: params.sessionEntry,
+        previousSessionEntry: params.previousSessionEntry,
+        workspaceDir: params.workspaceDir,
+      });
+      return {
+        shouldContinue: false,
+        reply: { text: "✅ Session reset. Start fresh!" },
+      };
+    }
+    // For /reset without ACP binding, continue to allow normal processing
     await emitResetCommandHooks({
       action: commandAction,
       ctx: params.ctx,


### PR DESCRIPTION
## 🐛 修复问题

修复 #53335 - /new 命令错误地 spawn subagent 而不是重置 session

## 🔧 修复内容

当 /new 命令没有 ACP binding 时：
- 触发 session reset hook
- 返回成功消息而不是继续处理
- 防止意外 spawn subagent

## ✅ 验证

- ✅ pnpm run lint 通过
- ✅ 修复前：/new 会 spawn subagent
- ✅ 修复后：/new 重置 session 并返回成功消息

## 📝 影响

- 修复用户无法清理 session 上下文的问题
- 不影响 /reset 命令的行为