### PR TITLE
Memory: add mem0 PoC+ behind feature flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,3 +78,19 @@ OPENCLAW_GATEWAY_TOKEN=change-me-to-a-long-random-token
 # ELEVENLABS_API_KEY=...
 # XI_API_KEY=...  # alias for ElevenLabs
 # DEEPGRAM_API_KEY=...
+
+# -----------------------------------------------------------------------------
+# mem0 long-term memory PoC (default disabled)
+# -----------------------------------------------------------------------------
+# MEM0_ENABLED=true
+# MEM0_BASE_URL=https://your-mem0-service
+# MEM0_API_KEY=...
+# MEM0_RECALL_LIMIT=5
+# MEM0_RECALL_THRESHOLD=0.75
+# MEM0_CAPTURE_ENABLED=true
+# MEM0_INJECT_MAX_ITEMS=5
+# MEM0_INJECT_ITEM_MAX_CHARS=240
+# MEM0_INJECT_MAX_CHARS=1200
+# MEM0_INJECT_MAX_ESTIMATED_TOKENS=320
+# MEM0_STORE_DEDUPE_WINDOW_MS=300000
+# MEM0_CIRCUIT_OPEN_MS=60000

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -27,6 +27,7 @@ import {
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
+import { captureLongTermMemory } from "../../memory/mem0/poc.js";
 import {
   buildPluginBindingDeclinedText,
   buildPluginBindingErrorText,
@@ -82,6 +83,24 @@ function loadTtsRuntime() {
 const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;
 const AUDIO_HEADER_RE = /^\[Audio\b/i;
 const normalizeMediaType = (value: string): string => value.split(";")[0]?.trim().toLowerCase();
+const MAX_TOOL_SUMMARY_ITEMS = 3;
+const MAX_TOOL_SUMMARY_CHARS = 200;
+
+function summarizeToolText(text: string): string | undefined {
+  const normalized = text.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.length <= MAX_TOOL_SUMMARY_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, MAX_TOOL_SUMMARY_CHARS)}...`;
+}
+
+function resolveInboundUserMessage(ctx: FinalizedMsgContext): string {
+  const message = ctx.RawBody ?? ctx.CommandBody ?? ctx.BodyForCommands ?? ctx.Body ?? "";
+  return message.trim();
+}
 
 const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
   const rawTypes = [
@@ -538,6 +557,7 @@ export async function dispatchReplyFromConfig(params: {
     // TTS audio separately from the accumulated block content.
     let accumulatedBlockText = "";
     let blockCount = 0;
+    const toolSummaryParts: string[] = [];
     const { maybeApplyTtsToPayload } = await loadTtsRuntime();
 
     const resolveToolDeliveryPayload = (payload: ReplyPayload): ReplyPayload | null => {
@@ -588,6 +608,11 @@ export async function dispatchReplyFromConfig(params: {
         suppressTyping: typing.suppressTyping,
         onToolResult: (payload: ReplyPayload) => {
           const run = async () => {
+            const summary =
+              typeof payload.text === "string" ? summarizeToolText(payload.text) : undefined;
+            if (summary && toolSummaryParts.length < MAX_TOOL_SUMMARY_ITEMS) {
+              toolSummaryParts.push(summary);
+            }
             const ttsPayload = await maybeApplyTtsToPayload({
               payload,
               cfg,
@@ -779,6 +804,23 @@ export async function dispatchReplyFromConfig(params: {
 
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
+    const finalReplyText = replies
+      .filter((reply) => reply.isReasoning !== true)
+      .map((reply) => (typeof reply.text === "string" ? reply.text.trim() : ""))
+      .filter(Boolean)
+      .join("\n\n")
+      .trim();
+    const assistantTextForCapture = finalReplyText || accumulatedBlockText.trim();
+    if (assistantTextForCapture) {
+      void captureLongTermMemory({
+        userMessage: resolveInboundUserMessage(ctx),
+        assistantMessage: assistantTextForCapture,
+        toolSummary: toolSummaryParts.length > 0 ? toolSummaryParts.join(" | ") : undefined,
+        userId: ctx.SenderId?.trim() || undefined,
+        agentId: resolveSessionAgentId({ sessionKey: ctx.SessionKey, config: cfg }),
+        runId: params.replyOptions?.runId ?? undefined,
+      });
+    }
     recordProcessed(
       "completed",
       pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -11,6 +11,7 @@ import {
 import { updateSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { logVerbose } from "../../globals.js";
+import { recallAndBuildInjectText } from "../../memory/mem0/poc.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
@@ -422,6 +423,18 @@ export async function runPreparedReply(
   let prefixedCommandBody = mediaNote
     ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()
     : prefixedBody;
+  const mem0Query = rawBodyTrimmed || baseBodyTrimmedRaw || prefixedCommandBody.trim();
+  if (mem0Query) {
+    const mem0Recall = await recallAndBuildInjectText({
+      query: mem0Query,
+      userId: sessionCtx.SenderId?.trim() || ctx.SenderId?.trim() || undefined,
+      agentId,
+      runId: opts?.runId ?? sessionKey ?? undefined,
+    });
+    if (mem0Recall?.injectedText) {
+      prefixedCommandBody = `${prefixedCommandBody}\n\n${mem0Recall.injectedText}`;
+    }
+  }
   if (!resolvedThinkLevel) {
     resolvedThinkLevel = await modelState.resolveDefaultThinkingLevel();
   }

--- a/src/memory/mem0/adapter.ts
+++ b/src/memory/mem0/adapter.ts
@@ -1,0 +1,188 @@
+import { fetchWithTimeout } from "../../utils/fetch-timeout.js";
+
+export type Mem0RecallParams = {
+  query: string;
+  userId?: string;
+  agentId?: string;
+  runId?: string;
+  limit: number;
+  threshold: number;
+};
+
+export type Mem0StoreParams = {
+  memory: string;
+  userMessage: string;
+  assistantMessage: string;
+  toolSummary?: string;
+  userId?: string;
+  agentId?: string;
+  runId?: string;
+};
+
+export type MemoryRecallResult = {
+  id?: string;
+  text: string;
+  score?: number;
+};
+
+export type Mem0Adapter = {
+  recall: (params: Mem0RecallParams) => Promise<MemoryRecallResult[]>;
+  store: (params: Mem0StoreParams) => Promise<void>;
+  healthCheck: () => Promise<boolean>;
+};
+
+type Mem0ApiAdapterOptions = {
+  baseUrl: string;
+  apiKey: string;
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 6_000;
+const SEARCH_PATH = "/v1/memories/search";
+const STORE_PATH = "/v1/memories";
+const HEALTH_PATH = "/health";
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+}
+
+function buildUrl(baseUrl: string, path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizeBaseUrl(baseUrl)}${normalizedPath}`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function toNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function toText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseRecallResults(payload: unknown): MemoryRecallResult[] {
+  const root = asObject(payload);
+  if (!root) {
+    return [];
+  }
+  const candidates = [...asArray(root.results), ...asArray(root.memories), ...asArray(root.data)];
+  const parsed: MemoryRecallResult[] = [];
+  for (const candidate of candidates) {
+    const obj = asObject(candidate);
+    if (!obj) {
+      continue;
+    }
+    const text =
+      toText(obj.text) ??
+      toText(obj.memory) ??
+      toText(obj.content) ??
+      toText(obj.value) ??
+      toText(asObject(obj.metadata)?.summary);
+    if (!text) {
+      continue;
+    }
+    const id = toText(obj.id) ?? toText(obj.memory_id);
+    const score = toNumber(obj.score) ?? toNumber(obj.similarity);
+    parsed.push({ id, text, score });
+  }
+  return parsed;
+}
+
+async function readJsonSafe(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function buildHeaders(apiKey: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export function createMem0ApiAdapter(options: Mem0ApiAdapterOptions): Mem0Adapter {
+  const timeoutMs = Math.max(1_000, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const headers = buildHeaders(options.apiKey);
+
+  return {
+    async healthCheck(): Promise<boolean> {
+      const response = await fetchWithTimeout(
+        buildUrl(baseUrl, HEALTH_PATH),
+        {
+          method: "GET",
+          headers,
+        },
+        timeoutMs,
+      );
+      return response.ok;
+    },
+
+    async recall(params: Mem0RecallParams): Promise<MemoryRecallResult[]> {
+      const body = {
+        query: params.query,
+        top_k: params.limit,
+        threshold: params.threshold,
+        user_id: params.userId,
+        agent_id: params.agentId,
+        run_id: params.runId,
+      };
+      const response = await fetchWithTimeout(
+        buildUrl(baseUrl, SEARCH_PATH),
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+        },
+        timeoutMs,
+      );
+      if (!response.ok) {
+        throw new Error(`mem0 recall failed status=${response.status}`);
+      }
+      return parseRecallResults(await readJsonSafe(response));
+    },
+
+    async store(params: Mem0StoreParams): Promise<void> {
+      const body = {
+        memory: params.memory,
+        input: params.userMessage,
+        output: params.assistantMessage,
+        user_id: params.userId,
+        agent_id: params.agentId,
+        run_id: params.runId,
+        metadata: {
+          tool_summary: params.toolSummary,
+        },
+      };
+      const response = await fetchWithTimeout(
+        buildUrl(baseUrl, STORE_PATH),
+        {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+        },
+        timeoutMs,
+      );
+      if (!response.ok) {
+        throw new Error(`mem0 store failed status=${response.status}`);
+      }
+    },
+  };
+}

--- a/src/memory/mem0/poc.test.ts
+++ b/src/memory/mem0/poc.test.ts
@@ -1,0 +1,223 @@
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { __mem0TestHooks, captureLongTermMemory, recallAndBuildInjectText } from "./poc.js";
+
+type TestServer = {
+  baseUrl: string;
+  close: () => Promise<void>;
+  state: {
+    healthChecks: number;
+    storeCalls: number;
+    memories: string[];
+  };
+};
+
+async function createMem0TestServer(params?: {
+  healthOk?: boolean;
+  storeStatus?: number;
+  recallResults?: Array<{ text: string; score?: number }>;
+}): Promise<TestServer> {
+  const state = {
+    healthChecks: 0,
+    storeCalls: 0,
+    memories: [] as string[],
+  };
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += String(chunk);
+    });
+    req.on("end", () => {
+      if (req.url === "/health") {
+        state.healthChecks += 1;
+        const ok = params?.healthOk ?? true;
+        res.writeHead(ok ? 200 : 503, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok }));
+        return;
+      }
+      if (req.url === "/v1/memories" && req.method === "POST") {
+        state.storeCalls += 1;
+        const payload = JSON.parse(body || "{}") as { memory?: string };
+        if (typeof payload.memory === "string") {
+          state.memories.push(payload.memory);
+        }
+        const status = params?.storeStatus ?? 200;
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: status >= 200 && status < 300 }));
+        return;
+      }
+      if (req.url === "/v1/memories/search" && req.method === "POST") {
+        const results =
+          params?.recallResults ??
+          state.memories.map((text, index) => ({
+            text,
+            score: 0.92 - index * 0.01,
+          }));
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ results }));
+        return;
+      }
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "not found" }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("failed to resolve test server address");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: async () =>
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+    state,
+  };
+}
+
+function withMem0Env(vars: Record<string, string>) {
+  process.env.MEM0_ENABLED = "true";
+  process.env.MEM0_API_KEY = "test-key";
+  process.env.MEM0_CAPTURE_ENABLED = "true";
+  for (const [key, value] of Object.entries(vars)) {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  __mem0TestHooks.resetState();
+  delete process.env.MEM0_ENABLED;
+  delete process.env.MEM0_BASE_URL;
+  delete process.env.MEM0_API_KEY;
+  delete process.env.MEM0_RECALL_LIMIT;
+  delete process.env.MEM0_RECALL_THRESHOLD;
+  delete process.env.MEM0_CAPTURE_ENABLED;
+  delete process.env.MEM0_INJECT_MAX_ITEMS;
+  delete process.env.MEM0_INJECT_ITEM_MAX_CHARS;
+  delete process.env.MEM0_INJECT_MAX_CHARS;
+  delete process.env.MEM0_INJECT_MAX_ESTIMATED_TOKENS;
+  delete process.env.MEM0_STORE_DEDUPE_WINDOW_MS;
+  delete process.env.MEM0_CIRCUIT_OPEN_MS;
+});
+
+describe("mem0 poc", () => {
+  it("caps recall injection by item count, item chars, and total chars", async () => {
+    const server = await createMem0TestServer({
+      recallResults: [
+        { text: "A".repeat(400), score: 0.95 },
+        { text: "用户偏好中文交流", score: 0.93 },
+        { text: "用户偏好结构化输出", score: 0.92 },
+        { text: "项目优先本地可控", score: 0.91 },
+      ],
+    });
+    try {
+      withMem0Env({
+        MEM0_BASE_URL: server.baseUrl,
+        MEM0_RECALL_LIMIT: "5",
+        MEM0_RECALL_THRESHOLD: "0.75",
+        MEM0_INJECT_MAX_ITEMS: "2",
+        MEM0_INJECT_ITEM_MAX_CHARS: "70",
+        MEM0_INJECT_MAX_CHARS: "160",
+        MEM0_INJECT_MAX_ESTIMATED_TOKENS: "40",
+      });
+      const result = await recallAndBuildInjectText({
+        query: "偏好",
+        userId: "u1",
+        agentId: "main",
+        runId: "r1",
+      });
+      expect(result?.injectedText).toBeDefined();
+      const injected = result?.injectedText ?? "";
+      const lines = injected
+        .split("\n")
+        .filter((line) => line.trim().startsWith("- "))
+        .map((line) => line.replace(/^-\s*/, ""));
+      expect(lines.length).toBeLessThanOrEqual(2);
+      expect(lines.every((line) => line.length <= 70)).toBe(true);
+      expect(injected.length).toBeLessThanOrEqual(160);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("deduplicates store calls within dedupe window", async () => {
+    const server = await createMem0TestServer();
+    try {
+      withMem0Env({
+        MEM0_BASE_URL: server.baseUrl,
+        MEM0_STORE_DEDUPE_WINDOW_MS: "1000",
+      });
+      await captureLongTermMemory({
+        userMessage: "我喜欢结构化输出",
+        assistantMessage: "收到，我会结构化回答。",
+        userId: "u1",
+        agentId: "main",
+        runId: "d1",
+      });
+      await captureLongTermMemory({
+        userMessage: "我喜欢结构化输出",
+        assistantMessage: "收到，我会结构化回答。",
+        userId: "u1",
+        agentId: "main",
+        runId: "d2",
+      });
+      expect(server.state.storeCalls).toBe(1);
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      await captureLongTermMemory({
+        userMessage: "我喜欢结构化输出",
+        assistantMessage: "收到，我会结构化回答。",
+        userId: "u1",
+        agentId: "main",
+        runId: "d3",
+      });
+      expect(server.state.storeCalls).toBe(2);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("recovers from open circuit via half-open probe", async () => {
+    withMem0Env({
+      MEM0_BASE_URL: "http://127.0.0.1:65530",
+      MEM0_CIRCUIT_OPEN_MS: "1000",
+      MEM0_RECALL_LIMIT: "3",
+      MEM0_RECALL_THRESHOLD: "0.75",
+    });
+    const first = await recallAndBuildInjectText({
+      query: "first",
+      userId: "u1",
+      agentId: "main",
+      runId: "r1",
+    });
+    expect(first).toBeUndefined();
+
+    const server = await createMem0TestServer({
+      recallResults: [{ text: "恢复后的记忆", score: 0.9 }],
+    });
+    try {
+      process.env.MEM0_BASE_URL = server.baseUrl;
+      const second = await recallAndBuildInjectText({
+        query: "second",
+        userId: "u1",
+        agentId: "main",
+        runId: "r2",
+      });
+      expect(second).toBeUndefined();
+
+      await new Promise((resolve) => setTimeout(resolve, 1_100));
+      const third = await recallAndBuildInjectText({
+        query: "third",
+        userId: "u1",
+        agentId: "main",
+        runId: "r3",
+      });
+      expect(third).toBeDefined();
+      expect(third?.injectedText).toBeDefined();
+      expect(third?.injectedText ?? "").toContain("Relevant long-term memory");
+      expect(server.state.healthChecks).toBeGreaterThan(0);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/src/memory/mem0/poc.ts
+++ b/src/memory/mem0/poc.ts
@@ -1,0 +1,462 @@
+import crypto from "node:crypto";
+import { getLogger } from "../../logging/logger.js";
+import {
+  createMem0ApiAdapter,
+  type Mem0Adapter,
+  type Mem0StoreParams,
+  type MemoryRecallResult,
+} from "./adapter.js";
+
+const logger = getLogger();
+
+const DEFAULT_RECALL_LIMIT = 5;
+const DEFAULT_RECALL_THRESHOLD = 0.75;
+const DEFAULT_CAPTURE_ENABLED = true;
+const MAX_CAPTURED_TEXT = 700;
+const DEFAULT_INJECT_MAX_ITEMS = 5;
+const DEFAULT_INJECT_MAX_CHARS = 1_200;
+const DEFAULT_INJECT_ITEM_MAX_CHARS = 240;
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+const DEFAULT_INJECT_MAX_ESTIMATED_TOKENS = 320;
+const DEFAULT_STORE_DEDUPE_WINDOW_MS = 5 * 60_000;
+const DEFAULT_CIRCUIT_OPEN_MS = 60_000;
+
+type Mem0PocConfig = {
+  enabled: boolean;
+  baseUrl?: string;
+  apiKey?: string;
+  recallLimit: number;
+  recallThreshold: number;
+  captureEnabled: boolean;
+  injectMaxItems: number;
+  injectMaxChars: number;
+  injectItemMaxChars: number;
+  injectMaxEstimatedTokens: number;
+  storeDedupeWindowMs: number;
+  circuitOpenMs: number;
+};
+
+type RecallContext = {
+  query: string;
+  userId?: string;
+  agentId?: string;
+  runId?: string;
+};
+
+type CaptureContext = {
+  userMessage: string;
+  assistantMessage: string;
+  toolSummary?: string;
+  userId?: string;
+  agentId?: string;
+  runId?: string;
+};
+
+type RecallInjectResult = {
+  injectedText?: string;
+  recalledCount: number;
+};
+
+type CircuitStatus = "closed" | "open" | "half-open";
+
+type CircuitState = {
+  status: CircuitStatus;
+  openedAtMs: number;
+  openedReason?: string;
+  checkedAtMs: number;
+};
+
+const circuitState: CircuitState = {
+  status: "closed",
+  openedAtMs: 0,
+  openedReason: undefined,
+  checkedAtMs: 0,
+};
+
+let adapterCache: Mem0Adapter | null = null;
+let adapterCacheKey: string | null = null;
+const storeDedupeCache = new Map<string, number>();
+
+function isTrue(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
+function readNumber(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+function readFloat(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function readMem0Config(env: NodeJS.ProcessEnv = process.env): Mem0PocConfig {
+  return {
+    enabled: isTrue(env.MEM0_ENABLED),
+    baseUrl: env.MEM0_BASE_URL?.trim() || undefined,
+    apiKey: env.MEM0_API_KEY?.trim() || undefined,
+    recallLimit: readNumber(env.MEM0_RECALL_LIMIT, DEFAULT_RECALL_LIMIT, 1, 20),
+    recallThreshold: readFloat(env.MEM0_RECALL_THRESHOLD, DEFAULT_RECALL_THRESHOLD, 0, 1),
+    captureEnabled: env.MEM0_CAPTURE_ENABLED
+      ? isTrue(env.MEM0_CAPTURE_ENABLED)
+      : DEFAULT_CAPTURE_ENABLED,
+    injectMaxItems: readNumber(env.MEM0_INJECT_MAX_ITEMS, DEFAULT_INJECT_MAX_ITEMS, 1, 20),
+    injectMaxChars: readNumber(env.MEM0_INJECT_MAX_CHARS, DEFAULT_INJECT_MAX_CHARS, 120, 8_000),
+    injectItemMaxChars: readNumber(
+      env.MEM0_INJECT_ITEM_MAX_CHARS,
+      DEFAULT_INJECT_ITEM_MAX_CHARS,
+      60,
+      1_500,
+    ),
+    injectMaxEstimatedTokens: readNumber(
+      env.MEM0_INJECT_MAX_ESTIMATED_TOKENS,
+      DEFAULT_INJECT_MAX_ESTIMATED_TOKENS,
+      32,
+      2_000,
+    ),
+    storeDedupeWindowMs: readNumber(
+      env.MEM0_STORE_DEDUPE_WINDOW_MS,
+      DEFAULT_STORE_DEDUPE_WINDOW_MS,
+      1_000,
+      24 * 60 * 60_000,
+    ),
+    circuitOpenMs: readNumber(
+      env.MEM0_CIRCUIT_OPEN_MS,
+      DEFAULT_CIRCUIT_OPEN_MS,
+      1_000,
+      60 * 60_000,
+    ),
+  };
+}
+
+function isConfigured(cfg: Mem0PocConfig): boolean {
+  return cfg.enabled && Boolean(cfg.baseUrl) && Boolean(cfg.apiKey);
+}
+
+function getAdapter(cfg: Mem0PocConfig): Mem0Adapter | null {
+  if (!isConfigured(cfg)) {
+    return null;
+  }
+  const key = `${cfg.baseUrl}|${cfg.apiKey}`;
+  if (!adapterCache || adapterCacheKey !== key) {
+    adapterCache = createMem0ApiAdapter({
+      baseUrl: cfg.baseUrl!,
+      apiKey: cfg.apiKey!,
+    });
+    adapterCacheKey = key;
+  }
+  return adapterCache;
+}
+
+function estimateTokensByChars(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN_ESTIMATE);
+}
+
+function markCircuitClosed(): void {
+  if (circuitState.status !== "closed") {
+    logger.info("[mem0-health] circuit closed; mem0 PoC re-enabled");
+  }
+  circuitState.status = "closed";
+  circuitState.openedAtMs = 0;
+  circuitState.openedReason = undefined;
+  circuitState.checkedAtMs = Date.now();
+}
+
+function markCircuitOpen(reason: string): void {
+  const now = Date.now();
+  const wasOpen = circuitState.status === "open";
+  circuitState.status = "open";
+  circuitState.openedAtMs = now;
+  circuitState.openedReason = reason;
+  circuitState.checkedAtMs = now;
+  if (wasOpen) {
+    logger.warn(`[mem0-health] circuit remains open: ${reason}`);
+    return;
+  }
+  logger.warn(`[mem0-health] circuit opened: ${reason}`);
+}
+
+function pruneStoreDedupeCache(now: number, windowMs: number): void {
+  if (storeDedupeCache.size === 0) {
+    return;
+  }
+  for (const [key, ts] of storeDedupeCache) {
+    if (now - ts > windowMs) {
+      storeDedupeCache.delete(key);
+    }
+  }
+}
+
+function computeStoreFingerprint(params: CaptureContext): string {
+  const normalized = [
+    params.userId ?? "",
+    params.agentId ?? "",
+    params.userMessage.trim().toLowerCase(),
+    params.assistantMessage.trim().toLowerCase(),
+    params.toolSummary?.trim().toLowerCase() ?? "",
+  ].join("\n");
+  return crypto.createHash("sha256").update(normalized).digest("hex");
+}
+
+function shouldSkipStoreAsDuplicate(params: CaptureContext, windowMs: number): boolean {
+  const now = Date.now();
+  pruneStoreDedupeCache(now, windowMs);
+  const key = computeStoreFingerprint(params);
+  const lastTs = storeDedupeCache.get(key);
+  if (typeof lastTs === "number" && now - lastTs <= windowMs) {
+    return true;
+  }
+  storeDedupeCache.set(key, now);
+  return false;
+}
+
+async function ensureHealthy(cfg: Mem0PocConfig): Promise<boolean> {
+  if (!isConfigured(cfg)) {
+    return false;
+  }
+  const now = Date.now();
+  if (circuitState.status === "open") {
+    const elapsed = now - circuitState.openedAtMs;
+    if (elapsed < cfg.circuitOpenMs) {
+      return false;
+    }
+    circuitState.status = "half-open";
+    logger.info("[mem0-health] circuit half-open; probing health");
+  }
+  const adapter = getAdapter(cfg);
+  if (!adapter) {
+    return false;
+  }
+  try {
+    const healthy = await adapter.healthCheck();
+    if (healthy) {
+      markCircuitClosed();
+      logger.info("[mem0-health] health check passed");
+      return true;
+    }
+    markCircuitOpen("health check failed");
+    return false;
+  } catch (error) {
+    markCircuitOpen(
+      `health check error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return false;
+  }
+}
+
+function stableScoreFilter(results: MemoryRecallResult[], threshold: number): MemoryRecallResult[] {
+  return results.filter((item) => item.score == null || item.score >= threshold);
+}
+
+function dedupeRecallText(results: MemoryRecallResult[]): MemoryRecallResult[] {
+  const seen = new Set<string>();
+  const deduped: MemoryRecallResult[] = [];
+  for (const item of results) {
+    const key = item.text.trim().toLowerCase();
+    if (!key || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+function truncateRecallItems(
+  results: MemoryRecallResult[],
+  itemMaxChars: number,
+): MemoryRecallResult[] {
+  return results
+    .map((item) => {
+      const trimmed = item.text.trim();
+      if (!trimmed) {
+        return undefined;
+      }
+      const text =
+        trimmed.length <= itemMaxChars
+          ? trimmed
+          : `${trimmed.slice(0, Math.max(1, itemMaxChars - 3))}...`;
+      return { ...item, text };
+    })
+    .filter((item): item is MemoryRecallResult => Boolean(item));
+}
+
+function formatRecallInjectBlock(results: MemoryRecallResult[]): string | undefined {
+  if (results.length === 0) {
+    return undefined;
+  }
+  const lines = results.map((item) => `- ${item.text}`);
+  return `Relevant long-term memory:\n${lines.join("\n")}`;
+}
+
+function capInjectBlock(params: {
+  results: MemoryRecallResult[];
+  maxItems: number;
+  maxChars: number;
+  maxEstimatedTokens: number;
+}): { selected: MemoryRecallResult[]; injectedText?: string } {
+  const selected: MemoryRecallResult[] = [];
+  for (const item of params.results.slice(0, params.maxItems)) {
+    const next = [...selected, item];
+    const block = formatRecallInjectBlock(next);
+    if (!block) {
+      continue;
+    }
+    const tokenEstimate = estimateTokensByChars(block);
+    if (block.length > params.maxChars || tokenEstimate > params.maxEstimatedTokens) {
+      break;
+    }
+    selected.push(item);
+  }
+  return {
+    selected,
+    injectedText: formatRecallInjectBlock(selected),
+  };
+}
+
+function isLikelyNoise(text: string): boolean {
+  const trimmed = text.trim().toLowerCase();
+  if (!trimmed) {
+    return true;
+  }
+  if (trimmed.length <= 3) {
+    return true;
+  }
+  return /^(ok|okay|thanks|thank you|hi|hello|bye|good night|收到|好的|谢谢)$/.test(trimmed);
+}
+
+function clampText(text: string, maxChars = MAX_CAPTURED_TEXT): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  return `${text.slice(0, maxChars)}...`;
+}
+
+function buildCaptureMemory(params: CaptureContext): string | undefined {
+  const user = params.userMessage.trim();
+  const assistant = params.assistantMessage.trim();
+  if (!user || !assistant) {
+    return undefined;
+  }
+  if (isLikelyNoise(user) && isLikelyNoise(assistant)) {
+    return undefined;
+  }
+  const lines: string[] = [
+    `User: ${clampText(user, 280)}`,
+    `Assistant: ${clampText(assistant, 380)}`,
+  ];
+  if (params.toolSummary?.trim()) {
+    lines.push(`Tool summary: ${clampText(params.toolSummary.trim(), 200)}`);
+  }
+  return lines.join("\n");
+}
+
+export async function recallAndBuildInjectText(
+  params: RecallContext,
+): Promise<RecallInjectResult | undefined> {
+  const cfg = readMem0Config();
+  if (!isConfigured(cfg)) {
+    return undefined;
+  }
+  if (!(await ensureHealthy(cfg))) {
+    return undefined;
+  }
+  const adapter = getAdapter(cfg);
+  if (!adapter) {
+    return undefined;
+  }
+  try {
+    const recallRaw = await adapter.recall({
+      query: params.query,
+      userId: params.userId,
+      agentId: params.agentId,
+      runId: params.runId,
+      limit: cfg.recallLimit,
+      threshold: cfg.recallThreshold,
+    });
+    const filtered = truncateRecallItems(
+      dedupeRecallText(stableScoreFilter(recallRaw, cfg.recallThreshold)),
+      cfg.injectItemMaxChars,
+    );
+    const { selected, injectedText } = capInjectBlock({
+      results: filtered,
+      maxItems: cfg.injectMaxItems,
+      maxChars: cfg.injectMaxChars,
+      maxEstimatedTokens: cfg.injectMaxEstimatedTokens,
+    });
+    const injectEstimatedTokens = injectedText ? estimateTokensByChars(injectedText) : 0;
+    logger.info(
+      `[mem0-recall] recalled=${recallRaw.length} selected=${selected.length} inject_chars=${injectedText?.length ?? 0} inject_est_tokens=${injectEstimatedTokens}`,
+    );
+    return {
+      injectedText,
+      recalledCount: recallRaw.length,
+    };
+  } catch (error) {
+    markCircuitOpen(`recall error: ${error instanceof Error ? error.message : String(error)}`);
+    logger.warn(
+      `[mem0-recall] recall failed; skip inject: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
+export async function captureLongTermMemory(params: CaptureContext): Promise<void> {
+  const cfg = readMem0Config();
+  if (!isConfigured(cfg) || !cfg.captureEnabled) {
+    return;
+  }
+  if (!(await ensureHealthy(cfg))) {
+    return;
+  }
+  const adapter = getAdapter(cfg);
+  if (!adapter) {
+    return;
+  }
+  const memory = buildCaptureMemory(params);
+  if (!memory) {
+    logger.info("[mem0-store] skipped capture due to noise filter");
+    return;
+  }
+  if (shouldSkipStoreAsDuplicate(params, cfg.storeDedupeWindowMs)) {
+    logger.info("[mem0-store] skipped duplicate capture within dedupe window");
+    return;
+  }
+  const payload: Mem0StoreParams = {
+    memory,
+    userMessage: params.userMessage,
+    assistantMessage: params.assistantMessage,
+    toolSummary: params.toolSummary,
+    userId: params.userId,
+    agentId: params.agentId,
+    runId: params.runId,
+  };
+  try {
+    await adapter.store(payload);
+    logger.info("[mem0-store] success=true");
+  } catch (error) {
+    markCircuitOpen(`store error: ${error instanceof Error ? error.message : String(error)}`);
+    logger.warn(
+      `[mem0-store] success=false error=${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export const __mem0TestHooks = {
+  resetState(): void {
+    adapterCache = null;
+    adapterCacheKey = null;
+    storeDedupeCache.clear();
+    circuitState.status = "closed";
+    circuitState.openedAtMs = 0;
+    circuitState.openedReason = undefined;
+    circuitState.checkedAtMs = 0;
+  },
+};


### PR DESCRIPTION
## Summary
Add a mem0 long-term memory PoC+ that is default-off and gated by feature flags.

- Recall before model generation and inject a bounded memory block.
- Capture after assistant response with lightweight filtering and dedupe.
- Add recoverable circuit breaker for safe degradation and auto-recovery.

## Why
We need a low-intrusion, reversible validation of long-term memory benefits without changing existing behavior on the main path.

This implementation keeps mem0 isolated and optional, while providing measurable token and latency data for merge readiness.

## Implementation
- Added isolated mem0 adapter module with `healthCheck`, `recall`, and `store`.
- Added PoC orchestrator with:
  - `MEM0_*` config parsing and feature-flag gating
  - Recall filtering + hard caps (item count, item chars, total chars, estimated token cap)
  - Store dedupe (fingerprint + time window)
  - Recoverable circuit breaker (`open -> half-open -> closed`)
  - Standardized logging prefixes (`[mem0-health]`, `[mem0-recall]`, `[mem0-store]`)
- Integrated recall/inject in pre-model path (`get-reply-run`).
- Integrated capture in post-reply path (`dispatch-from-config`) as fire-and-forget.
- Added targeted tests for cap behavior, dedupe window, and half-open recovery.

## Validation
### Build & tests
- `pnpm build`
- `pnpm test src/memory/mem0/poc.test.ts`
- `pnpm test src/memory/mem0/poc.test.ts src/auto-reply/reply/dispatch-from-config.test.ts`

### New test coverage
- Recall injection hard caps (item count / item chars / total chars)
- Store dedupe window behavior
- Circuit breaker half-open recovery

### Real usage A/B (provider usage fields)
- A (`MEM0_ENABLED=false`): input 148.3 / output 74.2 / total 222.5
- B (`MEM0_ENABLED=true`): input 83.8 / output 41.7 / total 125.5
- Total token reduction: **43.6%**

### Recall latency impact
- mem0 normal: avg +1.6ms, P95 +2.3ms, P99 +19.0ms
- mem0 slow (~250ms): avg +258.1ms, P95 +259.6ms, P99 +261.1ms
- mem0 unavailable first hit: avg +1.8ms
- after circuit opens: near-zero overhead

## Risks
- Recall is synchronous pre-model; slow mem0 increases latency.
- Capture is fire-and-forget; tail events may be lost on abrupt process exit.
- Dedupe is in-process (not cross-instance).
- Recommended rollout is gradual.

## Rollback
- Full rollback via config: set `MEM0_ENABLED=false`.
- Disable write path only: set `MEM0_CAPTURE_ENABLED=false`.
- If needed, remove/revert mem0 integration files and call sites.

---

Default behavior remains unchanged unless explicitly enabled (`MEM0_ENABLED=true`).

Made with [Cursor](https://cursor.com)