### PR TITLE
fix(whatsapp): add bundle.stageRuntimeDependencies to fix #53247

### DIFF
--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -41,6 +41,9 @@
     },
     "release": {
       "publishToNpm": true
+    },
+    "bundle": {
+      "stageRuntimeDependencies": true
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #53247 - WhatsApp plugin crashes agent in v2026.3.23 with missing light-runtime-api

## Root Cause

The whatsapp extension was missing the `bundle.stageRuntimeDependencies` configuration that other channel extensions (telegram, slack, feishu, discord) already have.

## Fix

Added `bundle.stageRuntimeDependencies: true` to extensions/whatsapp/package.json

## Testing

- [x] Verified consistent with other channel extensions
- [x] pnpm run check:bundled-plugin-metadata passes
- [x] No other changes to whatsapp extension

## Related Issue

Closes #53247