### PR TITLE
fix(session): add postRotationStartupUntilMs for Discord channel and thread resets

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -53,6 +53,9 @@ const refreshQueuedFollowupSessionMock = vi.fn();
 const compactState = vi.hoisted(() => ({
   compactEmbeddedPiSessionMock: vi.fn(),
 }));
+const embeddedRunsState = vi.hoisted(() => ({
+  queueEmbeddedPiMessageMock: vi.fn(() => false),
+}));
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -84,6 +87,14 @@ vi.mock("../../agents/pi-embedded.js", () => {
   };
 });
 
+vi.mock("../../agents/pi-embedded-runner/runs.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../../agents/pi-embedded-runner/runs.js")>();
+  return {
+    ...mod,
+    queueEmbeddedPiMessage: embeddedRunsState.queueEmbeddedPiMessageMock,
+  };
+});
+
 vi.mock("../../agents/cli-runner.js", () => ({
   runCliAgent: (...args: unknown[]) => runCliAgentMock(...args),
 }));
@@ -104,6 +115,8 @@ vi.mock("./queue.js", () => {
     scheduleFollowupDrain: vi.fn(),
     clearSessionQueues: (...args: unknown[]) => clearSessionQueuesMock(...args),
     refreshQueuedFollowupSession: (...args: unknown[]) => refreshQueuedFollowupSessionMock(...args),
+    resolvePiSteeringModeForQueueMode: (mode: string) =>
+      mode === "queue" ? "one-at-a-time" : "all",
   };
 });
 
@@ -162,6 +175,8 @@ beforeEach(() => {
     compacted: false,
     reason: "test-preflight-disabled",
   });
+  embeddedRunsState.queueEmbeddedPiMessageMock.mockReset();
+  embeddedRunsState.queueEmbeddedPiMessageMock.mockReturnValue(false);
   clearSessionQueuesMock.mockReset();
   clearSessionQueuesMock.mockReturnValue({ followupCleared: 0, laneCleared: 0, keys: [] });
   refreshQueuedFollowupSessionMock.mockReset();
@@ -2601,5 +2616,146 @@ describe("runReplyAgent mid-turn rate-limit fallback", () => {
       mediaUrl: "https://example.test/image.png",
     });
     expect(payload?.text).toBeUndefined();
