### PR TITLE
fix(launchd): stop embedding state-dir .env vars in service metadata

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -342,7 +342,7 @@ describe("buildGatewayInstallPlan", () => {
   });
 });
 
-describe("buildGatewayInstallPlan — dotenv merge", () => {
+describe("buildGatewayInstallPlan — durable env merge", () => {
   let tmpDir: string;
 
   beforeEach(() => {
@@ -353,7 +353,7 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("merges .env file vars into the install plan", async () => {
+  it("does not copy state-dir .env vars into the install plan", async () => {
     await writeStateDirDotEnv("BRAVE_API_KEY=BSA-from-env\nOPENROUTER_API_KEY=or-key\n", {
       stateDir: path.join(tmpDir, ".openclaw"),
     });
@@ -365,12 +365,12 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       runtime: "node",
     });
 
-    expect(plan.environment.BRAVE_API_KEY).toBe("BSA-from-env");
-    expect(plan.environment.OPENROUTER_API_KEY).toBe("or-key");
+    expect(plan.environment.BRAVE_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENROUTER_API_KEY).toBeUndefined();
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
   });
 
-  it("config env vars override .env file vars", async () => {
+  it("config env vars are still included", async () => {
     await writeStateDirDotEnv("MY_KEY=from-dotenv\n", {
       stateDir: path.join(tmpDir, ".openclaw"),
     });

--- a/src/config/state-dir-dotenv.ts
+++ b/src/config/state-dir-dotenv.ts
@@ -15,9 +15,12 @@ function isBlockedServiceEnvVar(key: string): boolean {
 }
 
 /**
- * Read and parse `~/.openclaw/.env` (or `$OPENCLAW_STATE_DIR/.env`), returning
- * a filtered record of key-value pairs suitable for embedding in a service
- * environment (LaunchAgent plist, systemd unit, Scheduled Task).
+ * Read and parse `~/.openclaw/.env` (or `$OPENCLAW_STATE_DIR/.env`).
+ *
+ * These vars are durable runtime inputs, but should not be baked into service
+ * manager metadata (for example launchd plist EnvironmentVariables) because
+ * that creates a stale second source of truth that can override later `.env`
+ * edits on restart.
  */
 export function readStateDirDotEnvVars(
   env: Record<string, string | undefined>,
@@ -52,18 +55,17 @@ export function readStateDirDotEnvVars(
 
 /**
  * Durable service env sources survive beyond the invoking shell and are safe to
- * persist into gateway install metadata.
+ * persist into service install metadata.
  *
- * Precedence:
- * 1. state-dir `.env` file vars
- * 2. config service env vars
+ * Intentionally excludes state-dir `.env` values: those should be read at
+ * process startup, not duplicated into launchd/systemd/task metadata where they
+ * would become stale after `.env` edits.
  */
 export function collectDurableServiceEnvVars(params: {
   env: Record<string, string | undefined>;
   config?: OpenClawConfig;
 }): Record<string, string> {
   return {
-    ...readStateDirDotEnvVars(params.env),
     ...collectConfigServiceEnvVars(params.config),
   };
 }


### PR DESCRIPTION
## Summary
- stop copying state-dir `.env` values into gateway install service metadata
- keep config-provided service env values in the install plan
- add coverage to ensure `.env` keys are not baked into the LaunchAgent/system service environment

## Why
`~/.openclaw/.env` should remain the single source of truth for user-managed secrets at gateway startup. Embedding those keys into LaunchAgent `EnvironmentVariables` makes later `.env` edits stale because launchd-provided env vars win over dotenv loading on restart.

Closes #53387.
