### PR TITLE
fix: inject basePath into Control UI HTML to fix logo loading

### DIFF
--- a/src/gateway/control-ui-favicon.test.ts
+++ b/src/gateway/control-ui-favicon.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import os from "node:os";
+import path from "node:path";
+// Test to reproduce issue #53172 - favicon.svg not served under basePath
+import { describe, expect, it } from "vitest";
+import { handleControlUiHttpRequest } from "./control-ui.js";
+
+function makeMockHttpResponse() {
+  const chunks: Buffer[] = [];
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 200,
+    setHeader: (name: string, value: string) => {
+      headers[name.toLowerCase()] = value;
+    },
+    getHeader: (name: string) => headers[name.toLowerCase()],
+    write: (chunk: Buffer) => chunks.push(chunk),
+    end: (chunk?: Buffer) => {
+      if (chunk) {
+        chunks.push(chunk);
+      }
+    },
+  } as unknown as ServerResponse;
+  const end = () => Buffer.concat(chunks);
+  return { res, end, headers };
+}
+
+async function withControlUiRoot(fn: (tmp: string) => Promise<void>) {
+  const tmp = await mkdtemp(path.join(os.tmpdir(), "openclaw-ui-root-"));
+  try {
+    await mkdir(path.join(tmp, "assets"), { recursive: true });
+    await writeFile(path.join(tmp, "index.html"), "<html>ok</html>\n");
+    await writeFile(path.join(tmp, "favicon.svg"), "<svg>ok</svg>\n");
+    return await fn(tmp);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+}
+
+describe("favicon.svg under basePath (issue #53172)", () => {
+  it("serves favicon.svg under basePath /openclaw", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/openclaw/favicon.svg", method: "GET" } as IncomingMessage,
+        res,
+        {
+          basePath: "/openclaw",
+          root: { kind: "resolved", path: tmp },
+        },
+      );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(end().toString()).toContain("<svg>");
+    });
+  });
+
+  it("serves favicon.svg at root when no basePath", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/favicon.svg", method: "GET" } as IncomingMessage,
+        res,
+        {
+          basePath: "", // no basePath
+          root: { kind: "resolved", path: tmp },
+        },
+      );
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(200);
+      expect(end().toString()).toContain("<svg>");
+    });
+  });
+
+  it("returns 404 for /openclaw/favicon.svg when no basePath configured", async () => {
+    await withControlUiRoot(async (tmp) => {
+      const { res, end } = makeMockHttpResponse();
+      const handled = handleControlUiHttpRequest(
+        { url: "/openclaw/favicon.svg", method: "GET" } as IncomingMessage,
+        res,
+        {
+          basePath: "", // no basePath - Control UI served at root
+          root: { kind: "resolved", path: tmp },
+        },
+      );
+      // When basePath is empty, the entire URL is treated as the file path
+      // So /openclaw/favicon.svg would look for a file named that
+      console.log("handled:", handled);
+      console.log("statusCode:", res.statusCode);
+      console.log("response body:", end().toString());
+    });
+  });
+});

--- a/src/gateway/control-ui-favicon.test.ts
+++ b/src/gateway/control-ui-favicon.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import { handleControlUiHttpRequest } from "./control-ui.js";
 
 function makeMockHttpResponse() {
-  const chunks: Buffer[] = [];
+  const chunks: (Buffer | string)[] = [];
   const headers: Record<string, string> = {};
   const res = {
     statusCode: 200,
@@ -15,14 +15,17 @@ function makeMockHttpResponse() {
       headers[name.toLowerCase()] = value;
     },
     getHeader: (name: string) => headers[name.toLowerCase()],
-    write: (chunk: Buffer) => chunks.push(chunk),
-    end: (chunk?: Buffer) => {
+    write: (chunk: Buffer | string) => chunks.push(chunk),
+    end: (chunk?: Buffer | string) => {
       if (chunk) {
         chunks.push(chunk);
       }
     },
   } as unknown as ServerResponse;
-  const end = () => Buffer.concat(chunks);
+  const end = () => {
+    const result = chunks.map(c => (typeof c === "string" ? c : c.toString())).join("");
+    return result;
+  };
   return { res, end, headers };
 }
 
@@ -85,10 +88,10 @@ describe("favicon.svg under basePath (issue #53172)", () => {
         },
       );
       // When basePath is empty, the entire URL is treated as the file path
-      // So /openclaw/favicon.svg would look for a file named that
-      console.log("handled:", handled);
-      console.log("statusCode:", res.statusCode);
-      console.log("response body:", end().toString());
+      // So /openclaw/favicon.svg would look for a file named that, which doesn't exist
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(404);
+      expect(end().toString()).toBe("Not Found");
     });
   });
 });

