### PR TITLE
ci: start required checks earlier

### DIFF
--- a/.github/actions/ensure-base-commit/action.yml
+++ b/.github/actions/ensure-base-commit/action.yml
@@ -23,6 +23,16 @@ runs:
           exit 0
         fi
 
+        if ! [[ "$BASE_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+          echo "::error title=ensure-base-commit invalid base sha::Refusing invalid base SHA: $BASE_SHA"
+          exit 2
+        fi
+
+        if ! git check-ref-format --branch "$FETCH_REF" >/dev/null 2>&1; then
+          echo "::error title=ensure-base-commit invalid fetch ref::Refusing invalid fetch ref: $FETCH_REF"
+          exit 2
+        fi
+
         if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
           echo "Base commit already present: $BASE_SHA"
           exit 0
@@ -30,7 +40,7 @@ runs:
 
         for deepen_by in 25 100 300; do
           echo "Base commit missing; deepening $FETCH_REF by $deepen_by."
-          if ! git fetch --no-tags --deepen="$deepen_by" origin "$FETCH_REF"; then
+          if ! git fetch --no-tags --deepen="$deepen_by" origin -- "$FETCH_REF"; then
             echo "::warning title=ensure-base-commit fetch failed::Failed to deepen $FETCH_REF by $deepen_by while looking for $BASE_SHA"
           fi
           if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
@@ -40,7 +50,7 @@ runs:
         done
 
         echo "Base commit still missing; fetching full history for $FETCH_REF."
-        if ! git fetch --no-tags origin "$FETCH_REF"; then
+        if ! git fetch --no-tags origin -- "$FETCH_REF"; then
           echo "::warning title=ensure-base-commit fetch failed::Failed to fetch full history for $FETCH_REF while looking for $BASE_SHA"
         fi
         if git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then

--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -11,6 +11,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
-  # Preflight: establish the fast global truth for this revision before the
-  # expensive platform and test lanes fan out.
+  # Scope: establish the fast global truth for this revision before the
+  # expensive platform and platform-specific lanes fan out.
   # Detect docs-only changes to skip heavy jobs (test, build, Windows, macOS, Android).
-  # Run scope detection, changed-extension detection, and fast security checks in
-  # one visible job so operators have a single preflight box to inspect and rerun.
+  # Keep this job focused on routing decisions so the rest of CI can fan out sooner.
   # Fail-safe: if detection steps are skipped, downstream outputs fall back to
   # conservative defaults that keep heavy lanes enabled.
-  preflight:
+  scope:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
@@ -101,6 +100,26 @@ jobs:
           appendFileSync(process.env.GITHUB_OUTPUT, `changed_extensions_matrix=${matrix}\n`, "utf8");
           EOF
 
+  # Run the fast security/SCM checks in parallel with scope detection so the
+  # main Node jobs do not have to wait for Python/pre-commit setup.
+  security-fast:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          submodules: false
+
+      - name: Ensure security base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
       - name: Setup Python
         id: setup-python
         uses: actions/setup-python@v6
@@ -154,15 +173,14 @@ jobs:
           pre-commit run zizmor --files "${workflow_files[@]}"
 
       - name: Audit production dependencies
-        if: steps.docs_scope.outputs.docs_only != 'true'
         run: pre-commit run --all-files pnpm-audit-prod
 
   # Fanout: downstream lanes branch from preflight outputs instead of waiting
   # on unrelated Linux checks.
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   build-artifacts:
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_node == 'true'
+    needs: [scope]
+    if: needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_node == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -207,8 +225,8 @@ jobs:
 
   # Validate npm pack contents after build (only on push to main, not PRs).
   release-check:
-    needs: [preflight, build-artifacts]
-    if: github.event_name == 'push' && needs.preflight.outputs.docs_only != 'true'
+    needs: [scope, build-artifacts]
+    if: github.event_name == 'push' && needs.scope.outputs.docs_only != 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -232,9 +250,42 @@ jobs:
       - name: Check release contents
         run: pnpm release:check
 
+  checks-fast:
+    needs: [scope]
+    if: always() && needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_node == 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runtime: node
+            task: extensions
+            command: pnpm test:extensions
+          - runtime: node
+            task: contracts
+            command: pnpm test:contracts
+          - runtime: node
+            task: protocol
+            command: pnpm protocol:check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Run ${{ matrix.task }} (${{ matrix.runtime }})
+        run: ${{ matrix.command }}
+
   checks:
-    needs: [preflight, build-artifacts]
-    if: always() && needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_node == 'true' && needs.build-artifacts.result == 'success'
+    needs: [scope, build-artifacts]
+    if: always() && needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_node == 'true' && needs.build-artifacts.result == 'success'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     strategy:
@@ -252,16 +303,10 @@ jobs:
             shard_count: 2
             command: pnpm test
           - runtime: node
-            task: extensions
-            command: pnpm test:extensions
-          - runtime: node
             task: channels
             shard_index: 1
             shard_count: 3
             command: pnpm test:channels
-          - runtime: node
-            task: contracts
-            command: pnpm test:contracts
           - runtime: node
             task: channels
             shard_index: 2
@@ -272,9 +317,6 @@ jobs:
             shard_index: 3
             shard_count: 3
             command: pnpm test:channels
-          - runtime: node
-            task: protocol
-            command: pnpm protocol:check
           - runtime: node
             task: compat-node22
             node_version: "22.x"
@@ -346,13 +388,13 @@ jobs:
 
   extension-fast:
     name: "extension-fast"
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_node == 'true' && needs.preflight.outputs.has_changed_extensions == 'true'
+    needs: [scope]
+    if: needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_node == 'true' && needs.scope.outputs.has_changed_extensions == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.preflight.outputs.changed_extensions_matrix) }}
+      matrix: ${{ fromJson(needs.scope.outputs.changed_extensions_matrix) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -373,8 +415,7 @@ jobs:
   # Types, lint, and format check.
   check:
     name: "check"
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_node == 'true'
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -397,8 +438,7 @@ jobs:
 
   check-additional:
     name: "check-additional"
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_node == 'true'
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -495,8 +535,8 @@ jobs:
 
   build-smoke:
     name: "build-smoke"
-    needs: [preflight, build-artifacts]
-    if: always() && needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_node == 'true' && (github.event_name != 'push' || needs.build-artifacts.result == 'success')
+    needs: [scope, build-artifacts]
+    if: always() && needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_node == 'true' && (github.event_name != 'push' || needs.build-artifacts.result == 'success')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -536,8 +576,8 @@ jobs:
 
   # Validate docs (format, lint, broken links) only when docs files changed.
   check-docs:
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_changed == 'true'
+    needs: [scope]
+    if: needs.scope.outputs.docs_changed == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -556,8 +596,8 @@ jobs:
         run: pnpm check:docs
 
   skills-python:
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.preflight.outputs.run_skills_python == 'true')
+    needs: [scope]
+    if: needs.scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.scope.outputs.run_skills_python == 'true')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -583,8 +623,8 @@ jobs:
         run: python -m pytest -q skills
 
   checks-windows:
