### PR TITLE
Providers: fix kimi-coding thinking normalization

### DIFF
--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -77,6 +77,7 @@ export default definePluginEntry({
         },
       },
       capabilities: {
+        openAiPayloadNormalizationMode: "moonshot-thinking",
         preserveAnthropicThinkingSignatures: false,
       },
     });

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -148,6 +148,11 @@ describe("resolveProviderCapabilities", () => {
     expect(usesMoonshotThinkingPayloadCompat("openai")).toBe(false);
   });
 
+  it("keeps the normalized kimi fallback aligned when plugin capabilities are unavailable", () => {
+    resolveProviderCapabilitiesWithPluginMock.mockImplementationOnce(() => undefined);
+    expect(usesMoonshotThinkingPayloadCompat("kimi-coding")).toBe(true);
+  });
+
   it("resolves transcript thought-signature and tool-call quirks through the registry", () => {
     expect(
       shouldSanitizeGeminiThoughtSignaturesForModel({

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -32,6 +32,7 @@ const resolveProviderCapabilitiesWithPluginMock = vi.fn((params: { provider: str
       };
     case "kimi":
       return {
+        openAiPayloadNormalizationMode: "moonshot-thinking",
         preserveAnthropicThinkingSignatures: false,
       };
     default:
@@ -122,7 +123,7 @@ describe("resolveProviderCapabilities", () => {
     expect(resolveProviderCapabilities("kimi-code")).toEqual({
       anthropicToolSchemaMode: "native",
       anthropicToolChoiceMode: "native",
-      openAiPayloadNormalizationMode: "default",
+      openAiPayloadNormalizationMode: "moonshot-thinking",
       providerFamily: "default",
       preserveAnthropicThinkingSignatures: false,
       openAiCompatTurnValidation: true,
@@ -143,6 +144,7 @@ describe("resolveProviderCapabilities", () => {
 
   it("routes moonshot payload compatibility through the capability registry", () => {
     expect(usesMoonshotThinkingPayloadCompat("moonshot")).toBe(true);
+    expect(usesMoonshotThinkingPayloadCompat("kimi-coding")).toBe(true);
     expect(usesMoonshotThinkingPayloadCompat("openai")).toBe(false);
   });
 

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -67,7 +67,7 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
   moonshot: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
   },
-  "kimi-coding": {
+  kimi: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
   },
   opencode: {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -67,6 +67,9 @@ const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities
   moonshot: {
     openAiPayloadNormalizationMode: "moonshot-thinking",
   },
+  "kimi-coding": {
+    openAiPayloadNormalizationMode: "moonshot-thinking",
+  },
   opencode: {
     openAiCompatTurnValidation: false,
     geminiThoughtSignatureSanitization: true,


### PR DESCRIPTION
## Summary
- teach the bundled Kimi provider to use the same moonshot thinking payload normalization as the Moonshot provider
- keep the fallback capability table aligned for non-plugin resolution paths
- add regression coverage for the kimi-coding payload compatibility path

## Testing
- pnpm test -- src/agents/provider-capabilities.test.ts

## Fixes
- Fixes #53591
- Fixes #53735