### PR TITLE
fix: support llama-cpp and Ollama usage field names (#53448)

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -116,8 +116,22 @@ export function normalizeCliModel(modelId: string, backend: CliBackendConfig): s
 function toUsage(raw: Record<string, unknown>): CliUsage | undefined {
   const pick = (key: string) =>
     typeof raw[key] === "number" && raw[key] > 0 ? raw[key] : undefined;
-  const input = pick("input_tokens") ?? pick("inputTokens");
-  const output = pick("output_tokens") ?? pick("outputTokens");
+  // Support multiple field name formats for different providers:
+  // - OpenAI/vLLM/HuggingFace: input_tokens, output_tokens
+  // - llama.cpp server: prompt_tokens, completion_tokens
+  // - Ollama: prompt_eval_count, eval_count
+  const input =
+    pick("input_tokens") ??
+    pick("inputTokens") ??
+    pick("prompt_tokens") ??
+    pick("promptTokens") ??
+    pick("prompt_eval_count");
+  const output =
+    pick("output_tokens") ??
+    pick("outputTokens") ??
+    pick("completion_tokens") ??
+    pick("completionTokens") ??
+    pick("eval_count");
   const cacheRead =
     pick("cache_read_input_tokens") ?? pick("cached_input_tokens") ?? pick("cacheRead");
   const cacheWrite = pick("cache_write_input_tokens") ?? pick("cacheWrite");


### PR DESCRIPTION
## Summary

Fixes #53448 - llama-cpp and Ollama providers return incorrect context usage due to field name mismatch

## Root Cause

OpenClaw expected only OpenAI-style field names but different providers use different formats:

| Provider | Input Field | Output Field |
|----------|-------------|--------------|
| OpenAI/vLLM/HuggingFace | input_tokens | output_tokens |
| llama.cpp server | prompt_tokens | completion_tokens |
| Ollama | prompt_eval_count | eval_count |

This caused context usage to display as 0/80k (0%) even when tokens were being consumed.

## Fix

Extended toUsage() function in src/agents/cli-runner/helpers.ts to support all field name formats.

## Testing

- [x] pnpm run check passes
- [x] pnpm run lint passes
- [x] Backward compatible with existing providers
- [x] No breaking changes

## Impact

- ✅ Fixes context usage display for llama-cpp server users
- ✅ Fixes context usage display for Ollama users
- ✅ Prevents context overflow without warning
- ✅ Enables LCM auto-compression mechanism
- ✅ Accurate cost monitoring

## Related Issue

Closes #53448