### PR TITLE
fix(usage): return accumulated input/cache tokens from toNormalizedUsage

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -177,11 +177,12 @@ function buildErrorAgentMeta(params: {
     usage.total = params.lastTurnTotal;
   }
   // Prefer the raw last-assistant snapshot; fall back to the accumulator's
-  // last-call fields so session persistence always has a context-size snapshot
-  // even on retry-limit paths where lastAssistant may be undefined.
-  const lastCallUsage = params.lastAssistant
-    ? normalizeUsage(params.lastAssistant.usage as UsageLike)
-    : toLastCallUsage(params.usageAccumulator);
+  // last-call fields so session persistence always has a context-size snapshot.
+  // Covers two cases: lastAssistant absent (retry-limit path) and
+  // lastAssistant present but lastAssistant.usage absent/empty.
+  const lastCallUsage =
+    (params.lastAssistant ? normalizeUsage(params.lastAssistant.usage as UsageLike) : undefined) ??
+    toLastCallUsage(params.usageAccumulator);
   const promptTokens = derivePromptTokens(params.lastRunPromptUsage);
   return {
     sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -80,6 +80,12 @@ import {
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
+import {
+  type UsageAccumulator,
+  createUsageAccumulator,
+  mergeUsageIntoAccumulator,
+  toNormalizedUsage,
+} from "./usage-accumulator.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
@@ -119,29 +125,6 @@ function scrubAnthropicRefusalMagic(prompt: string): string {
   );
 }
 
-type UsageAccumulator = {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  total: number;
-  /** Cache fields from the most recent API call (not accumulated). */
-  lastCacheRead: number;
-  lastCacheWrite: number;
-  lastInput: number;
-};
-
-const createUsageAccumulator = (): UsageAccumulator => ({
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  total: 0,
-  lastCacheRead: 0,
-  lastCacheWrite: 0,
-  lastInput: 0,
-});
-
 function createCompactionDiagId(): string {
   return `ovf-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
@@ -158,64 +141,6 @@ function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
     Math.max(1, profileCandidateCount) * RUN_RETRY_ITERATIONS_PER_PROFILE;
   return Math.min(MAX_RUN_RETRY_ITERATIONS, Math.max(MIN_RUN_RETRY_ITERATIONS, scaled));
 }
-
-const hasUsageValues = (
-  usage: ReturnType<typeof normalizeUsage>,
-): usage is NonNullable<ReturnType<typeof normalizeUsage>> =>
-  !!usage &&
-  [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.total].some(
-    (value) => typeof value === "number" && Number.isFinite(value) && value > 0,
-  );
-
-const mergeUsageIntoAccumulator = (
-  target: UsageAccumulator,
-  usage: ReturnType<typeof normalizeUsage>,
-) => {
-  if (!hasUsageValues(usage)) {
-    return;
-  }
-  target.input += usage.input ?? 0;
-  target.output += usage.output ?? 0;
-  target.cacheRead += usage.cacheRead ?? 0;
-  target.cacheWrite += usage.cacheWrite ?? 0;
-  target.total +=
-    usage.total ??
-    (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
-  // Track the most recent API call's cache fields for accurate context-size reporting.
-  // Accumulated cache totals inflate context size when there are multiple tool-call round-trips,
-  // since each call reports cacheRead ≈ current_context_size.
-  target.lastCacheRead = usage.cacheRead ?? 0;
-  target.lastCacheWrite = usage.cacheWrite ?? 0;
-  target.lastInput = usage.input ?? 0;
-};
-
-const toNormalizedUsage = (usage: UsageAccumulator) => {
-  const hasUsage =
-    usage.input > 0 ||
-    usage.output > 0 ||
-    usage.cacheRead > 0 ||
-    usage.cacheWrite > 0 ||
-    usage.total > 0;
-  if (!hasUsage) {
-    return undefined;
-  }
-  // Use the LAST API call's cache fields for context-size calculation.
-  // The accumulated cacheRead/cacheWrite inflate context size because each tool-call
-  // round-trip reports cacheRead ≈ current_context_size, and summing N calls gives
-  // N × context_size which gets clamped to contextWindow (e.g. 200k).
-  // See: https://github.com/openclaw/openclaw/issues/13698
-  //
-  // We use lastInput/lastCacheRead/lastCacheWrite (from the most recent API call) for
-  // cache-related fields, but keep accumulated output (total generated text this turn).
-  const lastPromptTokens = usage.lastInput + usage.lastCacheRead + usage.lastCacheWrite;
-  return {
-    input: usage.lastInput || undefined,
-    output: usage.output || undefined,
-    cacheRead: usage.lastCacheRead || undefined,
-    cacheWrite: usage.lastCacheWrite || undefined,
-    total: lastPromptTokens + usage.output || undefined,
-  };
-};
 
 function resolveActiveErrorContext(params: {
   lastAssistant: { provider?: string; model?: string } | undefined;

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -84,6 +84,7 @@ import {
   type UsageAccumulator,
   createUsageAccumulator,
   mergeUsageIntoAccumulator,
+  toLastCallUsage,
   toNormalizedUsage,
 } from "./usage-accumulator.js";
 import { describeUnknownError } from "./utils.js";
@@ -175,9 +176,12 @@ function buildErrorAgentMeta(params: {
   if (usage && params.lastTurnTotal && params.lastTurnTotal > 0) {
     usage.total = params.lastTurnTotal;
   }
+  // Prefer the raw last-assistant snapshot; fall back to the accumulator's
+  // last-call fields so session persistence always has a context-size snapshot
+  // even on retry-limit paths where lastAssistant may be undefined.
   const lastCallUsage = params.lastAssistant
     ? normalizeUsage(params.lastAssistant.usage as UsageLike)
-    : undefined;
+    : toLastCallUsage(params.usageAccumulator);
   const promptTokens = derivePromptTokens(params.lastRunPromptUsage);
   return {
     sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/usage-accumulator.test.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createUsageAccumulator,
   mergeUsageIntoAccumulator,
+  toLastCallUsage,
   toNormalizedUsage,
 } from "./usage-accumulator.js";
 
@@ -103,6 +104,38 @@ describe("UsageAccumulator", () => {
       expect(usage!.output).toBe(50);
       expect(usage!.cacheRead).toBeUndefined();
       expect(usage!.cacheWrite).toBeUndefined();
+    });
+  });
+
+  describe("toLastCallUsage", () => {
+    it("returns last-call snapshot for context-size fallback", () => {
+      const acc = createUsageAccumulator();
+
+      mergeUsageIntoAccumulator(acc, {
+        input: 100,
+        output: 50,
+        cacheRead: 80_000,
+        cacheWrite: 5_000,
+      });
+      mergeUsageIntoAccumulator(acc, {
+        input: 150,
+        output: 40,
+        cacheRead: 84_000,
+        cacheWrite: 0,
+      });
+
+      const snapshot = toLastCallUsage(acc);
+      expect(snapshot).toBeDefined();
+      // Should reflect only the last API call's prompt-side fields.
+      expect(snapshot!.input).toBe(150);
+      expect(snapshot!.cacheRead).toBe(84_000);
+      expect(snapshot!.cacheWrite).toBeUndefined(); // last call had 0
+      // Output is accumulated (total generated text in the turn).
+      expect(snapshot!.output).toBe(90);
+    });
+
+    it("returns undefined for a zero accumulator", () => {
+      expect(toLastCallUsage(createUsageAccumulator())).toBeUndefined();
     });
   });
 });

--- a/src/agents/pi-embedded-runner/usage-accumulator.test.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { normalizeUsage } from "../usage.js";
 import {
   createUsageAccumulator,
   mergeUsageIntoAccumulator,
@@ -136,6 +137,31 @@ describe("UsageAccumulator", () => {
 
     it("returns undefined for a zero accumulator", () => {
       expect(toLastCallUsage(createUsageAccumulator())).toBeUndefined();
+    });
+
+    it("serves as fallback when lastAssistant exists but usage is absent", () => {
+      // Reproduces the edge steipete identified: lastAssistant is truthy but
+      // lastAssistant.usage is undefined, so normalizeUsage returns undefined.
+      // The composition `normalizeUsage(...) ?? toLastCallUsage(acc)` must
+      // still yield a context-size snapshot from the accumulator.
+      const acc = createUsageAccumulator();
+      mergeUsageIntoAccumulator(acc, {
+        input: 200,
+        output: 60,
+        cacheRead: 90_000,
+        cacheWrite: 3_000,
+      });
+
+      // Simulate: lastAssistant present but usage absent.
+      const lastAssistant = { content: [{ type: "text", text: "ok" }] };
+      const lastCallUsage =
+        normalizeUsage((lastAssistant as { usage?: unknown }).usage as undefined) ??
+        toLastCallUsage(acc);
+
+      expect(lastCallUsage).toBeDefined();
+      expect(lastCallUsage!.input).toBe(200);
+      expect(lastCallUsage!.cacheRead).toBe(90_000);
+      expect(lastCallUsage!.cacheWrite).toBe(3_000);
     });
   });
 });

--- a/src/agents/pi-embedded-runner/usage-accumulator.test.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  createUsageAccumulator,
+  mergeUsageIntoAccumulator,
+  toNormalizedUsage,
+} from "./usage-accumulator.js";
+
+describe("UsageAccumulator", () => {
+  describe("mergeUsageIntoAccumulator", () => {
+    it("accumulates input/output/cache across multiple API calls", () => {
+      const acc = createUsageAccumulator();
+
+      // Simulate 3 tool-call round-trips with prompt caching.
+      // Each call reports its own input + cache tokens.
+      mergeUsageIntoAccumulator(acc, {
+        input: 100,
+        output: 50,
+        cacheRead: 80_000,
+        cacheWrite: 5_000,
+        total: 85_150,
+      });
+      mergeUsageIntoAccumulator(acc, {
+        input: 120,
+        output: 30,
+        cacheRead: 82_000,
+        cacheWrite: 0,
+        total: 82_150,
+      });
+      mergeUsageIntoAccumulator(acc, {
+        input: 150,
+        output: 40,
+        cacheRead: 84_000,
+        cacheWrite: 0,
+        total: 84_190,
+      });
+
+      // Accumulated totals reflect the sum of all calls.
+      expect(acc.input).toBe(370);
+      expect(acc.output).toBe(120);
+      expect(acc.cacheRead).toBe(246_000);
+      expect(acc.cacheWrite).toBe(5_000);
+
+      // Last-call fields reflect only the final API call.
+      expect(acc.lastInput).toBe(150);
+      expect(acc.lastCacheRead).toBe(84_000);
+      expect(acc.lastCacheWrite).toBe(0);
+    });
+
+    it("ignores undefined/null usage", () => {
+      const acc = createUsageAccumulator();
+      mergeUsageIntoAccumulator(acc, undefined);
+      expect(acc.input).toBe(0);
+      expect(acc.output).toBe(0);
+    });
+  });
+
+  describe("toNormalizedUsage", () => {
+    it("returns undefined for a zero accumulator", () => {
+      expect(toNormalizedUsage(createUsageAccumulator())).toBeUndefined();
+    });
+
+    it("returns accumulated input/cacheRead/cacheWrite for cost tracking (#53734)", () => {
+      const acc = createUsageAccumulator();
+
+      // Simulate a multi-call turn (3 tool-use round-trips with caching).
+      mergeUsageIntoAccumulator(acc, {
+        input: 100,
+        output: 50,
+        cacheRead: 80_000,
+        cacheWrite: 5_000,
+      });
+      mergeUsageIntoAccumulator(acc, {
+        input: 120,
+        output: 30,
+        cacheRead: 82_000,
+        cacheWrite: 0,
+      });
+      mergeUsageIntoAccumulator(acc, {
+        input: 150,
+        output: 40,
+        cacheRead: 84_000,
+        cacheWrite: 0,
+      });
+
+      const usage = toNormalizedUsage(acc);
+      expect(usage).toBeDefined();
+
+      // Cost tracking needs accumulated totals — the sum of all API calls
+      // in the turn, not just the last call's values.
+      expect(usage!.input).toBe(370); // 100 + 120 + 150
+      expect(usage!.output).toBe(120); // 50 + 30 + 40
+      expect(usage!.cacheRead).toBe(246_000); // 80k + 82k + 84k
+      expect(usage!.cacheWrite).toBe(5_000); // 5k + 0 + 0
+    });
+
+    it("omits zero fields as undefined", () => {
+      const acc = createUsageAccumulator();
+      mergeUsageIntoAccumulator(acc, { input: 100, output: 50 });
+
+      const usage = toNormalizedUsage(acc);
+      expect(usage).toBeDefined();
+      expect(usage!.input).toBe(100);
+      expect(usage!.output).toBe(50);
+      expect(usage!.cacheRead).toBeUndefined();
+      expect(usage!.cacheWrite).toBeUndefined();
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/usage-accumulator.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.ts
@@ -1,0 +1,83 @@
+import type { NormalizedUsage } from "../usage.js";
+
+export type UsageAccumulator = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  /** Cache fields from the most recent API call (not accumulated). */
+  lastCacheRead: number;
+  lastCacheWrite: number;
+  lastInput: number;
+};
+
+export const createUsageAccumulator = (): UsageAccumulator => ({
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  total: 0,
+  lastCacheRead: 0,
+  lastCacheWrite: 0,
+  lastInput: 0,
+});
+
+type MaybeUsage = NormalizedUsage | undefined;
+
+const hasUsageValues = (usage: MaybeUsage): usage is NormalizedUsage =>
+  !!usage &&
+  [usage.input, usage.output, usage.cacheRead, usage.cacheWrite, usage.total].some(
+    (value) => typeof value === "number" && Number.isFinite(value) && value > 0,
+  );
+
+export const mergeUsageIntoAccumulator = (target: UsageAccumulator, usage: MaybeUsage) => {
+  if (!hasUsageValues(usage)) {
+    return;
+  }
+  target.input += usage.input ?? 0;
+  target.output += usage.output ?? 0;
+  target.cacheRead += usage.cacheRead ?? 0;
+  target.cacheWrite += usage.cacheWrite ?? 0;
+  target.total +=
+    usage.total ??
+    (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+  // Track the most recent API call's cache fields for accurate context-size reporting.
+  // Accumulated cache totals inflate context size because each tool-call
+  // round-trip reports cacheRead ≈ current_context_size, and summing N calls gives
+  // N × context_size which gets clamped to contextWindow (e.g. 200k).
+  target.lastCacheRead = usage.cacheRead ?? 0;
+  target.lastCacheWrite = usage.cacheWrite ?? 0;
+  target.lastInput = usage.input ?? 0;
+};
+
+/**
+ * Convert a UsageAccumulator into a NormalizedUsage for cost/billing tracking.
+ *
+ * Returns **accumulated** input/cacheRead/cacheWrite/output so that downstream
+ * cost estimation sees the full billed token counts for the entire turn, not
+ * just the last API call.
+ *
+ * Context-size display should use `lastCallUsage` (the raw snapshot from the
+ * final API call), which is computed separately and stored alongside this value.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/53734
+ */
+export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | undefined => {
+  const hasUsage =
+    usage.input > 0 ||
+    usage.output > 0 ||
+    usage.cacheRead > 0 ||
+    usage.cacheWrite > 0 ||
+    usage.total > 0;
+  if (!hasUsage) {
+    return undefined;
+  }
+  return {
+    input: usage.input || undefined,
+    output: usage.output || undefined,
+    cacheRead: usage.cacheRead || undefined,
+    cacheWrite: usage.cacheWrite || undefined,
+    total: usage.total || undefined,
+  };
+};

--- a/src/agents/pi-embedded-runner/usage-accumulator.ts
+++ b/src/agents/pi-embedded-runner/usage-accumulator.ts
@@ -63,6 +63,25 @@ export const mergeUsageIntoAccumulator = (target: UsageAccumulator, usage: Maybe
  *
  * See: https://github.com/openclaw/openclaw/issues/53734
  */
+/**
+ * Extract a context-size snapshot from the accumulator using the last API
+ * call's prompt-side fields. Use this as a fallback `lastCallUsage` when the
+ * raw `lastAssistant` object is unavailable (e.g. retry-limit error paths).
+ */
+export const toLastCallUsage = (usage: UsageAccumulator): NormalizedUsage | undefined => {
+  const hasValues = usage.lastInput > 0 || usage.lastCacheRead > 0 || usage.lastCacheWrite > 0;
+  if (!hasValues && usage.output <= 0) {
+    return undefined;
+  }
+  return {
+    input: usage.lastInput || undefined,
+    output: usage.output || undefined,
+    cacheRead: usage.lastCacheRead || undefined,
+    cacheWrite: usage.lastCacheWrite || undefined,
+    total: usage.lastInput + usage.lastCacheRead + usage.lastCacheWrite + usage.output || undefined,
+  };
+};
+
 export const toNormalizedUsage = (usage: UsageAccumulator): NormalizedUsage | undefined => {
   const hasUsage =
     usage.input > 0 ||


### PR DESCRIPTION
## Summary

Fixes #53734.

`toNormalizedUsage()` was returning only the **last API call's** `input`/`cacheRead`/`cacheWrite` instead of accumulated totals from the `UsageAccumulator`. This caused cost tracking to severely underreport actual billed tokens in multi-tool-call turns.

- Extract `UsageAccumulator` logic into a dedicated, testable `usage-accumulator.ts` module
- Fix `toNormalizedUsage()` to return accumulated values for cost/billing tracking
- Context-size display is **unaffected** — it already uses the separate `lastCallUsage` field

## Local reproduction

Simulated 3 tool-call round-trips with prompt caching against the **original code on `main`**:

| Token field | Accumulated (actual billed) | Reported (buggy) | Lost |
|---|---|---|---|
| `input` | 370 | 150 | **59.5%** |
| `cacheRead` | 246,000 | 84,000 | **65.9%** |
| `cacheWrite` | 5,000 | `undefined` | **100%** |

`cacheWrite` is 100% lost because the last call had 0 cache writes, so `usage.lastCacheWrite` is 0, which becomes `undefined` via `|| undefined`.

After the fix, all fields report the correct accumulated values.

## Why this is safe

The downstream persistence layer (`session-usage.ts`) already handles cost vs context-size as separate concerns:

- **Cost estimation** (line 112–114): Uses `params.usage` → now gets correct accumulated totals
- **Session `cacheRead`/`cacheWrite`** (line 131): Prefers `params.lastCallUsage` when available → **unaffected**
- **`totalTokens` / context display** (line 104–110): Derives from `params.lastCallUsage` → **unaffected**
- **`usage.total` override** (run.ts): Already overwritten by `lastTurnTotal` → **unaffected**

## Test plan

- [x] New `usage-accumulator.test.ts` (5 tests) — covers accumulation, the #53734 regression, and edge cases
- [x] Existing `usage-reporting.test.ts` — 5/5 pass
- [x] Existing `session.test.ts` — 51/51 pass (downstream persistence)
- [x] Existing `agent-runner.misc.runreplyagent.test.ts` — 32/32 pass (integration)
- [x] `pnpm tsgo` — clean
- [x] `pnpm check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)