### PR TITLE
fix(config): redact Feishu encryptKey in config snapshots

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -84,7 +84,10 @@ describe("redactConfigSnapshot", () => {
           signingSecret: "slack-signing-secret-value-1234",
           token: "secret-slack-token-value-here",
         },
-        feishu: { appSecret: "feishu-app-secret-value-here-1234" },
+        feishu: {
+          appSecret: "feishu-app-secret-value-here-1234",
+          encryptKey: "feishu-encrypt-key-value-here-1234",
+        },
       },
       models: {
         providers: {
@@ -104,6 +107,7 @@ describe("redactConfigSnapshot", () => {
     expect(cfg.channels.slack.signingSecret).toBe(REDACTED_SENTINEL);
     expect(cfg.channels.slack.token).toBe(REDACTED_SENTINEL);
     expect(cfg.channels.feishu.appSecret).toBe(REDACTED_SENTINEL);
+    expect(cfg.channels.feishu.encryptKey).toBe(REDACTED_SENTINEL);
     expect(cfg.models.providers.openai.apiKey).toBe(REDACTED_SENTINEL);
     expect(cfg.models.providers.openai.baseUrl).toBe("https://api.openai.com");
     expect(cfg.shortSecret.token).toBe(REDACTED_SENTINEL);

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { buildSecretInputSchema } from "../plugin-sdk/secret-input-schema.js";
 import { __test__, isSensitiveConfigPath } from "./schema.hints.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -30,6 +31,8 @@ describe("isSensitiveConfigPath", () => {
     expect(isSensitiveConfigPath("channels.slack.token")).toBe(true);
     expect(isSensitiveConfigPath("models.providers.openai.apiKey")).toBe(true);
     expect(isSensitiveConfigPath("channels.irc.nickserv.password")).toBe(true);
+    expect(isSensitiveConfigPath("channels.feishu.encryptKey")).toBe(true);
+    expect(isSensitiveConfigPath("channels.feishu.accounts.default.encryptKey")).toBe(true);
   });
 });
 
@@ -137,5 +140,20 @@ describe("mapSensitivePaths", () => {
     expect(hints["gateway.auth.token"]?.sensitive).toBe(true);
     expect(hints["models.providers.*.headers.*"]?.sensitive).toBe(true);
     expect(hints["skills.entries.*.apiKey"]?.sensitive).toBe(true);
+  });
+
+  it("marks buildSecretInputSchema fields as sensitive via registry", () => {
+    const schema = z.object({
+      encryptKey: buildSecretInputSchema().optional(),
+      appSecret: buildSecretInputSchema().optional(),
+      nested: z.object({
+        verificationToken: buildSecretInputSchema().optional(),
+      }),
+    });
+    const hints = mapSensitivePaths(schema, "", {});
+
+    expect(hints["encryptKey"]?.sensitive).toBe(true);
+    expect(hints["appSecret"]?.sensitive).toBe(true);
+    expect(hints["nested.verificationToken"]?.sensitive).toBe(true);
   });
 });

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -106,6 +106,7 @@ const SENSITIVE_PATTERNS = [
   /password/i,
   /secret/i,
   /api.?key/i,
+  /encrypt.?key/i,
   /serviceaccount(?:ref)?$/i,
 ];
 

--- a/src/plugin-sdk/secret-input-schema.ts
+++ b/src/plugin-sdk/secret-input-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ENV_SECRET_REF_ID_RE } from "../config/types.secrets.js";
+import { sensitive } from "../config/zod-schema.sensitive.js";
 import {
   formatExecSecretRefIdValidationMessage,
   isValidExecSecretRefId,
@@ -7,16 +8,17 @@ import {
   SECRET_PROVIDER_ALIAS_PATTERN,
 } from "../secrets/ref-contract.js";
 
-/** Build the shared zod schema for secret inputs accepted by plugin auth/config surfaces. */
-export function buildSecretInputSchema() {
-  const providerSchema = z
-    .string()
-    .regex(
-      SECRET_PROVIDER_ALIAS_PATTERN,
-      'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
-    );
+const providerSchema = z
+  .string()
+  .regex(
+    SECRET_PROVIDER_ALIAS_PATTERN,
+    'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "default").',
+  );
 
-  return z.union([
+// Singleton registered with the sensitive registry so that mapSensitivePaths
+// marks every config field using this schema as sensitive (redacted).
+const secretInputSchema = z
+  .union([
     z.string(),
     z.discriminatedUnion("source", [
       z.object({
@@ -45,5 +47,10 @@ export function buildSecretInputSchema() {
         id: z.string().refine(isValidExecSecretRefId, formatExecSecretRefIdValidationMessage()),
       }),
     ]),
-  ]);
+  ])
+  .register(sensitive);
+
+/** Build the shared zod schema for secret inputs accepted by plugin auth/config surfaces. */
+export function buildSecretInputSchema() {
+  return secretInputSchema;
 }


### PR DESCRIPTION
## Fix Summary
When Feishu is configured in webhook mode, `channels.feishu.encryptKey` survives config redaction and is returned in plaintext to any `operator.read` client via `config.get`. The leaked key is the sole authenticator for inbound Feishu webhooks, enabling an attacker to forge accepted webhook events that OpenClaw processes as legitimate Feishu messages.

## Issue Linkage
Fixes #53412

## Security Snapshot
- CVSS v3.1: 9.1 (Critical)
- CVSS v4.0: 8.5 (High)

## Implementation Details
### Files Changed
- `src/config/redact-snapshot.test.ts` (+5/-1)
- `src/config/schema.hints.test.ts` (+18/-0)
- `src/config/schema.hints.ts` (+1/-0)
- `src/plugin-sdk/secret-input-schema.ts` (+17/-10)

### Technical Analysis
1. Configure Feishu with `connectionMode: "webhook"` and a plaintext `channels.feishu.encryptKey` value.
2. Pair a gateway client that holds only the `operator.read` scope.
3. Call `config.get`. Observe that the response payload at `config.channels.feishu.encryptKey` contains the raw key value rather than `__OPENCLAW_REDACTED__`.
4. Using the leaked key, compute `sha256(timestamp + nonce + encryptKey + JSON.stringify(payload))` and send a forged webhook to the Feishu path (default `/feishu/events`) with correct `x-lark-request-timestamp`, `x-lark-request-nonce`, and `x-lark-signature` headers.
5. The request passes `isFeishuWebhookSignatureValid()` and is dispatched via `eventDispatcher.invoke(..., { needCheck: false })`.
6. OpenClaw processes the forged event through its normal `im.message.receive_v1` handler.

## Validation Evidence
- Command: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Status: passed (with pre-existing baseline failures)

## Risk and Compatibility
non-breaking; no known regression impact

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: opencode/github-copilot/gpt-5.4