--- a/src/gateway/control-ui-favicon.test.ts
+++ b/src/gateway/control-ui-favicon.test.ts
@@ -23,7 +23,7 @@ function makeMockHttpResponse() {
     },
   } as unknown as ServerResponse;
   const end = () => {
-    const result = chunks.map(c => (typeof c === "string" ? c : c.toString())).join("");
+    const result = chunks.map((c) => (typeof c === "string" ? c : c.toString())).join("");
     return result;
   };
   return { res, end, headers };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -557,4 +557,48 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+
+  it("injects basePath into index.html when basePath is set", async () => {
+    const html = "<html><head></head><body>Hello</body></html>\n";
+    await withControlUiRoot({
+      indexHtml: html,
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = handleControlUiHttpRequest(
+          { url: "/openclaw/", method: "GET" } as IncomingMessage,
+          res,
+          {
+            basePath: "/openclaw",
+            root: { kind: "resolved", path: tmp },
+          },
+        );
+        expect(handled).toBe(true);
+        const servedHtml = end.mock.calls[0]?.[0] as string | undefined;
+        expect(servedHtml).toBeDefined();
+        expect(servedHtml).toContain(
+          '<script>window.__OPENCLAW_CONTROL_UI_BASE_PATH__="/openclaw";</script>',
+        );
+      },
+    });
+  });
+
+  it("does not inject basePath script when basePath is empty", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = handleControlUiHttpRequest(
+          { url: "/", method: "GET" } as IncomingMessage,
+          res,
+          {
+            basePath: "",
+            root: { kind: "resolved", path: tmp },
+          },
+        );
+        expect(handled).toBe(true);
+        const html = end.mock.calls[0]?.[0] as string | undefined;
+        expect(html).toBeDefined();
+        expect(html).not.toContain("__OPENCLAW_CONTROL_UI_BASE_PATH__");
+      },
+    });
+  });
 });

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -601,4 +601,30 @@ describe("handleControlUiHttpRequest", () => {
       },
     });
   });
+
+  it("injects basePath script at start when <head> tag is missing", async () => {
+    const html = "<html><body>No head tag</body></html>\n";
+    await withControlUiRoot({
+      indexHtml: html,
+      fn: async (tmp) => {
+        const { res, end } = makeMockHttpResponse();
+        const handled = handleControlUiHttpRequest(
+          { url: "/openclaw/", method: "GET" } as IncomingMessage,
+          res,
+          {
+            basePath: "/openclaw",
+            root: { kind: "resolved", path: tmp },
+          },
+        );
+        expect(handled).toBe(true);
+        const servedHtml = end.mock.calls[0]?.[0] as string | undefined;
+        expect(servedHtml).toBeDefined();
+        // Script should be prepended when <head> is not found
+        expect(servedHtml).toContain(
+          '<script>window.__OPENCLAW_CONTROL_UI_BASE_PATH__="/openclaw";</script>',
+        );
+        expect(servedHtml!.startsWith("<script>")).toBe(true);
+      },
+    });
+  });
 });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -233,8 +233,21 @@ function serveResolvedFile(res: ServerResponse, filePath: string, body: Buffer) 
   res.end(body);
 }
 
