### PR TITLE
fix(gateway): avoid snapshotting user env into services

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { writeStateDirDotEnv } from "../config/test-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   loadAuthProfileStoreForSecretsRuntime: vi.fn(),
@@ -85,9 +84,15 @@ function mockNodeGatewayPlanFixture(
   mocks.buildServiceEnvironment.mockReturnValue(serviceEnvironment);
 }
 
+function writeStateDirDotEnv(home: string, contents: string) {
+  const stateDir = path.join(home, ".openclaw");
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, ".env"), contents, "utf-8");
+}
+
 describe("buildGatewayInstallPlan", () => {
   // Prevent tests from reading the developer's real ~/.openclaw/.env when
-  // passing `env: {}` (which falls back to os.homedir for state-dir resolution).
+  // passing env objects that rely on HOME for state-dir resolution.
   let isolatedHome: string;
   beforeEach(() => {
     isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), "oc-plan-test-"));
@@ -157,7 +162,7 @@ describe("buildGatewayInstallPlan", () => {
     expect(mocks.resolvePreferredNodePath).toHaveBeenCalled();
   });
 
-  it("merges config env vars into the environment", async () => {
+  it("does not snapshot config env vars into the service environment", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
@@ -179,15 +184,13 @@ describe("buildGatewayInstallPlan", () => {
       },
     });
 
-    // Config env vars should be present
-    expect(plan.environment.GOOGLE_API_KEY).toBe("test-key");
-    expect(plan.environment.CUSTOM_VAR).toBe("custom-value");
-    // Service environment vars should take precedence
+    expect(plan.environment.GOOGLE_API_KEY).toBeUndefined();
+    expect(plan.environment.CUSTOM_VAR).toBeUndefined();
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
     expect(plan.environment.HOME).toBe("/Users/me");
   });
 
-  it("drops dangerous config env vars before service merge", async () => {
+  it("ignores config env vars even when they are otherwise valid", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
@@ -209,10 +212,10 @@ describe("buildGatewayInstallPlan", () => {
     });
 
     expect(plan.environment.NODE_OPTIONS).toBeUndefined();
-    expect(plan.environment.SAFE_KEY).toBe("safe-value");
+    expect(plan.environment.SAFE_KEY).toBeUndefined();
   });
 
-  it("does not include empty config env values", async () => {
+  it("keeps service env values without mixing in config env vars", async () => {
     mockNodeGatewayPlanFixture();
 
     const plan = await buildGatewayInstallPlan({
@@ -229,11 +232,12 @@ describe("buildGatewayInstallPlan", () => {
       },
     });
 
-    expect(plan.environment.VALID_KEY).toBe("valid");
+    expect(plan.environment.OPENCLAW_PORT).toBe("3000");
+    expect(plan.environment.VALID_KEY).toBeUndefined();
     expect(plan.environment.EMPTY_KEY).toBeUndefined();
   });
 
-  it("drops whitespace-only config env values", async () => {
+  it("ignores inline config env keys as well as vars entries", async () => {
     mockNodeGatewayPlanFixture({ serviceEnvironment: {} });
 
     const plan = await buildGatewayInstallPlan({
@@ -250,11 +254,11 @@ describe("buildGatewayInstallPlan", () => {
       },
     });
 
-    expect(plan.environment.VALID_KEY).toBe("valid");
+    expect(plan.environment.VALID_KEY).toBeUndefined();
     expect(plan.environment.TRIMMED_KEY).toBeUndefined();
   });
 
-  it("keeps service env values over config env vars", async () => {
+  it("does not let config env override service metadata fields", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         HOME: "/Users/service",
@@ -280,25 +284,10 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
   });
 
-  it("merges env-backed auth-profile refs into the service environment", async () => {
+  it("does not snapshot env-backed auth-profile refs into the service environment", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
-      },
-    });
-    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
-      version: 1,
-      profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-        },
-        "anthropic:default": {
-          type: "token",
-          provider: "anthropic",
-          tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
-        },
       },
     });
 
@@ -309,26 +298,31 @@ describe("buildGatewayInstallPlan", () => {
       },
       port: 3000,
       runtime: "node",
+      authStore: {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+          "anthropic:default": {
+            type: "token",
+            provider: "anthropic",
+            tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+          },
+        },
+      },
     });
 
-    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
-    expect(plan.environment.ANTHROPIC_TOKEN).toBe("ant-test-token");
+    expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
+    expect(plan.environment.ANTHROPIC_TOKEN).toBeUndefined();
   });
 
-  it("skips unresolved auth-profile env refs", async () => {
+  it("still leaves unresolved auth-profile env refs out of the service environment", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {
         OPENCLAW_PORT: "3000",
-      },
-    });
-    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
-      version: 1,
-      profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-        },
       },
     });
 
