### PR TITLE
Feat/sandbox docker volumes strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2824,6 +2824,7 @@ Docs: https://docs.openclaw.ai
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)
 - Crabbox/scripts: print the selected Crabbox binary, version, and supported providers before `pnpm crabbox:*` commands, and reject stale binaries that lack `blacksmith-testbox` provider support.
 - Agents/Codex: add committed happy-path prompt snapshots for Codex/message-tool Telegram direct, Discord group, and heartbeat turns so prompt drift can be reviewed. Thanks @pashpashpash.
+- Sandbox/Docker: add declarative `sandbox.docker.volumes` entries for ephemeral, named, and bind-style Docker mounts, while rejecting them on SSH and OpenShell backends that cannot mount Docker volumes. (#53822) Thanks @sasan1200.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1014,6 +1014,7 @@ Docs: https://docs.openclaw.ai
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)
 - Crabbox/scripts: print the selected Crabbox binary, version, and supported providers before `pnpm crabbox:*` commands, and reject stale binaries that lack `blacksmith-testbox` provider support.
 - Agents/Codex: add committed happy-path prompt snapshots for Codex/message-tool Telegram direct, Discord group, and heartbeat turns so prompt drift can be reviewed. Thanks @pashpashpash.
+- Sandbox/Docker: add declarative `sandbox.docker.volumes` entries for ephemeral, named, and bind-style Docker mounts, while rejecting them on SSH and OpenShell backends that cannot mount Docker volumes. (#53822) Thanks @sasan1200.
 
 ### Fixes
 

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -208,6 +208,7 @@ OpenShell modes:
   <Accordion title="Current OpenShell limitations">
     - sandbox browser is not supported yet
     - `sandbox.docker.binds` is not supported on the OpenShell backend
+    - `sandbox.docker.volumes` is not supported on the OpenShell backend
     - Docker-specific runtime knobs under `sandbox.docker.*` still apply only to the Docker backend
 
   </Accordion>
@@ -313,6 +314,16 @@ Inbound media is copied into the active sandbox workspace (`media/inbound/*`).
 
 Global and per-agent binds are **merged** (not replaced). Under `scope: "shared"`, per-agent binds are ignored.
 
+`agents.defaults.sandbox.docker.volumes` mounts additional Docker volumes into sandbox containers with declarative entries:
+
+- `strategy: "ephemeral"` creates an anonymous Docker volume and must omit `source`
+- `strategy: "named"` mounts the Docker volume named by `source`
+- `strategy: "bind"` mounts the host path named by absolute `source`
+
+Each entry requires an absolute POSIX `target` inside the container and may set `readOnly: true`. Global and per-agent volumes are merged the same way as `sandbox.docker.binds`; under `scope: "shared"`, per-agent volumes are ignored.
+
+Docker volumes are Docker-backend only. The SSH and OpenShell sandbox backends reject `sandbox.docker.volumes` because they do not mount Docker volumes.
+
 `agents.defaults.sandbox.browser.binds` mounts additional host directories into the **sandbox browser** container only.
 
 - When set (including `[]`), it replaces `agents.defaults.sandbox.docker.binds` for the browser container.
@@ -358,6 +369,29 @@ Example (read-only source + an extra data directory):
 - See [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) for how binds interact with tool policy and elevated exec.
 
 </Warning>
+
+Example (ephemeral cache + named dependency volume):
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        docker: {
+          volumes: [
+            { strategy: "ephemeral", target: "/tmp/cache" },
+            {
+              strategy: "named",
+              source: "openclaw-node-modules",
+              target: "/cache/node_modules",
+            },
+          ],
+        },
+      },
+    },
+  },
+}
+```
 
 ## Images and setup
 

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -222,6 +222,7 @@ OpenShell modes:
   <Accordion title="Current OpenShell limitations">
     - sandbox browser is not supported yet
     - `sandbox.docker.binds` is not supported on the OpenShell backend
+    - `sandbox.docker.volumes` is not supported on the OpenShell backend
     - Docker-specific runtime knobs under `sandbox.docker.*` still apply only to the Docker backend
 
   </Accordion>
@@ -327,6 +328,18 @@ Inbound media is copied into the active sandbox workspace (`media/inbound/*`).
 
 Global and per-agent binds are **merged** (not replaced). Under `scope: "shared"`, per-agent binds are ignored.
 
+`agents.defaults.sandbox.docker.volumes` mounts additional Docker volumes into sandbox containers with declarative entries:
+
+- `strategy: "ephemeral"` creates an anonymous Docker volume and must omit `source`
+- `strategy: "named"` mounts the Docker volume named by `source`
+- `strategy: "bind"` mounts the absolute host path named by `source`
+
+Each entry requires an absolute POSIX `target` inside the container and may set `readOnly: true`. Global and per-agent volumes are merged the same way as `sandbox.docker.binds`; under `scope: "shared"`, per-agent volumes are ignored.
+
+Docker volumes are Docker-backend only. The SSH and OpenShell sandbox backends reject `sandbox.docker.volumes` because they do not mount Docker volumes.
+
+For writable anonymous or named Docker volumes, OpenClaw initializes the volume target ownership before the sandbox process drops to the configured non-root user. Brand-new target paths such as `/tmp/cache` or `/cache/node_modules` are writable by the sandbox user without requiring a custom image.
+
 `agents.defaults.sandbox.browser.binds` mounts additional host directories into the **sandbox browser** container only.
 
 - When set (including `[]`), it replaces `agents.defaults.sandbox.docker.binds` for the browser container.
@@ -372,6 +385,29 @@ Example (read-only source + an extra data directory):
 - See [Sandbox vs Tool Policy vs Elevated](/gateway/sandbox-vs-tool-policy-vs-elevated) for how binds interact with tool policy and elevated exec.
 
 </Warning>
+
+Example (ephemeral cache + named dependency volume):
+
+```json5
+{
+  agents: {
+    defaults: {
+      sandbox: {
+        docker: {
+          volumes: [
+            { strategy: "ephemeral", target: "/tmp/cache" },
+            {
+              strategy: "named",
+              source: "openclaw-node-modules",
+              target: "/cache/node_modules",
+            },
+          ],
+        },
+      },
+    },
+  },
+}
+```
 
 ## Images and setup
 

--- a/extensions/openshell/src/backend.test.ts
+++ b/extensions/openshell/src/backend.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildOpenShellSshExecEnv } from "./backend.js";
+import { buildOpenShellSshExecEnv, createOpenShellSandboxBackendFactory } from "./backend.js";
+import { resolveOpenShellPluginConfig } from "./config.js";
 
 describe("openshell backend env", () => {
   const originalEnv = { ...process.env };
@@ -25,5 +26,62 @@ describe("openshell backend env", () => {
     expect(env.ANTHROPIC_API_KEY).toBeUndefined();
     expect(env.LANG).toBe("en_US.UTF-8");
     expect(env.NODE_ENV).toBe("test");
+  });
+});
+
+describe("openshell sandbox backend", () => {
+  it("rejects docker volumes because openshell does not mount them", async () => {
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig(undefined),
+    });
+
+    await expect(
+      factory({
+        sessionKey: "agent:worker:task",
+        scopeKey: "agent:worker",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/agent",
+        cfg: {
+          mode: "all",
+          backend: "openshell",
+          scope: "session",
+          workspaceAccess: "rw",
+          workspaceRoot: "~/.openclaw/sandboxes",
+          docker: {
+            image: "img",
+            containerPrefix: "prefix-",
+            workdir: "/workspace",
+            readOnlyRoot: true,
+            tmpfs: ["/tmp"],
+            network: "none",
+            capDrop: ["ALL"],
+            env: {},
+            volumes: [{ strategy: "named", source: "cache", target: "/cache" }],
+          },
+          ssh: {
+            command: "ssh",
+            workspaceRoot: "/remote/openclaw",
+            strictHostKeyChecking: true,
+            updateHostKeys: true,
+          },
+          browser: {
+            enabled: false,
+            image: "img",
+            containerPrefix: "prefix-",
+            network: "bridge",
+            cdpPort: 9222,
+            vncPort: 5900,
+            noVncPort: 6080,
+            headless: true,
+            enableNoVnc: false,
+            allowHostControl: false,
+            autoStart: false,
+            autoStartTimeoutMs: 1000,
+          },
+          tools: { allow: [], deny: [] },
+          prune: { idleHours: 24, maxAgeDays: 7 },
+        },
+      }),
+    ).rejects.toThrow("does not support sandbox.docker.volumes");
   });
 });

--- a/extensions/openshell/src/backend.test.ts
+++ b/extensions/openshell/src/backend.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { buildOpenShellSandboxName, buildOpenShellSshExecEnv } from "./backend.js";
+import {
+  buildOpenShellSandboxName,
+  buildOpenShellSshExecEnv,
+  createOpenShellSandboxBackendFactory,
+} from "./backend.js";
+import { resolveOpenShellPluginConfig } from "./config.js";
 
 describe("openshell backend env", () => {
   const originalEnv = { ...process.env };
@@ -36,5 +41,62 @@ describe("openshell sandbox names", () => {
     expect(name).toContain("somalley-alice");
     expect(name).not.toContain("_");
     expect(name.length).toBeLessThanOrEqual(63);
+  });
+});
+
+describe("openshell sandbox backend", () => {
+  it("rejects docker volumes because openshell does not mount them", async () => {
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig(undefined),
+    });
+
+    await expect(
+      factory({
+        sessionKey: "agent:worker:task",
+        scopeKey: "agent:worker",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/agent",
+        cfg: {
+          mode: "all",
+          backend: "openshell",
+          scope: "session",
+          workspaceAccess: "rw",
+          workspaceRoot: "~/.openclaw/sandboxes",
+          docker: {
+            image: "img",
+            containerPrefix: "prefix-",
+            workdir: "/workspace",
+            readOnlyRoot: true,
+            tmpfs: ["/tmp"],
+            network: "none",
+            capDrop: ["ALL"],
+            env: {},
+            volumes: [{ strategy: "named", source: "cache", target: "/cache" }],
+          },
+          ssh: {
+            command: "ssh",
+            workspaceRoot: "/remote/openclaw",
+            strictHostKeyChecking: true,
+            updateHostKeys: true,
+          },
+          browser: {
+            enabled: false,
+            image: "img",
+            containerPrefix: "prefix-",
+            network: "bridge",
+            cdpPort: 9222,
+            vncPort: 5900,
+            noVncPort: 6080,
+            headless: true,
+            enableNoVnc: false,
+            allowHostControl: false,
+            autoStart: false,
+            autoStartTimeoutMs: 1000,
+          },
+          tools: { allow: [], deny: [] },
+          prune: { idleHours: 24, maxAgeDays: 7 },
+        },
+      }),
+    ).rejects.toThrow("does not support sandbox.docker.volumes");
   });
 });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -98,6 +98,9 @@ async function createOpenShellSandboxBackend(params: {
   if ((params.createParams.cfg.docker.binds?.length ?? 0) > 0) {
     throw new Error("OpenShell sandbox backend does not support sandbox.docker.binds.");
   }
+  if ((params.createParams.cfg.docker.volumes?.length ?? 0) > 0) {
+    throw new Error("OpenShell sandbox backend does not support sandbox.docker.volumes.");
+  }
 
   const sandboxName = buildOpenShellSandboxName(params.createParams.scopeKey);
   const execContext: OpenShellExecContext = {

--- a/src/agents/bash-tools.build-docker-exec-args.test.ts
+++ b/src/agents/bash-tools.build-docker-exec-args.test.ts
@@ -68,6 +68,20 @@ describe("buildDockerExecArgs", () => {
     expect(args).toContain("/workspace");
   });
 
+  it("includes explicit docker exec user when specified", () => {
+    const args = buildDockerExecArgs({
+      containerName: "test-container",
+      command: "id",
+      env: { HOME: "/home/user" },
+      tty: false,
+      user: "1000:1001",
+    });
+
+    expect(args).toContain("--user");
+    expect(args).toContain("1000:1001");
+    expect(args.indexOf("--user")).toBeLessThan(args.indexOf("test-container"));
+  });
+
   it("uses login shell for consistent environment", () => {
     const args = buildDockerExecArgs({
       containerName: "test-container",

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -65,10 +65,14 @@ export function buildDockerExecArgs(params: {
   workdir?: string;
   env: Record<string, string>;
   tty: boolean;
+  user?: string;
 }) {
   const args = ["exec", "-i"];
   if (params.tty) {
     args.push("-t");
+  }
+  if (params.user) {
+    args.push("--user", params.user);
   }
   if (params.workdir) {
     args.push("-w", params.workdir);

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -684,4 +684,25 @@ describe("ensureSandboxBrowser create args", () => {
       false,
     );
   });
+
+  it("applies sandbox.docker.volumes to browser sandbox create args", async () => {
+    const cfg = buildConfig(false);
+    cfg.docker.volumes = [
+      { strategy: "named", source: "openclaw-cache", target: "/cache" },
+      { strategy: "ephemeral", target: "/tmp/browser-cache" },
+    ];
+
+    await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
+    const mountArgs = collectDockerFlagValues(createArgs ?? [], "--mount");
+
+    expect(mountArgs).toContain("type=volume,source=openclaw-cache,target=/cache");
+    expect(mountArgs).toContain("type=volume,target=/tmp/browser-cache");
+  });
 });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -600,4 +600,25 @@ describe("ensureSandboxBrowser create args", () => {
     const envEntries = collectDockerFlagValues(createArgs, "-e");
     expect(envEntries).toContain("OPENCLAW_BROWSER_CDP_SOURCE_RANGE=127.0.0.1/32");
   });
+
+  it("applies sandbox.docker.volumes to browser sandbox create args", async () => {
+    const cfg = buildConfig(false);
+    cfg.docker.volumes = [
+      { strategy: "named", source: "openclaw-cache", target: "/cache" },
+      { strategy: "ephemeral", target: "/tmp/browser-cache" },
+    ];
+
+    await ensureSandboxBrowser({
+      scopeKey: "session:test",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+    });
+
+    const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
+    const mountArgs = collectDockerFlagValues(createArgs ?? [], "--mount");
+
+    expect(mountArgs).toContain("type=volume,source=openclaw-cache,target=/cache");
+    expect(mountArgs).toContain("type=volume,target=/tmp/browser-cache");
+  });
 });

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -23,6 +23,7 @@ import { computeSandboxBrowserConfigHash } from "./config-hash.js";
 import { resolveSandboxBrowserDockerCreateConfig } from "./config.js";
 import { DEFAULT_SANDBOX_BROWSER_IMAGE, SANDBOX_BROWSER_SECURITY_HASH_EPOCH } from "./constants.js";
 import {
+  appendVolumeMounts,
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
@@ -311,6 +312,7 @@ export async function ensureSandboxBrowser(params: {
         args.push("-v", bind);
       }
     }
+    appendVolumeMounts(args, browserDockerCfg);
     args.push("-p", `127.0.0.1::${params.cfg.browser.cdpPort}`);
     if (noVncEnabled) {
       args.push("-p", `127.0.0.1::${params.cfg.browser.noVncPort}`);

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -27,6 +27,7 @@ import {
   SANDBOX_BROWSER_SECURITY_HASH_EPOCH,
 } from "./constants.js";
 import {
+  appendVolumeMounts,
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
@@ -340,6 +341,7 @@ export async function ensureSandboxBrowser(params: {
         args.push("-v", bind);
       }
     }
+    appendVolumeMounts(args, browserDockerCfg);
     args.push("-p", `127.0.0.1::${params.cfg.browser.cdpPort}`);
     if (noVncEnabled) {
       args.push("-p", `127.0.0.1::${params.cfg.browser.noVncPort}`);

--- a/src/agents/sandbox/config-hash.ts
+++ b/src/agents/sandbox/config-hash.ts
@@ -2,6 +2,7 @@ import { hashTextSha256 } from "./hash.js";
 import type { SandboxBrowserConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
 
 export const SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH = "explicit-config-env-v1";
+export const SANDBOX_DOCKER_VOLUME_OWNERSHIP_EPOCH = "volume-ownership-v1";
 
 type SandboxHashInput = {
   docker: SandboxDockerConfig;
@@ -54,7 +55,15 @@ function normalizeForHash(value: unknown): unknown {
 }
 
 export function computeSandboxConfigHash(input: SandboxHashInput): string {
-  return computeHash(input);
+  const hasWritableDockerVolumes = input.docker.volumes?.some(
+    (volume) => volume.strategy !== "bind" && volume.readOnly !== true,
+  );
+  return computeHash({
+    ...input,
+    dockerVolumeOwnershipEpoch: hasWritableDockerVolumes
+      ? SANDBOX_DOCKER_VOLUME_OWNERSHIP_EPOCH
+      : undefined,
+  });
 }
 
 export function computeSandboxBrowserConfigHash(input: SandboxBrowserHashInput): string {

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -97,6 +97,7 @@ export function resolveSandboxDockerConfig(params: {
     : globalDocker?.ulimits;
 
   const binds = [...(globalDocker?.binds ?? []), ...(agentDocker?.binds ?? [])];
+  const volumes = [...(globalDocker?.volumes ?? []), ...(agentDocker?.volumes ?? [])];
 
   return {
     image: agentDocker?.image ?? globalDocker?.image ?? DEFAULT_SANDBOX_IMAGE,
@@ -123,6 +124,7 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    volumes: volumes.length ? volumes : undefined,
     ...resolveDangerousSandboxDockerBooleans(agentDocker, globalDocker),
   };
 }

--- a/src/agents/sandbox/docker-backend.test.ts
+++ b/src/agents/sandbox/docker-backend.test.ts
@@ -19,7 +19,8 @@ vi.mock("./docker.js", async () => {
   };
 });
 
-const { dockerSandboxBackendManager } = await import("./docker-backend.js");
+const { dockerSandboxBackendManager, runDockerSandboxShellCommand } =
+  await import("./docker-backend.js");
 
 function createConfig(): OpenClawConfig {
   return {
@@ -187,5 +188,28 @@ describe("docker sandbox backend manager", () => {
         config: createConfig(),
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("runs backend shell commands as the resolved sandbox user", async () => {
+    dockerMocks.execDockerRaw.mockResolvedValueOnce({
+      code: 0,
+      stdout: Buffer.from(""),
+      stderr: Buffer.from(""),
+    });
+
+    await runDockerSandboxShellCommand({
+      containerName: "sandbox-1",
+      user: "1000:1001",
+      script: "id",
+    });
+
+    expect(dockerMocks.execDockerRaw).toHaveBeenCalledWith(
+      ["exec", "-i", "--user", "1000:1001", "sandbox-1", "sh", "-c", "id", "openclaw-sandbox-fs"],
+      {
+        allowFailure: undefined,
+        input: undefined,
+        signal: undefined,
+      },
+    );
   });
 });

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -11,6 +11,7 @@ import {
   ensureSandboxContainer,
   execDocker,
   execDockerRaw,
+  resolveDockerSandboxExecUser,
 } from "./docker.js";
 
 function resolveConfiguredDockerRuntimeImage(params: {
@@ -38,11 +39,13 @@ export async function createDockerSandboxBackend(
     agentWorkspaceDir: params.agentWorkspaceDir,
     cfg: params.cfg,
   });
+  const user = await resolveDockerSandboxExecUser(params.cfg.docker);
   return createDockerSandboxBackendHandle({
     containerName,
     workdir: params.cfg.docker.workdir,
     env: params.cfg.docker.env,
     image: params.cfg.docker.image,
+    user,
   });
 }
 
@@ -51,6 +54,7 @@ function createDockerSandboxBackendHandle(params: {
   workdir: string;
   env?: Record<string, string>;
   image: string;
+  user?: string;
 }): SandboxBackendHandle {
   return {
     id: "docker",
@@ -73,6 +77,7 @@ function createDockerSandboxBackendHandle(params: {
             workdir: workdir ?? params.workdir,
             env,
             tty: usePty,
+            user: params.user,
           }),
         ],
         env: process.env,
@@ -82,6 +87,7 @@ function createDockerSandboxBackendHandle(params: {
     runShellCommand(command) {
       return runDockerSandboxShellCommand({
         containerName: params.containerName,
+        user: params.user,
         ...command,
       });
     },
@@ -91,17 +97,14 @@ function createDockerSandboxBackendHandle(params: {
 export function runDockerSandboxShellCommand(
   params: {
     containerName: string;
+    user?: string;
   } & SandboxBackendCommandParams,
 ) {
-  const dockerArgs = [
-    "exec",
-    "-i",
-    params.containerName,
-    "sh",
-    "-c",
-    params.script,
-    "openclaw-sandbox-fs",
-  ];
+  const dockerArgs = ["exec", "-i"];
+  if (params.user) {
+    dockerArgs.push("--user", params.user);
+  }
+  dockerArgs.push(params.containerName, "sh", "-c", params.script, "openclaw-sandbox-fs");
   if (params.args?.length) {
     dockerArgs.push(...params.args);
   }

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -67,9 +67,11 @@ function spawnDockerProcess(command: string, args: string[]) {
   } else if (
     (args[0] === "rm" && args[1] === "-f") ||
     (args[0] === "image" && args[1] === "inspect") ||
-    args[0] === "create" ||
-    args[0] === "start"
+    args[0] === "create"
   ) {
+    code = 0;
+  } else if (args[0] === "start") {
+    spawnState.inspectRunning = true;
     code = 0;
   } else {
     code = 1;
@@ -328,6 +330,178 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     const customMountIdx = bindArgs.indexOf("/tmp/workspace-shared/USER.md:/workspace/USER.md:ro");
     expect(workspaceMountIdx).toBeGreaterThanOrEqual(0);
     expect(customMountIdx).toBeGreaterThan(workspaceMountIdx);
+  });
+
+  it.each([
+    { strategy: "named" as const, source: "openclaw-cache" },
+    { strategy: "ephemeral" as const },
+  ])(
+    "rejects reserved volume targets for $strategy strategy by default",
+    async ({ strategy, source }) => {
+      const workspaceDir = "/tmp/workspace";
+      const cfg = createSandboxConfig([]);
+      cfg.docker.dangerouslyAllowReservedContainerTargets = false;
+      cfg.docker.volumes = [
+        {
+          strategy,
+          source,
+          target: "/workspace",
+        },
+      ];
+
+      spawnState.inspectRunning = false;
+      spawnState.labelHash = "";
+      registryMocks.readRegistryEntry.mockResolvedValue(null);
+      registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+      await expect(
+        ensureSandboxContainer({
+          sessionKey: "agent:main:session-1",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          cfg,
+        }),
+      ).rejects.toThrow(/reserved container path/);
+
+      const createCall = spawnState.calls.find(
+        (call) => call.command === "docker" && call.args[0] === "create",
+      );
+      expect(createCall).toBeUndefined();
+    },
+  );
+
+  it("starts as root only to initialize writable docker volume ownership before dropping to the sandbox user", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    cfg.docker.user = "1000:1001";
+    cfg.docker.volumes = [
+      { strategy: "ephemeral", target: "/proof/ephemeral" },
+      { strategy: "named", source: "openclaw-cache", target: "/proof/named" },
+      { strategy: "bind", source: "/tmp/workspace/cache", target: "/proof/bind" },
+      { strategy: "named", source: "readonly-cache", target: "/proof/readonly", readOnly: true },
+    ];
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+    registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+    const createCall = await ensureSandboxCreateCallForTest({ cfg, workspaceDir });
+
+    expect(collectDockerFlagValues(createCall.args, "--user")).toEqual(["0:0"]);
+    expect(collectDockerFlagValues(createCall.args, "--cap-add")).toEqual([
+      "CHOWN",
+      "SETUID",
+      "SETGID",
+    ]);
+    expect(collectDockerFlagValues(createCall.args, "--mount")).toEqual([
+      "type=volume,target=/proof/ephemeral",
+      "type=volume,source=openclaw-cache,target=/proof/named",
+      "type=bind,source=/tmp/workspace/cache,target=/proof/bind",
+      "type=volume,source=readonly-cache,target=/proof/readonly,readonly",
+    ]);
+
+    const command = createCall.args.at(-1);
+    expect(command).toContain("setpriv");
+    expect(command).toContain("chown");
+    expect(command).toContain("/proof/ephemeral");
+    expect(command).toContain("/proof/named");
+    expect(command).not.toContain("/proof/bind");
+    expect(command).not.toContain("/proof/readonly");
+    expect(command).toContain("sleep infinity");
+  });
+
+  it("rejects comma-delimited docker volume mount source injection before create", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    cfg.docker.volumes = [
+      {
+        strategy: "named",
+        source: "cache,type=bind,source=/etc",
+        target: "/cache",
+      },
+    ];
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+    registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(/must not contain ","/);
+
+    const createCall = spawnState.calls.find(
+      (call) => call.command === "docker" && call.args[0] === "create",
+    );
+    expect(createCall).toBeUndefined();
+  });
+
+  it("rejects comma-delimited docker volume mount target injection before create", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    cfg.docker.volumes = [
+      {
+        strategy: "bind",
+        source: "/tmp/cache",
+        target: "/cache,target=/workspace",
+      },
+    ];
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+    registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(/must not contain ","/);
+
+    const createCall = spawnState.calls.find(
+      (call) => call.command === "docker" && call.args[0] === "create",
+    );
+    expect(createCall).toBeUndefined();
+  });
+
+  it("rejects bind volume sources outside allowed roots without legacy bind parsing", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    cfg.docker.volumes = [
+      {
+        strategy: "bind",
+        source: "/tmp/workspace:/outside",
+        target: "/cache",
+      },
+    ];
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+    registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(/outside allowed roots/);
+
+    const createCall = spawnState.calls.find(
+      (call) => call.command === "docker" && call.args[0] === "create",
+    );
+    expect(createCall).toBeUndefined();
   });
 
   it.each([

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -286,6 +286,106 @@ describe("ensureSandboxContainer config-hash recreation", () => {
   });
 
   it.each([
+    { strategy: "named" as const, source: "openclaw-cache" },
+    { strategy: "ephemeral" as const },
+  ])(
+    "rejects reserved volume targets for $strategy strategy by default",
+    async ({ strategy, source }) => {
+      const workspaceDir = "/tmp/workspace";
+      const cfg = createSandboxConfig([]);
+      cfg.docker.dangerouslyAllowReservedContainerTargets = false;
+      cfg.docker.volumes = [
+        {
+          strategy,
+          source,
+          target: "/workspace",
+        },
+      ];
+
+      spawnState.inspectRunning = false;
+      spawnState.labelHash = "";
+      registryMocks.readRegistryEntry.mockResolvedValue(null);
+      registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+      await expect(
+        ensureSandboxContainer({
+          sessionKey: "agent:main:session-1",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          cfg,
+        }),
+      ).rejects.toThrow(/reserved container path/);
+
+      const createCall = spawnState.calls.find(
+        (call) => call.command === "docker" && call.args[0] === "create",
+      );
+      expect(createCall).toBeUndefined();
+    },
+  );
+
+  it("rejects comma-delimited docker volume mount source injection before create", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    cfg.docker.volumes = [
+      {
+        strategy: "named",
+        source: "cache,type=bind,source=/etc",
+        target: "/cache",
+      },
+    ];
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+    registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(/must not contain ","/);
+
+    const createCall = spawnState.calls.find(
+      (call) => call.command === "docker" && call.args[0] === "create",
+    );
+    expect(createCall).toBeUndefined();
+  });
+
+  it("rejects comma-delimited docker volume mount target injection before create", async () => {
+    const workspaceDir = "/tmp/workspace";
+    const cfg = createSandboxConfig([]);
+    cfg.docker.volumes = [
+      {
+        strategy: "bind",
+        source: "/tmp/cache",
+        target: "/cache,target=/workspace",
+      },
+    ];
+
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+    registryMocks.updateRegistry.mockResolvedValue(undefined);
+
+    await expect(
+      ensureSandboxContainer({
+        sessionKey: "agent:main:session-1",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg,
+      }),
+    ).rejects.toThrow(/must not contain ","/);
+
+    const createCall = spawnState.calls.find(
+      (call) => call.command === "docker" && call.args[0] === "create",
+    );
+    expect(createCall).toBeUndefined();
+  });
+
+  it.each([
     { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace:z" },
     { workspaceAccess: "ro" as const, expectedMainMount: "/tmp/workspace:/workspace:ro,z" },
     { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:ro,z" },

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -166,6 +166,7 @@ export function execDockerRaw(
 }
 
 import { formatCliCommand } from "../../cli/command-format.js";
+import type { SandboxDockerVolumeSetting } from "../../config/types.sandbox.js";
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -342,6 +343,20 @@ async function inspectDockerImage(image: string): Promise<"exists" | "missing"> 
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
+export async function readDockerImageUser(image: string): Promise<string | undefined> {
+  const result = await execDocker(["image", "inspect", "-f", "{{.Config.User}}", image], {
+    allowFailure: true,
+  });
+  if (result.code !== 0) {
+    const stderr = result.stderr.trim();
+    if (isDockerDaemonUnavailable(stderr)) {
+      throw new Error(formatDockerDaemonUnavailableError(stderr));
+    }
+    throw new Error(`Failed to inspect sandbox image user: ${stderr}`);
+  }
+  return normalizeDockerUser(result.stdout);
+}
+
 export async function ensureDockerImage(image: string) {
   const imageState = await inspectDockerImage(image);
   if (imageState === "exists") {
@@ -376,6 +391,24 @@ function normalizeDockerLimit(value?: string | number) {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeDockerUser(value?: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isRootDockerUser(user: string | undefined): boolean {
+  if (!user) {
+    return true;
+  }
+  return user === "0" || user === "0:0" || user === "root" || user === "root:root";
+}
+
+export async function resolveDockerSandboxExecUser(
+  cfg: SandboxDockerConfig,
+): Promise<string | undefined> {
+  return normalizeDockerUser(cfg.user) ?? (await readDockerImageUser(cfg.image));
+}
+
 function formatUlimitValue(
   name: string,
   value: string | number | { soft?: number; hard?: number },
@@ -401,6 +434,84 @@ function formatUlimitValue(
   return `${name}=${soft}:${hard}`;
 }
 
+function normalizeDockerMountValue(value: string | undefined, field: "source" | "target"): string {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.includes(",")) {
+    throw new Error(
+      `Sandbox security: docker volume ${field} must not contain "," because Docker --mount parses comma-separated key/value fields.`,
+    );
+  }
+  return trimmed;
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+function getWritableDockerVolumeTargets(cfg: SandboxDockerConfig): string[] {
+  const targets = new Set<string>();
+  for (const volume of cfg.volumes ?? []) {
+    if (volume.readOnly || volume.strategy === "bind") {
+      continue;
+    }
+    const target = normalizeDockerMountValue(volume.target, "target");
+    if (target) {
+      targets.add(target);
+    }
+  }
+  return [...targets];
+}
+
+function buildVolumeOwnershipInitCommand(params: { user: string; targets: string[] }): string {
+  const targetArgs = params.targets.map(shellSingleQuote).join(" ");
+  const user = shellSingleQuote(params.user);
+  return [
+    "set -eu",
+    "if ! command -v setpriv >/dev/null 2>&1; then echo 'OpenClaw sandbox volume setup requires setpriv in the sandbox image.' >&2; exit 126; fi",
+    `openclaw_user=${user}`,
+    `set -- ${targetArgs}`,
+    'user_part="${openclaw_user%%:*}"',
+    'group_part="${openclaw_user#*:}"',
+    'if [ "$group_part" = "$openclaw_user" ]; then group_part=""; fi',
+    'case "$user_part" in ""|root) uid=0 ;; *[!0-9]*) uid="$(id -u "$user_part")" ;; *) uid="$user_part" ;; esac',
+    'if [ -n "$group_part" ]; then case "$group_part" in root) gid=0 ;; *[!0-9]*) gid="$(getent group "$group_part" | cut -d: -f3)" ;; *) gid="$group_part" ;; esac; else gid="$(id -g "$user_part" 2>/dev/null || printf 0)"; fi',
+    'for target do mkdir -p "$target"; chown "$uid:$gid" "$target"; done',
+    'exec setpriv --reuid "$uid" --regid "$gid" --clear-groups sleep infinity',
+  ].join("; ");
+}
+
+export function appendVolumeMounts(args: string[], cfg: SandboxDockerConfig): void {
+  for (const volume of cfg.volumes ?? []) {
+    const target = normalizeDockerMountValue(volume.target, "target");
+    if (!target) {
+      continue;
+    }
+    if (volume.strategy === "ephemeral") {
+      args.push("--mount", `type=volume,target=${target}${volume.readOnly ? ",readonly" : ""}`);
+      continue;
+    }
+    if (volume.strategy === "named") {
+      const source = normalizeDockerMountValue(volume.source, "source");
+      if (!source) {
+        continue;
+      }
+      args.push(
+        "--mount",
+        `type=volume,source=${source},target=${target}${volume.readOnly ? ",readonly" : ""}`,
+      );
+      continue;
+    }
+    const source = normalizeDockerMountValue(volume.source, "source");
+    if (!source) {
+      continue;
+    }
+    args.push(
+      "--mount",
+      `type=bind,source=${source},target=${target}${volume.readOnly ? ",readonly" : ""}`,
+    );
+  }
+}
+
 export function buildSandboxCreateArgs(params: {
   name: string;
   cfg: SandboxDockerConfig;
@@ -413,6 +524,8 @@ export function buildSandboxCreateArgs(params: {
   allowSourcesOutsideAllowedRoots?: boolean;
   allowReservedContainerTargets?: boolean;
   allowContainerNamespaceJoin?: boolean;
+  userOverride?: string;
+  capAdd?: string[];
   /**
    * @deprecated Docker container creation now treats cfg.env as explicit sandbox
    * configuration and ignores host-env name filters. This field is kept so SDK
@@ -420,16 +533,18 @@ export function buildSandboxCreateArgs(params: {
    */
   envSanitizationOptions?: EnvSanitizationOptions;
 }) {
-  // Runtime security validation: blocks dangerous bind mounts, network modes, and profiles.
+  const allowReservedContainerTargets =
+    params.allowReservedContainerTargets ??
+    params.cfg.dangerouslyAllowReservedContainerTargets === true;
+
+  // Runtime security validation: blocks dangerous mounts, network modes, and profiles.
   validateSandboxSecurity({
     ...params.cfg,
     allowedSourceRoots: params.bindSourceRoots,
     allowSourcesOutsideAllowedRoots:
       params.allowSourcesOutsideAllowedRoots ??
       params.cfg.dangerouslyAllowExternalBindSources === true,
-    allowReservedContainerTargets:
-      params.allowReservedContainerTargets ??
-      params.cfg.dangerouslyAllowReservedContainerTargets === true,
+    allowReservedContainerTargets,
     dangerouslyAllowContainerNamespaceJoin:
       params.allowContainerNamespaceJoin ??
       params.cfg.dangerouslyAllowContainerNamespaceJoin === true,
@@ -458,8 +573,10 @@ export function buildSandboxCreateArgs(params: {
   if (params.cfg.network) {
     args.push("--network", params.cfg.network);
   }
-  if (params.cfg.user) {
-    args.push("--user", params.cfg.user);
+  const createUser =
+    normalizeDockerUser(params.userOverride) ?? normalizeDockerUser(params.cfg.user);
+  if (createUser) {
+    args.push("--user", createUser);
   }
   const envSanitization = sanitizeExplicitSandboxEnvVars(params.cfg.env ?? {});
   if (envSanitization.blocked.length > 0) {
@@ -477,6 +594,9 @@ export function buildSandboxCreateArgs(params: {
   }
   for (const cap of params.cfg.capDrop) {
     args.push("--cap-drop", cap);
+  }
+  for (const cap of params.capAdd ?? []) {
+    args.push("--cap-add", cap);
   }
   args.push("--security-opt", "no-new-privileges");
   if (params.cfg.seccompProfile) {
@@ -547,6 +667,10 @@ async function createSandboxContainer(params: {
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
   await ensureDockerImage(cfg.image);
+  const runtimeUser = await resolveDockerSandboxExecUser(cfg);
+  const writableVolumeTargets = getWritableDockerVolumeTargets(cfg);
+  const shouldInitializeVolumeOwnership =
+    writableVolumeTargets.length > 0 && !isRootDockerUser(runtimeUser);
 
   const args = buildSandboxCreateArgs({
     name,
@@ -555,6 +679,8 @@ async function createSandboxContainer(params: {
     configHash: params.configHash,
     includeBinds: false,
     bindSourceRoots: [workspaceDir, params.agentWorkspaceDir],
+    userOverride: shouldInitializeVolumeOwnership ? "0:0" : undefined,
+    capAdd: shouldInitializeVolumeOwnership ? ["CHOWN", "SETUID", "SETGID"] : undefined,
   });
   args.push("--workdir", cfg.workdir);
   appendWorkspaceMountArgs({
@@ -565,13 +691,40 @@ async function createSandboxContainer(params: {
     workspaceAccess: params.workspaceAccess,
   });
   appendCustomBinds(args, cfg);
-  args.push(cfg.image, "sleep", "infinity");
+  appendVolumeMounts(args, cfg);
+  if (shouldInitializeVolumeOwnership && runtimeUser) {
+    args.push(
+      cfg.image,
+      "/bin/sh",
+      "-lc",
+      buildVolumeOwnershipInitCommand({
+        user: runtimeUser,
+        targets: writableVolumeTargets,
+      }),
+    );
+  } else {
+    args.push(cfg.image, "sleep", "infinity");
+  }
 
   await execDocker(args);
   await execDocker(["start", name]);
+  if (shouldInitializeVolumeOwnership) {
+    const startedState = await dockerContainerState(name);
+    if (!startedState.running) {
+      throw new Error(
+        `Sandbox container ${name} exited during Docker volume ownership setup. ` +
+          "Writable anonymous and named Docker volumes require setpriv plus CHOWN, SETUID, and SETGID capability support in the sandbox image.",
+      );
+    }
+  }
 
   if (cfg.setupCommand?.trim()) {
-    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
+    const setupArgs = ["exec", "-i"];
+    if (shouldInitializeVolumeOwnership && runtimeUser) {
+      setupArgs.push("--user", runtimeUser);
+    }
+    setupArgs.push(name, "/bin/sh", "-lc", cfg.setupCommand);
+    await execDocker(setupArgs);
   }
 }
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -163,6 +163,7 @@ export function execDockerRaw(
 }
 
 import { formatCliCommand } from "../../cli/command-format.js";
+import type { SandboxDockerVolumeSetting } from "../../config/types.sandbox.js";
 import { markOpenClawExecEnv } from "../../infra/openclaw-exec-env.js";
 import { defaultRuntime } from "../../runtime.js";
 import { computeSandboxConfigHash } from "./config-hash.js";
@@ -170,7 +171,10 @@ import { DEFAULT_SANDBOX_IMAGE } from "./constants.js";
 import { readRegistryEntry, updateRegistry } from "./registry.js";
 import { resolveSandboxAgentId, resolveSandboxScopeKey, slugifySessionKey } from "./shared.js";
 import type { SandboxConfig, SandboxDockerConfig, SandboxWorkspaceAccess } from "./types.js";
-import { validateSandboxSecurity } from "./validate-sandbox-security.js";
+import {
+  getReservedContainerTargetReason,
+  validateSandboxSecurity,
+} from "./validate-sandbox-security.js";
 import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 
 const log = createSubsystemLogger("docker");
@@ -370,6 +374,84 @@ function formatUlimitValue(
   return `${name}=${soft}:${hard}`;
 }
 
+function volumeSettingToBindSpec(volume: SandboxDockerVolumeSetting): string | null {
+  if (volume.strategy !== "bind") {
+    return null;
+  }
+  const source = normalizeDockerMountValue(volume.source, "source");
+  const target = normalizeDockerMountValue(volume.target, "target");
+  if (!source || !target) {
+    return null;
+  }
+  return `${source}:${target}:${volume.readOnly ? "ro" : "rw"}`;
+}
+
+function normalizeDockerMountValue(value: string | undefined, field: "source" | "target"): string {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.includes(",")) {
+    throw new Error(
+      `Sandbox security: docker volume ${field} must not contain "," because Docker --mount parses comma-separated key/value fields.`,
+    );
+  }
+  return trimmed;
+}
+
+export function appendVolumeMounts(args: string[], cfg: SandboxDockerConfig): void {
+  for (const volume of cfg.volumes ?? []) {
+    const target = normalizeDockerMountValue(volume.target, "target");
+    if (!target) {
+      continue;
+    }
+    if (volume.strategy === "ephemeral") {
+      args.push("--mount", `type=volume,target=${target}${volume.readOnly ? ",readonly" : ""}`);
+      continue;
+    }
+    if (volume.strategy === "named") {
+      const source = normalizeDockerMountValue(volume.source, "source");
+      if (!source) {
+        continue;
+      }
+      args.push(
+        "--mount",
+        `type=volume,source=${source},target=${target}${volume.readOnly ? ",readonly" : ""}`,
+      );
+      continue;
+    }
+    const source = normalizeDockerMountValue(volume.source, "source");
+    if (!source) {
+      continue;
+    }
+    args.push(
+      "--mount",
+      `type=bind,source=${source},target=${target}${volume.readOnly ? ",readonly" : ""}`,
+    );
+  }
+}
+
+function validateReservedVolumeTargets(params: {
+  volumes?: SandboxDockerVolumeSetting[];
+  allowReservedContainerTargets: boolean;
+}): void {
+  if (params.allowReservedContainerTargets || !params.volumes?.length) {
+    return;
+  }
+  for (const volume of params.volumes) {
+    const target = volume.target?.trim();
+    if (!target) {
+      continue;
+    }
+    const reason = getReservedContainerTargetReason(target);
+    if (!reason || reason.kind !== "reserved_target") {
+      continue;
+    }
+    throw new Error(
+      `Sandbox security: volume target "${target}" for strategy "${volume.strategy}" hits reserved container path "${reason.reservedPath}" ` +
+        `(resolved target: "${reason.targetPath}"). This can shadow OpenClaw sandbox mounts. ` +
+        "Use a dangerous override only when you fully trust this runtime.",
+    );
+  }
+}
+
 export function buildSandboxCreateArgs(params: {
   name: string;
   cfg: SandboxDockerConfig;
@@ -384,16 +466,28 @@ export function buildSandboxCreateArgs(params: {
   allowContainerNamespaceJoin?: boolean;
   envSanitizationOptions?: EnvSanitizationOptions;
 }) {
+  const allowReservedContainerTargets =
+    params.allowReservedContainerTargets ??
+    params.cfg.dangerouslyAllowReservedContainerTargets === true;
+
+  validateReservedVolumeTargets({
+    volumes: params.cfg.volumes,
+    allowReservedContainerTargets,
+  });
+
   // Runtime security validation: blocks dangerous bind mounts, network modes, and profiles.
+  const bindSpecsFromVolumes = (params.cfg.volumes ?? [])
+    .map((entry) => volumeSettingToBindSpec(entry))
+    .filter((entry): entry is string => typeof entry === "string");
+
   validateSandboxSecurity({
     ...params.cfg,
+    binds: [...(params.cfg.binds ?? []), ...bindSpecsFromVolumes],
     allowedSourceRoots: params.bindSourceRoots,
     allowSourcesOutsideAllowedRoots:
       params.allowSourcesOutsideAllowedRoots ??
       params.cfg.dangerouslyAllowExternalBindSources === true,
-    allowReservedContainerTargets:
-      params.allowReservedContainerTargets ??
-      params.cfg.dangerouslyAllowReservedContainerTargets === true,
+    allowReservedContainerTargets,
     dangerouslyAllowContainerNamespaceJoin:
       params.allowContainerNamespaceJoin ??
       params.cfg.dangerouslyAllowContainerNamespaceJoin === true,
@@ -525,6 +619,7 @@ async function createSandboxContainer(params: {
     workspaceAccess: params.workspaceAccess,
   });
   appendCustomBinds(args, cfg);
+  appendVolumeMounts(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 
   await execDocker(args);

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -61,7 +61,11 @@ function createSession() {
   };
 }
 
-function createBackendSandboxConfig(params?: { binds?: string[]; target?: string }): SandboxConfig {
+function createBackendSandboxConfig(params?: {
+  binds?: string[];
+  volumes?: SandboxConfig["docker"]["volumes"];
+  target?: string;
+}): SandboxConfig {
   return {
     mode: "all",
     backend: "ssh",
@@ -78,6 +82,7 @@ function createBackendSandboxConfig(params?: { binds?: string[]; target?: string
       capDrop: ["ALL"],
       env: {},
       ...(params?.binds ? { binds: params.binds } : {}),
+      ...(params?.volumes ? { volumes: params.volumes } : {}),
     },
     ssh: {
       ...createSandboxSshConfig(
@@ -100,6 +105,7 @@ function createBackendSandboxConfig(params?: { binds?: string[]; target?: string
 
 async function expectBackendCreationToReject(params: {
   binds?: string[];
+  volumes?: SandboxConfig["docker"]["volumes"];
   target?: string;
   error: string;
 }) {
@@ -111,6 +117,7 @@ async function expectBackendCreationToReject(params: {
       agentWorkspaceDir: "/tmp/workspace",
       cfg: createBackendSandboxConfig({
         binds: params.binds,
+        volumes: params.volumes,
         target: params.target,
       }),
     }),
@@ -338,6 +345,14 @@ describe("ssh sandbox backend", () => {
 
     await expectBackendCreationToReject({
       error: "requires agents.defaults.sandbox.ssh.target",
+    });
+  });
+
+  it("rejects docker volumes because ssh does not mount them", async () => {
+    await expectBackendCreationToReject({
+      volumes: [{ strategy: "named", source: "cache", target: "/cache" }],
+      target: "peter@example.com:22",
+      error: "does not support sandbox.docker.volumes",
     });
   });
 });

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -80,7 +80,11 @@ function requireSshUploadParams(callIndex: number, label: string) {
   return requireMockRecordArg(sshMocks.uploadDirectoryToSshTarget, callIndex, label);
 }
 
-function createBackendSandboxConfig(params?: { binds?: string[]; target?: string }): SandboxConfig {
+function createBackendSandboxConfig(params?: {
+  binds?: string[];
+  volumes?: SandboxConfig["docker"]["volumes"];
+  target?: string;
+}): SandboxConfig {
   return {
     mode: "all",
     backend: "ssh",
@@ -97,6 +101,7 @@ function createBackendSandboxConfig(params?: { binds?: string[]; target?: string
       capDrop: ["ALL"],
       env: {},
       ...(params?.binds ? { binds: params.binds } : {}),
+      ...(params?.volumes ? { volumes: params.volumes } : {}),
     },
     ssh: {
       ...createSandboxSshConfig(
@@ -119,6 +124,7 @@ function createBackendSandboxConfig(params?: { binds?: string[]; target?: string
 
 async function expectBackendCreationToReject(params: {
   binds?: string[];
+  volumes?: SandboxConfig["docker"]["volumes"];
   target?: string;
   error: string;
 }) {
@@ -130,6 +136,7 @@ async function expectBackendCreationToReject(params: {
       agentWorkspaceDir: "/tmp/workspace",
       cfg: createBackendSandboxConfig({
         binds: params.binds,
+        volumes: params.volumes,
         target: params.target,
       }),
     }),
@@ -352,6 +359,14 @@ describe("ssh sandbox backend", () => {
 
     await expectBackendCreationToReject({
       error: "requires agents.defaults.sandbox.ssh.target",
+    });
+  });
+
+  it("rejects docker volumes because ssh does not mount them", async () => {
+    await expectBackendCreationToReject({
+      volumes: [{ strategy: "named", source: "cache", target: "/cache" }],
+      target: "peter@example.com:22",
+      error: "does not support sandbox.docker.volumes",
     });
   });
 });

--- a/src/agents/sandbox/ssh-backend.ts
+++ b/src/agents/sandbox/ssh-backend.ts
@@ -106,6 +106,9 @@ export async function createSshSandboxBackend(
   if ((params.cfg.docker.binds?.length ?? 0) > 0) {
     throw new Error("SSH sandbox backend does not support sandbox.docker.binds.");
   }
+  if ((params.cfg.docker.volumes?.length ?? 0) > 0) {
+    throw new Error("SSH sandbox backend does not support sandbox.docker.volumes.");
+  }
   const target = params.cfg.ssh.target;
   if (!target) {
     throw new Error('Sandbox backend "ssh" requires agents.defaults.sandbox.ssh.target.');

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -6,6 +6,7 @@ import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
 import {
   getBlockedBindReason,
   validateBindMounts,
+  validateDockerVolumes,
   validateNetworkMode,
   validateSeccompProfile,
   validateApparmorProfile,
@@ -324,6 +325,63 @@ describe("validateBindMounts", () => {
   });
 });
 
+describe("validateDockerVolumes", () => {
+  it("validates bind volume sources as structured host paths", () => {
+    const allowedRoot = mkdtempSync(join(tmpdir(), "openclaw-volume-allowed-"));
+    const source = `${allowedRoot}:/outside`;
+
+    expect(() =>
+      validateDockerVolumes(
+        [
+          {
+            strategy: "bind",
+            source,
+            target: "/data",
+          },
+        ],
+        { allowedSourceRoots: [allowedRoot] },
+      ),
+    ).toThrow(/outside allowed roots/);
+  });
+
+  it("allows Windows drive-letter bind volume sources inside allowed roots", () => {
+    expect(
+      validateDockerVolumes(
+        [
+          {
+            strategy: "bind",
+            source: "D:\\data\\openclaw\\cache",
+            target: "/cache",
+          },
+        ],
+        { allowedSourceRoots: ["D:/data/openclaw"] },
+      ),
+    ).toBeUndefined();
+  });
+
+  it("blocks reserved targets for named and ephemeral volumes by default", () => {
+    expect(() =>
+      validateDockerVolumes([{ strategy: "named", source: "cache", target: "/workspace" }]),
+    ).toThrow(/reserved container path/);
+    expect(() =>
+      validateDockerVolumes([{ strategy: "ephemeral", target: "/agent/cache" }]),
+    ).toThrow(/reserved container path/);
+  });
+
+  it("rejects Docker mount field separators before args are assembled", () => {
+    expect(() =>
+      validateDockerVolumes([
+        { strategy: "named", source: "cache,type=bind,source=/etc", target: "/cache" },
+      ]),
+    ).toThrow(/must not contain ","/);
+    expect(() =>
+      validateDockerVolumes([
+        { strategy: "bind", source: "/tmp/cache", target: "/cache,target=/etc" },
+      ]),
+    ).toThrow(/must not contain ","/);
+  });
+});
+
 function normalizePathForSnapshot(input: string): string {
   return resolveSandboxHostPathViaExistingAncestor(input).replaceAll("\\", "/");
 }
@@ -409,6 +467,8 @@ describe("validateSandboxSecurity", () => {
     expect(
       validateSandboxSecurity({
         binds: [`${projectRoot}:/src:rw`],
+        volumes: [{ strategy: "bind", source: join(projectRoot, "cache"), target: "/cache" }],
+        allowedSourceRoots: [projectRoot],
         network: "none",
         seccompProfile: "/tmp/seccomp.json",
         apparmorProfile: "openclaw-sandbox",

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -50,7 +50,10 @@ const BLOCKED_HOME_SUBPATHS = [
 
 const BLOCKED_SECCOMP_PROFILES = new Set(["unconfined"]);
 const BLOCKED_APPARMOR_PROFILES = new Set(["unconfined"]);
-const RESERVED_CONTAINER_TARGET_PATHS = ["/workspace", SANDBOX_AGENT_WORKSPACE_MOUNT];
+export const RESERVED_CONTAINER_TARGET_PATHS = [
+  "/workspace",
+  SANDBOX_AGENT_WORKSPACE_MOUNT,
+] as const;
 let blockedHostPathsCache:
   | {
       key: string;
@@ -238,8 +241,7 @@ function getOutsideAllowedRootsReason(
   };
 }
 
-function getReservedTargetReason(bind: string): BlockedBindReason | null {
-  const targetRaw = parseBindTargetPath(bind);
+export function getReservedContainerTargetReason(targetRaw: string): BlockedBindReason | null {
   if (!targetRaw || !targetRaw.startsWith("/")) {
     return null;
   }
@@ -254,6 +256,10 @@ function getReservedTargetReason(bind: string): BlockedBindReason | null {
     }
   }
   return null;
+}
+
+function getReservedTargetReason(bind: string): BlockedBindReason | null {
+  return getReservedContainerTargetReason(parseBindTargetPath(bind));
 }
 
 function enforceSourcePathPolicy(params: {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -7,6 +7,7 @@
 
 import os from "node:os";
 import path from "node:path";
+import type { SandboxDockerVolumeSetting } from "../../config/types.sandbox.js";
 import { resolveRequiredHomeDir, resolveRequiredOsHomeDir } from "../../infra/home-dir.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
@@ -50,7 +51,10 @@ const BLOCKED_HOME_SUBPATHS = [
 
 const BLOCKED_SECCOMP_PROFILES = new Set(["unconfined"]);
 const BLOCKED_APPARMOR_PROFILES = new Set(["unconfined"]);
-const RESERVED_CONTAINER_TARGET_PATHS = ["/workspace", SANDBOX_AGENT_WORKSPACE_MOUNT];
+export const RESERVED_CONTAINER_TARGET_PATHS = [
+  "/workspace",
+  SANDBOX_AGENT_WORKSPACE_MOUNT,
+] as const;
 let blockedHostPathsCache:
   | {
       key: string;
@@ -79,6 +83,10 @@ type ParsedBindSpec = {
   source: string;
   target: string;
 };
+
+function hasDockerMountFieldSeparator(value: string | undefined): boolean {
+  return value?.includes(",") === true;
+}
 
 function parseBindSpec(bind: string): ParsedBindSpec {
   const trimmed = bind.trim();
@@ -245,8 +253,7 @@ function getOutsideAllowedRootsReason(
   };
 }
 
-function getReservedTargetReason(bind: string): BlockedBindReason | null {
-  const targetRaw = parseBindTargetPath(bind);
+export function getReservedContainerTargetReason(targetRaw: string): BlockedBindReason | null {
   if (!targetRaw || !targetRaw.startsWith("/")) {
     return null;
   }
@@ -261,6 +268,10 @@ function getReservedTargetReason(bind: string): BlockedBindReason | null {
     }
   }
   return null;
+}
+
+function getReservedTargetReason(bind: string): BlockedBindReason | null {
+  return getReservedContainerTargetReason(parseBindTargetPath(bind));
 }
 
 function enforceSourcePathPolicy(params: {
@@ -307,6 +318,40 @@ function formatBindBlockedError(params: { bind: string; reason: BlockedBindReaso
   return new Error(
     `Sandbox security: bind mount "${params.bind}" ${verb} blocked path "${params.reason.blockedPath}". ` +
       "Mounting system directories, credential paths, or Docker socket paths into sandbox containers is not allowed. " +
+      "Use project-specific paths instead (e.g. /home/user/myproject).",
+  );
+}
+
+function formatVolumeBlockedError(params: {
+  volume: SandboxDockerVolumeSetting;
+  sourcePath?: string;
+  reason: BlockedBindReason;
+}): Error {
+  const target = params.volume.target.trim();
+  if (params.reason.kind === "non_absolute") {
+    return new Error(
+      `Sandbox security: bind volume source "${params.reason.sourcePath}" for target "${target}" uses a non-absolute source path. ` +
+        "Only absolute POSIX or Windows drive-letter paths are supported for sandbox bind volumes.",
+    );
+  }
+  if (params.reason.kind === "outside_allowed_roots") {
+    return new Error(
+      `Sandbox security: bind volume source "${params.reason.sourcePath}" for target "${target}" is outside allowed roots ` +
+        `(${params.reason.allowedRoots.join(", ")}). Use a dangerous override only when you fully trust this runtime.`,
+    );
+  }
+  if (params.reason.kind === "reserved_target") {
+    return new Error(
+      `Sandbox security: volume target "${target}" for strategy "${params.volume.strategy}" targets reserved container path ` +
+        `"${params.reason.reservedPath}" (resolved target: "${params.reason.targetPath}"). ` +
+        "This can shadow OpenClaw sandbox mounts. Use a dangerous override only when you fully trust this runtime.",
+    );
+  }
+  const sourcePath = params.sourcePath ?? params.volume.source?.trim() ?? "";
+  const verb = params.reason.kind === "covers" ? "covers" : "targets";
+  return new Error(
+    `Sandbox security: bind volume source "${sourcePath}" for target "${target}" ${verb} blocked path ` +
+      `"${params.reason.blockedPath}". Mounting system directories, credential paths, or Docker socket paths into sandbox containers is not allowed. ` +
       "Use project-specific paths instead (e.g. /home/user/myproject).",
   );
 }
@@ -368,6 +413,105 @@ export function validateBindMounts(
   }
 }
 
+export function validateDockerVolumes(
+  volumes: SandboxDockerVolumeSetting[] | undefined,
+  options?: ValidateBindMountsOptions,
+): void {
+  if (!volumes?.length) {
+    return;
+  }
+
+  const allowedRoots = normalizeAllowedRoots(options?.allowedSourceRoots);
+  const blockedHostPaths = getBlockedHostPaths();
+
+  for (const volume of volumes) {
+    const target = volume.target?.trim() ?? "";
+    if (!target.startsWith("/")) {
+      throw new Error("Sandbox security: docker volume target must be an absolute POSIX path.");
+    }
+    if (hasDockerMountFieldSeparator(target)) {
+      throw new Error(
+        'Sandbox security: docker volume target must not contain "," because Docker --mount parses comma-separated key/value fields.',
+      );
+    }
+
+    if (!options?.allowReservedContainerTargets) {
+      const reservedTarget = getReservedContainerTargetReason(target);
+      if (reservedTarget) {
+        throw formatVolumeBlockedError({ volume, reason: reservedTarget });
+      }
+    }
+
+    const source = volume.source?.trim() ?? "";
+    if (hasDockerMountFieldSeparator(source)) {
+      throw new Error(
+        `Sandbox security: docker volume source for target "${target}" must not contain "," because Docker --mount parses comma-separated key/value fields.`,
+      );
+    }
+
+    if (volume.strategy === "ephemeral") {
+      continue;
+    }
+    if (!source) {
+      throw new Error(
+        `Sandbox security: ${volume.strategy} volume strategy requires source for target "${target}".`,
+      );
+    }
+    if (volume.strategy === "named") {
+      continue;
+    }
+
+    if (!isSandboxHostPathAbsolute(source)) {
+      throw formatVolumeBlockedError({
+        volume,
+        reason: { kind: "non_absolute", sourcePath: source },
+      });
+    }
+
+    const sourceNormalized = normalizeHostPath(source);
+    enforceVolumeSourcePathPolicy({
+      volume,
+      sourcePath: sourceNormalized,
+      allowedRoots,
+      blockedHostPaths,
+      allowSourcesOutsideAllowedRoots: options?.allowSourcesOutsideAllowedRoots === true,
+    });
+
+    const sourceCanonical = resolveSandboxHostPathViaExistingAncestor(sourceNormalized);
+    enforceVolumeSourcePathPolicy({
+      volume,
+      sourcePath: sourceCanonical,
+      allowedRoots,
+      blockedHostPaths,
+      allowSourcesOutsideAllowedRoots: options?.allowSourcesOutsideAllowedRoots === true,
+    });
+  }
+}
+
+function enforceVolumeSourcePathPolicy(params: {
+  volume: SandboxDockerVolumeSetting;
+  sourcePath: string;
+  allowedRoots: string[];
+  blockedHostPaths: string[];
+  allowSourcesOutsideAllowedRoots: boolean;
+}): void {
+  const blockedReason = getBlockedReasonForSourcePath(params.sourcePath, params.blockedHostPaths);
+  if (blockedReason) {
+    throw formatVolumeBlockedError({
+      volume: params.volume,
+      sourcePath: params.sourcePath,
+      reason: blockedReason,
+    });
+  }
+  if (params.allowSourcesOutsideAllowedRoots) {
+    return;
+  }
+  const allowedReason = getOutsideAllowedRootsReason(params.sourcePath, params.allowedRoots);
+  if (allowedReason) {
+    throw formatVolumeBlockedError({ volume: params.volume, reason: allowedReason });
+  }
+}
+
 export function validateNetworkMode(
   network: string | undefined,
   options?: ValidateNetworkModeOptions,
@@ -416,6 +560,7 @@ export function validateApparmorProfile(profile: string | undefined): void {
 export function validateSandboxSecurity(
   cfg: {
     binds?: string[];
+    volumes?: SandboxDockerVolumeSetting[];
     network?: string;
     seccompProfile?: string;
     apparmorProfile?: string;
@@ -423,6 +568,7 @@ export function validateSandboxSecurity(
   } & ValidateBindMountsOptions,
 ): void {
   validateBindMounts(cfg.binds, cfg);
+  validateDockerVolumes(cfg.volumes, cfg);
   validateNetworkMode(cfg.network, {
     allowContainerNamespaceJoin: cfg.dangerouslyAllowContainerNamespaceJoin === true,
   });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => ({
   resolveGatewayAuthTokenForService: vi.fn(),
   resolveGatewayPort: vi.fn(() => 18789),
   resolveIsNixMode: vi.fn(() => false),
+  resolveStateDir: vi.fn(() => "/tmp/openclaw-doctor-gateway-services-test"),
   findExtraGatewayServices: vi.fn().mockResolvedValue([]),
   renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
   needsNodeRuntimeMigration: vi.fn(() => false),
@@ -47,8 +48,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../config/paths.js", () => ({
+  STATE_DIR: "/tmp/openclaw-doctor-gateway-services-test",
   resolveGatewayPort: mocks.resolveGatewayPort,
   resolveIsNixMode: mocks.resolveIsNixMode,
+  resolveStateDir: mocks.resolveStateDir,
 }));
 
 vi.mock("../config/config.js", async () => {

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -246,6 +246,231 @@ describe("sandbox docker config", () => {
     });
     expect(res.ok).toBe(false);
   });
+
+  it("accepts sandbox.docker.volumes with mixed strategies", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                { strategy: "ephemeral", target: "/tmp/cache" },
+                { strategy: "named", source: "openclaw-cache", target: "/cache" },
+                {
+                  strategy: "bind",
+                  source: "/home/user/shared",
+                  target: "/shared",
+                  readOnly: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts Windows drive-letter bind volume sources", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                {
+                  strategy: "bind",
+                  source: "D:\\data\\openclaw\\shared",
+                  target: "/shared",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects bind volume strategy without absolute source", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "bind", source: "relative/path", target: "/shared" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects ephemeral volume strategy when source is provided", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "ephemeral", source: "not-allowed", target: "/tmp" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects docker volume source values that can inject --mount fields", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                {
+                  strategy: "named",
+                  source: "cache,type=bind,source=/etc",
+                  target: "/cache",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects docker volume target values that can inject --mount fields", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                {
+                  strategy: "bind",
+                  source: "/tmp/cache",
+                  target: "/cache,target=/workspace",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects reserved volume targets by default", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "named", source: "openclaw-cache", target: "/workspace" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("allows reserved volume targets with explicit dangerous override", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+              volumes: [{ strategy: "named", source: "openclaw-cache", target: "/workspace" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("allows agent reserved volume targets when dangerous override is inherited from defaults", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                volumes: [{ strategy: "named", source: "agent-cache", target: "/workspace" }],
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects agent reserved volume targets when agent explicitly disables inherited dangerous override", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                dangerouslyAllowReservedContainerTargets: false,
+                volumes: [{ strategy: "named", source: "agent-cache", target: "/workspace" }],
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects inherited default reserved volume targets when agent explicitly disables inherited dangerous override", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+              volumes: [{ strategy: "named", source: "default-cache", target: "/workspace" }],
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                dangerouslyAllowReservedContainerTargets: false,
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
 });
 
 describe("sandbox browser binds config", () => {

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -246,6 +246,210 @@ describe("sandbox docker config", () => {
     });
     expect(res.ok).toBe(false);
   });
+
+  it("accepts sandbox.docker.volumes with mixed strategies", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                { strategy: "ephemeral", target: "/tmp/cache" },
+                { strategy: "named", source: "openclaw-cache", target: "/cache" },
+                {
+                  strategy: "bind",
+                  source: "/home/user/shared",
+                  target: "/shared",
+                  readOnly: true,
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects bind volume strategy without absolute source", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "bind", source: "relative/path", target: "/shared" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects ephemeral volume strategy when source is provided", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "ephemeral", source: "not-allowed", target: "/tmp" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects docker volume source values that can inject --mount fields", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                {
+                  strategy: "named",
+                  source: "cache,type=bind,source=/etc",
+                  target: "/cache",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects docker volume target values that can inject --mount fields", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [
+                {
+                  strategy: "bind",
+                  source: "/tmp/cache",
+                  target: "/cache,target=/workspace",
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects reserved volume targets by default", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              volumes: [{ strategy: "named", source: "openclaw-cache", target: "/workspace" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("allows reserved volume targets with explicit dangerous override", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+              volumes: [{ strategy: "named", source: "openclaw-cache", target: "/workspace" }],
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("allows agent reserved volume targets when dangerous override is inherited from defaults", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                volumes: [{ strategy: "named", source: "agent-cache", target: "/workspace" }],
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects agent reserved volume targets when agent explicitly disables inherited dangerous override", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                dangerouslyAllowReservedContainerTargets: false,
+                volumes: [{ strategy: "named", source: "agent-cache", target: "/workspace" }],
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects inherited default reserved volume targets when agent explicitly disables inherited dangerous override", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowReservedContainerTargets: true,
+              volumes: [{ strategy: "named", source: "default-cache", target: "/workspace" }],
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            sandbox: {
+              docker: {
+                dangerouslyAllowReservedContainerTargets: false,
+              },
+            },
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+  });
 });
 
 describe("sandbox browser binds config", () => {

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -1,5 +1,16 @@
 import type { SecretInput } from "./types.secrets.js";
 
+export type SandboxDockerVolumeSetting = {
+  /** Host path (bind), volume name (named), or omitted for ephemeral strategy. */
+  source?: string;
+  /** Container mount target path. */
+  target: string;
+  /** Mount strategy. */
+  strategy: "ephemeral" | "named" | "bind";
+  /** Mount read-only inside container. */
+  readOnly?: boolean;
+};
+
 export type SandboxDockerSettings = {
   /** Docker image to use for sandbox containers. */
   image?: string;
@@ -46,6 +57,8 @@ export type SandboxDockerSettings = {
   extraHosts?: string[];
   /** Additional bind mounts (host:container:mode format, e.g. ["/host/path:/container/path:rw"]). */
   binds?: string[];
+  /** Declarative volume mounts with strategy (ephemeral|named|bind). */
+  volumes?: SandboxDockerVolumeSetting[];
   /**
    * Dangerous override: allow bind mounts that target reserved container paths
    * like /workspace or /agent.

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { getReservedContainerTargetReason } from "../agents/sandbox/validate-sandbox-security.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/ids.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
@@ -802,6 +803,113 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function collectReservedVolumeTargetIssues(params: {
+  docker: unknown;
+  pathPrefix: string;
+  inheritedAllowReservedContainerTargets?: boolean;
+}): ConfigValidationIssue[] {
+  if (!isRecord(params.docker)) {
+    return [];
+  }
+  const localAllowReserved = params.docker.dangerouslyAllowReservedContainerTargets;
+  const allowReservedContainerTargets =
+    typeof localAllowReserved === "boolean"
+      ? localAllowReserved
+      : params.inheritedAllowReservedContainerTargets === true;
+  if (allowReservedContainerTargets) {
+    return [];
+  }
+  const volumes = params.docker.volumes;
+  return collectReservedVolumeTargetIssuesFromVolumes({
+    volumes,
+    pathPrefix: params.pathPrefix,
+  });
+}
+
+function collectReservedVolumeTargetIssuesFromVolumes(params: {
+  volumes: unknown;
+  pathPrefix: string;
+}): ConfigValidationIssue[] {
+  const volumes = params.volumes;
+  if (!Array.isArray(volumes) || volumes.length === 0) {
+    return [];
+  }
+  const issues: ConfigValidationIssue[] = [];
+  for (let index = 0; index < volumes.length; index += 1) {
+    const volume = volumes[index];
+    if (!isRecord(volume)) {
+      continue;
+    }
+    const targetRaw = volume.target;
+    const target = typeof targetRaw === "string" ? targetRaw.trim() : "";
+    if (!target) {
+      continue;
+    }
+    const reservedTargetReason = getReservedContainerTargetReason(target);
+    if (!reservedTargetReason || reservedTargetReason.kind !== "reserved_target") {
+      continue;
+    }
+    issues.push({
+      path: `${params.pathPrefix}.volumes.${index}.target`,
+      message:
+        `Sandbox security: volume target "${target}" hits reserved container path ` +
+        `"${reservedTargetReason.reservedPath}". ` +
+        "Use dangerouslyAllowReservedContainerTargets=true only when you fully trust this runtime.",
+    });
+  }
+  return issues;
+}
+
+function validateReservedVolumeTargetsWithInheritedOverrides(
+  config: OpenClawConfig,
+): ConfigValidationIssue[] {
+  const defaultsDocker = config.agents?.defaults?.sandbox?.docker;
+  const defaultsAllowReservedContainerTargets =
+    defaultsDocker?.dangerouslyAllowReservedContainerTargets === true;
+  const issues: ConfigValidationIssue[] = collectReservedVolumeTargetIssues({
+    docker: defaultsDocker,
+    pathPrefix: "agents.defaults.sandbox.docker",
+  });
+  const agentsList = config.agents?.list;
+  if (!Array.isArray(agentsList) || agentsList.length === 0) {
+    return issues;
+  }
+  for (let agentIndex = 0; agentIndex < agentsList.length; agentIndex += 1) {
+    const docker = agentsList[agentIndex]?.sandbox?.docker;
+    issues.push(
+      ...collectReservedVolumeTargetIssues({
+        docker,
+        pathPrefix: `agents.list.${agentIndex}.sandbox.docker`,
+        inheritedAllowReservedContainerTargets: defaultsAllowReservedContainerTargets,
+      }),
+    );
+    if (!isRecord(docker) || !defaultsAllowReservedContainerTargets) {
+      continue;
+    }
+    // Only an explicit `false` opts this agent out of inherited defaults `true`; unset keeps inheritance.
+    if (docker.dangerouslyAllowReservedContainerTargets !== false) {
+      continue;
+    }
+    const inheritedDefaultVolumeIssues = collectReservedVolumeTargetIssuesFromVolumes({
+      volumes: defaultsDocker?.volumes,
+      pathPrefix: "agents.defaults.sandbox.docker",
+    });
+    if (inheritedDefaultVolumeIssues.length === 0) {
+      continue;
+    }
+    for (const inheritedIssue of inheritedDefaultVolumeIssues) {
+      issues.push({
+        path: `agents.list.${agentIndex}.sandbox.docker.dangerouslyAllowReservedContainerTargets`,
+        message:
+          `${inheritedIssue.message} This agent explicitly sets ` +
+          "dangerouslyAllowReservedContainerTargets=false, so inherited defaults " +
+          "cannot include reserved volume targets.",
+      });
+    }
+  }
+  return issues;
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -861,6 +969,12 @@ export function validateConfigObjectRaw(
   const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validatedConfig);
   if (gatewayTailscaleBindIssues.length > 0) {
     return { ok: false, issues: gatewayTailscaleBindIssues };
+  }
+  const reservedVolumeTargetIssues = validateReservedVolumeTargetsWithInheritedOverrides(
+    validated.data as OpenClawConfig,
+  );
+  if (reservedVolumeTargetIssues.length > 0) {
+    return { ok: false, issues: reservedVolumeTargetIssues };
   }
   return {
     ok: true,

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { getReservedContainerTargetReason } from "../agents/sandbox/validate-sandbox-security.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/ids.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { planManifestModelCatalogSuppressions } from "../model-catalog/index.js";
@@ -634,6 +635,113 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function collectReservedVolumeTargetIssues(params: {
+  docker: unknown;
+  pathPrefix: string;
+  inheritedAllowReservedContainerTargets?: boolean;
+}): ConfigValidationIssue[] {
+  if (!isRecord(params.docker)) {
+    return [];
+  }
+  const localAllowReserved = params.docker.dangerouslyAllowReservedContainerTargets;
+  const allowReservedContainerTargets =
+    typeof localAllowReserved === "boolean"
+      ? localAllowReserved
+      : params.inheritedAllowReservedContainerTargets === true;
+  if (allowReservedContainerTargets) {
+    return [];
+  }
+  const volumes = params.docker.volumes;
+  return collectReservedVolumeTargetIssuesFromVolumes({
+    volumes,
+    pathPrefix: params.pathPrefix,
+  });
+}
+
+function collectReservedVolumeTargetIssuesFromVolumes(params: {
+  volumes: unknown;
+  pathPrefix: string;
+}): ConfigValidationIssue[] {
+  const volumes = params.volumes;
+  if (!Array.isArray(volumes) || volumes.length === 0) {
+    return [];
+  }
+  const issues: ConfigValidationIssue[] = [];
+  for (let index = 0; index < volumes.length; index += 1) {
+    const volume = volumes[index];
+    if (!isRecord(volume)) {
+      continue;
+    }
+    const targetRaw = volume.target;
+    const target = typeof targetRaw === "string" ? targetRaw.trim() : "";
+    if (!target) {
+      continue;
+    }
+    const reservedTargetReason = getReservedContainerTargetReason(target);
+    if (!reservedTargetReason || reservedTargetReason.kind !== "reserved_target") {
+      continue;
+    }
+    issues.push({
+      path: `${params.pathPrefix}.volumes.${index}.target`,
+      message:
+        `Sandbox security: volume target "${target}" hits reserved container path ` +
+        `"${reservedTargetReason.reservedPath}". ` +
+        "Use dangerouslyAllowReservedContainerTargets=true only when you fully trust this runtime.",
+    });
+  }
+  return issues;
+}
+
+function validateReservedVolumeTargetsWithInheritedOverrides(
+  config: OpenClawConfig,
+): ConfigValidationIssue[] {
+  const defaultsDocker = config.agents?.defaults?.sandbox?.docker;
+  const defaultsAllowReservedContainerTargets =
+    defaultsDocker?.dangerouslyAllowReservedContainerTargets === true;
+  const issues: ConfigValidationIssue[] = collectReservedVolumeTargetIssues({
+    docker: defaultsDocker,
+    pathPrefix: "agents.defaults.sandbox.docker",
+  });
+  const agentsList = config.agents?.list;
+  if (!Array.isArray(agentsList) || agentsList.length === 0) {
+    return issues;
+  }
+  for (let agentIndex = 0; agentIndex < agentsList.length; agentIndex += 1) {
+    const docker = agentsList[agentIndex]?.sandbox?.docker;
+    issues.push(
+      ...collectReservedVolumeTargetIssues({
+        docker,
+        pathPrefix: `agents.list.${agentIndex}.sandbox.docker`,
+        inheritedAllowReservedContainerTargets: defaultsAllowReservedContainerTargets,
+      }),
+    );
+    if (!isRecord(docker) || !defaultsAllowReservedContainerTargets) {
+      continue;
+    }
+    // Only an explicit `false` opts this agent out of inherited defaults `true`; unset keeps inheritance.
+    if (docker.dangerouslyAllowReservedContainerTargets !== false) {
+      continue;
+    }
+    const inheritedDefaultVolumeIssues = collectReservedVolumeTargetIssuesFromVolumes({
+      volumes: defaultsDocker?.volumes,
+      pathPrefix: "agents.defaults.sandbox.docker",
+    });
+    if (inheritedDefaultVolumeIssues.length === 0) {
+      continue;
+    }
+    for (const inheritedIssue of inheritedDefaultVolumeIssues) {
+      issues.push({
+        path: `agents.list.${agentIndex}.sandbox.docker.dangerouslyAllowReservedContainerTargets`,
+        message:
+          `${inheritedIssue.message} This agent explicitly sets ` +
+          "dangerouslyAllowReservedContainerTargets=false, so inherited defaults " +
+          "cannot include reserved volume targets.",
+      });
+    }
+  }
+  return issues;
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -689,6 +797,12 @@ export function validateConfigObjectRaw(
   const gatewayTailscaleBindIssues = validateGatewayTailscaleBind(validatedConfig);
   if (gatewayTailscaleBindIssues.length > 0) {
     return { ok: false, issues: gatewayTailscaleBindIssues };
+  }
+  const reservedVolumeTargetIssues = validateReservedVolumeTargetsWithInheritedOverrides(
+    validated.data as OpenClawConfig,
+  );
+  if (reservedVolumeTargetIssues.length > 0) {
+    return { ok: false, issues: reservedVolumeTargetIssues };
   }
   return {
     ok: true,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -52,6 +52,10 @@ function validateSandboxBindEntries(
   }
 }
 
+function hasDockerMountFieldSeparator(value: string | undefined): boolean {
+  return value?.includes(",") === true;
+}
+
 export const AgentRunRetriesConfigSchema = z
   .object({
     base: z.number().int().positive().optional(),
@@ -194,6 +198,18 @@ const SandboxDockerSchema = z
     dns: z.array(z.string()).optional(),
     extraHosts: z.array(z.string()).optional(),
     binds: z.array(z.string()).optional(),
+    volumes: z
+      .array(
+        z
+          .object({
+            source: z.string().optional(),
+            target: z.string(),
+            strategy: z.union([z.literal("ephemeral"), z.literal("named"), z.literal("bind")]),
+            readOnly: z.boolean().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
@@ -201,6 +217,65 @@ const SandboxDockerSchema = z
   .strict()
   .superRefine((data, ctx) => {
     validateSandboxBindEntries(data.binds, ctx);
+    if (data.volumes) {
+      for (let i = 0; i < data.volumes.length; i += 1) {
+        const vol = data.volumes[i];
+        const target = vol?.target?.trim() ?? "";
+        if (!target || !target.startsWith("/")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "target"],
+            message: "Sandbox security: volume target must be an absolute POSIX path.",
+          });
+        } else if (hasDockerMountFieldSeparator(target)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "target"],
+            message:
+              'Sandbox security: volume target must not contain "," because Docker --mount parses comma-separated key/value fields.',
+          });
+        }
+        const source = vol?.source?.trim();
+        if (vol.strategy === "bind") {
+          if (!source || !isSandboxHostPathAbsolute(source)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                "Sandbox security: bind volume strategy requires an absolute POSIX or Windows drive-letter source path.",
+            });
+          } else if (hasDockerMountFieldSeparator(source)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                'Sandbox security: bind volume source must not contain "," because Docker --mount parses comma-separated key/value fields.',
+            });
+          }
+        } else if (vol.strategy === "named") {
+          if (!source) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message: "Sandbox config: named volume strategy requires source (volume name).",
+            });
+          } else if (hasDockerMountFieldSeparator(source)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                'Sandbox security: named volume source must not contain "," because Docker --mount parses comma-separated key/value fields.',
+            });
+          }
+        } else if (source) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "source"],
+            message: "Sandbox config: ephemeral strategy must not set source.",
+          });
+        }
+      }
+    }
     const blockedNetworkReason = getBlockedNetworkModeReason({
       network: data.network,
       allowContainerNamespaceJoin: data.dangerouslyAllowContainerNamespaceJoin === true,

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -19,6 +19,10 @@ import {
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
+function hasDockerMountFieldSeparator(value: string | undefined): boolean {
+  return value?.includes(",") === true;
+}
+
 export const HeartbeatSchema = z
   .object({
     every: z.string().optional(),
@@ -143,6 +147,18 @@ const SandboxDockerSchema = z
     dns: z.array(z.string()).optional(),
     extraHosts: z.array(z.string()).optional(),
     binds: z.array(z.string()).optional(),
+    volumes: z
+      .array(
+        z
+          .object({
+            source: z.string().optional(),
+            target: z.string(),
+            strategy: z.union([z.literal("ephemeral"), z.literal("named"), z.literal("bind")]),
+            readOnly: z.boolean().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
@@ -170,6 +186,65 @@ const SandboxDockerSchema = z
             message:
               `Sandbox security: bind mount "${bind}" uses a non-absolute source path "${source}". ` +
               "Only absolute POSIX or Windows drive-letter paths are supported for sandbox binds.",
+          });
+        }
+      }
+    }
+    if (data.volumes) {
+      for (let i = 0; i < data.volumes.length; i += 1) {
+        const vol = data.volumes[i];
+        const target = vol?.target?.trim() ?? "";
+        if (!target || !target.startsWith("/")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "target"],
+            message: "Sandbox security: volume target must be an absolute POSIX path.",
+          });
+        } else if (hasDockerMountFieldSeparator(target)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "target"],
+            message:
+              'Sandbox security: volume target must not contain "," because Docker --mount parses comma-separated key/value fields.',
+          });
+        }
+        const source = vol?.source?.trim();
+        if (vol.strategy === "bind") {
+          if (!source || !source.startsWith("/")) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                "Sandbox security: bind volume strategy requires an absolute POSIX source path.",
+            });
+          } else if (hasDockerMountFieldSeparator(source)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                'Sandbox security: bind volume source must not contain "," because Docker --mount parses comma-separated key/value fields.',
+            });
+          }
+        } else if (vol.strategy === "named") {
+          if (!source) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message: "Sandbox config: named volume strategy requires source (volume name).",
+            });
+          } else if (hasDockerMountFieldSeparator(source)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["volumes", i, "source"],
+              message:
+                'Sandbox security: named volume source must not contain "," because Docker --mount parses comma-separated key/value fields.',
+            });
+          }
+        } else if (source) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["volumes", i, "source"],
+            message: "Sandbox config: ephemeral strategy must not set source.",
           });
         }
       }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Sandbox mount config is currently bind-string oriented (`sandbox.docker.binds`), which makes Docker-managed volume workflows awkward.
- Why it matters: In containerized environments, forcing host bind semantics adds friction and can require unnecessary host path sharing.
- Solution: Add optional declarative `sandbox.docker.volumes` support for Docker sandboxes while keeping existing bind behavior unchanged.
- What changed: Added `ephemeral | named | bind` volume strategies, validation, config merge support, Docker `--mount` wiring, and startup ownership initialization so writable anonymous/named volumes work at new target paths under the default non-root sandbox user.
- What did NOT change (scope boundary): Existing `sandbox.docker.binds` behavior/defaults are unchanged.

## Motivation

- Docker-managed volumes are the native way to keep cache/data directories inside Docker without exposing extra host paths.
- Real Docker validation showed that Docker-created brand-new anonymous/named volume targets are root-owned, while the default OpenClaw sandbox image runs as a non-root user. The PR now handles that runtime behavior instead of requiring users to pick pre-existing writable image paths.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: `sandbox.docker.volumes` now supports ephemeral, named, and bind strategies; writable anonymous/named Docker volumes mounted at brand-new target paths are writable by the non-root sandbox user after container startup.
- Real environment tested: Docker Desktop 4.73.0 / Docker Engine 29.4.3 with `openclaw-sandbox:bookworm-slim`.
- Exact steps or command run after this patch: Created a Docker sandbox container with `--read-only`, `--cap-drop ALL`, writable anonymous volume target `/proof/ephemeral`, writable named volume target `/proof/named`, root-only ownership initialization, and `setpriv` drop to `1000:1001`; then ran `docker exec --user 1000:1001` to write result files into both new volume targets.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
uid=1000(sandbox) gid=1001(sandbox) groups=1001(sandbox)
CapEff: 0000000000000000
drwxr-xr-x 2 sandbox sandbox ... /proof/ephemeral
drwxr-xr-x 2 sandbox sandbox ... /proof/named
ephemeral=ephemeral-ok
named=named-ok
```

- Observed result after fix: Both new volume target paths were owned by `sandbox:sandbox`, the non-root sandbox user wrote successfully to both mounted volumes, and the final exec had no effective capabilities.
- What was not tested: Full production multi-node rollout and broad full CI.
- Before evidence (optional but encouraged): Before the ownership initialization fix, the same default-image/new-target flow failed with `/bin/sh: 1: cannot create /proof/ephemeral/result.txt: Permission denied` because Docker-created new volume target paths were root-owned.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Docker creates missing anonymous/named volume target directories as root-owned paths before the container process runs. The default OpenClaw sandbox image runs as a non-root `sandbox` user, so brand-new writable volume targets were not writable after startup.
- Missing detection / guardrail: Existing coverage checked schema and create args but did not run a real Docker container that writes to a brand-new anonymous/named volume target as the sandbox user.
- Contributing context (if known): The initial feature shape added declarative Docker `--mount` support; Docker's target-directory ownership behavior became visible under real default-image proof.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/sandbox/docker.config-hash-recreate.test.ts`, `src/agents/sandbox/docker-backend.test.ts`, `src/agents/bash-tools.build-docker-exec-args.test.ts`, `src/agents/sandbox/validate-sandbox-security.test.ts`, `src/config/config.sandbox-docker.test.ts`
- Scenario the test should lock in: Docker create args start as root only for writable anonymous/named volumes, add only the minimal init capabilities, chown writable volume targets, drop to the sandbox user, run backend exec commands with the resolved sandbox user, and reject unsafe volume source/target input before create.
- Why this is the smallest reliable guardrail: The Docker create/exec seam can verify the exact flags, ownership-init command, user drop, config-hash recreation, and security validation without running broad OpenClaw workflows.
- Existing test that already covers this (if any): Existing bind/security tests covered legacy binds; new tests cover declarative Docker volumes and ownership initialization.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- New optional config: `sandbox.docker.volumes` (global + agent override paths).
- Supported strategies:
  - `ephemeral` -> anonymous Docker volume mount
  - `named` -> named Docker volume mount
  - `bind` -> declarative bind mount
- Validation rules added:
  - `target` must be absolute POSIX
  - `bind` requires an absolute POSIX or Windows drive-letter `source`
  - `named` requires `source`
  - `ephemeral` must not set `source`
- Writable anonymous/named volumes at new target paths are initialized for the sandbox user automatically.
- SSH and OpenShell sandbox backends reject `sandbox.docker.volumes` because they do not mount Docker volumes.

## Diagram (if applicable)

```text
Before:
Docker --mount creates /cache/node_modules as root
  -> sandbox user writes
  -> permission denied

After:
Docker --mount creates /cache/node_modules as root
  -> OpenClaw startup init chowns writable volume targets
  -> setpriv drops to sandbox user
  -> sandbox user writes successfully
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) - Yes
- Secrets/tokens handling changed? (`Yes/No`) - No
- New/changed network calls? (`Yes/No`) - No
- Command/tool execution surface changed? (`Yes/No`) - Yes
- Data access scope changed? (`Yes/No`) - Yes
- If any `Yes`, explain risk + mitigation:
  - Runtime permission shape changes only for Docker sandboxes with writable anonymous/named volumes. Container startup runs as root with `CHOWN`, `SETUID`, and `SETGID` added only long enough to create/chown configured writable volume targets, then `exec setpriv` drops to the sandbox user with no effective capabilities.
  - Backend exec commands pass the resolved sandbox user explicitly, so later sandbox commands do not accidentally run as root.
  - Declarative `bind` volume entries are validated through structured host-path checks, blocked host path checks, reserved target checks, allowed roots, and comma-field injection rejection before Docker create.
  - Existing secrets/tokens handling is unchanged.

## Repro + Verification

### Environment

- OS: macOS host running Docker Desktop
- Runtime/container: Docker Desktop 4.73.0 / Docker Engine 29.4.3, `openclaw-sandbox:bookworm-slim`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `sandbox.docker.volumes` with mixed strategy entries in tests
  - writable anonymous/named Docker volumes at `/proof/ephemeral` and `/proof/named` in real Docker proof

### Steps

1. Configure `sandbox.docker.volumes` entries for `ephemeral`, `named`, and `bind`.
2. Run focused config, sandbox security, Docker create, backend exec, SSH/OpenShell rejection, and browser create tests.
3. Run a real Docker container using the fixed startup shape: root-only ownership initialization for `/proof/ephemeral` and `/proof/named`, `setpriv` drop to `1000:1001`, then `docker exec --user 1000:1001` writes into both targets.
4. Run the scoped core test typecheck and whitespace check.

### Expected

- Valid volume configs pass schema validation.
- Invalid strategy/source/target combinations are rejected before Docker create.
- Docker sandbox create args include expected `--mount` values.
- Writable anonymous/named volumes mounted at new target paths are writable by the non-root sandbox user.
- Runtime exec commands do not accidentally run as root after startup initialization.

### Actual

- Matched expected behavior.
- Targeted tests passed.
- Scoped core test typecheck passed.
- Real Docker proof passed with `CapEff: 0000000000000000` for the non-root write step.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added/ran volume strategy schema tests for valid mixed strategies and invalid cases.
  - Confirmed sandbox-related targeted suite passes.
  - Confirmed unsafe bind-volume sources outside allowed roots are rejected without legacy bind parsing.
  - Confirmed Docker `--mount` field injection through comma-delimited source/target values is rejected.
  - Confirmed SSH/OpenShell backends reject Docker volumes.
  - Confirmed real Docker container writes as non-root into new anonymous and named volume targets.
- Edge cases checked:
  - `ephemeral` with `source` is rejected.
  - `bind` with non-absolute source is rejected.
  - Reserved container targets are blocked for volume entries by default.
  - Existing `binds` path remains functional.
- What you did **not** verify:
  - Full production-like multi-node deployment rollout.
  - Broad full CI.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) - Yes
- Config/env changes? (`Yes/No`) - Yes, additive optional config only.
- Migration needed? (`Yes/No`) - No
- If yes, exact upgrade steps:
  - N/A.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Invalid/malformed volume entries could lead to Docker create failures.
  - Mitigation: Strategy-specific schema and runtime validation enforce required/forbidden fields, absolute targets, bind source constraints, reserved target checks, and comma-field injection rejection before create.
- Risk: Writable anonymous/named volume ownership initialization briefly starts the container as root.
  - Mitigation: The init path adds only `CHOWN`, `SETUID`, and `SETGID`, only touches configured writable Docker volume targets, then replaces itself with `setpriv` as the sandbox user; later backend exec commands explicitly use the resolved sandbox user.
- Risk: Existing containers created before the ownership fix could retain root-owned volume targets.
  - Mitigation: A conditional config-hash epoch recreates containers only when writable anonymous/named Docker volumes are configured.
