### PR TITLE
fix(agents): honor direct-session tool policies

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -15607,16 +15607,6 @@
       "hasChildren": false
     },
     {
-      "path": "channels.feishu.accounts.*.dms.*.historyLimit",
-      "kind": "channel",
-      "type": "integer",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
-    },
-    {
       "path": "channels.feishu.accounts.*.dms.*.systemPrompt",
       "kind": "channel",
       "type": "string",
@@ -16727,16 +16717,6 @@
       "path": "channels.feishu.dms.*.enabled",
       "kind": "channel",
       "type": "boolean",
-      "required": false,
-      "deprecated": false,
-      "sensitive": false,
-      "tags": [],
-      "hasChildren": false
-    },
-    {
-      "path": "channels.feishu.dms.*.historyLimit",
-      "kind": "channel",
-      "type": "integer",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -15607,7 +15607,167 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.accounts.*.dms.*.historyLimit",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.accounts.*.dms.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools.allow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools.allow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools.alsoAllow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools.alsoAllow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools.deny",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.tools.deny.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*.allow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*.allow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*.alsoAllow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*.alsoAllow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*.deny",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.accounts.*.dms.*.toolsBySender.*.deny.*",
       "kind": "channel",
       "type": "string",
       "required": false,
@@ -16574,7 +16734,167 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.dms.*.historyLimit",
+      "kind": "channel",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.dms.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.tools",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.tools.allow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.tools.allow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.tools.alsoAllow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.tools.alsoAllow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.tools.deny",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.tools.deny.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*",
+      "kind": "channel",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*.allow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*.allow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*.alsoAllow",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*.alsoAllow.*",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*.deny",
+      "kind": "channel",
+      "type": "array",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": true
+    },
+    {
+      "path": "channels.feishu.dms.*.toolsBySender.*.deny.*",
       "kind": "channel",
       "type": "string",
       "required": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5648}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5680}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1385,7 +1385,23 @@
 {"recordType":"path","path":"channels.feishu.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.alsoAllow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*.alsoAllow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.domain","kind":"channel","type":"string","required":false,"enumValues":["feishu","lark"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.encryptKey","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1472,7 +1488,23 @@
 {"recordType":"path","path":"channels.feishu.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.dms.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.dms.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.tools.alsoAllow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.tools.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.tools.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.tools.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*.alsoAllow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*.alsoAllow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*.deny","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
+{"recordType":"path","path":"channels.feishu.dms.*.toolsBySender.*.deny.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.domain","kind":"channel","type":"string","required":true,"enumValues":["feishu","lark"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.dynamicAgentCreation","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.dynamicAgentCreation.agentDirTemplate","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5680}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5678}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1385,7 +1385,6 @@
 {"recordType":"path","path":"channels.feishu.accounts.*.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.accounts.*.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.dms.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -1488,7 +1487,6 @@
 {"recordType":"path","path":"channels.feishu.dms","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.dms.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.dms.*.enabled","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
-{"recordType":"path","path":"channels.feishu.dms.*.historyLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.dms.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.dms.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.dms.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -240,6 +240,46 @@ describe("FeishuConfigSchema actions", () => {
   });
 });
 
+describe("FeishuConfigSchema tool policies", () => {
+  it("accepts dms tool policies", () => {
+    const result = FeishuConfigSchema.parse({
+      dms: {
+        "*": {
+          historyLimit: 5,
+          tools: { allow: ["read"], deny: ["exec"] },
+        },
+        ou_owner: {
+          tools: { alsoAllow: ["fd_*"] },
+          toolsBySender: {
+            "id:ou_owner": { alsoAllow: ["gateway"] },
+          },
+        },
+      },
+    });
+
+    expect(result.dms?.["*"]?.historyLimit).toBe(5);
+    expect(result.dms?.ou_owner?.tools).toEqual({ alsoAllow: ["fd_*"] });
+    expect(result.dms?.ou_owner?.toolsBySender?.["id:ou_owner"]).toEqual({
+      alsoAllow: ["gateway"],
+    });
+  });
+
+  it("rejects allow and alsoAllow in the same dm tools scope", () => {
+    const result = FeishuConfigSchema.safeParse({
+      dms: {
+        ou_owner: {
+          tools: {
+            allow: ["read"],
+            alsoAllow: ["exec"],
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("FeishuConfigSchema defaultAccount", () => {
   it("accepts defaultAccount when it matches an account key", () => {
     const result = FeishuConfigSchema.safeParse({

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -241,6 +241,26 @@ describe("FeishuConfigSchema actions", () => {
 });
 
 describe("FeishuConfigSchema tool policies", () => {
+  it("keeps dm tools optional for existing configs", () => {
+    const enabledOnly = FeishuConfigSchema.safeParse({
+      dms: {
+        ou_owner: {
+          enabled: true,
+        },
+      },
+    });
+    const promptOnly = FeishuConfigSchema.safeParse({
+      dms: {
+        ou_owner: {
+          systemPrompt: "Use the shared DM prompt.",
+        },
+      },
+    });
+
+    expect(enabledOnly.success).toBe(true);
+    expect(promptOnly.success).toBe(true);
+  });
+
   it("accepts dms tool policies", () => {
     const result = FeishuConfigSchema.parse({
       dms: {

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -265,7 +265,6 @@ describe("FeishuConfigSchema tool policies", () => {
     const result = FeishuConfigSchema.parse({
       dms: {
         "*": {
-          historyLimit: 5,
           tools: { allow: ["read"], deny: ["exec"] },
         },
         ou_owner: {
@@ -277,7 +276,7 @@ describe("FeishuConfigSchema tool policies", () => {
       },
     });
 
-    expect(result.dms?.["*"]?.historyLimit).toBe(5);
+    expect(result.dms?.["*"]?.tools).toEqual({ allow: ["read"], deny: ["exec"] });
     expect(result.dms?.ou_owner?.tools).toEqual({ alsoAllow: ["fd_*"] });
     expect(result.dms?.ou_owner?.toolsBySender?.["id:ou_owner"]).toEqual({
       alsoAllow: ["gateway"],

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -32,7 +32,6 @@ const ToolPolicySchema = z
 
 const DmConfigSchema = z
   .object({
-    historyLimit: z.number().int().min(0).optional(),
     enabled: z.boolean().optional(),
     tools: SharedToolPolicySchema.optional(),
     toolsBySender: z.record(z.string(), SharedToolPolicySchema).optional(),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -1,4 +1,5 @@
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { ToolPolicySchema as SharedToolPolicySchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { z } from "zod";
 export { z };
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
@@ -31,7 +32,10 @@ const ToolPolicySchema = z
 
 const DmConfigSchema = z
   .object({
+    historyLimit: z.number().int().min(0).optional(),
     enabled: z.boolean().optional(),
+    tools: SharedToolPolicySchema,
+    toolsBySender: z.record(z.string(), SharedToolPolicySchema).optional(),
     systemPrompt: z.string().optional(),
   })
   .strict()

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -34,7 +34,7 @@ const DmConfigSchema = z
   .object({
     historyLimit: z.number().int().min(0).optional(),
     enabled: z.boolean().optional(),
-    tools: SharedToolPolicySchema,
+    tools: SharedToolPolicySchema.optional(),
     toolsBySender: z.record(z.string(), SharedToolPolicySchema).optional(),
     systemPrompt: z.string().optional(),
   })

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -526,6 +526,33 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("keeps a thread-specific direct policy ahead of parent sender overrides", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner:thread:th_yyy": {
+              tools: { allow: ["read"] },
+            },
+            "ou-owner": {
+              toolsBySender: {
+                "id:ou-owner": { allow: ["read", "exec"] },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner:thread:th_yyy",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
   it("resolves account-scoped dm session keys from the session key itself", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -612,6 +612,67 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("prefers account-scoped dm candidates over higher-rank top-level sender matches", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "direct:ou-owner": {
+              toolsBySender: {
+                "id:sender-1": {
+                  allow: ["read"],
+                },
+              },
+            },
+          },
+          accounts: {
+            direct: {
+              dms: {
+                "ou-owner": {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:direct:ou-owner",
+        senderId: "sender-1",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("treats empty ambiguous account-scoped dms as explicit overrides over top-level dm matches", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "direct:ou-owner": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            direct: {
+              dms: {},
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:direct:ou-owner",
+      }),
+    ).toBeUndefined();
+  });
+
   it("uses messageProvider or spawnedBy channel hints for per-peer direct session keys", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -796,6 +796,53 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("does not let ambiguous account-derived direct probes read top-level dms when the account is absent", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+          },
+          dms: {
+            abc: {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:direct:abc",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("does not fall back to top-level dms for account-scoped direct session keys when the account is absent", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:ops:direct:ou-owner",
+      }),
+    ).toBeUndefined();
+  });
+
   it("checks alternate account-scoped group candidates before settling on wildcard group policy", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -421,6 +421,32 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("skips empty thread-specific DM entries and keeps probing parent direct policies", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+            "ou-owner:thread:th_yyy": {},
+            "ou-owner": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner:thread:th_yyy",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
   it("checks parent direct sender overrides before wildcard sender fallback when senderId is omitted", () => {
     const cfg = {
       channels: {
@@ -705,6 +731,36 @@ describe("resolveGroupToolPolicy", () => {
       resolveGroupToolPolicy({
         config: cfg,
         sessionKey: "agent:main:feishu:group:direct:abc",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("checks alternate account-scoped group candidates before settling on wildcard group policy", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            group: {
+              groups: {
+                abc: {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:group:abc",
       }),
     ).toEqual({ allow: ["read", "exec"] });
   });

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -1027,6 +1027,50 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read"] });
   });
 
+  it("does not let explicit account-scoped group lookups fall through to top-level groups when the account is absent", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            abc: {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        messageProvider: "feishu",
+        groupId: "abc",
+        accountId: "ops",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not let account-scoped group session keys fall through to top-level groups when the account is absent", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            abc: {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:ops:group:abc",
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not cross over from direct parsing into unrelated group policies", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -582,6 +582,32 @@ describe("resolveGroupToolPolicy", () => {
     ).toBeUndefined();
   });
 
+  it("lets resolved account-scoped direct sessions inherit top-level dms when the account omits dms", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+          accounts: {
+            ops: {
+              groups: {},
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:ops:direct:ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
   it("prefers account-scoped dm candidates when account ids are ambiguous with scope kinds", () => {
     const cfg = {
       channels: {
@@ -671,6 +697,32 @@ describe("resolveGroupToolPolicy", () => {
         sessionKey: "agent:main:feishu:direct:direct:ou-owner",
       }),
     ).toBeUndefined();
+  });
+
+  it("lets ambiguous account-scoped direct sessions inherit top-level dms when the account exists", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "direct:ou-owner": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+          accounts: {
+            direct: {
+              groups: {},
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:direct:ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
   });
 
   it("uses messageProvider or spawnedBy channel hints for per-peer direct session keys", () => {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -345,6 +345,57 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read"] });
   });
 
+  it("falls back to wildcard dm tools when a specific dm entry has no effective tools", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+            "ou-owner": {
+              tools: {},
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("falls back to dm tools when a sender-scoped dm override is empty", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              tools: { allow: ["read"] },
+              toolsBySender: {
+                "id:ou-owner": {},
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner",
+        messageProvider: "feishu",
+        senderId: "ou-owner",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
   it("falls back from thread directIds to the parent directId", () => {
     const cfg = {
       channels: {
@@ -365,6 +416,34 @@ describe("resolveGroupToolPolicy", () => {
       resolveGroupToolPolicy({
         config: cfg,
         sessionKey: "agent:main:feishu:direct:ou-owner:thread:th_yyy",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("prefers the full directId over the parent fallback when a thread token is part of the id", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner:thread:abc": {
+              tools: { allow: ["read"] },
+              toolsBySender: {
+                "id:ou-owner:thread:abc": { allow: ["read", "exec"] },
+              },
+            },
+            "ou-owner": {
+              tools: { allow: ["read"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner:thread:abc",
         messageProvider: "feishu",
       }),
     ).toEqual({ allow: ["read", "exec"] });
@@ -482,6 +561,36 @@ describe("resolveGroupToolPolicy", () => {
         config: cfg,
         sessionKey: "agent:main:direct:ou-owner",
         spawnedBy: "agent:main:feishu:direct:ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("does not misparse direct ids prefixed with group as account-scoped sessions", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "group:abc": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+          accounts: {
+            direct: {
+              groups: {
+                abc: {
+                  tools: { allow: ["read"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:group:abc",
       }),
     ).toEqual({ allow: ["read", "exec"] });
   });

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -446,6 +446,32 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("keeps id-based parent direct overrides ahead of name matches when senderId is omitted", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              toolsBySender: {
+                "name:alice": { allow: ["read"] },
+                "id:ou-owner": { allow: ["read", "exec"] },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner:thread:th_yyy",
+        messageProvider: "feishu",
+        senderName: "alice",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
   it("prefers the full directId over the parent fallback when a thread token is part of the id", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -7,6 +7,7 @@ import {
   filterToolsByPolicy,
   isToolAllowedByPolicyName,
   resolveEffectiveToolPolicy,
+  resolveGroupToolPolicy,
   resolveSubagentToolPolicy,
   resolveSubagentToolPolicyForSession,
 } from "./pi-tools.policy.js";
@@ -270,5 +271,311 @@ describe("resolveEffectiveToolPolicy", () => {
     } as OpenClawConfig;
     const result = resolveEffectiveToolPolicy({ config: cfg, agentId: "coder" });
     expect(result.profileAlsoAllow).toEqual(["read", "write", "edit"]);
+  });
+});
+
+describe("resolveGroupToolPolicy", () => {
+  it("applies exact direct-message tool policies before wildcard dm policies", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+            "ou-owner": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner",
+        messageProvider: "feishu",
+        senderId: "ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-member",
+        messageProvider: "feishu",
+        senderId: "ou-member",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("uses the session directId for dm entry matching and senderId for sender overrides", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-shared": {
+              tools: { allow: ["read"] },
+              toolsBySender: {
+                "id:ou-owner": { allow: ["read", "exec"] },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-shared",
+        messageProvider: "feishu",
+        senderId: "ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-shared",
+        messageProvider: "feishu",
+        senderId: "ou-member",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("falls back from thread directIds to the parent directId", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              tools: { allow: ["read"] },
+              toolsBySender: {
+                "id:ou-owner": { allow: ["read", "exec"] },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner:thread:th_yyy",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("resolves account-scoped dm session keys from the session key itself", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            ops: {
+              dms: {
+                "ou-owner": {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:ops:direct:ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("treats empty account-scoped dms as an explicit override over top-level wildcard dms", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "*": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+          accounts: {
+            ops: {
+              dms: {},
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:ops:direct:ou-owner",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("prefers account-scoped dm candidates when account ids are ambiguous with scope kinds", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "direct:ou-owner": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            direct: {
+              dms: {
+                "ou-owner": {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:direct:ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("uses messageProvider or spawnedBy channel hints for per-peer direct session keys", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:direct:ou-owner",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:direct:ou-owner",
+        spawnedBy: "agent:main:feishu:direct:ou-owner",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("keeps explicit Feishu group matches ahead of ambiguous direct fallbacks", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+            "DIRECT:ABC": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            group: {
+              dms: {
+                abc: {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:direct:abc",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("falls back to direct policy for ambiguous group keys when only wildcard group rules exist", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            group: {
+              dms: {
+                abc: {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:direct:abc",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
+  it("does not cross over from direct parsing into unrelated group policies", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+          },
+          accounts: {
+            direct: {
+              groups: {
+                abc: {
+                  tools: { allow: ["read", "exec"] },
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:group:abc",
+      }),
+    ).toEqual({ allow: ["read"] });
   });
 });

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -925,6 +925,81 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("does not let unresolved account-derived group candidates override literal group ids", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "group:abc": {
+              tools: { allow: ["read"] },
+            },
+            abc: {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:group:abc",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("does not let unresolved account-derived group candidates override wildcard group policy", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "*": {
+              tools: { allow: ["read"] },
+            },
+            abc: {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:group:abc",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
+  it("does not give inherited top-level group matches account-scoped precedence when the account omits groups", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "group:abc": {
+              tools: { allow: ["read"] },
+            },
+            abc: {
+              tools: { allow: ["read", "exec"] },
+            },
+          },
+          accounts: {
+            group: {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:group:group:abc",
+      }),
+    ).toEqual({ allow: ["read"] });
+  });
+
   it("does not cross over from direct parsing into unrelated group policies", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -421,6 +421,31 @@ describe("resolveGroupToolPolicy", () => {
     ).toEqual({ allow: ["read", "exec"] });
   });
 
+  it("checks parent direct sender overrides before wildcard sender fallback when senderId is omitted", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          dms: {
+            "ou-owner": {
+              toolsBySender: {
+                "*": { allow: ["read"] },
+                "id:ou-owner": { allow: ["read", "exec"] },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveGroupToolPolicy({
+        config: cfg,
+        sessionKey: "agent:main:feishu:direct:ou-owner:thread:th_yyy",
+        messageProvider: "feishu",
+      }),
+    ).toEqual({ allow: ["read", "exec"] });
+  });
+
   it("prefers the full directId over the parent fallback when a thread token is part of the id", () => {
     const cfg = {
       channels: {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -309,6 +309,11 @@ function resolveDirectToolPolicyEntries(
   return { wildcard: entries["*"] };
 }
 
+type DirectPolicyResolution = {
+  policy?: DirectToolPolicyConfig;
+  rank: number;
+};
+
 function resolveDirectToolPolicyFromConfig(params: {
   config: OpenClawConfig;
   channel: string;
@@ -343,22 +348,6 @@ function resolveDirectToolPolicyFromConfig(params: {
       ? [params.directIdParent]
       : []),
   ];
-
-  let directEntry: DirectToolPolicyEntry | undefined;
-  let wildcardEntry: DirectToolPolicyEntry | undefined;
-  for (const directId of directIdsToTry) {
-    const scopedEntries = resolveDirectToolPolicyEntries(entries, directId);
-    wildcardEntry ??= scopedEntries.wildcard;
-    if (scopedEntries.direct) {
-      directEntry = scopedEntries.direct;
-      wildcardEntry = scopedEntries.wildcard;
-      break;
-    }
-  }
-  if (!directEntry && !wildcardEntry) {
-    return { rank: 0 };
-  }
-
   const senderIdsToTry = params.senderId
     ? [params.senderId]
     : [
@@ -409,22 +398,42 @@ function resolveDirectToolPolicyFromConfig(params: {
     const wildcardPolicy = toolsBySender["*"];
     return wildcardPolicy && pickSandboxToolPolicy(wildcardPolicy) ? wildcardPolicy : undefined;
   };
+  const resolvePolicyFromEntries = ({
+    direct,
+    wildcard,
+  }: {
+    direct?: DirectToolPolicyEntry;
+    wildcard?: DirectToolPolicyEntry;
+  }): DirectPolicyResolution => {
+    const senderPolicy = resolveSenderScopedPolicy(direct?.toolsBySender);
+    if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
+      return { policy: senderPolicy, rank: 4 };
+    }
+    if (direct?.tools && pickSandboxToolPolicy(direct.tools)) {
+      return { policy: direct.tools, rank: 3 };
+    }
+    const wildcardSenderPolicy = resolveSenderScopedPolicy(wildcard?.toolsBySender);
+    if (wildcardSenderPolicy && pickSandboxToolPolicy(wildcardSenderPolicy)) {
+      return { policy: wildcardSenderPolicy, rank: 2 };
+    }
+    if (wildcard?.tools && pickSandboxToolPolicy(wildcard.tools)) {
+      return { policy: wildcard.tools, rank: 1 };
+    }
+    return { rank: 0 };
+  };
 
-  const senderPolicy = resolveSenderScopedPolicy(directEntry?.toolsBySender);
-  if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
-    return { policy: senderPolicy, rank: 4 };
+  let best: DirectPolicyResolution = { rank: 0 };
+  for (const directId of directIdsToTry) {
+    const scopedEntries = resolveDirectToolPolicyEntries(entries, directId);
+    const resolved = resolvePolicyFromEntries(scopedEntries);
+    if (resolved.rank > best.rank) {
+      best = resolved;
+      if (best.rank >= 4) {
+        break;
+      }
+    }
   }
-  if (directEntry?.tools && pickSandboxToolPolicy(directEntry.tools)) {
-    return { policy: directEntry.tools, rank: 3 };
-  }
-  const wildcardSenderPolicy = resolveSenderScopedPolicy(wildcardEntry?.toolsBySender);
-  if (wildcardSenderPolicy && pickSandboxToolPolicy(wildcardSenderPolicy)) {
-    return { policy: wildcardSenderPolicy, rank: 2 };
-  }
-  if (wildcardEntry?.tools && pickSandboxToolPolicy(wildcardEntry.tools)) {
-    return { policy: wildcardEntry.tools, rank: 1 };
-  }
-  return { rank: 0 };
+  return best;
 }
 
 function resolveGroupPolicyLookupOptions(channel: string): { groupIdCaseInsensitive?: boolean } {
@@ -703,10 +712,16 @@ export function resolveGroupToolPolicy(params: {
       typeof candidate.groupId === "string" && candidate.groupId.length > 0,
   );
 
+  type GroupPolicyResolution = {
+    policy?: SandboxToolPolicy;
+    hasExplicitGroupMatch: boolean;
+    specificity: number;
+  };
+
   const resolveGroupCandidatePolicy = (candidate: {
     groupId: string;
     accountId?: string | null;
-  }): { policy?: SandboxToolPolicy; hasExplicitGroupMatch: boolean } => {
+  }): GroupPolicyResolution => {
     const { groupConfig } = resolveChannelGroupPolicy({
       cfg: config,
       channel,
@@ -740,13 +755,15 @@ export function resolveGroupToolPolicy(params: {
     return {
       policy: pickSandboxToolPolicy(toolsConfig),
       hasExplicitGroupMatch: Boolean(groupConfig),
+      specificity: candidate.accountId ? 1 : 0,
     };
   };
 
-  const resolveFirstGroupPolicy = () => {
+  const resolveBestGroupPolicy = (): GroupPolicyResolution | undefined => {
     if (groupCandidates.length === 0) {
       return undefined;
     }
+    let best: GroupPolicyResolution | undefined;
     const seenGroupCandidates = new Set<string>();
     for (const candidate of groupCandidates) {
       const key = `${candidate.accountId ?? ""}\n${candidate.groupId}`;
@@ -754,12 +771,21 @@ export function resolveGroupToolPolicy(params: {
         continue;
       }
       seenGroupCandidates.add(key);
-      const { policy } = resolveGroupCandidatePolicy(candidate);
-      if (policy) {
-        return policy;
+      const resolved = resolveGroupCandidatePolicy(candidate);
+      if (!resolved.policy) {
+        continue;
+      }
+      if (
+        !best ||
+        Number(resolved.hasExplicitGroupMatch) > Number(best.hasExplicitGroupMatch) ||
+        (resolved.hasExplicitGroupMatch &&
+          best.hasExplicitGroupMatch &&
+          resolved.specificity > best.specificity)
+      ) {
+        best = resolved;
       }
     }
-    return undefined;
+    return best;
   };
 
   const preferredGroupCandidate = params.groupId
@@ -798,24 +824,28 @@ export function resolveGroupToolPolicy(params: {
     return directResolution.policy;
   }
   if (preferredScopeKind === "group") {
-    const groupPolicy = preferredGroupCandidate
+    const preferredGroupPolicy = preferredGroupCandidate
       ? resolveGroupCandidatePolicy({
           groupId: preferredGroupCandidate.groupId,
           accountId: preferredGroupCandidate.accountId,
         })
-      : { policy: resolveFirstGroupPolicy(), hasExplicitGroupMatch: false };
+      : undefined;
+    const bestGroupPolicy = resolveBestGroupPolicy();
+    if (preferredGroupPolicy?.hasExplicitGroupMatch) {
+      return preferredGroupPolicy.policy;
+    }
+    if (bestGroupPolicy?.hasExplicitGroupMatch) {
+      return bestGroupPolicy.policy;
+    }
     if (!preferredGroupCandidate?.alternateDirectId) {
-      return groupPolicy.policy;
+      return preferredGroupPolicy?.policy ?? bestGroupPolicy?.policy;
     }
-    if (groupPolicy.hasExplicitGroupMatch) {
-      return groupPolicy.policy;
-    }
-    return directResolution.policy ?? groupPolicy.policy;
+    return directResolution.policy ?? preferredGroupPolicy?.policy ?? bestGroupPolicy?.policy;
   }
 
-  const groupPolicy = resolveFirstGroupPolicy();
-  if (groupPolicy) {
-    return groupPolicy;
+  const groupPolicy = resolveBestGroupPolicy();
+  if (groupPolicy?.policy) {
+    return groupPolicy.policy;
   }
   return directResolution.policy;
 }

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -383,19 +383,27 @@ function resolveDirectToolPolicyFromConfig(params: {
     }
 
     // When we only have derived fallback IDs (for example a threaded DM directId and its parent),
-    // check all explicit sender keys before falling back to the wildcard entry.
+    // preserve resolveToolsBySender's ID > e164 > username > name precedence across all
+    // candidate direct IDs before falling back to wildcard.
     const explicitToolsBySender = omitWildcardToolsBySender(toolsBySender);
     for (const senderId of senderIdsToTry) {
       const senderPolicy = resolveToolsBySender({
         toolsBySender: explicitToolsBySender,
         senderId,
-        senderName: params.senderName,
-        senderUsername: params.senderUsername,
-        senderE164: params.senderE164,
       });
       if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
         return senderPolicy;
       }
+    }
+
+    const nonIdSenderPolicy = resolveToolsBySender({
+      toolsBySender: explicitToolsBySender,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+    });
+    if (nonIdSenderPolicy && pickSandboxToolPolicy(nonIdSenderPolicy)) {
+      return nonIdSenderPolicy;
     }
 
     const wildcardPolicy = toolsBySender["*"];

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -442,21 +442,33 @@ function resolveDirectToolPolicyFromConfig(params: {
     return { rank: 0, scopePriority };
   };
 
-  let best: DirectPolicyResolution = { rank: 0, scopePriority };
+  const resolveDirectEntryPolicy = (direct: DirectToolPolicyEntry | undefined) => {
+    const senderPolicy = resolveSenderScopedPolicy(direct?.toolsBySender);
+    if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
+      return { policy: senderPolicy, rank: 4, scopePriority };
+    }
+    if (direct?.tools && pickSandboxToolPolicy(direct.tools)) {
+      return { policy: direct.tools, rank: 3, scopePriority };
+    }
+    return { rank: 0, scopePriority };
+  };
+
   for (const directId of directIdsToTry) {
-    const scopedEntries = resolveDirectToolPolicyEntries(entries, directId);
-    const resolved = resolvePolicyFromEntries(scopedEntries);
-    if (resolved.rank > best.rank) {
-      best = {
+    const { direct } = resolveDirectToolPolicyEntries(entries, directId);
+    const resolved = resolveDirectEntryPolicy(direct);
+    // Parent directIds are only a fallback for thread-specific directIds. Keep probing parent
+    // candidates only until we find a direct-scoped match; wildcard DM policy is handled after
+    // the directId fallback chain so it cannot mask a more specific parent rule.
+    if (resolved.rank > 0) {
+      return {
         ...resolved,
         scopePriority,
       };
-      if (best.rank >= 4) {
-        break;
-      }
     }
   }
-  return best;
+
+  const wildcard = entries?.["*"];
+  return resolvePolicyFromEntries({ wildcard });
 }
 
 function resolveGroupPolicyLookupOptions(channel: string): { groupIdCaseInsensitive?: boolean } {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -1,9 +1,14 @@
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveChannelGroupToolsPolicy } from "../config/group-policy.js";
+import {
+  resolveChannelGroupPolicy,
+  resolveChannelGroupToolsPolicy,
+  resolveToolsBySender,
+} from "../config/group-policy.js";
 import type { AgentToolsConfig } from "../config/types.tools.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveAccountEntry } from "../routing/account-lookup.js";
+import { normalizeAccountId, normalizeAgentId } from "../routing/session-key.js";
 import { resolveThreadParentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentConfig, resolveAgentIdFromSessionKey } from "./agent-scope.js";
@@ -131,32 +136,265 @@ function normalizeProviderKey(value: string): string {
   return value.trim().toLowerCase();
 }
 
-function resolveGroupContextFromSessionKey(sessionKey?: string | null): {
+type ToolScopeContextVariant = {
   channel?: string;
+  accountId?: string;
   groupId?: string;
+  directId?: string;
+  directIdParent?: string;
+};
+
+function resolveToolScopeContextFromSessionKey(
+  sessionKey?: string | null,
+): ToolScopeContextVariant & {
+  alternate?: ToolScopeContextVariant;
 } {
   const raw = (sessionKey ?? "").trim();
   if (!raw) {
     return {};
   }
-  const base = resolveThreadParentSessionKey(raw) ?? raw;
-  const parts = base.split(":").filter(Boolean);
-  let body = parts[0] === "agent" ? parts.slice(2) : parts;
-  if (body[0] === "subagent") {
-    body = body.slice(1);
-  }
-  if (body.length < 3) {
+  const kinds = new Set(["group", "channel", "direct", "dm"]);
+  const baseForGroup = resolveThreadParentSessionKey(raw) ?? raw;
+
+  const parseParts = (input: string) => {
+    const parts = input.split(":").filter(Boolean);
+    let body = parts[0] === "agent" ? parts.slice(2) : parts;
+    if (body[0] === "subagent") {
+      body = body.slice(1);
+    }
+    if (body.length < 2) {
+      return [];
+    }
+
+    const candidates: Array<{
+      channel?: string;
+      accountId?: string;
+      kind: string;
+      scopeId: string;
+    }> = [];
+    const pushCandidate = (candidate: {
+      channel?: string;
+      accountId?: string;
+      kind: string;
+      scopeId: string;
+    }) => {
+      if (!kinds.has(candidate.kind) || !candidate.scopeId) {
+        return;
+      }
+      if (
+        candidates.some(
+          (existing) =>
+            existing.channel === candidate.channel &&
+            existing.accountId === candidate.accountId &&
+            existing.kind === candidate.kind &&
+            existing.scopeId === candidate.scopeId,
+        )
+      ) {
+        return;
+      }
+      candidates.push(candidate);
+    };
+
+    if (kinds.has(body[0])) {
+      pushCandidate({
+        channel: undefined,
+        kind: body[0],
+        scopeId: body.slice(1).join(":").trim(),
+      });
+      return candidates;
+    }
+
+    if (kinds.has(body[1])) {
+      pushCandidate({
+        channel: body[0].trim().toLowerCase(),
+        kind: body[1],
+        scopeId: body.slice(2).join(":").trim(),
+      });
+    }
+
+    if (body.length >= 4 && kinds.has(body[2])) {
+      pushCandidate({
+        channel: body[0].trim().toLowerCase(),
+        accountId: normalizeAccountId(body[1]),
+        kind: body[2],
+        scopeId: body.slice(3).join(":").trim(),
+      });
+    }
+
+    return candidates;
+  };
+
+  const parsedRaw = parseParts(raw);
+  const parsedBase = parseParts(baseForGroup);
+  if (parsedRaw.length === 0) {
     return {};
   }
-  const [channel, kind, ...rest] = body;
-  if (kind !== "group" && kind !== "channel") {
+
+  const toContextVariant = (candidate: {
+    channel?: string;
+    accountId?: string;
+    kind: string;
+    scopeId: string;
+  }): ToolScopeContextVariant => {
+    const baseCandidate = parsedBase.find(
+      (entry) =>
+        entry.channel === candidate.channel &&
+        entry.accountId === candidate.accountId &&
+        entry.kind === candidate.kind,
+    );
+    if (candidate.kind === "group" || candidate.kind === "channel") {
+      return {
+        channel: candidate.channel,
+        accountId: candidate.accountId,
+        groupId: baseCandidate?.scopeId ?? candidate.scopeId,
+      };
+    }
+    return {
+      channel: candidate.channel,
+      accountId: candidate.accountId,
+      directId: candidate.scopeId,
+      directIdParent:
+        baseCandidate && baseCandidate.scopeId !== candidate.scopeId
+          ? baseCandidate.scopeId
+          : undefined,
+    };
+  };
+
+  const [primary, alternate] = parsedRaw.map(toContextVariant);
+  return alternate ? { ...primary, alternate } : primary;
+}
+
+type DirectToolPolicyConfig = {
+  allow?: string[];
+  alsoAllow?: string[];
+  deny?: string[];
+};
+
+type DirectToolPolicyBySenderConfig = Record<string, DirectToolPolicyConfig>;
+
+type DirectToolPolicyEntry = {
+  tools?: DirectToolPolicyConfig;
+  toolsBySender?: DirectToolPolicyBySenderConfig;
+};
+
+function resolveDirectToolPolicyEntries(
+  entries: Record<string, DirectToolPolicyEntry> | undefined,
+  directId: string,
+): {
+  direct?: DirectToolPolicyEntry;
+  wildcard?: DirectToolPolicyEntry;
+} {
+  if (!entries) {
     return {};
   }
-  const groupId = rest.join(":").trim();
-  if (!groupId) {
-    return {};
+  const direct = entries[directId];
+  if (direct) {
+    return { direct, wildcard: entries["*"] };
   }
-  return { channel: channel.trim().toLowerCase(), groupId };
+  const lowered = directId.toLowerCase();
+  const matchKey = Object.keys(entries).find((key) => key !== "*" && key.toLowerCase() === lowered);
+  if (matchKey) {
+    return { direct: entries[matchKey], wildcard: entries["*"] };
+  }
+  return { wildcard: entries["*"] };
+}
+
+function resolveDirectToolPolicyFromConfig(params: {
+  config: OpenClawConfig;
+  channel: string;
+  directId: string;
+  directIdParent?: string;
+  accountId?: string | null;
+  senderId?: string | null;
+  senderName?: string | null;
+  senderUsername?: string | null;
+  senderE164?: string | null;
+}): { policy?: DirectToolPolicyConfig; rank: number } {
+  const channelConfig = params.config.channels?.[params.channel] as
+    | {
+        accounts?: Record<string, { dms?: Record<string, DirectToolPolicyEntry> }>;
+        dms?: Record<string, DirectToolPolicyEntry>;
+      }
+    | undefined;
+  if (!channelConfig) {
+    return { rank: 0 };
+  }
+
+  const accountEntry = resolveAccountEntry(
+    channelConfig.accounts,
+    normalizeAccountId(params.accountId),
+  ) as { dms?: Record<string, DirectToolPolicyEntry> } | undefined;
+  const hasAccountScopedDms =
+    accountEntry !== undefined && Object.prototype.hasOwnProperty.call(accountEntry, "dms");
+  const entries = hasAccountScopedDms ? accountEntry?.dms : channelConfig.dms;
+  const directIdsToTry = [
+    params.directId,
+    ...(params.directIdParent && params.directIdParent !== params.directId
+      ? [params.directIdParent]
+      : []),
+  ];
+
+  let directEntry: DirectToolPolicyEntry | undefined;
+  let wildcardEntry: DirectToolPolicyEntry | undefined;
+  for (const directId of directIdsToTry) {
+    const scopedEntries = resolveDirectToolPolicyEntries(entries, directId);
+    wildcardEntry ??= scopedEntries.wildcard;
+    if (scopedEntries.direct) {
+      directEntry = scopedEntries.direct;
+      wildcardEntry = scopedEntries.wildcard;
+      break;
+    }
+  }
+  if (!directEntry && !wildcardEntry) {
+    return { rank: 0 };
+  }
+
+  const senderIdsToTry = params.senderId
+    ? [params.senderId]
+    : [
+        params.directId,
+        ...(params.directIdParent && params.directIdParent !== params.directId
+          ? [params.directIdParent]
+          : []),
+      ];
+  const resolveSenderScopedPolicy = (toolsBySender: DirectToolPolicyBySenderConfig | undefined) => {
+    for (const senderId of senderIdsToTry) {
+      const senderPolicy = resolveToolsBySender({
+        toolsBySender,
+        senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      });
+      if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
+        return senderPolicy;
+      }
+    }
+    return undefined;
+  };
+
+  const senderPolicy = resolveSenderScopedPolicy(directEntry?.toolsBySender);
+  if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
+    return { policy: senderPolicy, rank: 4 };
+  }
+  if (directEntry?.tools && pickSandboxToolPolicy(directEntry.tools)) {
+    return { policy: directEntry.tools, rank: 3 };
+  }
+  const wildcardSenderPolicy = resolveSenderScopedPolicy(wildcardEntry?.toolsBySender);
+  if (wildcardSenderPolicy && pickSandboxToolPolicy(wildcardSenderPolicy)) {
+    return { policy: wildcardSenderPolicy, rank: 2 };
+  }
+  if (wildcardEntry?.tools && pickSandboxToolPolicy(wildcardEntry.tools)) {
+    return { policy: wildcardEntry.tools, rank: 1 };
+  }
+  return { rank: 0 };
+}
+
+function resolveGroupPolicyLookupOptions(channel: string): { groupIdCaseInsensitive?: boolean } {
+  if (channel === "feishu" || channel === "irc") {
+    return { groupIdCaseInsensitive: true };
+  }
+  return {};
 }
 
 function resolveProviderToolPolicy(params: {
@@ -304,12 +542,9 @@ export function resolveGroupToolPolicy(params: {
   if (!params.config) {
     return undefined;
   }
-  const sessionContext = resolveGroupContextFromSessionKey(params.sessionKey);
-  const spawnedContext = resolveGroupContextFromSessionKey(params.spawnedBy);
-  const groupId = params.groupId ?? sessionContext.groupId ?? spawnedContext.groupId;
-  if (!groupId) {
-    return undefined;
-  }
+  const config = params.config;
+  const sessionContext = resolveToolScopeContextFromSessionKey(params.sessionKey);
+  const spawnedContext = resolveToolScopeContextFromSessionKey(params.spawnedBy);
   const channelRaw = params.messageProvider ?? sessionContext.channel ?? spawnedContext.channel;
   const channel = normalizeMessageChannel(channelRaw);
   if (!channel) {
@@ -321,29 +556,231 @@ export function resolveGroupToolPolicy(params: {
   } catch {
     plugin = undefined;
   }
-  const toolsConfig =
-    plugin?.groups?.resolveToolPolicy?.({
-      cfg: params.config,
-      groupId,
-      groupChannel: params.groupChannel,
-      groupSpace: params.groupSpace,
-      accountId: params.accountId,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
-    }) ??
-    resolveChannelGroupToolsPolicy({
-      cfg: params.config,
+  const groupLookupOptions = resolveGroupPolicyLookupOptions(channel);
+
+  const rawDirectCandidates: Array<{
+    directId?: string;
+    directIdParent?: string;
+    accountId?: string | null;
+  }> = [
+    {
+      directId: sessionContext.directId,
+      directIdParent: sessionContext.directIdParent,
+      accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+    },
+    {
+      directId: sessionContext.alternate?.directId,
+      directIdParent: sessionContext.alternate?.directIdParent,
+      accountId:
+        params.accountId ?? sessionContext.alternate?.accountId ?? spawnedContext.accountId,
+    },
+    {
+      directId: spawnedContext.directId,
+      directIdParent: spawnedContext.directIdParent,
+      accountId: params.accountId ?? spawnedContext.accountId ?? sessionContext.accountId,
+    },
+    {
+      directId: spawnedContext.alternate?.directId,
+      directIdParent: spawnedContext.alternate?.directIdParent,
+      accountId:
+        params.accountId ?? spawnedContext.alternate?.accountId ?? sessionContext.accountId,
+    },
+  ];
+  const directCandidates = rawDirectCandidates.filter(
+    (
+      candidate,
+    ): candidate is { directId: string; directIdParent?: string; accountId?: string | null } =>
+      typeof candidate.directId === "string" && candidate.directId.length > 0,
+  );
+
+  const resolveBestDirectPolicy = () => {
+    let best: { policy?: SandboxToolPolicy; rank: number; specificity: number } = {
+      rank: 0,
+      specificity: 0,
+    };
+    if (params.groupId) {
+      return best;
+    }
+    const seenDirectCandidates = new Set<string>();
+    for (const candidate of directCandidates) {
+      const key = `${candidate.accountId ?? ""}\n${candidate.directId}\n${candidate.directIdParent ?? ""}`;
+      if (seenDirectCandidates.has(key)) {
+        continue;
+      }
+      seenDirectCandidates.add(key);
+      const resolved = resolveDirectToolPolicyFromConfig({
+        config,
+        channel,
+        directId: candidate.directId,
+        directIdParent: candidate.directIdParent,
+        accountId: candidate.accountId,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      });
+      const specificity = candidate.accountId ? 1 : 0;
+      if (
+        resolved.rank > best.rank ||
+        (resolved.rank === best.rank && specificity > best.specificity)
+      ) {
+        best = {
+          policy: pickSandboxToolPolicy(resolved.policy),
+          rank: resolved.rank,
+          specificity,
+        };
+      }
+    }
+    return best;
+  };
+
+  const rawGroupCandidates: Array<{ groupId?: string; accountId?: string | null }> = params.groupId
+    ? [
+        {
+          groupId: params.groupId,
+          accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+        },
+      ]
+    : [
+        {
+          groupId: sessionContext.groupId,
+          accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+        },
+        {
+          groupId: sessionContext.alternate?.groupId,
+          accountId:
+            params.accountId ?? sessionContext.alternate?.accountId ?? spawnedContext.accountId,
+        },
+        {
+          groupId: spawnedContext.groupId,
+          accountId: params.accountId ?? spawnedContext.accountId ?? sessionContext.accountId,
+        },
+        {
+          groupId: spawnedContext.alternate?.groupId,
+          accountId:
+            params.accountId ?? spawnedContext.alternate?.accountId ?? sessionContext.accountId,
+        },
+      ];
+  const groupCandidates = rawGroupCandidates.filter(
+    (candidate): candidate is { groupId: string; accountId?: string | null } =>
+      typeof candidate.groupId === "string" && candidate.groupId.length > 0,
+  );
+
+  const resolveGroupCandidatePolicy = (candidate: {
+    groupId: string;
+    accountId?: string | null;
+  }): { policy?: SandboxToolPolicy; hasExplicitGroupMatch: boolean } => {
+    const { groupConfig } = resolveChannelGroupPolicy({
+      cfg: config,
       channel,
-      groupId,
-      accountId: params.accountId,
-      senderId: params.senderId,
-      senderName: params.senderName,
-      senderUsername: params.senderUsername,
-      senderE164: params.senderE164,
+      groupId: candidate.groupId,
+      accountId: candidate.accountId,
+      ...groupLookupOptions,
     });
-  return pickSandboxToolPolicy(toolsConfig);
+    const toolsConfig =
+      plugin?.groups?.resolveToolPolicy?.({
+        cfg: config,
+        groupId: candidate.groupId,
+        groupChannel: params.groupChannel,
+        groupSpace: params.groupSpace,
+        accountId: candidate.accountId,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      }) ??
+      resolveChannelGroupToolsPolicy({
+        cfg: config,
+        channel,
+        groupId: candidate.groupId,
+        accountId: candidate.accountId,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+        ...groupLookupOptions,
+      });
+    return {
+      policy: pickSandboxToolPolicy(toolsConfig),
+      hasExplicitGroupMatch: Boolean(groupConfig),
+    };
+  };
+
+  const resolveFirstGroupPolicy = () => {
+    if (groupCandidates.length === 0) {
+      return undefined;
+    }
+    const seenGroupCandidates = new Set<string>();
+    for (const candidate of groupCandidates) {
+      const key = `${candidate.accountId ?? ""}\n${candidate.groupId}`;
+      if (seenGroupCandidates.has(key)) {
+        continue;
+      }
+      seenGroupCandidates.add(key);
+      const { policy } = resolveGroupCandidatePolicy(candidate);
+      if (policy) {
+        return policy;
+      }
+    }
+    return undefined;
+  };
+
+  const preferredGroupCandidate = params.groupId
+    ? {
+        groupId: params.groupId,
+        accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+        alternateDirectId: undefined,
+      }
+    : sessionContext.groupId
+      ? {
+          groupId: sessionContext.groupId,
+          accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+          alternateDirectId: sessionContext.alternate?.directId,
+        }
+      : spawnedContext.groupId
+        ? {
+            groupId: spawnedContext.groupId,
+            accountId: params.accountId ?? spawnedContext.accountId ?? sessionContext.accountId,
+            alternateDirectId: spawnedContext.alternate?.directId,
+          }
+        : undefined;
+  const preferredScopeKind = params.groupId
+    ? "group"
+    : sessionContext.directId
+      ? "direct"
+      : sessionContext.groupId
+        ? "group"
+        : spawnedContext.directId
+          ? "direct"
+          : spawnedContext.groupId
+            ? "group"
+            : undefined;
+
+  const directResolution = resolveBestDirectPolicy();
+  if (preferredScopeKind === "direct") {
+    return directResolution.policy;
+  }
+  if (preferredScopeKind === "group") {
+    const groupPolicy = preferredGroupCandidate
+      ? resolveGroupCandidatePolicy({
+          groupId: preferredGroupCandidate.groupId,
+          accountId: preferredGroupCandidate.accountId,
+        })
+      : { policy: resolveFirstGroupPolicy(), hasExplicitGroupMatch: false };
+    if (!preferredGroupCandidate?.alternateDirectId) {
+      return groupPolicy.policy;
+    }
+    if (groupPolicy.hasExplicitGroupMatch) {
+      return groupPolicy.policy;
+    }
+    return directResolution.policy ?? groupPolicy.policy;
+  }
+
+  const groupPolicy = resolveFirstGroupPolicy();
+  if (groupPolicy) {
+    return groupPolicy;
+  }
+  return directResolution.policy;
 }
 
 export { isToolAllowedByPolicies, isToolAllowedByPolicyName } from "./tool-policy-match.js";

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -277,6 +277,16 @@ type DirectToolPolicyEntry = {
   toolsBySender?: DirectToolPolicyBySenderConfig;
 };
 
+function omitWildcardToolsBySender(
+  toolsBySender: DirectToolPolicyBySenderConfig | undefined,
+): DirectToolPolicyBySenderConfig | undefined {
+  if (!toolsBySender || !Object.prototype.hasOwnProperty.call(toolsBySender, "*")) {
+    return toolsBySender;
+  }
+  const entries = Object.entries(toolsBySender).filter(([key]) => key !== "*");
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 function resolveDirectToolPolicyEntries(
   entries: Record<string, DirectToolPolicyEntry> | undefined,
   directId: string,
@@ -358,9 +368,26 @@ function resolveDirectToolPolicyFromConfig(params: {
           : []),
       ];
   const resolveSenderScopedPolicy = (toolsBySender: DirectToolPolicyBySenderConfig | undefined) => {
-    for (const senderId of senderIdsToTry) {
+    if (!toolsBySender) {
+      return undefined;
+    }
+    if (params.senderId) {
       const senderPolicy = resolveToolsBySender({
         toolsBySender,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      });
+      return senderPolicy && pickSandboxToolPolicy(senderPolicy) ? senderPolicy : undefined;
+    }
+
+    // When we only have derived fallback IDs (for example a threaded DM directId and its parent),
+    // check all explicit sender keys before falling back to the wildcard entry.
+    const explicitToolsBySender = omitWildcardToolsBySender(toolsBySender);
+    for (const senderId of senderIdsToTry) {
+      const senderPolicy = resolveToolsBySender({
+        toolsBySender: explicitToolsBySender,
         senderId,
         senderName: params.senderName,
         senderUsername: params.senderUsername,
@@ -370,7 +397,9 @@ function resolveDirectToolPolicyFromConfig(params: {
         return senderPolicy;
       }
     }
-    return undefined;
+
+    const wildcardPolicy = toolsBySender["*"];
+    return wildcardPolicy && pickSandboxToolPolicy(wildcardPolicy) ? wildcardPolicy : undefined;
   };
 
   const senderPolicy = resolveSenderScopedPolicy(directEntry?.toolsBySender);

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -312,6 +312,7 @@ function resolveDirectToolPolicyEntries(
 type DirectPolicyResolution = {
   policy?: DirectToolPolicyConfig;
   rank: number;
+  scopePriority: number;
 };
 
 function resolveDirectToolPolicyFromConfig(params: {
@@ -324,7 +325,7 @@ function resolveDirectToolPolicyFromConfig(params: {
   senderName?: string | null;
   senderUsername?: string | null;
   senderE164?: string | null;
-}): { policy?: DirectToolPolicyConfig; rank: number } {
+}): DirectPolicyResolution {
   const channelConfig = params.config.channels?.[params.channel] as
     | {
         accounts?: Record<string, { dms?: Record<string, DirectToolPolicyEntry> }>;
@@ -332,7 +333,7 @@ function resolveDirectToolPolicyFromConfig(params: {
       }
     | undefined;
   if (!channelConfig) {
-    return { rank: 0 };
+    return { rank: 0, scopePriority: 0 };
   }
 
   const accountEntry = resolveAccountEntry(
@@ -341,6 +342,7 @@ function resolveDirectToolPolicyFromConfig(params: {
   ) as { dms?: Record<string, DirectToolPolicyEntry> } | undefined;
   const hasAccountScopedDms =
     accountEntry !== undefined && Object.prototype.hasOwnProperty.call(accountEntry, "dms");
+  const scopePriority = hasAccountScopedDms ? 1 : 0;
   const entries = hasAccountScopedDms ? accountEntry?.dms : channelConfig.dms;
   const directIdsToTry = [
     params.directId,
@@ -407,27 +409,30 @@ function resolveDirectToolPolicyFromConfig(params: {
   }): DirectPolicyResolution => {
     const senderPolicy = resolveSenderScopedPolicy(direct?.toolsBySender);
     if (senderPolicy && pickSandboxToolPolicy(senderPolicy)) {
-      return { policy: senderPolicy, rank: 4 };
+      return { policy: senderPolicy, rank: 4, scopePriority };
     }
     if (direct?.tools && pickSandboxToolPolicy(direct.tools)) {
-      return { policy: direct.tools, rank: 3 };
+      return { policy: direct.tools, rank: 3, scopePriority };
     }
     const wildcardSenderPolicy = resolveSenderScopedPolicy(wildcard?.toolsBySender);
     if (wildcardSenderPolicy && pickSandboxToolPolicy(wildcardSenderPolicy)) {
-      return { policy: wildcardSenderPolicy, rank: 2 };
+      return { policy: wildcardSenderPolicy, rank: 2, scopePriority };
     }
     if (wildcard?.tools && pickSandboxToolPolicy(wildcard.tools)) {
-      return { policy: wildcard.tools, rank: 1 };
+      return { policy: wildcard.tools, rank: 1, scopePriority };
     }
-    return { rank: 0 };
+    return { rank: 0, scopePriority };
   };
 
-  let best: DirectPolicyResolution = { rank: 0 };
+  let best: DirectPolicyResolution = { rank: 0, scopePriority };
   for (const directId of directIdsToTry) {
     const scopedEntries = resolveDirectToolPolicyEntries(entries, directId);
     const resolved = resolvePolicyFromEntries(scopedEntries);
     if (resolved.rank > best.rank) {
-      best = resolved;
+      best = {
+        ...resolved,
+        scopePriority,
+      };
       if (best.rank >= 4) {
         break;
       }
@@ -640,9 +645,9 @@ export function resolveGroupToolPolicy(params: {
   );
 
   const resolveBestDirectPolicy = () => {
-    let best: { policy?: SandboxToolPolicy; rank: number; specificity: number } = {
+    let best: { policy?: SandboxToolPolicy; rank: number; scopePriority: number } = {
       rank: 0,
-      specificity: 0,
+      scopePriority: 0,
     };
     if (params.groupId) {
       return best;
@@ -665,15 +670,16 @@ export function resolveGroupToolPolicy(params: {
         senderUsername: params.senderUsername,
         senderE164: params.senderE164,
       });
-      const specificity = candidate.accountId ? 1 : 0;
+      // Prefer candidates backed by an explicit account-scoped DM surface over top-level
+      // candidates, then compare policy rank within that scope.
       if (
-        resolved.rank > best.rank ||
-        (resolved.rank === best.rank && specificity > best.specificity)
+        resolved.scopePriority > best.scopePriority ||
+        (resolved.scopePriority === best.scopePriority && resolved.rank > best.rank)
       ) {
         best = {
           policy: pickSandboxToolPolicy(resolved.policy),
           rank: resolved.rank,
-          specificity,
+          scopePriority: resolved.scopePriority,
         };
       }
     }

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -351,8 +351,10 @@ function resolveDirectToolPolicyFromConfig(params: {
     accountEntry !== undefined && Object.prototype.hasOwnProperty.call(accountEntry, "dms");
   const scopePriority = hasAccountScopedDms ? 1 : 0;
   // Account-derived candidates should not leak into top-level DM rules when the scoped
-  // account cannot be resolved.
-  const canFallbackToTopLevelDms = !params.requiresResolvedAccount || !params.accountId;
+  // account cannot be resolved. Resolved accounts without their own dms block still inherit
+  // the top-level DM policy.
+  const canFallbackToTopLevelDms =
+    !params.requiresResolvedAccount || !params.accountId || accountEntry !== undefined;
   const entries = hasAccountScopedDms
     ? accountEntry?.dms
     : canFallbackToTopLevelDms

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -906,18 +906,31 @@ export function resolveGroupToolPolicy(params: {
         groupId: params.groupId,
         accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
         alternateDirectId: undefined,
+        requiresResolvedAccount:
+          params.accountId !== undefined
+            ? true
+            : (sessionContext.requiresResolvedAccount ?? spawnedContext.requiresResolvedAccount),
       }
     : sessionContext.groupId
       ? {
           groupId: sessionContext.groupId,
           accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
           alternateDirectId: sessionContext.alternate?.directId,
+          requiresResolvedAccount:
+            params.accountId !== undefined
+              ? true
+              : (sessionContext.requiresResolvedAccount ?? spawnedContext.requiresResolvedAccount),
         }
       : spawnedContext.groupId
         ? {
             groupId: spawnedContext.groupId,
             accountId: params.accountId ?? spawnedContext.accountId ?? sessionContext.accountId,
             alternateDirectId: spawnedContext.alternate?.directId,
+            requiresResolvedAccount:
+              params.accountId !== undefined
+                ? true
+                : (spawnedContext.requiresResolvedAccount ??
+                  sessionContext.requiresResolvedAccount),
           }
         : undefined;
   const preferredScopeKind = params.groupId
@@ -941,6 +954,7 @@ export function resolveGroupToolPolicy(params: {
       ? resolveGroupCandidatePolicy({
           groupId: preferredGroupCandidate.groupId,
           accountId: preferredGroupCandidate.accountId,
+          requiresResolvedAccount: preferredGroupCandidate.requiresResolvedAccount,
         })
       : undefined;
     const bestGroupPolicy = resolveBestGroupPolicy();

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -2,6 +2,7 @@ import { getChannelPlugin } from "../channels/plugins/index.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  type ChannelGroupConfig,
   resolveChannelGroupPolicy,
   resolveChannelGroupToolsPolicy,
   resolveToolsBySender,
@@ -252,6 +253,7 @@ function resolveToolScopeContextFromSessionKey(
         channel: candidate.channel,
         accountId: candidate.accountId,
         groupId: baseCandidate?.scopeId ?? candidate.scopeId,
+        requiresResolvedAccount: candidate.requiresResolvedAccount,
       };
     }
     return {
@@ -726,36 +728,67 @@ export function resolveGroupToolPolicy(params: {
     return best;
   };
 
-  const rawGroupCandidates: Array<{ groupId?: string; accountId?: string | null }> = params.groupId
+  const rawGroupCandidates: Array<{
+    groupId?: string;
+    accountId?: string | null;
+    requiresResolvedAccount?: boolean;
+  }> = params.groupId
     ? [
         {
           groupId: params.groupId,
           accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+          requiresResolvedAccount:
+            params.accountId !== undefined
+              ? true
+              : (sessionContext.requiresResolvedAccount ?? spawnedContext.requiresResolvedAccount),
         },
       ]
     : [
         {
           groupId: sessionContext.groupId,
           accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+          requiresResolvedAccount:
+            params.accountId !== undefined
+              ? true
+              : (sessionContext.requiresResolvedAccount ?? spawnedContext.requiresResolvedAccount),
         },
         {
           groupId: sessionContext.alternate?.groupId,
           accountId:
             params.accountId ?? sessionContext.alternate?.accountId ?? spawnedContext.accountId,
+          requiresResolvedAccount:
+            params.accountId !== undefined
+              ? true
+              : (sessionContext.alternate?.requiresResolvedAccount ??
+                spawnedContext.requiresResolvedAccount),
         },
         {
           groupId: spawnedContext.groupId,
           accountId: params.accountId ?? spawnedContext.accountId ?? sessionContext.accountId,
+          requiresResolvedAccount:
+            params.accountId !== undefined
+              ? true
+              : (spawnedContext.requiresResolvedAccount ?? sessionContext.requiresResolvedAccount),
         },
         {
           groupId: spawnedContext.alternate?.groupId,
           accountId:
             params.accountId ?? spawnedContext.alternate?.accountId ?? sessionContext.accountId,
+          requiresResolvedAccount:
+            params.accountId !== undefined
+              ? true
+              : (spawnedContext.alternate?.requiresResolvedAccount ??
+                sessionContext.requiresResolvedAccount),
         },
       ];
   const groupCandidates = rawGroupCandidates.filter(
-    (candidate): candidate is { groupId: string; accountId?: string | null } =>
-      typeof candidate.groupId === "string" && candidate.groupId.length > 0,
+    (
+      candidate,
+    ): candidate is {
+      groupId: string;
+      accountId?: string | null;
+      requiresResolvedAccount?: boolean;
+    } => typeof candidate.groupId === "string" && candidate.groupId.length > 0,
   );
 
   type GroupPolicyResolution = {
@@ -767,7 +800,29 @@ export function resolveGroupToolPolicy(params: {
   const resolveGroupCandidatePolicy = (candidate: {
     groupId: string;
     accountId?: string | null;
+    requiresResolvedAccount?: boolean;
   }): GroupPolicyResolution => {
+    const channelConfig = config.channels?.[channel] as
+      | {
+          accounts?: Record<string, { groups?: Record<string, ChannelGroupConfig> }>;
+        }
+      | undefined;
+    const normalizedAccountId = normalizeAccountId(candidate.accountId);
+    const accountEntry =
+      candidate.accountId && channelConfig
+        ? (resolveAccountEntry(channelConfig.accounts, normalizedAccountId) as
+            | { groups?: Record<string, ChannelGroupConfig> }
+            | undefined)
+        : undefined;
+    if (candidate.requiresResolvedAccount && candidate.accountId && accountEntry === undefined) {
+      return {
+        policy: undefined,
+        hasExplicitGroupMatch: false,
+        specificity: 0,
+      };
+    }
+    const hasAccountScopedGroups =
+      accountEntry !== undefined && Object.prototype.hasOwnProperty.call(accountEntry, "groups");
     const { groupConfig } = resolveChannelGroupPolicy({
       cfg: config,
       channel,
@@ -801,7 +856,7 @@ export function resolveGroupToolPolicy(params: {
     return {
       policy: pickSandboxToolPolicy(toolsConfig),
       hasExplicitGroupMatch: Boolean(groupConfig),
-      specificity: candidate.accountId ? 1 : 0,
+      specificity: hasAccountScopedGroups ? 1 : 0,
     };
   };
 

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -142,6 +142,7 @@ type ToolScopeContextVariant = {
   groupId?: string;
   directId?: string;
   directIdParent?: string;
+  requiresResolvedAccount?: boolean;
 };
 
 function resolveToolScopeContextFromSessionKey(
@@ -171,12 +172,14 @@ function resolveToolScopeContextFromSessionKey(
       accountId?: string;
       kind: string;
       scopeId: string;
+      requiresResolvedAccount?: boolean;
     }> = [];
     const pushCandidate = (candidate: {
       channel?: string;
       accountId?: string;
       kind: string;
       scopeId: string;
+      requiresResolvedAccount?: boolean;
     }) => {
       if (!kinds.has(candidate.kind) || !candidate.scopeId) {
         return;
@@ -218,6 +221,7 @@ function resolveToolScopeContextFromSessionKey(
         accountId: normalizeAccountId(body[1]),
         kind: body[2],
         scopeId: body.slice(3).join(":").trim(),
+        requiresResolvedAccount: true,
       });
     }
 
@@ -235,6 +239,7 @@ function resolveToolScopeContextFromSessionKey(
     accountId?: string;
     kind: string;
     scopeId: string;
+    requiresResolvedAccount?: boolean;
   }): ToolScopeContextVariant => {
     const baseCandidate = parsedBase.find(
       (entry) =>
@@ -257,6 +262,7 @@ function resolveToolScopeContextFromSessionKey(
         baseCandidate && baseCandidate.scopeId !== candidate.scopeId
           ? baseCandidate.scopeId
           : undefined,
+      requiresResolvedAccount: candidate.requiresResolvedAccount,
     };
   };
 
@@ -321,6 +327,7 @@ function resolveDirectToolPolicyFromConfig(params: {
   directId: string;
   directIdParent?: string;
   accountId?: string | null;
+  requiresResolvedAccount?: boolean;
   senderId?: string | null;
   senderName?: string | null;
   senderUsername?: string | null;
@@ -343,7 +350,14 @@ function resolveDirectToolPolicyFromConfig(params: {
   const hasAccountScopedDms =
     accountEntry !== undefined && Object.prototype.hasOwnProperty.call(accountEntry, "dms");
   const scopePriority = hasAccountScopedDms ? 1 : 0;
-  const entries = hasAccountScopedDms ? accountEntry?.dms : channelConfig.dms;
+  // Account-derived candidates should not leak into top-level DM rules when the scoped
+  // account cannot be resolved.
+  const canFallbackToTopLevelDms = !params.requiresResolvedAccount || !params.accountId;
+  const entries = hasAccountScopedDms
+    ? accountEntry?.dms
+    : canFallbackToTopLevelDms
+      ? channelConfig.dms
+      : undefined;
   const directIdsToTry = [
     params.directId,
     ...(params.directIdParent && params.directIdParent !== params.directId
@@ -613,35 +627,58 @@ export function resolveGroupToolPolicy(params: {
     directId?: string;
     directIdParent?: string;
     accountId?: string | null;
+    requiresResolvedAccount?: boolean;
   }> = [
     {
       directId: sessionContext.directId,
       directIdParent: sessionContext.directIdParent,
       accountId: params.accountId ?? sessionContext.accountId ?? spawnedContext.accountId,
+      requiresResolvedAccount:
+        params.accountId !== undefined
+          ? true
+          : (sessionContext.requiresResolvedAccount ?? spawnedContext.requiresResolvedAccount),
     },
     {
       directId: sessionContext.alternate?.directId,
       directIdParent: sessionContext.alternate?.directIdParent,
       accountId:
         params.accountId ?? sessionContext.alternate?.accountId ?? spawnedContext.accountId,
+      requiresResolvedAccount:
+        params.accountId !== undefined
+          ? true
+          : (sessionContext.alternate?.requiresResolvedAccount ??
+            spawnedContext.requiresResolvedAccount),
     },
     {
       directId: spawnedContext.directId,
       directIdParent: spawnedContext.directIdParent,
       accountId: params.accountId ?? spawnedContext.accountId ?? sessionContext.accountId,
+      requiresResolvedAccount:
+        params.accountId !== undefined
+          ? true
+          : (spawnedContext.requiresResolvedAccount ?? sessionContext.requiresResolvedAccount),
     },
     {
       directId: spawnedContext.alternate?.directId,
       directIdParent: spawnedContext.alternate?.directIdParent,
       accountId:
         params.accountId ?? spawnedContext.alternate?.accountId ?? sessionContext.accountId,
+      requiresResolvedAccount:
+        params.accountId !== undefined
+          ? true
+          : (spawnedContext.alternate?.requiresResolvedAccount ??
+            sessionContext.requiresResolvedAccount),
     },
   ];
   const directCandidates = rawDirectCandidates.filter(
     (
       candidate,
-    ): candidate is { directId: string; directIdParent?: string; accountId?: string | null } =>
-      typeof candidate.directId === "string" && candidate.directId.length > 0,
+    ): candidate is {
+      directId: string;
+      directIdParent?: string;
+      accountId?: string | null;
+      requiresResolvedAccount?: boolean;
+    } => typeof candidate.directId === "string" && candidate.directId.length > 0,
   );
 
   const resolveBestDirectPolicy = () => {
@@ -654,7 +691,7 @@ export function resolveGroupToolPolicy(params: {
     }
     const seenDirectCandidates = new Set<string>();
     for (const candidate of directCandidates) {
-      const key = `${candidate.accountId ?? ""}\n${candidate.directId}\n${candidate.directIdParent ?? ""}`;
+      const key = `${candidate.accountId ?? ""}\n${candidate.directId}\n${candidate.directIdParent ?? ""}\n${candidate.requiresResolvedAccount ? "1" : "0"}`;
       if (seenDirectCandidates.has(key)) {
         continue;
       }
@@ -665,6 +702,7 @@ export function resolveGroupToolPolicy(params: {
         directId: candidate.directId,
         directIdParent: candidate.directIdParent,
         accountId: candidate.accountId,
+        requiresResolvedAccount: candidate.requiresResolvedAccount,
         senderId: params.senderId,
         senderName: params.senderName,
         senderUsername: params.senderUsername,

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./config.js";
-import { resolveChannelGroupPolicy, resolveToolsBySender } from "./group-policy.js";
+import {
+  resolveChannelGroupPolicy,
+  resolveChannelGroupToolsPolicy,
+  resolveToolsBySender,
+} from "./group-policy.js";
 
 describe("resolveChannelGroupPolicy", () => {
   it("fails closed when groupPolicy=allowlist and groups are missing", () => {
@@ -264,5 +268,34 @@ describe("resolveToolsBySender", () => {
     expect(warningSpy.mock.calls[0]?.[1]).toMatchObject({
       code: "OPENCLAW_TOOLS_BY_SENDER_UNTYPED_KEY",
     });
+  });
+});
+
+describe("resolveChannelGroupToolsPolicy", () => {
+  it("falls through to group tools when sender override is empty", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          groups: {
+            "*": {
+              tools: { allow: ["read"] },
+              toolsBySender: {
+                "id:ou-owner": {},
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveChannelGroupToolsPolicy({
+        cfg,
+        channel: "feishu",
+        groupId: "oc_group_1",
+        groupIdCaseInsensitive: true,
+        senderId: "ou-owner",
+      }),
+    ).toEqual({ allow: ["read"] });
   });
 });

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -1,3 +1,4 @@
+import { pickSandboxToolPolicy } from "../agents/sandbox-tool-policy.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
@@ -405,7 +406,7 @@ export function resolveChannelGroupToolsPolicy(
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
   });
-  if (groupSenderPolicy) {
+  if (groupSenderPolicy && pickSandboxToolPolicy(groupSenderPolicy)) {
     return groupSenderPolicy;
   }
   if (groupConfig?.tools) {
@@ -418,7 +419,7 @@ export function resolveChannelGroupToolsPolicy(
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
   });
-  if (defaultSenderPolicy) {
+  if (defaultSenderPolicy && pickSandboxToolPolicy(defaultSenderPolicy)) {
     return defaultSenderPolicy;
   }
   if (defaultConfig?.tools) {


### PR DESCRIPTION
## Summary
- honor `channels.<provider>.dms.*.tools` and `toolsBySender` when agent tool policy is resolved from direct-session keys
- add Feishu DM schema support for `tools` and `toolsBySender`
- ignore empty sender-scoped overrides and keep probing alternate DM/group candidates until an effective policy is found

## Context
This is the second smaller slice split out from #44602.

#53496 handles the Feishu group `toolsBySender` parity work.
This PR keeps the remaining DM/core policy path separate so reviewers can evaluate the direct-session resolver independently from the group-only changes.

## Review passes
I rebuilt this slice on top of the latest `main` and verified it in three passes before opening:
- focused unit tests for Feishu DM schema, direct-session resolution, and sender-override fallback behavior
- broader regression tests through the agent tool-policy call path (`pi-tools-agent-config`)
- full repository `pnpm check`

## Testing
- `pnpm test -- src/config/group-policy.test.ts src/agents/pi-tools.policy.test.ts extensions/feishu/src/config-schema.test.ts`
- `pnpm test -- src/agents/pi-tools-agent-config.test.ts src/agents/pi-tools.policy.test.ts src/config/group-policy.test.ts extensions/feishu/src/config-schema.test.ts`
- `pnpm check`
