### PR TITLE
fix(synology-chat): handle HEAD probe and return 200 on webhook ACK

### DIFF
--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -153,8 +153,8 @@ describe("Synology channel wiring integration", () => {
     const betaRes = makeRes();
     await betaRoute.handler(betaReq, betaRes);
 
-    expect(alphaRes._status).toBe(204);
-    expect(betaRes._status).toBe(204);
+    expect(alphaRes._status).toBe(200);
+    expect(betaRes._status).toBe(200);
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(2);
     expect(finalizeInboundContextMock).toHaveBeenCalledTimes(2);
 

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -90,6 +90,20 @@ describe("createWebhookHandler", () => {
     expect(res._status).toBe(405);
   });
 
+  it("responds 200 to HEAD probe (Synology availability check)", async () => {
+    const handler = createWebhookHandler({
+      account: makeAccount(),
+      deliver: vi.fn(),
+      log,
+    });
+
+    const req = makeReq("HEAD", "");
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(200);
+  });
+
   it("returns 400 for missing required fields", async () => {
     const handler = createWebhookHandler({
       account: makeAccount(),
@@ -168,7 +182,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         body: "Hello from json",
@@ -198,7 +212,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(deliver).toHaveBeenCalled();
   });
 
@@ -223,7 +237,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(deliver).toHaveBeenCalled();
   });
 
@@ -271,7 +285,7 @@ describe("createWebhookHandler", () => {
     const req1 = makeReq("POST", validBody);
     const res1 = makeRes();
     await handler(req1, res1);
-    expect(res1._status).toBe(204);
+    expect(res1._status).toBe(200);
 
     // Second request should be rate limited
     const req2 = makeReq("POST", validBody);
@@ -300,12 +314,12 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     // deliver should have been called with the stripped text
     expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ body: "Hello there" }));
   });
 
-  it("responds 204 immediately and delivers async", async () => {
+  it("responds 200 immediately and delivers async", async () => {
     const deliver = vi.fn().mockResolvedValue("Bot reply");
     const handler = createWebhookHandler({
       account: makeAccount({ accountId: "async-test-" + Date.now() }),
@@ -317,8 +331,8 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
-    expect(res._body).toBe("");
+    expect(res._status).toBe(200);
+    expect(res._body).toBe('{"success":true}');
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         body: "Hello bot",
@@ -343,7 +357,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(resolveLegacyWebhookNameToChatUserId).not.toHaveBeenCalled();
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -375,7 +389,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(resolveLegacyWebhookNameToChatUserId).toHaveBeenCalledWith({
       incomingUrl: "https://nas.example.com/incoming",
       mutableWebhookUsername: "testuser",
@@ -412,7 +426,7 @@ describe("createWebhookHandler", () => {
     const res = makeRes();
     await handler(req, res);
 
-    expect(res._status).toBe(204);
+    expect(res._status).toBe(200);
     expect(resolveLegacyWebhookNameToChatUserId).toHaveBeenCalledWith({
       incomingUrl: "https://nas.example.com/incoming",
       mutableWebhookUsername: "testuser",

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -211,10 +211,15 @@ function respondJson(res: ServerResponse, statusCode: number, body: Record<strin
   res.end(JSON.stringify(body));
 }
 
-/** Send a no-content ACK. */
-function respondNoContent(res: ServerResponse) {
-  res.writeHead(204);
-  res.end();
+/**
+ * Send a webhook ACK.
+ *
+ * Synology Chat requires 200 OK + {"success":true} — returning 204 No Content
+ * causes it to mark the bot as broken and stop delivering subsequent messages.
+ */
+function respondSuccess(res: ServerResponse) {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ success: true }));
 }
 
 export interface WebhookHandlerDeps {
@@ -236,7 +241,7 @@ export interface WebhookHandlerDeps {
  * 3. Checks user allowlist
  * 4. Checks rate limit
  * 5. Sanitizes input
- * 6. Immediately ACKs request (204)
+ * 6. Immediately ACKs request (200 + {"success":true})
  * 7. Delivers to the agent asynchronously and sends final reply via incomingUrl
  */
 type SynologyWebhookAuthorization =
@@ -354,7 +359,7 @@ async function parseAndAuthorizeSynologyWebhook(params: {
 
   const cleanText = sanitizeSynologyWebhookText(parsed.payload);
   if (!cleanText) {
-    respondNoContent(params.res);
+    respondSuccess(params.res);
     return { ok: false };
   }
   const preview = cleanText.length > 100 ? `${cleanText.slice(0, 100)}...` : cleanText;
@@ -455,7 +460,14 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
   const rateLimiter = getRateLimiter(account);
 
   return async (req: IncomingMessage, res: ServerResponse) => {
-    // Only accept POST
+    // Synology Chat sends a HEAD probe before each POST to test the endpoint.
+    // Respond 200 to HEAD so it doesn't mark the webhook as broken.
+    if (req.method === "HEAD") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end();
+      return;
+    }
+    // Only accept POST (and HEAD above)
     if (req.method !== "POST") {
       respondJson(res, 405, { error: "Method not allowed" });
       return;
@@ -476,7 +488,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     );
 
     // ACK immediately so Synology Chat won't remain in "Processing..."
-    respondNoContent(res);
+    respondSuccess(res);
     await processAuthorizedSynologyWebhook({
       account,
       deliver,


### PR DESCRIPTION
Fixes #53439

## Problem

Synology Chat bot webhooks fail silently in two ways, discovered through live debugging with a Synology NAS bot integration:

**1. HEAD probe**

Synology sends a `HEAD` request to the outgoing webhook URL before each `POST` to verify the endpoint is alive. This was observed in DSM's Synology Chat integration logs as a probe immediately preceding every message delivery attempt. OpenClaw returned `405 Method Not Allowed` for HEAD, causing Synology to mark the bot endpoint as unreachable and stop sending `POST` requests entirely.

**2. ACK response code**

After successfully accepting a message POST, OpenClaw responded with `204 No Content`. Synology Chat expects `200 OK` with `{"success":true}` in the body — this is what its own incoming webhook API returns on success. When it receives a 204, the Synology Chat UI shows:

> _(Only visible to you) Failed to send a request to the bot server. Please contact the bot owner._

After this error, Synology stops delivering subsequent messages from that conversation until the webhook URL is re-saved in the integration settings, resetting the failure state.

## Changes

- Respond `200 OK` to `HEAD` requests in `createWebhookHandler`
- Rename `respondNoContent` → `respondAck`, returning `200 OK` + `{"success":true}` to match Synology's expected response format
- Update all affected tests to expect `200`; add a new test covering the HEAD probe

## Testing

All 106 extension tests pass (`pnpm test:extension synology-chat`). Verified end-to-end on a Synology NAS running DSM 7 + Synology Chat bot integration — messages now deliver reliably without the "Failed" error, and the connection stays alive across multiple consecutive messages.

## AI disclosure

- [x] AI-assisted (GUPPI / Claude Sonnet 4.6 via OpenClaw)
- [x] Tested end-to-end on real hardware
- [x] Author understands the changes