### PR TITLE
feat(minimax): trim legacy model catalog to M2.7 only

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2153,9 +2153,8 @@ Quick answers plus deeper troubleshooting for real-world setups (local dev, VPS,
     1. Upgrade to a current OpenClaw release (or run from source `main`), then restart the gateway.
     2. Make sure MiniMax is configured (wizard or JSON), or that a MiniMax API key
        exists in env/auth profiles so the provider can be injected.
-    3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.7`,
-       `minimax/MiniMax-M2.7-highspeed`, `minimax/MiniMax-M2.5`, or
-       `minimax/MiniMax-M2.5-highspeed`.
+    3. Use the exact model id (case-sensitive): `minimax/MiniMax-M2.7` or
+       `minimax/MiniMax-M2.7-highspeed`.
     4. Run:
 
        ```bash

--- a/docs/providers/minimax.md
+++ b/docs/providers/minimax.md
@@ -8,16 +8,12 @@ title: "MiniMax"
 
 # MiniMax
 
-OpenClaw's MiniMax provider defaults to **MiniMax M2.7** and keeps
-**MiniMax M2.5** in the catalog for compatibility.
+OpenClaw's MiniMax provider defaults to **MiniMax M2.7**.
 
 ## Model lineup
 
 - `MiniMax-M2.7`: default hosted text model.
 - `MiniMax-M2.7-highspeed`: faster M2.7 text tier.
-- `MiniMax-M2.5`: previous text model, still available in the MiniMax catalog.
-- `MiniMax-M2.5-highspeed`: faster M2.5 text tier.
-- `MiniMax-VL-01`: vision model for text + image inputs.
 
 ## Choose a setup
 
@@ -80,24 +76,6 @@ Configure via CLI:
             contextWindow: 200000,
             maxTokens: 8192,
           },
-          {
-            id: "MiniMax-M2.5",
-            name: "MiniMax M2.5",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-            contextWindow: 200000,
-            maxTokens: 8192,
-          },
-          {
-            id: "MiniMax-M2.5-highspeed",
-            name: "MiniMax M2.5 Highspeed",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 0.3, output: 1.2, cacheRead: 0.03, cacheWrite: 0.12 },
-            contextWindow: 200000,
-            maxTokens: 8192,
-          },
         ],
       },
     },