-function serveResolvedIndexHtml(res: ServerResponse, body: string) {
-  const hashes = computeInlineScriptHashes(body);
+function serveResolvedIndexHtml(res: ServerResponse, body: string, basePath: string) {
+  // Inject basePath into the HTML so the frontend knows the correct basePath from the start.
+  // This fixes the issue where the frontend infers basePath from URL pathname before
+  // the bootstrap config is loaded, causing a mismatch when the gateway serves at a different path.
+  let html = body;
+  if (basePath) {
+    // Use JSON.stringify to safely escape the basePath and prevent XSS attacks
+    const escapedPath = JSON.stringify(basePath);
+    const script = `<script>window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${escapedPath};</script>`;
+    // Insert after the opening <head> tag, before any other content.
+    // Use a callback function to avoid replacement-token expansion (e.g., $&, $`, $').
+    html = html.replace(/<head[^>]*>/i, (match) => match + script);
+  }
+  // Compute CSP hashes for any inline scripts (including the basePath script we may have injected)
+  const hashes = computeInlineScriptHashes(html);
   if (hashes.length > 0) {
     res.setHeader(
       "Content-Security-Policy",
@@ -243,7 +256,7 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string) {
   }
   res.setHeader("Content-Type", "text/html; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache");
-  res.end(body);
+  res.end(html);
 }
 
 function isExpectedSafePathError(error: unknown): boolean {
@@ -450,7 +463,7 @@ export function handleControlUiHttpRequest(
         return true;
       }
       if (path.basename(safeFile.path) === "index.html") {
-        serveResolvedIndexHtml(res, fs.readFileSync(safeFile.fd, "utf8"));
+        serveResolvedIndexHtml(res, fs.readFileSync(safeFile.fd, "utf8"), basePath);
         return true;
       }
       serveResolvedFile(res, safeFile.path, fs.readFileSync(safeFile.fd));
@@ -478,7 +491,7 @@ export function handleControlUiHttpRequest(
       if (respondHeadForFile(req, res, safeIndex.path)) {
         return true;
       }
-      serveResolvedIndexHtml(res, fs.readFileSync(safeIndex.fd, "utf8"));
+      serveResolvedIndexHtml(res, fs.readFileSync(safeIndex.fd, "utf8"), basePath);
       return true;
     } finally {
       fs.closeSync(safeIndex.fd);

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -239,8 +239,11 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string, basePath: str
   // the bootstrap config is loaded, causing a mismatch when the gateway serves at a different path.
   let html = body;
   if (basePath) {
-    // Use JSON.stringify to safely escape the basePath and prevent XSS attacks
-    const escapedPath = JSON.stringify(basePath);
+    // Escape for safe embedding in an inline <script> tag:
+    // 1. JSON.stringify escapes JS string characters (quotes, backslashes, etc.)
+    // 2. Replace < and > with JS escape sequences to prevent </script> injection
+    //    which could break out of the script tag and allow XSS.
+    const escapedPath = JSON.stringify(basePath).replace(/</g, "\\x3c").replace(/>/g, "\\x3e");
     const script = `<script>window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${escapedPath};</script>`;
     // Insert after the opening <head> tag, before any other content.
     // Use a callback function to avoid replacement-token expansion (e.g., $&, $`, $').

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -247,7 +247,15 @@ function serveResolvedIndexHtml(res: ServerResponse, body: string, basePath: str
     const script = `<script>window.__OPENCLAW_CONTROL_UI_BASE_PATH__=${escapedPath};</script>`;
     // Insert after the opening <head> tag, before any other content.
     // Use a callback function to avoid replacement-token expansion (e.g., $&, $`, $').
-    html = html.replace(/<head[^>]*>/i, (match) => match + script);
+    // If <head> is not found, prepend the script as a fallback.
+    let injected = false;
+    html = html.replace(/<head[^>]*>/i, (match) => {
+      injected = true;
+      return match + script;
+    });
+    if (!injected) {
+      html = script + html;
+    }
   }
   // Compute CSP hashes for any inline scripts (including the basePath script we may have injected)
   const hashes = computeInlineScriptHashes(html);


### PR DESCRIPTION
## Summary

Fixes #53172

When serving the Control UI with a `basePath` (e.g., `/openclaw`), the gateway now injects `window.__OPENCLAW_CONTROL_UI_BASE_PATH__` into the HTML. This ensures the frontend knows the correct basePath immediately, fixing issues where static assets (like logos) were requested from the wrong path.

## Problem

Previously, the frontend inferred `basePath` from the URL pathname, which could be incorrect when the gateway was configured with a different `basePath`. This caused assets to fail loading with 404 errors.

## Solution

Inject the configured basePath directly into the HTML when serving `index.html`. The frontend already reads this variable in priority in `inferBasePath()` — it just wasn't being set by the backend.

## Changes

- Modified `serveResolvedIndexHtml()` in `src/gateway/control-ui.ts` to inject the basePath script
- Added 2 tests to verify injection behavior

## Testing

- All 23 tests pass in `control-ui.http.test.ts`
- Manual verification: basePath is correctly injected when configured, and not injected when empty (root mount)