### PR TITLE
fix(cron): return strictly future timestamp for every-interval schedules on exact boundaries

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -103,6 +103,25 @@ describe("cron schedule", () => {
     expect(next).toBe(anchor + 30_000);
   });
 
+  it("advances past current boundary when now is exactly on a non-anchor interval", () => {
+    const anchor = Date.parse("2025-12-13T00:00:00.000Z");
+    const everyMs = 30_000;
+    // nowMs is exactly one interval past the anchor
+    const nowMs = anchor + everyMs;
+    const next = computeNextRunAtMs({ kind: "every", everyMs, anchorMs: anchor }, nowMs);
+    expect(next).toBe(anchor + 2 * everyMs);
+    expect(next).toBeGreaterThan(nowMs);
+  });
+
+  it("advances past current boundary when now is exactly two intervals past anchor", () => {
+    const anchor = Date.parse("2025-12-13T00:00:00.000Z");
+    const everyMs = 60_000;
+    const nowMs = anchor + 2 * everyMs;
+    const next = computeNextRunAtMs({ kind: "every", everyMs, anchorMs: anchor }, nowMs);
+    expect(next).toBe(anchor + 3 * everyMs);
+    expect(next).toBeGreaterThan(nowMs);
+  });
+
   it("never returns a past timestamp for Asia/Shanghai daily schedule (#30351)", () => {
     const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
     const next = computeNextRunAtMs(

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -93,7 +93,7 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
       return anchor;
     }
     const elapsed = nowMs - anchor;
-    const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));
+    const steps = Math.floor(elapsed / everyMs) + 1;
     return anchor + steps * everyMs;
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** `computeNextRunAtMs()` returns the current boundary time (not a future time) when `nowMs` falls exactly on a schedule boundary for "every" interval schedules.
- **Why it matters:** Unlike cron schedules which have a `MIN_REFIRE_GAP_MS` safety net, "every" schedules set `nextRunAtMs = naturalNext` directly, so this off-by-one can cause rapid re-execution.
- **What changed:** Replaced the ceiling-division formula with `Math.floor(elapsed / everyMs) + 1` which always advances past the current boundary.
- **What did NOT change:** Cron schedule computation, `MIN_REFIRE_GAP_MS` safety net, stagger logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Root Cause

The formula `Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs))` is standard ceiling division for integers, but it fails at exact multiples:

```
anchor=0, everyMs=30000, nowMs=30000 (exactly on 1st boundary)
  elapsed = 30000
  (30000 + 30000 - 1) / 30000 = 59999/30000 = 1.9999...
  Math.floor(1.9999) = 1
  anchor + 1 * 30000 = 30000 == nowMs  ← NOT FUTURE!
```

The timer (timer.ts:444-466) then sets `nextRunAtMs = 30000`, and on the next tick `nowMs >= nextRunAtMs` is immediately true, causing the job to fire again. Cron schedules have `MIN_REFIRE_GAP_MS` protection (line 462) but "every" schedules do not (line 466).

## Fix

Replace line 96 in `schedule.ts`:
```typescript
// Before (buggy at exact boundaries):
const steps = Math.max(1, Math.floor((elapsed + everyMs - 1) / everyMs));

// After (always advances past current boundary):
const steps = Math.floor(elapsed / everyMs) + 1;
```

Verification across all edge cases:

| nowMs | Original | Fixed | Original > nowMs | Fixed > nowMs |
|-------|----------|-------|-----------------|--------------|
| 0 (anchor) | 30000 | 30000 | ✅ | ✅ |
| 15000 (mid) | 30000 | 30000 | ✅ | ✅ |
| 29999 (before) | 30000 | 30000 | ✅ | ✅ |
| **30000 (boundary)** | **30000** | **60000** | **❌** | **✅** |
| 30001 (after) | 60000 | 60000 | ✅ | ✅ |
| **60000 (boundary)** | **60000** | **90000** | **❌** | **✅** |

## Test Plan

- [x] Added two new test cases for exact boundary conditions (`schedule.test.ts`)
- [x] Verified all edge cases via Node.js script (see table above)
- [x] `pnpm tsgo` — no type errors in changed files
- [x] Existing test "advances when now matches anchor" still passes (anchor case uses `Math.max(1,0)=1` path, unaffected)
- [ ] Pre-existing test runner failure (`@mariozechner/pi-ai/oauth` missing) blocks `pnpm test` on `upstream/main` — not caused by this change

## User-visible / Behavior Changes

"Every" interval cron jobs will no longer occasionally double-fire when the timer tick lands exactly on a schedule boundary. This is a timing-dependent edge case that becomes more likely with short intervals.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this single commit
- Known bad symptoms: If the fix is wrong, jobs would fire one interval too late at boundaries (60s instead of 30s) — easily detectable via cron logs

## Risks and Mitigations

- Risk: Edge case in the new formula for non-integer elapsed values
  - Mitigation: `Math.floor` handles floating point correctly; `everyMs` is already floored to integer at line 89