### PR TITLE
fix(slack): include API error details in log messages

### DIFF
--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -1,5 +1,6 @@
 import { createDraftStreamLoop } from "openclaw/plugin-sdk/channel-lifecycle";
 import { deleteSlackMessage, editSlackMessage } from "./actions.js";
+import { formatSlackError } from "./errors.js";
 import { SLACK_TEXT_LIMIT } from "./limits.js";
 import { sendMessageSlack } from "./send.js";
 
@@ -80,9 +81,7 @@ export function createSlackDraftStream(params: {
       params.onMessageSent?.();
     } catch (err) {
       stopped = true;
-      params.warn?.(
-        `slack stream preview failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      params.warn?.(`slack stream preview failed: ${formatSlackError(err)}`);
     }
   };
   const loop = createDraftStreamLoop({
@@ -113,9 +112,7 @@ export function createSlackDraftStream(params: {
         accountId: params.accountId,
       });
     } catch (err) {
-      params.warn?.(
-        `slack stream preview cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      params.warn?.(`slack stream preview cleanup failed: ${formatSlackError(err)}`);
     }
   };
 

--- a/extensions/slack/src/errors.test.ts
+++ b/extensions/slack/src/errors.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { formatSlackError } from "./errors.js";
+
+describe("formatSlackError", () => {
+  it("returns String(err) for non-Error values", () => {
+    expect(formatSlackError("boom")).toBe("boom");
+    expect(formatSlackError(42)).toBe("42");
+    expect(formatSlackError(null)).toBe("null");
+  });
+
+  it("returns just the message for a plain Error", () => {
+    expect(formatSlackError(new Error("plain"))).toBe("plain");
+  });
+
+  it("includes code and data fields from a platform error", () => {
+    const err = Object.assign(new Error("not_authed"), {
+      code: "slack_webapi_platform_error",
+      data: {
+        ok: false,
+        error: "not_authed",
+        needed: "chat:write",
+        provided: "users:read",
+        response_metadata: {
+          scopes: ["users:read"],
+          acceptedScopes: ["chat:write", "chat:write.public"],
+          messages: ["missing required scope"],
+        },
+      },
+    });
+    const result = formatSlackError(err);
+    expect(result).toContain("code=slack_webapi_platform_error");
+    expect(result).toContain("error=not_authed");
+    expect(result).toContain("needed=chat:write");
+    expect(result).toContain("provided=users:read");
+    expect(result).toContain("scopes=users:read");
+    expect(result).toContain("acceptedScopes=chat:write,chat:write.public");
+    expect(result).toContain("messages=missing required scope");
+  });
+
+  it("includes retryAfter from rate-limited errors", () => {
+    const err = Object.assign(new Error("rate limited"), {
+      code: "slack_webapi_rate_limited_error",
+      data: {
+        ok: false,
+        error: "ratelimited",
+        response_metadata: { retryAfter: 30 },
+      },
+    });
+    const result = formatSlackError(err);
+    expect(result).toContain("retryAfter=30");
+  });
+
+  it("handles coded error with no data property", () => {
+    const err = Object.assign(new Error("request failed"), {
+      code: "slack_webapi_request_error",
+    });
+    const result = formatSlackError(err);
+    expect(result).toBe("request failed [code=slack_webapi_request_error]");
+  });
+});

--- a/extensions/slack/src/errors.ts
+++ b/extensions/slack/src/errors.ts
@@ -1,0 +1,19 @@
+import type { CodedError, WebAPICallResult } from "@slack/web-api";
+
+export function formatSlackError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const { code, data } = err as CodedError & {
+    data?: WebAPICallResult & { needed?: string; provided?: string };
+  };
+  const parts: string[] = [];
+  if (code) parts.push(`code=${code}`);
+  if (data?.error) parts.push(`error=${data.error}`);
+  if (data?.needed) parts.push(`needed=${data.needed}`);
+  if (data?.provided) parts.push(`provided=${data.provided}`);
+  const meta = data?.response_metadata;
+  if (meta?.retryAfter) parts.push(`retryAfter=${meta.retryAfter}`);
+  if (meta?.scopes?.length) parts.push(`scopes=${meta.scopes.join(",")}`);
+  if (meta?.acceptedScopes?.length) parts.push(`acceptedScopes=${meta.acceptedScopes.join(",")}`);
+  if (meta?.messages?.length) parts.push(`messages=${meta.messages.join(" | ")}`);
+  return parts.length ? `${err.message} [${parts.join(" ")}]` : err.message;
+}

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -12,6 +12,7 @@ import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { formatSlackError } from "../errors.js";
 import type { SlackMessageEvent } from "../types.js";
 import { normalizeAllowList, normalizeAllowListLower, normalizeSlackSlug } from "./allow-list.js";
 import type { SlackChannelConfigEntries } from "./channel-config.js";