@@ -336,6 +330,16 @@ describe("buildGatewayInstallPlan", () => {
       env: {},
       port: 3000,
       runtime: "node",
+      authStore: {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      },
     });
 
     expect(plan.environment.OPENAI_API_KEY).toBeUndefined();
@@ -353,10 +357,8 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("merges .env file vars into the install plan", async () => {
-    await writeStateDirDotEnv("BRAVE_API_KEY=BSA-from-env\nOPENROUTER_API_KEY=or-key\n", {
-      stateDir: path.join(tmpDir, ".openclaw"),
-    });
+  it("does not merge .env file vars into the install plan", async () => {
+    writeStateDirDotEnv(tmpDir, "BRAVE_API_KEY=BSA-from-env\nOPENROUTER_API_KEY=or-key\n");
     mockNodeGatewayPlanFixture({ serviceEnvironment: { OPENCLAW_PORT: "3000" } });
 
     const plan = await buildGatewayInstallPlan({
@@ -365,15 +367,13 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       runtime: "node",
     });
 
-    expect(plan.environment.BRAVE_API_KEY).toBe("BSA-from-env");
-    expect(plan.environment.OPENROUTER_API_KEY).toBe("or-key");
+    expect(plan.environment.BRAVE_API_KEY).toBeUndefined();
+    expect(plan.environment.OPENROUTER_API_KEY).toBeUndefined();
     expect(plan.environment.OPENCLAW_PORT).toBe("3000");
   });
 
-  it("config env vars override .env file vars", async () => {
-    await writeStateDirDotEnv("MY_KEY=from-dotenv\n", {
-      stateDir: path.join(tmpDir, ".openclaw"),
-    });
+  it("still does not snapshot config env vars when a .env file exists", async () => {
+    writeStateDirDotEnv(tmpDir, "MY_KEY=from-dotenv\n");
     mockNodeGatewayPlanFixture({ serviceEnvironment: {} });
 
     const plan = await buildGatewayInstallPlan({
@@ -389,13 +389,11 @@ describe("buildGatewayInstallPlan — dotenv merge", () => {
       },
     });
 
-    expect(plan.environment.MY_KEY).toBe("from-config");
+    expect(plan.environment.MY_KEY).toBeUndefined();
   });
 
-  it("service env overrides .env file vars", async () => {
-    await writeStateDirDotEnv("HOME=/from-dotenv\n", {
-      stateDir: path.join(tmpDir, ".openclaw"),
-    });
+  it("service env overrides stay intact without copying .env file vars", async () => {
+    writeStateDirDotEnv(tmpDir, "HOME=/from-dotenv\n");
     mockNodeGatewayPlanFixture({
       serviceEnvironment: { HOME: "/from-service" },
     });

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -1,9 +1,5 @@
-import {
-  loadAuthProfileStoreForSecretsRuntime,
-  type AuthProfileStore,
-} from "../agents/auth-profiles.js";
+import type { AuthProfileStore } from "../agents/auth-profiles.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { collectDurableServiceEnvVars } from "../config/state-dir-dotenv.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
@@ -24,53 +20,6 @@ export type GatewayInstallPlan = {
   environment: Record<string, string | undefined>;
 };
 
-function collectAuthProfileServiceEnvVars(params: {
-  env: Record<string, string | undefined>;
-  authStore?: AuthProfileStore;
-}): Record<string, string> {
-  const authStore = params.authStore ?? loadAuthProfileStoreForSecretsRuntime();
-  const entries: Record<string, string> = {};
-
-  for (const credential of Object.values(authStore.profiles)) {
-    const ref =
-      credential.type === "api_key"
-        ? credential.keyRef
-        : credential.type === "token"
-          ? credential.tokenRef
-          : undefined;
-    if (!ref || ref.source !== "env") {
-      continue;
-    }
-    const value = params.env[ref.id]?.trim();
-    if (!value) {
-      continue;
-    }
-    entries[ref.id] = value;
-  }
-
-  return entries;
-}
-
-function buildGatewayInstallEnvironment(params: {
-  env: Record<string, string | undefined>;
-  config?: OpenClawConfig;
-  authStore?: AuthProfileStore;
-  serviceEnvironment: Record<string, string | undefined>;
-}): Record<string, string | undefined> {
-  const environment: Record<string, string | undefined> = {
-    ...collectDurableServiceEnvVars({
-      env: params.env,
-      config: params.config,
-    }),
-    ...collectAuthProfileServiceEnvVars({
-      env: params.env,
-      authStore: params.authStore,
-    }),
-  };
-  Object.assign(environment, params.serviceEnvironment);
-  return environment;
-}
-
 export async function buildGatewayInstallPlan(params: {
   env: Record<string, string | undefined>;
   port: number;
@@ -78,10 +27,14 @@ export async function buildGatewayInstallPlan(params: {
   devMode?: boolean;
   nodePath?: string;
   warn?: DaemonInstallWarnFn;
-  /** Full config to extract env vars from (env vars + inline env keys). */
+  /** Full config is still used during install-time validation elsewhere. */
   config?: OpenClawConfig;
   authStore?: AuthProfileStore;
 }): Promise<GatewayInstallPlan> {
+  void params.config;
+  // authStore is accepted for caller compatibility, but env-backed auth refs are
+  // intentionally no longer snapshotted into service metadata during install.
+  void params.authStore;
   const { devMode, nodePath } = await resolveDaemonInstallRuntimeInputs({
     env: params.env,
     runtime: params.runtime,
@@ -112,22 +65,7 @@ export async function buildGatewayInstallPlan(params: {
     // a version-manager bin directory that isn't covered by static PATH guesses.
     extraPathDirs: resolveDaemonNodeBinDir(nodePath),
   });
-
-  // Merge env sources into the service environment in ascending priority:
-  //   1. ~/.openclaw/.env file vars  (lowest — user secrets / fallback keys)
-  //   2. Config env vars              (openclaw.json env.vars + inline keys)
-  //   3. Auth-profile env refs        (credential store → env var lookups)
-  //   4. Service environment          (HOME, PATH, OPENCLAW_* — highest)
-  return {
-    programArguments,
-    workingDirectory,
-    environment: buildGatewayInstallEnvironment({
-      env: params.env,
-      config: params.config,
-      authStore: params.authStore,
-      serviceEnvironment,
-    }),
-  };
+  return { programArguments, workingDirectory, environment: serviceEnvironment };
 }
 
 export function gatewayInstallErrorHint(platform = process.platform): string {


### PR DESCRIPTION
## Summary

- Problem: openclaw gateway install snapshots user-managed config/auth env values into supervised service metadata, so editing ~/.openclaw/.env and restarting can keep using stale install-time values.
- Why it matters: .env becomes a misleading second source of truth; rotated API keys or updated env-backed auth refs are ignored until the user reinstalls the service.
- What changed: gateway install plans now persist only the internal service environment returned by uildServiceEnvironment(...) instead of copying config env vars and env-backed auth-profile refs into service metadata.
- What did NOT change (scope boundary): runtime config env resolution is unchanged; install-time validation still uses the config/auth data it already had.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53387
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: uildGatewayInstallPlan() merged collectConfigServiceEnvVars(config) and env-backed auth-profile refs into the service environment, which LaunchAgent/systemd/schtasks then persisted as install-time metadata.
- Missing guardrail: install-plan tests were asserting those user env vars should be copied into the service snapshot.

## User-visible / Behavior Changes

After reinstalling onto this version, users can update ~/.openclaw/.env and restart the gateway without the service metadata pinning old install-time env values.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: this reduces secret persistence by stopping service installs from copying user-managed config/auth env values into service metadata.

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: local test run
- Integration/channel (if any): gateway install plan / supervised service metadata

### Steps

1. Configure a user-managed env value in config or via an env-backed auth profile.
2. Build the gateway install plan.
3. Verify only internal service metadata remains in the persisted service environment.

## Evidence

- [x] Targeted regression test
- [x] Local verification

Targeted verification:
- pnpm test -- src/commands/daemon-install-helpers.test.ts
- pnpm exec oxfmt --check src/commands/daemon-install-helpers.ts src/commands/daemon-install-helpers.test.ts

## Human Verification (required)

- Verified scenarios: config env vars and env-backed auth-profile refs are no longer copied into the service install environment; internal service metadata still remains.
- What you did **not** verify: full install flow against a live LaunchAgent/systemd service.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No explicit migration, but users may want to rerun openclaw gateway install --force once to clear already-snapshotted values from existing service metadata.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: src/commands/daemon-install-helpers.ts, src/commands/daemon-install-helpers.test.ts

## Risks and Mitigations

- Risk: users relying on install-time snapshotting of shell-only env vars may need to move those values into ~/.openclaw/.env or another durable runtime source.
  - Mitigation: that aligns service behavior with documented .env loading and avoids stale plist/systemd values shadowing later updates.