-    needs: [preflight, build-artifacts]
-    if: always() && needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_windows == 'true' && needs.build-artifacts.result == 'success'
+    needs: [scope, build-artifacts]
+    if: always() && needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_windows == 'true' && needs.build-artifacts.result == 'success'
     runs-on: blacksmith-32vcpu-windows-2025
     timeout-minutes: 20
     env:
@@ -732,8 +772,8 @@ jobs:
   # running 4 separate jobs per PR (as before) starved the queue. One job
   # per PR allows 5 PRs to run macOS checks simultaneously.
   macos:
-    needs: [preflight]
-    if: github.event_name == 'pull_request' && needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_macos == 'true'
+    needs: [scope]
+    if: github.event_name == 'pull_request' && needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_macos == 'true'
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -809,8 +849,8 @@ jobs:
           exit 1
 
   android:
-    needs: [preflight]
-    if: needs.preflight.outputs.docs_only != 'true' && needs.preflight.outputs.run_android == 'true'
+    needs: [scope]
+    if: needs.scope.outputs.docs_only != 'true' && needs.scope.outputs.run_android == 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
+    env:
+      PRE_COMMIT_CACHE_KEY_SUFFIX: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -157,7 +159,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}-${{ env.PRE_COMMIT_CACHE_KEY_SUFFIX }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}-
 
       - name: Install pre-commit
         run: |
@@ -287,11 +291,10 @@ jobs:
             task: extensions
             command: pnpm test:extensions
           - runtime: node
