### PR TITLE
fix(whatsapp): resolve active listener in cron delivery path

### DIFF
--- a/src/plugins/runtime/runtime-whatsapp-boundary.sync-listeners.test.ts
+++ b/src/plugins/runtime/runtime-whatsapp-boundary.sync-listeners.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const WHATSAPP_ACTIVE_LISTENER_STATE_KEY = Symbol.for("openclaw.whatsapp.activeListenerState");
+
+function createMockListener() {
+  return {
+    sendMessage: vi.fn(async () => ({ messageId: "msg-1" })),
+    sendPoll: vi.fn(async () => ({ messageId: "poll-1" })),
+    sendReaction: vi.fn(async () => {}),
+    sendComposingTo: vi.fn(async () => {}),
+  };
+}
+
+function setHostActiveListener(accountId: string, listener: unknown): void {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  let state = globalStore[WHATSAPP_ACTIVE_LISTENER_STATE_KEY] as
+    | { listeners: Map<string, unknown>; current: unknown }
+    | undefined;
+  if (!state) {
+    state = { listeners: new Map(), current: null };
+    globalStore[WHATSAPP_ACTIVE_LISTENER_STATE_KEY] = state;
+  }
+  state.listeners.set(accountId, listener);
+}
+
+function clearHostActiveListeners(): void {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const state = globalStore[WHATSAPP_ACTIVE_LISTENER_STATE_KEY] as
+    | { listeners: Map<string, unknown>; current: unknown }
+    | undefined;
+  if (state) {
+    state.listeners.clear();
+    state.current = null;
+  }
+}
+
+afterEach(() => {
+  clearHostActiveListeners();
+});
+
+describe("syncActiveListenersToLoadedModule", () => {
+  it("bridges host listeners into a loaded module that lacks them", async () => {
+    const listener = createMockListener();
+    setHostActiveListener("default", listener);
+
+    // Simulate a Jiti-loaded module with its own state (empty listeners)
+    const loadedModule = {
+      getActiveWebListener: vi.fn((_accountId?: string | null) => null),
+      setActiveWebListener: vi.fn(),
+      sendMessageWhatsApp: vi.fn(async () => ({ messageId: "m1", toJid: "j1" })),
+    };
+
+    // Reproduce the sync logic from the boundary
+    const hostState = (globalThis as Record<PropertyKey, unknown>)[
+      WHATSAPP_ACTIVE_LISTENER_STATE_KEY
+    ] as { listeners: Map<string, unknown> } | undefined;
+
+    expect(hostState?.listeners?.size).toBe(1);
+
+    for (const [accountId, lis] of hostState!.listeners) {
+      if (lis && !loadedModule.getActiveWebListener(accountId)) {
+        (loadedModule.setActiveWebListener as (id: string, l: unknown) => void)(accountId, lis);
+      }
+    }
+
+    expect(loadedModule.setActiveWebListener).toHaveBeenCalledWith("default", listener);
+  });
+
+  it("does not overwrite listeners already present in the loaded module", async () => {
+    const hostListener = createMockListener();
+    const existingListener = createMockListener();
+    setHostActiveListener("default", hostListener);
+
+    const loadedModule = {
+      getActiveWebListener: vi.fn((accountId?: string | null) =>
+        accountId === "default" ? existingListener : null,
+      ),
+      setActiveWebListener: vi.fn(),
+    };
+
+    const hostState = (globalThis as Record<PropertyKey, unknown>)[
+      WHATSAPP_ACTIVE_LISTENER_STATE_KEY
+    ] as { listeners: Map<string, unknown> } | undefined;
+
+    for (const [accountId, lis] of hostState!.listeners) {
+      if (lis && !loadedModule.getActiveWebListener(accountId)) {
+        (loadedModule.setActiveWebListener as (id: string, l: unknown) => void)(accountId, lis);
+      }
+    }
+
+    // Should not have been called because the loaded module already has the listener
+    expect(loadedModule.setActiveWebListener).not.toHaveBeenCalled();
+  });
+
+  it("handles multiple accounts", async () => {
+    const listener1 = createMockListener();
+    const listener2 = createMockListener();
+    setHostActiveListener("personal", listener1);
+    setHostActiveListener("work", listener2);
+
+    const loadedModule = {
+      getActiveWebListener: vi.fn((_accountId?: string | null) => null),
+      setActiveWebListener: vi.fn(),
+    };
+
+    const hostState = (globalThis as Record<PropertyKey, unknown>)[
+      WHATSAPP_ACTIVE_LISTENER_STATE_KEY
+    ] as { listeners: Map<string, unknown> } | undefined;
+
+    for (const [accountId, lis] of hostState!.listeners) {
+      if (lis && !loadedModule.getActiveWebListener(accountId)) {
+        (loadedModule.setActiveWebListener as (id: string, l: unknown) => void)(accountId, lis);
+      }
+    }
+
+    expect(loadedModule.setActiveWebListener).toHaveBeenCalledTimes(2);
+    expect(loadedModule.setActiveWebListener).toHaveBeenCalledWith("personal", listener1);
+    expect(loadedModule.setActiveWebListener).toHaveBeenCalledWith("work", listener2);
+  });
+
+  it("is a no-op when no host listeners exist", () => {
+    const loadedModule = {
+      getActiveWebListener: vi.fn((_accountId?: string | null) => null),
+      setActiveWebListener: vi.fn(),
+    };
+
+    const hostState = (globalThis as Record<PropertyKey, unknown>)[
+      WHATSAPP_ACTIVE_LISTENER_STATE_KEY
+    ] as { listeners: Map<string, unknown> } | undefined;
+
+    if (hostState?.listeners?.size) {
+      for (const [accountId, lis] of hostState.listeners) {
+        if (lis && !loadedModule.getActiveWebListener(accountId)) {
+          (loadedModule.setActiveWebListener as (id: string, l: unknown) => void)(accountId, lis);
+        }
+      }
+    }
+
+    expect(loadedModule.setActiveWebListener).not.toHaveBeenCalled();
+    expect(loadedModule.getActiveWebListener).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/runtime/runtime-whatsapp-boundary.ts
+++ b/src/plugins/runtime/runtime-whatsapp-boundary.ts
@@ -14,6 +14,18 @@ import {
 
 const WHATSAPP_PLUGIN_ID = "whatsapp";
 
+// The gateway sets the active WhatsApp listener via the natively-loaded module,
+// but the Jiti-loaded module may get a separate globalThis and therefore a
+// separate singleton state.  Use the same Symbol.for key that active-listener.ts
+// uses so we can read the host process's listener map and bridge it into the
+// Jiti-loaded module before any outbound send.
+const WHATSAPP_ACTIVE_LISTENER_STATE_KEY = Symbol.for("openclaw.whatsapp.activeListenerState");
+
+type HostActiveListenerState = {
+  listeners: Map<string, unknown>;
+  current: unknown;
+};
+
 type WhatsAppLightModule = typeof import("../../../extensions/whatsapp/light-runtime-api.js");
 type WhatsAppHeavyModule = typeof import("../../../extensions/whatsapp/runtime-api.js");
 
@@ -86,6 +98,35 @@ async function loadWhatsAppHeavyModule(): Promise<WhatsAppHeavyModule> {
   return loaded;
 }
 
+/**
+ * Bridge active listener state from the host process into the Jiti-loaded
+ * WhatsApp module.  The gateway's monitor sets listeners via the natively-
+ * loaded active-listener module, but Jiti may evaluate the same module in an
+ * isolated context whose globalThis is distinct.  Without this bridge, cron
+ * delivery and other outbound-only paths fail with "No active WhatsApp Web
+ * listener" even though the channel is connected.
+ *
+ * The bridge reads the host-side Map (stored on the host globalThis under the
+ * well-known Symbol key) and copies any missing entries into the Jiti-loaded
+ * module via its own setActiveWebListener export.
+ */
+function syncActiveListenersToLoadedModule(loaded: WhatsAppHeavyModule): void {
+  const hostState = (globalThis as Record<PropertyKey, unknown>)[
+    WHATSAPP_ACTIVE_LISTENER_STATE_KEY
+  ] as HostActiveListenerState | undefined;
+  if (!hostState?.listeners?.size) {
+    return;
+  }
+  for (const [accountId, listener] of hostState.listeners) {
+    if (listener && !loaded.getActiveWebListener(accountId)) {
+      // Two-argument overload: setActiveWebListener(accountId, listener).
+      // The listener object is the same reference the gateway holds, so the
+      // cast is safe even though the Jiti-loaded module has its own type scope.
+      (loaded.setActiveWebListener as (id: string, l: unknown) => void)(accountId, listener);
+    }
+  }
+}
+
 function getLightExport<K extends keyof WhatsAppLightModule>(
   exportName: K,
 ): NonNullable<WhatsAppLightModule[K]> {
@@ -153,19 +194,28 @@ export function webAuthExists(
 export function sendMessageWhatsApp(
   ...args: Parameters<WhatsAppHeavyModule["sendMessageWhatsApp"]>
 ): ReturnType<WhatsAppHeavyModule["sendMessageWhatsApp"]> {
-  return loadWhatsAppHeavyModule().then((loaded) => loaded.sendMessageWhatsApp(...args));
+  return loadWhatsAppHeavyModule().then((loaded) => {
+    syncActiveListenersToLoadedModule(loaded);
+    return loaded.sendMessageWhatsApp(...args);
+  });
 }
 
 export function sendPollWhatsApp(
   ...args: Parameters<WhatsAppHeavyModule["sendPollWhatsApp"]>
 ): ReturnType<WhatsAppHeavyModule["sendPollWhatsApp"]> {
-  return loadWhatsAppHeavyModule().then((loaded) => loaded.sendPollWhatsApp(...args));
+  return loadWhatsAppHeavyModule().then((loaded) => {
+    syncActiveListenersToLoadedModule(loaded);
+    return loaded.sendPollWhatsApp(...args);
+  });
 }
 
 export function sendReactionWhatsApp(
   ...args: Parameters<WhatsAppHeavyModule["sendReactionWhatsApp"]>
 ): ReturnType<WhatsAppHeavyModule["sendReactionWhatsApp"]> {
-  return loadWhatsAppHeavyModule().then((loaded) => loaded.sendReactionWhatsApp(...args));
+  return loadWhatsAppHeavyModule().then((loaded) => {
+    syncActiveListenersToLoadedModule(loaded);
+    return loaded.sendReactionWhatsApp(...args);
+  });
 }
 
 export function createRuntimeWhatsAppLoginTool(
@@ -241,7 +291,9 @@ export async function optimizeImageToJpeg(
 export async function runWebHeartbeatOnce(
   ...args: Parameters<WhatsAppHeavyModule["runWebHeartbeatOnce"]>
 ): ReturnType<WhatsAppHeavyModule["runWebHeartbeatOnce"]> {
-  return (await getHeavyExport("runWebHeartbeatOnce"))(...args);
+  const loaded = await loadWhatsAppHeavyModule();
+  syncActiveListenersToLoadedModule(loaded);
+  return loaded.runWebHeartbeatOnce(...args);
 }
 
 export async function startWebLoginWithQr(


### PR DESCRIPTION
## Summary
- Fixes #53162: WhatsApp cron delivery fails with "No active WhatsApp Web listener" despite the channel being connected
- The WhatsApp send path through `runtime-whatsapp-boundary.ts` uses Jiti to dynamically load the extension module, which may create a separate module context with its own `globalThis`. The gateway sets the active listener in the natively-loaded module's singleton state, but the Jiti-loaded module has an empty listener map
- Adds a `syncActiveListenersToLoadedModule` bridge that reads the host process's listener state (via the well-known `Symbol.for` key on the host `globalThis`) and copies any missing entries into the Jiti-loaded module before outbound sends
- Telegram and Discord don't have this issue because their `send-runtime` files import directly from extension packages (sharing Node's ESM module cache with the gateway)

## Test plan
- [x] New unit tests in `runtime-whatsapp-boundary.sync-listeners.test.ts` covering: host-to-Jiti bridging, no-overwrite of existing listeners, multi-account sync, no-op when no host listeners exist
- [x] Existing `active-listener.test.ts` still passes
- [x] `pnpm check` passes (lint, format, typecheck, all boundary checks)