### PR TITLE
fix(config): apply missing compaction and context pruning defaults in config snapshot

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1213,7 +1213,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           applyModelDefaults(
             applyCompactionDefaults(
               applyContextPruningDefaults(
-                applyAgentDefaults(applySessionDefaults(applyMessageDefaults({}))),
+                applyAgentDefaults(
+                  applySessionDefaults(applyLoggingDefaults(applyMessageDefaults({}))),
+                ),
               ),
             ),
           ),
@@ -1324,8 +1326,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         applyTalkApiKey(
           applyTalkConfigNormalization(
             applyModelDefaults(
-              applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+              applyCompactionDefaults(
+                applyContextPruningDefaults(
+                  applyAgentDefaults(
+                    applySessionDefaults(
+                      applyLoggingDefaults(applyMessageDefaults(validated.config)),
+                    ),
+                  ),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary

- **Problem:** `readConfigFileSnapshotInternal()` applies an incomplete default chain when a config file exists, omitting `applyCompactionDefaults` and `applyContextPruningDefaults`. The no-file path also omits `applyLoggingDefaults`.
- **Why it matters:** Config snapshot consumers (MCP config listing, `readBestEffortConfig`, config write operations) see missing defaults—no `compaction.mode: "safeguard"`, no auth-mode-derived context pruning, and no `redactSensitive: "tools"` default.
- **What changed:** Aligned both snapshot paths with the canonical default chain in `loadConfig()`.
- **What did NOT change:** `loadConfig()` itself (already correct), `applyTalkApiKey` (snapshot-specific, already present).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage

## Root Cause

`readConfigFileSnapshotInternal()` has three default-application chains that should be identical but diverged:

| Path | `applyLoggingDefaults` | `applyContextPruningDefaults` | `applyCompactionDefaults` |
|------|----------------------|------------------------------|--------------------------|
| `loadConfig()` (line 1120) | ✅ | ✅ | ✅ |
| Snapshot no-file (line 1211) | ❌ **missing** | ✅ | ✅ |
| Snapshot file-exists (line 1323) | ✅ | ❌ **missing** | ❌ **missing** |

## Fix

Added the missing defaults to each path so all three chains now match:

```
applyMessageDefaults → applyLoggingDefaults → applySessionDefaults →
applyAgentDefaults → applyContextPruningDefaults → applyCompactionDefaults →
applyModelDefaults → applyTalkConfigNormalization
```

## Test Plan

- [x] `pnpm tsgo` — no type errors in `src/config/io.ts`
- [x] Pre-existing test runner failure confirmed on clean `upstream/main` (broken lockfile for `acpx@0.1.15(zod@4.3.6)`) — not caused by this change
- [x] Code review: both paths now match the canonical chain in `loadConfig()`

## User-visible / Behavior Changes

Config snapshots now correctly include:
- Default compaction mode (`"safeguard"`) when no explicit mode is set
- Context pruning defaults derived from Anthropic auth mode
- Logging `redactSensitive: "tools"` default in the no-config-file case

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit
- Known bad symptoms: If a default function throws, the snapshot read would fail — but these functions are pure and already tested via `loadConfig()`

## Risks and Mitigations

None — the fix applies the same defaults that `loadConfig()` already applies successfully at startup.