### PR TITLE
feat(plugins): expose runId in agent hook context

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -327,6 +327,7 @@ export async function runEmbeddedPiAgent(
       let legacyBeforeAgentStartResult: PluginHookBeforeAgentStartResult | undefined;
       const hookRunner = getGlobalHookRunner();
       const hookCtx = {
+        runId: params.runId,
         agentId: workspaceResolution.agentId,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2730,6 +2730,7 @@ export async function runEmbeddedAttempt(
           },
         );
         const hookCtx = {
+          runId: params.runId,
           agentId: hookAgentId,
           sessionKey: params.sessionKey,
           sessionId: params.sessionId,
@@ -2862,6 +2863,7 @@ export async function runEmbeddedAttempt(
                   imagesCount: imageResult.images.length,
                 },
                 {
+                  runId: params.runId,
                   agentId: hookAgentId,
                   sessionKey: params.sessionKey,
                   sessionId: params.sessionId,
@@ -3092,6 +3094,7 @@ export async function runEmbeddedAttempt(
                 durationMs: Date.now() - promptStartedAt,
               },
               {
+                runId: params.runId,
                 agentId: hookAgentId,
                 sessionKey: params.sessionKey,
                 sessionId: params.sessionId,
@@ -3154,6 +3157,7 @@ export async function runEmbeddedAttempt(
               usage: getUsageTotals(),
             },
             {
+              runId: params.runId,
               agentId: hookAgentId,
               sessionKey: params.sessionKey,
               sessionId: params.sessionId,

--- a/src/plugins/hooks.before-agent-start.test.ts
+++ b/src/plugins/hooks.before-agent-start.test.ts
@@ -175,4 +175,24 @@ describe("before_agent_start hook merger", () => {
     expect(result?.modelOverride).toBe("llama3.3:8b");
     expect(result?.providerOverride).toBe("ollama");
   });
+
+  it("passes runId through the agent context to hook handlers", async () => {
+    const registry = createEmptyPluginRegistry();
+    let capturedCtx: typeof stubCtx | undefined;
+    addTestHook({
+      registry,
+      pluginId: "ctx-spy",
+      hookName: "before_agent_start",
+      handler: ((_event: unknown, ctx: typeof stubCtx) => {
+        capturedCtx = ctx;
+        return {};
+      }) as PluginHookRegistration["handler"],
+    });
+
+    const runner = createHookRunner(registry);
+    await runner.runBeforeAgentStart({ prompt: "test" }, stubCtx);
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.runId).toBe("test-run-id");
+  });
 });

--- a/src/plugins/hooks.test-helpers.ts
+++ b/src/plugins/hooks.test-helpers.ts
@@ -56,6 +56,7 @@ export function createMockPluginRegistry(
 }
 
 export const TEST_PLUGIN_AGENT_CTX: PluginHookAgentContext = {
+  runId: "test-run-id",
   agentId: "test-agent",
   sessionKey: "test-session",
   sessionId: "test-session-id",

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1478,6 +1478,8 @@ export const isPromptInjectionHookName = (hookName: PluginHookName): boolean =>
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
+  /** Unique identifier for this agent run. */
+  runId?: string;
   agentId?: string;
   sessionKey?: string;
   sessionId?: string;


### PR DESCRIPTION
## Summary
- Adds `runId` to agent hook context so plugins can identify the current run
- Enables correlation between hook events and specific agent executions

## Test plan
- [ ] Existing agent hook tests pass
- [ ] runId is present in hook context during agent execution