### PR TITLE
fix(runtime): stabilize dist runtime artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Discord/config types: add missing `autoArchiveDuration` to `DiscordGuildChannelConfig` so TypeScript config definitions match the existing schema and runtime support. (#43427) Thanks @davidguttman.
 - Feishu/startup: treat unresolved `SecretRef` app credentials as not configured during account resolution so CLI startup and read-only Feishu config surfaces stop crashing before runtime-backed secret resolution is available. (#53675) Thanks @hpt.
 - WhatsApp/groups: track recent gateway-sent message IDs and suppress only matching group echoes, preserving owner `/status`, `/new`, and `/activation` commands from linked-account `fromMe` traffic. (#53624) Thanks @w-sss.
+- Runtime/build: stabilize long-lived lazy `dist` runtime entry paths and harden bundled plugin npm staging so local rebuilds stop breaking on missing hashed chunks or broken shell `npm` shims. (#53855) Thanks @vincentkoc.
 
 ## 2026.3.23
 

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -90,14 +90,6 @@ export function resolveNpmRunner(params = {}) {
   const pathImpl = platform === "win32" ? path.win32 : path;
   const nodeDir = pathImpl.dirname(execPath);
   const npmCliPath = pathImpl.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js");
-  const npmExecPath = env.npm_execpath;
-  if (typeof npmExecPath === "string" && isNpmExecPath(npmExecPath)) {
-    return {
-      command: execPath,
-      args: [npmExecPath],
-      shell: false,
-    };
-  }
   if (existsSync(npmCliPath)) {
     return {
       command: execPath,
@@ -120,10 +112,6 @@ export function resolveNpmRunner(params = {}) {
           : nodeDir,
     },
   };
-}
-
-function isNpmExecPath(value) {
-  return /^npm(?:-cli)?(?:\.(?:c?js|cmd|exe))?$/.test(path.basename(value).toLowerCase());
 }
 
 function resolvePathEnvKey(env) {

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
+const WINDOWS_UNSAFE_CMD_CHARS_RE = /[&|<>^%\r\n]/;
+
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
@@ -84,27 +86,42 @@ function sanitizeBundledManifestForRuntimeInstall(pluginDir) {
 
 export function resolveNpmRunner(params = {}) {
   const execPath = params.execPath ?? process.execPath;
+  const npmArgs = params.npmArgs ?? [];
   const existsSync = params.existsSync ?? fs.existsSync;
   const env = params.env ?? process.env;
   const platform = params.platform ?? process.platform;
+  const comSpec = params.comSpec ?? env.ComSpec ?? "cmd.exe";
   const pathImpl = platform === "win32" ? path.win32 : path;
   const nodeDir = pathImpl.dirname(execPath);
-  const npmCliPath = resolveToolchainNpmCliPath({ existsSync, nodeDir, pathImpl });
-  if (npmCliPath) {
-    return {
-      command: execPath,
-      args: [npmCliPath],
-      shell: false,
-    };
+  const npmToolchain = resolveToolchainNpmRunner({
+    comSpec,
+    existsSync,
+    nodeDir,
+    npmArgs,
+    pathImpl,
+    platform,
+  });
+  if (npmToolchain) {
+    return npmToolchain;
   }
   if (platform === "win32") {
-    throw new Error(`failed to resolve a toolchain-local npm CLI next to ${execPath}`);
+    const expectedPaths = [
+      pathImpl.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
+      pathImpl.resolve(nodeDir, "node_modules/npm/bin/npm-cli.js"),
+      pathImpl.resolve(nodeDir, "npm.exe"),
+      pathImpl.resolve(nodeDir, "npm.cmd"),
+    ];
+    throw new Error(
+      `failed to resolve a toolchain-local npm next to ${execPath}. ` +
+        `Checked: ${expectedPaths.join(", ")}. ` +
+        "OpenClaw refuses to shell out to bare npm on Windows; install a Node.js toolchain that bundles npm or run with a matching Node installation.",
+    );
   }
   const pathKey = resolvePathEnvKey(env);
   const currentPath = env[pathKey];
   return {
     command: "npm",
-    args: [],
+    args: npmArgs,
     shell: false,
     env: {
       ...env,
@@ -116,25 +133,67 @@ export function resolveNpmRunner(params = {}) {
   };
 }
 
-function resolveToolchainNpmCliPath(params) {
-  const candidates = [
+function resolveToolchainNpmRunner(params) {
+  const npmCliCandidates = [
     params.pathImpl.resolve(params.nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
     params.pathImpl.resolve(params.nodeDir, "node_modules/npm/bin/npm-cli.js"),
   ];
-  return candidates.find((candidate) => params.existsSync(candidate));
+  const npmCliPath = npmCliCandidates.find((candidate) => params.existsSync(candidate));
+  if (npmCliPath) {
+    return {
+      command:
+        params.platform === "win32"
+          ? params.pathImpl.join(params.nodeDir, "node.exe")
+          : params.pathImpl.join(params.nodeDir, "node"),
+      args: [npmCliPath, ...params.npmArgs],
+      shell: false,
+    };
+  }
+  if (params.platform !== "win32") {
+    return null;
+  }
+  const npmExePath = params.pathImpl.resolve(params.nodeDir, "npm.exe");
+  if (params.existsSync(npmExePath)) {
+    return {
+      command: npmExePath,
+      args: params.npmArgs,
+      shell: false,
+    };
+  }
+  const npmCmdPath = params.pathImpl.resolve(params.nodeDir, "npm.cmd");
+  if (params.existsSync(npmCmdPath)) {
+    return {
+      command: params.comSpec,
+      args: ["/d", "/s", "/c", buildCmdExeCommandLine(npmCmdPath, params.npmArgs)],
+      shell: false,
+      windowsVerbatimArguments: true,
+    };
+  }
+  return null;
 }
 
 function resolvePathEnvKey(env) {
   return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
 }
 
+function escapeForCmdExe(arg) {
+  if (WINDOWS_UNSAFE_CMD_CHARS_RE.test(arg)) {
+    throw new Error(`unsafe Windows cmd.exe argument detected: ${JSON.stringify(arg)}`);
+  }
+  if (!arg.includes(" ") && !arg.includes('"')) {
+    return arg;
+  }
+  return `"${arg.replace(/"/g, '""')}"`;
+}
+
+function buildCmdExeCommandLine(command, args) {
+  return [escapeForCmdExe(command), ...args.map(escapeForCmdExe)].join(" ");
+}
+
 function installPluginRuntimeDeps(pluginDir, pluginId) {
   sanitizeBundledManifestForRuntimeInstall(pluginDir);
-  const npmRunner = resolveNpmRunner();
-  const result = spawnSync(
-    npmRunner.command,
-    [
-      ...npmRunner.args,
+  const npmRunner = resolveNpmRunner({
+    npmArgs: [
       "install",
       "--omit=dev",
       "--silent",
@@ -142,12 +201,17 @@ function installPluginRuntimeDeps(pluginDir, pluginId) {
       "--legacy-peer-deps",
       "--package-lock=false",
     ],
+  });
+  const result = spawnSync(
+    npmRunner.command,
+    npmRunner.args,
     {
       cwd: pluginDir,
       encoding: "utf8",
       env: npmRunner.env,
       stdio: "pipe",
       shell: npmRunner.shell,
+      windowsVerbatimArguments: npmRunner.windowsVerbatimArguments,
     },
   );
   if (result.status === 0) {

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -85,9 +85,19 @@ function sanitizeBundledManifestForRuntimeInstall(pluginDir) {
 export function resolveNpmRunner(params = {}) {
   const execPath = params.execPath ?? process.execPath;
   const existsSync = params.existsSync ?? fs.existsSync;
+  const env = params.env ?? process.env;
   const platform = params.platform ?? process.platform;
-  const nodeDir = path.dirname(execPath);
-  const npmCliPath = path.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js");
+  const pathImpl = platform === "win32" ? path.win32 : path;
+  const nodeDir = pathImpl.dirname(execPath);
+  const npmCliPath = pathImpl.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js");
+  const npmExecPath = env.npm_execpath;
+  if (typeof npmExecPath === "string" && isNpmExecPath(npmExecPath)) {
+    return {
+      command: execPath,
+      args: [npmExecPath],
+      shell: false,
+    };
+  }
   if (existsSync(npmCliPath)) {
     return {
       command: execPath,
@@ -95,11 +105,29 @@ export function resolveNpmRunner(params = {}) {
       shell: false,
     };
   }
+  const pathKey = resolvePathEnvKey(env);
+  const currentPath = env[pathKey];
+  const pathDelimiter = platform === "win32" ? ";" : path.delimiter;
   return {
     command: "npm",
     args: [],
     shell: platform === "win32",
+    env: {
+      ...env,
+      [pathKey]:
+        typeof currentPath === "string" && currentPath.length > 0
+          ? `${nodeDir}${pathDelimiter}${currentPath}`
+          : nodeDir,
+    },
   };
+}
+
+function isNpmExecPath(value) {
+  return /^npm(?:-cli)?(?:\.(?:c?js|cmd|exe))?$/.test(path.basename(value).toLowerCase());
+}
+
+function resolvePathEnvKey(env) {
+  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
 }
 
 function installPluginRuntimeDeps(pluginDir, pluginId) {
@@ -119,6 +147,7 @@ function installPluginRuntimeDeps(pluginDir, pluginId) {
     {
       cwd: pluginDir,
       encoding: "utf8",
+      env: npmRunner.env,
       stdio: "pipe",
       shell: npmRunner.shell,
     },

--- a/scripts/stage-bundled-plugin-runtime-deps.mjs
+++ b/scripts/stage-bundled-plugin-runtime-deps.mjs
@@ -89,29 +89,39 @@ export function resolveNpmRunner(params = {}) {
   const platform = params.platform ?? process.platform;
   const pathImpl = platform === "win32" ? path.win32 : path;
   const nodeDir = pathImpl.dirname(execPath);
-  const npmCliPath = pathImpl.resolve(nodeDir, "../lib/node_modules/npm/bin/npm-cli.js");
-  if (existsSync(npmCliPath)) {
+  const npmCliPath = resolveToolchainNpmCliPath({ existsSync, nodeDir, pathImpl });
+  if (npmCliPath) {
     return {
       command: execPath,
       args: [npmCliPath],
       shell: false,
     };
   }
+  if (platform === "win32") {
+    throw new Error(`failed to resolve a toolchain-local npm CLI next to ${execPath}`);
+  }
   const pathKey = resolvePathEnvKey(env);
   const currentPath = env[pathKey];
-  const pathDelimiter = platform === "win32" ? ";" : path.delimiter;
   return {
     command: "npm",
     args: [],
-    shell: platform === "win32",
+    shell: false,
     env: {
       ...env,
       [pathKey]:
         typeof currentPath === "string" && currentPath.length > 0
-          ? `${nodeDir}${pathDelimiter}${currentPath}`
+          ? `${nodeDir}${path.delimiter}${currentPath}`
           : nodeDir,
     },
   };
+}
+
+function resolveToolchainNpmCliPath(params) {
+  const candidates = [
+    params.pathImpl.resolve(params.nodeDir, "../lib/node_modules/npm/bin/npm-cli.js"),
+    params.pathImpl.resolve(params.nodeDir, "node_modules/npm/bin/npm-cli.js"),
+  ];
+  return candidates.find((candidate) => params.existsSync(candidate));
 }
 
 function resolvePathEnvKey(env) {

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -34,8 +34,12 @@ describe("tsdown config", () => {
     expect(distGraphs).toHaveLength(1);
     expect(entryKeys(distGraphs[0])).toEqual(
       expect.arrayContaining([
+        "agents/auth-profiles.runtime",
+        "agents/pi-model-discovery-runtime",
         "index",
         "cli/memory-cli",
+        "commands/status.summary.runtime",
+        "plugins/provider-runtime.runtime",
         "plugins/runtime/index",
         "plugin-sdk/compat",
         "plugin-sdk/index",

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -24,6 +24,27 @@ describe("resolveNpmRunner", () => {
     });
   });
 
+  it("anchors Windows npm staging to the adjacent npm-cli.js without a shell", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const expectedNpmCliPath = path.win32.resolve(
+      path.win32.dirname(execPath),
+      "node_modules/npm/bin/npm-cli.js",
+    );
+
+    const runner = resolveNpmRunner({
+      execPath,
+      env: {},
+      existsSync: (candidate: string) => candidate === expectedNpmCliPath,
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: execPath,
+      args: [expectedNpmCliPath],
+      shell: false,
+    });
+  });
+
   it("prefixes PATH with the active node dir when falling back to bare npm", () => {
     expect(
       resolveNpmRunner({
@@ -44,8 +65,8 @@ describe("resolveNpmRunner", () => {
     });
   });
 
-  it("keeps shell mode for bare npm fallback on Windows", () => {
-    expect(
+  it("fails closed on Windows when no toolchain-local npm CLI exists", () => {
+    expect(() =>
       resolveNpmRunner({
         execPath: "C:\\node\\node.exe",
         env: {
@@ -54,13 +75,6 @@ describe("resolveNpmRunner", () => {
         existsSync: () => false,
         platform: "win32",
       }),
-    ).toEqual({
-      command: "npm",
-      args: [],
-      shell: true,
-      env: {
-        Path: "C:\\node;C:\\Windows\\System32",
-      },
-    });
+    ).toThrow("failed to resolve a toolchain-local npm CLI");
   });
 });

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -3,23 +3,6 @@ import { describe, expect, it } from "vitest";
 import { resolveNpmRunner } from "../../scripts/stage-bundled-plugin-runtime-deps.mjs";
 
 describe("resolveNpmRunner", () => {
-  it("uses npm_execpath when it already points to npm", () => {
-    expect(
-      resolveNpmRunner({
-        env: {
-          npm_execpath: "/usr/local/lib/node_modules/npm/bin/npm-cli.js",
-        },
-        execPath: "/usr/local/bin/node",
-        existsSync: () => false,
-        platform: "linux",
-      }),
-    ).toEqual({
-      command: "/usr/local/bin/node",
-      args: ["/usr/local/lib/node_modules/npm/bin/npm-cli.js"],
-      shell: false,
-    });
-  });
-
   it("anchors npm staging to the active node toolchain when npm-cli.js exists", () => {
     const execPath = "/Users/test/.nodenv/versions/24.13.0/bin/node";
     const expectedNpmCliPath = path.resolve(
@@ -29,6 +12,7 @@ describe("resolveNpmRunner", () => {
 
     const runner = resolveNpmRunner({
       execPath,
+      env: {},
       existsSync: (candidate: string) => candidate === expectedNpmCliPath,
       platform: "darwin",
     });

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -45,6 +45,46 @@ describe("resolveNpmRunner", () => {
     });
   });
 
+  it("uses an adjacent npm.exe on Windows without a shell", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const expectedNpmExePath = path.win32.resolve(path.win32.dirname(execPath), "npm.exe");
+
+    const runner = resolveNpmRunner({
+      execPath,
+      env: {},
+      existsSync: (candidate: string) => candidate === expectedNpmExePath,
+      npmArgs: ["install", "--silent"],
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: expectedNpmExePath,
+      args: ["install", "--silent"],
+      shell: false,
+    });
+  });
+
+  it("wraps an adjacent npm.cmd via cmd.exe without enabling shell mode", () => {
+    const execPath = "C:\\nodejs\\node.exe";
+    const npmCmdPath = path.win32.resolve(path.win32.dirname(execPath), "npm.cmd");
+
+    const runner = resolveNpmRunner({
+      comSpec: "C:\\Windows\\System32\\cmd.exe",
+      execPath,
+      env: {},
+      existsSync: (candidate: string) => candidate === npmCmdPath,
+      npmArgs: ["install", "--omit=dev"],
+      platform: "win32",
+    });
+
+    expect(runner).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", `${npmCmdPath} install --omit=dev`],
+      shell: false,
+      windowsVerbatimArguments: true,
+    });
+  });
+
   it("prefixes PATH with the active node dir when falling back to bare npm", () => {
     expect(
       resolveNpmRunner({
@@ -75,6 +115,6 @@ describe("resolveNpmRunner", () => {
         existsSync: () => false,
         platform: "win32",
       }),
-    ).toThrow("failed to resolve a toolchain-local npm CLI");
+    ).toThrow("OpenClaw refuses to shell out to bare npm on Windows");
   });
 });

--- a/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
+++ b/test/scripts/stage-bundled-plugin-runtime-deps.test.ts
@@ -3,6 +3,23 @@ import { describe, expect, it } from "vitest";
 import { resolveNpmRunner } from "../../scripts/stage-bundled-plugin-runtime-deps.mjs";
 
 describe("resolveNpmRunner", () => {
+  it("uses npm_execpath when it already points to npm", () => {
+    expect(
+      resolveNpmRunner({
+        env: {
+          npm_execpath: "/usr/local/lib/node_modules/npm/bin/npm-cli.js",
+        },
+        execPath: "/usr/local/bin/node",
+        existsSync: () => false,
+        platform: "linux",
+      }),
+    ).toEqual({
+      command: "/usr/local/bin/node",
+      args: ["/usr/local/lib/node_modules/npm/bin/npm-cli.js"],
+      shell: false,
+    });
+  });
+
   it("anchors npm staging to the active node toolchain when npm-cli.js exists", () => {
     const execPath = "/Users/test/.nodenv/versions/24.13.0/bin/node";
     const expectedNpmCliPath = path.resolve(
@@ -23,10 +40,13 @@ describe("resolveNpmRunner", () => {
     });
   });
 
-  it("falls back to bare npm when npm-cli.js is unavailable", () => {
+  it("prefixes PATH with the active node dir when falling back to bare npm", () => {
     expect(
       resolveNpmRunner({
         execPath: "/tmp/node",
+        env: {
+          PATH: "/usr/bin:/bin",
+        },
         existsSync: () => false,
         platform: "linux",
       }),
@@ -34,6 +54,9 @@ describe("resolveNpmRunner", () => {
       command: "npm",
       args: [],
       shell: false,
+      env: {
+        PATH: `/tmp${path.delimiter}/usr/bin:/bin`,
+      },
     });
   });
 
@@ -41,6 +64,9 @@ describe("resolveNpmRunner", () => {
     expect(
       resolveNpmRunner({
         execPath: "C:\\node\\node.exe",
+        env: {
+          Path: "C:\\Windows\\System32",
+        },
         existsSync: () => false,
         platform: "win32",
       }),
@@ -48,6 +74,9 @@ describe("resolveNpmRunner", () => {
       command: "npm",
       args: [],
       shell: true,
+      env: {
+        Path: "C:\\node;C:\\Windows\\System32",
+      },
     });
   });
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -119,6 +119,12 @@ function buildCoreDistEntries(): Record<string, string> {
     // it by a deterministic path instead of a content-hashed chunk name.
     // See https://github.com/openclaw/openclaw/issues/51676
     "cli/memory-cli": "src/cli/memory-cli.ts",
+    // Keep long-lived lazy runtime boundaries on stable filenames so rebuilt
+    // dist/ trees do not strand already-running gateways on stale hashed chunks.
+    "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
+    "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
+    "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
+    "plugins/provider-runtime.runtime": "src/plugins/provider-runtime.runtime.ts",
     extensionAPI: "src/extensionAPI.ts",
     "infra/warning-filter": "src/infra/warning-filter.ts",
     "telegram/audit": "extensions/telegram/src/audit.ts",


### PR DESCRIPTION
AI-assisted: yes

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: long-lived lazy runtime seams in `dist/` were emitted behind content-hashed filenames, so a rebuilt tree could strand already-running processes on missing chunk imports.
- Why it matters: local gateway/debug flows broke after rebuilds with errors like `Cannot find module '/.../dist/provider-runtime-*.js'` or `status.summary.runtime-*` / `auth-profiles.runtime-*` misses, and bundled plugin staging could still fall back to a broken bare-`npm` shell path, and on Windows that fallback ran through shell resolution from the plugin directory.
- What changed: pinned the affected lazy runtime seams to stable entry paths, and hardened bundled plugin runtime dependency staging to prefer the toolchain-local npm CLI, then an absolute adjacent `npm.exe`/`npm.cmd` on Windows, and fail closed with a clearer message only after those local fallbacks are exhausted.
- What did NOT change (scope boundary): no `run-node` retry/rebuild control-flow changes in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: a few lazy runtime boundaries that stay live in long-running processes were emitted as hashed chunks instead of stable entry files, and bundled plugin staging could still drop to a broken bare-`npm` shell path when toolchain-local npm resolution was unavailable.
- Missing detection / guardrail: we had coverage for `cli/memory-cli` stable entry emission, but not these other runtime seams; the npm runner tests also did not cover PATH-prefixed fallback behavior or isolate themselves from ambient `process.env`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `cli/memory-cli` already used the same stable-entry pattern for deterministic runtime imports.
- Why this regressed now: Slack demo/debug flows kept a gateway process alive across rebuilds, which exposed the missing stable filenames; the same environment also had a broken default `nodenv` shim on bare `PATH`.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/tsdown-config.test.ts`, `test/scripts/stage-bundled-plugin-runtime-deps.test.ts`
- Scenario the test should lock in: the affected runtime seams stay on deterministic `dist/...runtime.js` paths, and bundled plugin staging resolves npm from the active Node toolchain, and on Windows use an adjacent `npm-cli.js`, `npm.exe`, or wrapped absolute `npm.cmd` before failing closed.
- Why this is the smallest reliable guardrail: both bugs are emitted/selection logic bugs, so unit tests at the config/runner seam catch them directly without a longer gateway harness.
- Existing test that already covers this (if any): the existing `cli/memory-cli` stable-entry expectation in `src/infra/tsdown-config.test.ts`.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- local rebuilds are less likely to break long-running gateway/CLI processes on missing hashed runtime chunks.
- bundled plugin runtime dep staging is more resilient on broken shell PATHs, and Windows now uses only absolute toolchain-local npm paths with a clearer fail-closed error if none exist.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout, Node 24.13.0 via `nodenv`
- Model/provider: N/A
- Integration/channel (if any): Slack-triggered local gateway/debug flows
- Relevant config (redacted): default shell `PATH` had broken `nodenv` shims unless Node 24 bin was prefixed

### Steps

1. Keep a process alive against a built `dist/` tree and rebuild the repo.
2. Trigger code paths that lazy-load provider/auth/status runtime helpers, or stage bundled plugin runtime deps.
3. Observe missing hashed-chunk imports or bare-`npm` staging failures.

### Expected

- runtime helpers stay importable after rebuilds.
- bundled plugin staging uses the active toolchain instead of a broken shell shim.

### Actual

- before: `Cannot find module '/.../dist/provider-runtime-*.js'` and similar `auth-profiles.runtime-*` / `status.summary.runtime-*` misses.
- before: runtime staging could fail behind a broken bare `npm` resolution, and Windows fallback execution depended on shell command lookup from the plugin directory.
- after: deterministic runtime entry files are emitted and `pnpm openclaw agent --help` succeeds after `pnpm build`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- test/scripts/stage-bundled-plugin-runtime-deps.test.ts src/infra/tsdown-config.test.ts`, `pnpm build`, `pnpm openclaw agent --help`.
- Edge cases checked: PATH-prefixed non-Windows bare-`npm` fallback, Windows adjacent `npm-cli.js`/`npm.exe` resolution, wrapped absolute `npm.cmd` fallback, and the clearer Windows fail-closed message, deterministic `dist/agents/*.runtime.js` / `dist/commands/status.summary.runtime.js` / `dist/plugins/provider-runtime.runtime.js` emission.
- What you did **not** verify: full `pnpm test`, parallel build/CLI races, or a full gateway smoke after this branch split.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `2349807f12`, `f100570827`, `036a077fc0`, `a27d88e24c`, and `a42589c69d`.
- Files/config to restore: `tsdown.config.ts`, `src/infra/tsdown-config.test.ts`, `scripts/stage-bundled-plugin-runtime-deps.mjs`, `test/scripts/stage-bundled-plugin-runtime-deps.test.ts`.
- Known bad symptoms reviewers should watch for: missing `dist/...runtime.js` stable entries, or bundled plugin staging regressing back to broken bare-`npm` behavior.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: adding stable entry points can slightly change dist layout expectations.
  - Mitigation: the config test asserts the exact entry presence, and the emitted files were verified locally.
- Risk: npm runner fallback env shaping could behave differently on Windows.
  - Mitigation: added explicit Windows-path unit coverage and kept the shell-mode behavior unchanged.


