### PR TITLE
fix(feishu): make card field optional in message tool schema

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,3 +1,4 @@
+import { Type } from "@sinclair/typebox";
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import { createMessageToolCardSchema } from "openclaw/plugin-sdk/channel-actions";
@@ -108,7 +109,7 @@ function describeFeishuMessageTool({
       schema: enabled
         ? {
             properties: {
-              card: createMessageToolCardSchema(),
+              card: Type.Optional(createMessageToolCardSchema()),
             },
           }
         : null,
@@ -136,7 +137,7 @@ function describeFeishuMessageTool({
     schema: enabled
       ? {
           properties: {
-            card: createMessageToolCardSchema(),
+            card: Type.Optional(createMessageToolCardSchema()),
           },
         }
       : null,


### PR DESCRIPTION
Fixes #53656

## Problem
Feishu message tool schema marks `card` as required, but the handler supports three mutually exclusive message types: card, media, or text. This causes schema validation to reject pure media/text messages.

## Solution
Mark `card` property as `Type.Optional()` in both schema contributions of `describeFeishuMessageTool()`.

## Changes
- extensions/feishu/src/channel.ts: 2 lines changed

## Verification
- ✅ Only 1 file modified
- ✅ Only 1 commit
- ✅ Branch created from clean main
- ✅ pnpm tsgo passed
- ✅ pnpm format passed