### PR TITLE
test: stabilize preaction process title assertion

### DIFF
--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -57,6 +57,8 @@ const mockedModuleIds = [
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
 let originalProcessArgv: string[];
 let originalProcessTitle: string;
+let originalProcessTitleDescriptor: PropertyDescriptor | undefined;
+let observedProcessTitle: string;
 let originalNodeNoWarnings: string | undefined;
 let originalHideBanner: string | undefined;
 let originalForceStderr: boolean;
@@ -76,9 +78,19 @@ beforeEach(() => {
   vi.clearAllMocks();
   originalProcessArgv = [...process.argv];
   originalProcessTitle = process.title;
+  originalProcessTitleDescriptor = Object.getOwnPropertyDescriptor(process, "title");
+  observedProcessTitle = originalProcessTitle;
   originalNodeNoWarnings = process.env.NODE_NO_WARNINGS;
   originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
   originalForceStderr = loggingState.forceConsoleToStderr;
+  Object.defineProperty(process, "title", {
+    configurable: true,
+    enumerable: originalProcessTitleDescriptor?.enumerable ?? true,
+    get: () => observedProcessTitle,
+    set: (value: string) => {
+      observedProcessTitle = value;
+    },
+  });
   loggingState.forceConsoleToStderr = false;
   delete process.env.NODE_NO_WARNINGS;
   delete process.env.OPENCLAW_HIDE_BANNER;
@@ -86,7 +98,16 @@ beforeEach(() => {
 
 afterEach(() => {
   process.argv = originalProcessArgv;
-  process.title = originalProcessTitle;
+  if (originalProcessTitleDescriptor && "value" in originalProcessTitleDescriptor) {
+    Object.defineProperty(process, "title", {
+      ...originalProcessTitleDescriptor,
+      value: originalProcessTitle,
+    });
+  } else if (originalProcessTitleDescriptor) {
+    Object.defineProperty(process, "title", originalProcessTitleDescriptor);
+  } else {
+    process.title = originalProcessTitle;
+  }
   loggingState.forceConsoleToStderr = originalForceStderr;
   if (originalNodeNoWarnings === undefined) {
     delete process.env.NODE_NO_WARNINGS;


### PR DESCRIPTION
## What
Stabilizes the preaction process-title test by observing `process.title` through a temporary local property wrapper instead of relying on the host runtime to expose the title change directly during Vitest execution.

## Why
Current `origin/main` fails `src/cli/program/preaction.test.ts` because the test expects `process.title` to read back `openclaw-status`, but in the test runtime it stays `node` even though the hook still performs the assignment.

## Changes
- Wrap `process.title` in the test setup
- Restore the original descriptor after each test
- Keep production preaction behavior unchanged

## Testing
- `pnpm test -- src/cli/program/preaction.test.ts`
- `pnpm check`
