### PR TITLE
fix(talk): prevent double TTS playback when system voice times out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: trigger timeout recovery compaction before retrying high-context LLM timeouts so embedded runs stop repeating oversized requests. (#46417) thanks @joeykrug.
 - Agents/compaction: reconcile `sessions.json.compactionCount` after a late embedded auto-compaction success so persisted session counts catch up once the handler reports completion. (#45493) Thanks @jackal092927.
 - Agents/failover: classify Codex accountId token extraction failures as auth errors so model fallback continues to the next configured candidate. (#55206) Thanks @cosmicnet.
+- Talk/macOS: stop direct system-voice failures from replaying system speech, use app-locale fallback for shared watchdog timing, and add regression coverage for the macOS fallback route and language-aware timeout policy. (#53511) thanks @hongsw.
 
 ## 2026.3.24
 
@@ -433,7 +434,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/replies: set `allow_sending_without_reply` on reply-targeted sends and media-error notices so deleted parent messages no longer drop otherwise valid replies. (#52524) Thanks @moltbot886.
 - Gateway/status: resolve env-backed `gateway.auth.*` SecretRefs before read-only probe auth checks so status no longer reports false probe failures when auth is configured through SecretRef. (#52513) Thanks @CodeForgeNet.
 - Agents/exec: return plain-text failed tool output for timeouts and other non-success exec outcomes so models no longer parrot raw JSON error payloads back to users. (#52508) Thanks @martingarramon.
-- Talk/macOS: stop direct system-voice failures from replaying system speech, use app-locale fallback for shared watchdog timing, and add regression coverage for the macOS fallback route and language-aware timeout policy. (#53511) thanks @hongsw.
 - CLI/startup: lazy-load channel add and root help startup paths to trim avoidable RSS and help latency on constrained hosts. (#46784) Thanks @vincentkoc.
 - CLI/onboarding: import static provider definitions directly for onboarding model/config helpers so those paths no longer pull provider discovery just for built-in defaults. (#47467) Thanks @vincentkoc.
 - CLI/configure: clarify fresh-setup memory-search warnings so they say semantic recall needs at least one embedding provider, and scope the initial model allowlist picker to the provider selected in configure. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,6 +430,17 @@ Docs: https://docs.openclaw.ai
 - Security/network: harden explicit-proxy SSRF pinning by translating target-hop transport hints onto HTTPS proxy tunnels and failing closed for plain HTTP guarded fetches that cannot preserve pinned DNS.
 - Security/Synology Chat: require explicit per-account webhook paths for multi-account setups by default, reject duplicate exact webhook paths fail-closed, and keep inherited-path behavior behind an explicit dangerous opt-in so shared routes can no longer collapse DM policy contexts across accounts. Thanks @tdjackey for reporting.
 - Browser/remote CDP: honor strict browser SSRF policy during remote CDP reachability and `/json/version` discovery checks, redact sensitive `cdpUrl` tokens from status output, and warn when remote CDP targets private/internal hosts.
+- Telegram/replies: set `allow_sending_without_reply` on reply-targeted sends and media-error notices so deleted parent messages no longer drop otherwise valid replies. (#52524) Thanks @moltbot886.
+- Gateway/status: resolve env-backed `gateway.auth.*` SecretRefs before read-only probe auth checks so status no longer reports false probe failures when auth is configured through SecretRef. (#52513) Thanks @CodeForgeNet.
+- Agents/exec: return plain-text failed tool output for timeouts and other non-success exec outcomes so models no longer parrot raw JSON error payloads back to users. (#52508) Thanks @martingarramon.
+- Talk/macOS: stop direct system-voice failures from replaying system speech, use app-locale fallback for shared watchdog timing, and add regression coverage for the macOS fallback route and language-aware timeout policy. (#53511) thanks @hongsw.
+- CLI/startup: lazy-load channel add and root help startup paths to trim avoidable RSS and help latency on constrained hosts. (#46784) Thanks @vincentkoc.
+- CLI/onboarding: import static provider definitions directly for onboarding model/config helpers so those paths no longer pull provider discovery just for built-in defaults. (#47467) Thanks @vincentkoc.
+- CLI/configure: clarify fresh-setup memory-search warnings so they say semantic recall needs at least one embedding provider, and scope the initial model allowlist picker to the provider selected in configure. Thanks @vincentkoc.
+- CLI/auth choice: lazy-load plugin/provider fallback resolution so mapped auth choices stay on the static path and only unknown choices pay the heavy provider load. (#47495) Thanks @vincentkoc.
+- CLI: avoid loading provider discovery during startup model normalization. (#46522) Thanks @ItsAditya-xyz and @vincentkoc.
+- CLI/status: keep `status --json` stdout clean by skipping plugin compatibility scans that were not rendered in the JSON payload. (#52449) Thanks @cgdusek.
+- Agents/Telegram: avoid rebuilding the full model catalog on ordinary inbound replies so Telegram message handling no longer pays multi-second core startup latency before reply generation. Thanks @vincentkoc.
 - Media/security: bound remote-media error-body snippets with the same streaming caps and idle timeouts as successful downloads, so malicious HTTP error responses cannot force unbounded buffering before OpenClaw throws.
 - Gateway/auth: ignore spoofed loopback hops in trusted forwarding chains and block device approvals that request scopes above the caller session. (#46800) Thanks @vincentkoc.
 - Gateway/auth: clear self-declared scopes for device-less trusted-proxy Control UI sessions so proxy-authenticated connects cannot claim admin or secrets scopes without a bound device identity.

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -8,6 +8,11 @@ import Speech
 actor TalkModeRuntime {
     static let shared = TalkModeRuntime()
 
+    enum PlaybackPlan: Equatable {
+        case elevenLabsThenSystemVoice(apiKey: String, voiceId: String)
+        case systemVoiceOnly
+    }
+
     private let logger = Logger(subsystem: "ai.openclaw", category: "talk.runtime")
     private let ttsLogger = Logger(subsystem: "ai.openclaw", category: "talk.tts")
     private static let defaultModelIdFallback = "eleven_v3"
@@ -451,7 +456,8 @@ actor TalkModeRuntime {
 
     private func playAssistant(text: String) async {
         guard let input = await self.preparePlaybackInput(text: text) else { return }
-        if let apiKey = input.apiKey, !apiKey.isEmpty, let voiceId = input.voiceId {
+        switch Self.playbackPlan(apiKey: input.apiKey, voiceId: input.voiceId) {
+        case let .elevenLabsThenSystemVoice(apiKey, voiceId):
             do {
                 try await self.playElevenLabs(input: input, apiKey: apiKey, voiceId: voiceId)
             } catch {
@@ -465,7 +471,7 @@ actor TalkModeRuntime {
                     self.ttsLogger.error("talk system voice failed: \(error.localizedDescription, privacy: .public)")
                 }
             }
-        } else {
+        case .systemVoiceOnly:
             do {
                 try await self.playSystemVoice(input: input)
             } catch {
@@ -477,6 +483,13 @@ actor TalkModeRuntime {
             self.phase = .thinking
             await MainActor.run { TalkModeController.shared.updatePhase(.thinking) }
         }
+    }
+
+    static func playbackPlan(apiKey: String?, voiceId: String?) -> PlaybackPlan {
+        guard let apiKey, !apiKey.isEmpty, let voiceId else {
+            return .systemVoiceOnly
+        }
+        return .elevenLabsThenSystemVoice(apiKey: apiKey, voiceId: voiceId)
     }
 
     private struct TalkPlaybackInput {

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -451,17 +451,21 @@ actor TalkModeRuntime {
 
     private func playAssistant(text: String) async {
         guard let input = await self.preparePlaybackInput(text: text) else { return }
-        do {
-            if let apiKey = input.apiKey, !apiKey.isEmpty, let voiceId = input.voiceId {
+        if let apiKey = input.apiKey, !apiKey.isEmpty, let voiceId = input.voiceId {
+            do {
                 try await self.playElevenLabs(input: input, apiKey: apiKey, voiceId: voiceId)
-            } else {
-                try await self.playSystemVoice(input: input)
+            } catch {
+                self.ttsLogger
+                    .error(
+                        "talk TTS failed: \(error.localizedDescription, privacy: .public); " +
+                            "falling back to system voice")
+                do {
+                    try await self.playSystemVoice(input: input)
+                } catch {
+                    self.ttsLogger.error("talk system voice failed: \(error.localizedDescription, privacy: .public)")
+                }
             }
-        } catch {
-            self.ttsLogger
-                .error(
-                    "talk TTS failed: \(error.localizedDescription, privacy: .public); " +
-                        "falling back to system voice")
+        } else {
             do {
                 try await self.playSystemVoice(input: input)
             } catch {

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -668,9 +668,12 @@ actor TalkModeRuntime {
         await MainActor.run { TalkModeController.shared.updatePhase(.speaking) }
         self.phase = .speaking
         await TalkSystemSpeechSynthesizer.shared.stop()
+        // Use app locale as fallback when no explicit language is set (e.g. system voice without ElevenLabs directive).
+        let appLocale = await MainActor.run { AppStateStore.shared.voiceWakeLocaleID }
+        let ttsLanguage = input.language ?? appLocale
         try await TalkSystemSpeechSynthesizer.shared.speak(
             text: input.cleanedText,
-            language: input.language)
+            language: ttsLanguage)
         self.ttsLogger.info("talk system voice done")
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/TalkModeRuntimeSpeechTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkModeRuntimeSpeechTests.swift
@@ -11,4 +11,13 @@ struct TalkModeRuntimeSpeechTests {
         #expect(request.shouldReportPartialResults)
         #expect(request.taskHint == .dictation)
     }
+
+    @Test func `playback plan falls back only from elevenlabs`() {
+        #expect(
+            TalkModeRuntime.playbackPlan(apiKey: "key", voiceId: "voice")
+                == .elevenLabsThenSystemVoice(apiKey: "key", voiceId: "voice"))
+        #expect(TalkModeRuntime.playbackPlan(apiKey: nil, voiceId: "voice") == .systemVoiceOnly)
+        #expect(TalkModeRuntime.playbackPlan(apiKey: "key", voiceId: nil) == .systemVoiceOnly)
+        #expect(TalkModeRuntime.playbackPlan(apiKey: "", voiceId: "voice") == .systemVoiceOnly)
+    }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
@@ -54,12 +54,12 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
         // Estimate speech duration per language, then apply 3x safety margin.
         // The watchdog is a hang guard — normal completion relies on didFinish.
         //
-        // Speech rates based on Pellegrino et al. (2011) syllable-per-second data,
-        // adjusted ~1.3x slower for TTS synthesis vs natural speech:
+        // Speech rates based on Pellegrino et al. (2019) syllable-per-second data,
+        // adjusted for TTS synthesis (slower than natural speech):
         // https://www.science.org/doi/10.1126/sciadv.aaw2594
-        //   Japanese: 7.84 SPS → ~0.19s/char (mixed kana/kanji avg ~1.5 mora/char)
-        //   Korean:   5.96 SPS → ~0.22s/char (1 char = 1 syllable)
-        //   Chinese:  5.18 SPS → ~0.25s/char (1 char = 1 syllable)
+        //   Japanese: 7.84 SPS → ~0.20s/char (mixed kana/kanji avg ~1.5 mora/char)
+        //   Korean:   5.96 SPS → ~0.25s/char (1 char = 1 syllable)
+        //   Chinese:  5.18 SPS → ~0.28s/char (1 char = 1 syllable)
         //   English:  6.19 SPS → ~0.08s/char (avg ~5 chars/syllable)
         let resolvedLang = language ?? utterance.voice?.language ?? "en"
         let perCharSeconds: Double

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
@@ -51,34 +51,7 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
         }
         self.currentUtterance = utterance
 
-        // Estimate speech duration per language, then apply 3x safety margin.
-        // The watchdog is a hang guard — normal completion relies on didFinish.
-        //
-        // Speech rates based on Pellegrino et al. (2019) syllable-per-second data,
-        // adjusted for TTS synthesis (slower than natural speech):
-        // https://www.science.org/doi/10.1126/sciadv.aaw2594
-        //   Japanese: 7.84 SPS → ~0.20s/char (mixed kana/kanji avg ~1.5 mora/char)
-        //   Korean:   5.96 SPS → ~0.25s/char (1 char = 1 syllable)
-        //   Chinese:  5.18 SPS → ~0.28s/char (1 char = 1 syllable)
-        //   English:  6.19 SPS → ~0.08s/char (avg ~5 chars/syllable)
-        let resolvedLang = language ?? utterance.voice?.language ?? "en"
-        let perCharSeconds: Double
-        let minSeconds: Double
-        if resolvedLang.hasPrefix("ko") {
-            perCharSeconds = 0.25  // Korean: 1 syllable block per char
-            minSeconds = 10.0
-        } else if resolvedLang.hasPrefix("zh") {
-            perCharSeconds = 0.28  // Chinese: 1 syllable per hanzi, tonal = slightly slower
-            minSeconds = 10.0
-        } else if resolvedLang.hasPrefix("ja") {
-            perCharSeconds = 0.20  // Japanese: kana ~0.15s, kanji ~0.3s, blended avg
-            minSeconds = 10.0
-        } else {
-            perCharSeconds = 0.08  // Latin-script languages
-            minSeconds = 3.0
-        }
-        let estimatedSeconds = max(minSeconds, min(300.0, Double(trimmed.count) * perCharSeconds))
-        let watchdogTimeout = estimatedSeconds * 3.0
+        let watchdogTimeout = Self.watchdogTimeoutSeconds(text: trimmed, language: language ?? utterance.voice?.language)
         self.watchdog?.cancel()
         self.watchdog = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -108,6 +81,37 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
         if self.currentToken != token {
             throw SpeakError.canceled
         }
+    }
+
+    static func watchdogTimeoutSeconds(text: String, language: String?) -> Double {
+        // Estimate speech duration per language, then apply 3x safety margin.
+        // The watchdog is a hang guard — normal completion relies on didFinish.
+        //
+        // Speech rates based on Pellegrino et al. (2019) syllable-per-second data,
+        // adjusted for TTS synthesis (slower than natural speech):
+        // https://www.science.org/doi/10.1126/sciadv.aaw2594
+        //   Japanese: 7.84 SPS -> ~0.20s/char (mixed kana/kanji avg ~1.5 mora/char)
+        //   Korean:   5.96 SPS -> ~0.25s/char (1 char = 1 syllable)
+        //   Chinese:  5.18 SPS -> ~0.28s/char (1 char = 1 syllable)
+        //   English:  6.19 SPS -> ~0.08s/char (avg ~5 chars/syllable)
+        let normalizedLanguage = language?.lowercased() ?? "en"
+        let perCharSeconds: Double
+        let minSeconds: Double
+        if normalizedLanguage.hasPrefix("ko") {
+            perCharSeconds = 0.25
+            minSeconds = 10.0
+        } else if normalizedLanguage.hasPrefix("zh") {
+            perCharSeconds = 0.28
+            minSeconds = 10.0
+        } else if normalizedLanguage.hasPrefix("ja") {
+            perCharSeconds = 0.20
+            minSeconds = 10.0
+        } else {
+            perCharSeconds = 0.08
+            minSeconds = 3.0
+        }
+        let estimatedSeconds = max(minSeconds, min(300.0, Double(text.count) * perCharSeconds))
+        return estimatedSeconds * 3.0
     }
 
     private func matchesCurrentUtterance(_ utteranceID: ObjectIdentifier) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
@@ -51,11 +51,38 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
         }
         self.currentUtterance = utterance
 
-        let estimatedSeconds = max(3.0, min(180.0, Double(trimmed.count) * 0.08))
+        // Estimate speech duration per language, then apply 3x safety margin.
+        // The watchdog is a hang guard — normal completion relies on didFinish.
+        //
+        // Speech rates based on Pellegrino et al. (2011) syllable-per-second data,
+        // adjusted ~1.3x slower for TTS synthesis vs natural speech:
+        // https://www.science.org/doi/10.1126/sciadv.aaw2594
+        //   Japanese: 7.84 SPS → ~0.19s/char (mixed kana/kanji avg ~1.5 mora/char)
+        //   Korean:   5.96 SPS → ~0.22s/char (1 char = 1 syllable)
+        //   Chinese:  5.18 SPS → ~0.25s/char (1 char = 1 syllable)
+        //   English:  6.19 SPS → ~0.08s/char (avg ~5 chars/syllable)
+        let resolvedLang = language ?? utterance.voice?.language ?? "en"
+        let perCharSeconds: Double
+        let minSeconds: Double
+        if resolvedLang.hasPrefix("ko") {
+            perCharSeconds = 0.25  // Korean: 1 syllable block per char
+            minSeconds = 10.0
+        } else if resolvedLang.hasPrefix("zh") {
+            perCharSeconds = 0.28  // Chinese: 1 syllable per hanzi, tonal = slightly slower
+            minSeconds = 10.0
+        } else if resolvedLang.hasPrefix("ja") {
+            perCharSeconds = 0.20  // Japanese: kana ~0.15s, kanji ~0.3s, blended avg
+            minSeconds = 10.0
+        } else {
+            perCharSeconds = 0.08  // Latin-script languages
+            minSeconds = 3.0
+        }
+        let estimatedSeconds = max(minSeconds, min(300.0, Double(trimmed.count) * perCharSeconds))
+        let watchdogTimeout = estimatedSeconds * 3.0
         self.watchdog?.cancel()
         self.watchdog = Task { @MainActor [weak self] in
             guard let self else { return }
-            try? await Task.sleep(nanoseconds: UInt64(estimatedSeconds * 1_000_000_000))
+            try? await Task.sleep(nanoseconds: UInt64(watchdogTimeout * 1_000_000_000))
             if Task.isCancelled { return }
             guard self.currentToken == token else { return }
             if self.synth.isSpeaking {
@@ -63,7 +90,7 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
             }
             self.finishCurrent(
                 with: NSError(domain: "TalkSystemSpeechSynthesizer", code: 408, userInfo: [
-                    NSLocalizedDescriptionKey: "system TTS timed out after \(estimatedSeconds)s",
+                    NSLocalizedDescriptionKey: "system TTS timed out after \(watchdogTimeout)s",
                 ]))
         }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import OpenClawKit
+
+final class TalkSystemSpeechSynthesizerTests: XCTestCase {
+    func testWatchdogTimeoutDefaultsToLatinProfile() {
+        let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
+            text: String(repeating: "a", count: 100),
+            language: nil)
+
+        XCTAssertEqual(timeout, 24.0, accuracy: 0.001)
+    }
+
+    func testWatchdogTimeoutUsesKoreanProfile() {
+        let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
+            text: String(repeating: "가", count: 100),
+            language: "ko-KR")
+
+        XCTAssertEqual(timeout, 75.0, accuracy: 0.001)
+    }
+
+    func testWatchdogTimeoutUsesChineseProfile() {
+        let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
+            text: String(repeating: "你", count: 100),
+            language: "zh-CN")
+
+        XCTAssertEqual(timeout, 84.0, accuracy: 0.001)
+    }
+
+    func testWatchdogTimeoutUsesJapaneseProfile() {
+        let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
+            text: String(repeating: "あ", count: 100),
+            language: "ja-JP")
+
+        XCTAssertEqual(timeout, 60.0, accuracy: 0.001)
+    }
+
+    func testWatchdogTimeoutClampsVeryLongUtterances() {
+        let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
+            text: String(repeating: "a", count: 10_000),
+            language: "en-US")
+
+        XCTAssertEqual(timeout, 900.0, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

- Fix Talk Mode playing every assistant reply **twice** when using a non-ElevenLabs TTS provider
- Fix CJK (Korean, Japanese, Chinese) system voice watchdog cutting off speech mid-sentence

## Changes

### 1. Prevent double TTS playback (`TalkModeRuntime.swift`)

Split the ElevenLabs and system-voice error paths. Previously `playAssistant()` unconditionally retried `playSystemVoice()` in its catch block — even when system voice itself threw the error. Now system voice failures are logged without retrying; only ElevenLabs failures fall back to system voice.

### 2. Language-aware watchdog timeout (`TalkSystemSpeechSynthesizer.swift` + `TalkModeRuntime.swift`)

Two fixes:

**a) Per-language timing estimates**: The watchdog timer now uses per-language estimates based on [Pellegrino et al. (2019)](https://www.science.org/doi/10.1126/sciadv.aaw2594) syllable-per-second research, adjusted for TTS synthesis speed:

| Language | Per-char estimate | Min timeout | 50 chars × 3x → watchdog |
|----------|-------------------|-------------|--------------------------|
| Korean   | 0.25s             | 10s         | 37.5s                    |
| Chinese  | 0.28s             | 10s         | 42.0s                    |
| Japanese | 0.20s             | 10s         | 30.0s                    |
| English  | 0.08s             | 3s          | 12.0s                    |

A 3x safety margin is applied so the watchdog only fires on genuine hangs where `didFinish` never arrives — not during normal speech.

**b) App locale fallback**: `playSystemVoice` was passing `nil` as language (ElevenLabs directive field) which caused `TalkSystemSpeechSynthesizer` to default to English timing (`0.08s/char`). Now falls back to the app's voice wake locale (e.g. `ko-KR`) so the correct language-specific timing is used.

Closes #53510

## Test plan

- [x] Talk Mode with `talk.provider = system` — response plays once (not twice)
- [x] Korean long response (50+ chars) — plays to completion without timeout
- [x] English short response — still completes quickly
- [x] Verified watchdog uses correct language (not defaulting to English)
- [x] Pre-commit hooks pass (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)