### PR TITLE
Skill Creator: add RFC 2119 requirement-level language guidance

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -316,6 +316,19 @@ If you used `--examples`, delete any placeholder files that are not needed for t
 
 **Writing Guidelines:** Always use imperative/infinitive form.
 
+**Normative keywords (RECOMMENDED):** For coding standards and policy-oriented skills, use RFC 2119 requirement keywords to remove ambiguity.
+
+- `MUST` / `SHALL`: non-negotiable requirement (blocking)
+- `MUST NOT` / `SHALL NOT`: hard prohibition
+- `SHOULD` / `SHOULD NOT`: strong default; deviation requires explicit rationale
+- `MAY` / `OPTIONAL`: context-dependent choice
+
+When using these keywords, include an explicit line near the top of the SKILL body:
+
+> The key words MUST, SHOULD, MAY, etc. are used as defined in RFC 2119.
+
+Do not use all-caps keywords as emphasis unless they are intended to carry RFC 2119 semantics.
+
 ##### Frontmatter
 
 Write the YAML frontmatter with `name` and `description`:


### PR DESCRIPTION
## Summary
Update the `skill-creator` guidance to explicitly support RFC 2119 normative keywords for standards/policy-oriented skills.

## Changes
- Added a new section under SKILL authoring guidance that maps:
  - MUST/SHALL
  - MUST NOT/SHALL NOT
  - SHOULD/SHOULD NOT
  - MAY/OPTIONAL
- Added recommended declaration line for SKILL bodies:
  - `The key words MUST, SHOULD, MAY, etc. are used as defined in RFC 2119.`
- Added note to avoid using all-caps keywords as emphasis unless intentional normative semantics are intended.

## Why
This makes requirement levels explicit and unambiguous for both human readers and AI agents, and improves consistency when using skills to encode coding standards.