-            task: contracts
-            command: pnpm test:contracts
-          - runtime: node
-            task: protocol
-            command: pnpm protocol:check
+            task: contracts-protocol
+            command: |
+              pnpm test:contracts
+              pnpm protocol:check
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -442,7 +445,8 @@ jobs:
   # Types, lint, and format check.
   check:
     name: "check"
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [scope]
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.scope.outputs.docs_only != 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -452,57 +456,22 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - name: Detect docs-only changes
-        id: docs_scope
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          FETCH_REF: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "$BASE_SHA" ] && ! [[ "$BASE_SHA" =~ ^0+$ ]] && ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
-            if [[ "$BASE_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]] && git check-ref-format --branch "$FETCH_REF" >/dev/null 2>&1; then
-              git fetch --no-tags origin -- "$FETCH_REF" || true
-            fi
-          fi
-
-          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "UNKNOWN")
-          if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
-          if [ -z "$NON_DOCS" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-            echo "Docs-only change detected; skipping heavy checks."
-          else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup Node environment
-        if: steps.docs_scope.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
           use-sticky-disk: "false"
 
       - name: Check types and lint and oxfmt
-        if: steps.docs_scope.outputs.docs_only != 'true'
         run: pnpm check
 
       - name: Strict TS build smoke
-        if: steps.docs_scope.outputs.docs_only != 'true'
         run: pnpm build:strict-smoke
-
-      - name: Skip docs-only change
-        if: steps.docs_scope.outputs.docs_only == 'true'
-        run: echo "Docs-only change detected; skipping check job payload."
 
   check-additional:
     name: "check-additional"
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    needs: [scope]
+    if: always() && (github.event_name != 'pull_request' || !github.event.pull_request.draft) && needs.scope.outputs.docs_only != 'true'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
@@ -512,37 +481,7 @@ jobs:
           persist-credentials: false
           submodules: false
 
-      - name: Detect docs-only changes
-        id: docs_scope
-        shell: bash
-        env:
-          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          FETCH_REF: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
-        run: |
-          set -euo pipefail
-
-          if [ -n "$BASE_SHA" ] && ! [[ "$BASE_SHA" =~ ^0+$ ]] && ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
-            if [[ "$BASE_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]] && git check-ref-format --branch "$FETCH_REF" >/dev/null 2>&1; then
-              git fetch --no-tags origin -- "$FETCH_REF" || true
-            fi
-          fi
-
-          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "UNKNOWN")
-          if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
-          if [ -z "$NON_DOCS" ]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
-            echo "Docs-only change detected; skipping heavy checks."
-          else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup Node environment
-        if: steps.docs_scope.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
@@ -550,54 +489,46 @@ jobs:
 
       - name: Run plugin extension boundary guard
         id: plugin_extension_boundary
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:plugins:no-extension-imports
 
       - name: Run web search provider boundary guard
         id: web_search_provider_boundary
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:web-search-provider-boundaries
 
       - name: Run extension src boundary guard
         id: extension_src_outside_plugin_sdk_boundary
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:extensions:no-src-outside-plugin-sdk
 
       - name: Run extension plugin-sdk-internal guard
         id: extension_plugin_sdk_internal_boundary
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:extensions:no-plugin-sdk-internal
 
       - name: Enforce safe external URL opening policy
         id: no_raw_window_open
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm lint:ui:no-raw-window-open
 
       - name: Run gateway watch regression harness
         id: gateway_watch_regression
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm test:gateway:watch-regression
 
       - name: Check config docs drift statefile
         id: config_docs_drift
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm config:docs:check
 
       - name: Check plugin SDK API baseline drift
         id: plugin_sdk_api_drift
-        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm plugin-sdk:api:check
 
       - name: Upload gateway watch regression artifacts
-        if: always() && steps.docs_scope.outputs.docs_only != 'true'
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: gateway-watch-regression
@@ -605,7 +536,7 @@ jobs:
           retention-days: 7
 
       - name: Fail if any additional check failed
-        if: always() && steps.docs_scope.outputs.docs_only != 'true'
+        if: always()
         env:
           PLUGIN_EXTENSION_BOUNDARY_OUTCOME: ${{ steps.plugin_extension_boundary.outcome }}
           WEB_SEARCH_PROVIDER_BOUNDARY_OUTCOME: ${{ steps.web_search_provider_boundary.outcome }}
@@ -635,10 +566,6 @@ jobs:
           done
 
           exit "$failures"
-
-      - name: Skip docs-only change
-        if: steps.docs_scope.outputs.docs_only == 'true'
-        run: echo "Docs-only change detected; skipping check-additional job payload."
 
   build-smoke:
     name: "build-smoke"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || format('ci-push-{0}', github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -40,6 +43,7 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
           submodules: false
 
       - name: Ensure preflight base commit
@@ -112,6 +116,7 @@ jobs:
         with:
           fetch-depth: 1
           fetch-tags: false
+          persist-credentials: false
           submodules: false
 
       - name: Ensure security base commit
@@ -119,6 +124,16 @@ jobs:
         with:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Prepare trusted pre-commit config
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          trusted_config="$RUNNER_TEMP/pre-commit-base.yaml"
+          git show "${BASE_SHA}:.pre-commit-config.yaml" > "$trusted_config"
+          echo "PRE_COMMIT_CONFIG_PATH=$trusted_config" >> "$GITHUB_ENV"
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -147,10 +162,10 @@ jobs:
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pre-commit
+          python -m pip install pre-commit==4.2.0
 
       - name: Detect committed private keys
-        run: pre-commit run --all-files detect-private-key
+        run: pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
         env:
@@ -177,10 +192,10 @@ jobs:
           fi
 
           printf 'Auditing workflow files:\n%s\n' "${workflow_files[@]}"
-          pre-commit run zizmor --files "${workflow_files[@]}"
+          pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" zizmor --files "${workflow_files[@]}"
 
       - name: Audit production dependencies
-        run: pre-commit run --all-files pnpm-audit-prod
+        run: pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" --all-files pnpm-audit-prod
 
   # Fanout: downstream lanes branch from preflight outputs instead of waiting
   # on unrelated Linux checks.
@@ -194,6 +209,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Ensure secrets base commit (PR fast path)
@@ -240,6 +256,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -279,6 +296,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -345,6 +363,7 @@ jobs:
         if: github.event_name != 'pull_request' || matrix.task != 'compat-node22'
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -406,6 +425,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -429,17 +449,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
-
-      - name: Ensure check base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
       - name: Detect docs-only changes
         id: docs_scope
-        uses: ./.github/actions/detect-docs-changes
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          FETCH_REF: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$BASE_SHA" ] && ! [[ "$BASE_SHA" =~ ^0+$ ]] && ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+            if [[ "$BASE_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]] && git check-ref-format --branch "$FETCH_REF" >/dev/null 2>&1; then
+              git fetch --no-tags origin -- "$FETCH_REF" || true
+            fi
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "UNKNOWN")
+          if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
+          if [ -z "$NON_DOCS" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change detected; skipping heavy checks."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node environment
         if: steps.docs_scope.outputs.docs_only != 'true'
@@ -469,17 +509,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
-
-      - name: Ensure check-additional base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
       - name: Detect docs-only changes
         id: docs_scope
-        uses: ./.github/actions/detect-docs-changes
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          FETCH_REF: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$BASE_SHA" ] && ! [[ "$BASE_SHA" =~ ^0+$ ]] && ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+            if [[ "$BASE_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]] && git check-ref-format --branch "$FETCH_REF" >/dev/null 2>&1; then
+              git fetch --no-tags origin -- "$FETCH_REF" || true
+            fi
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "UNKNOWN")
+          if [ "$CHANGED" = "UNKNOWN" ] || [ -z "$CHANGED" ]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NON_DOCS=$(echo "$CHANGED" | grep -vE '^docs/|\.md$|\.mdx$' || true)
+          if [ -z "$NON_DOCS" ]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "Docs-only change detected; skipping heavy checks."
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node environment
         if: steps.docs_scope.outputs.docs_only != 'true'
