### PR TITLE
fix(secrets): prevent unresolved SecretRef from crashing embedded agent runs

### DIFF
--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -587,25 +587,24 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     // and proactive sends within the same session.
     // Apply Teams clientInfo timezone if no explicit userTimezone is configured.
     const senderTimezone = clientInfo?.timezone || conversationRef.timezone;
-    const effectiveCfg =
+    const configOverride =
       senderTimezone && !cfg.agents?.defaults?.userTimezone
         ? {
-            ...cfg,
             agents: {
-              ...cfg.agents,
               defaults: { ...cfg.agents?.defaults, userTimezone: senderTimezone },
             },
           }
-        : cfg;
+        : undefined;
 
     log.info("dispatching to agent", { sessionKey: route.sessionKey });
     try {
       const { queuedFinal, counts } = await dispatchReplyFromConfigWithSettledDispatcher({
-        cfg: effectiveCfg,
+        cfg,
         ctxPayload,
         dispatcher,
         onSettled: () => markDispatchIdle(),
         replyOptions,
+        configOverride,
       });
 
       log.info("dispatch complete", { queuedFinal, counts });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2659,7 +2659,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(receivedCfg).toBe(overrideCfg);
   });
 
-  it("passes base cfg to replyResolver when configOverride is not provided", async () => {
+  it("does not pass cfg as implicit configOverride when configOverride is not provided", async () => {
     setNoAbort();
     const cfg = { agents: { defaults: { userTimezone: "UTC" } } } as OpenClawConfig;
     const dispatcher = createDispatcher();
@@ -2677,7 +2677,7 @@ describe("dispatchReplyFromConfig", () => {
 
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(receivedCfg).toBe(cfg);
+    expect(receivedCfg).toBeUndefined();
   });
 
   it("suppresses isReasoning payloads from final replies (WhatsApp channel)", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -643,7 +643,7 @@ export async function dispatchReplyFromConfig(params: {
           return run();
         },
       },
-      params.configOverride ?? cfg,
+      params.configOverride,
     );
 
     if (ctx.AcpDispatchTailAfterReset === true) {

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
+import { registerGetReplyCommonMocks } from "./get-reply.test-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+
+registerGetReplyCommonMocks();
+
+vi.mock("../../link-understanding/apply.runtime.js", () => ({
+  applyLinkUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("../../media-understanding/apply.runtime.js", () => ({
+  applyMediaUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("./directive-handling.defaults.js", () => ({
+  resolveDefaultModel: vi.fn(() => ({
+    defaultProvider: "openai",
+    defaultModel: "gpt-4o-mini",
+    aliasIndex: new Map(),
+  })),
+}));
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+vi.mock("./get-reply-inline-actions.js", () => ({
+  handleInlineActions: vi.fn(async () => ({ kind: "reply", reply: { text: "ok" } })),
+}));
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+
+let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let loadConfigMock: typeof import("../../config/config.js").loadConfig;
+
+async function loadFreshGetReplyModuleForTest() {
+  vi.resetModules();
+  ({ getReplyFromConfig } = await import("./get-reply.js"));
+  ({ loadConfig: loadConfigMock } = await import("../../config/config.js"));
+}
+
+function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    ChatType: "direct",
+    Body: "hello",
+    BodyForAgent: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    SessionKey: "agent:main:telegram:123",
+    From: "telegram:user:42",
+    To: "telegram:123",
+    Timestamp: 1710000000000,
+    ...overrides,
+  };
+}
+
+describe("getReplyFromConfig configOverride", () => {
+  beforeEach(async () => {
+    await loadFreshGetReplyModuleForTest();
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    vi.mocked(loadConfigMock).mockReset();
+
+    vi.mocked(loadConfigMock).mockReturnValue({});
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: false,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+  });
+
+  it("merges configOverride over fresh loadConfig()", async () => {
+    vi.mocked(loadConfigMock).mockReturnValue({
+      channels: {
+        telegram: {
+          botToken: "resolved-telegram-token",
+        },
+      },
+      agents: {
+        defaults: {
+          userTimezone: "UTC",
+        },
+      },
+    } satisfies OpenClawConfig);
+
+    await getReplyFromConfig(buildCtx(), undefined, {
+      agents: {
+        defaults: {
+          userTimezone: "America/New_York",
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: expect.objectContaining({
+          channels: expect.objectContaining({
+            telegram: expect.objectContaining({
+              botToken: "resolved-telegram-token",
+            }),
+          }),
+          agents: expect.objectContaining({
+            defaults: expect.objectContaining({
+              userTimezone: "America/New_York",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -9,7 +9,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
-import { coerceSecretRef } from "../../config/types.secrets.js";
+import { applyMergePatch } from "../../config/merge-patch.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -100,74 +100,16 @@ async function applyLinkUnderstandingIfNeeded(params: {
   return true;
 }
 
-/**
- * Check whether a config object has unresolved SecretRef values in channel
- * token fields.  Channel monitors (Telegram, Slack, Discord) capture a config
- * snapshot at startup and pass it as `configOverride` into the reply pipeline.
- * If the snapshot was taken before secrets were resolved, it still contains raw
- * SecretRef objects.  Falling back to `loadConfig()` (which reads the runtime
- * snapshot with resolved secrets) prevents the embedded agent run from crashing
- * with "unresolved SecretRef" errors.
- *
- * See: https://github.com/openclaw/openclaw/issues/45838
- */
-function hasUnresolvedChannelSecrets(cfg: OpenClawConfig): boolean {
-  const check = (value: unknown): boolean => coerceSecretRef(value) !== null;
-  const telegram = cfg.channels?.telegram;
-  if (telegram) {
-    if (check(telegram.botToken)) {
-      return true;
-    }
-    for (const account of Object.values(telegram.accounts ?? {})) {
-      if (account && check((account as Record<string, unknown>).botToken)) {
-        return true;
-      }
-    }
-  }
-  const channels = cfg.channels as Record<string, unknown> | undefined;
-  for (const channelKey of ["slack", "discord"] as const) {
-    const channel = channels?.[channelKey] as Record<string, unknown> | undefined;
-    if (!channel) {
-      continue;
-    }
-    for (const tokenKey of ["botToken", "appToken", "token", "userToken"]) {
-      if (check(channel[tokenKey])) {
-        return true;
-      }
-    }
-    const accounts = channel.accounts as Record<string, unknown> | undefined;
-    if (accounts) {
-      for (const account of Object.values(accounts)) {
-        if (account && typeof account === "object") {
-          for (const tokenKey of ["botToken", "appToken", "token", "userToken"]) {
-            if (check((account as Record<string, unknown>)[tokenKey])) {
-              return true;
-            }
-          }
-        }
-      }
-    }
-  }
-  return false;
-}
-
 export async function getReplyFromConfig(
   ctx: MsgContext,
   opts?: GetReplyOptions,
   configOverride?: OpenClawConfig,
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const isFastTestEnv = process.env.OPENCLAW_TEST_FAST === "1";
-  // When the caller-supplied config still contains unresolved SecretRef objects
-  // (for example a stale startup snapshot from a channel monitor), discard it
-  // and use the runtime snapshot via loadConfig() instead.
-  const hasStaleSecrets = configOverride != null && hasUnresolvedChannelSecrets(configOverride);
-  if (hasStaleSecrets) {
-    defaultRuntime.error?.(
-      "getReplyFromConfig: configOverride contains unresolved SecretRef — falling back to loadConfig()",
-    );
-  }
-  const safeOverride = hasStaleSecrets ? undefined : configOverride;
-  const cfg = safeOverride ?? loadConfig();
+  const cfg =
+    configOverride == null
+      ? loadConfig()
+      : (applyMergePatch(loadConfig(), configOverride) as OpenClawConfig);
   const targetSessionKey =
     ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
   const agentSessionKey = targetSessionKey || ctx.SessionKey;

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -9,6 +9,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { coerceSecretRef } from "../../config/types.secrets.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
@@ -99,13 +100,74 @@ async function applyLinkUnderstandingIfNeeded(params: {
   return true;
 }
 
+/**
+ * Check whether a config object has unresolved SecretRef values in channel
+ * token fields.  Channel monitors (Telegram, Slack, Discord) capture a config
+ * snapshot at startup and pass it as `configOverride` into the reply pipeline.
+ * If the snapshot was taken before secrets were resolved, it still contains raw
+ * SecretRef objects.  Falling back to `loadConfig()` (which reads the runtime
+ * snapshot with resolved secrets) prevents the embedded agent run from crashing
+ * with "unresolved SecretRef" errors.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/45838
+ */
+function hasUnresolvedChannelSecrets(cfg: OpenClawConfig): boolean {
+  const check = (value: unknown): boolean => coerceSecretRef(value) !== null;
+  const telegram = cfg.channels?.telegram;
+  if (telegram) {
+    if (check(telegram.botToken)) {
+      return true;
+    }
+    for (const account of Object.values(telegram.accounts ?? {})) {
+      if (account && check((account as Record<string, unknown>).botToken)) {
+        return true;
+      }
+    }
+  }
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  for (const channelKey of ["slack", "discord"] as const) {
+    const channel = channels?.[channelKey] as Record<string, unknown> | undefined;
+    if (!channel) {
+      continue;
+    }
+    for (const tokenKey of ["botToken", "appToken", "token", "userToken"]) {
+      if (check(channel[tokenKey])) {
+        return true;
+      }
+    }
+    const accounts = channel.accounts as Record<string, unknown> | undefined;
+    if (accounts) {
+      for (const account of Object.values(accounts)) {
+        if (account && typeof account === "object") {
+          for (const tokenKey of ["botToken", "appToken", "token", "userToken"]) {
+            if (check((account as Record<string, unknown>)[tokenKey])) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 export async function getReplyFromConfig(
   ctx: MsgContext,
   opts?: GetReplyOptions,
   configOverride?: OpenClawConfig,
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const isFastTestEnv = process.env.OPENCLAW_TEST_FAST === "1";
-  const cfg = configOverride ?? loadConfig();
+  // When the caller-supplied config still contains unresolved SecretRef objects
+  // (for example a stale startup snapshot from a channel monitor), discard it
+  // and use the runtime snapshot via loadConfig() instead.
+  const hasStaleSecrets = configOverride != null && hasUnresolvedChannelSecrets(configOverride);
+  if (hasStaleSecrets) {
+    defaultRuntime.error?.(
+      "getReplyFromConfig: configOverride contains unresolved SecretRef — falling back to loadConfig()",
+    );
+  }
+  const safeOverride = hasStaleSecrets ? undefined : configOverride;
+  const cfg = safeOverride ?? loadConfig();
   const targetSessionKey =
     ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
   const agentSessionKey = targetSessionKey || ctx.SessionKey;

--- a/src/plugin-sdk/inbound-reply-dispatch.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.ts
@@ -27,6 +27,7 @@ export async function dispatchReplyFromConfigWithSettledDispatcher(params: {
   dispatcher: ReplyDispatcher;
   onSettled: () => void | Promise<void>;
   replyOptions?: ReplyDispatchFromConfigOptions;
+  configOverride?: OpenClawConfig;
 }): Promise<DispatchFromConfigResult> {
   return await withReplyDispatcher({
     dispatcher: params.dispatcher,
@@ -37,6 +38,7 @@ export async function dispatchReplyFromConfigWithSettledDispatcher(params: {
         cfg: params.cfg,
         dispatcher: params.dispatcher,
         replyOptions: params.replyOptions,
+        configOverride: params.configOverride,
       }),
   });
 }


### PR DESCRIPTION
## Before
<img width="736" height="332" alt="CleanShot 2026-03-24 at 12 00 15@2x" src="https://github.com/user-attachments/assets/88fcc0e9-d0fe-43cd-a8de-22bdd69c4d80" />


## After
<img width="716" height="510" alt="CleanShot 2026-03-24 at 12 00 24@2x" src="https://github.com/user-attachments/assets/87f283cc-c5ab-4af9-bef2-f505a4c3c5fc" />


## Summary

When channel monitors (Telegram, Slack, Discord) start, they capture a config snapshot via `loadConfig()`. If this happens before the secrets runtime snapshot is activated, the captured config still contains raw `SecretRef` objects (e.g. `{source: "exec", provider: "doppler", id: "TG_PERSONAL_BOT_TOKEN"}`).

This captured config is then passed as `configOverride` through the dispatch chain into `getReplyFromConfig()`, which uses it directly — skipping the snapshot-aware `loadConfig()` that would return resolved secrets. The stale config propagates into `FollowupRun.run.config` and eventually crashes `runEmbeddedPiAgent()` with:

```
channels.telegram.accounts.personal.botToken: unresolved SecretRef "exec:doppler:TG_PERSONAL_BOT_TOKEN".
Resolve this command against an active gateway runtime snapshot before reading it.
```

This affects all channels using `exec:`, `env:`, or `file:` SecretRef providers for bot tokens.

## Root cause

The dispatch chain from channel monitor to embedded agent:

1. `server-channels.ts`: `const cfg = loadConfig()` at startup (before secrets resolved)
2. Telegram monitor stores `cfg` in long-lived closure
3. `bot-message-dispatch.ts`: passes stale `cfg` as `configOverride`
4. `get-reply.ts:108`: `const cfg = configOverride ?? loadConfig()` — since `configOverride` exists, `loadConfig()` is never called
5. `get-reply-run.ts`: stores in `FollowupRun.run.config`
6. `runEmbeddedPiAgent()` receives unresolved config — crash

## Fix

Add `hasUnresolvedChannelSecrets()` check in `getReplyFromConfig()`. When `configOverride` contains unresolved `SecretRef` objects in channel token fields, discard it and fall back to `loadConfig()` which returns the resolved runtime snapshot.

## Test plan

- [x] Verified `/new` and `/reset` commands no longer crash with SecretRef error
- [x] Verified normal message flow works after fix
- [x] `pnpm lint` clean
- [x] `pnpm check` clean (no new type errors)
- [x] Tested on real setup with `exec:doppler` SecretRef for Telegram bot token

## Related issues

- Fixes #45838
- Related to #51263 (Discord), #48347 (Mattermost fix, same pattern)

## Codebase search

- Traced full dispatch chain: `server-channels.ts` -> `channel.ts` -> `bot-message-dispatch.ts` -> `dispatch-from-config.ts` -> `get-reply.ts` -> `get-reply-run.ts` -> `runEmbeddedPiAgent`
- Verified `runtimeConfigSnapshot` is set correctly but bypassed via `configOverride`
- Added debug instrumentation (PID, moduleId, clear traces) confirming same-process, no clear, snapshot set but unused

lobster-biscuit

## Sign-Off

AI-assisted: Claude Opus 4 + GPT-5.4 (via OpenClaw). Fully tested on real setup. The author understands the code and the fix.