### PR TITLE
fix(auth): keep fresher Codex re-auth state

### DIFF
--- a/src/agents/auth-profiles.external-cli-sync.test.ts
+++ b/src/agents/auth-profiles.external-cli-sync.test.ts
@@ -95,4 +95,40 @@ describe("syncExternalCliCredentials", () => {
       expires: freshExpiry,
     });
   });
+
+  it("does not overwrite newer stored Codex credentials with older external CLI credentials", () => {
+    const staleExpiry = Date.now() + 30 * 60_000;
+    const freshExpiry = Date.now() + 5 * 24 * 60 * 60_000;
+    mocks.readCodexCliCredentialsCached.mockReturnValue({
+      type: "oauth",
+      provider: "openai-codex",
+      access: "stale-access-token",
+      refresh: "stale-refresh-token",
+      expires: staleExpiry,
+      accountId: "acct_789",
+    });
+
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [OPENAI_CODEX_DEFAULT_PROFILE_ID]: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "fresh-access-token",
+          refresh: "fresh-refresh-token",
+          expires: freshExpiry,
+          accountId: "acct_789",
+        },
+      },
+    };
+
+    const mutated = syncExternalCliCredentials(store);
+
+    expect(mutated).toBe(false);
+    expect(store.profiles[OPENAI_CODEX_DEFAULT_PROFILE_ID]).toMatchObject({
+      access: "fresh-access-token",
+      refresh: "fresh-refresh-token",
+      expires: freshExpiry,
+    });
+  });
 });

--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -36,6 +36,18 @@ function shallowEqualOAuthCredentials(a: OAuthCredential | undefined, b: OAuthCr
   );
 }
 