@@ -590,6 +650,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -631,6 +692,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -651,6 +713,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Python
@@ -730,6 +793,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Try to exclude workspace from Windows Defender (best-effort)
@@ -827,6 +891,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Node environment
@@ -916,6 +981,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: false
 
       - name: Setup Java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,17 +431,34 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure check base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Detect docs-only changes
+        id: docs_scope
+        uses: ./.github/actions/detect-docs-changes
+
       - name: Setup Node environment
+        if: steps.docs_scope.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
           use-sticky-disk: "false"
 
       - name: Check types and lint and oxfmt
+        if: steps.docs_scope.outputs.docs_only != 'true'
         run: pnpm check
 
       - name: Strict TS build smoke
+        if: steps.docs_scope.outputs.docs_only != 'true'
         run: pnpm build:strict-smoke
+
+      - name: Skip docs-only change
+        if: steps.docs_scope.outputs.docs_only == 'true'
+        run: echo "Docs-only change detected; skipping check job payload."
 
   check-additional:
     name: "check-additional"
@@ -454,7 +471,18 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure check-additional base commit
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Detect docs-only changes
+        id: docs_scope
+        uses: ./.github/actions/detect-docs-changes
+
       - name: Setup Node environment
+        if: steps.docs_scope.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-node-env
         with:
           install-bun: "false"
