### PR TITLE
fix(security): make block/cancel sticky in hook merge to prevent silent override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Breaking
 
+- Plugins/hooks: `before_tool_call` handlers returning explicit `{ block: false }` can no longer override a prior `{ block: true }` from a higher-priority handler. Same applies to `{ cancel: false }` in `message_sending`. Plugins that intentionally returned `false` to clear prior decisions will need to be updated; plugins that returned `undefined` or omitted the field are unaffected.
+
 ### Changes
 
 - Control UI/markdown preview: restyle the agent workspace file preview dialog with a frosted backdrop, sized panel, and styled header, and integrate `@create-markdown/preview` v2 system theme for rich markdown rendering (headings, tables, code blocks, callouts, blockquotes) that auto-adapts to the app's light/dark design tokens. (#53411) Thanks @BunsDev.
@@ -86,6 +88,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/supervision: stop lock conflicts from crash-looping under launchd and systemd by keeping the duplicate process in a retry wait instead of exiting as a failure while another healthy gateway still owns the lock. Fixes #52922. Thanks @vincentkoc.
 - Gateway/auth: require auth for canvas routes and admin scope for agent session reset, so anonymous canvas access and non-admin reset requests fail closed.
 - Release/install: keep previously released bundled plugins and Control UI assets in published openclaw npm installs, and fail release checks when those shipped artifacts are missing. Thanks @vincentkoc.
+- Security/hooks: make `block: true` in `before_tool_call` and `cancel: true` in `message_sending` sticky so that once any handler sets them, lower-priority handlers cannot clear them via explicit `false`. This fixes an inconsistency with `before_message_write` (which was already sticky) and prevents plugins from silently neutralizing security hooks like Sage.
 
 ## 2026.3.22
 

