### PR TITLE
Channels: resolve installed channel plugins in add

### DIFF
--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentId: vi.fn(),
   getChannelPluginCatalogEntry: vi.fn(),
+  loadPluginManifestRegistry: vi.fn(),
   listChannelPluginCatalogEntries: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
   getChannelPlugin: vi.fn(),
@@ -31,6 +32,10 @@ vi.mock("../agents/agent-scope.js", () => ({
 vi.mock("../channels/plugins/catalog.js", () => ({
   getChannelPluginCatalogEntry: mocks.getChannelPluginCatalogEntry,
   listChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
+}));
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
 }));
 
 vi.mock("../channels/plugins/helpers.js", () => ({
@@ -84,6 +89,7 @@ describe("channel-auth", () => {
     mocks.normalizeChannelId.mockReturnValue("whatsapp");
     mocks.getChannelPlugin.mockReturnValue(plugin);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
+    mocks.loadPluginManifestRegistry.mockReturnValue({ plugins: [], diagnostics: [] });
     mocks.listChannelPluginCatalogEntries.mockReturnValue([]);
     mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {} } });
     mocks.readConfigFileSnapshot.mockResolvedValue({ hash: "config-1" });
@@ -309,7 +315,7 @@ describe("channel-auth", () => {
     expect(mocks.loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "whatsapp",
-        pluginId: "whatsapp",
+        pluginId: "@openclaw/whatsapp",
         workspaceDir: "/tmp/workspace",
       }),
     );

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -7,6 +7,7 @@ import {
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelId, ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
@@ -26,10 +27,45 @@ type ResolveInstallableChannelPluginResult = {
   plugin?: ChannelPlugin;
   catalogEntry?: ChannelPluginCatalogEntry;
   configChanged: boolean;
+  installDeclined: boolean;
 };
 
 function resolveWorkspaceDir(cfg: OpenClawConfig) {
   return resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+}
+
+function resolveManifestInstalledChannel(params: {
+  cfg: OpenClawConfig;
+  rawChannel?: string | null;
+  channelId?: ChannelId;
+}): { channelId: ChannelId; pluginId: string } | undefined {
+  const requested =
+    params.channelId ??
+    (typeof params.rawChannel === "string" && params.rawChannel.trim()
+      ? (params.rawChannel.trim().toLowerCase() as ChannelId)
+      : undefined);
+  if (!requested) {
+    return undefined;
+  }
+  let match;
+  try {
+    match = loadPluginManifestRegistry({
+      config: params.cfg,
+      workspaceDir: resolveWorkspaceDir(params.cfg),
+      env: process.env,
+    }).plugins.find((plugin) =>
+      plugin.channels.some((channel) => channel.trim().toLowerCase() === requested),
+    );
+  } catch {
+    return undefined;
+  }
+  if (!match) {
+    return undefined;
+  }
+  return {
+    channelId: requested,
+    pluginId: match.id,
+  };
 }
 
 function resolveResolvedChannelId(params: {
@@ -106,19 +142,30 @@ export async function resolveInstallableChannelPlugin(params: {
           workspaceDir,
         })
       : undefined);
-  const channelId =
+  let channelId =
     params.channelId ??
     resolveResolvedChannelId({
       rawChannel: params.rawChannel,
       catalogEntry,
     });
+  let manifestInstalled: ReturnType<typeof resolveManifestInstalledChannel>;
+  if (!channelId) {
+    manifestInstalled = resolveManifestInstalledChannel({
+      cfg: nextCfg,
+      rawChannel: params.rawChannel,
+    });
+    channelId = manifestInstalled?.channelId;
+  }
   if (!channelId) {
     return {
       cfg: nextCfg,
       catalogEntry,
       configChanged: false,
+      installDeclined: false,
     };
   }
+
+  manifestInstalled ??= resolveManifestInstalledChannel({ cfg: nextCfg, channelId });
 
   const existing = getChannelPlugin(channelId);
   if (existing && supports(existing)) {
@@ -128,11 +175,12 @@ export async function resolveInstallableChannelPlugin(params: {
       plugin: existing,
       catalogEntry,
       configChanged: false,
+      installDeclined: false,
     };
   }
 
-  const resolvedPluginId = catalogEntry?.pluginId;
-  if (catalogEntry) {
+  const resolvedPluginId = manifestInstalled?.pluginId ?? catalogEntry?.pluginId;
+  if (resolvedPluginId ?? catalogEntry) {
     const scoped = loadScopedChannelPlugin({
       cfg: nextCfg,
       runtime: params.runtime,
@@ -147,9 +195,12 @@ export async function resolveInstallableChannelPlugin(params: {
         plugin: scoped,
         catalogEntry,
         configChanged: false,
+        installDeclined: false,
       };
     }
+  }
 
+  if (catalogEntry) {
     if (params.allowInstall !== false) {
       const installResult = await ensureChannelSetupPluginInstalled({
         cfg: nextCfg,
@@ -178,6 +229,7 @@ export async function resolveInstallableChannelPlugin(params: {
             ? { ...catalogEntry, pluginId: installedPluginId }
             : catalogEntry,
         configChanged: nextCfg !== params.cfg,
+        installDeclined: !installResult.installed,
       };
     }
   }
@@ -188,5 +240,6 @@ export async function resolveInstallableChannelPlugin(params: {
     plugin: existing,
     catalogEntry,
     configChanged: false,
+    installDeclined: false,
   };
 }

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -284,7 +284,7 @@ describe("channelsAddCommand", () => {
     expect(offsetMocks.deleteTelegramUpdateOffset).not.toHaveBeenCalled();
   });
 
-  it("falls back to a scoped snapshot after installing an external channel plugin", async () => {
+  it("uses a scoped snapshot before reinstalling an external channel plugin", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
     setActivePluginRegistry(createTestRegistry());
     const catalogEntry = createMSTeamsCatalogEntry();
@@ -301,9 +301,7 @@ describe("channelsAddCommand", () => {
       { hasFlags: true },
     );
 
-    expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
-      expect.objectContaining({ entry: catalogEntry }),
-    );
+    expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
     expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "msteams",
@@ -392,32 +390,37 @@ describe("channelsAddCommand", () => {
       installed: true,
       pluginId: "@vendor/teams-runtime",
     }));
-    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
-      createTestRegistry([
-        {
-          pluginId: "@vendor/teams-runtime",
-          plugin: {
-            ...createChannelTestPluginBase({
-              id: "msteams",
-              label: "Microsoft Teams",
-              docsPath: "/channels/msteams",
-            }),
-            setup: {
-              applyAccountConfig: vi.fn(({ cfg, input }) => ({
-                ...cfg,
-                channels: {
-                  ...cfg.channels,
-                  msteams: {
-                    enabled: true,
-                    tenantId: input.token,
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockImplementation(
+      ({ pluginId }) => {
+        if (pluginId !== "@vendor/teams-runtime") {
+          return createTestRegistry();
+        }
+        return createTestRegistry([
+          {
+            pluginId: "@vendor/teams-runtime",
+            plugin: {
+              ...createChannelTestPluginBase({
+                id: "msteams",
+                label: "Microsoft Teams",
+                docsPath: "/channels/msteams",
+              }),
+              setup: {
+                applyAccountConfig: vi.fn(({ cfg, input }) => ({
+                  ...cfg,
+                  channels: {
+                    ...cfg.channels,
+                    msteams: {
+                      enabled: true,
+                      tenantId: input.token,
+                    },
                   },
-                },
-              })),
+                })),
+              },
             },
+            source: "test",
           },
-          source: "test",
-        },
-      ]),
+        ]);
+      },
     );
 
     await channelsAddCommand(
@@ -430,10 +433,121 @@ describe("channelsAddCommand", () => {
       { hasFlags: true },
     );
 
-    expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith(
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         channel: "msteams",
         pluginId: "@vendor/teams-runtime",
+      }),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("returns cleanly when external plugin install is skipped", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+    setActivePluginRegistry(createTestRegistry());
+    const catalogEntry: ChannelPluginCatalogEntry = {
+      id: "qqbot",
+      pluginId: "openclaw-qqbot",
+      meta: {
+        id: "qqbot",
+        label: "Tencent QQ Bot",
+        selectionLabel: "Tencent QQ Bot",
+        docsPath: "/channels/qqbot",
+        blurb: "Tencent channel",
+      },
+      install: {
+        npmSpec: "openclaw-qqbot",
+      },
+    };
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
+    vi.mocked(ensureChannelSetupPluginInstalled).mockImplementation(async ({ cfg }) => ({
+      cfg,
+      installed: false,
+    }));
+
+    await channelsAddCommand(
+      {
+        channel: "qqbot",
+        account: "default",
+        token: "appid:secret",
+      },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: catalogEntry }),
+    );
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("uses plugin manifest fallback when an installed external channel is missing from the catalog", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+    setActivePluginRegistry(createTestRegistry());
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([]);
+    manifestRegistryMocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "openclaw-qqbot",
+          channels: ["qqbot"],
+        } as never,
+      ],
+      diagnostics: [],
+    });
+    const scopedQqbotPlugin = {
+      ...createChannelTestPluginBase({
+        id: "qqbot",
+        label: "QQ Bot",
+        docsPath: "/channels/qqbot",
+      }),
+      setup: {
+        applyAccountConfig: vi.fn(({ cfg, input }) => ({
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            qqbot: {
+              enabled: true,
+              token: input.token,
+            },
+          },
+        })),
+      },
+    };
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
+      createTestRegistry([
+        { pluginId: "openclaw-qqbot", plugin: scopedQqbotPlugin, source: "test" },
+      ]),
+    );
+
+    await channelsAddCommand(
+      {
+        channel: "qqbot",
+        account: "default",
+        token: "appid:secret",
+      },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "qqbot",
+        pluginId: "openclaw-qqbot",
+      }),
+    );
+    expect(configMocks.writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: {
+          qqbot: {
+            enabled: true,
+            token: "appid:secret",
+          },
+        },
       }),
     );
     expect(runtime.error).not.toHaveBeenCalled();

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,16 +1,15 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { listChannelPluginCatalogEntries } from "../../channels/plugins/catalog.js";
+import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { parseOptionalDelimitedEntries } from "../../channels/plugins/helpers.js";
-import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
+import { getChannelPlugin } from "../../channels/plugins/index.js";
 import { moveSingleAccountChannelSectionToDefaultAccount } from "../../channels/plugins/setup-helpers.js";
 import type { ChannelSetupPlugin } from "../../channels/plugins/setup-wizard-types.js";
-import type { ChannelId, ChannelPlugin, ChannelSetupInput } from "../../channels/plugins/types.js";
+import type { ChannelSetupInput } from "../../channels/plugins/types.js";
 import { replaceConfigFile, type OpenClawConfig } from "../../config/config.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
-import { isCatalogChannelInstalled } from "../channel-setup/discovery.js";
+import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
 import {
   createChannelOnboardingPostWriteHookCollector,
   runCollectedChannelOnboardingPostWriteHooks,
@@ -26,20 +25,6 @@ export type ChannelsAddOptions = {
   groupChannels?: string;
   dmAllowlist?: string;
 } & Omit<ChannelSetupInput, "groupChannels" | "dmAllowlist" | "initialSyncLimit">;
-
-function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
-  const trimmed = raw.trim().toLowerCase();
-  if (!trimmed) {
-    return undefined;
-  }
-  const workspaceDir = cfg ? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)) : undefined;
-  return listChannelPluginCatalogEntries({ workspaceDir }).find((entry) => {
-    if (entry.id.toLowerCase() === trimmed) {
-      return true;
-    }
-    return (entry.meta.aliases ?? []).some((alias) => alias.trim().toLowerCase() === trimmed);
-  });
-}
 
 export async function channelsAddCommand(
   opts: ChannelsAddOptions,
@@ -193,77 +178,26 @@ export async function channelsAddCommand(
   }
 
   const rawChannel = String(opts.channel ?? "");
-  let channel = normalizeChannelId(rawChannel);
-  let catalogEntry = channel ? undefined : resolveCatalogChannelEntry(rawChannel, nextConfig);
-  const resolveWorkspaceDir = () =>
-    resolveAgentWorkspaceDir(nextConfig, resolveDefaultAgentId(nextConfig));
-  // May trigger loadOpenClawPlugins on cache miss (disk scan + jiti import)
-  const loadScopedPlugin = async (
-    channelId: ChannelId,
-    pluginId?: string,
-  ): Promise<ChannelPlugin | undefined> => {
-    const existing = getChannelPlugin(channelId);
-    if (existing) {
-      return existing;
-    }
-    const { loadChannelSetupPluginRegistrySnapshotForChannel } =
-      await import("../channel-setup/plugin-install.js");
-    const snapshot = loadChannelSetupPluginRegistrySnapshotForChannel({
-      cfg: nextConfig,
-      runtime,
-      channel: channelId,
-      ...(pluginId ? { pluginId } : {}),
-      workspaceDir: resolveWorkspaceDir(),
-    });
-    return (
-      snapshot.channels.find((entry) => entry.plugin.id === channelId)?.plugin ??
-      snapshot.channelSetups.find((entry) => entry.plugin.id === channelId)?.plugin
-    );
-  };
+  const resolution = await resolveInstallableChannelPlugin({
+    cfg: nextConfig,
+    runtime,
+    rawChannel,
+    prompter: createClackPrompter(),
+    supports: (plugin) => Boolean(plugin.setup?.applyAccountConfig),
+  });
+  nextConfig = resolution.cfg;
+  const channel = resolution.channelId;
+  const plugin = resolution.plugin ?? (channel ? getChannelPlugin(channel) : undefined);
 
-  if (!channel && catalogEntry) {
-    const workspaceDir = resolveWorkspaceDir();
-    if (
-      !isCatalogChannelInstalled({
-        cfg: nextConfig,
-        entry: catalogEntry,
-        workspaceDir,
-      })
-    ) {
-      const { ensureChannelSetupPluginInstalled } =
-        await import("../channel-setup/plugin-install.js");
-      const prompter = createClackPrompter();
-      const result = await ensureChannelSetupPluginInstalled({
-        cfg: nextConfig,
-        entry: catalogEntry,
-        prompter,
-        runtime,
-        workspaceDir,
-      });
-      nextConfig = result.cfg;
-      if (!result.installed) {
-        return;
-      }
-      catalogEntry = {
-        ...catalogEntry,
-        ...(result.pluginId ? { pluginId: result.pluginId } : {}),
-      };
-    }
-    channel = normalizeChannelId(catalogEntry.id) ?? (catalogEntry.id as ChannelId);
-  }
-
-  if (!channel) {
-    const hint = catalogEntry
-      ? `Plugin ${catalogEntry.meta.label} could not be loaded after install.`
-      : `Unknown channel: ${String(opts.channel ?? "")}`;
-    runtime.error(hint);
-    runtime.exit(1);
+  if (resolution.installDeclined) {
     return;
   }
 
-  const plugin = await loadScopedPlugin(channel, catalogEntry?.pluginId);
-  if (!plugin?.setup?.applyAccountConfig) {
-    runtime.error(`Channel ${channel} does not support add.`);
+  if (!channel || !plugin?.setup?.applyAccountConfig) {
+    const hint = resolution.catalogEntry
+      ? `Plugin ${resolution.catalogEntry.meta.label} could not be loaded after install.`
+      : `Unknown channel: ${String(opts.channel ?? "")}`;
+    runtime.error(hint);
     runtime.exit(1);
     return;
   }


### PR DESCRIPTION
## Summary

`openclaw channels add` can fail to resolve already-installed external channel plugins

Describe the problem and fix in 2–5 bullets:

- **Problem:** `channels add` resolves channels purely from the active in-process registry and catalog, ignoring the installed plugin manifest registry. Plugins that are installed but not currently loaded in-process are missed, causing unnecessary reinstall attempts or outright failures.
- **Why it matters:** Users with valid external channel plugins already installed can still hit "unknown channel" / "could not be loaded after install" errors, making `channels add` unreliable for extension-heavy deployments and brittle across plugin migrations where the channel id diverges from the installed plugin id.
- **What changed:** Resolution order now checks the active registry first, then resolves a candidate plugin id from the catalog entry or installed manifest registry, loads a scoped channel setup snapshot before attempting installation, and reloads using the installed plugin id if the installer returns a different id than the catalog id.
- **What did NOT change (scope boundary):** Built-in channel behavior, routing/pairing logic, onboarding flows, and all unrelated command paths are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- **Root cause:** `channels add` consulted only the active in-process plugin registry and the catalog on each invocation. It had no fallback to the installed plugin manifest registry and no logic to attempt a scoped snapshot load before calling the installer.
- **Missing detection / guardrail:** No test covered the case where a plugin is installed and manifest-recorded but absent from the current process registry or omitted from the catalog response.
- **Prior context (`git blame`, prior PR, issue, or refactor if known):** Unknown — the command appears to have always assumed the in-process registry was authoritative.
- **Why this regressed now:** More operators are using extension channels that are installed independently of the catalog, and plugin migrations increasingly produce ids that differ between the catalog entry and the installed plugin.
- **If unknown, what was ruled out:** N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `channels add` resolution logic unit tests
- **Scenario the test should lock in:**
  - Use scoped snapshot before reinstalling an external channel plugin
  - Use installed external channel snapshot without reinstalling
  - Use installed plugin id when channel and plugin ids differ
  - Use plugin manifest fallback when an installed external channel is missing from the catalog
- **Why this is the smallest reliable guardrail:** These four cases directly exercise each new resolution branch without requiring a live plugin environment.
- **Existing test that already covers this (if any):** None — the failure modes were not previously tested.
- **If no new test is added, why not:** N/A — new tests are added.

## User-visible / Behavior Changes

- `channels add` no longer attempts to reinstall an external channel plugin that is already installed and resolvable via a scoped snapshot.
- Previously-failing "unknown channel" or "could not be loaded after install" errors for installed-but-not-loaded plugins are resolved.
- Channel configuration works correctly across plugin migrations where the catalog plugin id differs from the installed plugin id.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any): external channel plugin (extension)
- Relevant config (redacted):

### Steps

1. Install an external channel plugin so it is recorded in the manifest registry.
2. Start `openclaw` in a process that does not preload the plugin into the active registry (or remove it from the catalog response).
3. Run `openclaw channels add <external-channel-id>`.

### Expected

- `channels add` resolves the plugin via the manifest registry or catalog, loads the scoped snapshot, and completes channel setup without reinstalling.

### Actual

- `channels add` fails with "unknown channel" or attempts to reinstall the already-present plugin, then may fail with "could not be loaded after install".

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- **Verified scenarios:**
  - Catalog-backed external channel present but not in process registry → scoped snapshot loaded, no reinstall triggered.
  - Plugin installed and in manifest registry but absent from catalog → resolved and configured successfully.
  - Installer returns a different runtime plugin id than the catalog id → reloaded using installed plugin id.
- **Edge cases checked:** Plugin manifest registry empty (falls through to installer as before); catalog and manifest both missing entry (fails with clear error, no silent hang).
- **What you did not verify:** Live multi-plugin environments with conflicting catalog versions; plugin hot-reload paths.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert this change quickly:** Revert the resolution-order changes in the `channels add` command handler; the prior behavior (active registry + catalog only, no manifest fallback) is restored immediately.
- **Files/config to restore:** `channels add` command handler and any new snapshot-resolution helpers introduced by this PR.
- **Known bad symptoms reviewers should watch for:** `channels add` hanging or silently skipping installation for plugins not yet in the manifest registry; snapshot load errors surfaced as unhandled rejections instead of falling through to the installer.

## Risks and Mitigations

- **Risk:** A scoped snapshot loaded from an outdated or corrupt installed plugin could serve stale setup behavior rather than triggering a clean reinstall.
  - **Mitigation:** Snapshot load errors are not silently swallowed; any failure falls through to the installer path, preserving the existing install-on-error behavior.
- **Risk:** Manifest registry lookup adds a new I/O path that could be slow or fail in constrained environments.
  - **Mitigation:** Lookup is a fast local read; errors are non-fatal and fall through to the existing catalog + install path.