### PR TITLE
Plugins: resolve sdk aliases from the running CLI

### DIFF
--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -341,6 +341,9 @@ describe("plugin sdk alias helpers", () => {
         "./plugin-sdk/compat": { default: "./dist/plugin-sdk/compat.js" },
         "./plugin-sdk/telegram": { default: "./dist/plugin-sdk/telegram.js" },
         "./plugin-sdk/nested/value": { default: "./dist/plugin-sdk/nested/value.js" },
+        "./plugin-sdk/..\\..\\evil": { default: "./dist/plugin-sdk/evil.js" },
+        "./plugin-sdk/C:temp": { default: "./dist/plugin-sdk/drive.js" },
+        "./plugin-sdk/.hidden": { default: "./dist/plugin-sdk/hidden.js" },
       },
     });
     const subpaths = listPluginSdkExportedSubpaths({

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -255,7 +255,12 @@ describe("plugin sdk alias helpers", () => {
     },
     {
       name: "resolves plugin-sdk alias from package root when loader runs from transpiler cache path",
-      buildFixture: () => createPluginSdkAliasFixture(),
+      buildFixture: () =>
+        createPluginSdkAliasFixture({
+          packageExports: {
+            "./plugin-sdk/index": { default: "./dist/plugin-sdk/index.js" },
+          },
+        }),
       modulePath: () => "/tmp/tsx-cache/openclaw-loader.js",
       argv1: (root: string) => path.join(root, "openclaw.mjs"),
       srcFile: "index.ts",
@@ -486,9 +491,9 @@ describe("plugin sdk alias helpers", () => {
     mkdirSafe(externalPluginRoot);
     fs.writeFileSync(externalPluginEntry, 'export const plugin = "demo";\n', "utf-8");
 
-    const aliases = withArgv1(path.join(fixture.root, "openclaw.mjs"), () =>
-      withCwd(externalPluginRoot, () =>
-        withEnv({ NODE_ENV: undefined }, () => buildPluginLoaderAliasMap(externalPluginEntry)),
+    const aliases = withCwd(externalPluginRoot, () =>
+      withEnv({ NODE_ENV: undefined }, () =>
+        buildPluginLoaderAliasMap(externalPluginEntry, path.join(fixture.root, "openclaw.mjs")),
       ),
     );
 

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -60,6 +60,16 @@ function withCwd<T>(cwd: string, run: () => T): T {
   }
 }
 
+function withArgv1<T>(argv1: string, run: () => T): T {
+  const originalArgv = process.argv;
+  process.argv = [originalArgv[0] ?? "node", argv1, ...originalArgv.slice(2)];
+  try {
+    return run();
+  } finally {
+    process.argv = originalArgv;
+  }
+}
+
 function createPluginSdkAliasFixture(params?: {
   srcFile?: string;
   distFile?: string;
@@ -458,6 +468,35 @@ describe("plugin sdk alias helpers", () => {
     );
     expect(fs.realpathSync(distAliases["openclaw/plugin-sdk/channel-runtime"] ?? "")).toBe(
       fs.realpathSync(path.join(fixture.root, "dist", "plugin-sdk", "channel-runtime.js")),
+    );
+  });
+
+  it("resolves plugin-sdk aliases for user-installed plugins via the running openclaw argv hint", () => {
+    const fixture = createPluginSdkAliasFixture({
+      srcFile: "channel-runtime.ts",
+      distFile: "channel-runtime.js",
+      packageExports: {
+        "./plugin-sdk/channel-runtime": { default: "./dist/plugin-sdk/channel-runtime.js" },
+      },
+    });
+    const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
+    fs.writeFileSync(sourceRootAlias, "module.exports = {};\n", "utf-8");
+    const externalPluginRoot = path.join(makeTempDir(), ".openclaw", "extensions", "demo");
+    const externalPluginEntry = path.join(externalPluginRoot, "index.ts");
+    mkdirSafe(externalPluginRoot);
+    fs.writeFileSync(externalPluginEntry, 'export const plugin = "demo";\n', "utf-8");
+
+    const aliases = withArgv1(path.join(fixture.root, "openclaw.mjs"), () =>
+      withCwd(externalPluginRoot, () =>
+        withEnv({ NODE_ENV: undefined }, () => buildPluginLoaderAliasMap(externalPluginEntry)),
+      ),
+    );
+
+    expect(fs.realpathSync(aliases["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(sourceRootAlias),
+    );
+    expect(fs.realpathSync(aliases["openclaw/plugin-sdk/channel-runtime"] ?? "")).toBe(
+      fs.realpathSync(path.join(fixture.root, "src", "plugin-sdk", "channel-runtime.ts")),
     );
   });
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -17,6 +17,8 @@ type PluginSdkPackageJson = {
   bin?: string | Record<string, unknown>;
 };
 
+const STARTUP_ARGV1 = process.argv[1];
+
 function resolveLoaderModulePath(params: LoaderModuleResolveParams = {}): string {
   return params.modulePath ?? fileURLToPath(params.moduleUrl ?? import.meta.url);
 }
@@ -73,6 +75,27 @@ function readPluginSdkSubpathsFromPackageRoot(packageRoot: string): string[] | n
   return subpaths.length > 0 ? subpaths : null;
 }
 
+function resolveTrustedOpenClawRootFromArgvHint(params: {
+  argv1?: string;
+  cwd: string;
+}): string | null {
+  if (!params.argv1) {
+    return null;
+  }
+  const packageRoot = resolveOpenClawPackageRootSync({
+    cwd: params.cwd,
+    argv1: params.argv1,
+  });
+  if (!packageRoot) {
+    return null;
+  }
+  const packageJson = readPluginSdkPackageJson(packageRoot);
+  if (!packageJson) {
+    return null;
+  }
+  return hasTrustedOpenClawRootIndicator({ packageRoot, packageJson }) ? packageRoot : null;
+}
+
 function findNearestPluginSdkPackageRoot(startDir: string, maxDepth = 12): string | null {
   let cursor = path.resolve(startDir);
   for (let i = 0; i < maxDepth; i += 1) {
@@ -112,13 +135,13 @@ function resolveLoaderPluginSdkPackageRoot(
   const cwd = params.cwd ?? path.dirname(params.modulePath);
   const fromCwd = resolveOpenClawPackageRootSync({ cwd });
   const fromExplicitHints =
-    params.argv1 || params.moduleUrl
+    resolveTrustedOpenClawRootFromArgvHint({ cwd, argv1: params.argv1 }) ??
+    (params.moduleUrl
       ? resolveOpenClawPackageRootSync({
           cwd,
-          ...(params.argv1 ? { argv1: params.argv1 } : {}),
-          ...(params.moduleUrl ? { moduleUrl: params.moduleUrl } : {}),
+          moduleUrl: params.moduleUrl,
         })
-      : null;
+      : null);
   return (
     fromCwd ??
     fromExplicitHints ??
@@ -287,18 +310,21 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
   return null;
 }
 
-export function buildPluginLoaderAliasMap(modulePath: string): Record<string, string> {
+export function buildPluginLoaderAliasMap(
+  modulePath: string,
+  argv1: string | undefined = STARTUP_ARGV1,
+): Record<string, string> {
   const pluginSdkAlias = resolvePluginSdkAliasFile({
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
     modulePath,
-    argv1: process.argv[1],
+    argv1,
   });
   const extensionApiAlias = resolveExtensionApiAlias({ modulePath });
   return {
     ...(extensionApiAlias ? { "openclaw/extension-api": extensionApiAlias } : {}),
     ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-    ...resolvePluginSdkScopedAliasMap({ modulePath, argv1: process.argv[1] }),
+    ...resolvePluginSdkScopedAliasMap({ modulePath, argv1 }),
   };
 }
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -207,9 +207,11 @@ export function resolvePluginSdkAliasFile(params: {
 const cachedPluginSdkExportedSubpaths = new Map<string, string[]>();
 const cachedPluginSdkScopedAliasMaps = new Map<string, Record<string, string>>();
 
-export function listPluginSdkExportedSubpaths(params: { modulePath?: string } = {}): string[] {
+export function listPluginSdkExportedSubpaths(
+  params: { modulePath?: string; argv1?: string } = {},
+): string[] {
   const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
-  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath });
+  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath, argv1: params.argv1 });
   if (!packageRoot) {
     return [];
   }
@@ -223,10 +225,10 @@ export function listPluginSdkExportedSubpaths(params: { modulePath?: string } = 
 }
 
 export function resolvePluginSdkScopedAliasMap(
-  params: { modulePath?: string } = {},
+  params: { modulePath?: string; argv1?: string } = {},
 ): Record<string, string> {
   const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
-  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath });
+  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath, argv1: params.argv1 });
   if (!packageRoot) {
     return {};
   }
@@ -240,7 +242,7 @@ export function resolvePluginSdkScopedAliasMap(
     return cached;
   }
   const aliasMap: Record<string, string> = {};
-  for (const subpath of listPluginSdkExportedSubpaths({ modulePath })) {
+  for (const subpath of listPluginSdkExportedSubpaths({ modulePath, argv1: params.argv1 })) {
     const candidateMap = {
       src: path.join(packageRoot, "src", "plugin-sdk", `${subpath}.ts`),
       dist: path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`),
@@ -290,12 +292,13 @@ export function buildPluginLoaderAliasMap(modulePath: string): Record<string, st
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
     modulePath,
+    argv1: process.argv[1],
   });
   const extensionApiAlias = resolveExtensionApiAlias({ modulePath });
   return {
     ...(extensionApiAlias ? { "openclaw/extension-api": extensionApiAlias } : {}),
     ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-    ...resolvePluginSdkScopedAliasMap({ modulePath }),
+    ...resolvePluginSdkScopedAliasMap({ modulePath, argv1: process.argv[1] }),
   };
 }
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -32,11 +32,15 @@ function readPluginSdkPackageJson(packageRoot: string): PluginSdkPackageJson | n
   }
 }
 
+function isSafePluginSdkSubpathSegment(subpath: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(subpath);
+}
+
 function listPluginSdkSubpathsFromPackageJson(pkg: PluginSdkPackageJson): string[] {
   return Object.keys(pkg.exports ?? {})
     .filter((key) => key.startsWith("./plugin-sdk/"))
     .map((key) => key.slice("./plugin-sdk/".length))
-    .filter((subpath) => Boolean(subpath) && !subpath.includes("/"))
+    .filter((subpath) => isSafePluginSdkSubpathSegment(subpath))
     .toSorted();
 }
 


### PR DESCRIPTION
## Summary
- let plugin-sdk alias resolution use the running openclaw CLI path as a package-root hint for user-installed plugins outside the package tree
- thread that argv hint through the loader alias map so `openclaw/plugin-sdk/*` subpaths resolve consistently
- add a regression test that models a plugin under `~/.openclaw/extensions/...`

## Testing
- pnpm test -- src/plugins/sdk-alias.test.ts

## Fixes
- Fixes #53403
- Fixes #53517