### PR TITLE
fix(whatsapp): filter fromMe messages in groups to prevent infinite loop

### DIFF
--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -167,3 +167,68 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });
+
+describe("WhatsApp group fromMe filtering", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ checkInboundAccessControl } = await import("./access-control.js"));
+  });
+
+  it("blocks fromMe messages in groups to prevent infinite loops (#53386)", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: {
+              groupPolicy: "open",
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "1234567890@g.us",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: true,
+      pushName: "Owner",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "1234567890@g.us",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.shouldMarkRead).toBe(false);
+  });
+
+  it("allows fromMe=false messages in groups", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          accounts: {
+            default: {
+              groupPolicy: "open",
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "1234567890@g.us",
+      selfE164: "+15550009999",
+      senderE164: "+15550001111",
+      group: true,
+      pushName: "Other User",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "1234567890@g.us",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.shouldMarkRead).toBe(true);
+  });
+});

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -83,6 +83,19 @@ export async function checkInboundAccessControl(params: {
     typeof params.messageTimestampMs === "number" &&
     params.messageTimestampMs < params.connectedAtMs - pairingGraceMs;
 
+  // Filter fromMe messages in groups to prevent infinite loops
+  // When an agent sends a message to a group, WhatsApp echoes it back.
+  // Without this filter, the agent would respond to its own message.
+  if (params.group && params.isFromMe) {
+    logVerbose("Skipping fromMe group message (prevents infinite loop)");
+    return {
+      allowed: false,
+      shouldMarkRead: false,
+      isSelfChat,
+      resolvedAccountId: account.accountId,
+    };
+  }
+
   // Group policy filtering:
   // - "open": groups bypass allowFrom, only mention-gating applies
   // - "disabled": block all group messages entirely


### PR DESCRIPTION
Fixes #53386

## Problem
When an agent sends a message to a WhatsApp group, the WhatsApp gateway does not filter the fromMe echo message, causing the agent to receive its own message with was_mentioned=true due to implicit reply-to-bot detection, triggering an infinite response loop.

## Solution
Add fromMe filtering in the group message access control check. When a message in a group has isFromMe=true, it is now blocked at the plugin level before being processed as an inbound message.

## Changes
- extensions/whatsapp/src/inbound/access-control.ts: Add fromMe check for group messages
- extensions/whatsapp/src/inbound/access-control.test.ts: Add test cases for fromMe filtering

## Testing
- ✅ All existing tests pass (8/8)
- ✅ New test cases verify fromMe messages are blocked in groups
- ✅ New test cases verify fromMe=false messages are still allowed

## Verification
- Only 2 files modified
- Only 1 commit
- Clean branch from main