### PR TITLE
perf: add startup prewarm for session usage cache

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -32,6 +32,7 @@ import {
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+import { prewarmSessionUsageCache } from "./session-utils.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
 
@@ -68,7 +69,7 @@ export async function startGatewaySidecars(params: {
   defaultWorkspaceDir: string;
   deps: CliDeps;
   startChannels: () => Promise<void>;
-  log: { warn: (msg: string) => void };
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
   logHooks: {
     info: (msg: string) => void;
     warn: (msg: string) => void;
@@ -214,6 +215,10 @@ export async function startGatewaySidecars(params: {
 
   void startGatewayMemoryBackend({ cfg: params.cfg, log: params.log }).catch((err) => {
     params.log.warn(`qmd memory startup initialization failed: ${String(err)}`);
+  });
+
+  void prewarmSessionUsageCache({ cfg: params.cfg, log: params.log }).catch((err) => {
+    params.log.warn(`session usage cache prewarm failed: ${String(err)}`);
   });
 
   if (shouldWakeFromRestartSentinel()) {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -24,6 +24,7 @@ import {
   resolveGatewaySessionStoreTarget,
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
+  prewarmSessionUsageCache,
   resolveSessionStoreKey,
 } from "./session-utils.js";
 
@@ -1534,5 +1535,182 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
       expect(store["agent:main:main"]).toBeDefined();
       expect(store["agent:codex:acp-task"]).toBeDefined();
     });
+  });
+});
+
+describe("prewarmSessionUsageCache", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-prewarm-"));
+  });
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  function writeStore(storePath: string, store: Record<string, SessionEntry>) {
+    fs.writeFileSync(storePath, JSON.stringify(store), "utf-8");
+  }
+
+  function writeTranscript(dir: string, sessionId: string, totalTokens: number) {
+    fs.writeFileSync(
+      path.join(dir, `${sessionId}.jsonl`),
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: Math.floor(totalTokens / 2),
+              output: totalTokens - Math.floor(totalTokens / 2),
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+  }
+
+  test("does nothing when prewarmUsageCache is not enabled", async () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const cfg = { session: { store: path.join(tmpDir, "sessions.json") } } as OpenClawConfig;
+    writeStore(path.join(tmpDir, "sessions.json"), {});
+
+    await prewarmSessionUsageCache({ cfg, log });
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  test("warms usage and title caches for sessions", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const store: Record<string, SessionEntry> = {
+      main: {
+        sessionId: "prewarm-sess-1",
+        updatedAt: Date.now(),
+        totalTokens: 0,
+        totalTokensFresh: false,
+      } as SessionEntry,
+      other: {
+        sessionId: "prewarm-sess-2",
+        updatedAt: Date.now(),
+        totalTokens: 0,
+        totalTokensFresh: false,
+      } as SessionEntry,
+    };
+    writeStore(storePath, store);
+    writeTranscript(tmpDir, "prewarm-sess-1", 200);
+    writeTranscript(tmpDir, "prewarm-sess-2", 400);
+
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const cfg = {
+      session: { store: storePath },
+      gateway: { sessionsList: { prewarmUsageCache: true } },
+    } as OpenClawConfig;
+
+    await prewarmSessionUsageCache({ cfg, log });
+
+    const infoMessages = log.info.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(infoMessages.some((m: string) => m.includes("warming 2 session"))).toBe(true);
+    expect(infoMessages.some((m: string) => m.includes("usage=2") && m.includes("title=2"))).toBe(
+      true,
+    );
+  });
+
+  test("skips usage warming for sessions that already have metadata", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    const store: Record<string, SessionEntry> = {
+      "has-usage": {
+        sessionId: "prewarm-has-usage",
+        updatedAt: Date.now(),
+        totalTokens: 500,
+        totalTokensFresh: true,
+        contextTokens: 200000,
+        estimatedCostUsd: 0.01,
+      } as SessionEntry,
+      "no-usage": {
+        sessionId: "prewarm-no-usage",
+        updatedAt: Date.now(),
+        totalTokens: 0,
+        totalTokensFresh: false,
+      } as SessionEntry,
+    };
+    writeStore(storePath, store);
+    writeTranscript(tmpDir, "prewarm-no-usage", 300);
+
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const cfg = {
+      session: { store: storePath },
+      gateway: { sessionsList: { prewarmUsageCache: true } },
+    } as OpenClawConfig;
+
+    await prewarmSessionUsageCache({ cfg, log });
+
+    const infoMessages = log.info.mock.calls.map((c: unknown[]) => String(c[0]));
+    // 1 usage (no-usage only) + 2 title (both sessions)
+    expect(infoMessages.some((m: string) => m.includes("1 usage"))).toBe(true);
+    expect(infoMessages.some((m: string) => m.includes("usage=1") && m.includes("title=2"))).toBe(
+      true,
+    );
+  });
+
+  test("applies usageCacheMaxEntries from config", async () => {
+    const storePath = path.join(tmpDir, "sessions.json");
+    writeStore(storePath, {});
+
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const cfg = {
+      session: { store: storePath },
+      gateway: { sessionsList: { usageCacheMaxEntries: 50000 } },
+    } as OpenClawConfig;
+
+    await prewarmSessionUsageCache({ cfg, log });
+    // No error means usageCacheMaxEntries was accepted
+  });
+});
+
+describe("gateway.sessionsList config validation", () => {
+  test("zod schema accepts valid sessionsList config", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const config = {
+      gateway: {
+        sessionsList: {
+          usageCacheMaxEntries: 10000,
+          prewarmUsageCache: true,
+          prewarmConcurrency: 8,
+        },
+      },
+    };
+    const result = OpenClawSchema.safeParse(config);
+    expect(result.success).toBe(true);
+  });
+
+  test("zod schema rejects invalid sessionsList values", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const config = {
+      gateway: {
+        sessionsList: {
+          usageCacheMaxEntries: -1,
+        },
+      },
+    };
+    const result = OpenClawSchema.safeParse(config);
+    expect(result.success).toBe(false);
+  });
+
+  test("zod schema rejects unknown keys in sessionsList", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const config = {
+      gateway: {
+        sessionsList: {
+          unknownKey: true,
+        },
+      },
+    };
+    const result = OpenClawSchema.safeParse(config);
+    expect(result.success).toBe(false);
   });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -47,10 +47,14 @@ import {
   resolveAvatarMime,
 } from "../shared/avatar-policy.js";
 import { normalizeSessionDeliveryFields } from "../utils/delivery-context.js";
