### PR TITLE
OpenAI WS: map reasoning output to thinking blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - CLI/message send: write manual `openclaw message send` deliveries into the resolved agent session transcript again by always threading the default CLI agent through outbound mirroring. (#54187) Thanks @KevInTheCloud5617.
 - CLI/onboarding: show the Kimi Code API key option again in the Moonshot setup menu so the interactive picker includes all Kimi setup paths together. Fixes #54412 Thanks @sparkyrider
 - Agents/status: use provider-aware context window lookup for fresh Anthropic 4.6 model overrides so `/status` shows the correct 1.0m window instead of an underreported shared-cache minimum. (#54796) Thanks @neeravmakwana.
+- OpenAI/WS: restore reasoning blocks for Responses WebSocket runs and keep reasoning/tool-call replay metadata intact so resumed sessions do not lose or break follow-up reasoning-capable turns. (#53856) Thanks @xujingchen1996.
 - Agents/errors: surface provider quota/reset details when available, but keep HTML/Cloudflare rate-limit pages on the generic fallback so raw error pages are not shown to users. (#54512) Thanks @bugkill3r.
 - Claude CLI: switch the bundled Claude CLI backend to `stream-json` output so watchdogs see progress on long runs, and keep session/usage metadata even when Claude finishes with an empty result line. (#49698) Thanks @felear2022.
 - Claude CLI/MCP: always pass a strict generated `--mcp-config` overlay for background Claude CLI runs, including the empty-server case, so Claude does not inherit ambient user/global MCP servers. (#54961) Thanks @markojak.

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -58,10 +58,10 @@ export type OutputItem =
       status?: "in_progress" | "completed";
     }
   | {
-      type: "reasoning";
+      type: "reasoning" | `reasoning.${string}`;
       id: string;
       content?: string;
-      summary?: string;
+      summary?: unknown;
     };
 
 export interface ResponseCreatedEvent {
@@ -198,7 +198,13 @@ export type InputItem =
     }
   | { type: "function_call"; id?: string; call_id?: string; name: string; arguments: string }
   | { type: "function_call_output"; call_id: string; output: string }
-  | { type: "reasoning"; content?: string; encrypted_content?: string; summary?: string }
+  | {
+      type: "reasoning";
+      id?: string;
+      content?: string;
+      encrypted_content?: string;
+      summary?: string;
+    }
   | { type: "item_reference"; id: string };
 
 export type ToolChoice =

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -587,6 +587,35 @@ describe("convertMessagesToInputItems", () => {
       typeof convertMessagesToInputItems
     >[0]);
     expect(items.map((item) => item.type)).toEqual(["reasoning", "message"]);
+    expect(items[0]).toMatchObject({ type: "reasoning", id: "rs_test" });
+  });
+
+  it("replays reasoning blocks when signature type is reasoning.*", () => {
+    const msg = {
+      role: "assistant" as const,
+      content: [
+        {
+          type: "thinking" as const,
+          thinking: "internal reasoning...",
+          thinkingSignature: JSON.stringify({
+            type: "reasoning.summary",
+            id: "rs_summary",
+          }),
+        },
+        { type: "text" as const, text: "Here is my answer." },
+      ],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items.map((item) => item.type)).toEqual(["reasoning", "message"]);
+    expect(items[0]).toMatchObject({ type: "reasoning", id: "rs_summary" });
   });
 
   it("returns empty array for empty messages", () => {
@@ -625,7 +654,7 @@ describe("buildAssistantMessageFromResponse", () => {
     };
     expect(tc).toBeDefined();
     expect(tc.name).toBe("exec");
-    expect(tc.id).toBe("call_abc");
+    expect(tc.id).toBe("call_abc|item_2");
     expect(tc.arguments).toEqual({ arg: "value" });
   });
 
@@ -674,6 +703,106 @@ describe("buildAssistantMessageFromResponse", () => {
     };
     expect(msg.phase).toBe("final_answer");
     expect(msg.content[0]?.text).toBe("Final answer");
+  });
+
+  it("maps reasoning output items to thinking blocks with signature", () => {
+    const response = {
+      id: "resp_reasoning",
+      object: "response",
+      created_at: Date.now(),
+      status: "completed",
+      model: "gpt-5.2",
+      output: [
+        {
+          type: "reasoning",
+          id: "rs_123",
+          summary: [{ text: "Plan step A" }, { text: "Plan step B" }],
+        },
+        {
+          type: "message",
+          id: "item_1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Final answer" }],
+        },
+      ],
+      usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    } as unknown as ResponseObject;
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    const thinkingBlock = msg.content.find((c) => c.type === "thinking") as
+      | { type: "thinking"; thinking: string; thinkingSignature?: string }
+      | undefined;
+    expect(thinkingBlock?.thinking).toBe("Plan step A\nPlan step B");
+    expect(thinkingBlock?.thinkingSignature).toBe(
+      JSON.stringify({ id: "rs_123", type: "reasoning" }),
+    );
+  });
+
+  it("maps reasoning.* output items to thinking blocks", () => {
+    const response = {
+      id: "resp_reasoning_kind",
+      object: "response",
+      created_at: Date.now(),
+      status: "completed",
+      model: "gpt-5.2",
+      output: [
+        {
+          type: "reasoning.summary",
+          id: "rs_456",
+          content: "Derived hidden reasoning",
+        },
+      ],
+      usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    } as unknown as ResponseObject;
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    const thinkingBlock = msg.content[0] as
+      | { type: "thinking"; thinking: string; thinkingSignature?: string }
+      | undefined;
+    expect(thinkingBlock?.type).toBe("thinking");
+    expect(thinkingBlock?.thinking).toBe("Derived hidden reasoning");
+    expect(thinkingBlock?.thinkingSignature).toBe(
+      JSON.stringify({ id: "rs_456", type: "reasoning.summary" }),
+    );
+  });
+
+  it("preserves function call item ids for replay when reasoning is present", () => {
+    const response = {
+      id: "resp_tool_reasoning",
+      object: "response",
+      created_at: Date.now(),
+      status: "completed",
+      model: "gpt-5.2",
+      output: [
+        {
+          type: "reasoning",
+          id: "rs_tool",
+          content: "Thinking before tool call",
+        },
+        {
+          type: "function_call",
+          id: "fc_tool",
+          call_id: "call_tool",
+          name: "exec",
+          arguments: '{"arg":"value"}',
+        },
+      ],
+      usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    } as ResponseObject;
+
+    const assistant = buildAssistantMessageFromResponse(response, modelInfo);
+    const toolCall = assistant.content.find((item) => item.type === "toolCall") as
+      | { type: "toolCall"; id: string }
+      | undefined;
+    expect(toolCall?.id).toBe("call_tool|fc_tool");
+
+    const replayItems = convertMessagesToInputItems([assistant] as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(replayItems.map((item) => item.type)).toEqual(["reasoning", "function_call"]);
+    expect(replayItems[1]).toMatchObject({
+      type: "function_call",
+      call_id: "call_tool",
+      id: "fc_tool",
+    });
   });
 });
 

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -31,8 +31,6 @@ import type {
   Context,
   Message,
   StopReason,
-  TextContent,
-  ToolCall,
 } from "@mariozechner/pi-ai";
 import {
   OpenAIWebSocketManager,
@@ -330,21 +328,33 @@ function contentToOpenAIParts(content: unknown, modelOverride?: ReplayModelInfo)
   return parts;
 }
 
+function isReplayableReasoningType(value: unknown): value is "reasoning" | `reasoning.${string}` {
+  return typeof value === "string" && (value === "reasoning" || value.startsWith("reasoning."));
+}
+
+function toReplayableReasoningId(value: unknown): string | null {
+  const id = toNonEmptyString(value);
+  return id && id.startsWith("rs_") ? id : null;
+}
+
 function parseReasoningItem(value: unknown): Extract<InputItem, { type: "reasoning" }> | null {
   if (!value || typeof value !== "object") {
     return null;
   }
   const record = value as {
     type?: unknown;
+    id?: unknown;
     content?: unknown;
     encrypted_content?: unknown;
     summary?: unknown;
   };
-  if (record.type !== "reasoning") {
+  if (!isReplayableReasoningType(record.type)) {
     return null;
   }
+  const reasoningId = toReplayableReasoningId(record.id);
   return {
     type: "reasoning",
+    ...(reasoningId ? { id: reasoningId } : {}),
     ...(typeof record.content === "string" ? { content: record.content } : {}),
     ...(typeof record.encrypted_content === "string"
       ? { encrypted_content: record.encrypted_content }
@@ -362,6 +372,41 @@ function parseThinkingSignature(value: unknown): Extract<InputItem, { type: "rea
   } catch {
     return null;
   }
+}
+
+function extractReasoningSummaryText(value: unknown): string {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  return value
+    .map((item) => {
+      if (typeof item === "string") {
+        return item.trim();
+      }
+      if (!item || typeof item !== "object") {
+        return "";
+      }
+      const record = item as { text?: unknown };
+      return typeof record.text === "string" ? record.text.trim() : "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function extractResponseReasoningText(item: unknown): string {
+  if (!item || typeof item !== "object") {
+    return "";
+  }
+  const record = item as { summary?: unknown; content?: unknown };
+  const summaryText = extractReasoningSummaryText(record.summary);
+  if (summaryText) {
+    return summaryText;
+  }
+  return typeof record.content === "string" ? record.content.trim() : "";
 }
 
 /** Convert pi-ai tool array to OpenAI FunctionToolDefinition[]. */
@@ -535,7 +580,7 @@ export function buildAssistantMessageFromResponse(
   response: ResponseObject,
   modelInfo: { api: string; provider: string; id: string },
 ): AssistantMessage {
-  const content: (TextContent | ToolCall)[] = [];
+  const content: AssistantMessage["content"] = [];
   let assistantPhase: OpenAIResponsesAssistantPhase | undefined;
 
   for (const item of response.output ?? []) {
@@ -561,9 +606,11 @@ export function buildAssistantMessageFromResponse(
       if (!toolName) {
         continue;
       }
+      const callId = toNonEmptyString(item.call_id);
+      const itemId = toNonEmptyString(item.id);
       content.push({
         type: "toolCall",
-        id: toNonEmptyString(item.call_id) ?? `call_${randomUUID()}`,
+        id: callId ? (itemId ? `${callId}|${itemId}` : callId) : `call_${randomUUID()}`,
         name: toolName,
         arguments: (() => {
           try {
@@ -573,8 +620,28 @@ export function buildAssistantMessageFromResponse(
           }
         })(),
       });
+    } else {
+      if (!isReplayableReasoningType(item.type)) {
+        continue;
+      }
+      const reasoning = extractResponseReasoningText(item);
+      if (!reasoning) {
+        continue;
+      }
+      const reasoningId = toReplayableReasoningId(item.id);
+      content.push({
+        type: "thinking",
+        thinking: reasoning,
+        ...(reasoningId
+          ? {
+              thinkingSignature: JSON.stringify({
+                id: reasoningId,
+                type: item.type,
+              }),
+            }
+          : {}),
+      } as AssistantMessage["content"][number]);
     }
-    // "reasoning" items are informational only; skip.
   }
 
   const hasToolCalls = content.some((c) => c.type === "toolCall");


### PR DESCRIPTION
## Summary

- Problem: In recent builds, OpenAI WS/Responses output could carry reasoning data without being mapped into `thinking` blocks/callbacks, so streamed reasoning was not rendered in downstream channels.
- Why it matters: Users saw the tool/action progress but lost the visible reasoning stream, which looked like partial silence and reduced transparency.
- What changed: Added/normalised WS response mapping so reasoning output items are converted into `thinking` content blocks and surfaced through reasoning stream callbacks.
- What changed: Preserved assistant phase/signature handling while restoring reasoning stream delivery on the WS path.
- What did NOT change (scope boundary): No model catalogue changes, no channel default/policy changes, no non-WS/completions behaviour changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway/orchestration
- [ ] Skills/tool execution
- [ ] Auth/tokens
- [ ] Memory/storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: WS Responses handling did not consistently map reasoning output items into `thinking` blocks consumed by the embedded subscribe/reply pipeline.
- Missing detection/guardrail: No focused regression assertion guaranteeing reasoning item -> `thinking` mapping on WS response parsing.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Regression manifested after WS/Responses path evolution; channel-side reasoning handlers remained present.
- Why this regressed now: Payload shape handling on WS path emphasised text/tool events and missed full reasoning mapping parity.
- If unknown, what was ruled out: Ruled out Feishu/Lark renderer removal; channel dispatcher still supports `onReasoningStream`/`onReasoningEnd`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
- [x] Unit test
- [ ] Seam/integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-ws-stream.test.ts`
- Scenario the test should lock in: WS `response.output` reasoning items are parsed into assistant `thinking` blocks and emitted through normal downstream flow.
- Why this is the smallest reliable guardrail: It isolates the parsing/mapping seam where the regression occurred.
- Existing test that already covers this (if any): Updated/added WS stream mapping assertions in `openai-ws-stream` tests.
- If no new test is added, why not: N/A

## User-visible / Behaviour Changes

- Reasoning stream is visible again for WS/Responses runs where providers return reasoning output items.
- Channels that already consume reasoning callbacks (including openclaw-lark) can render `reasoningLevel=stream` again on this path.
- No behaviour change for completions/non-WS runs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm (repo CI matrix)
- Model/provider: OpenAI-compatible WS Responses path
- Integration/channel (if any): Feishu/Lark downstream rendering
- Relevant config (redacted): `reasoningLevel=stream`, WS transport enabled

### Steps

1. Run a WS/Responses model with reasoning enabled and stream replies.
2. Observe reasoning callback/render output in the channel during run.
3. Verify final answer still arrives and tool flow remains unchanged.

### Expected

- Reasoning chunks are surfaced during stream (`thinking` path) and rendered by reasoning-capable channel handlers.
- Final answer and tool behaviour remain unchanged.

### Actual

- After fix: expected behaviour observed.
- Before fix: reasoning stream missing/intermittent despite the provider payload containing reasoning output items.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: WS response with reasoning + text, reasoning-only chunks, mixed tool + reasoning flow.
- Edge cases checked: reasoning item without visible text, assistant phase propagation, tool call parsing unchanged.
- What you did **not** verify: Non-WS provider-specific rendering paths beyond existing CI coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need a reviewer or maintainer judgment.

## Compatibility / Migration

- Backwards compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; or force non-WS path as temporary mitigation.
- Files/config to restore: `src/agents/openai-ws-stream.ts` (and related tests if reverted together).
- Known bad symptoms reviewers should watch for: Missing reasoning stream again, or duplicated/misclassified thinking blocks.

## Risks and Mitigations

- Risk: Provider-specific WS payload variance may still miss some reasoning variants.
- Mitigation: Keep parser tolerant, extend unit cases on new payload samples, and rely on HTTP fallback path for run continuity.
