### PR TITLE
fix(paths): expand env placeholders in resolveUserPath

### DIFF
--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -219,4 +219,20 @@ describe("resolveOsHomeRelativePath", () => {
       }),
     ).toBe(path.resolve("/home/alice/docs"));
   });
+
+  it("expands braced environment placeholders", () => {
+    expect(
+      resolveOsHomeRelativePath("${XDG_CONFIG_HOME}/workspace/skills", {
+        env: { XDG_CONFIG_HOME: "/home/node/.openclaw" } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.resolve("/home/node/.openclaw/workspace/skills"));
+  });
+
+  it("keeps empty-string environment placeholders unchanged", () => {
+    expect(
+      resolveOsHomeRelativePath("${XDG_CONFIG_HOME}/workspace", {
+        env: { XDG_CONFIG_HOME: "   " } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.resolve("${XDG_CONFIG_HOME}/workspace"));
+  });
 });

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -174,6 +174,28 @@ describe("resolveHomeRelativePath", () => {
     ).toBe(path.resolve("/srv/openclaw-home/docs"));
   });
 
+  it("expands braced environment placeholders", () => {
+    expect(
+      resolveHomeRelativePath("${XDG_CONFIG_HOME}/workspace/skills", {
+        env: { XDG_CONFIG_HOME: "/home/node/.openclaw" } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.resolve("/home/node/.openclaw/workspace/skills"));
+  });
+
+  it("expands bare environment placeholders", () => {
+    expect(
+      resolveHomeRelativePath("$XDG_CONFIG_HOME/workspace/skills", {
+        env: { XDG_CONFIG_HOME: "/home/node/.openclaw" } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.resolve("/home/node/.openclaw/workspace/skills"));
+  });
+
+  it("keeps unknown placeholders unchanged", () => {
+    expect(resolveHomeRelativePath("${MISSING_ENV}/workspace")).toBe(
+      path.resolve("${MISSING_ENV}/workspace"),
+    );
+  });
+
   it("falls back to cwd when tilde paths have no home source", () => {
     expect(
       resolveHomeRelativePath("~", {

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -196,6 +196,23 @@ describe("resolveHomeRelativePath", () => {
     );
   });
 
+  it("keeps inherited placeholder names unchanged", () => {
+    expect(resolveHomeRelativePath("$toString/workspace", { env: {} as NodeJS.ProcessEnv })).toBe(
+      path.resolve("$toString/workspace"),
+    );
+  });
+
+  it("expands env placeholders with tilde values without duplicating home", () => {
+    expect(
+      resolveHomeRelativePath("${OPENCLAW_HOME}/plugins", {
+        env: {
+          OPENCLAW_HOME: "~/.openclaw",
+          HOME: "/home/alice",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.resolve("/home/alice/.openclaw/plugins"));
+  });
+
   it("falls back to cwd when tilde paths have no home source", () => {
     expect(
       resolveHomeRelativePath("~", {
@@ -234,5 +251,22 @@ describe("resolveOsHomeRelativePath", () => {
         env: { XDG_CONFIG_HOME: "   " } as NodeJS.ProcessEnv,
       }),
     ).toBe(path.resolve("${XDG_CONFIG_HOME}/workspace"));
+  });
+
+  it("keeps inherited placeholder names unchanged", () => {
+    expect(resolveOsHomeRelativePath("$toString/workspace", { env: {} as NodeJS.ProcessEnv })).toBe(
+      path.resolve("$toString/workspace"),
+    );
+  });
+
+  it("expands env placeholders with tilde values using OS home", () => {
+    expect(
+      resolveOsHomeRelativePath("${XDG_CONFIG_HOME}/workspace", {
+        env: {
+          XDG_CONFIG_HOME: "~/.openclaw",
+          HOME: "/home/bob",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toBe(path.resolve("/home/bob/.openclaw/workspace"));
   });
 });

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -98,6 +98,20 @@ export function expandHomePrefix(
   return input.replace(/^~(?=$|[\\/])/, home);
 }
 
+function expandEnvPlaceholders(input: string, env: NodeJS.ProcessEnv): string {
+  return input.replace(
+    /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+    (token, braced, bare) => {
+      const key = String(braced ?? bare ?? "");
+      if (!key) {
+        return token;
+      }
+      const resolved = normalize(env[key]);
+      return resolved ?? token;
+    },
+  );
+}
+
 export function resolveHomeRelativePath(
   input: string,
   opts?: {
@@ -105,19 +119,21 @@ export function resolveHomeRelativePath(
     homedir?: () => string;
   },
 ): string {
+  const env = opts?.env ?? process.env;
   const trimmed = input.trim();
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed.startsWith("~")) {
-    const expanded = expandHomePrefix(trimmed, {
-      home: resolveRequiredHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir),
-      env: opts?.env,
+  const expandedEnv = expandEnvPlaceholders(trimmed, env);
+  if (expandedEnv.startsWith("~")) {
+    const expanded = expandHomePrefix(expandedEnv, {
+      home: resolveRequiredHomeDir(env, opts?.homedir ?? os.homedir),
+      env,
       homedir: opts?.homedir,
     });
     return path.resolve(expanded);
   }
-  return path.resolve(trimmed);
+  return path.resolve(expandedEnv);
 }
 
 export function resolveOsHomeRelativePath(
@@ -127,17 +143,19 @@ export function resolveOsHomeRelativePath(
     homedir?: () => string;
   },
 ): string {
+  const env = opts?.env ?? process.env;
   const trimmed = input.trim();
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed.startsWith("~")) {
-    const expanded = expandHomePrefix(trimmed, {
-      home: resolveRequiredOsHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir),
-      env: opts?.env,
+  const expandedEnv = expandEnvPlaceholders(trimmed, env);
+  if (expandedEnv.startsWith("~")) {
+    const expanded = expandHomePrefix(expandedEnv, {
+      home: resolveRequiredOsHomeDir(env, opts?.homedir ?? os.homedir),
+      env,
       homedir: opts?.homedir,
     });
     return path.resolve(expanded);
   }
-  return path.resolve(trimmed);
+  return path.resolve(expandedEnv);
 }

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -106,6 +106,7 @@ function expandEnvPlaceholders(input: string, env: NodeJS.ProcessEnv): string {
       if (!key) {
         return token;
       }
+      // 空字符串环境变量按未设置处理，保留原占位符，避免把路径段替换成空值。
       const resolved = normalize(env[key]);
       return resolved ?? token;
     },

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -98,7 +98,18 @@ export function expandHomePrefix(
   return input.replace(/^~(?=$|[\\/])/, home);
 }
 
-function expandEnvPlaceholders(input: string, env: NodeJS.ProcessEnv): string {
+function normalizeEnvValue(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return normalize(value);
+}
+
+function expandEnvPlaceholders(
+  input: string,
+  env: NodeJS.ProcessEnv,
+  expandTilde?: (value: string) => string,
+): string {
   return input.replace(
     /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
     (token, braced, bare) => {
@@ -106,9 +117,15 @@ function expandEnvPlaceholders(input: string, env: NodeJS.ProcessEnv): string {
       if (!key) {
         return token;
       }
+      if (!Object.hasOwn(env, key)) {
+        return token;
+      }
       // 空字符串环境变量按未设置处理，保留原占位符，避免把路径段替换成空值。
-      const resolved = normalize(env[key]);
-      return resolved ?? token;
+      const resolved = normalizeEnvValue(env[key]);
+      if (!resolved) {
+        return token;
+      }
+      return expandTilde ? expandTilde(resolved) : resolved;
     },
   );
 }
@@ -125,14 +142,23 @@ export function resolveHomeRelativePath(
   if (!trimmed) {
     return trimmed;
   }
-  const expandedEnv = expandEnvPlaceholders(trimmed, env);
-  if (expandedEnv.startsWith("~")) {
-    const expanded = expandHomePrefix(expandedEnv, {
-      home: resolveRequiredHomeDir(env, opts?.homedir ?? os.homedir),
+  const home = resolveRequiredHomeDir(env, opts?.homedir ?? os.homedir);
+  const osHome = resolveRequiredOsHomeDir(env, opts?.homedir ?? os.homedir);
+  const expandedEnv = expandEnvPlaceholders(trimmed, env, (value) =>
+    expandHomePrefix(value, {
+      home: osHome,
       env,
       homedir: opts?.homedir,
-    });
-    return path.resolve(expanded);
+    }),
+  );
+  if (expandedEnv.startsWith("~")) {
+    return path.resolve(
+      expandHomePrefix(expandedEnv, {
+        home,
+        env,
+        homedir: opts?.homedir,
+      }),
+    );
   }
   return path.resolve(expandedEnv);
 }
@@ -149,14 +175,22 @@ export function resolveOsHomeRelativePath(
   if (!trimmed) {
     return trimmed;
   }
-  const expandedEnv = expandEnvPlaceholders(trimmed, env);
-  if (expandedEnv.startsWith("~")) {
-    const expanded = expandHomePrefix(expandedEnv, {
-      home: resolveRequiredOsHomeDir(env, opts?.homedir ?? os.homedir),
+  const home = resolveRequiredOsHomeDir(env, opts?.homedir ?? os.homedir);
+  const expandedEnv = expandEnvPlaceholders(trimmed, env, (value) =>
+    expandHomePrefix(value, {
+      home,
       env,
       homedir: opts?.homedir,
-    });
-    return path.resolve(expanded);
+    }),
+  );
+  if (expandedEnv.startsWith("~")) {
+    return path.resolve(
+      expandHomePrefix(expandedEnv, {
+        home,
+        env,
+        homedir: opts?.homedir,
+      }),
+    );
   }
   return path.resolve(expandedEnv);
 }


### PR DESCRIPTION
## Summary
Fix path resolution so environment placeholders are expanded before filesystem resolution.

This addresses issue #53628 where `${XDG_CONFIG_HOME}` in configured path strings was treated as a literal directory name.

## Changes
- Add environment placeholder expansion in `src/infra/home-dir.ts`.
  - Support `${VAR_NAME}` and `$VAR_NAME` forms.
  - Keep unknown placeholders unchanged.
  - Preserve existing `~` home expansion behavior.
- Add tests in `src/infra/home-dir.test.ts`:
  - braced env placeholder expansion
  - bare env placeholder expansion
  - unknown placeholder passthrough

## Why this fixes the bug
`resolveUserPath` delegates to `resolveHomeRelativePath`. After this change, inputs like:
- `${XDG_CONFIG_HOME}/workspace/skills`
- `$XDG_CONFIG_HOME/workspace/skills`
are resolved using `process.env.XDG_CONFIG_HOME` (or provided env), so skill installation no longer writes into a literal `${XDG_CONFIG_HOME}` folder.

## Testing
```bash
npx vitest run src/infra/home-dir.test.ts src/utils.test.ts
```
Result: pass (`3 files, 51 tests`).

## Risk / boundaries
- Scope is limited to path normalization helpers.
- Unknown env placeholders are intentionally left unchanged.
- Existing behavior for plain paths and tilde expansion is preserved.
