### PR TITLE
fix(image-generation): reload providers when active registry is empty

### DIFF
--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 
@@ -55,6 +56,36 @@ describe("image-generation provider registry", () => {
 
     expect(provider?.id).toBe("custom-image");
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to config-backed plugin loading when the active registry has no image providers", () => {
+    const activeRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(activeRegistry, "existing-registry");
+
+    const loadedRegistry = createEmptyPluginRegistry();
+    loadedRegistry.imageGenerationProviders.push({
+      pluginId: "openai",
+      pluginName: "OpenAI",
+      source: "test",
+      provider: {
+        id: "openai",
+        capabilities: {
+          generate: {},
+          edit: { enabled: false },
+        },
+        generateImage: async () => ({
+          images: [{ buffer: Buffer.from("image"), mimeType: "image/png" }],
+        }),
+      },
+    });
+    loadOpenClawPluginsMock.mockReturnValue(loadedRegistry);
+
+    const provider = getImageGenerationProvider("openai", {} as OpenClawConfig);
+
+    expect(provider?.id).toBe("openai");
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith({
+      config: {},
+    });
   });
 
   it("ignores prototype-like provider ids and aliases", () => {

--- a/src/image-generation/provider-registry.test.ts
+++ b/src/image-generation/provider-registry.test.ts
@@ -88,6 +88,22 @@ describe("image-generation provider registry", () => {
     });
   });
 
+  it("does not reload the same empty registry key on every lookup", () => {
+    const activeRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(activeRegistry, "existing-registry");
+
+    loadOpenClawPluginsMock.mockImplementation(() => {
+      const loadedRegistry = createEmptyPluginRegistry();
+      setActivePluginRegistry(loadedRegistry, "existing-registry");
+      return loadedRegistry;
+    });
+
+    expect(getImageGenerationProvider("openai", {} as OpenClawConfig)).toBeUndefined();
+    expect(getImageGenerationProvider("openai", {} as OpenClawConfig)).toBeUndefined();
+
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("ignores prototype-like provider ids and aliases", () => {
     const registry = createEmptyPluginRegistry();
     registry.imageGenerationProviders.push(

--- a/src/image-generation/provider-registry.ts
+++ b/src/image-generation/provider-registry.ts
@@ -2,11 +2,12 @@ import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getActivePluginRegistry, getActivePluginRegistryKey } from "../plugins/runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_IMAGE_GENERATION_PROVIDERS: readonly ImageGenerationProviderPlugin[] = [];
 const UNSAFE_PROVIDER_IDS = new Set(["__proto__", "constructor", "prototype"]);
+const imageGenerationBootstrapAttempts = new Set<string>();
 
 function normalizeImageGenerationProviderId(id: string | undefined): string | undefined {
   const normalized = normalizeProviderId(id ?? "");
@@ -20,14 +21,36 @@ function isSafeImageGenerationProviderId(id: string | undefined): id is string {
   return Boolean(id && !UNSAFE_PROVIDER_IDS.has(id));
 }
 
+function getImageGenerationBootstrapAttemptKey(): string {
+  return getActivePluginRegistryKey() ?? "<none>";
+}
+
 function resolvePluginImageGenerationProviders(
   cfg?: OpenClawConfig,
 ): ImageGenerationProviderPlugin[] {
   const active = getActivePluginRegistry();
-  const registry =
-    (active?.imageGenerationProviders?.length ?? 0) > 0 || !cfg
-      ? active
-      : loadOpenClawPlugins({ config: cfg });
+  if ((active?.imageGenerationProviders?.length ?? 0) > 0 || !cfg) {
+    return active?.imageGenerationProviders?.map((entry) => entry.provider) ?? [];
+  }
+
+  const attemptKey = getImageGenerationBootstrapAttemptKey();
+  if (imageGenerationBootstrapAttempts.has(attemptKey)) {
+    return active?.imageGenerationProviders?.map((entry) => entry.provider) ?? [];
+  }
+
+  imageGenerationBootstrapAttempts.add(attemptKey);
+  let registry;
+  try {
+    registry = loadOpenClawPlugins({ config: cfg });
+  } catch (error) {
+    imageGenerationBootstrapAttempts.delete(attemptKey);
+    throw error;
+  }
+
+  const activeKeyAfterLoad = getActivePluginRegistryKey();
+  if (activeKeyAfterLoad) {
+    imageGenerationBootstrapAttempts.add(activeKeyAfterLoad);
+  }
   return registry?.imageGenerationProviders?.map((entry) => entry.provider) ?? [];
 }
 

--- a/src/image-generation/provider-registry.ts
+++ b/src/image-generation/provider-registry.ts
@@ -2,7 +2,7 @@ import { normalizeProviderId } from "../agents/model-selection.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
-import { getActivePluginRegistry, getActivePluginRegistryKey } from "../plugins/runtime.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
 import type { ImageGenerationProviderPlugin } from "../plugins/types.js";
 
 const BUILTIN_IMAGE_GENERATION_PROVIDERS: readonly ImageGenerationProviderPlugin[] = [];
@@ -25,7 +25,7 @@ function resolvePluginImageGenerationProviders(
 ): ImageGenerationProviderPlugin[] {
   const active = getActivePluginRegistry();
   const registry =
-    (active?.imageGenerationProviders?.length ?? 0) > 0 || getActivePluginRegistryKey() || !cfg
+    (active?.imageGenerationProviders?.length ?? 0) > 0 || !cfg
       ? active
       : loadOpenClawPlugins({ config: cfg });
   return registry?.imageGenerationProviders?.map((entry) => entry.provider) ?? [];


### PR DESCRIPTION
## Summary
Image-generation provider lookup could get stuck on an active plugin registry snapshot that already had a cache key but no image-generation providers. In that state, `image_generate` would skip the config-backed plugin reload path and incorrectly report `No image-generation provider registered for ...` even when the provider plugin was configured and available.

This change only falls back to `loadOpenClawPlugins({ config })` when the active registry does not currently expose any image-generation providers, and adds a regression test that covers the empty-active-registry-with-config path.

## Testing
- `./node_modules/.bin/vitest run src/image-generation/provider-registry.test.ts --maxWorkers=1`
- `./node_modules/.bin/vitest run src/image-generation/provider-registry.test.ts src/agents/openclaw-tools.image-generation.test.ts --maxWorkers=1`

Fixes #53450
Fixes #53210