+import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import {
+  getSessionUsageCacheMaxEntries,
   readLatestSessionUsageFromTranscript,
+  readLatestSessionUsageFromTranscriptAsync,
   readSessionTitleFieldsFromTranscript,
+  setSessionUsageCacheMaxEntries,
 } from "./session-utils.fs.js";
 import type {
   GatewayAgentRow,
@@ -1294,4 +1298,148 @@ export function listSessionsFromStore(params: {
     defaults: getSessionDefaults(cfg),
     sessions,
   };
+}
+
+function needsTranscriptUsageFallback(params: {
+  cfg: OpenClawConfig;
+  entry?: SessionEntry;
+  fallbackProvider?: string;
+  fallbackModel?: string;
+}): boolean {
+  return (
+    resolvePositiveNumber(resolveFreshSessionTotalTokens(params.entry)) === undefined ||
+    resolvePositiveNumber(params.entry?.contextTokens) === undefined ||
+    resolveEstimatedSessionCostUsd({
+      cfg: params.cfg,
+      provider: params.fallbackProvider,
+      model: params.fallbackModel,
+      entry: params.entry,
+    }) === undefined
+  );
+}
+
+const DEFAULT_PREWARM_CONCURRENCY = 16;
+
+/**
+ * Pre-warm the session transcript caches (usage and title) by reading
+ * transcript files at gateway startup. Runs in the background so gateway
+ * startup is not delayed. Uses async I/O with bounded concurrency.
+ */
+export async function prewarmSessionUsageCache(params: {
+  cfg: OpenClawConfig;
+  log: { info: (msg: string) => void; warn: (msg: string) => void };
+}): Promise<void> {
+  const { cfg, log } = params;
+  // Apply cache limit immediately (before yielding) so early sessions.list
+  // requests see the configured capacity even while prewarm is deferred.
+  setSessionUsageCacheMaxEntries(cfg.gateway?.sessionsList?.usageCacheMaxEntries);
+
+  // Yield to the macrotask queue so the synchronous store scan below
+  // does not block early HTTP request handling. The HTTP server is
+  // already listening when startGatewaySidecars runs, so a microtask
+  // yield (Promise.resolve) is not sufficient.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  if (cfg.gateway?.sessionsList?.prewarmUsageCache !== true) {
+    return;
+  }
+
+  const concurrency = Math.max(
+    1,
+    Math.min(64, cfg.gateway?.sessionsList?.prewarmConcurrency ?? DEFAULT_PREWARM_CONCURRENCY),
+  );
+
+  const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
+  const resolvedStorePath = storePath === "(multiple)" ? undefined : storePath;
+  const entries = Object.entries(store);
+  const toWarm: Array<{
+    sessionId: string;
+    sessionFile?: string;
+    agentId: string;
+    needsUsage: boolean;
+  }> = [];
+
+  for (const [key, entry] of entries) {
+    if (isCronRunSessionKey(key) || !entry?.sessionId) {
+      continue;
+    }
+    const parsed = parseAgentSessionKey(key);
+    const agentId = parsed?.agentId ? normalizeAgentId(parsed.agentId) : resolveDefaultAgentId(cfg);
+    const resolvedModel = resolveSessionModelIdentityRef(cfg, entry, agentId);
+    const needsUsage = needsTranscriptUsageFallback({
+      cfg,
+      entry,
+      fallbackProvider: resolvedModel.provider,
+      fallbackModel: resolvedModel.model,
+    });
+    // Always warm title cache; only warm usage cache when metadata is missing.
+    toWarm.push({
+      sessionId: entry.sessionId,
+      sessionFile: entry.sessionFile,
+      agentId,
+      needsUsage,
+    });
+  }
+
+  if (toWarm.length === 0) {
+    return;
+  }
+
+  const usageCount = toWarm.filter((t) => t.needsUsage).length;
+  const currentMax = getSessionUsageCacheMaxEntries();
+  if (usageCount > currentMax) {
+    log.warn(
+      `[sessions] prewarm: ${usageCount} sessions need usage warming but usageCacheMaxEntries is ${currentMax}. ` +
+        `Only the last ${currentMax} will remain cached. Consider increasing gateway.sessionsList.usageCacheMaxEntries.`,
+    );
+  }
+
+  log.info(
+    `[sessions] prewarm: warming ${toWarm.length} session(s) (${usageCount} usage + ${toWarm.length} title, concurrency=${concurrency})`,
+  );
+
+  let usageAttempted = 0;
+  let usageFound = 0;
+  let titleWarmed = 0;
+  let failed = 0;
+
+  const tasks = toWarm.map((item) => async () => {
+    // Warm usage cache (async I/O)
+    if (item.needsUsage) {
+      const result = await readLatestSessionUsageFromTranscriptAsync(
+        item.sessionId,
+        resolvedStorePath,
+        item.sessionFile,
+        item.agentId,
+      );
+      usageAttempted++;
+      if (result !== null) {
+        usageFound++;
+      }
+    }
+    // Warm title cache (sync I/O). This is a partial file read (~1ms per file)
+    // reading only the head and tail of the transcript. An async variant does not
+    // exist yet; the sync call runs inside the concurrency limiter so at most
+    // `concurrency` reads overlap on the event loop at a time.
+    readSessionTitleFieldsFromTranscript(
+      item.sessionId,
+      resolvedStorePath,
+      item.sessionFile,
+      item.agentId,
+    );
+    titleWarmed++;
+  });
+
+  await runTasksWithConcurrency({
+    tasks,
+    limit: concurrency,
+    errorMode: "continue",
+    onTaskError: () => {
+      failed++;
+    },
+  });
+
+  log.info(
+    `[sessions] prewarm: done (usage=${usageFound}/${usageAttempted} title=${titleWarmed} failed=${failed})`,
+  );
 }


### PR DESCRIPTION
## Summary
- What changed: prewarmSessionUsageCache, prewarmUsageCache/prewarmConcurrency config, fire-and-forget startup
- What did NOT change: Default behavior (prewarm disabled)

## Change Type
- [x] Feature

## Scope
- [x] Gateway / orchestration

## Security Impact
All No.

## FAQ
### Q: Why setTimeout(0)?
A: HTTP server already listening. Microtask yield insufficient for I/O.
### Q: setSessionUsageCacheMaxEntries before yield?
A: Early requests see configured capacity immediately.
### Q: Sync title read in async tasks?
A: Partial read ~1ms, inside concurrency limiter. Async variant is follow-up.
### Q: usage=X/Y in log?
A: X=found data, Y=attempted. Difference is no-data transcripts.