### PR TITLE
fix(discord): catch thrown errors from gateway WebSocket close handler

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -1,0 +1,87 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { __gatewayPluginTesting } from "./gateway-plugin.js";
+
+const { wrapWebSocketWithErrorGuard } = __gatewayPluginTesting;
+
+describe("wrapWebSocketWithErrorGuard", () => {
+  function createMockWebSocket() {
+    const emitter = new EventEmitter();
+    return emitter as unknown as import("ws").WebSocket;
+  }
+
+  it("passes through non-close events unchanged", () => {
+    const ws = createMockWebSocket();
+    const wrapped = wrapWebSocketWithErrorGuard(ws);
+    const messageHandler = vi.fn();
+
+    wrapped.on("message", messageHandler);
+    wrapped.emit("message", "hello");
+
+    expect(messageHandler).toHaveBeenCalledWith("hello");
+  });
+
+  it("passes through close events when no error is thrown", () => {
+    const ws = createMockWebSocket();
+    const wrapped = wrapWebSocketWithErrorGuard(ws);
+    const closeHandler = vi.fn();
+
+    wrapped.on("close", closeHandler);
+    wrapped.emit("close", 1000, "normal");
+
+    expect(closeHandler).toHaveBeenCalledWith(1000, "normal");
+  });
+
+  it("converts thrown errors during close to error events (#53644)", async () => {
+    const ws = createMockWebSocket();
+    const wrapped = wrapWebSocketWithErrorGuard(ws);
+    const errorHandler = vi.fn();
+
+    const thrownError = new Error("Max reconnect attempts (0) reached after code 1006");
+
+    wrapped.on("close", () => {
+      throw thrownError;
+    });
+    wrapped.on("error", errorHandler);
+
+    // The emit should not throw
+    expect(() => wrapped.emit("close", 1006, "abnormal")).not.toThrow();
+
+    // Wait for setImmediate to fire
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(errorHandler).toHaveBeenCalledWith(thrownError);
+  });
+
+  it("does not convert thrown errors from non-close events", () => {
+    const ws = createMockWebSocket();
+    const wrapped = wrapWebSocketWithErrorGuard(ws);
+    const thrownError = new Error("some other error");
+
+    wrapped.on("message", () => {
+      throw thrownError;
+    });
+
+    // Non-close events should still throw (Node.js default EventEmitter behavior)
+    expect(() => wrapped.emit("message", "test")).toThrow(thrownError);
+  });
+
+  it("returns true from emit when close handler throws", async () => {
+    const ws = createMockWebSocket();
+    const wrapped = wrapWebSocketWithErrorGuard(ws);
+    const errorHandler = vi.fn();
+
+    wrapped.on("close", () => {
+      throw new Error("close error");
+    });
+    // Add error handler to prevent unhandled error in test
+    wrapped.on("error", errorHandler);
+
+    const result = wrapped.emit("close", 1006);
+    expect(result).toBe(true);
+
+    // Wait for setImmediate to fire
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(errorHandler).toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -84,4 +84,22 @@ describe("wrapWebSocketWithErrorGuard", () => {
     await new Promise((resolve) => setImmediate(resolve));
     expect(errorHandler).toHaveBeenCalled();
   });
+
+  it("swallows error when no error listeners are registered during setImmediate", async () => {
+    const ws = createMockWebSocket();
+    const wrapped = wrapWebSocketWithErrorGuard(ws);
+
+    wrapped.on("close", () => {
+      throw new Error("close error with no listeners");
+    });
+
+    // No error handler registered - should not throw
+    expect(() => wrapped.emit("close", 1006)).not.toThrow();
+
+    // Wait for setImmediate to fire - should swallow the error (log it)
+    // and not throw an uncaught exception
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // If we get here without an uncaught exception, the test passes
+  });
 });

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -225,6 +225,11 @@ function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; error: u
  * GatewayPlugin from crashing the process when it throws "Max reconnect attempts"
  * errors instead of emitting them.
  *
+ * Known limitation: if a close handler throws, remaining close listeners registered
+ * after it will be skipped (standard EventEmitter behavior). Carbon currently
+ * registers a single close handler, so this is not an issue, but should be
+ * revisited if Carbon's close handler count changes.
+ *
  * @see https://github.com/openclaw/openclaw/issues/53644
  */
 function wrapWebSocketWithErrorGuard(ws: WebSocket): WebSocket {
@@ -241,7 +246,16 @@ function wrapWebSocketWithErrorGuard(ws: WebSocket): WebSocket {
         // error handling in provider.lifecycle.ts can process it gracefully.
         // Use setImmediate to avoid re-entrancy issues with emit.
         setImmediate(() => {
-          originalEmit("error", error);
+          // Guard against missing error listeners: if Carbon cleaned up listeners
+          // before setImmediate fires, emitting 'error' with no listeners would
+          // throw an uncaught exception (Node.js EventEmitter contract).
+          if (emitter.listenerCount("error") > 0) {
+            originalEmit("error", error);
+          } else {
+            logVerbose(
+              `discord gateway: no error listeners, swallowing close error: ${String(error)}`,
+            );
+          }
         });
         return true;
       }

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -1,8 +1,9 @@
+import type { EventEmitter } from "node:events";
 import { GatewayIntents, GatewayPlugin } from "@buape/carbon/gateway";
 import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import WebSocket from "ws";
@@ -218,6 +219,39 @@ function resolveGatewayInfoWithFallback(params: { runtime?: RuntimeEnv; error: u
   };
 }
 
+/**
+ * Wraps a WebSocket to catch errors thrown by event handlers (particularly the
+ * 'close' event) and convert them to 'error' events. This prevents Carbon's
+ * GatewayPlugin from crashing the process when it throws "Max reconnect attempts"
+ * errors instead of emitting them.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/53644
+ */
+function wrapWebSocketWithErrorGuard(ws: WebSocket): WebSocket {
+  const emitter = ws as EventEmitter;
+  const originalEmit = emitter.emit.bind(emitter);
+
+  emitter.emit = function wrappedEmit(eventName: string | symbol, ...args: unknown[]) {
+    if (eventName === "close") {
+      try {
+        return originalEmit(eventName, ...args);
+      } catch (error) {
+        logVerbose(`discord gateway: caught thrown error during WebSocket close: ${String(error)}`);
+        // Convert the thrown error to an emitted 'error' event so existing
+        // error handling in provider.lifecycle.ts can process it gracefully.
+        // Use setImmediate to avoid re-entrancy issues with emit.
+        setImmediate(() => {
+          originalEmit("error", error);
+        });
+        return true;
+      }
+    }
+    return originalEmit(eventName, ...args);
+  } as typeof emitter.emit;
+
+  return ws;
+}
+
 function createGatewayPlugin(params: {
   options: {
     reconnect: { maxAttempts: number };
@@ -255,10 +289,10 @@ function createGatewayPlugin(params: {
     }
 
     override createWebSocket(url: string) {
-      if (!params.wsAgent) {
-        return super.createWebSocket(url);
-      }
-      return new WebSocket(url, { agent: params.wsAgent });
+      const ws = params.wsAgent
+        ? new WebSocket(url, { agent: params.wsAgent })
+        : super.createWebSocket(url);
+      return wrapWebSocketWithErrorGuard(ws as WebSocket);
     }
   }
 
@@ -307,3 +341,7 @@ export function createDiscordGatewayPlugin(params: {
     });
   }
 }
+
+export const __gatewayPluginTesting = {
+  wrapWebSocketWithErrorGuard,
+};


### PR DESCRIPTION
## Summary

When the Discord WebSocket drops with code 1006 (abnormal closure), the internal `@buape/carbon` GatewayPlugin **throws** an exception (`Max reconnect attempts (0) reached after code 1006`) instead of emitting it as an error event. This thrown exception bypasses OpenClaw's lifecycle error handling and crashes the entire gateway process.

This PR wraps the WebSocket's `emit` method to catch errors thrown during the `close` event and converts them to emitted `error` events, allowing the existing error handling in `provider.lifecycle.ts` to process them gracefully.

## Changes

- Added `wrapWebSocketWithErrorGuard()` helper that intercepts the WebSocket's `emit` method and wraps close event handlers in try-catch
- Modified `SafeGatewayPlugin.createWebSocket()` to apply the error guard to all WebSocket instances
- Added comprehensive tests for the error wrapping behavior

## Root Cause

The Carbon library's `GatewayPlugin.handleReconnectionAttempt()` throws an error when reconnect attempts are exhausted. This error originates in a WebSocket event callback, so it escapes the normal Promise/async error handling and becomes an uncaught exception that Node.js cannot catch without a process-level handler.

## Test Plan

- [x] Added unit tests for `wrapWebSocketWithErrorGuard`
- [x] Verified existing `provider.lifecycle.test.ts` tests still pass
- [x] Verified all related gateway tests pass

Fixes #53644

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
