### PR TITLE
fix(security): resolve 5 Aisle findings from #53411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/skills: validate skill installer metadata against strict regex allowlists per package manager, sanitize skill metadata for terminal output, add URL protocol allowlisting in markdown preview and skill homepage links, warn on non-bundled skill install sources, and remove unsafe `file://` workspace links. (#53471) Thanks @BunsDev.
 - Feishu/docx block ordering: preserve the document tree order from `docx.document.convert` when inserting blocks, fixing heading/paragraph/list misordering in newly written Feishu documents. (#40524) Thanks @TaoXieSZ.
 - Agents/cron: suppress the default heartbeat system prompt for cron-triggered embedded runs even when they target non-cron session keys, so cron tasks stop reading `HEARTBEAT.md` and polluting unrelated threads. (#53152) Thanks @Protocol-zero-0.
 - TUI/chat: preserve pending user messages when a slow local run emits an empty final event, but still defer and flush the needed history reload after the newer active run finishes so silent/tool-only runs do not stay incomplete. (#53130) Thanks @joelnishanth.

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -114,7 +114,7 @@ function buildNodeInstallCommand(packageName: string, prefs: SkillsInstallPrefer
 // Strict allowlist patterns to prevent option injection and malicious package names.
 const SAFE_BREW_FORMULA = /^[a-z0-9][a-z0-9+._-]*(\/[a-z0-9][a-z0-9+._-]*){0,2}$/;
 const SAFE_NODE_PACKAGE = /^(@[a-z0-9._-]+\/)?[a-z0-9._-]+(@[a-z0-9^~>=<.*|-]+)?$/;
-const SAFE_GO_MODULE = /^[a-z0-9][a-z0-9._/-]*@[a-z0-9v._-]+$/;
+const SAFE_GO_MODULE = /^[a-zA-Z0-9][a-zA-Z0-9._/-]*@[a-z0-9v._-]+$/;
 const SAFE_UV_PACKAGE = /^[a-z0-9][a-z0-9._-]*(>=?[a-z0-9._-]+)?$/i;
 
 function assertSafeInstallerValue(value: string, kind: string, pattern: RegExp): string | null {

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -111,6 +111,23 @@ function buildNodeInstallCommand(packageName: string, prefs: SkillsInstallPrefer
   }
 }
 
+// Strict allowlist patterns to prevent option injection and malicious package names.
+const SAFE_BREW_FORMULA = /^[a-z0-9][a-z0-9+._-]*(\/[a-z0-9][a-z0-9+._-]*){0,2}$/;
+const SAFE_NODE_PACKAGE = /^(@[a-z0-9._-]+\/)?[a-z0-9._-]+(@[a-z0-9^~>=<.*|-]+)?$/;
+const SAFE_GO_MODULE = /^[a-z0-9][a-z0-9._/-]*@[a-z0-9v._-]+$/;
+const SAFE_UV_PACKAGE = /^[a-z0-9][a-z0-9._-]*(>=?[a-z0-9._-]+)?$/i;
+
+function assertSafeInstallerValue(value: string, kind: string, pattern: RegExp): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("-")) {
+    return `${kind} value is empty or starts with a dash`;
+  }
+  if (!pattern.test(trimmed)) {
+    return `${kind} value contains invalid characters: ${trimmed}`;
+  }
+  return null;
+}
+
 function buildInstallCommand(
   spec: SkillInstallSpec,
   prefs: SkillsInstallPreferences,
@@ -123,27 +140,43 @@ function buildInstallCommand(
       if (!spec.formula) {
         return { argv: null, error: "missing brew formula" };
       }
-      return { argv: ["brew", "install", spec.formula] };
+      const err = assertSafeInstallerValue(spec.formula, "brew formula", SAFE_BREW_FORMULA);
+      if (err) {
+        return { argv: null, error: err };
+      }
+      return { argv: ["brew", "install", spec.formula.trim()] };
     }
     case "node": {
       if (!spec.package) {
         return { argv: null, error: "missing node package" };
       }
+      const err = assertSafeInstallerValue(spec.package, "node package", SAFE_NODE_PACKAGE);
+      if (err) {
+        return { argv: null, error: err };
+      }
       return {
-        argv: buildNodeInstallCommand(spec.package, prefs),
+        argv: buildNodeInstallCommand(spec.package.trim(), prefs),
       };
     }
     case "go": {
       if (!spec.module) {
         return { argv: null, error: "missing go module" };
       }
-      return { argv: ["go", "install", spec.module] };
+      const err = assertSafeInstallerValue(spec.module, "go module", SAFE_GO_MODULE);
+      if (err) {
+        return { argv: null, error: err };
+      }
+      return { argv: ["go", "install", spec.module.trim()] };
     }
     case "uv": {
       if (!spec.package) {
         return { argv: null, error: "missing uv package" };
       }
-      return { argv: ["uv", "tool", "install", spec.package] };
+      const err = assertSafeInstallerValue(spec.package, "uv package", SAFE_UV_PACKAGE);
+      if (err) {
+        return { argv: null, error: err };
+      }
+      return { argv: ["uv", "tool", "install", spec.package.trim()] };
     }
     case "download": {
       return { argv: null, error: "download install handled separately" };
@@ -406,6 +439,15 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
   const spec = findInstallSpec(entry, params.installId);
   const warnings = await collectSkillInstallScanWarnings(entry);
+
+  // Warn when install is triggered from a non-bundled source.
+  // Workspace/project/personal agent skills can contain attacker-controlled metadata.
+  const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);
+  if (!trustedInstallSources.has(entry.skill.source)) {
+    warnings.push(
+      `WARNING: Skill "${params.skillName}" install triggered from non-bundled source "${entry.skill.source}". Verify the install recipe is trusted.`,
+    );
+  }
   if (!spec) {
     return withWarnings(
       {

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -1,5 +1,5 @@
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
-import { stripAnsi } from "../terminal/ansi.js";
+import { sanitizeForLog, stripAnsi } from "../terminal/ansi.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
@@ -71,7 +71,7 @@ function sanitizeJsonValue(value: unknown): unknown {
 }
 function formatSkillName(skill: SkillStatusEntry): string {
   const emoji = normalizeSkillEmoji(skill.emoji);
-  return `${emoji} ${theme.command(skill.name)}`;
+  return `${emoji} ${theme.command(sanitizeForLog(skill.name))}`;
 }
 
 function formatSkillMissingSummary(skill: SkillStatusEntry): string {
@@ -194,16 +194,20 @@ export function formatSkillInfo(
         ? theme.warn("🚫 Blocked by allowlist")
         : theme.warn("△ Needs setup");
 
-  lines.push(`${emoji} ${theme.heading(skill.name)} ${status}`);
+  const safeName = sanitizeForLog(skill.name);
+  const safeHomepage = skill.homepage ? sanitizeForLog(skill.homepage) : undefined;
+  const safeSkillKey = sanitizeForLog(skill.skillKey);
+
+  lines.push(`${emoji} ${theme.heading(safeName)} ${status}`);
   lines.push("");
-  lines.push(skill.description);
+  lines.push(sanitizeForLog(skill.description));
   lines.push("");
 
   lines.push(theme.heading("Details:"));
-  lines.push(`${theme.muted("  Source:")} ${skill.source}`);
+  lines.push(`${theme.muted("  Source:")} ${sanitizeForLog(skill.source)}`);
   lines.push(`${theme.muted("  Path:")} ${shortenHomePath(skill.filePath)}`);
-  if (skill.homepage) {
-    lines.push(`${theme.muted("  Homepage:")} ${skill.homepage}`);
+  if (safeHomepage) {
+    lines.push(`${theme.muted("  Homepage:")} ${safeHomepage}`);
   }
   if (skill.primaryEnv) {
     lines.push(`${theme.muted("  Primary env:")} ${skill.primaryEnv}`);
@@ -268,17 +272,17 @@ export function formatSkillInfo(
   if (skill.primaryEnv && skill.missing.env.includes(skill.primaryEnv)) {
     lines.push("");
     lines.push(theme.heading("API key setup:"));
-    if (skill.homepage) {
-      lines.push(`  Get your key: ${skill.homepage}`);
+    if (safeHomepage) {
+      lines.push(`  Get your key: ${safeHomepage}`);
     }
     lines.push(
-      `  Save via UI: ${theme.muted("Control UI → Skills → ")}${skill.name}${theme.muted(" → Save key")}`,
+      `  Save via UI: ${theme.muted("Control UI → Skills → ")}${safeName}${theme.muted(" → Save key")}`,
     );
     lines.push(
-      `  Save via CLI: ${formatCliCommand(`openclaw config set skills.entries.${skill.skillKey}.apiKey YOUR_KEY`)}`,
+      `  Save via CLI: ${formatCliCommand(`openclaw config set skills.entries.${safeSkillKey}.apiKey YOUR_KEY`)}`,
     );
     lines.push(
-      `  Stored in: ${theme.muted("~/.openclaw/openclaw.json")} ${theme.muted(`(skills.entries.${skill.skillKey}.apiKey)`)}`,
+      `  Stored in: ${theme.muted("~/.openclaw/openclaw.json")} ${theme.muted(`(skills.entries.${safeSkillKey}.apiKey)`)}`,
     );
   }
 
@@ -331,7 +335,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     lines.push(theme.heading("Ready to use:"));
     for (const skill of eligible) {
       const emoji = normalizeSkillEmoji(skill.emoji);
-      lines.push(`  ${emoji} ${skill.name}`);
+      lines.push(`  ${emoji} ${sanitizeForLog(skill.name)}`);
     }
   }
 
@@ -341,7 +345,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     for (const skill of missingReqs) {
       const emoji = normalizeSkillEmoji(skill.emoji);
       const missing = formatSkillMissingSummary(skill);
-      lines.push(`  ${emoji} ${skill.name} ${theme.muted(`(${missing})`)}`);
+      lines.push(`  ${emoji} ${sanitizeForLog(skill.name)} ${theme.muted(`(${missing})`)}`);
     }
   }
 

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -99,6 +99,20 @@ function installHooks() {
     if (!href) {
       return;
     }
+
+    // Block dangerous URL schemes (javascript:, data:, vbscript:, etc.)
+    try {
+      const url = new URL(href, window.location.href);
+      if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "mailto:") {
+        node.removeAttribute("href");
+        return;
+      }
+    } catch {
+      // Relative URLs are fine; malformed absolute URLs with dangerous schemes
+      // will fail to parse and keep their href — but DOMPurify already strips
+      // javascript: by default. This is defense-in-depth.
+    }
+
     node.setAttribute("rel", "noreferrer noopener");
     node.setAttribute("target", "_blank");
     if (href.toLowerCase().includes("tail")) {

--- a/ui/src/ui/views/agents-panels-status-files.ts
+++ b/ui/src/ui/views/agents-panels-status-files.ts
@@ -388,10 +388,7 @@ export function renderAgentFiles(params: {
       </div>
       ${
         list
-          ? html`<div class="muted mono" style="margin-top: 8px;">Workspace: <a
-              href="file://${list.workspace}"
-              class="workspace-link"
-            >${list.workspace}</a></div>`
+          ? html`<div class="muted mono" style="margin-top: 8px;">Workspace: <span>${list.workspace}</span></div>`
           : nothing
       }
       ${

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -352,7 +352,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
           <div style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: 12px; color: var(--muted);">
             <div><span style="font-weight: 600;">Source:</span> ${skill.source}</div>
             <div style="font-family: var(--mono); word-break: break-all;">${skill.filePath}</div>
-            ${safeExternalHref(skill.homepage) ? html`<div><a href="${safeExternalHref(skill.homepage)}" target="_blank" rel="noopener noreferrer">${skill.homepage}</a></div>` : nothing}
+            ${(() => { const safeHref = safeExternalHref(skill.homepage); return safeHref ? html`<div><a href="${safeHref}" target="_blank" rel="noopener noreferrer">${skill.homepage}</a></div>` : nothing; })()}
           </div>
         </div>
       </div>

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -1,8 +1,16 @@
 import { html, nothing } from "lit";
 import type { SkillMessageMap } from "../controllers/skills.ts";
 import { clampText } from "../format.ts";
+import { resolveSafeExternalUrl } from "../open-external-url.ts";
 import type { SkillStatusEntry, SkillStatusReport } from "../types.ts";
 import { groupSkills } from "./skills-grouping.ts";
+
+function safeExternalHref(raw?: string): string | null {
+  if (!raw) {
+    return null;
+  }
+  return resolveSafeExternalUrl(raw, window.location.href);
+}
 import {
   computeSkillMissing,
   computeSkillReasons,
@@ -323,9 +331,9 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                     />
                   </div>
                   ${
-                    skill.homepage
+                    safeExternalHref(skill.homepage)
                       ? html`<div class="muted" style="font-size: 13px;">
-                        Get your key: <a href="${skill.homepage}" target="_blank" rel="noopener">${skill.homepage}</a>
+                        Get your key: <a href="${safeExternalHref(skill.homepage)}" target="_blank" rel="noopener noreferrer">${skill.homepage}</a>
                       </div>`
                       : nothing
                   }
@@ -344,7 +352,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
           <div style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: 12px; color: var(--muted);">
             <div><span style="font-weight: 600;">Source:</span> ${skill.source}</div>
             <div style="font-family: var(--mono); word-break: break-all;">${skill.filePath}</div>
-            ${skill.homepage ? html`<div><a href="${skill.homepage}" target="_blank" rel="noopener">${skill.homepage}</a></div>` : nothing}
+            ${safeExternalHref(skill.homepage) ? html`<div><a href="${safeExternalHref(skill.homepage)}" target="_blank" rel="noopener noreferrer">${skill.homepage}</a></div>` : nothing}
           </div>
         </div>
       </div>

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -4,6 +4,11 @@ import { clampText } from "../format.ts";
 import { resolveSafeExternalUrl } from "../open-external-url.ts";
 import type { SkillStatusEntry, SkillStatusReport } from "../types.ts";
 import { groupSkills } from "./skills-grouping.ts";
+import {
+  computeSkillMissing,
+  computeSkillReasons,
+  renderSkillStatusChips,
+} from "./skills-shared.ts";
 
 function safeExternalHref(raw?: string): string | null {
   if (!raw) {
@@ -11,11 +16,6 @@ function safeExternalHref(raw?: string): string | null {
   }
   return resolveSafeExternalUrl(raw, window.location.href);
 }
-import {
-  computeSkillMissing,
-  computeSkillReasons,
-  renderSkillStatusChips,
-} from "./skills-shared.ts";
 
 export type SkillsStatusFilter = "all" | "ready" | "needs-setup" | "disabled";
 


### PR DESCRIPTION
## Summary

Resolves the 5 remaining security findings from the [Aisle scan on PR #53411](https://github.com/openclaw/openclaw/pull/53411#issuecomment-4115479974). Finding #5 (SwiftUI homepage validation) was already fixed in #53411 via commit `3aecbc3a`.

## Aisle Findings — Full Breakdown

| # | Severity | Finding | Resolved in |
|---|----------|---------|-------------|
| 1 | 🟠 High | Unvalidated `skill.homepage` in web UI (javascript:/data: injection) | **This PR** |
| 2 | 🟠 High | Untrusted skill install metadata → arbitrary package install (RCE) | **This PR** |
| 3 | 🟡 Medium | Terminal escape injection via skill metadata in CLI output | **This PR** |
| 4 | 🟡 Medium | XSS in markdown preview (`marked.parse + unsafeHTML`) | **This PR** |
| 5 | 🔵 Low | Unvalidated `skill.homepage` in SwiftUI Link destination | **#53411** (commit `3aecbc3a`) |
| 6 | 🔵 Low | Unsafe clickable `file://` link from workspace path | **This PR** |

## What changed

### 1. Web UI: skill homepage URL validation (`ui/src/ui/views/skills.ts`)
- Added `safeExternalHref()` wrapper using existing `resolveSafeExternalUrl` (http/https only)
- Applied to both API key setup link and details footer link
- Added `rel="noopener noreferrer"` consistently

### 2. Skill installer input validation (`src/agents/skills-install.ts`)
- Added strict regex allowlists per installer kind:
  - `brew`: `^[a-z0-9][a-z0-9+._-]*(\/[a-z0-9][a-z0-9+._-]*){0,2}$`
  - `node`: scoped/unscoped package names with optional version
  - `go`: module path with version suffix
  - `uv`: package name with optional version constraint
- Reject all values starting with `-` (option injection)
- Warn when install is triggered from non-bundled skill source

### 3. CLI terminal escape sanitization (`src/cli/skills-cli.format.ts`)
- Applied `sanitizeForLog()` to `skill.name`, `homepage`, `skillKey`, `description`, and `source` in all non-JSON output paths
- JSON output was already sanitized via `sanitizeJsonValue()`

### 4. Markdown DOMPurify protocol validation (`ui/src/ui/markdown.ts`)
- Added URL protocol allowlist (http/https/mailto) in `afterSanitizeAttributes` hook
- Defense-in-depth alongside DOMPurify's built-in javascript: stripping

### 5. Remove file:// workspace link (`ui/src/ui/views/agents-panels-status-files.ts`)
- Changed clickable `file://` link to plain text `<span>`

## Testing
- `pnpm check` passes (format, typecheck, lint, all boundary checks)
- `pnpm vitest run src/agents/skills-install.test.ts` — 2/2 pass
- Existing `open-external-url.test.ts` already covers `resolveSafeExternalUrl` blocking `file://`

Refs: #53411

Co-authored-by: Nova <nova@openknot.ai>