### PR TITLE
fix(googlechat): harden webhook auth matching and diagnostics

### DIFF
--- a/extensions/googlechat/src/auth.test.ts
+++ b/extensions/googlechat/src/auth.test.ts
@@ -39,6 +39,20 @@ describe("verifyGoogleChatRequest", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  it("accepts app-url tokens when issuer is Chat issuer and email is absent", async () => {
+    mockTicket({
+      iss: "chat@system.gserviceaccount.com",
+    });
+
+    await expect(
+      verifyGoogleChatRequest({
+        bearer: "token",
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   it("rejects add-on tokens when no principal binding is configured", async () => {
     mockTicket({
       email: "service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
@@ -62,6 +76,22 @@ describe("verifyGoogleChatRequest", () => {
     mockTicket({
       email: "service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
       email_verified: true,
+      sub: "principal-1",
+    });
+
+    await expect(
+      verifyGoogleChatRequest({
+        bearer: "token",
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+        expectedAddOnPrincipal: "principal-1",
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
+  it("accepts add-on tokens matched by issuer with principal binding", async () => {
+    mockTicket({
+      iss: "service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
       sub: "principal-1",
     });
 

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -116,14 +116,25 @@ export async function verifyGoogleChatRequest(params: {
       const email = String(payload?.email ?? "")
         .trim()
         .toLowerCase();
-      if (!payload?.email_verified) {
+      const issuer = String(payload?.iss ?? "")
+        .trim()
+        .toLowerCase();
+
+      // Some token variants omit email claims; when email is present, keep
+      // enforcing verification.
+      if (email && !payload?.email_verified) {
         return { ok: false, reason: "email not verified" };
       }
-      if (email === CHAT_ISSUER) {
+      if (issuer === CHAT_ISSUER || email === CHAT_ISSUER) {
         return { ok: true };
       }
-      if (!ADDON_ISSUER_PATTERN.test(email)) {
-        return { ok: false, reason: `invalid issuer: ${email}` };
+      const addOnIssuerMatches =
+        ADDON_ISSUER_PATTERN.test(issuer) || ADDON_ISSUER_PATTERN.test(email);
+      if (!addOnIssuerMatches) {
+        return {
+          ok: false,
+          reason: `invalid issuer/email: iss=${issuer || "<missing>"} email=${email || "<missing>"}`,
+        };
       }
       const expectedAddOnPrincipal = params.expectedAddOnPrincipal?.trim().toLowerCase();
       if (!expectedAddOnPrincipal) {

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const readJsonWebhookBodyOrReject = vi.hoisted(() => vi.fn());
 const resolveWebhookTargetWithAuthOrReject = vi.hoisted(() => vi.fn());
@@ -67,6 +67,13 @@ function installSimplePipeline(targets: unknown[]) {
 }
 
 describe("googlechat monitor webhook", () => {
+  beforeEach(() => {
+    readJsonWebhookBodyOrReject.mockReset();
+    resolveWebhookTargetWithAuthOrReject.mockReset();
+    withResolvedWebhookRequestPipeline.mockReset();
+    verifyGoogleChatRequest.mockReset();
+  });
+
   it("accepts add-on payloads that carry systemIdToken in the body", async () => {
     installSimplePipeline([
       {
@@ -172,5 +179,55 @@ describe("googlechat monitor webhook", () => {
     expect(processEvent).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(401);
     expect(res.body).toBe("unauthorized");
+  });
+
+  it("logs auth rejection reasons for header-bearer requests", async () => {
+    const error = vi.fn();
+    installSimplePipeline([
+      {
+        account: {
+          accountId: "default",
+          config: { appPrincipal: "chat-app" },
+        },
+        runtime: { error },
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+      },
+    ]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        type: "MESSAGE",
+        space: { name: "spaces/AAA" },
+        message: { name: "spaces/AAA/messages/1", text: "hello" },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockImplementation(async ({ isMatch, targets }) => {
+      for (const target of targets) {
+        if (await isMatch(target)) {
+          return target;
+        }
+      }
+      return null;
+    });
+    verifyGoogleChatRequest.mockResolvedValue({ ok: false, reason: "invalid token" });
+    const processEvent = vi.fn(async () => {});
+
+    const { createGoogleChatWebhookRequestHandler } = await import("./monitor-webhook.js");
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets: new Map(),
+      webhookInFlightLimiter: {} as never,
+      processEvent,
+    });
+
+    const req = createRequest("Bearer test-token");
+    const res = createResponse();
+    await expect(handler(req, res)).resolves.toBe(true);
+
+    expect(processEvent).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("webhook auth rejected (header) path=/googlechat"),
+    );
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("reason=invalid token"));
   });
 });

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -96,6 +96,23 @@ export function createGoogleChatWebhookRequestHandler(params: {
   webhookInFlightLimiter: WebhookInFlightLimiter;
   processEvent: (event: GoogleChatEvent, target: WebhookTarget) => Promise<void>;
 }): (req: IncomingMessage, res: ServerResponse) => Promise<boolean> {
+  const logAuthFailure = (opts: {
+    targets: WebhookTarget[];
+    source: "header" | "addon";
+    reasons: string[];
+    reqUrl: string;
+  }) => {
+    const { targets, source, reasons, reqUrl } = opts;
+    const reasonText = reasons.length > 0 ? reasons.join("; ") : "no match";
+    const message = `[googlechat] webhook auth rejected (${source}) path=${reqUrl} reasons=${reasonText}`;
+    const logger = targets[0]?.runtime.error ?? targets[0]?.runtime.log;
+    if (logger) {
+      logger(message);
+      return;
+    }
+    console.error(message);
+  };
+
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     return await withResolvedWebhookRequestPipeline({
       req,
@@ -133,6 +150,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
         };
 
         if (headerBearer) {
+          const authFailures: string[] = [];
           selectedTarget = await resolveWebhookTargetWithAuthOrReject({
             targets,
             res,
@@ -143,10 +161,21 @@ export function createGoogleChatWebhookRequestHandler(params: {
                 audience: target.audience,
                 expectedAddOnPrincipal: target.account.config.appPrincipal,
               });
+              if (!verification.ok) {
+                authFailures.push(
+                  `account=${target.account.accountId} reason=${verification.reason ?? "unauthorized"}`,
+                );
+              }
               return verification.ok;
             },
           });
           if (!selectedTarget) {
+            logAuthFailure({
+              targets,
+              source: "header",
+              reasons: authFailures,
+              reqUrl: String(req.url ?? "/"),
+            });
             return true;
           }
 
@@ -168,6 +197,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
             return true;
           }
 
+          const authFailures: string[] = [];
           selectedTarget = await resolveWebhookTargetWithAuthOrReject({
             targets,
             res,
@@ -178,10 +208,21 @@ export function createGoogleChatWebhookRequestHandler(params: {
                 audience: target.audience,
                 expectedAddOnPrincipal: target.account.config.appPrincipal,
               });
+              if (!verification.ok) {
+                authFailures.push(
+                  `account=${target.account.accountId} reason=${verification.reason ?? "unauthorized"}`,
+                );
+              }
               return verification.ok;
             },
           });
           if (!selectedTarget) {
+            logAuthFailure({
+              targets,
+              source: "addon",
+              reasons: authFailures,
+              reqUrl: String(req.url ?? "/"),
+            });
             return true;
           }
         }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -160,7 +160,7 @@ async function processMessageWithPipeline(params: {
   const sender = message.sender ?? event.user;
   const senderId = sender?.name ?? "";
   const senderName = sender?.displayName ?? "";
-  const senderEmail = sender?.email ?? undefined;
+  const senderEmail = sender?.email ?? event.user?.email ?? undefined;
 
   const allowBots = account.config.allowBots === true;
   if (!allowBots) {


### PR DESCRIPTION
## Summary
- accept Google Chat app-url JWTs when `iss` is the Chat issuer even when `email` is absent
- allow add-on issuer matching via either `iss` or `email` while preserving principal binding checks
- include explicit per-account auth rejection reasons in webhook logs to diagnose silent 401/404 behavior
- preserve sender personalization by falling back to `event.user.email` when `message.sender.email` is absent

## Tests
- pnpm exec vitest run extensions/googlechat/src/auth.test.ts extensions/googlechat/src/monitor-webhook.test.ts
- pnpm exec vitest run extensions/googlechat/src/*.test.ts