### PR TITLE
fix: preserve approved heredoc commands on gateway exec

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -285,10 +285,11 @@ export async function processGatewayAllowlist(
       recordMatchedAllowlistUse(resolvedPath ?? undefined);
 
       let run: Awaited<ReturnType<typeof runExecProcess>> | null = null;
+      const approvedExecCommand = requiresHeredocApproval ? params.command : enforcedCommand;
       try {
         run = await runExecProcess({
           command: params.command,
-          execCommand: enforcedCommand,
+          execCommand: approvedExecCommand,
           workdir: params.workdir,
           env: params.env,
           sandbox: undefined,


### PR DESCRIPTION
## Summary\n- preserve approved heredoc commands as-authored in the gateway exec approval flow\n- avoid routing approved heredoc commands through the rebuilt allowlist wrapper command\n- fixes approval-gated multiline commands like `osascript <<'APPLESCRIPT' ... APPLESCRIPT` failing with `No such file or directory`\n\n## Root cause\nThe gateway exec approval path rebuilt allowlist-satisfied commands into `enforcedCommand`. That rebuild does not preserve heredoc bodies correctly, so once a heredoc command was approved it could execute in a mangled form.\n\n## Fix\nWhen the command required heredoc-specific approval, execute the original command text (`params.command`) instead of the rebuilt wrapper command. Keep the rebuilt command path for non-heredoc cases.\n\n## Validation\n- reproduced locally with an approval-gated AppleScript heredoc\n- smoke-tested plain shell heredocs and `osascript` heredocs after the fix\n