### PR TITLE
warn on startup when legacy CLAWDBOT_* env vars are present

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -413,11 +413,10 @@ export async function startGatewayServer(
   }
 
   configSnapshot = await readConfigFileSnapshot();
+  warnLegacyClawdbotEnvVars();
   if (configSnapshot.exists) {
     assertValidGatewayStartupConfigSnapshot(configSnapshot, { includeDoctorHint: true });
   }
-
-  warnLegacyClawdbotEnvVars();
 
   const autoEnable = applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
   if (autoEnable.changes.length > 0) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -176,6 +176,17 @@ const logSecrets = log.child("secrets");
 const gatewayRuntime = runtimeForLogger(log);
 const canvasRuntime = runtimeForLogger(logCanvas);
 
+function warnLegacyClawdbotEnvVars(): void {
+  const legacyKeys = Object.keys(process.env).filter((k) => k.startsWith("CLAWDBOT_"));
+  if (legacyKeys.length === 0) {
+    return;
+  }
+  log.warn(
+    `Legacy CLAWDBOT_* environment variables detected and will be ignored: ${legacyKeys.join(", ")}. ` +
+      `Rename them to use the OPENCLAW_ prefix or run \`openclaw onboard\` to migrate.`,
+  );
+}
+
 type AuthRateLimitConfig = Parameters<typeof createAuthRateLimiter>[0];
 
 function createGatewayAuthRateLimiters(rateLimitConfig: AuthRateLimitConfig | undefined): {
@@ -405,6 +416,8 @@ export async function startGatewayServer(
   if (configSnapshot.exists) {
     assertValidGatewayStartupConfigSnapshot(configSnapshot, { includeDoctorHint: true });
   }
+
+  warnLegacyClawdbotEnvVars();
 
   const autoEnable = applyPluginAutoEnable({ config: configSnapshot.config, env: process.env });
   if (autoEnable.changes.length > 0) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -182,7 +182,7 @@ function warnLegacyClawdbotEnvVars(): void {
     return;
   }
   log.warn(
-    `Legacy CLAWDBOT_* environment variables detected and will be ignored: ${legacyKeys.join(", ")}. ` +
+    `Legacy CLAWDBOT_* environment variables detected: ${legacyKeys.join(", ")}. ` +
       `Rename them to use the OPENCLAW_ prefix or run \`openclaw onboard\` to migrate.`,
   );
 }


### PR DESCRIPTION
after the CLAWDBOT_ -> OPENCLAW_ migration, gateway silently ignores old env vars with no warning. users end up with channels not connecting and no idea why.

adds a preflight check in startGatewayServer that scans process.env for CLAWDBOT_ prefixed keys and logs a warning with the detected keys and migration instructions. runs before config validation so the warning is visible even when config is invalid.

fixes #53482