### PR TITLE
Control UI: show full date-time in session list (fixes #53088)

### DIFF
--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -127,4 +127,13 @@ describe("formatFullDateTime", () => {
   it("returns fallback for NaN", () => {
     expect(formatFullDateTime(NaN)).toBe("n/a");
   });
+
+  it("returns fallback for epoch 0 (unset sentinel)", () => {
+    expect(formatFullDateTime(0)).toBe("n/a");
+  });
+
+  it("returns fallback for negative epoch values", () => {
+    expect(formatFullDateTime(-1)).toBe("n/a");
+    expect(formatFullDateTime(-1_000_000)).toBe("n/a");
+  });
 });

--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeTimestamp, stripThinkingTags } from "./format.ts";
+import { formatFullDateTime, formatRelativeTimestamp, stripThinkingTags } from "./format.ts";
 
 describe("formatAgo", () => {
   it("returns 'in <1m' for timestamps less than 60s in the future", () => {
@@ -97,5 +97,34 @@ describe("stripThinkingTags", () => {
   it("hides unfinished <relevant-memories> block tails", () => {
     const input = ["Hello", "<relevant-memories>", "internal-only"].join("\n");
     expect(stripThinkingTags(input)).toBe("Hello\n");
+  });
+});
+
+describe("formatFullDateTime", () => {
+  it("formats a known epoch to YYYY-MM-DD HH:mm in local time", () => {
+    // Use a fixed date so the test is timezone-independent: build from local parts.
+    const d = new Date(2026, 2, 20, 14, 30, 0); // March 20, 2026 14:30 local
+    expect(formatFullDateTime(d.getTime())).toBe("2026-03-20 14:30");
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    const d = new Date(2026, 0, 5, 9, 3, 0); // Jan 5, 2026 09:03 local
+    expect(formatFullDateTime(d.getTime())).toBe("2026-01-05 09:03");
+  });
+
+  it("returns fallback for null", () => {
+    expect(formatFullDateTime(null)).toBe("n/a");
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(formatFullDateTime(undefined)).toBe("n/a");
+  });
+
+  it("returns custom fallback when provided", () => {
+    expect(formatFullDateTime(null, "—")).toBe("—");
+  });
+
+  it("returns fallback for NaN", () => {
+    expect(formatFullDateTime(NaN)).toBe("n/a");
   });
 });

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -6,10 +6,11 @@ export { formatRelativeTimestamp, formatDurationHuman };
 
 /**
  * Format an epoch timestamp as a full date-time string (e.g. "2026-03-20 14:30").
- * Uses the user's local timezone via `Intl.DateTimeFormat`.
+ * Uses the user's local timezone via the `Date` instance methods
+ * (`getFullYear`, `getMonth`, `getDate`, `getHours`, `getMinutes`).
  */
 export function formatFullDateTime(epochMs: number | null | undefined, fallback = "n/a"): string {
-  if (epochMs == null || !Number.isFinite(epochMs)) {
+  if (epochMs == null || !Number.isFinite(epochMs) || epochMs <= 0) {
     return fallback;
   }
   const d = new Date(epochMs);

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -4,6 +4,26 @@ import { stripAssistantInternalScaffolding } from "../../../src/shared/text/assi
 
 export { formatRelativeTimestamp, formatDurationHuman };
 
+/**
+ * Format an epoch timestamp as a full date-time string (e.g. "2026-03-20 14:30").
+ * Uses the user's local timezone via `Intl.DateTimeFormat`.
+ */
+export function formatFullDateTime(
+  epochMs: number | null | undefined,
+  fallback = "n/a",
+): string {
+  if (epochMs == null || !Number.isFinite(epochMs)) {
+    return fallback;
+  }
+  const d = new Date(epochMs);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  const hours = String(d.getHours()).padStart(2, "0");
+  const minutes = String(d.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+}
+
 export function formatMs(ms?: number | null): string {
   if (!ms && ms !== 0) {
     return "n/a";

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -8,10 +8,7 @@ export { formatRelativeTimestamp, formatDurationHuman };
  * Format an epoch timestamp as a full date-time string (e.g. "2026-03-20 14:30").
  * Uses the user's local timezone via `Intl.DateTimeFormat`.
  */
-export function formatFullDateTime(
-  epochMs: number | null | undefined,
-  fallback = "n/a",
-): string {
+export function formatFullDateTime(epochMs: number | null | undefined, fallback = "n/a"): string {
   if (epochMs == null || !Number.isFinite(epochMs)) {
     return fallback;
   }

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -1,5 +1,5 @@
 import { html, nothing } from "lit";
-import { formatRelativeTimestamp } from "../format.ts";
+import { formatFullDateTime, formatRelativeTimestamp } from "../format.ts";
 import { icons } from "../icons.ts";
 import { pathForTab } from "../navigation.ts";
 import { formatSessionTokens } from "../presenter.ts";
@@ -432,7 +432,8 @@ function renderRow(
   disabled: boolean,
   onNavigateToChat?: (sessionKey: string) => void,
 ) {
-  const updated = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "n/a";
+  const updatedFull = formatFullDateTime(row.updatedAt);
+  const updatedRelative = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "";
   const rawThinking = row.thinkingLevel ?? "";
   const isBinaryThinking = isBinaryThinkingProvider(row.modelProvider);
   const thinking = resolveThinkLevelDisplay(rawThinking, isBinaryThinking);
@@ -523,7 +524,7 @@ function renderRow(
       <td>
         <span class="data-table-badge ${badgeClass}">${row.kind}</span>
       </td>
-      <td>${updated}</td>
+      <td title=${updatedRelative}>${updatedFull}</td>
       <td>${formatSessionTokens(row)}</td>
       <td>
         <select


### PR DESCRIPTION
## Summary

- Problem: The Control UI session list "Updated" column only shows relative time (e.g. "5m ago", "3h ago"), making it hard to know the actual date/time a session was last active.
- Why it matters: When managing many sessions, users need to see the exact date and time to identify stale or recent sessions at a glance.
- What changed: The "Updated" column now displays full date-time in `YYYY-MM-DD HH:mm` format (local timezone). The relative time is preserved as a tooltip on hover.
- What did NOT change (scope boundary): The underlying data model, API responses, sort behavior, and all other session list columns remain untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53088
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- Session list "Updated" column now shows `2026-03-20 14:30` instead of `5m ago`.
- Hovering over the date shows the relative time (e.g. "5m ago") as a tooltip.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 22+

### Steps

1. Open the Control UI dashboard
2. Navigate to the Sessions page
3. Observe the "Updated" column

### Expected

- Full date-time displayed (e.g. `2026-03-20 14:30`)
- Relative time shown on hover tooltip

### Actual

- Before: Only relative time shown ("5m ago")
- After: Full date-time shown with relative time on hover

## Evidence

- [x] Failing test/log before + passing after

All existing tests pass, plus 6 new tests for `formatFullDateTime`:
- `pnpm test -- ui/src/ui/views/sessions.test.ts` — 4 tests passed
- `ui/vitest` format.test.ts — 23 tests passed (including 6 new)

## Human Verification (required)

- Verified scenarios: Ran unit tests for sessions view and format utilities
- Edge cases checked: null/undefined/NaN input, zero-padded months/days/hours/minutes
- What you did **not** verify: Visual rendering in a live browser (no running gateway available)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 3 changed files
- Files/config to restore: `ui/src/ui/format.ts`, `ui/src/ui/views/sessions.ts`
- Known bad symptoms reviewers should watch for: Incorrect date/time display in session list

## Risks and Mitigations

`None` — This is a purely cosmetic UI change with no logic or data model impact.