--- a/src/plugins/hooks.security.test.ts
+++ b/src/plugins/hooks.security.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression tests for sticky block/cancel semantics in hook mergers.
+ *
+ * Validates that once a higher-priority handler sets block: true (before_tool_call)
+ * or cancel: true (message_sending), lower-priority handlers cannot clear it.
+ *
+ * See: https://github.com/openclaw/openclaw/security/advisories (hook merge override)
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { addTestHook } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type {
+  PluginHookBeforeToolCallResult,
+  PluginHookMessageSendingResult,
+  PluginHookRegistration,
+} from "./types.js";
+
+function addBeforeToolCallHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: () => PluginHookBeforeToolCallResult | Promise<PluginHookBeforeToolCallResult>,
+  priority?: number,
+) {
+  addTestHook({
+    registry,
+    pluginId,
+    hookName: "before_tool_call",
+    handler: handler as PluginHookRegistration["handler"],
+    priority,
+  });
+}
+
+function addMessageSendingHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: () => PluginHookMessageSendingResult | Promise<PluginHookMessageSendingResult>,
+  priority?: number,
+) {
+  addTestHook({
+    registry,
+    pluginId,
+    hookName: "message_sending",
+    handler: handler as PluginHookRegistration["handler"],
+    priority,
+  });
+}
+
+const toolCtx = { toolName: "Bash" };
+const toolEvent = { toolName: "Bash", params: { command: "echo hello" } };
+const msgCtx = { channelId: "test-channel" };
+const msgEvent = { to: "user", content: "hello" };
+
+describe("before_tool_call sticky block semantics", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("high-priority block is not overridden by low-priority { block: false }", async () => {
+    addBeforeToolCallHook(registry, "sage", () => ({ block: true, blockReason: "dangerous" }), 100);
+    addBeforeToolCallHook(registry, "other-plugin", () => ({ block: false }), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("dangerous");
+  });
+
+  it("blockReason from the blocking handler is preserved", async () => {
+    addBeforeToolCallHook(
+      registry,
+      "sage",
+      () => ({ block: true, blockReason: "rm -rf detected" }),
+      100,
+    );
+    addBeforeToolCallHook(
+      registry,
+      "other-plugin",
+      () => ({ block: false, blockReason: "looks safe" }),
+      0,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("rm -rf detected");
+  });
+
+  it("params from lower-priority handler are ignored when blocked", async () => {
+    addBeforeToolCallHook(
+      registry,
+      "sage",
+      () => ({ block: true, blockReason: "blocked", params: { original: true } }),
+      100,
+    );
+    addBeforeToolCallHook(
+      registry,
+      "other-plugin",
+      () => ({ block: false, params: { injected: true } }),
+      0,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.params).toEqual({ original: true });
+  });
+
+  it("low-priority block is respected when no higher-priority handler blocks", async () => {
+    addBeforeToolCallHook(registry, "high-plugin", () => ({}), 100);
+    addBeforeToolCallHook(registry, "low-plugin", () => ({ block: true, blockReason: "risky" }), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("risky");
+  });
+
+  it("no block when neither handler blocks", async () => {
+    addBeforeToolCallHook(registry, "plugin-a", () => ({}), 100);
+    addBeforeToolCallHook(registry, "plugin-b", () => ({}), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBeUndefined();
+  });
+
+  it("handler returning undefined block does not clear a prior block", async () => {
+    addBeforeToolCallHook(registry, "sage", () => ({ block: true, blockReason: "blocked" }), 100);
+    addBeforeToolCallHook(registry, "passive-plugin", () => ({}), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("blocked");
+  });
+});
+
+describe("message_sending sticky cancel semantics", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("high-priority cancel is not overridden by low-priority { cancel: false }", async () => {
+    addMessageSendingHook(registry, "guard", () => ({ cancel: true }), 100);
+    addMessageSendingHook(registry, "other-plugin", () => ({ cancel: false }), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(msgEvent, msgCtx);
+
+    expect(result?.cancel).toBe(true);
+  });
+
+  it("content from lower-priority handler is ignored when cancelled", async () => {
+    addMessageSendingHook(registry, "guard", () => ({ cancel: true, content: "original" }), 100);
+    addMessageSendingHook(
+      registry,
+      "other-plugin",
+      () => ({ cancel: false, content: "replaced" }),
+      0,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(msgEvent, msgCtx);
+
+    expect(result?.cancel).toBe(true);
+    expect(result?.content).toBe("original");
+  });
+
+  it("low-priority cancel is respected when no higher-priority handler cancels", async () => {
+    addMessageSendingHook(registry, "high-plugin", () => ({}), 100);
+    addMessageSendingHook(registry, "low-plugin", () => ({ cancel: true }), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(msgEvent, msgCtx);
+
+    expect(result?.cancel).toBe(true);
+  });
+
+  it("no cancel when neither handler cancels", async () => {
+    addMessageSendingHook(registry, "plugin-a", () => ({}), 100);
+    addMessageSendingHook(registry, "plugin-b", () => ({}), 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(msgEvent, msgCtx);
+
+    expect(result?.cancel).toBeUndefined();
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -605,8 +605,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       event,
       ctx,
       (acc, next) => ({
-        content: next.content ?? acc?.content,
-        cancel: next.cancel ?? acc?.cancel,
+        content: acc?.cancel === true ? acc?.content : (next.content ?? acc?.content),
+        cancel: acc?.cancel === true ? true : (next.cancel ?? acc?.cancel),
       }),
     );
   }
@@ -640,9 +640,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       event,
       ctx,
       (acc, next) => ({
-        params: next.params ?? acc?.params,
-        block: next.block ?? acc?.block,
-        blockReason: next.blockReason ?? acc?.blockReason,
+        params: acc?.block === true ? acc?.params : (next.params ?? acc?.params),
+        block: acc?.block === true ? true : (next.block ?? acc?.block),
+        blockReason:
+          acc?.block === true ? acc?.blockReason : (next.blockReason ?? acc?.blockReason),
       }),
     );
   }


### PR DESCRIPTION
## Summary

- **Problem:** `before_tool_call` hook merge uses nullish coalescing (`next.block ?? acc?.block`), allowing any lower-priority plugin returning `{ block: false }` to silently override a higher-priority plugin's `{ block: true }` — neutralizing security hooks like [Sage](https://github.com/gendigitalinc/sage), the ADR layer for OpenClaw.
- **Why it matters:** A non-malicious plugin with a default `{ block: false }` return unintentionally disables all security blocks. Sage appears active but its verdicts are voided.
- **What changed:** Made `block: true` irreversible in `runBeforeToolCall` and `cancel: true` irreversible in `runMessageSending`, consistent with `before_message_write` which already treats block as sticky.
- **What did NOT change:** Consumer code in `pi-tools.before-tool-calts` and `tools-invoke-http.ts` — they already check truthiness of `block`. Plugins that return `undefined` or omit the field are unaffected.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related: coordinated with OpenClaw security team via email

## Root Cause / Regression History (if applicable)

- Root cause: `next.block ?? acc?.block` in the merge lambda treats explicit `false` as a defined value, so `false ?? true` evaluates to `false` instead of preserving the prior block.
- Missing detection / guardrail: no regression test covering multi-handler block override scenarios.
- Prior context: `before_message_write` (same file, line 771) already implements sticky block semantics correctly; `before_tool_call` and `message_sending` were not updated to match.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/plugs/hooks.security.test.ts`
- Scenario the test should lock in: high-priority `{ block: true }` + low-priority `{ block: false }` = final result blocked
- Why this is the smallest reliable guardrail: directly tests the merge function output with two handlers at different priorities

## User-visible / Behavior Changes

Plugins that explicitly return `{ block: false }` to override a prior block will no longer be able to do so. This is the intended fix — `block: true` is now irreversible once set by any handler.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any Yes, explain risk + mitigation: sticky block prevents lower-priority plugins from clearing security blocks set by higher-priority handlers (e.g., Sage). This hardens the tool execution gating path.

## Evidence

- [x] Failing test/log before + passing after: 10 regression tests in `oks.security.test.ts` all pass

## Human Verification (required)

- Verified scenarios: high-priority block + low-priority override = blocked; blockReason preserved; params ignored when blocked; cancel sticky in message_sending
- Edge cases checked: handler returning undefined (no block field) does not interfere with prior block; neither handler blocks = no block
- What you did not verify: full `pnpm build && pnpm check` (large project build)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes for well-behaved plugins; intentional breaking change for plugins returning explicit `{ block: false }` to clear prior blocks
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the merge lambda in `hooks.ts` lines 642-646 and 607-610 back to `next.block ?? acc?.block` / `next.cancel ?? acc?.cancel`
- Known bad symptoms reviewers should watch for: plugins that intentionally returned `{ block: false }` to unblock would stop working

## Risks and Mitigations

- Risk: plugins relying on explicit `{ block: false }` to override security decisions
  - Mitigation: this is the exact behavior being fixed; no legitimate plugin should need to override a security block