### PR TITLE
perf(gateway): add async transcript reader and concurrent fallback

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -49,7 +49,7 @@ import {
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
   archiveFileOnDisk,
-  listSessionsFromStore,
+  listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
   loadGatewaySessionRow,
   loadSessionEntry,
@@ -471,14 +471,14 @@ async function handleSessionSend(params: {
   }
 }
 export const sessionsHandlers: GatewayRequestHandlers = {
-  "sessions.list": ({ params, respond }) => {
+  "sessions.list": async ({ params, respond }) => {
     if (!assertValidParams(params, validateSessionsListParams, "sessions.list", respond)) {
       return;
     }
     const p = params;
     const cfg = loadConfig();
     const { storePath, store } = loadCombinedSessionStoreForGateway(cfg);
-    const result = listSessionsFromStore({
+    const result = await listSessionsFromStoreAsync({
       cfg,
       storePath,
       store,

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -8,6 +8,7 @@ import {
   readFirstUserMessageFromTranscript,
   readLastMessagePreviewFromTranscript,
   readLatestSessionUsageFromTranscript,
+  readLatestSessionUsageFromTranscriptAsync,
   readSessionMessages,
   readSessionTitleFieldsFromTranscript,
   readSessionPreviewItemsFromTranscript,
@@ -697,6 +698,30 @@ describe("readLatestSessionUsageFromTranscript", () => {
       totalTokensFresh: true,
       costUsd: 0.0042,
     });
+  });
+
+  test("supports async usage fallback reads with matching results", async () => {
+    const sessionId = "usage-session-async";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      {
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.4",
+          usage: {
+            input: 900,
+            output: 200,
+            cacheRead: 100,
+            cost: { total: 0.0031 },
+          },
+        },
+      },
+    ]);
+
+    await expect(readLatestSessionUsageFromTranscriptAsync(sessionId, storePath)).resolves.toEqual(
+      readLatestSessionUsageFromTranscript(sessionId, storePath),
+    );
   });
 
   test("aggregates assistant usage across the full transcript and keeps the latest context snapshot", () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -783,6 +783,27 @@ export function readLatestSessionUsageFromTranscript(
   });
 }
 
+export async function readLatestSessionUsageFromTranscriptAsync(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+  agentId?: string,
+): Promise<SessionTranscriptUsageSnapshot | null> {
+  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile, agentId);
+  if (!filePath) {
+    return null;
+  }
+  try {
+    const chunk = await fs.promises.readFile(filePath, "utf-8");
+    if (!chunk) {
+      return null;
+    }
+    return extractLatestUsageFromTranscriptChunk(chunk);
+  } catch {
+    return null;
+  }
+}
+
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
 const PREVIEW_MAX_LINES = 200;
 


### PR DESCRIPTION
## Summary
- What changed: readLatestSessionUsageFromTranscriptAsync, listSessionsFromStoreAsync, sessions handler uses async variant
- Depends on: sessions-list-config-refactor PR for normalizeSessionsListOptions/filterSessionListEntries/finalizeSessionListRows
- What did NOT change: Sync fallback path

## Change Type
- [x] Feature

## Scope
- [x] Gateway / orchestration

## Security Impact
All No.