### PR TITLE
fix: confirm saved model selections conservatively

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -619,4 +619,28 @@ describe("session_status tool", () => {
     expect(saved.modelOverride).toBeUndefined();
     expect(saved.authProfileOverride).toBeUndefined();
   });
+
+  it("notes that a saved model selection applies on the next reply cycle", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "s1",
+        updatedAt: 10,
+      },
+    });
+
+    const tool = getSessionStatusTool();
+    const result = await tool.execute("call-model-note", { model: "anthropic/claude-sonnet-4-6" });
+    const details = result.details as {
+      ok?: boolean;
+      changedModel?: boolean;
+      modelActivation?: string;
+      statusText?: string;
+    };
+
+    expect(details.ok).toBe(true);
+    expect(details.changedModel).toBe(true);
+    expect(details.modelActivation).toBe("next_reply");
+    expect(details.statusText).toContain("Model selection saved.");
+    expect(details.statusText).toContain("next reply cycle");
+  });
 });

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -510,14 +510,19 @@ export function createSessionStatusTool(opts?: {
         },
         includeTranscriptUsage: true,
       });
+      const modelChangeNote = changedModel
+        ? "\nℹ️ Model selection saved. The updated selection will be used on the next reply cycle."
+        : "";
+      const finalStatusText = `${statusText}${modelChangeNote}`;
 
       return {
-        content: [{ type: "text", text: statusText }],
+        content: [{ type: "text", text: finalStatusText }],
         details: {
           ok: true,
           sessionKey: resolved.key,
           changedModel,
-          statusText,
+          statusText: finalStatusText,
+          modelActivation: changedModel ? "next_reply" : "current",
         },
       };
     },

--- a/src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts
@@ -87,7 +87,7 @@ describe("directive behavior", () => {
     storePath: string;
   }) {
     const text = Array.isArray(params.response) ? params.response[0]?.text : params.response?.text;
-    expect(text).toContain("Model set to moonshot/kimi-k2-0905-preview.");
+    expect(text).toContain("Model selection saved as moonshot/kimi-k2-0905-preview.");
     assertModelSelection(params.storePath, {
       provider: "moonshot",
       model: "kimi-k2-0905-preview",
@@ -243,7 +243,7 @@ describe("directive behavior", () => {
       );
 
       const text = replyText(res);
-      expect(text).toContain("Model set to Kimi (moonshot/kimi-k2-0905-preview).");
+      expect(text).toContain("Model selection saved as Kimi (moonshot/kimi-k2-0905-preview).");
       assertModelSelection(storePath, {
         provider: "moonshot",
         model: "kimi-k2-0905-preview",
@@ -298,7 +298,7 @@ describe("directive behavior", () => {
       );
 
       let events = drainSystemEvents(MAIN_SESSION_KEY);
-      expect(events).toContain("Model switched to Opus (anthropic/claude-opus-4-5).");
+      expect(events).toContain("Model selection saved as Opus (anthropic/claude-opus-4-5).");
 
       drainSystemEvents(MAIN_SESSION_KEY);
 

--- a/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts
@@ -504,7 +504,7 @@ describe("trigger handling", () => {
       );
 
       const text = Array.isArray(res) ? res[0]?.text : res?.text;
-      expect(text).toContain("Model set to openai/gpt-4.1-mini");
+      expect(text).toContain("Model selection saved as openai/gpt-4.1-mini");
 
       const store = loadSessionStore(storePath);
       expect(store[targetSessionKey]?.providerOverride).toBe("openai");

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -12,6 +12,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { formatThinkingLevels, formatXHighModelHint, supportsXHighThinking } from "../thinking.js";
+import { resolveSelectedAndActiveModel } from "../model-runtime.js";
 import type { ReplyPayload } from "../types.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import { maybeHandleModelDirectiveInfo } from "./directive-handling.model.js";
@@ -330,6 +331,13 @@ export async function handleDirectiveOnly(
     directives.fastMode !== currentFastMode;
   let reasoningChanged =
     directives.hasReasoningDirective && directives.reasoningLevel !== undefined;
+  const previousModelRefs = modelSelection
+    ? resolveSelectedAndActiveModel({
+        selectedProvider: provider,
+        selectedModel: model,
+        sessionEntry,
+      })
+    : null;
   if (shouldPersistSessionEntry) {
     if (directives.hasThinkDirective && directives.thinkLevel) {
       sessionEntry.thinkingLevel = directives.thinkLevel;
@@ -500,11 +508,16 @@ export async function handleDirectiveOnly(
   if (modelSelection) {
     const label = `${modelSelection.provider}/${modelSelection.model}`;
     const labelWithAlias = modelSelection.alias ? `${modelSelection.alias} (${label})` : label;
-    parts.push(
-      modelSelection.isDefault
-        ? `Model reset to default (${labelWithAlias}).`
-        : `Model set to ${labelWithAlias}.`,
-    );
+    const savedLine = modelSelection.isDefault
+      ? `Model selection reset to default (${labelWithAlias}).`
+      : `Model selection saved as ${labelWithAlias}.`;
+    if (previousModelRefs && previousModelRefs.active.label !== label) {
+      parts.push(
+        `${savedLine} Active runtime was ${previousModelRefs.active.label}; the new selection will be used on the next reply.`,
+      );
+    } else {
+      parts.push(savedLine);
+    }
     if (profileOverride) {
       parts.push(`Auth profile set to ${profileOverride}.`);
     }

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -600,7 +600,7 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     };
   }
 
-  it("shows success message when session state is available", async () => {
+  it("uses a saved-selection message when session state is available", async () => {
     const directives = parseInlineDirectives("/model openai/gpt-4o");
     const sessionEntry = createSessionEntry();
     const result = await handleDirectiveOnly(
@@ -610,9 +610,9 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       }),
     );
 
-    expect(result?.text).toContain("Model set to");
+    expect(result?.text).toContain("Model selection saved as");
     expect(result?.text).toContain("openai/gpt-4o");
-    expect(result?.text).not.toContain("failed");
+    expect(result?.text).toContain("the new selection will be used on the next reply");
   });
 
   it("shows no model message when no /model directive", async () => {
@@ -625,7 +625,7 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       }),
     );
 
-    expect(result?.text ?? "").not.toContain("Model set to");
+    expect(result?.text ?? "").not.toContain("Model selection saved as");
     expect(result?.text ?? "").not.toContain("failed");
   });
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -457,7 +457,9 @@ export async function resolveReplyDirectives(params: {
 
   const initialModelLabel = `${provider}/${model}`;
   const formatModelSwitchEvent = (label: string, alias?: string) =>
-    alias ? `Model switched to ${alias} (${label}).` : `Model switched to ${label}.`;
+    alias
+      ? `Model selection saved as ${alias} (${label}).`
+      : `Model selection saved as ${label}.`;
   const isModelListAlias =
     directives.hasModelDirective &&
     ["status", "list"].includes(directives.rawModelDirective?.trim().toLowerCase() ?? "");


### PR DESCRIPTION
## Summary
- stop claiming model directives immediately switched the active runtime
- report model selections as saved selections in chat acknowledgements and system events
- annotate `session_status` mutations so agents know the new selection applies on the next reply cycle

## Validation
- `pnpm exec vitest run src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts src/auto-reply/reply.triggers.trigger-handling.targets-active-session-native-stop.e2e.test.ts src/agents/openclaw-tools.session-status.test.ts`