### PR TITLE
fix(doctor): add missing baseUrl and models when migrating nano-banana apiKey to google provider

### DIFF
--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -318,6 +318,10 @@ describe("normalizeCompatibilityConfigValues", () => {
       provider: "default",
       id: "GEMINI_API_KEY",
     });
+    expect(res.config.models?.providers?.google?.baseUrl).toBe(
+      "https://generativelanguage.googleapis.com",
+    );
+    expect(res.config.models?.providers?.google?.models).toEqual([]);
     expect(res.config.skills?.entries).toBeUndefined();
     expect(res.changes).toEqual([
       "Moved skills.entries.nano-banana-pro → agents.defaults.imageGenerationModel.primary (google/gemini-3-pro-image-preview).",
@@ -341,6 +345,10 @@ describe("normalizeCompatibilityConfigValues", () => {
     });
 
     expect(res.config.models?.providers?.google?.apiKey).toBe("env-gemini-key");
+    expect(res.config.models?.providers?.google?.baseUrl).toBe(
+      "https://generativelanguage.googleapis.com",
+    );
+    expect(res.config.models?.providers?.google?.models).toEqual([]);
     expect(res.changes).toContain(
       "Moved skills.entries.nano-banana-pro.env.GEMINI_API_KEY → models.providers.google.apiKey.",
     );

--- a/src/commands/doctor-legacy-config.ts
+++ b/src/commands/doctor-legacy-config.ts
@@ -579,6 +579,12 @@ export function normalizeCompatibilityConfigValues(cfg: OpenClawConfig): {
     const hasGoogleApiKey = rawGoogle.apiKey !== undefined;
     if (!hasGoogleApiKey && legacyApiKey) {
       rawGoogle.apiKey = legacyApiKey;
+      if (!rawGoogle.baseUrl) {
+        rawGoogle.baseUrl = "https://generativelanguage.googleapis.com";
+      }
+      if (!Array.isArray(rawGoogle.models)) {
+        rawGoogle.models = [];
+      }
       rawProviders.google = rawGoogle;
       rawModels.providers = rawProviders as NonNullable<OpenClawConfig["models"]>["providers"];
       next = {


### PR DESCRIPTION
## Summary

Fixes #53756

The legacy nano-banana-pro skill migration moves the Gemini API key to `models.providers.google.apiKey` but does not populate the required `baseUrl` and `models` fields on the provider entry. When the google provider object is freshly created (no pre-existing config), the resulting config fails Zod validation on write:

```
Error: Config validation failed: models.providers.google.baseUrl: Invalid input: expected string, received undefined
```

## Fix

When migrating the API key to a new google provider entry, default `baseUrl` to `"https://generativelanguage.googleapis.com"` and `models` to `[]` if not already set. This matches the defaults used elsewhere in the codebase (`embeddings-gemini.ts`, `pdf-native-providers.ts`).

## Changes

- `src/commands/doctor-legacy-config.ts`: Add `baseUrl` and `models` defaults when creating the google provider entry during nano-banana migration
- `src/commands/doctor-legacy-config.migrations.test.ts`: Verify `baseUrl` and `models` are set in migration test cases