### PR TITLE
docs: update ollama reasoning heuristic guidance

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -120,7 +120,7 @@ When you set `OLLAMA_API_KEY` (or an auth profile) and **do not** define `models
 
 - Queries `/api/tags`
 - Uses best-effort `/api/show` lookups to read `contextWindow` when available
-- Marks `reasoning` with a model-name heuristic (`r1`, `reasoning`, `think`)
+- Marks `reasoning` with a model-name heuristic (for example `r1`, `reasoning`, `think`, `qwen3`, `qwq`, `glm-5`, `kimi-k2`, `deepseek-v3`, `marco-o`, `skywork-o`)
 - Sets `maxTokens` to the default Ollama max-token cap used by OpenClaw
 - Sets all costs to `0`
 
@@ -239,11 +239,13 @@ You can also sign in directly at [ollama.com/signin](https://ollama.com/signin).
 
 ### Reasoning models
 
-OpenClaw treats models with names such as `deepseek-r1`, `reasoning`, or `think` as reasoning-capable by default:
+OpenClaw treats models with known reasoning-oriented names as reasoning-capable by default. Common examples include `deepseek-r1`, `qwen3`, `qwq`, `glm-5`, `kimi-k2`, `deepseek-v3`, `marco-o`, `skywork-o`, plus generic names containing `reasoning`, `reason`, or `think`:
 
 ```bash
 ollama pull deepseek-r1:32b
 ```
+
+If a heuristic result is wrong for your deployment, define the model explicitly in `models.providers.ollama` and set `reasoning` yourself.
 
 ### Model Costs
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -120,7 +120,7 @@ When you set `OLLAMA_API_KEY` (or an auth profile) and **do not** define `models
 
 - Queries `/api/tags`
 - Uses best-effort `/api/show` lookups to read `contextWindow` when available
-- Marks `reasoning` with a model-name heuristic (for example `r1`, `reasoning`, `think`, `qwen3`, `qwq`, `glm-5`, `kimi-k2`, `deepseek-v3`, `marco-o`, `skywork-o`)
+- Marks `reasoning` with a model-name heuristic (for example `r1`, `reasoning`, `reason`, or `think`)
 - Sets `maxTokens` to the default Ollama max-token cap used by OpenClaw
 - Sets all costs to `0`
 
@@ -239,7 +239,7 @@ You can also sign in directly at [ollama.com/signin](https://ollama.com/signin).
 
 ### Reasoning models
 
-OpenClaw treats models with known reasoning-oriented names as reasoning-capable by default. Common examples include `deepseek-r1`, `qwen3`, `qwq`, `glm-5`, `kimi-k2`, `deepseek-v3`, `marco-o`, `skywork-o`, plus generic names containing `reasoning`, `reason`, or `think`:
+OpenClaw treats models with names that match its reasoning heuristic as reasoning-capable by default. Common examples include `deepseek-r1` plus generic names containing `reasoning`, `reason`, or `think`:
 
 ```bash
 ollama pull deepseek-r1:32b

--- a/docs/zh-CN/providers/ollama.md
+++ b/docs/zh-CN/providers/ollama.md
@@ -127,7 +127,7 @@ openclaw models set ollama/glm-4.7-flash
 
 - 查询 `/api/tags`
 - 在可用时，尽力通过 `/api/show` 查找 `contextWindow`
-- 通过模型名称启发式规则标记 `reasoning`（`r1`、`reasoning`、`think`）
+- 通过模型名称启发式规则标记 `reasoning`（例如 `r1`、`reasoning`、`think`、`qwen3`、`qwq`、`glm-5`、`kimi-k2`、`deepseek-v3`、`marco-o`、`skywork-o`）
 - 将 `maxTokens` 设置为 OpenClaw 使用的默认 Ollama 最大 token 上限
 - 将所有成本设置为 `0`
 
@@ -246,11 +246,13 @@ export OLLAMA_API_KEY="ollama-local"
 
 ### 推理模型
 
-OpenClaw 默认会将名称中包含 `deepseek-r1`、`reasoning` 或 `think` 的模型视为支持推理的模型：
+OpenClaw 默认会将一些常见的推理模型名称模式视为支持推理。常见例子包括 `deepseek-r1`、`qwen3`、`qwq`、`glm-5`、`kimi-k2`、`deepseek-v3`、`marco-o`、`skywork-o`，以及名称中包含 `reasoning`、`reason` 或 `think` 的模型：
 
 ```bash
 ollama pull deepseek-r1:32b
 ```
+
+如果启发式判断与你的实际部署不符，请在 `models.providers.ollama` 中显式定义该模型，并手动设置 `reasoning`。
 
 ### 模型成本
 

--- a/docs/zh-CN/providers/ollama.md
+++ b/docs/zh-CN/providers/ollama.md
@@ -127,7 +127,7 @@ openclaw models set ollama/glm-4.7-flash
 
 - 查询 `/api/tags`
 - 在可用时，尽力通过 `/api/show` 查找 `contextWindow`
-- 通过模型名称启发式规则标记 `reasoning`（例如 `r1`、`reasoning`、`think`、`qwen3`、`qwq`、`glm-5`、`kimi-k2`、`deepseek-v3`、`marco-o`、`skywork-o`）
+- 通过模型名称启发式规则标记 `reasoning`（例如 `r1`、`reasoning`、`reason` 或 `think`）
 - 将 `maxTokens` 设置为 OpenClaw 使用的默认 Ollama 最大 token 上限
 - 将所有成本设置为 `0`
 
@@ -246,7 +246,7 @@ export OLLAMA_API_KEY="ollama-local"
 
 ### 推理模型
 
-OpenClaw 默认会将一些常见的推理模型名称模式视为支持推理。常见例子包括 `deepseek-r1`、`qwen3`、`qwq`、`glm-5`、`kimi-k2`、`deepseek-v3`、`marco-o`、`skywork-o`，以及名称中包含 `reasoning`、`reason` 或 `think` 的模型：
+OpenClaw 默认会将匹配其推理启发式规则的模型名称视为支持推理。常见例子包括 `deepseek-r1`，以及名称中包含 `reasoning`、`reason` 或 `think` 的模型：
 
 ```bash
 ollama pull deepseek-r1:32b


### PR DESCRIPTION
## Summary
- update the Ollama provider docs to reflect the broader reasoning-model heuristic families already used in code
- add a note that explicit `models.providers.ollama` entries override heuristic reasoning detection
- mirror the same guidance in zh-CN docs

## Why
The public docs still describe the old `r1/reasoning/think` heuristic shape, while current code also recognizes families such as `qwen3`, `qwq`, `glm-5`, `kimi-k2`, and `deepseek-v3`. This PR aligns docs with real behavior.

## Validation
- docs-only change
- reviewed rendered markdown locally