### PR TITLE
fix(cli): make Matrix recovery paths tolerate stale plugin config during install/doctor (#52899)

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createCliRuntimeCapture } from "./test-runtime-capture.js";
 
 export const loadConfig = vi.fn<() => OpenClawConfig>(() => ({}) as OpenClawConfig);
+export const readConfigFileSnapshot = vi.fn();
 export const writeConfigFile = vi.fn<(config: OpenClawConfig) => Promise<void>>(
   async () => undefined,
 );
@@ -39,6 +40,7 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("../config/config.js", () => ({
   loadConfig: () => loadConfig(),
+  readConfigFileSnapshot: (...args: unknown[]) => readConfigFileSnapshot(...args),
   writeConfigFile: (config: OpenClawConfig) => writeConfigFile(config),
 }));
 
@@ -138,6 +140,7 @@ export function runPluginsCommand(argv: string[]) {
 export function resetPluginsCliTestState() {
   resetRuntimeCapture();
   loadConfig.mockReset();
+  readConfigFileSnapshot.mockReset();
   writeConfigFile.mockReset();
   resolveStateDir.mockReset();
   installPluginFromMarketplace.mockReset();
@@ -161,6 +164,19 @@ export function resetPluginsCliTestState() {
   recordHookInstall.mockReset();
 
   loadConfig.mockReturnValue({} as OpenClawConfig);
+  readConfigFileSnapshot.mockResolvedValue({
+    path: "/tmp/openclaw-config.json5",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    resolved: {},
+    valid: true,
+    config: {} as OpenClawConfig,
+    hash: "mock",
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  });
   writeConfigFile.mockResolvedValue(undefined);
   resolveStateDir.mockReturnValue("/tmp/openclaw-state");
   resolveMarketplaceInstallShortcut.mockResolvedValue(null);

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig } from "../config/config.js";
+import { loadConfig, readBestEffortConfig } from "../config/config.js";
 import { installHooksFromNpmSpec, installHooksFromPath } from "../hooks/install.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub.js";
@@ -167,6 +167,17 @@ async function tryInstallHookPackFromNpmSpec(params: {
   return { ok: true };
 }
 
+// loadConfig() throws when config is invalid; fall back to best-effort so
+// repair-oriented installs (e.g. reinstalling a broken Matrix plugin) can
+// still proceed from a partially valid config snapshot.
+async function loadConfigForInstall(): Promise<OpenClawConfig> {
+  try {
+    return loadConfig();
+  } catch {
+    return readBestEffortConfig();
+  }
+}
+
 export async function runPluginInstallCommand(params: {
   raw: string;
   opts: { link?: boolean; pin?: boolean; marketplace?: string };
@@ -196,7 +207,7 @@ export async function runPluginInstallCommand(params: {
       return defaultRuntime.exit(1);
     }
 
-    const cfg = loadConfig();
+    const cfg = await loadConfigForInstall();
     const result = await installPluginFromMarketplace({
       marketplace: opts.marketplace,
       plugin: raw,
@@ -230,7 +241,7 @@ export async function runPluginInstallCommand(params: {
   }
   const normalized = fileSpec && fileSpec.ok ? fileSpec.path : raw;
   const resolved = resolveUserPath(normalized);
-  const cfg = loadConfig();
+  const cfg = await loadConfigForInstall();
 
   if (fs.existsSync(resolved)) {
     if (opts.link) {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { cleanStaleMatrixPluginConfig } from "../commands/doctor/providers/matrix.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig, readBestEffortConfig } from "../config/config.js";
 import { installHooksFromNpmSpec, installHooksFromPath } from "../hooks/install.js";
@@ -170,12 +171,28 @@ async function tryInstallHookPackFromNpmSpec(params: {
 // loadConfig() throws when config is invalid; fall back to best-effort so
 // repair-oriented installs (e.g. reinstalling a broken Matrix plugin) can
 // still proceed from a partially valid config snapshot.
+// Only catch config-validation errors — real failures (fs permission, OOM)
+// must surface so the user sees the actual problem.
+// After loading, clean any stale Matrix plugin references so that
+// persistPluginInstall() → writeConfigFile() does not fail validation
+// on paths that no longer exist (#52899 concern 4).
 async function loadConfigForInstall(): Promise<OpenClawConfig> {
+  let cfg: OpenClawConfig;
   try {
-    return loadConfig();
-  } catch {
-    return readBestEffortConfig();
+    cfg = loadConfig();
+  } catch (err) {
+    if (isConfigValidationError(err)) {
+      cfg = await readBestEffortConfig();
+    } else {
+      throw err;
+    }
   }
+  const cleaned = await cleanStaleMatrixPluginConfig(cfg);
+  return cleaned.config;
+}
+
+function isConfigValidationError(err: unknown): boolean {
+  return err instanceof Error && (err as { code?: string }).code === "INVALID_CONFIG";
 }
 
 export async function runPluginInstallCommand(params: {

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs";
 import { cleanStaleMatrixPluginConfig } from "../commands/doctor/providers/matrix.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig, readBestEffortConfig } from "../config/config.js";
+import { loadConfig, readConfigFileSnapshot } from "../config/config.js";
 import { installHooksFromNpmSpec, installHooksFromPath } from "../hooks/install.js";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub.js";
+import { extractErrorCode } from "../infra/errors.js";
 import { type BundledPluginSource, findBundledPluginSource } from "../plugins/bundled-sources.js";
 import { formatClawHubSpecifier, installPluginFromClawHub } from "../plugins/clawhub.js";
 import { installPluginFromNpmSpec, installPluginFromPath } from "../plugins/install.js";
@@ -168,31 +169,37 @@ async function tryInstallHookPackFromNpmSpec(params: {
   return { ok: true };
 }
 
-// loadConfig() throws when config is invalid; fall back to best-effort so
-// repair-oriented installs (e.g. reinstalling a broken Matrix plugin) can
-// still proceed from a partially valid config snapshot.
+// loadConfig() throws when config is invalid; fall back to the raw config
+// snapshot so repair-oriented installs (e.g. reinstalling a broken Matrix
+// plugin) can still proceed.
 // Only catch config-validation errors — real failures (fs permission, OOM)
 // must surface so the user sees the actual problem.
-// After loading, clean any stale Matrix plugin references so that
-// persistPluginInstall() → writeConfigFile() does not fail validation
-// on paths that no longer exist (#52899 concern 4).
-async function loadConfigForInstall(): Promise<OpenClawConfig> {
-  let cfg: OpenClawConfig;
+// Narrow guard: only proceed from the snapshot when the file was parsed
+// successfully (snapshot.parsed has content). For parse/read failures the
+// snapshot config is {} which would cause writeConfigFile() to overwrite
+// the user's real config with a minimal stub (#52899 concern 4).
+export async function loadConfigForInstall(): Promise<OpenClawConfig> {
   try {
-    cfg = loadConfig();
+    const cfg = loadConfig();
+    const cleaned = await cleanStaleMatrixPluginConfig(cfg);
+    return cleaned.config;
   } catch (err) {
-    if (isConfigValidationError(err)) {
-      cfg = await readBestEffortConfig();
-    } else {
+    if (extractErrorCode(err) !== "INVALID_CONFIG") {
       throw err;
     }
   }
-  const cleaned = await cleanStaleMatrixPluginConfig(cfg);
+  // Config validation failed — recover from the raw snapshot.
+  const snapshot = await readConfigFileSnapshot();
+  const parsed = (snapshot.parsed ?? {}) as Record<string, unknown>;
+  if (!snapshot.exists || Object.keys(parsed).length === 0) {
+    const configErr = new Error(
+      "Config file could not be parsed; run `openclaw doctor` to repair it.",
+    );
+    (configErr as { code?: string }).code = "INVALID_CONFIG";
+    throw configErr;
+  }
+  const cleaned = await cleanStaleMatrixPluginConfig(snapshot.config);
   return cleaned.config;
-}
-
-function isConfigValidationError(err: unknown): boolean {
-  return err instanceof Error && (err as { code?: string }).code === "INVALID_CONFIG";
 }
 
 export async function runPluginInstallCommand(params: {

--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+
+const loadConfigMock = vi.fn<() => OpenClawConfig>();
+const readConfigFileSnapshotMock = vi.fn<() => Promise<ConfigFileSnapshot>>();
+const cleanStaleMatrixPluginConfigMock = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => loadConfigMock(),
+  readConfigFileSnapshot: () => readConfigFileSnapshotMock(),
+}));
+
+vi.mock("../commands/doctor/providers/matrix.js", () => ({
+  cleanStaleMatrixPluginConfig: (cfg: OpenClawConfig) => cleanStaleMatrixPluginConfigMock(cfg),
+}));
+
+const { loadConfigForInstall } = await import("./plugins-install-command.js");
+
+function makeSnapshot(overrides: Partial<ConfigFileSnapshot> = {}): ConfigFileSnapshot {
+  return {
+    path: "/tmp/config.json5",
+    exists: true,
+    raw: '{ "plugins": {} }',
+    parsed: { plugins: {} },
+    resolved: { plugins: {} } as OpenClawConfig,
+    valid: false,
+    config: { plugins: {} } as OpenClawConfig,
+    hash: "abc",
+    issues: [{ path: "plugins.installs.matrix", message: "stale path" }],
+    warnings: [],
+    legacyIssues: [],
+    ...overrides,
+  };
+}
+
+describe("loadConfigForInstall", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    readConfigFileSnapshotMock.mockReset();
+    cleanStaleMatrixPluginConfigMock.mockReset();
+
+    cleanStaleMatrixPluginConfigMock.mockImplementation((cfg: OpenClawConfig) => ({
+      config: cfg,
+      changes: [],
+    }));
+  });
+
+  it("returns the config directly when loadConfig succeeds", async () => {
+    const cfg = { plugins: { entries: { matrix: { enabled: true } } } } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+
+    const result = await loadConfigForInstall();
+    expect(result).toBe(cfg);
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("runs stale Matrix cleanup on the happy path", async () => {
+    const cfg = { plugins: {} } as OpenClawConfig;
+    const cleanedCfg = { plugins: { cleaned: true } } as unknown as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+    cleanStaleMatrixPluginConfigMock.mockReturnValue({ config: cleanedCfg, changes: ["cleaned"] });
+
+    const result = await loadConfigForInstall();
+    expect(cleanStaleMatrixPluginConfigMock).toHaveBeenCalledWith(cfg);
+    expect(result).toBe(cleanedCfg);
+  });
+
+  it("falls back to snapshot config when loadConfig throws INVALID_CONFIG and snapshot was parsed", async () => {
+    const invalidConfigErr = new Error("config invalid");
+    (invalidConfigErr as { code?: string }).code = "INVALID_CONFIG";
+    loadConfigMock.mockImplementation(() => {
+      throw invalidConfigErr;
+    });
+
+    const snapshotCfg = {
+      plugins: { installs: { matrix: { source: "path", installPath: "/gone" } } },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { plugins: { installs: { matrix: {} } } },
+        config: snapshotCfg,
+      }),
+    );
+
+    const result = await loadConfigForInstall();
+    expect(readConfigFileSnapshotMock).toHaveBeenCalled();
+    expect(cleanStaleMatrixPluginConfigMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(result).toBe(snapshotCfg);
+  });
+
+  it("throws when loadConfig fails with INVALID_CONFIG and snapshot parsed is empty (parse failure)", async () => {
+    const invalidConfigErr = new Error("config invalid");
+    (invalidConfigErr as { code?: string }).code = "INVALID_CONFIG";
+    loadConfigMock.mockImplementation(() => {
+      throw invalidConfigErr;
+    });
+
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: {},
+        config: {} as OpenClawConfig,
+      }),
+    );
+
+    await expect(loadConfigForInstall()).rejects.toThrow(
+      "Config file could not be parsed; run `openclaw doctor` to repair it.",
+    );
+  });
+
+  it("throws when loadConfig fails with INVALID_CONFIG and config file does not exist", async () => {
+    const invalidConfigErr = new Error("config invalid");
+    (invalidConfigErr as { code?: string }).code = "INVALID_CONFIG";
+    loadConfigMock.mockImplementation(() => {
+      throw invalidConfigErr;
+    });
+
+    readConfigFileSnapshotMock.mockResolvedValue(makeSnapshot({ exists: false, parsed: {} }));
+
+    await expect(loadConfigForInstall()).rejects.toThrow(
+      "Config file could not be parsed; run `openclaw doctor` to repair it.",
+    );
+  });
+
+  it("re-throws non-config errors from loadConfig", async () => {
+    const fsErr = new Error("EACCES: permission denied");
+    (fsErr as { code?: string }).code = "EACCES";
+    loadConfigMock.mockImplementation(() => {
+      throw fsErr;
+    });
+
+    await expect(loadConfigForInstall()).rejects.toThrow("EACCES: permission denied");
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -144,6 +144,12 @@ describe("ensureConfigReady", () => {
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
   });
 
+  it("does not exit for invalid config on plugins install", async () => {
+    setInvalidSnapshot();
+    const runtime = await runEnsureConfigReady(["plugins", "install"]);
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
   it("runs doctor migration flow only once per module instance", async () => {
     const runtimeA = makeRuntime();
     const runtimeB = makeRuntime();

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -15,6 +15,7 @@ const ALLOWED_INVALID_GATEWAY_SUBCOMMANDS = new Set([
   "stop",
   "restart",
 ]);
+const ALLOWED_INVALID_PLUGINS_SUBCOMMANDS = new Set(["install"]);
 let didRunDoctorConfigFlow = false;
 let configSnapshotPromise: Promise<Awaited<ReturnType<typeof readConfigFileSnapshot>>> | null =
   null;
@@ -76,7 +77,10 @@ export async function ensureConfigReady(params: {
     ? ALLOWED_INVALID_COMMANDS.has(commandName) ||
       (commandName === "gateway" &&
         subcommandName &&
-        ALLOWED_INVALID_GATEWAY_SUBCOMMANDS.has(subcommandName))
+        ALLOWED_INVALID_GATEWAY_SUBCOMMANDS.has(subcommandName)) ||
+      (commandName === "plugins" &&
+        subcommandName &&
+        ALLOWED_INVALID_PLUGINS_SUBCOMMANDS.has(subcommandName))
     : false;
   const { formatConfigIssueLines } = await import("../../config/issue-format.js");
   const issues =

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -9,7 +9,10 @@ import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
 import { emitDoctorNotes } from "./doctor/emit-notes.js";
 import { finalizeDoctorConfigFlow } from "./doctor/finalize-config-flow.js";
-import { runMatrixDoctorSequence } from "./doctor/providers/matrix.js";
+import {
+  cleanStaleMatrixPluginConfig,
+  runMatrixDoctorSequence,
+} from "./doctor/providers/matrix.js";
 import { runDoctorRepairSequence } from "./doctor/repair-sequencing.js";
 import {
   applyLegacyCompatibilityStep,
@@ -86,6 +89,17 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     changeNotes: matrixSequence.changeNotes,
     warningNotes: matrixSequence.warningNotes,
   });
+
+  const staleMatrixCleanup = await cleanStaleMatrixPluginConfig(candidate);
+  if (staleMatrixCleanup.changes.length > 0) {
+    note(staleMatrixCleanup.changes.join("\n"), "Doctor changes");
+    ({ cfg, candidate, pendingChanges, fixHints } = applyDoctorConfigMutation({
+      state: { cfg, candidate, pendingChanges, fixHints },
+      mutation: staleMatrixCleanup,
+      shouldRepair,
+      fixHint: `Run "${doctorFixCommand}" to remove stale Matrix plugin references.`,
+    }));
+  }
 
   const missingDefaultAccountBindingWarnings =
     collectMissingDefaultAccountBindingWarnings(candidate);

--- a/src/commands/doctor/providers/matrix.test.ts
+++ b/src/commands/doctor/providers/matrix.test.ts
@@ -170,6 +170,8 @@ describe("doctor matrix provider helpers", () => {
     // Config should have stale refs removed
     expect(result.config.plugins?.installs?.matrix).toBeUndefined();
     expect(result.config.plugins?.load?.paths).toEqual(["/other/path"]);
+    // Allowlist should have matrix removed but keep other entries
+    expect(result.config.plugins?.allow).toEqual(["other-plugin"]);
   });
 
   it("returns no changes when Matrix install path exists", async () => {

--- a/src/commands/doctor/providers/matrix.test.ts
+++ b/src/commands/doctor/providers/matrix.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyMatrixDoctorRepair,
+  cleanStaleMatrixPluginConfig,
   collectMatrixInstallPathWarnings,
   formatMatrixLegacyCryptoPreview,
   formatMatrixLegacyStatePreview,
@@ -137,6 +138,62 @@ describe("doctor matrix provider helpers", () => {
       expect.stringContaining("Matrix encrypted-state migration prepared."),
     ]);
     expect(result.warnings).toEqual([]);
+  });
+
+  it("removes stale Matrix plugin config when install path is missing", async () => {
+    const missingPath = path.join(tmpdir(), "openclaw-matrix-stale-cleanup-test-" + Date.now());
+    await fs.rm(missingPath, { recursive: true, force: true });
+
+    const cfg = {
+      plugins: {
+        installs: {
+          matrix: {
+            source: "path" as const,
+            sourcePath: missingPath,
+            installPath: missingPath,
+          },
+        },
+        load: {
+          paths: [missingPath, "/other/path"],
+        },
+        allow: ["matrix", "other-plugin"],
+      },
+    };
+
+    const result = await cleanStaleMatrixPluginConfig(cfg);
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("Removed stale Matrix plugin references");
+    expect(result.changes[0]).toContain("install record");
+    expect(result.changes[0]).toContain("load path");
+    expect(result.changes[0]).toContain(missingPath);
+    // Config should have stale refs removed
+    expect(result.config.plugins?.installs?.matrix).toBeUndefined();
+    expect(result.config.plugins?.load?.paths).toEqual(["/other/path"]);
+  });
+
+  it("returns no changes when Matrix install path exists", async () => {
+    const existingPath = tmpdir();
+    const cfg = {
+      plugins: {
+        installs: {
+          matrix: {
+            source: "path" as const,
+            sourcePath: existingPath,
+            installPath: existingPath,
+          },
+        },
+      },
+    };
+
+    const result = await cleanStaleMatrixPluginConfig(cfg);
+    expect(result.changes).toHaveLength(0);
+    expect(result.config).toBe(cfg);
+  });
+
+  it("returns no changes when no Matrix install record exists", async () => {
+    const result = await cleanStaleMatrixPluginConfig({});
+    expect(result.changes).toHaveLength(0);
   });
 
   it("collects matrix preview and install warnings through the provider sequence", async () => {

--- a/src/commands/doctor/providers/matrix.ts
+++ b/src/commands/doctor/providers/matrix.ts
@@ -17,6 +17,8 @@ import {
   detectPluginInstallPathIssue,
   formatPluginInstallPathIssue,
 } from "../../../infra/plugin-install-path-warnings.js";
+import { removePluginFromConfig } from "../../../plugins/uninstall.js";
+import type { DoctorConfigMutationResult } from "../shared/config-mutation-state.js";
 
 export function formatMatrixLegacyStatePreview(
   detection: Exclude<ReturnType<typeof detectLegacyMatrixState>, null | { warning: string }>,
@@ -66,6 +68,48 @@ export async function collectMatrixInstallPathWarnings(cfg: OpenClawConfig): Pro
     repoInstallCommand: "openclaw plugins install ./extensions/matrix",
     formatCommand: formatCliCommand,
   }).map((entry) => `- ${entry}`);
+}
+
+/**
+ * Produces a config mutation that removes stale Matrix plugin install/load-path
+ * references left behind by the old bundled-plugin layout.  When the install
+ * record points to a path that no longer exists on disk the config entry blocks
+ * validation, so removing it lets reinstall proceed cleanly.
+ */
+export async function cleanStaleMatrixPluginConfig(
+  cfg: OpenClawConfig,
+): Promise<DoctorConfigMutationResult> {
+  const issue = await detectPluginInstallPathIssue({
+    pluginId: "matrix",
+    install: cfg.plugins?.installs?.matrix,
+  });
+  if (!issue || issue.kind !== "missing-path") {
+    return { config: cfg, changes: [] };
+  }
+  const { config, actions } = removePluginFromConfig(cfg, "matrix");
+  const removed: string[] = [];
+  if (actions.install) {
+    removed.push("install record");
+  }
+  if (actions.loadPath) {
+    removed.push("load path");
+  }
+  if (actions.entry) {
+    removed.push("plugin entry");
+  }
+  if (actions.allowlist) {
+    removed.push("allowlist entry");
+  }
+  if (removed.length === 0) {
+    return { config: cfg, changes: [] };
+  }
+  return {
+    config,
+    changes: [
+      `Removed stale Matrix plugin references (${removed.join(", ")}). ` +
+        `The previous install path no longer exists: ${issue.path}`,
+    ],
+  };
 }
 
 export async function applyMatrixDoctorRepair(params: {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -4,6 +4,7 @@ import { onAgentEvent } from "../../infra/agent-events.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import * as execModule from "../../process/exec.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { VERSION } from "../../version.js";
 import {
   clearGatewaySubagentRuntime,
   createPluginRuntime,
@@ -140,5 +141,10 @@ describe("plugin runtime command execution", () => {
       runId: "run-1",
     });
     expect(run).toHaveBeenCalledWith({ sessionKey: "s-2", message: "hello" });
+  });
+
+  it("exposes runtime.version from the shared VERSION constant", () => {
+    const runtime = createPluginRuntime();
+    expect(runtime.version).toBe(VERSION);
   });
 });

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -184,6 +184,8 @@ export type CreatePluginRuntimeOptions = {
 export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): PluginRuntime {
   const mediaUnderstanding = createRuntimeMediaUnderstandingFacade();
   const runtime = {
+    // Sourced from the shared OpenClaw version resolver (#52899) so plugins
+    // always see the same version the CLI reports, avoiding API-version drift.
     version: VERSION,
     config: createRuntimeConfig(),
     agent: createRuntimeAgent(),

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import { resolveStateDir } from "../../config/paths.js";
 import {
   listRuntimeImageGenerationProviders,
@@ -10,6 +9,7 @@ import {
   createLazyRuntimeMethodBinder,
   createLazyRuntimeModule,
 } from "../../shared/lazy-runtime.js";
+import { VERSION } from "../../version.js";
 import { listWebSearchProviders, runWebSearch } from "../../web-search/runtime.js";
 import { createRuntimeAgent } from "./runtime-agent.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
@@ -94,23 +94,6 @@ function createRuntimeModelAuth(): PluginRuntime["modelAuth"] {
         cfg: params.cfg,
       }),
   };
-}
-
-let cachedVersion: string | null = null;
-
-function resolveVersion(): string {
-  if (cachedVersion) {
-    return cachedVersion;
-  }
-  try {
-    const require = createRequire(import.meta.url);
-    const pkg = require("../../../package.json") as { version?: string };
-    cachedVersion = pkg.version ?? "unknown";
-    return cachedVersion;
-  } catch {
-    cachedVersion = "unknown";
-    return cachedVersion;
-  }
 }
 
 function createUnavailableSubagentRuntime(): PluginRuntime["subagent"] {
@@ -201,7 +184,7 @@ export type CreatePluginRuntimeOptions = {
 export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): PluginRuntime {
   const mediaUnderstanding = createRuntimeMediaUnderstandingFacade();
   const runtime = {
-    version: resolveVersion(),
+    version: VERSION,
     config: createRuntimeConfig(),
     agent: createRuntimeAgent(),
     subagent: createLateBindingSubagent(


### PR DESCRIPTION
Matrix upgrades can leave config in a state that blocks reinstall/repair, and plugin runtime version reporting can disagree with the actual OpenClaw version.

Closes #52899

Changes:
- Change plugin runtime version exposure to use the shared version resolver instead of reading package.json directly so plugin compatibility checks report the same runtime version as the CLI/update path.
- Allow repair-oriented plugin install flow to proceed from an invalid config snapshot for `plugins install`, using best-effort config instead of hard-failing in preflight.
- During doctor repair and/or Matrix plugin reinstall, remove stale Matrix plugin load-path/install references left by the old bundled-plugin layout so the rewritten config becomes valid again.
- Add regression coverage for invalid-config Matrix reinstall, doctor cleanup of stale Matrix plugin refs, and runtime version exposure used by plugin compatibility checks.

Testing:
- pnpm build && pnpm check && pnpm test
- Add targeted Vitest coverage around `src/cli/plugins-cli.test.ts`, `src/cli/program/config-guard.test.ts`, `src/commands/doctor-config-flow.test.ts`, and `src/plugins/runtime/index.test.ts`, then run those scoped tests plus `pnpm build` to verify the runtime/version boundary still compiles cleanly.

---
AI-assisted (Claude + Codex committee consensus, fully tested).

---

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved