### PR TITLE
Feishu: avoid CLI startup failure on unresolved SecretRef

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -328,24 +328,24 @@ describe("resolveFeishuAccount", () => {
     expect(account.appId).toBe("cli_default");
   });
 
-  it("surfaces unresolved SecretRef errors in account resolution", () => {
-    expect(() =>
-      resolveFeishuAccount({
-        cfg: {
-          channels: {
-            feishu: {
-              accounts: {
-                main: {
-                  appId: "cli_123",
-                  appSecret: { source: "file", provider: "default", id: "path/to/secret" },
-                } as never,
-              },
+  it("treats unresolved SecretRef as not configured in account resolution", () => {
+    const account = resolveFeishuAccount({
+      cfg: {
+        channels: {
+          feishu: {
+            accounts: {
+              main: {
+                appId: "cli_123",
+                appSecret: { source: "file", provider: "default", id: "path/to/secret" },
+              } as never,
             },
           },
-        } as never,
-        accountId: "main",
-      }),
-    ).toThrow(/unresolved SecretRef/i);
+        },
+      } as never,
+      accountId: "main",
+    });
+    expect(account.configured).toBe(false);
+    expect(account.appSecret).toBeUndefined();
   });
 
   it("does not throw when account name is non-string", () => {

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -25,6 +25,13 @@ const {
 
 export { listFeishuAccountIds };
 
+function isUnresolvedSecretRefError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return /unresolved SecretRef/i.test(error.message);
+}
+
 /**
  * Resolve the default account selection and its source.
  */
@@ -191,8 +198,17 @@ export function resolveFeishuAccount(params: {
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
 
-  // Resolve credentials from merged config
-  const creds = resolveFeishuCredentials(merged);
+  // Resolve credentials from merged config.
+  // CLI startup can parse config before gateway-backed SecretRef resolution is available.
+  // Treat unresolved refs as "not configured" here instead of crashing plugin load.
+  let creds: ReturnType<typeof resolveFeishuCredentials> = null;
+  try {
+    creds = resolveFeishuCredentials(merged);
+  } catch (error) {
+    if (!isUnresolvedSecretRefError(error)) {
+      throw error;
+    }
+  }
   const accountName = (merged as FeishuAccountConfig).name;
 
   return {


### PR DESCRIPTION
## Summary

- avoid throwing during Feishu account resolution when `channels.feishu.*` still contains unresolved `SecretRef` values during CLI startup/plugin registration
- treat unresolved SecretRef credentials as "not configured" for that account in this path, so commands can continue to run and later resolve secrets via gateway/runtime paths
- update Feishu account tests to assert the new behavior (`configured=false` instead of throwing)

## Problem

Some CLI commands could fail before command handlers ran because plugin registry loading happened first, and Feishu account resolution threw on unresolved SecretRef values (for example `exec:sops_feishu_app_secret:value`).

This blocked commands that should still proceed, such as `openclaw channels status --probe` and `openclaw status --deep`.

## Test plan

- [x] `pnpm test -- extensions/feishu/src/accounts.test.ts`
- [x] `node dist/entry.js channels status --probe` (local validation)


Made with [Cursor](https://cursor.com)