### PR TITLE
fix(feishu): recognize common audio formats (mp3/wav/m4a/flac/aac) as playable audio messages

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.60.0",
     "@sinclair/typebox": "0.34.48",
-    "https-proxy-agent": "^8.0.0"
+    "https-proxy-agent": "^8.0.0",
+    "music-metadata": "^11.12.3"
   },
   "devDependencies": {
     "openclaw": "workspace:*"

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -4,6 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolvePreferredOpenClawTmpDir } from "../../../src/infra/tmp-openclaw-dir.js";
 import type { ClawdbotConfig } from "../runtime-api.js";
 
+const parseBufferMock = vi.hoisted(() => vi.fn());
+vi.mock("music-metadata", () => ({
+  parseBuffer: parseBufferMock,
+}));
+
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const normalizeFeishuTargetMock = vi.hoisted(() => vi.fn());
@@ -133,6 +138,9 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     imageGetMock.mockResolvedValue(Buffer.from("image-bytes"));
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
+
+    // music-metadata mock: return undefined duration by default (graceful degradation)
+    parseBufferMock.mockResolvedValue({ format: { duration: undefined } });
   });
 
   it("uses msg_type=media for mp4 video", async () => {
@@ -224,7 +232,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("falls back to generic file for unsupported audio formats", async () => {
+  it("uses msg_type=audio for mp3 via content-type fallback", async () => {
     loadWebMediaMock.mockResolvedValueOnce({
       buffer: Buffer.from("remote-mp3"),
       fileName: "song.mp3",
@@ -240,12 +248,63 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(fileCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ file_type: "stream" }),
+        data: expect.objectContaining({ file_type: "opus" }),
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "file" }),
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+  });
+
+  it.each([
+    { ext: "wav", contentType: "audio/wav" },
+    { ext: "m4a", contentType: "audio/mp4" },
+    { ext: "flac", contentType: "audio/flac" },
+    { ext: "aac", contentType: "audio/aac" },
+  ])("uses msg_type=audio for $ext files", async ({ ext }) => {
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: Buffer.from("audio-data"),
+      fileName: `test.${ext}`,
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_type: "opus" }),
+      }),
+    );
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "audio" }),
+      }),
+    );
+  });
+
+  it("uses msg_type=audio for unknown extension with audio/* content-type", async () => {
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: Buffer.from("remote-audio"),
+      fileName: "download",
+      kind: "audio",
+      contentType: "audio/mpeg",
+    });
+
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaUrl: "https://example.com/audio-stream",
+    });
+
+    expect(fileCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ file_type: "opus" }),
+      }),
+    );
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "audio" }),
       }),
     );
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -2,7 +2,8 @@ import fs from "fs";
 import path from "path";
 import { Readable } from "stream";
 import type * as Lark from "@larksuiteoapi/node-sdk";