+  });
+});
+
+describe("runReplyAgent queued post-rotation startup messages", () => {
+  function createQueuedPostRotationParams(params: {
+    senderIsOwner: boolean;
+    storePath: string;
+    sessionEntry: SessionEntry;
+    sessionStore: Record<string, SessionEntry>;
+  }): Parameters<typeof runReplyAgent>[0] {
+    const sessionKey = "agent:main:discord:channel:c1";
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "discord",
+      ChatType: "channel",
+      OriginatingChannel: "discord",
+      AccountId: "default",
+      MessageSid: "msg-1",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "please continue startup",
+      summaryLine: "please continue startup",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        sessionId: "session-current",
+        sessionKey,
+        messageProvider: "discord",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        senderIsOwner: params.senderIsOwner,
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return {
+      commandBody: "please continue startup",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: true,
+      shouldFollowup: false,
+      isActive: true,
+      isStreaming: true,
+      typing,
+      sessionCtx,
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey,
+      storePath: params.storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    };
+  }
+
+  it("wraps and consumes the Discord post-reset window when an owner message is queued into an active run", async () => {
+    vi.setSystemTime(new Date("2026-05-04T15:00:00Z"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-post-rotation-owner-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:c1";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-current",
+      updatedAt: Date.now(),
+      postRotationStartupUntilMs: Date.now() + 30_000,
+    };
+    await saveSessionStore(storePath, { [sessionKey]: sessionEntry });
+    embeddedRunsState.queueEmbeddedPiMessageMock.mockReturnValueOnce(true);
+
+    const result = await runReplyAgent(
+      createQueuedPostRotationParams({
+        senderIsOwner: true,
+        storePath,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(embeddedRunsState.queueEmbeddedPiMessageMock).toHaveBeenCalledTimes(1);
+    const firstQueueCall = embeddedRunsState.queueEmbeddedPiMessageMock.mock.calls[0] as
+      | unknown[]
+      | undefined;
+    expect(firstQueueCall?.[0]).toBe("session-current");
+    const queuedPrompt = firstQueueCall?.[1] as string;
+    expect(queuedPrompt).toContain("first owner message after /new or /reset");
+    expect(queuedPrompt).toContain("Owner message:\n\nplease continue startup");
+
+    const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+    expect(persisted?.postRotationStartupUntilMs).toBeUndefined();
+  });
+
+  it("does not consume the Discord post-reset window for a non-owner queued message", async () => {
+    vi.setSystemTime(new Date("2026-05-04T15:00:00Z"));
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-post-rotation-non-owner-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "agent:main:discord:channel:c1";
+    const untilMs = Date.now() + 30_000;
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-current",
+      updatedAt: Date.now(),
+      postRotationStartupUntilMs: untilMs,
+    };
+    await saveSessionStore(storePath, { [sessionKey]: sessionEntry });
+    embeddedRunsState.queueEmbeddedPiMessageMock.mockReturnValueOnce(true);
+
+    const result = await runReplyAgent(
+      createQueuedPostRotationParams({
+        senderIsOwner: false,
+        storePath,
+        sessionEntry,
+        sessionStore: { [sessionKey]: sessionEntry },
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(embeddedRunsState.queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "session-current",
+      "please continue startup",
+      { steeringMode: "all" },
+    );
+    const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+    expect(persisted?.postRotationStartupUntilMs).toBe(untilMs);
   });
 });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -93,6 +93,67 @@ import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
+function shouldApplyPostRotationStartupSteer(params: {
+  sessionEntry?: SessionEntry;
+  followupRun: FollowupRun;
+  sessionCtx: TemplateContext;
+  now?: number;
+}): boolean {
+  const now = params.now ?? Date.now();
+  return (
+    params.followupRun.run.senderIsOwner === true &&
+    params.sessionCtx.Provider === "discord" &&
+    typeof params.sessionEntry?.postRotationStartupUntilMs === "number" &&
+    params.sessionEntry.postRotationStartupUntilMs > now
+  );
+}
+
+function buildPostRotationStartupSteerPrompt(text: string): string {
+  const trimmed = text.trim();
+  const ownerMessage = trimmed.length > 0 ? trimmed : text;
+  return [
+    "System: This is the first owner message after /new or /reset in a Discord channel or thread session.",
+    "It arrived while Session Startup preload reads were still running.",
+    "Treat it as implicit-mention-equivalent for this turn. Prioritize the owner message now.",
+    "If any Session Startup preload reads were interrupted or skipped because this message was queued, continue and finish them before you end the turn.",
+    "Do not re-greet or explain the startup mechanics unless the owner asks.",
+    "Owner message:",
+    ownerMessage,
+  ].join("\n\n");
+}
+
+async function clearPostRotationStartupWindow(params: {
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+}): Promise<void> {
+  const { sessionEntry, sessionStore, sessionKey, storePath } = params;
+  if (!sessionKey) {
+    return;
+  }
+  const persistedEntry = sessionStore?.[sessionKey] ?? sessionEntry;
+  if (typeof persistedEntry?.postRotationStartupUntilMs !== "number") {
+    return;
+  }
+  if (sessionEntry) {
+    sessionEntry.postRotationStartupUntilMs = undefined;
+  }
+  if (sessionStore?.[sessionKey]) {
+    sessionStore[sessionKey] = {
+      ...sessionStore[sessionKey],
+      postRotationStartupUntilMs: undefined,
+    };
+  }
+  if (storePath) {
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async () => ({ postRotationStartupUntilMs: undefined }),
+    });
+  }
+}
+
 function buildInlinePluginStatusPayload(params: {
   entry: SessionEntry | undefined;
   includeTraceLines: boolean;
@@ -1019,11 +1080,27 @@ export async function runReplyAgent(params: {
     const steerSessionId =
       (sessionKey ? replyRunRegistry.resolveSessionId(sessionKey) : undefined) ??
       followupRun.run.sessionId;
-    const steered = queueEmbeddedPiMessage(steerSessionId, followupRun.prompt, {
+    const shouldApplyPostRotationSteer = shouldApplyPostRotationStartupSteer({
+      sessionEntry: activeSessionEntry,
+      followupRun,
+      sessionCtx,
+    });
+    const steerPrompt = shouldApplyPostRotationSteer
+      ? buildPostRotationStartupSteerPrompt(followupRun.prompt)
+      : followupRun.prompt;
+    const steered = queueEmbeddedPiMessage(steerSessionId, steerPrompt, {
       steeringMode: resolvePiSteeringModeForQueueMode(resolvedQueue.mode),
       ...(resolvedQueue.debounceMs !== undefined ? { debounceMs: resolvedQueue.debounceMs } : {}),
     });
     if (steered && !effectiveShouldFollowup) {
+      if (shouldApplyPostRotationSteer) {
+        await clearPostRotationStartupWindow({
+          sessionEntry: activeSessionEntry,
+          sessionStore: activeSessionStore,
+          sessionKey,
+          storePath,
+        });
+      }
       await touchActiveSessionEntry();
       typing.cleanup();
       return undefined;
@@ -1162,6 +1239,12 @@ export async function runReplyAgent(params: {
   };
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
+  const shouldClearPostRotationStartupAfterRun = shouldApplyPostRotationStartupSteer({
+    sessionEntry: activeSessionEntry,
+    followupRun,
+    sessionCtx,
+  });
+  let startedRun = false;
 
   try {
     await typingSignals.signalRunStart();
@@ -1261,6 +1344,7 @@ export async function runReplyAgent(params: {
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();
+    startedRun = true;
     const runOutcome = await runAgentTurnWithFallback({
       commandBody,
       transcriptCommandBody,
@@ -1927,6 +2011,14 @@ export async function runReplyAgent(params: {
     returnWithQueuedFollowupDrain(undefined);
     throw error;
   } finally {
+    if (startedRun && shouldClearPostRotationStartupAfterRun) {
+      await clearPostRotationStartupWindow({
+        sessionEntry: activeSessionEntry,
+        sessionStore: activeSessionStore,
+        sessionKey,
+        storePath,
+      });
+    }
     if (shouldDrainQueuedFollowupsAfterClear) {
       replyOperation.completeThen(drainQueuedFollowupsAfterClear);
     } else {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -729,6 +729,53 @@ describe("initSessionState RawBody", () => {
     expect(result.triggerBodyNormalized).toBe("/NEW KeepThisCase");
   });
 
+  it("marks explicit Discord channel resets with a short post-rotation startup window", async () => {
+    vi.setSystemTime(new Date("2026-05-04T15:00:00Z"));
+    const root = await makeCaseDir("openclaw-discord-channel-reset-startup-window-");
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath, resetTriggers: ["/new"] } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Provider: "discord",
+        Surface: "discord",
+        ChatType: "channel",
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        SessionKey: "agent:main:discord:channel:c1",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.postRotationStartupUntilMs).toBe(Date.now() + 30_000);
+  });
+
+  it("does not mark non-Discord group resets with a post-rotation startup window", async () => {
+    vi.setSystemTime(new Date("2026-05-04T15:00:00Z"));
+    const root = await makeCaseDir("openclaw-whatsapp-reset-no-startup-window-");
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath, resetTriggers: ["/new"] } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Provider: "whatsapp",
+        ChatType: "group",
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        SessionKey: "agent:main:whatsapp:group:g1",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.postRotationStartupUntilMs).toBeUndefined();
+  });
+
   it("drains stale system events when /new rotates an existing session", async () => {
     const root = await makeCaseDir("openclaw-rawbody-reset-system-events-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -66,6 +66,7 @@ import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./sess
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
 const log = createSubsystemLogger("session-init");
+const POST_ROTATION_STARTUP_WINDOW_MS = 30_000;
 const sessionArchiveRuntimeLoader = createLazyImportLoader(
   () => import("../../gateway/session-archive.runtime.js"),
 );
@@ -609,6 +610,15 @@ export async function initSessionState(params: {
   const lastTo = deliveryFields.lastTo ?? lastToRaw;
   const lastAccountId = deliveryFields.lastAccountId ?? lastAccountIdRaw;
   const lastThreadId = deliveryFields.lastThreadId ?? lastThreadIdRaw;
+  const isDiscordSession = ctx.Provider === "discord" || ctx.Surface === "discord";
+  const postRotationStartupUntilMs =
+    isDiscordSession && resetTriggered && (isGroup || isThread)
+      ? now + POST_ROTATION_STARTUP_WINDOW_MS
+      : isDiscordSession &&
+          typeof baseEntry?.postRotationStartupUntilMs === "number" &&
+          baseEntry.postRotationStartupUntilMs > now
+        ? baseEntry.postRotationStartupUntilMs
+        : undefined;
   sessionEntry = {
     ...baseEntry,
     sessionId,
@@ -619,6 +629,7 @@ export async function initSessionState(params: {
     lastInteractionAt: isSystemEvent ? baseEntry?.lastInteractionAt : now,
     systemSent,
     abortedLastRun,
+    postRotationStartupUntilMs,
     // Persist previously stored thinking/verbose levels when present.
     thinkingLevel: persistedThinking ?? baseEntry?.thinkingLevel,
     verboseLevel: persistedVerbose ?? baseEntry?.verboseLevel,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -190,6 +190,12 @@ export type SessionEntry = {
   pluginOwnerId?: string;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  /**
+   * Short grace window for the first owner message after an explicit Discord
+   * channel/thread /new or /reset. While active, a queued owner message can be
+   * wrapped with startup-recovery instructions before the window is consumed.
+   */
+  postRotationStartupUntilMs?: number;
   /** Durable guard state for automatic subagent orphan recovery. */
   subagentRecovery?: SubagentRecoveryState;
   /** Timestamp (ms) when the current sessionId first became active. */

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -25,6 +25,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "pluginOwnerId",
   "systemSent",
   "abortedLastRun",
+  "postRotationStartupUntilMs",
   "sessionStartedAt",
   "lastInteractionAt",
   "startedAt",


### PR DESCRIPTION
## Summary

Reworks the Discord post-reset startup grace window on top of current `main` and consolidates the overlap with #49001.

This keeps the existing goal of #53524: after an explicit `/new` or `/reset` in a Discord channel or thread, the first owner message that gets queued behind an active startup/run can be wrapped with startup-recovery instructions instead of being treated as an ordinary background message.

## Changes

- Add `postRotationStartupUntilMs` to `SessionEntry`.
- Set a 30s post-rotation startup window only for explicit Discord channel/thread resets.
- When an owner message is steered into an active embedded run during that window:
  - wrap it with startup-recovery instructions;
  - preserve the currently active reply-run session id when queueing;
  - clear the window before returning from the successful embedded steer enqueue.
- If the first owner message proceeds as a normal run instead of a queued steer, clear the window only after that owner run actually starts.
- Do not let non-owner messages consume the window.

## Review blockers addressed

- Clears the window only when an owner turn consumes it; non-owner queued messages leave it intact.
- Clears the window before returning from successful embedded steer enqueue.
- Preserves the active session id by using `replyRunRegistry.resolveSessionId(sessionKey)` before falling back to the follow-up run session id.
- Rebased/reworked on current `main`; PR is no longer conflicting.

## Tests

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/session.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
corepack pnpm check:test-types
```

Results:

```text
2 test files passed / 119 tests passed
check:test-types passed
```