@@ -282,7 +283,7 @@ export function createSlackMonitorContext(params: {
         await client.apiCall("assistant.threads.setStatus", payload);
       }
     } catch (err) {
-      logVerbose(`slack status update failed for channel ${p.channelId}: ${String(err)}`);
+      logVerbose(`slack status update failed for channel ${p.channelId}: ${formatSlackError(err)}`);
     }
   };
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -79,6 +79,8 @@ function shouldUseStreaming(params: {
   return true;
 }
 
+import { formatSlackError } from "../../errors.js";
+
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
   const { ctx, account, message, route } = prepared;
   const cfg = ctx.cfg;
@@ -293,7 +295,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     } catch (err) {
       runtime.error?.(
-        danger(`slack-stream: streaming API call failed: ${String(err)}, falling back`),
+        danger(`slack-stream: streaming API call failed: ${formatSlackError(err)}, falling back`),
       );
       streamFailed = true;
       await deliverNormally(payload, streamSession?.threadTs ?? plannedThreadTs);
@@ -341,7 +343,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           return;
         } catch (err) {
           logVerbose(
-            `slack: preview final edit failed; falling back to standard send (${String(err)})`,
+            `slack: preview final edit failed; falling back to standard send (${formatSlackError(err)})`,
           );
         }
       } else if (previewStreamingEnabled && streamMode === "status_final" && hasStreamedMessage) {
@@ -357,7 +359,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             });
           }
         } catch (err) {
-          logVerbose(`slack: status_final completion update failed (${String(err)})`);
+          logVerbose(`slack: status_final completion update failed (${formatSlackError(err)})`);
         }
       } else if (reply.hasMedia) {
         await draftStream?.clear();
@@ -367,7 +369,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       await deliverNormally(payload);
     },
     onError: (err, info) => {
-      runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));
+      runtime.error?.(danger(`slack ${info.kind} reply failed: ${formatSlackError(err)}`));
       replyPipeline.typingCallbacks?.onIdle?.();
     },
   });
@@ -478,7 +480,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     try {
       await stopSlackStream({ session: finalStream });
     } catch (err) {
-      runtime.error?.(danger(`slack-stream: failed to stop stream: ${String(err)}`));
+      runtime.error?.(danger(`slack-stream: failed to stop stream: ${formatSlackError(err)}`));
     }
   }
 

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -32,6 +32,7 @@ import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { resolveSlackReplyToMode, type ResolvedSlackAccount } from "../../accounts.js";
 import { reactSlackMessage } from "../../actions.js";
+import { formatSlackError } from "../../errors.js";
 import { sendMessageSlack } from "../../send.js";
 import { hasSlackThreadParticipation } from "../../sent-thread-cache.js";
 import { resolveSlackThreadContext } from "../../threading.js";
@@ -563,7 +564,9 @@ export async function prepareSlackMessage(params: {
         }).then(
           () => true,
           (err) => {
-            logVerbose(`slack react failed for channel ${message.channel}: ${String(err)}`);
+            logVerbose(
+              `slack react failed for channel ${message.channel}: ${formatSlackError(err)}`,
+            );
             return false;
           },
         )

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -27,6 +27,7 @@ import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-i
 import { normalizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
 import { resolveSlackAccount } from "../accounts.js";
 import { resolveSlackWebClientOptions } from "../client.js";
+import { formatSlackError } from "../errors.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { SLACK_TEXT_LIMIT } from "../limits.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
@@ -408,7 +409,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             summarizeMapping("slack channels", mapping, unresolved, runtime);
           }
         } catch (err) {
-          runtime.log?.(`slack channel resolve failed; using config entries. ${String(err)}`);
+          runtime.log?.(
+            `slack channel resolve failed; using config entries. ${formatSlackError(err)}`,
+          );
         }
       }
 
@@ -434,7 +437,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           ctx.allowFrom = normalizeAllowList(allowFrom);
           summarizeMapping("slack users", mapping, unresolved, runtime);
         } catch (err) {
-          runtime.log?.(`slack user resolve failed; using config entries. ${String(err)}`);
+          runtime.log?.(
+            `slack user resolve failed; using config entries. ${formatSlackError(err)}`,
+          );
         }
       }
 
@@ -462,7 +467,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
             summarizeMapping("slack channel users", mapping, unresolved, runtime);
           } catch (err) {
             runtime.log?.(
-              `slack channel user resolve failed; using config entries. ${String(err)}`,
+              `slack channel user resolve failed; using config entries. ${formatSlackError(err)}`,
             );
           }
         }

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -13,6 +13,7 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems } from "openclaw/plugin-sdk/text-runtime";
 import type { ResolvedSlackAccount } from "../accounts.js";
+import { formatSlackError } from "../errors.js";
 import { truncateSlackText } from "../truncate.js";
 import { resolveSlackAllowListMatch, resolveSlackUserAllowed } from "./allow-list.js";
 import { resolveSlackEffectiveAllowFrom } from "./auth.js";