@@ -128,46 +106,6 @@ Example below uses Opus as a concrete primary; swap to your preferred latest-gen
 }
 ```
 
-### Optional: Local via LM Studio (manual)
-
-**Best for:** local inference with LM Studio.
-We have seen strong results with MiniMax M2.5 on powerful hardware (e.g. a
-desktop/server) using LM Studio's local server.
-
-Configure manually via `openclaw.json`:
-
-```json5
-{
-  agents: {
-    defaults: {
-      model: { primary: "lmstudio/minimax-m2.5-gs32" },
-      models: { "lmstudio/minimax-m2.5-gs32": { alias: "Minimax" } },
-    },
-  },
-  models: {
-    mode: "merge",
-    providers: {
-      lmstudio: {
-        baseUrl: "http://127.0.0.1:1234/v1",
-        apiKey: "lmstudio",
-        api: "openai-responses",
-        models: [
-          {
-            id: "minimax-m2.5-gs32",
-            name: "MiniMax M2.5 GS32",
-            reasoning: true,
-            input: ["text"],
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            contextWindow: 196608,
-            maxTokens: 8192,
-          },
-        ],
-      },
-    },
-  },
-}
-```
-
 ## Configure via `openclaw configure`
 
 Use the interactive config wizard to set MiniMax without editing JSON:
@@ -190,7 +128,7 @@ Use the interactive config wizard to set MiniMax without editing JSON:
 
 - Model refs are `minimax/<model>`.
 - Default text model: `MiniMax-M2.7`.
-- Alternate text models: `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`.
+- Alternate text model: `MiniMax-M2.7-highspeed`.
 - Coding Plan usage API: `https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains` (requires a coding plan key).
 - Update pricing values in `models.json` if you need exact cost tracking.
 - Referral link for MiniMax Coding Plan (10% off): [https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link](https://platform.minimax.io/subscribe/coding-plan?code=DbXJTRClnb&source=link)
@@ -214,8 +152,6 @@ Make sure the model id is **case‑sensitive**:
 
 - `minimax/MiniMax-M2.7`
 - `minimax/MiniMax-M2.7-highspeed`
-- `minimax/MiniMax-M2.5`
-- `minimax/MiniMax-M2.5-highspeed`
 
 Then recheck with:
 

--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -130,21 +130,9 @@ function createOAuthHandler(region: MiniMaxRegion) {
           agents: {
             defaults: {
               models: {
-                [portalModelRef("MiniMax-M2")]: { alias: "minimax-m2" },
-                [portalModelRef("MiniMax-M2.1")]: { alias: "minimax-m2.1" },
-                [portalModelRef("MiniMax-M2.1-highspeed")]: {
-                  alias: "minimax-m2.1-highspeed",
-                },
                 [portalModelRef("MiniMax-M2.7")]: { alias: "minimax-m2.7" },
                 [portalModelRef("MiniMax-M2.7-highspeed")]: {
                   alias: "minimax-m2.7-highspeed",
-                },
-                [portalModelRef("MiniMax-M2.5")]: { alias: "minimax-m2.5" },
-                [portalModelRef("MiniMax-M2.5-highspeed")]: {
-                  alias: "minimax-m2.5-highspeed",
-                },
-                [portalModelRef("MiniMax-M2.5-Lightning")]: {
-                  alias: "minimax-m2.5-lightning",
                 },
               },
             },
@@ -243,6 +231,9 @@ export default definePluginEntry({
         await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn),
     });
 
+    api.registerMediaUnderstandingProvider(minimaxMediaUnderstandingProvider);
+    api.registerMediaUnderstandingProvider(minimaxPortalMediaUnderstandingProvider);
+
     api.registerProvider({
       id: PORTAL_PROVIDER_ID,
       label: PROVIDER_LABEL,
@@ -285,7 +276,5 @@ export default definePluginEntry({
       ],
       isModernModelRef: ({ modelId }) => isMiniMaxModernModelId(modelId),
     });
-    api.registerMediaUnderstandingProvider(minimaxMediaUnderstandingProvider);
-    api.registerMediaUnderstandingProvider(minimaxPortalMediaUnderstandingProvider);
   },
 });

--- a/extensions/minimax/model-definitions.test.ts
+++ b/extensions/minimax/model-definitions.test.ts
@@ -26,14 +26,14 @@ describe("minimax model definitions", () => {
 
   it("builds catalog model with name and reasoning from catalog", () => {
     const model = buildMinimaxModelDefinition({
-      id: "MiniMax-M2.1",
+      id: "MiniMax-M2.7",
       cost: MINIMAX_API_COST,
       contextWindow: DEFAULT_MINIMAX_CONTEXT_WINDOW,
       maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
     });
     expect(model).toMatchObject({
-      id: "MiniMax-M2.1",
-      name: "MiniMax M2.1",
+      id: "MiniMax-M2.7",
+      name: "MiniMax M2.7",
       reasoning: true,
     });
   });

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -9,7 +9,6 @@ import {
 } from "openclaw/plugin-sdk/provider-models";
 
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
-const MINIMAX_DEFAULT_VISION_MODEL_ID = "MiniMax-VL-01";
 const MINIMAX_DEFAULT_CONTEXT_WINDOW = 204800;
 const MINIMAX_DEFAULT_MAX_TOKENS = 131072;
 const MINIMAX_API_COST = {
@@ -45,22 +44,14 @@ function buildMinimaxTextModel(params: {
 }
 
 function buildMinimaxCatalog(): ModelDefinitionConfig[] {
-  return [
-    buildMinimaxModel({
-      id: MINIMAX_DEFAULT_VISION_MODEL_ID,
-      name: "MiniMax VL 01",
-      reasoning: false,
-      input: ["text", "image"],
-    }),
-    ...MINIMAX_TEXT_MODEL_ORDER.map((id) => {
-      const model = MINIMAX_TEXT_MODEL_CATALOG[id];
-      return buildMinimaxTextModel({
-        id,
-        name: model.name,
-        reasoning: model.reasoning,
-      });
-    }),
-  ];
+  return MINIMAX_TEXT_MODEL_ORDER.map((id) => {
+    const model = MINIMAX_TEXT_MODEL_CATALOG[id];
+    return buildMinimaxTextModel({
+      id,
+      name: model.name,
+      reasoning: model.reasoning,
+    });
+  });
 }
 
 export function buildMinimaxProvider(): ModelProviderConfig {

--- a/src/agents/models-config.providers.minimax.test.ts
+++ b/src/agents/models-config.providers.minimax.test.ts
@@ -36,18 +36,12 @@ describe("minimax provider catalog", () => {
 
     const providers = await resolveImplicitProvidersForTest({ agentDir });
     expect(providers?.minimax?.models?.map((model) => model.id)).toEqual([
-      "MiniMax-VL-01",
       "MiniMax-M2.7",
       "MiniMax-M2.7-highspeed",
-      "MiniMax-M2.5",
-      "MiniMax-M2.5-highspeed",
     ]);
     expect(providers?.["minimax-portal"]?.models?.map((model) => model.id)).toEqual([
-      "MiniMax-VL-01",
       "MiniMax-M2.7",
       "MiniMax-M2.7-highspeed",
-      "MiniMax-M2.5",
-      "MiniMax-M2.5-highspeed",
     ]);
   });
 });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1869,20 +1869,20 @@ describe("applyExtraParamsToAgent", () => {
     expect(resolvedModelId).toBe("MiniMax-M2.7-highspeed");
   });
 
-  it("maps MiniMax M2.1 /fast to the matching highspeed model", () => {
+  it("maps MiniMax M2.7 /fast to the matching highspeed model", () => {
     const resolvedModelId = runResolvedModelIdCase({
       applyProvider: "minimax",
-      applyModelId: "MiniMax-M2.1",
+      applyModelId: "MiniMax-M2.7",
       extraParamsOverride: { fastMode: true },
       model: {
         api: "anthropic-messages",
         provider: "minimax",
-        id: "MiniMax-M2.1",
+        id: "MiniMax-M2.7",
         baseUrl: "https://api.minimax.io/anthropic",
       } as Model<"anthropic-messages">,
     });
 
-    expect(resolvedModelId).toBe("MiniMax-M2.1-highspeed");
+    expect(resolvedModelId).toBe("MiniMax-M2.7-highspeed");
   });
 
   it("keeps explicit MiniMax highspeed models unchanged when /fast is off", () => {

--- a/src/agents/pi-embedded-runner/minimax-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/minimax-stream-wrappers.ts
@@ -2,8 +2,6 @@ import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 
 const MINIMAX_FAST_MODEL_IDS = new Map<string, string>([
-  ["MiniMax-M2.1", "MiniMax-M2.1-highspeed"],
-  ["MiniMax-M2.5", "MiniMax-M2.5-highspeed"],
   ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
 ]);
 

--- a/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.defaults-think-low-reasoning-capable-models-no.test.ts
@@ -244,7 +244,7 @@ describe("directive behavior", () => {
                 api: "anthropic-messages",
                 models: [
                   { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
-                  { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
+                  { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed" },
                 ],
               },
             },

--- a/src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts
@@ -124,8 +124,7 @@ describe("directive behavior", () => {
                 workspace: path.join(home, "openclaw"),
                 models: {
                   "minimax/MiniMax-M2.7": {},
-                  "minimax/MiniMax-M2.5": {},
-                  "minimax/MiniMax-M2.5-highspeed": {},
+                  "minimax/MiniMax-M2.7-highspeed": {},
                   "lmstudio/minimax-m2.5-gs32": {},
                 },
               },
@@ -139,7 +138,7 @@ describe("directive behavior", () => {
                   api: "anthropic-messages",
                   models: [
                     makeModelDefinition("MiniMax-M2.7", "MiniMax M2.7"),
-                    makeModelDefinition("MiniMax-M2.5", "MiniMax M2.5"),
+                    makeModelDefinition("MiniMax-M2.7-highspeed", "MiniMax M2.7 Highspeed"),
                   ],
                 },
                 lmstudio: {
@@ -153,7 +152,7 @@ describe("directive behavior", () => {
           },
         },
         {
-          body: "/model minimax/m2.5",
+          body: "/model minimax/m2.7",
           storePath: path.join(home, "sessions-provider-fuzzy.json"),
           expectedSelection: {
             provider: "minimax",
@@ -166,8 +165,7 @@ describe("directive behavior", () => {
                 workspace: path.join(home, "openclaw"),
                 models: {
                   "minimax/MiniMax-M2.7": {},
-                  "minimax/MiniMax-M2.5": {},
-                  "minimax/MiniMax-M2.5-highspeed": {},
+                  "minimax/MiniMax-M2.7-highspeed": {},
                 },
               },
             },
@@ -180,8 +178,7 @@ describe("directive behavior", () => {
                   api: "anthropic-messages",
                   models: [
                     makeModelDefinition("MiniMax-M2.7", "MiniMax M2.7"),
-                    makeModelDefinition("MiniMax-M2.5", "MiniMax M2.5"),
-                    makeModelDefinition("MiniMax-M2.5-highspeed", "MiniMax M2.5 Highspeed"),
+                    makeModelDefinition("MiniMax-M2.7-highspeed", "MiniMax M2.7 Highspeed"),
                   ],
                 },
               },

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -231,7 +231,7 @@ describe("buildStatusMessage", () => {
         models: {
           providers: {
             "minimax-portal": {
-              models: [{ id: "MiniMax-M2.5", contextWindow: 200_000 }],
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
             },
             xiaomi: {
               models: [{ id: "mimo-v2-flash", contextWindow: 1_048_576 }],
@@ -248,9 +248,9 @@ describe("buildStatusMessage", () => {
         providerOverride: "xiaomi",
         modelOverride: "mimo-v2-flash",
         modelProvider: "minimax-portal",
-        model: "MiniMax-M2.5",
+        model: "MiniMax-M2.7",
         fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
-        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.5",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
         contextTokens: 1_048_576,
@@ -263,7 +263,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
     expect(normalized).toContain("Context: 49k/200k");
     expect(normalized).not.toContain("Context: 49k/1.0m");
   });
@@ -274,7 +274,7 @@ describe("buildStatusMessage", () => {
         models: {
           providers: {
             "minimax-portal": {
-              models: [{ id: "MiniMax-M2.5", contextWindow: 200_000 }],
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
             },
             xiaomi: {
               models: [{ id: "mimo-v2-flash", contextWindow: 1_048_576 }],
@@ -292,9 +292,9 @@ describe("buildStatusMessage", () => {
         providerOverride: "xiaomi",
         modelOverride: "mimo-v2-flash",
         modelProvider: "minimax-portal",
-        model: "MiniMax-M2.5",
+        model: "MiniMax-M2.7",
         fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
-        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.5",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
         contextTokens: 1_048_576,
@@ -307,7 +307,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
     expect(normalized).toContain("Context: 49k/123k");
     expect(normalized).not.toContain("Context: 49k/1.0m");
     expect(normalized).not.toContain("Context: 49k/200k");
@@ -319,7 +319,7 @@ describe("buildStatusMessage", () => {
         models: {
           providers: {
             "minimax-portal": {
-              models: [{ id: "MiniMax-M2.5", contextWindow: 200_000 }],
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
             },
             xiaomi: {
               models: [{ id: "mimo-v2-flash", contextWindow: 1_048_576 }],
@@ -336,9 +336,9 @@ describe("buildStatusMessage", () => {
         providerOverride: "xiaomi",
         modelOverride: "mimo-v2-flash",
         modelProvider: "minimax-portal",
-        model: "MiniMax-M2.5",
+        model: "MiniMax-M2.7",
         fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
-        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.5",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
         contextTokens: 123_456,
@@ -351,7 +351,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
     expect(normalized).toContain("Context: 49k/123k");
     expect(normalized).not.toContain("Context: 49k/1.0m");
     expect(normalized).not.toContain("Context: 49k/200k");
@@ -363,7 +363,7 @@ describe("buildStatusMessage", () => {
         models: {
           providers: {
             "minimax-portal": {
-              models: [{ id: "MiniMax-M2.5", contextWindow: 200_000 }],
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
             },
             xiaomi: {
               models: [{ id: "mimo-v2-flash", contextWindow: 1_048_576 }],
@@ -382,9 +382,9 @@ describe("buildStatusMessage", () => {
         providerOverride: "xiaomi",
         modelOverride: "mimo-v2-flash",
         modelProvider: "minimax-portal",
-        model: "MiniMax-M2.5",
+        model: "MiniMax-M2.7",
         fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
-        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.5",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
       },
@@ -396,7 +396,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
     expect(normalized).toContain("Context: 49k/120k");
     expect(normalized).not.toContain("Context: 49k/200k");
     expect(normalized).not.toContain("Context: 49k/1.0m");
@@ -408,7 +408,7 @@ describe("buildStatusMessage", () => {
         models: {
           providers: {
             "minimax-portal": {
-              models: [{ id: "MiniMax-M2.5", contextWindow: 200_000 }],
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
             },
             xiaomi: {
               models: [{ id: "mimo-v2-flash", contextWindow: 128_000 }],
@@ -427,9 +427,9 @@ describe("buildStatusMessage", () => {
         providerOverride: "xiaomi",
         modelOverride: "mimo-v2-flash",
         modelProvider: "minimax-portal",
-        model: "MiniMax-M2.5",
+        model: "MiniMax-M2.7",
         fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
-        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.5",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
       },
@@ -441,7 +441,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
     expect(normalized).toContain("Context: 49k/128k");
     expect(normalized).not.toContain("Context: 49k/200k");
   });
@@ -452,7 +452,7 @@ describe("buildStatusMessage", () => {
         models: {
           providers: {
             "minimax-portal": {
-              models: [{ id: "MiniMax-M2.5", contextWindow: 200_000 }],
+              models: [{ id: "MiniMax-M2.7", contextWindow: 200_000 }],
             },
             xiaomi: {
               models: [{ id: "mimo-v2-flash", contextWindow: 1_048_576 }],
@@ -471,9 +471,9 @@ describe("buildStatusMessage", () => {
         providerOverride: "xiaomi",
         modelOverride: "mimo-v2-flash",
         modelProvider: "minimax-portal",
-        model: "MiniMax-M2.5",
+        model: "MiniMax-M2.7",
         fallbackNoticeSelectedModel: "xiaomi/mimo-v2-flash",
-        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.5",
+        fallbackNoticeActiveModel: "minimax-portal/MiniMax-M2.7",
         fallbackNoticeReason: "model not allowed",
         totalTokens: 49_000,
       },
@@ -485,7 +485,7 @@ describe("buildStatusMessage", () => {
     });
 
     const normalized = normalizeTestText(text);
-    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.5");
+    expect(normalized).toContain("Fallback: minimax-portal/MiniMax-M2.7");
     expect(normalized).toContain("Context: 49k/200k");
     expect(normalized).not.toContain("Context: 49k/1.0m");
   });

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -533,8 +533,8 @@ describe("primary model defaults", () => {
   it("sets correct primary model", () => {
     const configCases = [
       {
-        getConfig: () => applyMinimaxApiConfig({}, "MiniMax-M2.5-highspeed"),
-        primaryModel: "minimax/MiniMax-M2.5-highspeed",
+        getConfig: () => applyMinimaxApiConfig({}, "MiniMax-M2.7-highspeed"),
+        primaryModel: "minimax/MiniMax-M2.7-highspeed",
       },
       {
         getConfig: () => applyZaiConfig({}, { modelId: "glm-5" }),

--- a/src/plugins/contracts/discovery.contract.test.ts
+++ b/src/plugins/contracts/discovery.contract.test.ts
@@ -457,7 +457,7 @@ describe("provider discovery contract", () => {
         apiKey: "minimax-key",
         models: expect.arrayContaining([
           expect.objectContaining({ id: "MiniMax-M2.7" }),
-          expect.objectContaining({ id: "MiniMax-VL-01" }),
+          expect.objectContaining({ id: "MiniMax-M2.7-highspeed" }),
         ]),
       },
     });

--- a/src/plugins/provider-model-minimax.ts
+++ b/src/plugins/provider-model-minimax.ts
@@ -3,36 +3,18 @@ import { matchesExactOrPrefix } from "./provider-model-helpers.js";
 export const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.7";
 export const MINIMAX_DEFAULT_MODEL_REF = `minimax/${MINIMAX_DEFAULT_MODEL_ID}`;
 
-export const MINIMAX_TEXT_MODEL_ORDER = [
-  "MiniMax-M2",
-  "MiniMax-M2.1",
-  "MiniMax-M2.1-highspeed",
-  "MiniMax-M2.7",
-  "MiniMax-M2.7-highspeed",
-  "MiniMax-M2.5",
-  "MiniMax-M2.5-highspeed",
-] as const;
+export const MINIMAX_TEXT_MODEL_ORDER = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"] as const;
 
 export const MINIMAX_TEXT_MODEL_CATALOG = {
-  "MiniMax-M2": { name: "MiniMax M2", reasoning: true },
-  "MiniMax-M2.1": { name: "MiniMax M2.1", reasoning: true },
-  "MiniMax-M2.1-highspeed": { name: "MiniMax M2.1 Highspeed", reasoning: true },
   "MiniMax-M2.7": { name: "MiniMax M2.7", reasoning: true },
   "MiniMax-M2.7-highspeed": { name: "MiniMax M2.7 Highspeed", reasoning: true },
-  "MiniMax-M2.5": { name: "MiniMax M2.5", reasoning: true },
-  "MiniMax-M2.5-highspeed": { name: "MiniMax M2.5 Highspeed", reasoning: true },
 } as const;
 
 export const MINIMAX_TEXT_MODEL_REFS = MINIMAX_TEXT_MODEL_ORDER.map(
   (modelId) => `minimax/${modelId}`,
 );
 
-export const MINIMAX_MODERN_MODEL_MATCHERS = [
-  "minimax-m2",
-  "minimax-m2.1",
-  "minimax-m2.5",
-  "minimax-m2.7",
-] as const;
+export const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
 
 export function isMiniMaxModernModelId(modelId: string): boolean {
   return matchesExactOrPrefix(modelId, MINIMAX_MODERN_MODEL_MATCHERS);


### PR DESCRIPTION
## Summary

- Problem: MiniMax provider catalog contained stale legacy models (M2, M2.1, M2.5, VL-01) that are no longer relevant.
- Why it matters: Keeps the model list clean and avoids user confusion from deprecated model choices.
- What changed: Removed M2, M2.1, M2.1-highspeed, M2.5, M2.5-highspeed, M2.5-Lightning, and VL-01 from the provider catalog, aliases config, stream-wrapper fast-model map, and docs. Only M2.7 and M2.7-highspeed remain.
- What did NOT change: API endpoints, auth flow, provider registration logic, and media understanding provider registration order are unchanged (media understanding providers were moved earlier in the init sequence, which is a minor ordering fix).

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

N/A — this is a catalog cleanup, not a bug fix.

## User-visible / Behavior Changes

MiniMax model picker will show only M2.7 and M2.7-highspeed. Users who previously configured M2.5 or older models via `openclaw.json` will need to update their config to M2.7.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? No — configs referencing M2.5 or older model IDs will need to be updated to M2.7.
- Config/env changes? Yes — legacy model IDs removed from catalog.
- Migration needed? Yes — update `model.primary` / `model.secondary` to `minimax/MiniMax-M2.7`.

## Failure Recovery (if this breaks)

Revert this commit and re-add the legacy model entries to `src/plugins/provider-model-minimax.ts` and `extensions/minimax/provider-catalog.ts`.

## Risks and Mitigations

- Risk: Users with hardcoded M2.5 configs lose the model entry silently.
  - Mitigation: Docs updated to reflect the new catalog; migration path is straightforward (change model ID).

Made with [Cursor](https://cursor.com)