### PR TITLE
fix(cron): allow cron-triggered heartbeat runs when heartbeat.every="0m" (#46046)

### DIFF
--- a/src/infra/heartbeat-runner.cron-bypass.test.ts
+++ b/src/infra/heartbeat-runner.cron-bypass.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { runHeartbeatOnce, setHeartbeatsEnabled } from "./heartbeat-runner.js";
+
+/**
+ * Verifies that event-driven heartbeat reasons (cron, exec-event, wake, hook)
+ * bypass the heartbeat-interval-disabled guard so that cron-triggered runs
+ * are not silently skipped when `heartbeat.every` is "0m".
+ *
+ * See: https://github.com/openclaw/openclaw/issues/46046
+ */
+
+const agentId = "test-agent";
+
+function buildConfig(every: string): OpenClawConfig {
+  return {
+    agents: {
+      defaultId: agentId,
+      list: [{ id: agentId, heartbeat: { every } }],
+    },
+  } as OpenClawConfig;
+}
+
+describe("runHeartbeatOnce – cron bypass when interval disabled", () => {
+  beforeEach(() => {
+    setHeartbeatsEnabled(true);
+  });
+
+  afterEach(() => {
+    setHeartbeatsEnabled(true);
+  });
+
+  it('returns skipped/disabled for interval reason when every="0m"', async () => {
+    const result = await runHeartbeatOnce({
+      cfg: buildConfig("0m"),
+      agentId,
+      reason: "interval",
+      // Provide getQueueSize so we know we'd get a different skip if the guard were bypassed
+      deps: { getQueueSize: () => 1 },
+    });
+    expect(result).toEqual({ status: "skipped", reason: "disabled" });
+  });
+
+  it('does NOT return skipped/disabled for cron reason when every="0m"', async () => {
+    const result = await runHeartbeatOnce({
+      cfg: buildConfig("0m"),
+      agentId,
+      reason: "cron:job-123",
+      deps: { getQueueSize: () => 1 },
+    });
+    // Should have passed the interval guard and hit a later skip reason
+    expect(result.status).toBe("skipped");
+    expect((result as { reason: string }).reason).not.toBe("disabled");
+  });
+
+  it('does NOT return skipped/disabled for exec-event reason when every="0m"', async () => {
+    const result = await runHeartbeatOnce({
+      cfg: buildConfig("0m"),
+      agentId,
+      reason: "exec-event",
+      deps: { getQueueSize: () => 1 },
+    });
+    expect(result.status).toBe("skipped");
+    expect((result as { reason: string }).reason).not.toBe("disabled");
+  });
+
+  it('does NOT return skipped/disabled for wake reason when every="0m"', async () => {
+    const result = await runHeartbeatOnce({
+      cfg: buildConfig("0m"),
+      agentId,
+      reason: "wake",
+      deps: { getQueueSize: () => 1 },
+    });
+    expect(result.status).toBe("skipped");
+    expect((result as { reason: string }).reason).not.toBe("disabled");
+  });
+
+  it('does NOT return skipped/disabled for hook reason when every="0m"', async () => {
+    const result = await runHeartbeatOnce({
+      cfg: buildConfig("0m"),
+      agentId,
+      reason: "hook:my-hook",
+      deps: { getQueueSize: () => 1 },
+    });
+    expect(result.status).toBe("skipped");
+    expect((result as { reason: string }).reason).not.toBe("disabled");
+  });
+
+  it("still allows interval reason when every is set to a valid duration", async () => {
+    const result = await runHeartbeatOnce({
+      cfg: buildConfig("30m"),
+      agentId,
+      reason: "interval",
+      deps: { getQueueSize: () => 1 },
+    });
+    // Should pass the interval guard and hit the queue-size skip
+    expect(result.status).toBe("skipped");
+    expect((result as { reason: string }).reason).not.toBe("disabled");
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -57,7 +57,7 @@ import {
   isExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
-import { resolveHeartbeatReasonKind } from "./heartbeat-reason.js";
+import { isHeartbeatEventDrivenReason, resolveHeartbeatReasonKind } from "./heartbeat-reason.js";
 import {
   isHeartbeatEnabledForAgent,
   resolveHeartbeatIntervalMs,
@@ -542,7 +542,10 @@ export async function runHeartbeatOnce(opts: {
   if (!isHeartbeatEnabledForAgent(cfg, agentId)) {
     return { status: "skipped", reason: "disabled" };
   }
-  if (!resolveHeartbeatIntervalMs(cfg, undefined, heartbeat)) {
+  if (
+    !resolveHeartbeatIntervalMs(cfg, undefined, heartbeat) &&
+    !isHeartbeatEventDrivenReason(opts.reason)
+  ) {
     return { status: "skipped", reason: "disabled" };
   }
 


### PR DESCRIPTION
## What
Bypass the heartbeat interval check in `runHeartbeatOnce()` for event-driven reasons (cron, exec-event, wake, hook).

## Why
Fixes #46046 — When `agents.defaults.heartbeat.every` is set to `"0m"`, `sessionTarget="main"` cron jobs are silently skipped with `status: "skipped", error: "disabled"`. The interval check treats `0m` as falsy and blocks all heartbeat runs, including those triggered by cron events that have their own scheduling.

## How
Added `!isHeartbeatEventDrivenReason(opts.reason)` to the interval-ms guard in `runHeartbeatOnce()`. The existing `isHeartbeatEventDrivenReason()` helper (from `heartbeat-reason.ts`) already correctly identifies cron/exec-event/wake/hook reasons. Regular interval-based heartbeats still respect `every: "0m"` as disabled.

## Testing
- [x] `pnpm vitest run src/infra/heartbeat` — 154/154 tests pass
- [x] New test file: `heartbeat-runner.cron-bypass.test.ts` (6 tests)
  - interval reason still blocked when every="0m" ✅
  - cron reason bypasses interval check ✅
  - exec-event reason bypasses interval check ✅
  - wake reason bypasses interval check ✅
  - hook reason bypasses interval check ✅
  - interval reason works normally with valid duration ✅
- [x] AI-assisted (Claude Code via ACP, fully tested)