### PR TITLE
fix(markdown): preserve intra-word underscores in stripMarkdown

### DIFF
--- a/src/shared/text/strip-markdown.ts
+++ b/src/shared/text/strip-markdown.ts
@@ -9,7 +9,10 @@ export function stripMarkdown(text: string): string {
   result = result.replace(/__(.+?)__/g, "$1");
 
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
-  result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
+  result = result.replace(
+    /(?<=\s|^|[("'\[{<\/])_(?!_)(.+?)(?<!_)_(?=\s|$|[.,;:!?"')\]}\/>])/g,
+    "$1",
+  );
 
   result = result.replace(/~~(.+?)~~/g, "$1");
   result = result.replace(/^#{1,6}\s+(.+)$/gm, "$1");


### PR DESCRIPTION
Fixes part of #46146

## Problem
`stripMarkdown()` was too aggressive with underscore italic stripping, removing underscores inside words like `here_is_a_test`.

## Solution
Use word boundary regex to only strip italic underscores at proper boundaries (whitespace, punctuation, brackets, etc.)

## Changes
- src/shared/text/strip-markdown.ts: 1 line changed

## Verification
- ✅ Only 1 file modified
- ✅ Only 1 commit  
- ✅ Branch created from clean main
- ✅ No merge conflicts