### PR TITLE
strip whitespace from setup-token input

### DIFF
--- a/extensions/anthropic/index.ts
+++ b/extensions/anthropic/index.ts
@@ -207,14 +207,14 @@ async function runAnthropicSetupToken(ctx: ProviderAuthContext): Promise<Provide
         envVarPlaceholder: "ANTHROPIC_SETUP_TOKEN",
       },
     });
-    token = resolved.resolvedValue.trim();
+    token = resolved.resolvedValue.replace(/\s+/g, "");
     tokenRef = resolved.ref;
   } else {
     const tokenRaw = await ctx.prompter.text({
       message: "Paste Anthropic setup-token",
       validate: (value) => validateAnthropicSetupToken(String(value ?? "")),
     });
-    token = String(tokenRaw ?? "").trim();
+    token = String(tokenRaw ?? "").replace(/\s+/g, "");
   }
   const tokenError = validateAnthropicSetupToken(token);
   if (tokenError) {

--- a/extensions/anthropic/index.ts
+++ b/extensions/anthropic/index.ts
@@ -267,7 +267,7 @@ async function runAnthropicSetupTokenNonInteractive(ctx: {
     return null;
   }
 
-  const token = normalizeSecretInput(ctx.opts.token);
+  const token = normalizeSecretInput(ctx.opts.token).replace(/\s+/g, "");
   if (!token) {
     ctx.runtime.error("Missing --token for --auth-choice token.");
     ctx.runtime.exit(1);

--- a/src/plugins/provider-auth-token.ts
+++ b/src/plugins/provider-auth-token.ts
@@ -24,7 +24,7 @@ export function buildTokenProfileId(params: { provider: string; name: string }):
 }
 
 export function validateAnthropicSetupToken(raw: string): string | undefined {
-  const trimmed = raw.trim();
+  const trimmed = raw.replace(/\s+/g, "");
   if (!trimmed) {
     return "Required";
   }


### PR DESCRIPTION
replaces .trim() with .replace(/\s+/g, "") when handling anthropic setup-token values. tokens shouldn't contain whitespace, but pasting from terminals that wrap long lines can introduce newline characters that silently truncate the token.

four spots changed:
- validateAnthropicSetupToken in provider-auth-token.ts
- env var / secret ref path in extensions/anthropic/index.ts
- interactive paste path in extensions/anthropic/index.ts
- non-interactive --token flag path in extensions/anthropic/index.ts

fixes #53464