### PR TITLE
fix(auto-reply): pass agentId and topicId in Gemini corruption transcript cleanup

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -17,6 +17,7 @@ import {
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
+  resolveAgentIdFromSessionKey,
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
   type SessionEntry,
@@ -607,7 +608,12 @@ export async function runAgentTurnWithFallback(params: {
         try {
           // Delete transcript file if it exists
           if (corruptedSessionId) {
-            const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
+            const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+            const transcriptPath = resolveSessionTranscriptPath(
+              corruptedSessionId,
+              agentId,
+              params.sessionCtx.MessageThreadId,
+            );
             try {
               fs.unlinkSync(transcriptPath);
             } catch {


### PR DESCRIPTION
## Summary

- **Problem:** When Gemini session corruption is detected, the transcript cleanup calls `resolveSessionTranscriptPath(corruptedSessionId)` without `agentId` or `topicId`, producing a wrong path for non-default agents and Telegram forum topic sessions.
- **Why it matters:** Orphaned transcript files accumulate on disk; the corrupted transcript is never actually deleted for topic-based or multi-agent sessions.
- **What changed:** Added `agentId` (derived from `sessionKey`) and `sessionCtx.MessageThreadId` parameters to the `resolveSessionTranscriptPath` call in the Gemini corruption recovery handler.
- **What did NOT change:** No behavioral change for default-agent, non-topic sessions (parameters resolve to the same path as before).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related: same bug class as the session-reset cleanup path fixed in `agent-runner.ts` (lines 320-324, 352-354)

## User-visible / Behavior Changes

None — this only affects internal transcript file cleanup. Users won't see different behavior, but disk hygiene improves for topic-based and multi-agent sessions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Root Cause

`resolveSessionTranscriptPath` builds the transcript file path using optional `agentId` (for agent-specific subdirectory) and `topicId` (for topic filename suffix). The Gemini corruption handler at `agent-runner-execution.ts:608` called it with only `sessionId`, while both `agentId` and `MessageThreadId` were available in scope via `params`.

The session-reset handler in `agent-runner.ts:320-324` correctly passes all three parameters — this was a missed call site.

## Fix

Added `resolveAgentIdFromSessionKey` import and passed both `agentId` and `params.sessionCtx.MessageThreadId` to `resolveSessionTranscriptPath` in the corruption cleanup path, matching the pattern used in the session-reset path.

## Test Plan

- [x] Verified no new TypeScript errors (`pnpm tsgo` — only pre-existing unrelated errors)
- [x] Confirmed the test file (`agent-runner-execution.test.ts`) has a pre-existing import failure unrelated to this change
- [x] Code review: the fix follows the exact same pattern as the correct call site in `agent-runner.ts:320-324`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Integration/channel: Telegram (forum topics), any multi-agent setup

### Steps

1. Configure a Telegram forum topic session (MessageThreadId is set)
2. Trigger a Gemini session with function call ordering corruption
3. Observe the corruption recovery handler attempts to delete the transcript

### Expected

The correct transcript file (with topic suffix) is deleted.

### Actual (before fix)

The cleanup targets a path without the topic suffix, failing silently. The actual transcript file remains on disk.

## Evidence

- [x] Code review comparison with correct call site (`agent-runner.ts:320-324`)

## Human Verification (required)

- Verified scenarios: Compared all call sites of `resolveSessionTranscriptPath` — this was the only one missing parameters
- Edge cases checked: Default agent (agentId = undefined) and non-topic sessions (MessageThreadId = undefined) produce identical paths as before
- What I did **not** verify: Live Gemini corruption scenario (requires specific model behavior)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit
- Known bad symptoms: If `resolveAgentIdFromSessionKey` throws, the outer catch block at line 623 handles it gracefully

## Risks and Mitigations

None — the fix adds parameters that were already available and follows an established pattern.