### PR TITLE
fix(feishu): refine streaming card delivery

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -4,6 +4,7 @@ const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const getFeishuRuntimeMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
+const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
@@ -17,6 +18,7 @@ vi.mock("./runtime.js", () => ({ getFeishuRuntime: getFeishuRuntimeMock }));
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
+  sendStructuredCardFeishu: sendStructuredCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({ sendMediaFeishu: sendMediaFeishuMock }));
 vi.mock("./client.js", () => ({ createFeishuClient: createFeishuClientMock }));
@@ -56,6 +58,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
     sendMediaFeishuMock.mockResolvedValue(undefined);
+    sendStructuredCardFeishuMock.mockResolvedValue(undefined);
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -72,14 +75,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     createFeishuClientMock.mockReturnValue({});
 
     createReplyDispatcherWithTypingMock.mockImplementation((opts) => ({
-      dispatcher: {
-        sendToolResult: vi.fn(() => true),
-        sendBlockReply: vi.fn(() => true),
-        sendFinalReply: vi.fn(() => true),
-        waitForIdle: vi.fn(async () => {}),
-        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
-        markComplete: vi.fn(),
-      },
+      dispatcher: {},
       replyOptions: {},
       markDispatchIdle: vi.fn(),
       _opts: opts,
@@ -232,98 +228,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("uses streaming session for long structured replies in auto mode", async () => {
-    createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: { log: vi.fn(), error: vi.fn() } as never,
-      chatId: "oc_chat",
-    });
-
-    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
-    await options.deliver(
-      {
-        text: [
-          "# 第一章：概述",
-          "",
-          "这是一段比较长的正文，用来模拟真正的长篇回复。".repeat(40),
-          "",
-          "## 第二章：细节",
-          "",
-          "- 要点一",
-          "- 要点二",
-        ].join("\n"),
-      },
-      { kind: "final" },
-    );
-
-    expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
-  });
-
-  it("prefers a single markdown card for long structured final replies when streaming is unavailable", async () => {
-    const options = setupNonStreamingAutoDispatcher();
-    const longStructured = [
-      "# 第一章：概述",
-      "",
-      "这是一段比较长的正文，用来模拟真正的长篇回复。".repeat(40),
-      "",
-      "## 第二章：细节",
-      "",
-      "- 要点一",
-      "- 要点二",
-    ].join("\n");
-
-    await options.deliver({ text: longStructured }, { kind: "final" });
-
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: longStructured,
-      }),
-    );
-    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-  });
-
-  it("falls back to chunked cards when single-card delivery fails", async () => {
-    const chunkTextWithMode = vi.fn(() => ["第一段", "第二段"]);
-    getFeishuRuntimeMock.mockReturnValue({
-      channel: {
-        text: {
-          resolveTextChunkLimit: vi.fn(() => 4000),
-          resolveChunkMode: vi.fn(() => "line"),
-          resolveMarkdownTableMode: vi.fn(() => "preserve"),
-          convertMarkdownTables: vi.fn((text) => text),
-          chunkTextWithMode,
-        },
-        reply: {
-          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
-          resolveHumanDelayConfig: vi.fn(() => undefined),
-        },
-      },
-    });
-    sendMarkdownCardFeishuMock
-      .mockRejectedValueOnce(new Error("card too large"))
-      .mockResolvedValue(undefined);
-
-    const options = setupNonStreamingAutoDispatcher();
-    await options.deliver({ text: "# 标题\n\n正文".repeat(50) }, { kind: "final" });
-
-    expect(chunkTextWithMode).toHaveBeenCalledTimes(1);
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(3);
-    expect(sendMarkdownCardFeishuMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ text: "第一段" }),
-    );
-    expect(sendMarkdownCardFeishuMock).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ text: "第二段" }),
-    );
-  });
-
   it("suppresses internal block payload delivery", async () => {
     const { options } = createDispatcherHarness();
     await options.deliver({ text: "internal reasoning chunk" }, { kind: "block" });
@@ -334,7 +238,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("keeps block streaming disabled so internal chunks stay internal", async () => {
+  it("sets disableBlockStreaming in replyOptions to prevent silent reply drops", async () => {
     const result = createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -354,43 +258,20 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
-      replyToMessageId: undefined,
-      replyInThread: undefined,
-      rootId: "om_root_topic",
-    });
+    expect(streamingInstances[0].start).toHaveBeenCalledWith(
+      "oc_chat",
+      "chat_id",
+      expect.objectContaining({
+        replyToMessageId: undefined,
+        replyInThread: undefined,
+        rootId: "om_root_topic",
+        header: { title: "agent", template: "blue" },
+        note: "Agent: agent",
+      }),
+    );
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
-  });
-
-  it("closes streaming with partial text when final reply is missing", async () => {
-    resolveFeishuAccountMock.mockReturnValue({
-      accountId: "main",
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-      config: {
-        renderMode: "card",
-        streaming: true,
-      },
-    });
-    const result = createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: { log: vi.fn(), error: vi.fn() } as never,
-      chatId: "oc_chat",
-    });
-
-    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
-    await options.onReplyStart?.();
-    await result.replyOptions.onPartialReply?.({ text: "```md\npartial answer\n```" });
-    await options.onIdle?.();
-
-    expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
   });
 
   it("closes streaming with block text when final reply is missing", async () => {
@@ -403,7 +284,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```", {
+      note: "Agent: agent",
+    });
   });
 
   it("delivers distinct final payloads after streaming close", async () => {
@@ -415,9 +298,16 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(2);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```");
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```", {
+      note: "Agent: agent",
+    });
     expect(streamingInstances[1].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[1].close).toHaveBeenCalledWith("```md\n完整回复第一段 + 第二段\n```");
+    expect(streamingInstances[1].close).toHaveBeenCalledWith(
+      "```md\n完整回复第一段 + 第二段\n```",
+      {
+        note: "Agent: agent",
+      },
+    );
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
@@ -431,99 +321,12 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n同一条回复\n```");
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n同一条回复\n```", {
+      note: "Agent: agent",
+    });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
-
-  it("closes an active stream when the dispatcher is superseded", async () => {
-    resolveFeishuAccountMock.mockReturnValue({
-      accountId: "main",
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-      config: {
-        renderMode: "card",
-        streaming: true,
-      },
-    });
-    const dispatcher = {} as {
-      setDeliveryGuard?: (guard: (() => boolean) | undefined) => void;
-      notifySuperseded?: () => void;
-    };
-    createReplyDispatcherWithTypingMock.mockImplementationOnce((opts) => ({
-      dispatcher,
-      replyOptions: {},
-      markDispatchIdle: vi.fn(),
-      _opts: opts,
-    }));
-
-    const result = createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: { log: vi.fn(), error: vi.fn() } as never,
-      chatId: "oc_chat",
-    });
-
-    const options = createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0];
-    await options.onReplyStart?.();
-    await result.replyOptions.onPartialReply?.({ text: "```md\npartial answer\n```" });
-
-    expect(streamingInstances).toHaveLength(1);
-    dispatcher.notifySuperseded?.();
-    await vi.waitFor(() => {
-      expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-      expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
-    });
-  });
-
-  it("wraps the delivery guard to close active streaming cards when blocked", async () => {
-    resolveFeishuAccountMock.mockReturnValue({
-      accountId: "main",
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-      config: {
-        renderMode: "card",
-        streaming: true,
-      },
-    });
-    const setDeliveryGuard = vi.fn();
-    const dispatcher = {
-      setDeliveryGuard,
-    } as {
-      setDeliveryGuard?: (guard: (() => boolean) | undefined) => void;
-      notifySuperseded?: () => void;
-    };
-    createReplyDispatcherWithTypingMock.mockImplementationOnce((opts) => ({
-      dispatcher,
-      replyOptions: {},
-      markDispatchIdle: vi.fn(),
-      _opts: opts,
-    }));
-
-    const result = createFeishuReplyDispatcher({
-      cfg: {} as never,
-      agentId: "agent",
-      runtime: { log: vi.fn(), error: vi.fn() } as never,
-      chatId: "oc_chat",
-    });
-
-    const options = createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0];
-    await options.onReplyStart?.();
-    await result.replyOptions.onPartialReply?.({ text: "```md\npartial answer\n```" });
-
-    expect(streamingInstances).toHaveLength(1);
-    expect(setDeliveryGuard).not.toHaveBeenCalled();
-    result.dispatcher.setDeliveryGuard?.(() => false);
-    const forwardedGuard = setDeliveryGuard.mock.calls[0]?.[0] as (() => boolean) | undefined;
-    expect(forwardedGuard).toBeTypeOf("function");
-    expect(forwardedGuard?.()).toBe(false);
-    await vi.waitFor(() => {
-      expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    });
-  });
-
   it("suppresses duplicate final text while still sending media", async () => {
     const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });
@@ -562,7 +365,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
-  it("keeps the latest partial snapshot when streaming closes", async () => {
+  it("treats block updates as delta chunks", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -579,12 +382,14 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     await options.onReplyStart?.();
     await result.replyOptions.onPartialReply?.({ text: "hello" });
-    await result.replyOptions.onPartialReply?.({ text: "hello world" });
+    await options.deliver({ text: "lo world" }, { kind: "block" });
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("hello world");
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("hellolo world", {
+      note: "Agent: agent",
+    });
   });
 
   it("sends media-only payloads as attachments", async () => {
@@ -653,7 +458,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
-  it("passes replyInThread to sendMarkdownCardFeishu for card text", async () => {
+  it("passes replyInThread to sendStructuredCardFeishu for card text", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -671,12 +476,132 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     await options.deliver({ text: "card text" }, { kind: "final" });
 
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
     );
+  });
+
+  it("streams reasoning content as blockquote before answer", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    // Core agent sends pre-formatted text from formatReasoningMessage
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_thinking step 1_" });
+    result.replyOptions.onReasoningStream?.({
+      text: "Reasoning:\n_thinking step 1_\n_step 2_",
+    });
+    result.replyOptions.onPartialReply?.({ text: "answer part" });
+    result.replyOptions.onReasoningEnd?.();
+    await options.deliver({ text: "answer part final" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    const updateCalls = streamingInstances[0].update.mock.calls.map((c: unknown[]) => c[0]);
+    const reasoningUpdate = updateCalls.find((c: string) => c.includes("Thinking"));
+    expect(reasoningUpdate).toContain("> 💭 **Thinking**");
+    // formatReasoningPrefix strips "Reasoning:" prefix and italic markers
+    expect(reasoningUpdate).toContain("> thinking step");
+    expect(reasoningUpdate).not.toContain("Reasoning:");
+    expect(reasoningUpdate).not.toMatch(/> _.*_/);
+
+    const combinedUpdate = updateCalls.find(
+      (c: string) => c.includes("Thinking") && c.includes("---"),
+    );
+    expect(combinedUpdate).toBeDefined();
+
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    expect(closeArg).toContain("> 💭 **Thinking**");
+    expect(closeArg).toContain("---");
+    expect(closeArg).toContain("answer part final");
+  });
+
+  it("provides onReasoningStream and onReasoningEnd when streaming is enabled", () => {
+    const { result } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    expect(result.replyOptions.onReasoningStream).toBeTypeOf("function");
+    expect(result.replyOptions.onReasoningEnd).toBeTypeOf("function");
+  });
+
+  it("omits reasoning callbacks when streaming is disabled", () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: false,
+      },
+    });
+
+    const { result } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    expect(result.replyOptions.onReasoningStream).toBeUndefined();
+    expect(result.replyOptions.onReasoningEnd).toBeUndefined();
+  });
+
+  it("renders reasoning-only card when no answer text arrives", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_deep thought_" });
+    result.replyOptions.onReasoningEnd?.();
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    expect(closeArg).toContain("> 💭 **Thinking**");
+    expect(closeArg).toContain("> deep thought");
+    expect(closeArg).not.toContain("Reasoning:");
+    expect(closeArg).not.toContain("---");
+  });
+
+  it("ignores empty reasoning payloads", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "" });
+    result.replyOptions.onPartialReply?.({ text: "```ts\ncode\n```" });
+    await options.deliver({ text: "```ts\ncode\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
+    expect(closeArg).not.toContain("Thinking");
+    expect(closeArg).toBe("```ts\ncode\n```");
+  });
+
+  it("deduplicates final text by raw answer payload, not combined card text", async () => {
+    const { result, options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    await options.onReplyStart?.();
+    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_thought_" });
+    result.replyOptions.onReasoningEnd?.();
+    await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+
+    // Deliver the same raw answer text again — should be deduped
+    await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
+
+    // No second streaming session since the raw answer text matches
+    expect(streamingInstances).toHaveLength(1);
   });
 
   it("passes replyToMessageId and replyInThread to streaming.start()", async () => {
@@ -688,10 +613,16 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
-      replyToMessageId: "om_msg",
-      replyInThread: true,
-    });
+    expect(streamingInstances[0].start).toHaveBeenCalledWith(
+      "oc_chat",
+      "chat_id",
+      expect.objectContaining({
+        replyToMessageId: "om_msg",
+        replyInThread: true,
+        header: { title: "agent", template: "blue" },
+        note: "Agent: agent",
+      }),
+    );
   });
 
   it("disables streaming for thread replies and keeps reply metadata", async () => {
@@ -705,7 +636,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(0);
-    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_msg",
         replyInThread: true,
@@ -726,5 +657,51 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyInThread: true,
       }),
     );
