### PR TITLE
feat(android): Multiple nodes session context isolated from each other

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -195,7 +195,7 @@ class NodeRuntime(
 
   private fun generateNodeSessionKey(): String {
     val deviceId = identityStore.loadOrCreate().deviceId
-    val shortDeviceId = deviceId.take(8)
+    val shortDeviceId = deviceId.take(12)
     return "agent:main:node-$shortDeviceId"
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -24,7 +24,6 @@ import ai.openclaw.app.voice.TalkModeManager
 import ai.openclaw.app.voice.VoiceConversationEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,7 +33,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -195,7 +193,13 @@ class NodeRuntime(
   private val _pendingGatewayTrust = MutableStateFlow<GatewayTrustPrompt?>(null)
   val pendingGatewayTrust: StateFlow<GatewayTrustPrompt?> = _pendingGatewayTrust.asStateFlow()
 
-  private val _mainSessionKey = MutableStateFlow("main")
+  private fun generateNodeSessionKey(): String {
+    val deviceId = identityStore.loadOrCreate().deviceId
+    val shortDeviceId = deviceId.take(8)
+    return "agent:main:node-$shortDeviceId"
+  }
+
+  private val _mainSessionKey = MutableStateFlow(generateNodeSessionKey())
   val mainSessionKey: StateFlow<String> = _mainSessionKey.asStateFlow()
 
   private val cameraHudSeq = AtomicLong(0)
@@ -260,7 +264,7 @@ class NodeRuntime(
         _remoteAddress.value = null
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
         if (!isCanonicalMainSessionKey(_mainSessionKey.value)) {
-          _mainSessionKey.value = "main"
+          _mainSessionKey.value = generateNodeSessionKey()
         }
         chat.applyMainSessionKey(resolveMainSessionKey())
         chat.onDisconnected(message)
@@ -320,7 +324,9 @@ class NodeRuntime(
       session = operatorSession,
       json = json,
       supportsChatSubscribe = false,
-    )
+    ).also {
+      it.applyMainSessionKey(_mainSessionKey.value)
+    }
   private val voiceReplySpeakerLazy: Lazy<TalkModeManager> = lazy {
     // Reuse the existing TalkMode speech engine for native Android TTS playback
     // without enabling the legacy talk capture loop.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -193,13 +193,12 @@ class NodeRuntime(
   private val _pendingGatewayTrust = MutableStateFlow<GatewayTrustPrompt?>(null)
   val pendingGatewayTrust: StateFlow<GatewayTrustPrompt?> = _pendingGatewayTrust.asStateFlow()
 
-  private fun generateNodeSessionKey(agentId: String = "main"): String {
+  private fun resolveNodeMainSessionKey(agentId: String? = gatewayDefaultAgentId): String {
     val deviceId = identityStore.loadOrCreate().deviceId
-    val shortDeviceId = deviceId.take(12)
-    return "agent:$agentId:node-$shortDeviceId"
+    return buildNodeMainSessionKey(deviceId, agentId)
   }
 
-  private val _mainSessionKey = MutableStateFlow("main")
+  private val _mainSessionKey = MutableStateFlow(resolveNodeMainSessionKey())
   val mainSessionKey: StateFlow<String> = _mainSessionKey.asStateFlow()
 
   private val cameraHudSeq = AtomicLong(0)
@@ -247,15 +246,7 @@ class NodeRuntime(
         _serverName.value = name
         _remoteAddress.value = remote
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
-        
-        val resolvedKey = if (isCanonicalMainSessionKey(mainSessionKey)) {
-          mainSessionKey
-        } else {
-          val agentId = gatewayDefaultAgentId?.ifEmpty { "main" } ?: "main"
-          generateNodeSessionKey(agentId)
-        }
-        applyMainSessionKey(resolvedKey)
-        
+        syncMainSessionKey(resolveAgentIdFromMainSessionKey(mainSessionKey))
         updateStatus()
         micCapture.onGatewayConnectionChanged(true)
         scope.launch {
@@ -271,10 +262,6 @@ class NodeRuntime(
         _serverName.value = null
         _remoteAddress.value = null
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
-        if (!isCanonicalMainSessionKey(_mainSessionKey.value)) {
-          _mainSessionKey.value = generateNodeSessionKey()
-          talkMode.setMainSessionKey(_mainSessionKey.value)
-        }
         chat.applyMainSessionKey(resolveMainSessionKey())
         chat.onDisconnected(message)
         updateStatus()
@@ -419,13 +406,12 @@ class NodeRuntime(
     )
   }
 
-  private fun applyMainSessionKey(candidate: String?) {
-    val trimmed = normalizeMainKey(candidate) ?: return
-    if (isCanonicalMainSessionKey(_mainSessionKey.value)) return
-    if (_mainSessionKey.value == trimmed) return
-    _mainSessionKey.value = trimmed
-    talkMode.setMainSessionKey(trimmed)
-    chat.applyMainSessionKey(trimmed)
+  private fun syncMainSessionKey(agentId: String?) {
+    val resolvedKey = resolveNodeMainSessionKey(agentId)
+    if (_mainSessionKey.value == resolvedKey) return
+    _mainSessionKey.value = resolvedKey
+    talkMode.setMainSessionKey(resolvedKey)
+    chat.applyMainSessionKey(resolvedKey)
     updateHomeCanvasState()
   }
 
@@ -975,16 +961,7 @@ class NodeRuntime(
       val config = root?.get("config").asObjectOrNull()
       val ui = config?.get("ui").asObjectOrNull()
       val raw = ui?.get("seamColor").asStringOrNull()?.trim()
-      val sessionCfg = config?.get("session").asObjectOrNull()
-      val mainKey = normalizeMainKey(sessionCfg?.get("mainKey").asStringOrNull())
-      
-      val resolvedKey = if (isCanonicalMainSessionKey(mainKey)) {
-        mainKey
-      } else {
-        val agentId = gatewayDefaultAgentId?.ifEmpty { "main" } ?: "main"
-        generateNodeSessionKey(agentId)
-      }
-      applyMainSessionKey(resolvedKey)
+      syncMainSessionKey(gatewayDefaultAgentId)
 
       val parsed = parseHexColorArgb(raw)
       _seamColorArgb.value = parsed ?: DEFAULT_SEAM_COLOR_ARGB
@@ -1017,14 +994,7 @@ class NodeRuntime(
 
       gatewayDefaultAgentId = defaultAgentId.ifEmpty { null }
       gatewayAgents = agents
-      
-      val resolvedKey = if (isCanonicalMainSessionKey(mainKey)) {
-        mainKey
-      } else {
-        val agentId = defaultAgentId.ifEmpty { "main" }
-        generateNodeSessionKey(agentId)
-      }
-      applyMainSessionKey(resolvedKey)
+      syncMainSessionKey(resolveAgentIdFromMainSessionKey(mainKey) ?: gatewayDefaultAgentId)
       updateHomeCanvasState()
     } catch (_: Throwable) {
       // ignore

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -193,13 +193,13 @@ class NodeRuntime(
   private val _pendingGatewayTrust = MutableStateFlow<GatewayTrustPrompt?>(null)
   val pendingGatewayTrust: StateFlow<GatewayTrustPrompt?> = _pendingGatewayTrust.asStateFlow()
 
-  private fun generateNodeSessionKey(): String {
+  private fun generateNodeSessionKey(agentId: String = "main"): String {
     val deviceId = identityStore.loadOrCreate().deviceId
     val shortDeviceId = deviceId.take(12)
-    return "agent:main:node-$shortDeviceId"
+    return "agent:$agentId:node-$shortDeviceId"
   }
 
-  private val _mainSessionKey = MutableStateFlow(generateNodeSessionKey())
+  private val _mainSessionKey = MutableStateFlow("main")
   val mainSessionKey: StateFlow<String> = _mainSessionKey.asStateFlow()
 
   private val cameraHudSeq = AtomicLong(0)
@@ -247,7 +247,15 @@ class NodeRuntime(
         _serverName.value = name
         _remoteAddress.value = remote
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
-        applyMainSessionKey(mainSessionKey)
+        
+        val resolvedKey = if (isCanonicalMainSessionKey(mainSessionKey)) {
+          mainSessionKey
+        } else {
+          val agentId = gatewayDefaultAgentId?.ifEmpty { "main" } ?: "main"
+          generateNodeSessionKey(agentId)
+        }
+        applyMainSessionKey(resolvedKey)
+        
         updateStatus()
         micCapture.onGatewayConnectionChanged(true)
         scope.launch {
@@ -968,7 +976,14 @@ class NodeRuntime(
       val raw = ui?.get("seamColor").asStringOrNull()?.trim()
       val sessionCfg = config?.get("session").asObjectOrNull()
       val mainKey = normalizeMainKey(sessionCfg?.get("mainKey").asStringOrNull())
-      applyMainSessionKey(mainKey)
+      
+      val resolvedKey = if (isCanonicalMainSessionKey(mainKey)) {
+        mainKey
+      } else {
+        val agentId = gatewayDefaultAgentId?.ifEmpty { "main" } ?: "main"
+        generateNodeSessionKey(agentId)
+      }
+      applyMainSessionKey(resolvedKey)
 
       val parsed = parseHexColorArgb(raw)
       _seamColorArgb.value = parsed ?: DEFAULT_SEAM_COLOR_ARGB
@@ -1001,7 +1016,14 @@ class NodeRuntime(
 
       gatewayDefaultAgentId = defaultAgentId.ifEmpty { null }
       gatewayAgents = agents
-      applyMainSessionKey(mainKey)
+      
+      val resolvedKey = if (isCanonicalMainSessionKey(mainKey)) {
+        mainKey
+      } else {
+        val agentId = defaultAgentId.ifEmpty { "main" }
+        generateNodeSessionKey(agentId)
+      }
+      applyMainSessionKey(resolvedKey)
       updateHomeCanvasState()
     } catch (_: Throwable) {
       // ignore

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -273,6 +273,7 @@ class NodeRuntime(
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
         if (!isCanonicalMainSessionKey(_mainSessionKey.value)) {
           _mainSessionKey.value = generateNodeSessionKey()
+          talkMode.setMainSessionKey(_mainSessionKey.value)
         }
         chat.applyMainSessionKey(resolveMainSessionKey())
         chat.onDisconnected(message)

--- a/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SessionKey.kt
@@ -11,3 +11,14 @@ internal fun isCanonicalMainSessionKey(raw: String?): Boolean {
   if (trimmed == "global") return true
   return trimmed.startsWith("agent:")
 }
+
+internal fun resolveAgentIdFromMainSessionKey(raw: String?): String? {
+  val trimmed = raw?.trim().orEmpty()
+  if (!trimmed.startsWith("agent:")) return null
+  return trimmed.removePrefix("agent:").substringBefore(':').trim().ifEmpty { null }
+}
+
+internal fun buildNodeMainSessionKey(deviceId: String, agentId: String?): String {
+  val resolvedAgentId = agentId?.trim().orEmpty().ifEmpty { "main" }
+  return "agent:$resolvedAgentId:node-${deviceId.take(12)}"
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -82,7 +82,6 @@ class ChatController(
     val trimmed = mainSessionKey.trim()
     if (trimmed.isEmpty()) return
     if (_sessionKey.value == trimmed) return
-    if (_sessionKey.value != "main") return
     _sessionKey.value = trimmed
     scope.launch { bootstrap(forceHealth = true, refreshSessions = true) }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -24,6 +24,7 @@ class ChatController(
   private val json: Json,
   private val supportsChatSubscribe: Boolean,
 ) {
+  private var appliedMainSessionKey = "main"
   private val _sessionKey = MutableStateFlow("main")
   val sessionKey: StateFlow<String> = _sessionKey.asStateFlow()
 
@@ -73,7 +74,7 @@ class ChatController(
   }
 
   fun load(sessionKey: String) {
-    val key = sessionKey.trim().ifEmpty { "main" }
+    val key = normalizeRequestedSessionKey(sessionKey)
     _sessionKey.value = key
     scope.launch { bootstrap(forceHealth = true, refreshSessions = true) }
   }
@@ -81,8 +82,15 @@ class ChatController(
   fun applyMainSessionKey(mainSessionKey: String) {
     val trimmed = mainSessionKey.trim()
     if (trimmed.isEmpty()) return
-    if (_sessionKey.value == trimmed) return
-    _sessionKey.value = trimmed
+    val nextState =
+      applyMainSessionKey(
+        currentSessionKey = normalizeRequestedSessionKey(_sessionKey.value),
+        appliedMainSessionKey = appliedMainSessionKey,
+        nextMainSessionKey = trimmed,
+      )
+    appliedMainSessionKey = nextState.appliedMainSessionKey
+    if (_sessionKey.value == nextState.currentSessionKey) return
+    _sessionKey.value = nextState.currentSessionKey
     scope.launch { bootstrap(forceHealth = true, refreshSessions = true) }
   }
 
@@ -101,13 +109,20 @@ class ChatController(
   }
 
   fun switchSession(sessionKey: String) {
-    val key = sessionKey.trim()
+    val key = normalizeRequestedSessionKey(sessionKey)
     if (key.isEmpty()) return
     if (key == _sessionKey.value) return
     _sessionKey.value = key
     // Keep the thread switch path lean: history + health are needed immediately,
     // but the session list is usually unchanged and can refresh on explicit pull-to-refresh.
     scope.launch { bootstrap(forceHealth = true, refreshSessions = false) }
+  }
+
+  private fun normalizeRequestedSessionKey(sessionKey: String): String {
+    val key = sessionKey.trim()
+    if (key.isEmpty()) return appliedMainSessionKey
+    if (key == "main" && appliedMainSessionKey != "main") return appliedMainSessionKey
+    return key
   }
 
   fun sendMessage(
@@ -529,6 +544,28 @@ class ChatController(
       else -> "off"
     }
   }
+}
+
+internal data class MainSessionState(
+  val currentSessionKey: String,
+  val appliedMainSessionKey: String,
+)
+
+internal fun applyMainSessionKey(
+  currentSessionKey: String,
+  appliedMainSessionKey: String,
+  nextMainSessionKey: String,
+): MainSessionState {
+  if (currentSessionKey == appliedMainSessionKey) {
+    return MainSessionState(
+      currentSessionKey = nextMainSessionKey,
+      appliedMainSessionKey = nextMainSessionKey,
+    )
+  }
+  return MainSessionState(
+    currentSessionKey = currentSessionKey,
+    appliedMainSessionKey = nextMainSessionKey,
+  )
 }
 
 internal fun reconcileMessageIds(previous: List<ChatMessage>, incoming: List<ChatMessage>): List<ChatMessage> {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -61,7 +61,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
 
-  LaunchedEffect(mainSessionKey) {
+  LaunchedEffect(Unit) {
     viewModel.loadChat(mainSessionKey)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -19,7 +19,6 @@ import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
-import ai.openclaw.app.isCanonicalMainSessionKey
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
@@ -131,7 +130,6 @@ class TalkModeManager(
   fun setMainSessionKey(sessionKey: String?) {
     val trimmed = sessionKey?.trim().orEmpty()
     if (trimmed.isEmpty()) return
-    if (isCanonicalMainSessionKey(mainSessionKey)) return
     mainSessionKey = trimmed
   }
 
@@ -911,9 +909,6 @@ class TalkModeManager(
       val res = session.request("talk.config", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull()
       val parsed = TalkModeGatewayConfigParser.parse(root?.get("config").asObjectOrNull())
-      if (!isCanonicalMainSessionKey(mainSessionKey)) {
-        mainSessionKey = parsed.mainSessionKey
-      }
       silenceWindowMs = parsed.silenceTimeoutMs
       parsed.interruptOnSpeech?.let { interruptOnSpeech = it }
       configLoaded = true

--- a/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SessionKeyTest.kt
@@ -1,0 +1,20 @@
+package ai.openclaw.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SessionKeyTest {
+  @Test
+  fun buildNodeMainSessionKeyUsesStableDeviceScopedSuffix() {
+    val key = buildNodeMainSessionKey(deviceId = "1234567890abcdef", agentId = "ops")
+
+    assertEquals("agent:ops:node-1234567890ab", key)
+  }
+
+  @Test
+  fun resolveAgentIdFromMainSessionKeyParsesCanonicalAgentKey() {
+    assertEquals("ops", resolveAgentIdFromMainSessionKey("agent:ops:main"))
+    assertNull(resolveAgentIdFromMainSessionKey("global"))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionPolicyTest.kt
@@ -1,0 +1,32 @@
+package ai.openclaw.app.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatControllerSessionPolicyTest {
+  @Test
+  fun applyMainSessionKeyMovesCurrentSessionWhenStillOnDefault() {
+    val state =
+      applyMainSessionKey(
+        currentSessionKey = "main",
+        appliedMainSessionKey = "main",
+        nextMainSessionKey = "agent:ops:node-device",
+      )
+
+    assertEquals("agent:ops:node-device", state.currentSessionKey)
+    assertEquals("agent:ops:node-device", state.appliedMainSessionKey)
+  }
+
+  @Test
+  fun applyMainSessionKeyKeepsUserSelectedSession() {
+    val state =
+      applyMainSessionKey(
+        currentSessionKey = "custom",
+        appliedMainSessionKey = "agent:ops:node-old",
+        nextMainSessionKey = "agent:ops:node-new",
+      )
+
+    assertEquals("custom", state.currentSessionKey)
+    assertEquals("agent:ops:node-new", state.appliedMainSessionKey)
+  }
+}


### PR DESCRIPTION
## Summary
My family have ``two Android Device`` connected to the ``same gateway``.
Due to the same session ``agent:main:main``, we can see everyone 's chat history.

Like this,
1. I can see ``Find X7 Ultra`` chat history on  ``OnePlus 13T``
2. I can see ``OnePlus 13T`` chat history on ``Find X7 Ultra``

**This is a bad experience.** When communicating with OpenClaw, the context interferes with each other

<img width="200" height="400" alt="Image" src="https://github.com/user-attachments/assets/bf784485-844c-4fcf-ab99-0ed65778a990" />

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related # https://github.com/openclaw/openclaw/issues/45854

## User-visible / Behavior Changes
Users can see ``independent sessions of multiple nodes at the top of chatSheetContent``, and the context does not interfere with each other when communicating with OpenClaw

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Windows host
- Runtime/container: Android Gradle app module
- Model/provider: n/a
- Integration/channel (if any): Android Node
- Relevant config (redacted):none

### Steps

1. Build Android Kotlin sources and targeted Android unit tests.
2. [device1] Install Android apk and connect openclaw gateway
3. [device2] Install Android apk and connect openclaw gateway
4. Two devices chatting with OpenClaw without interfering with each other

### Expected

Two devices chatting with OpenClaw ``without interfering with each other``


### Actual

Matches expected.


## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

And We can see every node session on WebUI.
Like this
``[agent:main:node-c682443feaa8]``
``[agent:main:node-6bc70a46c7ea]``

<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/4fa14719-57db-410b-bbd4-e25404b25f05" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:  Multiple devices chat with OpenClaw without interfering with each other
- Edge cases checked: NA
- What you did **not** verify: NA


## Compatibility / Migration

- Backward compatible? (`No`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: NA
- Files/config to restore: NA
- Known bad symptoms reviewers should watch for: NA

## Risks and Mitigations
none
