### PR TITLE
fix(agents): prevent agents from using exec for gateway management

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -213,6 +213,12 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("## OpenClaw CLI Quick Reference");
     expect(prompt).toContain("openclaw gateway restart");
     expect(prompt).toContain("Do not invent commands");
+    expect(prompt).toContain(
+      "Do not use exec for gateway stop/restart/config — use the gateway tool instead",
+    );
+    expect(prompt).toContain(
+      "The gateway tool preserves session context across restarts; exec does not",
+    );
   });
 
   it("guides runtime completion events without exposing internal metadata", () => {
@@ -464,6 +470,10 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("update.run");
     expect(prompt).not.toContain("Use config.schema to");
     expect(prompt).not.toContain("config.schema, config.apply");
+    expect(prompt).toContain("never edit config files directly");
+    expect(prompt).toContain(
+      "Config changes via config.apply/config.patch are validated before writing and restart the gateway automatically",
+    );
   });
 
   it("includes skills guidance when skills prompt is present", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -461,6 +461,7 @@ export function buildAgentSystemPrompt(params: {
     "- openclaw gateway start",
     "- openclaw gateway stop",
     "- openclaw gateway restart",
+    "Do not use exec for gateway stop/restart/config — use the gateway tool instead. The gateway tool preserves session context across restarts; exec does not.",
     "If unsure, ask the user to run `openclaw help` (or `openclaw gateway --help`) and paste the output.",
     "",
     ...skillsSection,
@@ -473,6 +474,7 @@ export function buildAgentSystemPrompt(params: {
           "Do not run config.apply or update.run unless the user explicitly requests an update or config change; if it's not explicit, ask first.",
           "Use config.schema.lookup with a specific dot path to inspect only the relevant config subtree before making config changes or answering config-field questions; avoid guessing field names/types.",
           "Actions: config.schema.lookup, config.get, config.apply (validate + write full config, then restart), config.patch (partial update, merges with existing), update.run (update deps or git, then restart).",
+          "Config changes via config.apply/config.patch are validated before writing and restart the gateway automatically — never edit config files directly.",
           "After restart, OpenClaw pings the last active session automatically.",
         ].join("\n")
       : "",


### PR DESCRIPTION
## Summary

- **Problem:** System prompt teaches agents CLI commands for gateway management and implies manual restart is needed after config changes
- **Why it matters:** Agents use `exec openclaw gateway restart` (full process kill, no session preservation) instead of the gateway tool, and manually edit config files when `config.apply` rejects invalid input — breaking their own gateway
- **What changed:** Added warnings against using exec for gateway operations; clarified config changes auto-restart; documented that config files should never be edited directly
- **What did NOT change:** CLI reference still lists commands for user reference; no runtime logic changed

Closes #17189

## Root Cause

Two system prompt issues combine:
1. CLI Quick Reference lists `openclaw gateway stop/restart` without warning that `exec` bypasses the gateway tool's restart sentinel (session context lost)
2. Self-Update section says `config.apply (validate + write full config, then restart)` — agents misread "then restart" as something they need to do manually

## Changes

**`src/agents/system-prompt.ts`** (+2 lines):
- "Do not use exec for gateway stop/restart/config — use the gateway tool instead. The gateway tool preserves session context across restarts; exec does not."
- "Config changes via config.apply/config.patch are validated before writing and restart the gateway automatically — never edit config files directly."

**`src/agents/system-prompt.test.ts`** (+10 lines):
- Verify exec warning present in CLI reference section
- Verify `config.patch` auto-restart and "never edit config files directly" in self-update section

## Testing

All 44 tests pass (`pnpm test -- src/agents/system-prompt.test.ts`).
`pnpm build` and `pnpm check` gates pass.

## Compatibility

Backward compatible — additive prompt text only.

### AI-Assisted PR Checklist
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested (pnpm build + check + test gates passed)
- [x] Code reviewed by LLM committee (Claude Opus + Codex dual-model review with consensus gate)
- [x] I understand what the code does
- [x] Bot review conversations addressed and resolved