### PR TITLE
fix: mark card field as optional in message tool schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Discord/timeouts: send a visible timeout reply when the inbound Discord worker times out before a final reply starts, including created auto-thread targets and queued-run ordering. (#53823) Thanks @Kimbo7870.
 - Models/google: normalize bare Google Generative AI API roots for custom provider names, and keep built-in Google model-id rewrites working when `api` is declared only on individual models, so custom Google lanes and older configs stop missing `/v1beta` or preview-id normalization. (#44969) Thanks @Kathie-yu.
 - Gateway/ports: parse Docker Compose-style `OPENCLAW_GATEWAY_PORT` host publish values correctly without reviving the legacy `CLAWDBOT_GATEWAY_PORT` override. (#44083) Thanks @bebule.
+- Feishu/MSTeams message tool: keep provider-native `card` payloads optional in merged tool schemas so media-only sends stop failing validation before channel runtime dispatch. (#53715) Thanks @lndyzwdxhs.
 
 ## 2026.3.23
 

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -576,6 +576,45 @@ describe("feishuPlugin actions", () => {
     ).rejects.toThrow("Feishu thread-reply requires messageId.");
   });
 
+  it("declares card as optional in the tool schema", () => {
+    const discovery = feishuPlugin.actions?.describeMessageTool?.({ cfg });
+    const schema = Array.isArray(discovery?.schema) ? discovery.schema[0] : discovery?.schema;
+    const cardSchema = schema?.properties?.card;
+    expect(cardSchema).toBeDefined();
+    // TypeBox marks Optional schemas with Symbol(TypeBox.Optional) = "Optional".
+    expect(
+      (cardSchema as unknown as Record<symbol, unknown>)?.[Symbol.for("TypeBox.Optional")],
+    ).toBe("Optional");
+  });
+
+  it("sends media-only messages without requiring card", async () => {
+    feishuOutboundSendMediaMock.mockResolvedValueOnce({
+      channel: "feishu",
+      messageId: "om_media_only",
+      details: { messageId: "om_media_only", chatId: "oc_group_1" },
+    });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        media: "https://example.com/image.png",
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+      mediaLocalRoots: [],
+    } as never);
+
+    expect(feishuOutboundSendMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_group_1",
+        mediaUrl: "https://example.com/image.png",
+      }),
+    );
+    expect(result?.details).toMatchObject({ messageId: "om_media_only" });
+  });
+
   it("fails for unsupported action names", async () => {
     await expect(
       feishuPlugin.actions?.handleAction?.({

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { ChannelMessageCapability } from "../../channels/plugins/message-capabilities.js";
 import type { ChannelMessageActionName, ChannelPlugin } from "../../channels/plugins/types.js";
 import type { MessageActionRunResult } from "../../infra/outbound/message-action-runner.js";
-import { createMessageToolButtonsSchema } from "../../plugin-sdk/channel-actions.js";
+import {
+  createMessageToolButtonsSchema,
+  createMessageToolCardSchema,
+} from "../../plugin-sdk/channel-actions.js";
 type CreateMessageTool = typeof import("./message-tool.js").createMessageTool;
 type SetActivePluginRegistry = typeof import("../../plugins/runtime.js").setActivePluginRegistry;
 type CreateTestRegistry = typeof import("../../test-utils/channel-plugins.js").createTestRegistry;
@@ -416,6 +419,38 @@ describe("message tool schema scoping", () => {
     const actionEnum = getActionEnum(getToolProperties(tool));
 
     expect(actionEnum).toContain("poll");
+  });
+
+  it("keeps provider card schema optional after merging into the message tool schema", () => {
+    const feishuPlugin = createChannelPlugin({
+      id: "feishu",
+      label: "Feishu",
+      docsPath: "/channels/feishu",
+      blurb: "Feishu test plugin.",
+      actions: ["send"],
+      capabilities: ["cards"],
+      toolSchema: () => ({
+        properties: {
+          card: createMessageToolCardSchema(),
+        },
+      }),
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", source: "test", plugin: feishuPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "feishu",
+    });
+    const schema = tool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(schema.properties?.card).toBeDefined();
+    expect(schema.required ?? []).not.toContain("card");
   });
 
   it("hides telegram poll extras when telegram polls are disabled in scoped mode", () => {

--- a/src/plugin-sdk/channel-actions.ts
+++ b/src/plugin-sdk/channel-actions.ts
@@ -25,11 +25,13 @@ export function createMessageToolButtonsSchema(): TSchema {
 
 /** Schema helper for channels that accept provider-native card payloads. */
 export function createMessageToolCardSchema(): TSchema {
-  return Type.Object(
-    {},
-    {
-      additionalProperties: true,
-      description: "Structured card payload for channels that support card-style messages.",
-    },
+  return Type.Optional(
+    Type.Object(
+      {},
+      {
+        additionalProperties: true,
+        description: "Structured card payload for channels that support card-style messages.",
+      },
+    ),
   );
 }


### PR DESCRIPTION
Fixes #53697. The `createMessageToolCardSchema()` helper returned a bare `Type.Object()` which TypeBox marks as required when merged into the parent message tool schema. This blocked media-only sends on Feishu (and MSTeams) with a "must have required property card" validation error. Wrap the return value in `Type.Optional()` so the `card` field is correctly excluded from JSON Schema `required`.

## Summary

- Problem: When sending images through Feishu using `{ action: "send", media: "/path/to/image.png" }`, schema validation rejects the payload with `"card: must have required property card"`. Including an empty `card: {}` bypasses validation but then hits the runtime guard `"Feishu send does not support card with media."` — a catch-22.
- Why it matters: Users cannot send media-only messages through Feishu or MSTeams channels at all. The `card` field is only needed for interactive card messages, not for text or media sends.
- What changed: Wrapped `createMessageToolCardSchema()` return value in `Type.Optional()` so TypeBox excludes `card` from the JSON Schema `required` array. Added 2 tests: schema optionality assertion + media-only send integration test.
- What did NOT change (scope boundary): The card schema shape itself is unchanged (`Type.Object({}, { additionalProperties: true })`). The runtime handling logic in `channel.ts` is unchanged. No new config, no fallback behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53697
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `createMessageToolCardSchema()` in `src/plugin-sdk/channel-actions.ts` returns `Type.Object(...)` without `Type.Optional()`. When channel plugins (Feishu, MSTeams) contribute this as `{ properties: { card: createMessageToolCardSchema() } }`, the schema merge in `message-action-discovery.ts` passes it into `Type.Object({ ...props })`, which makes `card` a required field in the final JSON Schema.
- Missing detection / guardrail: No test verified that the `card` field was optional in the contributed schema. Existing tests only tested card sends (which include the field) and text sends (which happen to not trigger the validation path in unit tests because they bypass schema validation).
- Prior context: The `createMessageToolCardSchema()` helper was added alongside card support for Feishu and MSTeams. The `Type.Optional()` wrapper was likely omitted by oversight, since the implementation code in `channel.ts` already treats `card` as optional (lines 508-511).
- Why this regressed now: Likely present since card schema was first introduced; may have been masked if schema validation was previously lenient or if a TypeBox version change tightened required-field enforcement.
- If unknown, what was ruled out: N/A — root cause is clear from TypeBox semantics.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/channel.test.ts`
- Scenario the test should lock in: (1) The `card` property in the Feishu tool schema must carry TypeBox's `Optional` marker. (2) A media-only send (no card, no text) succeeds through the action handler.
- Why this is the smallest reliable guardrail: The schema optionality test directly asserts the TypeBox `Optional` symbol on the contributed `card` property — if someone removes `Type.Optional()`, the test fails immediately.
- Existing test that already covers this (if any): None — existing "sends card messages" test only covers the card-present path.
- If no new test is added, why not: N/A — 2 new tests added.

## User-visible / Behavior Changes

- Feishu and MSTeams media-only sends (without a card) now pass schema validation and execute correctly.
- No change for card sends or text-only sends.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (also reproducible on Linux)
- Runtime/container: Node.js 23.x
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): Feishu channel configured with valid credentials

### Steps

1. Configure a Feishu channel
2. Send a message with only media: `{ action: "send", channel: "feishu", to: "chat:oc_group_1", media: "/path/to/image.png" }`
3. Observe validation error

### Expected

- Media send succeeds (no schema validation error for missing `card`)

### Actual

- Before this PR: `Validation failed for tool "message": card: must have required property "card"`
- After this PR: media send proceeds to the runtime handler

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2 new tests in `extensions/feishu/src/channel.test.ts`: schema optionality assertion and media-only send test. All existing Feishu channel tests remain green.

## Human Verification (required)

- Verified scenarios: TypeBox schema output confirms `card` is excluded from `required` array after the fix; `Type.Optional` symbol is present on the card schema. Media-only send handler test passes.
- Edge cases checked: Card-present sends still work (existing test). Text-only sends still work (existing test). Empty env (no card, no text, no media) still throws correct error.
- What you did **not** verify: Full `pnpm build` and `pnpm check` (pnpm not available locally — relies on CI). Manual end-to-end Feishu media send with real API.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes` — the card field was always intended to be optional; this restores correct behavior.
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit.
- Files/config to restore: `src/plugin-sdk/channel-actions.ts` to prior version; remove new tests from `extensions/feishu/src/channel.test.ts`.
- Known bad symptoms reviewers should watch for: Any schema validation change for channels that use `createMessageToolCardSchema()` (currently Feishu and MSTeams). If a channel plugin relied on `card` being required (unlikely — none do), that would be a behavior change.

## Risks and Mitigations

- Risk: MSTeams also uses `createMessageToolCardSchema()` — the fix applies there too.
  - Mitigation: This is intentional and correct. MSTeams card field should also be optional for the same reason. The MSTeams action handler already treats card as optional in its implementation.
