### PR TITLE
fix: group and thread sessions default to idle reset instead of daily

### DIFF
--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -20,6 +20,13 @@ export type SessionFreshness = {
 export const DEFAULT_RESET_MODE: SessionResetMode = "daily";
 export const DEFAULT_RESET_AT_HOUR = 4;
 
+/**
+ * Default idle timeout for group and thread sessions when no explicit reset
+ * policy is configured. 7 days (10080 minutes) — long enough to survive a
+ * weekend without losing context, but still expires stale threads eventually.
+ */
+export const DEFAULT_GROUP_THREAD_IDLE_MINUTES = 10080;
+
 const THREAD_SESSION_MARKERS = [":thread:", ":topic:"];
 const GROUP_SESSION_MARKERS = [":group:", ":channel:"];
 
@@ -97,10 +104,20 @@ export function resolveSessionResetPolicy(params: {
         : undefined));
   const hasExplicitReset = Boolean(baseReset || sessionCfg?.resetByType);
   const legacyIdleMinutes = params.resetOverride ? undefined : sessionCfg?.idleMinutes;
+
+  // Group and thread sessions default to idle mode when no explicit policy is
+  // configured. Daily resets are disruptive for ongoing group conversations and
+  // forum topics — they wipe context overnight even for active threads.
+  // See: github.com/openclaw/openclaw/issues/32109
+  const isGroupOrThread =
+    params.resetType === "group" || params.resetType === "thread";
+  const impliedDefaultMode: SessionResetMode =
+    !hasExplicitReset && isGroupOrThread ? "idle" : DEFAULT_RESET_MODE;
+
   const mode =
     typeReset?.mode ??
     baseReset?.mode ??
-    (!hasExplicitReset && legacyIdleMinutes != null ? "idle" : DEFAULT_RESET_MODE);
+    (!hasExplicitReset && legacyIdleMinutes != null ? "idle" : impliedDefaultMode);
   const atHour = normalizeResetAtHour(
     typeReset?.atHour ?? baseReset?.atHour ?? DEFAULT_RESET_AT_HOUR,
   );
@@ -113,7 +130,9 @@ export function resolveSessionResetPolicy(params: {
       idleMinutes = Math.max(normalized, 0);
     }
   } else if (mode === "idle") {
-    idleMinutes = DEFAULT_IDLE_MINUTES;
+    // Group/thread sessions get a 7-day idle window by default; direct sessions
+    // keep the legacy DEFAULT_IDLE_MINUTES (0 = no idle expiry beyond daily reset).
+    idleMinutes = isGroupOrThread ? DEFAULT_GROUP_THREAD_IDLE_MINUTES : DEFAULT_IDLE_MINUTES;
   }
 
   return { mode, atHour, idleMinutes };

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -144,7 +144,10 @@ describe("resolveSessionResetPolicy", () => {
         resetType: "group",
       });
 
-      expect(groupPolicy.mode).toBe("daily");
+      // Group sessions default to idle (not daily), but should NOT inherit the
+      // dm-specific idleMinutes (45) — they get the group/thread default instead.
+      expect(groupPolicy.mode).toBe("idle");
+      expect(groupPolicy.idleMinutes).not.toBe(45);
     });
   });
 


### PR DESCRIPTION
## Problem

OpenClaw resets all session types on a **daily** schedule by default. For DMs this makes sense — a fresh start each morning is reasonable.

But for group channels and forum topics/threads, daily resets are actively harmful:
- A Telegram forum topic in active use gets its context wiped at 4am, even mid-conversation
- Discord threads spanning multiple days lose all history at midnight
- Slack threads reset between working sessions on consecutive days

The result: the agent wakes up every morning with no memory of the thread it's been participating in, forcing users to re-explain context constantly.

This was raised in #32109.

## Root Cause

`resolveSessionResetPolicy()` in `reset.ts` uses `DEFAULT_RESET_MODE = "daily"` unconditionally when no explicit policy is configured. The `resetType` parameter (`"direct"` / `"group"` / `"thread"`) is already correctly derived and passed in — but it wasn't being used to vary the default.

## Fix

When no explicit `session.resetByType` config is set:
- **Group and thread sessions** → default to `idle` mode with a **7-day window** (10080 minutes)
- **Direct/DM sessions** → unchanged, still default to `daily`

7 days matches Discord's own maximum thread archive duration and is long enough to survive a weekend without losing context, while still expiring genuinely stale threads.

Explicit `session.resetByType.group` / `session.resetByType.thread` config always takes precedence — this only changes the implicit default.

## Changes

- `reset.ts`: add `DEFAULT_GROUP_THREAD_IDLE_MINUTES = 10080`, use `impliedDefaultMode` based on session type
- `sessions.test.ts`: update the group policy test to reflect the new correct default (`idle`, not `daily`), and add assertion that `dm`-specific `idleMinutes` does not bleed into group sessions

## Fixes

Fixes #32109