+function hasNewerStoredOAuthCredential(
+  existing: OAuthCredential | undefined,
+  incoming: OAuthCredential,
+): boolean {
+  return Boolean(
+    existing &&
+    existing.provider === incoming.provider &&
+    Number.isFinite(existing.expires) &&
+    (!Number.isFinite(incoming.expires) || existing.expires > incoming.expires),
+  );
+}
+
 /** Sync external CLI credentials into the store for a given provider. */
 function syncExternalCliCredentialsForProvider(
   store: AuthProfileStore,
@@ -52,6 +64,18 @@ function syncExternalCliCredentialsForProvider(
 
   const existingOAuth = existing?.type === "oauth" ? existing : undefined;
   if (shallowEqualOAuthCredentials(existingOAuth, creds)) {
+    return false;
+  }
+  if (hasNewerStoredOAuthCredential(existingOAuth, creds)) {
+    if (options.log !== false) {
+      log.debug(`kept newer stored ${provider} credentials over external cli sync`, {
+        profileId,
+        storedExpires: new Date(existingOAuth!.expires).toISOString(),
+        externalExpires: Number.isFinite(creds.expires)
+          ? new Date(creds.expires).toISOString()
+          : null,
+      });
+    }
     return false;
   }
 

--- a/src/agents/cli-credentials.test.ts
+++ b/src/agents/cli-credentials.test.ts
@@ -7,6 +7,7 @@ const execSyncMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const CLI_CREDENTIALS_CACHE_TTL_MS = 15 * 60 * 1000;
 let readClaudeCliCredentialsCached: typeof import("./cli-credentials.js").readClaudeCliCredentialsCached;
+let readCodexCliCredentialsCached: typeof import("./cli-credentials.js").readCodexCliCredentialsCached;
 let resetCliCredentialCachesForTest: typeof import("./cli-credentials.js").resetCliCredentialCachesForTest;
 let writeClaudeCliKeychainCredentials: typeof import("./cli-credentials.js").writeClaudeCliKeychainCredentials;
 let writeClaudeCliCredentials: typeof import("./cli-credentials.js").writeClaudeCliCredentials;
@@ -56,6 +57,7 @@ describe("cli credentials", () => {
   beforeAll(async () => {
     ({
       readClaudeCliCredentialsCached,
+      readCodexCliCredentialsCached,
       resetCliCredentialCachesForTest,
       writeClaudeCliKeychainCredentials,
       writeClaudeCliCredentials,
@@ -291,5 +293,65 @@ describe("cli credentials", () => {
       provider: "openai-codex",
       expires: expSeconds * 1000,
     });
+  });
+
+  it("invalidates cached Codex credentials when auth.json changes within the TTL window", () => {
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-cache-"));
+    process.env.CODEX_HOME = tempHome;
+    const authPath = path.join(tempHome, "auth.json");
+    const firstExpiry = Math.floor(Date.parse("2026-03-24T12:34:56Z") / 1000);
+    const secondExpiry = Math.floor(Date.parse("2026-03-25T12:34:56Z") / 1000);
+    try {
+      fs.mkdirSync(tempHome, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          tokens: {
+            access_token: createJwtWithExp(firstExpiry),
+            refresh_token: "stale-refresh",
+          },
+        }),
+        "utf8",
+      );
+      fs.utimesSync(authPath, new Date("2026-03-24T10:00:00Z"), new Date("2026-03-24T10:00:00Z"));
+      vi.setSystemTime(new Date("2026-03-24T10:00:00Z"));
+
+      const first = readCodexCliCredentialsCached({
+        ttlMs: CLI_CREDENTIALS_CACHE_TTL_MS,
+        platform: "linux",
+        execSync: execSyncMock,
+      });
+
+      expect(first).toMatchObject({
+        refresh: "stale-refresh",
+        expires: firstExpiry * 1000,
+      });
+
+      fs.writeFileSync(
+        authPath,
+        JSON.stringify({
+          tokens: {
+            access_token: createJwtWithExp(secondExpiry),
+            refresh_token: "fresh-refresh",
+          },
+        }),
+        "utf8",
+      );
+      fs.utimesSync(authPath, new Date("2026-03-24T10:05:00Z"), new Date("2026-03-24T10:05:00Z"));
+      vi.advanceTimersByTime(60_000);
+
+      const second = readCodexCliCredentialsCached({
+        ttlMs: CLI_CREDENTIALS_CACHE_TTL_MS,
+        platform: "linux",
+        execSync: execSyncMock,
+      });
+
+      expect(second).toMatchObject({
+        refresh: "fresh-refresh",
+        expires: secondExpiry * 1000,
+      });
+    } finally {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -21,6 +21,7 @@ type CachedValue<T> = {
   value: T | null;
   readAt: number;
   cacheKey: string;
+  sourceMtimeMs?: number | null;
 };
 
 let claudeCliCache: CachedValue<ClaudeCliCredential> | null = null;
@@ -146,6 +147,14 @@ function resolveQwenCliCredentialsPath(homeDir?: string) {
 function resolveMiniMaxCliCredentialsPath(homeDir?: string) {
   const baseDir = homeDir ?? resolveUserPath("~");
   return path.join(baseDir, MINIMAX_CLI_CREDENTIALS_RELATIVE_PATH);
+}
+
+function readFileMtimeMs(filePath: string): number | null {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
 }
 
 function computeCodexKeychainAccount(codexHome: string) {
@@ -526,11 +535,14 @@ export function readCodexCliCredentialsCached(options?: {
 }): CodexCliCredential | null {
   const ttlMs = options?.ttlMs ?? 0;
   const now = Date.now();
-  const cacheKey = `${options?.platform ?? process.platform}|${resolveCodexCliAuthPath()}`;
+  const authPath = resolveCodexCliAuthPath();
+  const cacheKey = `${options?.platform ?? process.platform}|${authPath}`;
+  const sourceMtimeMs = readFileMtimeMs(authPath);
   if (
     ttlMs > 0 &&
     codexCliCache &&
     codexCliCache.cacheKey === cacheKey &&
+    codexCliCache.sourceMtimeMs === sourceMtimeMs &&
     now - codexCliCache.readAt < ttlMs
   ) {
     return codexCliCache.value;
@@ -539,8 +551,16 @@ export function readCodexCliCredentialsCached(options?: {
     platform: options?.platform,
     execSync: options?.execSync,
   });
-  if (ttlMs > 0) {
-    codexCliCache = { value, readAt: now, cacheKey };
+  const cachedSourceMtimeMs = readFileMtimeMs(authPath);
+  if (ttlMs > 0 && cachedSourceMtimeMs === sourceMtimeMs) {
+    codexCliCache = {
+      value,
+      readAt: now,
+      cacheKey,
+      sourceMtimeMs: cachedSourceMtimeMs,
+    };
+  } else if (ttlMs > 0) {
+    codexCliCache = null;
   }
   return value;
 }


### PR DESCRIPTION
## Summary
- invalidate cached Codex CLI credentials as soon as `~/.codex/auth.json` changes, even inside the normal TTL window
- skip external CLI sync when the stored `openai-codex:default` OAuth credential is already newer than the imported one
- cover both stale-cache and stale-overwrite paths with focused regression tests

Fixes #53466.

## Root cause
`readCodexCliCredentialsCached()` only honored a time-based TTL, so a stale external Codex credential could survive in memory after `auth.json` changed.

Later, `syncExternalCliCredentials()` would blindly replace the stored `openai-codex:default` credential whenever the imported OAuth payload differed, even if the stored credential had a later expiry from a fresh `openclaw models auth login` re-auth flow.

## What changed
- `src/agents/cli-credentials.ts`
  - track Codex `auth.json` mtime alongside the cache entry
  - invalidate the cached entry immediately when the file mtime changes
  - only store a new cached entry when the file mtime stayed stable across the read
- `src/agents/auth-profiles/external-cli-sync.ts`
  - keep the fresher stored OAuth credential when the imported external Codex credential is older
- targeted regression coverage for both behaviors

## Validation
Focused suite, run twice consecutively on the final code state:

```bash
pnpm exec vitest --run \
  src/agents/cli-credentials.test.ts \
  src/agents/auth-profiles.external-cli-sync.test.ts \
  src/agents/auth-profiles.store-cache.test.ts \
  src/agents/auth-profiles.markauthprofilefailure.test.ts \
  src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
```

Both consecutive runs passed: **27/27 tests** each time.

Live proof 1 (changed `auth.json` invalidates the stale cached Codex credential inside the TTL window):

```json
{
  "cacheProof": true,
  "firstRefresh": "stale-external-refresh",
  "secondRefresh": "fresh-external-refresh"
}
```

Live proof 2 (a warmed stale external Codex credential no longer overwrites a fresher stored `openai-codex:default` credential on the real auth-store load path):

```json
{
  "overwriteProof": true,
  "finalRefresh": "fresh-store-refresh"
}
```

The repo commit hook also completed successfully and committed the change after running the project `pnpm check` stack.