-import { mediaKindFromMime } from "openclaw/plugin-sdk/media-runtime";
+import { mediaKindFromMime, isAudioFileName } from "openclaw/plugin-sdk/media-runtime";
+import { parseBuffer as parseAudioMetadata } from "music-metadata";
 import { withTempDownloadPath, type ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
@@ -12,6 +13,31 @@ import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result
 import { resolveFeishuSendTarget } from "./send-target.js";
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
+
+/**
+ * Parse audio duration in milliseconds using music-metadata.
+ * Returns undefined if parsing fails (graceful degradation — Feishu will
+ * still accept the upload, just without a seek bar in the player).
+ */
+async function parseAudioDurationMs(
+  buffer: Buffer,
+  options?: { fileName?: string; contentType?: string },
+): Promise<number | undefined> {
+  try {
+    const metadata = await parseAudioMetadata(
+      buffer,
+      { mimeType: options?.contentType, path: options?.fileName, size: buffer.length },
+      { duration: true, skipCovers: true },
+    );
+    const seconds = metadata.format.duration;
+    if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+      return undefined;
+    }
+    return Math.round(seconds * 1000);
+  } catch {
+    return undefined;
+  }
+}
 
 export type DownloadImageResult = {
   buffer: Buffer;
@@ -499,6 +525,13 @@ export function detectFileType(
   switch (ext) {
     case ".opus":
     case ".ogg":
+    case ".mp3":
+    case ".m4a":
+    case ".aac":
+    case ".wav":
+    case ".flac":
+    case ".caf":
+    case ".oga":
       return "opus";
     case ".mp4":
     case ".mov":
@@ -535,12 +568,7 @@ function resolveFeishuOutboundMediaKind(params: { fileName: string; contentType?
     return { msgType: "image" };
   }
 
-  if (
-    ext === ".opus" ||
-    ext === ".ogg" ||
-    contentType === "audio/ogg" ||
-    contentType === "audio/opus"
-  ) {
+  if (isAudioFileName(fileName) || mimeKind === "audio") {
     return { fileType: "opus", msgType: "audio" };
   }
 
@@ -627,11 +655,16 @@ export async function sendMediaFeishu(params: {
     const { imageKey } = await uploadImageFeishu({ cfg, image: buffer, accountId });
     return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, replyInThread, accountId });
   } else {
+    const duration =
+      routing.msgType === "audio" || routing.msgType === "media"
+        ? await parseAudioDurationMs(buffer, { fileName: name, contentType })
+        : undefined;
     const { fileKey } = await uploadFileFeishu({
       cfg,
       file: buffer,
       fileName: name,
       fileType: routing.fileType ?? "stream",
+      duration,
       accountId,
     });
     return sendFileFeishu({

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -15,11 +15,12 @@ import { resolveFeishuSendTarget } from "./send-target.js";
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 
 /**
- * Parse audio duration in milliseconds using music-metadata.
+ * Parse media duration in milliseconds using music-metadata.
+ * Works for both audio and video containers (e.g. mp4/mov).
  * Returns undefined if parsing fails (graceful degradation — Feishu will
  * still accept the upload, just without a seek bar in the player).
  */
-async function parseAudioDurationMs(
+async function parseMediaDurationMs(
   buffer: Buffer,
   options?: { fileName?: string; contentType?: string },
 ): Promise<number | undefined> {
@@ -30,10 +31,10 @@ async function parseAudioDurationMs(
       { duration: true, skipCovers: true },
     );
     const seconds = metadata.format.duration;
-    if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
+    if (typeof seconds !== "number" || !Number.isFinite(seconds)) {
       return undefined;
     }
-    return Math.round(seconds * 1000);
+    return Math.max(0, Math.round(seconds * 1000));
   } catch {
     return undefined;
   }
@@ -657,7 +658,7 @@ export async function sendMediaFeishu(params: {
   } else {
     const duration =
       routing.msgType === "audio" || routing.msgType === "media"
-        ? await parseAudioDurationMs(buffer, { fileName: name, contentType })
+        ? await parseMediaDurationMs(buffer, { fileName: name, contentType })
         : undefined;
     const { fileKey } = await uploadFileFeishu({
       cfg,


### PR DESCRIPTION
## Summary

The Feishu outbound media router (`resolveFeishuOutboundMediaKind`) only recognizes `.opus` and `.ogg` as audio — common formats like `.mp3`, `.wav`, `.m4a`, `.flac`, and `.aac` are sent as `msg_type: "file"` (downloadable attachment) instead of `msg_type: "audio"` (inline playable voice bubble).

This PR:
1. Broadens audio format recognition using the existing `isAudioFileName()` helper and `mimeKind === "audio"` fallback — consistent with how image routing already uses `mimeKind === "image"`.
2. Adds `music-metadata` (already a monorepo dependency via `extensions/matrix`) to parse audio duration for the Feishu upload API, so the player displays correct seek/progress.

## Problem

When an agent sends an MP3, WAV, or M4A file via the Feishu channel, the user sees a file attachment instead of a playable audio bubble. This is because `resolveFeishuOutboundMediaKind()` hardcodes only `.opus`/`.ogg` and `audio/ogg`/`audio/opus`:

```typescript
// Before — only 4 conditions:
if (ext === ".opus" || ext === ".ogg" ||
    contentType === "audio/ogg" || contentType === "audio/opus")
```

Meanwhile, the image branch correctly uses `mimeKind === "image"` as a catch-all, and `src/media/mime.ts` already exports `isAudioFileName()` (covers 9 extensions) and `AUDIO_FILE_EXTENSIONS` — but neither is used in the routing function.

## Solution

- Use `isAudioFileName(fileName) || mimeKind === "audio"` for audio detection — symmetric with the image branch.
- Expand `detectFileType()` to map common audio extensions (mp3, m4a, aac, wav, flac, caf, oga) to `"opus"`.
- Add audio duration parsing via `music-metadata` (pure JS, zero native deps, already in monorepo for `extensions/matrix`). Graceful degradation: if parsing fails, upload proceeds without duration.

## Verified behavior

Tested against the Feishu `im/v1/files` API: uploading MP3, WAV, M4A, FLAC, and AAC with `file_type=opus` succeeds and plays correctly in the Feishu client. The API does not validate the actual codec. This is consistent with the approach used by the community Feishu plugin [`@m1heng-clawd/feishu`](https://github.com/m1heng/clawdbot-feishu) (2.3k+ stars), which maps all common audio extensions to `file_type=opus` in production.

## Related

- #33060 — pass audio duration to file upload (ffprobe-based, open)
- #43388 — transcode audio to opus before upload (ffmpeg-based, open)
- #33736 — feature request: Feishu audio message support
- PR #28269 — original `msg_type: "audio"` fix for opus files

## Test plan

- Manually verified: mp3, wav, m4a, flac, aac sent to Feishu → inline audio player ✅
- Manually verified: opus/ogg → still works as before ✅
- Manually verified: image/video routing unchanged ✅
- Unit tests: updated existing test + added coverage for mp3/wav/m4a/flac/aac routing and content-type fallback