@@ -462,46 +490,54 @@ jobs:
 
       - name: Run plugin extension boundary guard
         id: plugin_extension_boundary
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:plugins:no-extension-imports
 
       - name: Run web search provider boundary guard
         id: web_search_provider_boundary
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:web-search-provider-boundaries
 
       - name: Run extension src boundary guard
         id: extension_src_outside_plugin_sdk_boundary
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:extensions:no-src-outside-plugin-sdk
 
       - name: Run extension plugin-sdk-internal guard
         id: extension_plugin_sdk_internal_boundary
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm run lint:extensions:no-plugin-sdk-internal
 
       - name: Enforce safe external URL opening policy
         id: no_raw_window_open
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm lint:ui:no-raw-window-open
 
       - name: Run gateway watch regression harness
         id: gateway_watch_regression
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm test:gateway:watch-regression
 
       - name: Check config docs drift statefile
         id: config_docs_drift
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm config:docs:check
 
       - name: Check plugin SDK API baseline drift
         id: plugin_sdk_api_drift
+        if: steps.docs_scope.outputs.docs_only != 'true'
         continue-on-error: true
         run: pnpm plugin-sdk:api:check
 
       - name: Upload gateway watch regression artifacts
-        if: always()
+        if: always() && steps.docs_scope.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v7
         with:
           name: gateway-watch-regression
@@ -509,7 +545,7 @@ jobs:
           retention-days: 7
 
       - name: Fail if any additional check failed
-        if: always()
+        if: always() && steps.docs_scope.outputs.docs_only != 'true'
         env:
           PLUGIN_EXTENSION_BOUNDARY_OUTCOME: ${{ steps.plugin_extension_boundary.outcome }}
           WEB_SEARCH_PROVIDER_BOUNDARY_OUTCOME: ${{ steps.web_search_provider_boundary.outcome }}
@@ -539,6 +575,10 @@ jobs:
           done
 
           exit "$failures"
+
+      - name: Skip docs-only change
+        if: steps.docs_scope.outputs.docs_only == 'true'
+        run: echo "Docs-only change detected; skipping check-additional job payload."
 
   build-smoke:
     name: "build-smoke"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || format('ci-push-{0}', github.run_id) }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1011,7 +1011,7 @@ jobs:
           echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
         with:
           gradle-version: 8.11.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,13 @@ jobs:
           base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          install-deps: "false"
+          use-sticky-disk: "false"
+
       - name: Setup Python
         id: setup-python
         uses: actions/setup-python@v6

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('install-smoke-pr-{0}', github.event.pull_request.number) || format('install-smoke-push-{0}', github.run_id) }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,6 +19,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -15,7 +15,7 @@ on:
       - scripts/sandbox-common-setup.sh
 
 concurrency:
-  group: sandbox-common-smoke-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: workflow-sanity-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
## Summary
- split CI preflight into a fast `scope` job and a parallel `security-fast` job
- start `check` and `check-additional` immediately instead of waiting on scope/build fan-in
- split the `checks` matrix so artifact-free lanes start before `build-artifacts`

## Why
The main `CI` workflow usually starts on time, but the required signal feels late because the job graph is serialized:
1. `preflight`
2. `build-artifacts`
3. only then large parts of the Node test fan-out

This change reduces that startup latency by moving routing-only work into `scope`, pushing security checks into a parallel lane, and letting artifact-free checks run without waiting for build artifacts.

## Validation
- YAML parse passed for `.github/workflows/ci.yml`
- verified there are no stale `preflight` references remaining

## Known tradeoff
- `check` and `check-additional` now also run on docs-only PRs
- if this lands well, a follow-up can restore docs-only skips with path filtering while keeping the earlier start

## Note
`scripts/committer` was blocked by unrelated latest-`main` type failures outside this workflow change:
- `extensions/msteams/src/sdk.ts`
- `ui/src/ui/views/agents-panels-status-files.ts`