@@ -628,7 +629,9 @@ export async function registerSlackMonitorSlashCommands(params: {
           ...replyPipeline,
           deliver: async (payload) => deliverSlashPayloads([payload]),
           onError: (err, info) => {
-            runtime.error?.(danger(`slack slash ${info.kind} reply failed: ${String(err)}`));
+            runtime.error?.(
+              danger(`slack slash ${info.kind} reply failed: ${formatSlackError(err)}`),
+            );
           },
         },
         replyOptions: {

--- a/extensions/slack/src/probe.ts
+++ b/extensions/slack/src/probe.ts
@@ -1,6 +1,7 @@
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import { withTimeout } from "openclaw/plugin-sdk/text-runtime";
 import { createSlackWebClient } from "./client.js";
+import { formatSlackError } from "./errors.js";
 
 export type SlackProbe = BaseProbeResult & {
   status?: number | null;
@@ -30,7 +31,7 @@ export async function probeSlack(token: string, timeoutMs = 2500): Promise<Slack
       team: { id: result.team_id, name: result.team },
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatSlackError(err);
     const status =
       typeof (err as { status?: number }).status === "number"
         ? (err as { status?: number }).status

--- a/extensions/slack/src/scopes.ts
+++ b/extensions/slack/src/scopes.ts
@@ -1,6 +1,7 @@
 import type { WebClient } from "@slack/web-api";
 import { isRecord } from "openclaw/plugin-sdk/text-runtime";
 import { createSlackWebClient } from "./client.js";
+import { formatSlackError } from "./errors.js";
 
 export type SlackScopesResult = {
   ok: boolean;
@@ -84,7 +85,7 @@ async function callSlack(
   } catch (err) {
     return {
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      error: formatSlackError(err),
     };
   }
 }


### PR DESCRIPTION
## Summary

- Problem: Slack API errors carry structured fields (needed/provided scopes, error codes, rate-limit retry info) that were lost when logged via `String(err)`, making scope mismatches and auth failures hard to diagnose.
- Why it matters: During Slack integration setup, missing-scope errors showed only `An API error occurred: missing_scope` with no detail about which scopes were needed vs provided.
- What changed: Added `formatSlackError()` helper in `extensions/slack/src/errors.ts` that extracts `code`, `data.error`, `needed`, `provided`, `retryAfter`, `scopes`, `acceptedScopes`, and `messages` from `@slack/web-api` `CodedError` objects. Updated 11 Slack API error logging sites across 8 files to use it.
- What did NOT change (scope boundary): Non-API error catches (event handlers, debounce flush, general handler failures) still use `String(err)` — only call sites that catch direct Slack API responses were updated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `String(err)` on `@slack/web-api` errors only produces the generic `Error.message` (e.g. `An API error occurred: missing_scope`). The library attaches rich detail (`code`, `data.needed`, `data.provided`, `response_metadata.scopes`, `retryAfter`) as extra properties on the error object, but none of these override `toString()`.
- Missing detection / guardrail: No formatting helper existed to extract these structured fields.
- Prior context: Original error logging was written before these structured fields were needed for troubleshooting.
- Why this regressed now: Not a regression — this was always the behavior, but became noticeable during Slack bot setup when scope errors gave no actionable detail.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/errors.test.ts`
- Scenario the test should lock in: Given a Slack `CodedError` with `data.needed`, `data.provided`, `response_metadata.scopes`, `retryAfter`, etc., the formatted string includes all fields. Given a plain `Error`, falls back to `err.message`. Given a non-Error, falls back to `String(err)`.
- Why this is the smallest reliable guardrail: Pure function with no dependencies — unit tests fully cover all branches.
- Existing test that already covers this (if any): None previously.

## User-visible / Behavior Changes

Log messages for Slack API errors now include structured detail. Example before:
```
slack channel resolve failed; using config entries. Error: An API error occurred: missing_scope
```
After:
```
slack channel resolve failed; using config entries. An API error occurred: missing_scope [code=slack_webapi_platform_error error=missing_scope needed=channels:write,groups:write provided=chat:write,app_mentions:read scopes=chat:write,app_mentions:read acceptedScopes=channels:write,groups:write]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.4
- Runtime/container: Node 22, pnpm dev
- Model/provider: N/A (Slack API integration)
- Integration/channel: Slack
- Relevant config: Slack bot token with limited scopes

### Steps

1. Configure a Slack bot with insufficient scopes (e.g. missing `channels:write`)
2. Start OpenClaw gateway with Slack enabled
3. Observe startup log for channel resolve failure

### Expected

- Error log includes which scopes are needed vs provided

### Actual

- Before: `Error: An API error occurred: missing_scope`
- After: Full structured detail including `needed=`, `provided=`, `scopes=`, `acceptedScopes=`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Gateway startup with missing Slack scopes, message dispatch with missing scopes — both now show full error details
- Edge cases checked: Plain errors, non-Error values, coded errors without data property, rate-limited errors with retryAfter
- What you did **not** verify: Live rate-limited error (tested via unit test only)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Truncated or malformed log lines (unlikely — function is additive and has fallbacks)

## Risks and Mitigations

- Risk: `as CodedError` cast on non-CodedError errors could surface unexpected properties
  - Mitigation: Guard checks `instanceof Error` first, and all property accesses are optional-chained

🤖 Generated with [Claude Code](https://claude.com/claude-code)