### PR TITLE
fix(telegram): flush buffered final answer when reasoning delivery is skipped [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WhatsApp: honor the configured default account when the active listener helper is used without an explicit account id, so named default accounts do not get registered under `default`. (#53918) Thanks @yhyatt.
+- Telegram/streaming: fix silently dropped final answer text when a combined `<think>…</think>answer` payload is delivered after a tool call with `streaming: "partial"` enabled and a reasoning-capable model. (#53762) Thanks @amitgaur.
 
 ## 2026.4.10
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2515,4 +2515,54 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(generateTopicLabel).not.toHaveBeenCalled();
     expect(bot.api.editForumTopic).not.toHaveBeenCalled();
   });
+
+  // Regression test for: final answer text dropped when reasoning delivery is
+  // skipped in a combined <think>…</think>answer payload after a tool boundary.
+  //
+  // Scenario:
+  //   Turn 1: onReasoningStream fires (marks reasoningLane.hasStreamedMessage=true),
+  //           then final deliver is answer-only. The answer segment processing sets
+  //           activePreviewLifecycleByLane.reasoning="complete".
+  //   Turn 2: final deliver contains "<think>…</think>answer". The reasoning segment
+  //           delivery is "skipped" (lifecycle="complete", sendPayload returns false),
+  //           so reasoningStatus stays "hinted" and the answer segment is buffered.
+  //           Without the fix, the early `return` at line 686 exits before flushing
+  //           the buffer, silently dropping the answer.
+  it("delivers final answer text when reasoning delivery is skipped in combined think-tag payload after tool boundary", async () => {
+    setupDraftStreams({ answerMessageId: 999, reasoningMessageId: 111 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // Turn 1: reasoning stream sets hasStreamedMessage on the reasoning lane.
+        await replyOptions?.onReasoningStream?.({ text: "Reasoning:\n_step one_" });
+        // Turn 1 final: answer-only payload. The answer segment processing marks
+        // activePreviewLifecycleByLane.reasoning="complete" because hasStreamedMessage is true.
+        await dispatcherOptions.deliver({ text: "Here is my answer" }, { kind: "final" });
+        // Tool boundary: resets reasoningStatus to "none", rotates answer lane.
+        await replyOptions?.onAssistantMessageStart?.();
+        // Turn 2 final: combined reasoning+answer. Reasoning delivery is "skipped"
+        // (lifecycle="complete", sendPayload fails), leaving the answer buffered.
+        await dispatcherOptions.deliver(
+          { text: "<think>step two</think>final answer text" },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+    // sendPayload calls deliverReplies. Returning { delivered: false } causes the
+    // reasoning segment delivery to return "skipped", triggering the buffer path.
+    deliverReplies.mockResolvedValue({ delivered: false });
+    // editMessageTelegram is used for preview-based delivery (both turns).
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createReasoningStreamContext(), streamMode: "partial" });
+
+    // The buffered final answer must be delivered — fix calls flushBufferedFinalAnswer()
+    // before the early return in the segment loop.
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "final answer text",
+      expect.any(Object),
+    );
+  });
 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -693,6 +693,14 @@ export const dispatchTelegramMessage = async ({
             }
           }
           if (segments.length > 0) {
+            // Flush any buffered final answer that was held while waiting for
+            // reasoning delivery. This can happen when the final payload
+            // contains both reasoning and answer text but reasoning delivery
+            // is skipped (e.g., lifecycle already "complete"), leaving the
+            // answer buffered but never flushed before the early return.
+            if (info.kind === "final") {
+              await flushBufferedFinalAnswer();
+            }
             return;
           }
           if (split.suppressedReasoningOnly) {


### PR DESCRIPTION
## Summary

- **Problem:** When `streaming: "partial"` is enabled for Telegram and the model produces a turn with both a thinking block and a text block after a tool call, OpenClaw silently drops the text block (fixes #53384).
- **Why it matters:** Users receive the reasoning preview but never get the actual answer — a complete silent message loss.
- **What changed:** Added a `flushBufferedFinalAnswer()` call before the early `return` in the segment delivery loop (`bot-message-dispatch.ts`) when `info.kind === "final"`. A matching regression test was added.
- **What did NOT change:** No behaviour change for non-final deliveries, non-reasoning payloads, or other channels.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #53384
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** The segment delivery loop in `deliverPayload` (bot-message-dispatch.ts) processes reasoning and answer segments from a final payload. When a prior turn set `activePreviewLifecycleByLane.reasoning = "complete"` (because the answer segment processing at lines 678–683 saw `reasoningLane.hasStreamedMessage = true`), the reasoning delivery in the next turn returns `"skipped"` (lifecycle is "complete" → falls to `sendPayload` which fails). When reasoning is skipped, `noteReasoningDelivered()` is never called, so `reasoningStatus` stays `"hinted"`. The answer segment then hits `shouldBufferFinalAnswer() === true` and is buffered. The loop exits via the `if (segments.length > 0) { return; }` early-return **without** flushing the buffer.
- **Missing detection / guardrail:** The `flushBufferedFinalAnswer()` call was missing from this early-return path. It existed in the `suppressedReasoningOnly` path directly below (line 696) but not in the segment-processed path.
- **Prior context:** The `suppressedReasoningOnly` branch already had the flush, making the omission in the segment branch the gap.
- **Why this regressed now:** The buffering logic was added to handle the race between reasoning delivery and the final answer, but the "reasoning skipped" edge case after a tool boundary was not covered.

## Regression Test Plan (if applicable)

- Coverage level:
  - [x] Unit test
- **Target test:** `extensions/telegram/src/bot-message-dispatch.test.ts` — "delivers final answer text when reasoning delivery is skipped in combined think-tag payload after tool boundary"
- **Scenario:** Two-turn sequence: Turn 1 fires `onReasoningStream` then delivers an answer-only final (marking reasoning lifecycle "complete"). After `onAssistantMessageStart`, Turn 2 delivers `<think>…</think>answer`. The reasoning `sendPayload` is mocked to fail (`{ delivered: false }`), leaving the answer buffered. Without the fix the test fails (answer never delivered); with the fix it passes.
- **Why smallest reliable guardrail:** Directly exercises the exact code path at the exact failure point with minimal setup.

## User-visible / Behavior Changes

After a tool call in a Telegram conversation with `streaming: partial` and a reasoning-capable model, the assistant's text reply will now be delivered instead of silently dropped.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / Bun
- Model/provider: Any reasoning model (e.g. claude-sonnet-4-6 with extended thinking)
- Integration/channel: Telegram with `streaming: "partial"`
- Relevant config: `channels.telegram.streaming: "partial"`, `reasoningLevel: "stream"`

### Steps

1. Configure Telegram channel with `streaming: "partial"` and a reasoning-capable model.
2. Send a message that triggers a tool call followed by a reply that includes both thinking and a text block.
3. Observe the Telegram conversation.

### Expected

- Reasoning block is shown as a preview (or skipped if already finalized).
- Final text answer is delivered as a Telegram message.

### Actual (before fix)

- Reasoning block shown.
- Text answer silently dropped — user receives no response.

## Evidence

- [x] Failing test/log before + passing after

Test fails before fix:
```
Number of calls: 1
❯ extensions/telegram/src/bot-message-dispatch.test.ts:2493:33
    expect(editMessageTelegram).toHaveBeenCalledWith(123, 999, "final answer text", ...)
    AssertionError: expected "editMessageTelegram" to have been called with arguments: ...
```

Test passes after fix: `Tests 1 passed (73)`

## Human Verification (required)

- **Verified scenarios:** Two-turn reasoning+answer payload after tool boundary with skipped reasoning delivery; all 73 existing `bot-message-dispatch` tests still pass; `pnpm check` clean.
- **Edge cases checked:** Single-turn reasoning (unaffected — goes through `noteReasoningDelivered` path, not the skipped path). `suppressedReasoningOnly` path (already had flush, unchanged).
- **What I did not verify:** Live end-to-end on a real Telegram bot with a reasoning model.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert commit `fix(telegram): flush buffered final answer when reasoning delivery is skipped`.
- Known bad symptoms: if the flush itself throws, the final delivery would surface an error instead of silently dropping — this is strictly better than the previous silent drop.

## Risks and Mitigations

- **Risk:** `flushBufferedFinalAnswer()` is now called even when the buffer is empty (it returns early if `takeBufferedFinalAnswer()` returns undefined), so there is no functional risk for the normal (non-bug) path.
  - Mitigation: `flushBufferedFinalAnswer` is a no-op when no answer is buffered.

---

## AI-Assisted PR Checklist

- [x] Built with Claude Code (claude-sonnet-4-6)
- [x] Fully tested — `pnpm test:extension telegram` (1020 passed), `pnpm check`, `pnpm build` all green
- [x] I understand what the code does — root cause traced through `reasoningStepState`, `activePreviewLifecycleByLane`, `flushBufferedFinalAnswer`, and `deliverLaneText` call chain
- [x] Greptile summary reviewed — informational only, no action items