### PR TITLE
docs(node): clarify version manager must be initialized in ~/.bashrc …

### DIFF
--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -82,7 +82,7 @@ fnm use 24
 ```
 
   <Warning>
-  Make sure your version manager is initialized in your shell startup file (`~/.zshrc` or `~/.bashrc`). If it isn't, `openclaw` may not be found in new terminal sessions because the PATH won't include Node's bin directory.
+  Make sure your version manager is initialized in **both** `~/.zshrc` (for interactive zsh sessions) **and** `~/.bashrc` (for bash sessions). This matters because the recommended install script runs under `bash` — if your version manager is only initialized in `~/.zshrc`, the installer won't see the fnm-managed Node and may fall back to a system-level npm prefix instead. If `~/.bashrc` doesn't exist yet, create it and add the initialization line there.
   </Warning>
 </Accordion>
 


### PR DESCRIPTION
…for curl|bash installer

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:docs/install/node.md only told users to initialize their version manager (fnm/nvm/mise) in ~/.zshrc or ~/.bashrc, without explaining which one matters when.
- Why it matters:The recommended install path (curl … | bash) runs under bash, which  does not source ~/.zshrc. macOS users who only configured their version manager in ~/.zshrc (the default shell's startup file) would have fnm invisible to the installer, causing it to fall back to the system-level npm prefix and install OpenClaw in the wrong location.
- What changed:The <Warning> block in the version-manager accordion now explicitly states that ~/.bashrc is required for the curl | bash installer, explains why, and tells users to create the file if it doesn't exist yet.
- What did NOT change (scope boundary):No code, installer scripts, or other docs were modified.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — docs-only clarification, no regression.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Users following the Node version-manager setup docs will now see a clearer warning that ~/.bashrc must also be configured when using the curl | bash installer on macOS/Linux.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (default shell: zsh)
- Runtime/container:N/A
- Model/provider:N/A
- Integration/channel (if any):N/A
- Relevant config (redacted):N/A

### Steps

  1. Install fnm, add eval "$(fnm env)" only to ~/.zshrc
  2. Run curl -fsSL https://openclaw.ai/install.sh | bash
  3. Observe installer does not see fnm-managed Node; OpenClaw installs under system npm prefix

### Expected

  - Docs warn the user that ~/.bashrc must also be configured before running the installer

### Actual

  - Warning only mentioned ~/.zshrc or ~/.bashrc without explaining the bash-vs-zsh distinction

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Warning text reviewed in context; correctly describes the curl | bash → bash → ~/.bashrc dependency chain.
- Edge cases checked: Edge cases checked: Users who have neither ~/.bashrc nor ~/.zshrc are covered by the "create it if it doesn't exist" instruction.
- What you did **not** verify: Live installer run end-to-end with fnm.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:Revert the one-line edit to docs/install/node.md
- Files/config to restore:docs/install/node.md line 85
- Known bad symptoms reviewers should watch for:None — docs only

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None