### PR TITLE
fix(session-reset): resolve thinkingLevel from model config after /reset

### DIFF
--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -311,7 +311,7 @@ export async function performGatewaySessionReset(params: {
       updatedAt: now,
       systemSent: false,
       abortedLastRun: false,
-      thinkingLevel: currentEntry?.thinkingLevel,
+      thinkingLevel: undefined,
       fastMode: currentEntry?.fastMode,
       verboseLevel: currentEntry?.verboseLevel,
       reasoningLevel: currentEntry?.reasoningLevel,


### PR DESCRIPTION
## Summary

When a session is reset via `/reset`, the old session's `thinkingLevel` was copied to the new session entry. This caused models that previously had `thinkingLevel=off` to keep that stale value after reset, even when the model's default should be different (e.g., OpenAI Codex models need thinking enabled for tool calling).

## Root Cause

In `src/gateway/session-reset-service.ts` line 314, the reset entry preserved:
```typescript
thinkingLevel: currentEntry?.thinkingLevel,
```

This means if the old session had `thinkingLevel: off`, the reset session inherits it.

## Fix

Set `thinkingLevel: undefined` on reset so it's freshly resolved from model config on the next message via `resolveThinkingDefault()` in `chat.ts`:

```typescript
thinkingLevel: undefined,
```

## Impact

- Users who `/reset` a session will now get the correct thinking level for their model
- Fixes regression introduced in v2026.3.23
- Minimal change (1 line)

## Testing

The existing `resolveThinkingDefault` logic in `chat.ts:1122-1127` already handles undefined thinkingLevel by resolving from model config.

Fixes #53480