+  });
+
+  it("recovers streaming after start() throws (HTTP 400)", async () => {
+    const errorMock = vi.fn();
+    let shouldFailStart = true;
+
+    // Intercept streaming instance creation to make first start() reject
+    const origPush = streamingInstances.push;
+    streamingInstances.push = function (this: any[], ...args: any[]) {
+      if (shouldFailStart) {
+        args[0].start = vi
+          .fn()
+          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
+        shouldFailStart = false;
+      }
+      return origPush.apply(this, args);
+    } as any;
+
+    try {
+      createFeishuReplyDispatcher({
+        cfg: {} as never,
+        agentId: "agent",
+        runtime: { log: vi.fn(), error: errorMock } as never,
+        chatId: "oc_chat",
+      });
+
+      const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+      // First deliver with markdown triggers startStreaming - which will fail
+      await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "block" });
+
+      // Wait for the async error to propagate
+      await vi.waitFor(() => {
+        expect(errorMock).toHaveBeenCalledWith(expect.stringContaining("streaming start failed"));
+      });
+
+      // Second deliver should create a NEW streaming session (not stuck)
+      await options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" });
+
+      // Two instances created: first failed, second succeeded and closed
+      expect(streamingInstances).toHaveLength(2);
+      expect(streamingInstances[1].start).toHaveBeenCalled();
+      expect(streamingInstances[1].close).toHaveBeenCalled();
+    } finally {
+      streamingInstances.push = origPush;
+    }
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -4,7 +4,6 @@ const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const getFeishuRuntimeMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
-const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
@@ -18,7 +17,6 @@ vi.mock("./runtime.js", () => ({ getFeishuRuntime: getFeishuRuntimeMock }));
 vi.mock("./send.js", () => ({
   sendMessageFeishu: sendMessageFeishuMock,
   sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
-  sendStructuredCardFeishu: sendStructuredCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({ sendMediaFeishu: sendMediaFeishuMock }));
 vi.mock("./client.js", () => ({ createFeishuClient: createFeishuClientMock }));
@@ -58,7 +56,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
     sendMediaFeishuMock.mockResolvedValue(undefined);
-    sendStructuredCardFeishuMock.mockResolvedValue(undefined);
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -75,7 +72,14 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     createFeishuClientMock.mockReturnValue({});
 
     createReplyDispatcherWithTypingMock.mockImplementation((opts) => ({
-      dispatcher: {},
+      dispatcher: {
+        sendToolResult: vi.fn(() => true),
+        sendBlockReply: vi.fn(() => true),
+        sendFinalReply: vi.fn(() => true),
+        waitForIdle: vi.fn(async () => {}),
+        getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
+        markComplete: vi.fn(),
+      },
       replyOptions: {},
       markDispatchIdle: vi.fn(),
       _opts: opts,
@@ -228,6 +232,98 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("uses streaming session for long structured replies in auto mode", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver(
+      {
+        text: [
+          "# 第一章：概述",
+          "",
+          "这是一段比较长的正文，用来模拟真正的长篇回复。".repeat(40),
+          "",
+          "## 第二章：细节",
+          "",
+          "- 要点一",
+          "- 要点二",
+        ].join("\n"),
+      },
+      { kind: "final" },
+    );
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers a single markdown card for long structured final replies when streaming is unavailable", async () => {
+    const options = setupNonStreamingAutoDispatcher();
+    const longStructured = [
+      "# 第一章：概述",
+      "",
+      "这是一段比较长的正文，用来模拟真正的长篇回复。".repeat(40),
+      "",
+      "## 第二章：细节",
+      "",
+      "- 要点一",
+      "- 要点二",
+    ].join("\n");
+
+    await options.deliver({ text: longStructured }, { kind: "final" });
+
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: longStructured,
+      }),
+    );
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to chunked cards when single-card delivery fails", async () => {
+    const chunkTextWithMode = vi.fn(() => ["第一段", "第二段"]);
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 4000),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "preserve"),
+          convertMarkdownTables: vi.fn((text) => text),
+          chunkTextWithMode,
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+    });
+    sendMarkdownCardFeishuMock
+      .mockRejectedValueOnce(new Error("card too large"))
+      .mockResolvedValue(undefined);
+
+    const options = setupNonStreamingAutoDispatcher();
+    await options.deliver({ text: "# 标题\n\n正文".repeat(50) }, { kind: "final" });
+
+    expect(chunkTextWithMode).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(3);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "第一段" }),
+    );
+    expect(sendMarkdownCardFeishuMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ text: "第二段" }),
+    );
+  });
+
   it("suppresses internal block payload delivery", async () => {
     const { options } = createDispatcherHarness();
     await options.deliver({ text: "internal reasoning chunk" }, { kind: "block" });
@@ -238,7 +334,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("sets disableBlockStreaming in replyOptions to prevent silent reply drops", async () => {
+  it("keeps block streaming disabled so internal chunks stay internal", async () => {
     const result = createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -258,20 +354,43 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].start).toHaveBeenCalledWith(
-      "oc_chat",
-      "chat_id",
-      expect.objectContaining({
-        replyToMessageId: undefined,
-        replyInThread: undefined,
-        rootId: "om_root_topic",
-        header: { title: "agent", template: "blue" },
-        note: "Agent: agent",
-      }),
-    );
+    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
+      replyToMessageId: undefined,
+      replyInThread: undefined,
+      rootId: "om_root_topic",
+    });
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("closes streaming with partial text when final reply is missing", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onReplyStart?.();
+    await result.replyOptions.onPartialReply?.({ text: "```md\npartial answer\n```" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
   });
 
   it("closes streaming with block text when final reply is missing", async () => {
@@ -284,9 +403,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```", {
-      note: "Agent: agent",
-    });
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
   });
 
   it("delivers distinct final payloads after streaming close", async () => {
@@ -298,16 +415,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(2);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```", {
-      note: "Agent: agent",
-    });
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```");
     expect(streamingInstances[1].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[1].close).toHaveBeenCalledWith(
-      "```md\n完整回复第一段 + 第二段\n```",
-      {
-        note: "Agent: agent",
-      },
-    );
+    expect(streamingInstances[1].close).toHaveBeenCalledWith("```md\n完整回复第一段 + 第二段\n```");
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
@@ -321,12 +431,99 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n同一条回复\n```", {
-      note: "Agent: agent",
-    });
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n同一条回复\n```");
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
+
+  it("closes an active stream when the dispatcher is superseded", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+    const dispatcher = {} as {
+      setDeliveryGuard?: (guard: (() => boolean) | undefined) => void;
+      notifySuperseded?: () => void;
+    };
+    createReplyDispatcherWithTypingMock.mockImplementationOnce((opts) => ({
+      dispatcher,
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      _opts: opts,
+    }));
+
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0];
+    await options.onReplyStart?.();
+    await result.replyOptions.onPartialReply?.({ text: "```md\npartial answer\n```" });
+
+    expect(streamingInstances).toHaveLength(1);
+    dispatcher.notifySuperseded?.();
+    await vi.waitFor(() => {
+      expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+      expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
+    });
+  });
+
+  it("wraps the delivery guard to close active streaming cards when blocked", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+    const setDeliveryGuard = vi.fn();
+    const dispatcher = {
+      setDeliveryGuard,
+    } as {
+      setDeliveryGuard?: (guard: (() => boolean) | undefined) => void;
+      notifySuperseded?: () => void;
+    };
+    createReplyDispatcherWithTypingMock.mockImplementationOnce((opts) => ({
+      dispatcher,
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      _opts: opts,
+    }));
+
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0];
+    await options.onReplyStart?.();
+    await result.replyOptions.onPartialReply?.({ text: "```md\npartial answer\n```" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(setDeliveryGuard).not.toHaveBeenCalled();
+    result.dispatcher.setDeliveryGuard?.(() => false);
+    const forwardedGuard = setDeliveryGuard.mock.calls[0]?.[0] as (() => boolean) | undefined;
+    expect(forwardedGuard).toBeTypeOf("function");
+    expect(forwardedGuard?.()).toBe(false);
+    await vi.waitFor(() => {
+      expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("suppresses duplicate final text while still sending media", async () => {
     const options = setupNonStreamingAutoDispatcher();
     await options.deliver({ text: "plain final" }, { kind: "final" });
@@ -365,7 +562,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
-  it("treats block updates as delta chunks", async () => {
+  it("keeps the latest partial snapshot when streaming closes", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -382,14 +579,12 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     await options.onReplyStart?.();
     await result.replyOptions.onPartialReply?.({ text: "hello" });
-    await options.deliver({ text: "lo world" }, { kind: "block" });
+    await result.replyOptions.onPartialReply?.({ text: "hello world" });
     await options.onIdle?.();
 
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("hellolo world", {
-      note: "Agent: agent",
-    });
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("hello world");
   });
 
   it("sends media-only payloads as attachments", async () => {
@@ -458,7 +653,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
-  it("passes replyInThread to sendStructuredCardFeishu for card text", async () => {
+  it("passes replyInThread to sendMarkdownCardFeishu for card text", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -476,132 +671,12 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     await options.deliver({ text: "card text" }, { kind: "final" });
 
-    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
     );
-  });
-
-  it("streams reasoning content as blockquote before answer", async () => {
-    const { result, options } = createDispatcherHarness({
-      runtime: createRuntimeLogger(),
-    });
-
-    await options.onReplyStart?.();
-    // Core agent sends pre-formatted text from formatReasoningMessage
-    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_thinking step 1_" });
-    result.replyOptions.onReasoningStream?.({
-      text: "Reasoning:\n_thinking step 1_\n_step 2_",
-    });
-    result.replyOptions.onPartialReply?.({ text: "answer part" });
-    result.replyOptions.onReasoningEnd?.();
-    await options.deliver({ text: "answer part final" }, { kind: "final" });
-
-    expect(streamingInstances).toHaveLength(1);
-    const updateCalls = streamingInstances[0].update.mock.calls.map((c: unknown[]) => c[0]);
-    const reasoningUpdate = updateCalls.find((c: string) => c.includes("Thinking"));
-    expect(reasoningUpdate).toContain("> 💭 **Thinking**");
-    // formatReasoningPrefix strips "Reasoning:" prefix and italic markers
-    expect(reasoningUpdate).toContain("> thinking step");
-    expect(reasoningUpdate).not.toContain("Reasoning:");
-    expect(reasoningUpdate).not.toMatch(/> _.*_/);
-
-    const combinedUpdate = updateCalls.find(
-      (c: string) => c.includes("Thinking") && c.includes("---"),
-    );
-    expect(combinedUpdate).toBeDefined();
-
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
-    expect(closeArg).toContain("> 💭 **Thinking**");
-    expect(closeArg).toContain("---");
-    expect(closeArg).toContain("answer part final");
-  });
-
-  it("provides onReasoningStream and onReasoningEnd when streaming is enabled", () => {
-    const { result } = createDispatcherHarness({
-      runtime: createRuntimeLogger(),
-    });
-
-    expect(result.replyOptions.onReasoningStream).toBeTypeOf("function");
-    expect(result.replyOptions.onReasoningEnd).toBeTypeOf("function");
-  });
-
-  it("omits reasoning callbacks when streaming is disabled", () => {
-    resolveFeishuAccountMock.mockReturnValue({
-      accountId: "main",
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-      config: {
-        renderMode: "auto",
-        streaming: false,
-      },
-    });
-
-    const { result } = createDispatcherHarness({
-      runtime: createRuntimeLogger(),
-    });
-
-    expect(result.replyOptions.onReasoningStream).toBeUndefined();
-    expect(result.replyOptions.onReasoningEnd).toBeUndefined();
-  });
-
-  it("renders reasoning-only card when no answer text arrives", async () => {
-    const { result, options } = createDispatcherHarness({
-      runtime: createRuntimeLogger(),
-    });
-
-    await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_deep thought_" });
-    result.replyOptions.onReasoningEnd?.();
-    await options.onIdle?.();
-
-    expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
-    expect(closeArg).toContain("> 💭 **Thinking**");
-    expect(closeArg).toContain("> deep thought");
-    expect(closeArg).not.toContain("Reasoning:");
-    expect(closeArg).not.toContain("---");
-  });
-
-  it("ignores empty reasoning payloads", async () => {
-    const { result, options } = createDispatcherHarness({
-      runtime: createRuntimeLogger(),
-    });
-
-    await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "" });
-    result.replyOptions.onPartialReply?.({ text: "```ts\ncode\n```" });
-    await options.deliver({ text: "```ts\ncode\n```" }, { kind: "final" });
-
-    expect(streamingInstances).toHaveLength(1);
-    const closeArg = streamingInstances[0].close.mock.calls[0][0] as string;
-    expect(closeArg).not.toContain("Thinking");
-    expect(closeArg).toBe("```ts\ncode\n```");
-  });
-
-  it("deduplicates final text by raw answer payload, not combined card text", async () => {
-    const { result, options } = createDispatcherHarness({
-      runtime: createRuntimeLogger(),
-    });
-
-    await options.onReplyStart?.();
-    result.replyOptions.onReasoningStream?.({ text: "Reasoning:\n_thought_" });
-    result.replyOptions.onReasoningEnd?.();
-    await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
-
-    expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-
-    // Deliver the same raw answer text again — should be deduped
-    await options.deliver({ text: "```ts\nfinal answer\n```" }, { kind: "final" });
-
-    // No second streaming session since the raw answer text matches
-    expect(streamingInstances).toHaveLength(1);
   });
 
   it("passes replyToMessageId and replyInThread to streaming.start()", async () => {
@@ -613,16 +688,10 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].start).toHaveBeenCalledWith(
-      "oc_chat",
-      "chat_id",
-      expect.objectContaining({
-        replyToMessageId: "om_msg",
-        replyInThread: true,
-        header: { title: "agent", template: "blue" },
-        note: "Agent: agent",
-      }),
-    );
+    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
+      replyToMessageId: "om_msg",
+      replyInThread: true,
+    });
   });
 
   it("disables streaming for thread replies and keeps reply metadata", async () => {
@@ -636,7 +705,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
 
     expect(streamingInstances).toHaveLength(0);
-    expect(sendStructuredCardFeishuMock).toHaveBeenCalledWith(
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_msg",
         replyInThread: true,
@@ -657,51 +726,5 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyInThread: true,
       }),
     );
-  });
-
-  it("recovers streaming after start() throws (HTTP 400)", async () => {
-    const errorMock = vi.fn();
-    let shouldFailStart = true;
-
-    // Intercept streaming instance creation to make first start() reject
-    const origPush = streamingInstances.push;
-    streamingInstances.push = function (this: any[], ...args: any[]) {
-      if (shouldFailStart) {
-        args[0].start = vi
-          .fn()
-          .mockRejectedValue(new Error("Create card request failed with HTTP 400"));
-        shouldFailStart = false;
-      }
-      return origPush.apply(this, args);
-    } as any;
-
-    try {
-      createFeishuReplyDispatcher({
-        cfg: {} as never,
-        agentId: "agent",
-        runtime: { log: vi.fn(), error: errorMock } as never,
-        chatId: "oc_chat",
-      });
-
-      const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
-
-      // First deliver with markdown triggers startStreaming - which will fail
-      await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "block" });
-
-      // Wait for the async error to propagate
-      await vi.waitFor(() => {
-        expect(errorMock).toHaveBeenCalledWith(expect.stringContaining("streaming start failed"));
-      });
-
-      // Second deliver should create a NEW streaming session (not stuck)
-      await options.deliver({ text: "```ts\nconst y = 2\n```" }, { kind: "final" });
-
-      // Two instances created: first failed, second succeeded and closed
-      expect(streamingInstances).toHaveLength(2);
-      expect(streamingInstances[1].start).toHaveBeenCalled();
-      expect(streamingInstances[1].close).toHaveBeenCalled();
-    } finally {
-      streamingInstances.push = origPush;
-    }
   });
 });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -3,26 +3,14 @@
  */
 
 import type { Client } from "@larksuiteoapi/node-sdk";
-import { fetchWithSsrFGuard } from "../runtime-api.js";
-import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/feishu";
 import type { FeishuDomain } from "./types.js";
 
 type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
-type CardState = {
-  cardId: string;
-  messageId: string;
-  sequence: number;
-  currentText: string;
-  hasNote: boolean;
-};
+type CardState = { cardId: string; messageId: string; sequence: number; currentText: string };
 
-/** Options for customising the initial streaming card appearance. */
-export type StreamingCardOptions = {
-  /** Optional header with title and color template. */
-  header?: CardHeaderConfig;
-  /** Optional grey note footer text. */
-  note?: string;
-};
+const STREAMING_UPDATE_THROTTLE_MS = 160;
+const STREAMING_SIGNIFICANT_DELTA_CHARS = 18;
 
 /** Optional header for streaming cards (title bar with color template) */
 export type StreamingCardHeader = {
@@ -111,6 +99,21 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
+function hasNaturalStreamingBoundary(text: string): boolean {
+  return /[\n。！？!?；;：:]$/.test(text);
+}
+
+function shouldPushStreamingUpdate(previousText: string, nextText: string): boolean {
+  if (!previousText) {
+    return true;
+  }
+  if (hasNaturalStreamingBoundary(nextText)) {
+    return true;
+  }
+  const delta = nextText.length - previousText.length;
+  return delta >= STREAMING_SIGNIFICANT_DELTA_CHARS;
+}
+
 export function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
@@ -168,7 +171,7 @@ export class FeishuStreamingSession {
   private lastUpdateTime = 0;
   private pendingText: string | null = null;
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
-  private updateThrottleMs = 100; // Throttle updates to max 10/sec
+  private updateThrottleMs = STREAMING_UPDATE_THROTTLE_MS;
 
   constructor(client: Client, creds: Credentials, log?: (msg: string) => void) {
     this.client = client;
@@ -179,24 +182,13 @@ export class FeishuStreamingSession {
   async start(
     receiveId: string,
     receiveIdType: "open_id" | "user_id" | "union_id" | "email" | "chat_id" = "chat_id",
-    options?: StreamingCardOptions & StreamingStartOptions,
+    options?: StreamingStartOptions,
   ): Promise<void> {
     if (this.state) {
       return;
     }
 
     const apiBase = resolveApiBase(this.creds.domain);
-    const elements: Record<string, unknown>[] = [
-      { tag: "markdown", content: "⏳ Thinking...", element_id: "content" },
-    ];
-    if (options?.note) {
-      elements.push({ tag: "hr" });
-      elements.push({
-        tag: "markdown",
-        content: `<font color='grey'>${options.note}</font>`,
-        element_id: "note",
-      });
-    }
     const cardJson: Record<string, unknown> = {
       schema: "2.0",
       config: {
@@ -204,12 +196,14 @@ export class FeishuStreamingSession {
         summary: { content: "[Generating...]" },
         streaming_config: { print_frequency_ms: { default: 50 }, print_step: { default: 1 } },
       },
-      body: { elements },
+      body: {
+        elements: [{ tag: "markdown", content: "⏳ Thinking...", element_id: "content" }],
+      },
     };
     if (options?.header) {
       cardJson.header = {
         title: { tag: "plain_text", content: options.header.title },
-        template: resolveFeishuCardTemplate(options.header.template) ?? "blue",
+        template: options.header.template ?? "blue",
       };
     }
 
@@ -282,13 +276,7 @@ export class FeishuStreamingSession {
       throw new Error(`Send card failed: ${sendRes.msg}`);
     }
 
-    this.state = {
-      cardId,
-      messageId: sendRes.data.message_id,
-      sequence: 1,
-      currentText: "",
-      hasNote: !!options?.note,
-    };
+    this.state = { cardId, messageId: sendRes.data.message_id, sequence: 1, currentText: "" };
     this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
   }
 
@@ -321,6 +309,28 @@ export class FeishuStreamingSession {
       .catch((error) => onError?.(error));
   }
 
+  private clearFlushTimer(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  private schedulePendingFlush(): void {
+    if (this.flushTimer || !this.pendingText || this.closed) {
+      return;
+    }
+    const delayMs = Math.max(0, this.updateThrottleMs - (Date.now() - this.lastUpdateTime));
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      const pending = this.pendingText;
+      if (!pending || this.closed) {
+        return;
+      }
+      void this.update(pending);
+    }, delayMs);
+  }
+
   async update(text: string): Promise<void> {
     if (!this.state || this.closed) {
       return;
@@ -329,72 +339,42 @@ export class FeishuStreamingSession {
     if (!mergedInput || mergedInput === this.state.currentText) {
       return;
     }
+    this.pendingText = mergedInput;
+    this.clearFlushTimer();
 
-    // Throttle: skip if updated recently, but remember pending text
+    const shouldForceUpdate = shouldPushStreamingUpdate(this.state.currentText, mergedInput);
+
+    // Throttle tiny intermediate changes, but always flush quickly once we have a
+    // meaningful chunk or a natural boundary so the card feels like deliberate typing.
     const now = Date.now();
-    if (now - this.lastUpdateTime < this.updateThrottleMs) {
-      this.pendingText = mergedInput;
+    if (!shouldForceUpdate && now - this.lastUpdateTime < this.updateThrottleMs) {
+      this.schedulePendingFlush();
       return;
     }
-    this.pendingText = null;
     this.lastUpdateTime = now;
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
 
     this.queue = this.queue.then(async () => {
       if (!this.state || this.closed) {
         return;
       }
-      const mergedText = mergeStreamingText(this.state.currentText, mergedInput);
+      const nextText = this.pendingText ?? mergedInput;
+      const mergedText = mergeStreamingText(this.state.currentText, nextText);
       if (!mergedText || mergedText === this.state.currentText) {
         return;
       }
+      this.pendingText = null;
       this.state.currentText = mergedText;
       await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
     await this.queue;
   }
 
-  private async updateNoteContent(note: string): Promise<void> {
-    if (!this.state || !this.state.hasNote) {
-      return;
-    }
-    const apiBase = resolveApiBase(this.creds.domain);
-    this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/note/content`,
-      init: {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          content: `<font color='grey'>${note}</font>`,
-          sequence: this.state.sequence,
-          uuid: `n_${this.state.cardId}_${this.state.sequence}`,
-        }),
-      },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.note-update",
-    })
-      .then(async ({ release }) => {
-        await release();
-      })
-      .catch((e) => this.log?.(`Note update failed: ${String(e)}`));
-  }
-
-  async close(finalText?: string, options?: { note?: string }): Promise<void> {
+  async close(finalText?: string): Promise<void> {
     if (!this.state || this.closed) {
       return;
     }
     this.closed = true;
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
+    this.clearFlushTimer();
     await this.queue;
 
     const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
@@ -405,11 +385,6 @@ export class FeishuStreamingSession {
     if (text && text !== this.state.currentText) {
       await this.updateCardContent(text);
       this.state.currentText = text;
-    }
-
-    // Update note with final model/provider info
-    if (options?.note) {
-      await this.updateNoteContent(options.note);
     }
 
     // Close streaming mode
@@ -437,11 +412,8 @@ export class FeishuStreamingSession {
         await release();
       })
       .catch((e) => this.log?.(`Close failed: ${String(e)}`));
-    const finalState = this.state;
-    this.state = null;
-    this.pendingText = null;
 
-    this.log?.(`Closed streaming: cardId=${finalState.cardId}`);
+    this.log?.(`Closed streaming: cardId=${this.state.cardId}`);
   }
 
   isActive(): boolean {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Client } from "@larksuiteoapi/node-sdk";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/feishu";
+import { fetchWithSsrFGuard } from "../runtime-api.js";
 import { resolveFeishuCardTemplate } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -8,7 +8,13 @@ import { resolveFeishuCardTemplate } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
 type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
-type CardState = { cardId: string; messageId: string; sequence: number; currentText: string };
+type CardState = {
+  cardId: string;
+  messageId: string;
+  sequence: number;
+  currentText: string;
+  hasNote: boolean;
+};
 
 const STREAMING_UPDATE_THROTTLE_MS = 160;
 const STREAMING_SIGNIFICANT_DELTA_CHARS = 18;
@@ -25,6 +31,7 @@ type StreamingStartOptions = {
   replyInThread?: boolean;
   rootId?: string;
   header?: StreamingCardHeader;
+  note?: string;
 };
 
 // Token cache (keyed by domain + appId)
@@ -201,6 +208,14 @@ export class FeishuStreamingSession {
         elements: [{ tag: "markdown", content: "⏳ Thinking...", element_id: "content" }],
       },
     };
