### PR TITLE
Agents: keep memory flush daily files append-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - LINE/status: stop `openclaw status` from warning about missing credentials when sanitized LINE snapshots are already configured, while still surfacing whether the missing field is the token or secret. (#45701) Thanks @tamaosamu.
 - Gateway/health: carry webhook-vs-polling account mode from channel descriptors into runtime snapshots so passive channels like LINE and BlueBubbles skip false stale-socket health failures. (#47488) Thanks @karesansui-u.
 - Memory/QMD: honor `memory.qmd.update.embedInterval` even when regular QMD update cadence is disabled or slower by arming a dedicated embed-cadence maintenance timer, while avoiding redundant timers when regular updates are already frequent enough. (#37326) Thanks @barronlroth.
+- Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 
 ## 2026.3.28-beta.1
 

--- a/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+
+describe("runEmbeddedAttempt memory flush tool forwarding", () => {
+  it("forwards memory trigger metadata into tool creation so append-only guards activate", async () => {
+    vi.resetModules();
+
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-memory-flush-"));
+    const stop = new Error("stop after tool creation");
+    const capturedOptions: Array<Record<string, unknown> | undefined> = [];
+
+    try {
+      vi.doMock("../../pi-tools.js", async () => {
+        const actual =
+          await vi.importActual<typeof import("../../pi-tools.js")>("../../pi-tools.js");
+        return {
+          ...actual,
+          createOpenClawCodingTools: vi.fn((options) => {
+            capturedOptions.push(options as Record<string, unknown> | undefined);
+            throw stop;
+          }),
+        };
+      });
+
+      const { runEmbeddedAttempt } = await import("./attempt.js");
+
+      await expect(
+        runEmbeddedAttempt({
+          sessionId: "session-memory-flush",
+          sessionKey: "agent:main",
+          sessionFile: path.join(workspaceDir, "session.json"),
+          workspaceDir,
+          prompt: "flush durable notes",
+          timeoutMs: 30_000,
+          runId: "run-memory-flush",
+          provider: "openai",
+          modelId: "gpt-5.4",
+          model: {
+            api: "responses",
+            provider: "openai",
+            id: "gpt-5.4",
+            input: ["text"],
+            contextWindow: 128_000,
+          } as Model<Api>,
+          authStorage: {} as AuthStorage,
+          modelRegistry: {} as ModelRegistry,
+          thinkLevel: "off",
+          trigger: "memory",
+          memoryFlushWritePath: "memory/2026-03-24.md",
+        }),
+      ).rejects.toBe(stop);
+
+      expect(capturedOptions).toHaveLength(1);
+      expect(capturedOptions[0]).toMatchObject({
+        trigger: "memory",
+        memoryFlushWritePath: "memory/2026-03-24.md",
+      });
+    } finally {
+      vi.doUnmock("../../pi-tools.js");
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "../../pi-tools.types.js";
 
 const MEMORY_RELATIVE_PATH = "memory/2026-03-24.md";
 
@@ -69,47 +70,52 @@ describe("runEmbeddedAttempt memory flush tool forwarding", () => {
     }
   });
 
-  it("keeps the forwarded memory flush write tool append-only", async () => {
-    vi.resetModules();
-
-    const workspaceDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-attempt-memory-flush-append-"),
-    );
+  it("activates the memory flush append-only write wrapper", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-memory-flush-"));
     const memoryFile = path.join(workspaceDir, MEMORY_RELATIVE_PATH);
-    const stop = new Error("stop after append-only write check");
-    let appendOnlyWrite: Promise<unknown> | undefined;
 
     try {
       await fs.mkdir(path.dirname(memoryFile), { recursive: true });
       await fs.writeFile(memoryFile, "seed", "utf-8");
 
-      vi.doMock("../../pi-tools.js", async () => {
-        const actual =
-          await vi.importActual<typeof import("../../pi-tools.js")>("../../pi-tools.js");
-        return {
-          ...actual,
-          createOpenClawCodingTools: vi.fn((options) => {
-            const tools = actual.createOpenClawCodingTools(options);
-            const writeTool = tools.find((tool) => tool.name === "write");
-            expect(writeTool).toBeDefined();
-
-            appendOnlyWrite = writeTool!.execute("call-memory-flush", {
-              path: MEMORY_RELATIVE_PATH,
-              content: "new durable note",
-            });
-
-            throw stop;
-          }),
-        };
+      const { wrapToolMemoryFlushAppendOnlyWrite } = await import("../../pi-tools.read.js");
+      const fallbackWrite = vi.fn(async () => {
+        throw new Error("append-only wrapper should not delegate to the base write tool");
+      });
+      const writeTool: AnyAgentTool = {
+        name: "write",
+        description: "Write content to a file.",
+        parameters: { type: "object", properties: {} },
+        execute: fallbackWrite,
+      };
+      const wrapped = wrapToolMemoryFlushAppendOnlyWrite(writeTool, {
+        root: workspaceDir,
+        relativePath: MEMORY_RELATIVE_PATH,
       });
 
-      const { runEmbeddedAttempt } = await import("./attempt.js");
-
-      await expect(runEmbeddedAttempt(createAttemptParams(workspaceDir))).rejects.toBe(stop);
-      await expect(appendOnlyWrite).resolves.toBeDefined();
+      await expect(
+        wrapped.execute("call-memory-flush-append", {
+          path: MEMORY_RELATIVE_PATH,
+          content: "new durable note",
+        }),
+      ).resolves.toMatchObject({
+        content: [{ type: "text", text: `Appended content to ${MEMORY_RELATIVE_PATH}.` }],
+        details: {
+          path: MEMORY_RELATIVE_PATH,
+          appendOnly: true,
+        },
+      });
       await expect(fs.readFile(memoryFile, "utf-8")).resolves.toBe("seed\nnew durable note");
+      await expect(
+        wrapped.execute("call-memory-flush-deny", {
+          path: "memory/other-day.md",
+          content: "wrong target",
+        }),
+      ).rejects.toThrow(
+        `Memory flush writes are restricted to ${MEMORY_RELATIVE_PATH}; use that path only.`,
+      );
+      expect(fallbackWrite).not.toHaveBeenCalled();
     } finally {
-      vi.doUnmock("../../pi-tools.js");
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });

--- a/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
@@ -5,6 +5,34 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 
+const MEMORY_RELATIVE_PATH = "memory/2026-03-24.md";
+
+function createAttemptParams(workspaceDir: string) {
+  return {
+    sessionId: "session-memory-flush",
+    sessionKey: "agent:main",
+    sessionFile: path.join(workspaceDir, "session.json"),
+    workspaceDir,
+    prompt: "flush durable notes",
+    timeoutMs: 30_000,
+    runId: "run-memory-flush",
+    provider: "openai",
+    modelId: "gpt-5.4",
+    model: {
+      api: "responses",
+      provider: "openai",
+      id: "gpt-5.4",
+      input: ["text"],
+      contextWindow: 128_000,
+    } as Model<Api>,
+    authStorage: {} as AuthStorage,
+    modelRegistry: {} as ModelRegistry,
+    thinkLevel: "off" as const,
+    trigger: "memory" as const,
+    memoryFlushWritePath: MEMORY_RELATIVE_PATH,
+  };
+}
+
 describe("runEmbeddedAttempt memory flush tool forwarding", () => {
   it("forwards memory trigger metadata into tool creation so append-only guards activate", async () => {
     vi.resetModules();
@@ -28,37 +56,58 @@ describe("runEmbeddedAttempt memory flush tool forwarding", () => {
 
       const { runEmbeddedAttempt } = await import("./attempt.js");
 
-      await expect(
-        runEmbeddedAttempt({
-          sessionId: "session-memory-flush",
-          sessionKey: "agent:main",
-          sessionFile: path.join(workspaceDir, "session.json"),
-          workspaceDir,
-          prompt: "flush durable notes",
-          timeoutMs: 30_000,
-          runId: "run-memory-flush",
-          provider: "openai",
-          modelId: "gpt-5.4",
-          model: {
-            api: "responses",
-            provider: "openai",
-            id: "gpt-5.4",
-            input: ["text"],
-            contextWindow: 128_000,
-          } as Model<Api>,
-          authStorage: {} as AuthStorage,
-          modelRegistry: {} as ModelRegistry,
-          thinkLevel: "off",
-          trigger: "memory",
-          memoryFlushWritePath: "memory/2026-03-24.md",
-        }),
-      ).rejects.toBe(stop);
+      await expect(runEmbeddedAttempt(createAttemptParams(workspaceDir))).rejects.toBe(stop);
 
       expect(capturedOptions).toHaveLength(1);
       expect(capturedOptions[0]).toMatchObject({
         trigger: "memory",
-        memoryFlushWritePath: "memory/2026-03-24.md",
+        memoryFlushWritePath: MEMORY_RELATIVE_PATH,
       });
+    } finally {
+      vi.doUnmock("../../pi-tools.js");
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the forwarded memory flush write tool append-only", async () => {
+    vi.resetModules();
+
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-attempt-memory-flush-append-"),
+    );
+    const memoryFile = path.join(workspaceDir, MEMORY_RELATIVE_PATH);
+    const stop = new Error("stop after append-only write check");
+    let appendOnlyWrite: Promise<unknown> | undefined;
+
+    try {
+      await fs.mkdir(path.dirname(memoryFile), { recursive: true });
+      await fs.writeFile(memoryFile, "seed", "utf-8");
+
+      vi.doMock("../../pi-tools.js", async () => {
+        const actual =
+          await vi.importActual<typeof import("../../pi-tools.js")>("../../pi-tools.js");
+        return {
+          ...actual,
+          createOpenClawCodingTools: vi.fn((options) => {
+            const tools = actual.createOpenClawCodingTools(options);
+            const writeTool = tools.find((tool) => tool.name === "write");
+            expect(writeTool).toBeDefined();
+
+            appendOnlyWrite = writeTool!.execute("call-memory-flush", {
+              path: MEMORY_RELATIVE_PATH,
+              content: "new durable note",
+            });
+
+            throw stop;
+          }),
+        };
+      });
+
+      const { runEmbeddedAttempt } = await import("./attempt.js");
+
+      await expect(runEmbeddedAttempt(createAttemptParams(workspaceDir))).rejects.toBe(stop);
+      await expect(appendOnlyWrite).resolves.toBeDefined();
+      await expect(fs.readFile(memoryFile, "utf-8")).resolves.toBe("seed\nnew durable note");
     } finally {
       vi.doUnmock("../../pi-tools.js");
       await fs.rm(workspaceDir, { recursive: true, force: true });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -419,6 +419,8 @@ export async function runEmbeddedAttempt(
       ? []
       : createOpenClawCodingTools({
           agentId: sessionAgentId,
+          trigger: params.trigger,
+          memoryFlushWritePath: params.memoryFlushWritePath,
           exec: {
             ...params.execOverrides,
             elevated: params.bashElevated,


### PR DESCRIPTION
## Summary

- Problem: pre-compaction memory flush runs could overwrite an existing `memory/YYYY-MM-DD.md` file instead of appending to it.
- Why it matters: this breaks the append-only durability guard and can destroy earlier daily-memory entries.
- What changed: forward `trigger` and `memoryFlushWritePath` from `runEmbeddedAttempt` into `createOpenClawCodingTools(...)`, so memory-triggered write runs keep the append-only wrapper active.
- What did NOT change (scope boundary): the append-only implementation itself in the tool layer was not rewritten; this PR only restores the missing runner-to-tool plumbing and adds regression coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53463
- Related #41761
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `runReplyAgent` and `runEmbeddedPiAgent` forwarded memory flush metadata, but `runEmbeddedAttempt` dropped `trigger` and `memoryFlushWritePath` before tool creation.
- Missing detection / guardrail: existing tests covered the caller-side parameter forwarding and the append-only tool wrapper in isolation, but not the seam between runner attempt setup and tool creation.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #41761 explicitly restored `memoryFlushWritePath` forwarding into embedded runs, but the runner attempt layer still did not hand the data to `createOpenClawCodingTools(...)`.
- Why this regressed now: the append-only guard depends on memory-trigger metadata surviving all the way into tool construction; losing it at this seam silently downgraded the write path to normal overwrite semantics.
- If unknown, what was ruled out: ruled out prompt/docs mismatch and ruled out a defect inside the append-only write helper itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts`
- Scenario the test should lock in: a memory-triggered embedded attempt must pass `trigger: "memory"` and `memoryFlushWritePath` into tool creation so the append-only write wrapper activates.
- Why this is the smallest reliable guardrail: the bug was not at the caller or the write helper; it lived in the plumbing seam between them.
- Existing test that already covers this (if any): `src/agents/pi-tools.workspace-only-false.test.ts` already verifies append-only enforcement once the tool layer receives the right inputs.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Pre-compaction memory flush once again appends to an existing `memory/YYYY-MM-DD.md` file instead of overwriting it.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev shell
- Model/provider: openai-codex / gpt-5.4
- Integration/channel (if any): embedded direct session
- Relevant config (redacted): `agents.defaults.compaction.memoryFlush.enabled = true`

### Steps

1. Create an existing `memory/YYYY-MM-DD.md` file with prior content.
2. Trigger a long-enough embedded session so pre-compaction memory flush runs.
3. Inspect the resulting daily memory file.

### Expected

- Existing content remains and new flush content is appended.

### Actual

- Existing content could be replaced by the shorter flush summary.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: memory-triggered runner attempt now forwards append-only metadata into tool creation; existing append-only tool guard still passes; memory flush e2e tests still pass.
- Edge cases checked: existing canonical memory file path is still enforced by the tool wrapper.
- What you did **not** verify: full local `pnpm build` did not complete in this environment because postbuild runtime-deps staging failed on `npm install` for bundled `discord` deps.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or disable `agents.defaults.compaction.memoryFlush.enabled`.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: memory flush writes behaving like ordinary overwrites again.

## Risks and Mitigations

- Risk: another runner path could drop memory-trigger metadata before tool construction.
  - Mitigation: add the seam-level regression test to lock the runner-to-tool contract in place.
