### PR TITLE
fix(media-tools): apply models.providers baseUrl override in image and pdf tools

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -797,7 +797,7 @@ export async function resolveModelAsync(
  *
  * See: https://github.com/openclaw/openclaw/issues/17328
  */
-function buildUnknownModelError(params: {
+export function buildUnknownModelError(params: {
   provider: string;
   modelId: string;
   cfg?: OpenClawConfig;

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -395,18 +395,6 @@ export function buildTextToolResult(
   };
 }
 
-export function resolveModelFromRegistry(params: {
-  modelRegistry: { find: (provider: string, modelId: string) => unknown };
-  provider: string;
-  modelId: string;
-}): Model<Api> {
-  const model = params.modelRegistry.find(params.provider, params.modelId) as Model<Api> | null;
-  if (!model) {
-    throw new Error(`Unknown model: ${params.provider}/${params.modelId}`);
-  }
-  return model;
-}
-
 export async function resolveModelRuntimeApiKey(params: {
   model: Model<Api>;
   cfg: OpenClawConfig | undefined;

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -282,6 +282,82 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("uses text extraction for registry-backed text-only model when PDF has images", async () => {
+    // Regression: registry-backed text-only models should use text extraction, not throw
+    await withTempAgentDir(async (agentDir) => {
+      // Model IS in the registry with input: ["text"] (definitive text-only declaration)
+      await stubPdfToolInfra(agentDir, { provider: "openai", input: ["text"] });
+
+      const extractSpy = vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted text from PDF",
+        images: [{ base64: "aW1n", mimeType: "image/png", pageIndex: 0 }],
+      } as never);
+
+      completeMock.mockResolvedValue({
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "text", text: "text-only summary" }],
+      } as never);
+
+      const cfg = withPdfModel(OPENAI_PDF_MODEL);
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      const result = await tool.execute("t1", { prompt: "summarize", pdf: "/tmp/doc.pdf" });
+
+      expect(extractSpy).toHaveBeenCalledTimes(1);
+      expect(result).toMatchObject({
+        content: [{ type: "text", text: "text-only summary" }],
+        details: { native: false, model: OPENAI_PDF_MODEL },
+      });
+    });
+  });
+
+  it("throws for synthesized fallback model (not in registry) when PDF has images", async () => {
+    // Synthesized fallback models (baseUrl configured but no registry entry) should throw
+    // so runWithImageModelFallback can try the next candidate
+    await withTempAgentDir(async (agentDir) => {
+      // Model is NOT in the registry (modelFound: false) but provider has a baseUrl config
+      vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue(FAKE_PDF_MEDIA as never);
+      vi.spyOn(modelDiscovery, "discoverAuthStorage").mockReturnValue({
+        setRuntimeApiKey: vi.fn(),
+      } as never);
+      vi.spyOn(modelDiscovery, "discoverModels").mockReturnValue({
+        find: () => undefined,
+      } as never);
+      vi.spyOn(modelsConfig, "ensureOpenClawModelsJson").mockResolvedValue({
+        agentDir,
+        wrote: false,
+      });
+      vi.spyOn(modelAuth, "getApiKeyForModel").mockResolvedValue({ apiKey: "test-key" } as never); // pragma: allowlist secret
+      vi.spyOn(modelAuth, "requireApiKey").mockReturnValue("test-key");
+
+      vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "Extracted text",
+        images: [{ base64: "aW1n", mimeType: "image/png", pageIndex: 0 }],
+      } as never);
+
+      // Provider has a baseUrl (synthesized fallback scenario) but model not in registry
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            pdfModel: { primary: "custom-provider/some-model" },
+          },
+        },
+        models: {
+          providers: {
+            "custom-provider": { baseUrl: "https://custom.example.com/v1" },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const tool = requirePdfTool(createPdfTool({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", { prompt: "summarize", pdf: "/tmp/doc.pdf" }),
+      ).rejects.toThrow(/does not support images|image model/i);
+    });
+  });
+
   it("tool parameters have correct schema shape", async () => {
     await loadCreatePdfTool();
     const schema = PdfToolSchema;

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -3,6 +3,9 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
+import { normalizeStaticProviderModelId } from "../model-ref-shared.js";
+import { buildUnknownModelError, resolveModelWithRegistry } from "../pi-embedded-runner/model.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../provider-id.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -12,7 +15,6 @@ import { type ImageModelConfig } from "./image-tool.helpers.js";
 import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
-  resolveModelFromRegistry,
   resolveMediaToolLocalRoots,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
@@ -104,6 +106,36 @@ function buildPdfExtractionContext(prompt: string, extractions: PdfExtractedCont
 // Run PDF prompt with model fallback
 // ---------------------------------------------------------------------------
 
+// Returns true when the model is definitively known to be text-only — either
+// because the user explicitly declared it in models.providers.[provider].models[].input,
+// or because the model registry has an entry that declares text-only input.
+// Synthesized fallback models (provider has a baseUrl but the model has no registry
+// entry and no explicit config) are excluded: their input defaults to ["text"] as a
+// placeholder, not a deliberate declaration, so callers can try the next candidate.
+function isKnownTextOnlyModel(
+  cfg: OpenClawConfig | undefined,
+  modelRegistry: { find(provider: string, modelId: string): { input?: string[] } | undefined },
+  provider: string,
+  modelId: string,
+): boolean {
+  // Explicitly configured as text-only via models.providers.<provider>.models[].input
+  const providerConfig = findNormalizedProviderValue(cfg?.models?.providers, provider);
+  const entry = providerConfig?.models?.find((m) => m.id === modelId);
+  if (entry !== undefined && entry.input !== undefined && !entry.input.includes("image")) {
+    return true;
+  }
+  // Registry-backed and declared text-only (not a synthesized fallback with a default input)
+  const normalizedProvider = normalizeProviderId(provider);
+  const normalizedModelId = normalizeStaticProviderModelId(normalizedProvider, modelId);
+  const registryModel = modelRegistry.find(normalizedProvider, normalizedModelId);
+  return (
+    registryModel !== undefined &&
+    Array.isArray(registryModel.input) &&
+    registryModel.input.length > 0 &&
+    !registryModel.input.includes("image")
+  );
+}
+
 type PdfSandboxConfig = {
   root: string;
   bridge: SandboxFsBridge;
@@ -143,7 +175,15 @@ async function runPdfPrompt(params: {
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
-      const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
+      const model = resolveModelWithRegistry({
+        modelRegistry,
+        provider,
+        modelId,
+        cfg: effectiveCfg,
+      });
+      if (!model) {
+        throw new Error(buildUnknownModelError({ provider, modelId, cfg: effectiveCfg, agentDir: params.agentDir }));
+      }
       const apiKey = await resolveModelRuntimeApiKey({
         model,
         cfg: effectiveCfg,
@@ -190,6 +230,15 @@ async function runPdfPrompt(params: {
       const extractions = await getExtractions();
       const hasImages = extractions.some((e) => e.images.length > 0);
       if (hasImages && !model.input?.includes("image")) {
+        // resolveModelWithRegistry may synthesize a text-only fallback model when a provider
+        // config (e.g. baseUrl) is present but the model has no registry entry. That synthetic
+        // model defaults to text-only input, which is effectively the same as "unknown" —
+        // throw so runWithImageModelFallback can try the next candidate instead of silently
+        // dropping PDF images. Registry-backed models with a definitive text-only declaration
+        // are allowed through to the text-extraction fallback below.
+        if (!isKnownTextOnlyModel(effectiveCfg, modelRegistry, provider, modelId)) {
+          throw new Error(`Model ${provider}/${modelId} does not support images.`);
+        }
         const hasText = extractions.some((e) => e.text.trim().length > 0);
         if (!hasText) {
           throw new Error(

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -324,4 +324,53 @@ describe("describeImageWithModel", () => {
     );
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
   });
+
+  it("rethrows image-not-supported error when model is explicitly text-only under a non-canonical provider key", async () => {
+    // Provider key in cfg uses non-canonical casing ("MiniMax-Portal" instead of "minimax-portal").
+    // Before the fix, isExplicitlyTextOnlyModel used a direct property lookup and returned false,
+    // causing the fallback to describeImagesWithMinimax despite the explicit text-only restriction.
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "minimax-portal",
+        id: "MiniMax-VL-01",
+        input: ["text"],
+        api: "openai-responses",
+        baseUrl: "https://api.minimax.io/v1",
+      })),
+    });
+
+    await expect(
+      describeImageWithModel({
+        cfg: {
+          models: {
+            providers: {
+              "MiniMax-Portal": {
+                baseUrl: "",
+                models: [
+                  {
+                    id: "MiniMax-VL-01",
+                    name: "MiniMax-VL-01",
+                    reasoning: false,
+                    input: ["text" as const],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 4096,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-agent",
+        provider: "minimax-portal",
+        model: "MiniMax-VL-01",
+        buffer: Buffer.from("png-bytes"),
+        fileName: "image.png",
+        mime: "image/png",
+        prompt: "Describe the image.",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("Model does not support images:");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -7,7 +7,12 @@ import {
   resolveApiKeyForProvider,
 } from "../agents/model-auth.js";
 import { normalizeModelRef } from "../agents/model-selection.js";
+import { findNormalizedProviderValue } from "../agents/provider-id.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import {
+  buildUnknownModelError,
+  resolveModelWithRegistry,
+} from "../agents/pi-embedded-runner/model.js";
 import { coerceImageAssistantText } from "../agents/tools/image-tool.helpers.js";
 import type {
   ImageDescriptionRequest,
@@ -49,9 +54,14 @@ async function resolveImageRuntime(params: {
   const authStorage = discoverAuthStorage(params.agentDir);
   const modelRegistry = discoverModels(authStorage, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
-  const model = modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model<Api> | null;
+  const model = resolveModelWithRegistry({
+    modelRegistry,
+    provider: resolvedRef.provider,
+    modelId: resolvedRef.model,
+    cfg: params.cfg,
+  });
   if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
+    throw new Error(buildUnknownModelError({ provider: resolvedRef.provider, modelId: resolvedRef.model, cfg: params.cfg, agentDir: params.agentDir }));
   }
   if (!model.input?.includes("image")) {
     throw new Error(`Model does not support images: ${params.provider}/${params.model}`);
@@ -119,6 +129,26 @@ function isUnknownModelError(err: unknown): boolean {
   return err instanceof Error && /^Unknown model:/i.test(err.message);
 }
 
+// resolveModelWithRegistry may synthesize a text-only fallback model when a provider config
+// (e.g. baseUrl) is present but the model has no registry entry. For MiniMax VLM models that
+// is effectively the same as "unknown" — preserve the fallback path.
+function isImageNotSupportedError(err: unknown): boolean {
+  return err instanceof Error && err.message.startsWith("Model does not support images:");
+}
+
+// Returns true when the user has explicitly restricted a model to text-only via
+// models.providers.[provider].models[].input. A synthesized fallback model (no
+// registry entry) never has an explicit config entry, so this stays false for it.
+function isExplicitlyTextOnlyModel(
+  cfg: ImageDescriptionRequest["cfg"],
+  provider: string,
+  modelId: string,
+): boolean {
+  const providerConfig = findNormalizedProviderValue(cfg.models?.providers, provider);
+  const entry = providerConfig?.models?.find((m) => m.id === modelId);
+  return entry !== undefined && entry.input !== undefined && !entry.input.includes("image");
+}
+
 function resolveConfiguredProviderBaseUrl(
   cfg: ImageDescriptionRequest["cfg"],
   provider: string,
@@ -162,7 +192,11 @@ export async function describeImagesWithModel(
     apiKey = resolved.apiKey;
     model = resolved.model;
   } catch (err) {
-    if (!isMinimaxVlmModel(params.provider, params.model) || !isUnknownModelError(err)) {
+    if (
+      !isMinimaxVlmModel(params.provider, params.model) ||
+      isExplicitlyTextOnlyModel(params.cfg, params.provider, params.model) ||
+      (!isUnknownModelError(err) && !isImageNotSupportedError(err))
+    ) {
       throw err;
     }
     const fallback = await resolveMinimaxVlmFallbackRuntime(params);


### PR DESCRIPTION
## Summary

- **Problem:** `image-tool` and `pdf-tool` resolved models by calling `resolveModelFromRegistry()`, a thin wrapper around `modelRegistry.find()` that accepts no `cfg` parameter. Any overrides configured under `models.providers[provider]` — including `baseUrl`, `api`, `headers`, and `compat` — were silently ignored, and requests always went to the default provider endpoint.
- **Why it matters:** Deployments that rely on a custom baseUrl for proxying or routing (e.g. Cloudflare AI Gateway, remote Ollama, custom endpoint mirrors) work correctly for the main agent but silently fail for image and pdf tool calls.
- **What changed:** Replace `resolveModelFromRegistry()` with `resolveModelWithRegistry({..., cfg})` so both tools go through the same `applyConfiguredProviderOverrides` pipeline as the main agent. Export `buildUnknownModelError` from `pi-embedded-runner/model.ts` for consistent error messages. Remove the now-unused `resolveModelFromRegistry` from `media-tool-shared.ts`.
- **What did NOT change:** audio/video media understanding paths (already handled correctly via `resolveProviderExecutionContext`), auth logic, tool external interfaces, and entry-level `tools.media.image.models[].baseUrl` overrides (separate pre-existing gap, tracked separately).

## Change Type

- [x] Bug fix
- [x] Refactor required for the fix

## Scope

- [x] Skills / tool execution

## Root Cause / Regression History

- **Root cause:** `resolveModelFromRegistry()` calls `modelRegistry.find()` directly and returns the raw registry model. `complete(model, context, ...)` uses `model.baseUrl`, which always reflected the `models.json` default, never the user-configured `cfg.models.providers[provider].baseUrl`.
- **Missing detection / guardrail:** No test covered the path where a configured `baseUrl` should be reflected in the actual endpoint used by image/pdf tools.
- **Prior context:** The main agent correctly applies config overrides via `resolveModelWithRegistry`. The media tools were implemented independently with a bare registry lookup that was never aligned with that pipeline.
- **Why this regressed now:** This was a gap from the original implementation, not a recent regression.

## Regression Test Plan

- **Coverage level:** Unit test
- **Target test:** `src/agents/tools/image-tool.test.ts`, `src/agents/tools/pdf-tool.test.ts`
- **Scenario:** When `cfg.models.providers[provider].baseUrl` is set, `complete()` calls inside image/pdf tools should use that baseUrl rather than the registry default.
- **If no new test is added, why not:** End-to-end verification of baseUrl routing requires live network access. The existing tests validate overall tool flow; a seam-level test can be added in a follow-up.

## User-visible / Behavior Changes

When `models.providers[provider].baseUrl` is configured, requests from `image-tool` and `pdf-tool` (non-native PDF path) will be routed to the configured endpoint instead of the default provider address. No behavior change for users who have not configured a custom `baseUrl`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — request target is determined by user config, consistent with main agent behavior
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure `models.providers.anthropic.baseUrl = "https://proxy.example.com/v1"`
2. Trigger a request via `image-tool` or `pdf-tool`
3. Observe whether traffic reaches the proxy endpoint

### Expected

Request is sent to `https://proxy.example.com/v1`

### Actual (before fix)

Request is sent to `https://api.anthropic.com`

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert commit `bfc98758`
- Files to restore: `src/agents/pi-embedded-runner/model.ts`, `src/agents/tools/media-tool-shared.ts`, `src/agents/tools/pdf-tool.ts`, `src/media-understanding/image.ts`

## Risks and Mitigations

- **Risk:** `resolveModelWithRegistry` returns `undefined` for suppressed models, which now throws `buildUnknownModelError` instead of silently passing the model through.
  - **Mitigation:** `runWithImageModelFallback` catches this error and continues to the next fallback candidate — the correct behavior, since a suppressed model should not be used.