+    if (options?.note) {
+      (cardJson.body as { elements: Record<string, unknown>[] }).elements.push({ tag: "hr" });
+      (cardJson.body as { elements: Record<string, unknown>[] }).elements.push({
+        tag: "markdown",
+        content: `<font color='grey'>${options.note}</font>`,
+        element_id: "note",
+      });
+    }
     if (options?.header) {
       cardJson.header = {
         title: { tag: "plain_text", content: options.header.title },
@@ -277,7 +292,13 @@ export class FeishuStreamingSession {
       throw new Error(`Send card failed: ${sendRes.msg}`);
     }
 
-    this.state = { cardId, messageId: sendRes.data.message_id, sequence: 1, currentText: "" };
+    this.state = {
+      cardId,
+      messageId: sendRes.data.message_id,
+      sequence: 1,
+      currentText: "",
+      hasNote: !!options?.note,
+    };
     this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
   }
 
@@ -370,7 +391,36 @@ export class FeishuStreamingSession {
     await this.queue;
   }
 
-  async close(finalText?: string): Promise<void> {
+  private async updateNoteContent(note: string): Promise<void> {
+    if (!this.state || !this.state.hasNote) {
+      return;
+    }
+    const apiBase = resolveApiBase(this.creds.domain);
+    this.state.sequence += 1;
+    await fetchWithSsrFGuard({
+      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/note/content`,
+      init: {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${await getToken(this.creds)}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          content: `<font color='grey'>${note}</font>`,
+          sequence: this.state.sequence,
+          uuid: `n_${this.state.cardId}_${this.state.sequence}`,
+        }),
+      },
+      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+      auditContext: "feishu.streaming-card.note-update",
+    })
+      .then(async ({ release }) => {
+        await release();
+      })
+      .catch((e) => this.log?.(`Note update failed: ${String(e)}`));
+  }
+
+  async close(finalText?: string, options?: { note?: string }): Promise<void> {
     if (!this.state || this.closed) {
       return;
     }
@@ -386,6 +436,10 @@ export class FeishuStreamingSession {
     if (text && text !== this.state.currentText) {
       await this.updateCardContent(text);
       this.state.currentText = text;
+    }
+
+    if (options?.note) {
+      await this.updateNoteContent(options.note);
     }
 
     // Close streaming mode

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -4,6 +4,7 @@
 
 import type { Client } from "@larksuiteoapi/node-sdk";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/feishu";
+import { resolveFeishuCardTemplate } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
 type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
@@ -203,7 +204,7 @@ export class FeishuStreamingSession {
     if (options?.header) {
       cardJson.header = {
         title: { tag: "plain_text", content: options.header.title },
-        template: options.header.template ?? "blue",
+        template: resolveFeishuCardTemplate(options.header.template) ?? "blue",
       };
     }
 
@@ -413,7 +414,10 @@ export class FeishuStreamingSession {
       })
       .catch((e) => this.log?.(`Close failed: ${String(e)}`));
 
-    this.log?.(`Closed streaming: cardId=${this.state.cardId}`);
+    const finalState = this.state;
+    this.pendingText = null;
+    this.state = null;
+    this.log?.(`Closed streaming: cardId=${finalState.cardId}`);
   }
 
   isActive(): boolean {


### PR DESCRIPTION
## Summary
- throttle tiny intermediate streaming-card edits so Feishu cards update on meaningful deltas or natural text boundaries
- prefer a single markdown card for long structured final replies when live streaming is unavailable
- fall back to chunked markdown cards only after single-card delivery fails, with updated dispatcher coverage

## Testing
- pnpm test -- extensions/feishu/src/reply-dispatcher.test.ts
- pnpm test -- extensions/feishu/src/streaming-card.test.ts

## Notes
- this PR is scoped to streaming-card delivery behavior and its tests
