### PR TITLE
docs: add plugin manifest example for bundled skills

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -115,6 +115,51 @@ Those belong in your plugin code and `package.json`.
 }
 ```
 
+## Example with bundled skills and operator-friendly config
+
+Use this shape when a plugin ships its own `skills/` directory and wants config
+surfaces to render clean labels in setup or Control UI:
+
+```json
+{
+  "id": "security-guard",
+  "name": "Security Guard",
+  "description": "Lightweight prompt-injection and dangerous-command guardrails.",
+  "version": "0.2.0",
+  "skills": ["./skills"],
+  "uiHints": {
+    "monitorOnly": {
+      "label": "Monitor only",
+      "description": "Audit risky activity without blocking calls."
+    },
+    "auditLogPath": {
+      "label": "Audit log path",
+      "placeholder": "~/.openclaw/logs/security-guard.audit.jsonl"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "monitorOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "auditLogPath": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+Notes:
+
+- `skills` paths are relative to the plugin root.
+- `uiHints` improves config editors, but does not replace `configSchema`.
+- `version` is informational metadata; package updates and pinning still follow
+  the installed package state.
+
 ## Top-level field reference
 
 | Field                 | Required | Type                             | What it means                                                                                                                |

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -130,7 +130,7 @@ surfaces to render clean labels in setup or Control UI:
   "uiHints": {
     "monitorOnly": {
       "label": "Monitor only",
-      "description": "Audit risky activity without blocking calls."
+      "help": "Audit risky activity without blocking calls."
     },
     "auditLogPath": {
       "label": "Audit log path",

--- a/docs/zh-CN/plugins/manifest.md
+++ b/docs/zh-CN/plugins/manifest.md
@@ -62,7 +62,7 @@ x-i18n:
   "uiHints": {
     "monitorOnly": {
       "label": "Monitor only",
-      "description": "Audit risky activity without blocking calls."
+      "help": "Audit risky activity without blocking calls."
     },
     "auditLogPath": {
       "label": "Audit log path",

--- a/docs/zh-CN/plugins/manifest.md
+++ b/docs/zh-CN/plugins/manifest.md
@@ -48,6 +48,49 @@ x-i18n:
 - `uiHints`（对象）：用于 UI 渲染的配置字段标签/占位符/敏感标志。
 - `version`（字符串）：插件版本（仅供参考）。
 
+## 带 bundled skills 与运维友好配置的示例
+
+当插件会随包一起分发 `skills/` 目录，并且希望配置界面显示更清晰的字段标签时，可以使用下面这种形式：
+
+```json
+{
+  "id": "security-guard",
+  "name": "Security Guard",
+  "description": "Lightweight prompt-injection and dangerous-command guardrails.",
+  "version": "0.2.0",
+  "skills": ["./skills"],
+  "uiHints": {
+    "monitorOnly": {
+      "label": "Monitor only",
+      "description": "Audit risky activity without blocking calls."
+    },
+    "auditLogPath": {
+      "label": "Audit log path",
+      "placeholder": "~/.openclaw/logs/security-guard.audit.jsonl"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "monitorOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "auditLogPath": {
+        "type": "string"
+      }
+    }
+  }
+}
+```
+
+说明：
+
+- `skills` 路径相对于插件根目录解析。
+- `uiHints` 用来优化配置编辑器或 setup surface 的显示体验，但不替代 `configSchema`。
+- `version` 只是展示性元数据；升级与 pinning 仍以实际安装包状态为准。
+
 ## JSON Schema 要求
 
 - **每个插件都必须提供 JSON Schema**，即使不接受任何配置也是如此。


### PR DESCRIPTION
## Summary
- add a concrete native plugin manifest example that bundles `skills`, exposes `version`, and uses `uiHints`
- explain how these optional fields interact with `configSchema`
- mirror the same guidance in the zh-CN manifest page

## Why
Community plugins that ship bundled skills or operator-facing config labels currently have to infer the intended manifest shape from scattered references. A concrete example lowers the packaging/documentation gap for third-party plugins.

## Validation
- docs-only change
- reviewed rendered markdown locally