### PR TITLE
fix(discord): pass proxy-aware fetch to RequestClient (#30221)

### DIFF
--- a/extensions/discord/src/client.test.ts
+++ b/extensions/discord/src/client.test.ts
@@ -1,7 +1,8 @@
 import { RequestClient } from "@buape/carbon";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { createDiscordRestClient } from "./client.js";
+import * as restFetchMod from "./monitor/rest-fetch.js";
 
 describe("createDiscordRestClient", () => {
   const fakeRest = {} as RequestClient;
@@ -67,19 +68,24 @@ describe("createDiscordRestClient", () => {
   });
 
   it("creates a proxy-aware RequestClient when proxy is configured", () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot proxy-token",
-          proxy: "http://proxy.test:8080",
+    const spy = vi.spyOn(restFetchMod, "resolveDiscordRestFetch");
+    try {
+      const cfg = {
+        channels: {
+          discord: {
+            token: "Bot proxy-token",
+            proxy: "http://proxy.test:8080",
+          },
         },
-      },
-    } as OpenClawConfig;
+      } as OpenClawConfig;
 
-    const result = createDiscordRestClient({ token: "Bot proxy-token" }, cfg);
+      const result = createDiscordRestClient({ token: "Bot proxy-token" }, cfg);
 
-    expect(result.rest).toBeInstanceOf(RequestClient);
-    expect((result.rest as unknown as Record<string, unknown>).customFetch).toBeDefined();
+      expect(result.rest).toBeInstanceOf(RequestClient);
+      expect(spy).toHaveBeenCalledWith("http://proxy.test:8080", expect.any(Object));
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("skips proxy fetch when opts.rest is already provided", () => {
@@ -97,19 +103,24 @@ describe("createDiscordRestClient", () => {
     expect(result.rest).toBe(fakeRest);
   });
 
-  it("does not set customFetch when no proxy is configured", () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "Bot no-proxy-token",
+  it("does not invoke resolveDiscordRestFetch when no proxy is configured", () => {
+    const spy = vi.spyOn(restFetchMod, "resolveDiscordRestFetch");
+    try {
+      const cfg = {
+        channels: {
+          discord: {
+            token: "Bot no-proxy-token",
+          },
         },
-      },
-    } as OpenClawConfig;
+      } as OpenClawConfig;
 
-    const result = createDiscordRestClient({ token: "Bot no-proxy-token" }, cfg);
+      const result = createDiscordRestClient({ token: "Bot no-proxy-token" }, cfg);
 
-    expect(result.rest).toBeInstanceOf(RequestClient);
-    expect((result.rest as unknown as Record<string, unknown>).customFetch).toBeUndefined();
+      expect(result.rest).toBeInstanceOf(RequestClient);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("still throws when no explicit token is provided and config token is unresolved", () => {

--- a/extensions/discord/src/client.test.ts
+++ b/extensions/discord/src/client.test.ts
@@ -1,4 +1,4 @@
-import type { RequestClient } from "@buape/carbon";
+import { RequestClient } from "@buape/carbon";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
 import { createDiscordRestClient } from "./client.js";
@@ -64,6 +64,52 @@ describe("createDiscordRestClient", () => {
     expect(result.token).toBe("explicit-account-token");
     expect(result.account.accountId).toBe("ops");
     expect(result.account.config.retry).toMatchObject({ attempts: 7 });
+  });
+
+  it("creates a proxy-aware RequestClient when proxy is configured", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot proxy-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = createDiscordRestClient({ token: "Bot proxy-token" }, cfg);
+
+    expect(result.rest).toBeInstanceOf(RequestClient);
+    expect((result.rest as unknown as Record<string, unknown>).customFetch).toBeDefined();
+  });
+
+  it("skips proxy fetch when opts.rest is already provided", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot proxy-token",
+          proxy: "http://proxy.test:8080",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = createDiscordRestClient({ token: "Bot proxy-token", rest: fakeRest }, cfg);
+
+    expect(result.rest).toBe(fakeRest);
+  });
+
+  it("does not set customFetch when no proxy is configured", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          token: "Bot no-proxy-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = createDiscordRestClient({ token: "Bot no-proxy-token" }, cfg);
+
+    expect(result.rest).toBeInstanceOf(RequestClient);
+    expect((result.rest as unknown as Record<string, unknown>).customFetch).toBeUndefined();
   });
 
   it("still throws when no explicit token is provided and config token is unresolved", () => {

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -74,7 +74,11 @@ export function createDiscordRestClient(
   const proxyUrl = account.config.proxy?.trim();
   const proxyFetch =
     !opts.rest && proxyUrl
-      ? resolveDiscordRestFetch(proxyUrl, { log: () => {}, error: () => {}, exit: () => {} })
+      ? resolveDiscordRestFetch(proxyUrl, {
+          log: console.warn,
+          error: console.error,
+          exit: process.exit,
+        })
       : undefined;
   const rest = resolveRest(token, opts.rest, proxyFetch);
   return { token, rest, account };

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -8,6 +8,7 @@ import {
   resolveDiscordAccount,
   type ResolvedDiscordAccount,
 } from "./accounts.js";
+import { resolveDiscordRestFetch } from "./monitor/rest-fetch.js";
 import { createDiscordRetryRunner } from "./retry.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -30,8 +31,9 @@ function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+function resolveRest(token: string, rest?: RequestClient, proxyFetch?: typeof fetch) {
+  if (rest) return rest;
+  return proxyFetch ? new RequestClient(token, { fetch: proxyFetch }) : new RequestClient(token);
 }
 
 function resolveAccountWithoutToken(params: {
@@ -67,7 +69,14 @@ export function createDiscordRestClient(
       accountId: account.accountId,
       fallbackToken: account.token,
     });
-  const rest = resolveRest(token, opts.rest);
+  // When no pre-built RequestClient is provided, honour the proxy config so
+  // all Discord REST calls route through the configured HTTP(S) proxy.
+  const proxyUrl = account.config.proxy?.trim();
+  const proxyFetch =
+    !opts.rest && proxyUrl
+      ? resolveDiscordRestFetch(proxyUrl, { log: () => {}, error: () => {}, exit: () => {} })
+      : undefined;
+  const rest = resolveRest(token, opts.rest, proxyFetch);
   return { token, rest, account };
 }
 


### PR DESCRIPTION
## What
Pass the configured `channels.discord.proxy` URL through to `@buape/carbon` `RequestClient` so that Discord REST API calls (message sends, reactions, etc.) honour the proxy setting — matching the existing gateway WebSocket proxy behaviour.

## Why
Fixes #30221 — When `channels.discord.proxy` is configured, only the WebSocket gateway connection uses the proxy. REST API calls via `RequestClient` use `globalThis.fetch` directly, bypassing the proxy entirely. This breaks Discord in environments where `discord.com` requires a proxy (e.g., regions where Discord is blocked).

## How
- `@buape/carbon` `RequestClient` already supports an `options.fetch` field (uses `this.customFetch ?? fetch` internally)
- Reused the existing `resolveDiscordRestFetch()` from `monitor/rest-fetch.ts` which creates a proxy-aware fetch via undici `ProxyAgent`
- Wired it into `createDiscordRestClient()` → `resolveRest()` so the proxy fetch is injected when `account.config.proxy` is set
- When `opts.rest` is already provided (pre-built client), the proxy is skipped to avoid double-wrapping

## Testing
- [x] `pnpm check` passed
- [x] 6/6 tests passed (`extensions/discord/src/client.test.ts`)
- [x] Added 3 test cases: proxy configured, proxy with pre-built rest, no proxy
- [x] AI-assisted (Claude Code via ACP, fully tested)