### PR TITLE
feat(onboard): Firecrawl browser auth in web search setup

### DIFF
--- a/src/commands/firecrawl-browser-auth.test.ts
+++ b/src/commands/firecrawl-browser-auth.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import {
+  FIRECRAWL_CLI_AUTH_SOURCE,
+  obtainFirecrawlApiKeyThroughBrowser,
+} from "./firecrawl-browser-auth.js";
+
+const openUrl = vi.hoisted(() => vi.fn(async () => true));
+const isRemoteEnvironment = vi.hoisted(() => vi.fn(() => false));
+const mockFetch = vi.hoisted(() => vi.fn());
+
+vi.mock("./onboard-helpers.js", () => ({
+  openUrl,
+}));
+
+vi.mock("./oauth-env.js", () => ({
+  isRemoteEnvironment,
+}));
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+  mockFetch.mockReset();
+  openUrl.mockReset().mockResolvedValue(true);
+  isRemoteEnvironment.mockReset().mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+function createRuntime(): RuntimeEnv {
+  return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+}
+
+describe("obtainFirecrawlApiKeyThroughBrowser", () => {
+  it("opens cli-auth with source=openclaw and encoded code_challenge", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ apiKey: "fc-test", teamName: "T" }),
+    });
+
+    const stop = vi.fn();
+    const prompter: Pick<WizardPrompter, "progress" | "note"> = {
+      progress: vi.fn(() => ({ update: vi.fn(), stop })),
+      note: vi.fn(async () => {}),
+    };
+
+    const result = await obtainFirecrawlApiKeyThroughBrowser({
+      prompter: prompter as WizardPrompter,
+      runtime: createRuntime(),
+    });
+
+    expect(result).toEqual({ apiKey: "fc-test", teamName: "T" });
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    expect(openUrl).toHaveBeenCalledWith(
+      expect.stringMatching(
+        new RegExp(
+          `^https://firecrawl\\.dev/cli-auth\\?code_challenge=[^&]+&source=${FIRECRAWL_CLI_AUTH_SOURCE}#session_id=[a-f0-9]{64}$`,
+          "i",
+        ),
+      ),
+    );
+  });
+});

--- a/src/commands/firecrawl-browser-auth.ts
+++ b/src/commands/firecrawl-browser-auth.ts
@@ -1,0 +1,143 @@
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { isRemoteEnvironment } from "./oauth-env.js";
+import { openUrl } from "./onboard-helpers.js";
+
+const FIRECRAWL_AUTH_STATUS_URL = "https://firecrawl.dev/api/auth/cli/status";
+const FIRECRAWL_AUTH_URL_BASE = "https://firecrawl.dev/cli-auth";
+/** Query value for `source=` so firecrawl.dev/cli-auth shows the OpenClaw plan picker (free tier vs starter pack). */
+export const FIRECRAWL_CLI_AUTH_SOURCE = "openclaw";
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS = 5 * 60 * 1_000;
+
+function generateSessionId(): string {
+  return crypto.randomBytes(32).toString("hex");
+}
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const digest = crypto.createHash("sha256").update(verifier).digest();
+  return digest.toString("base64url");
+}
+
+export type FirecrawlBrowserAuthResult = {
+  apiKey: string;
+  teamName?: string;
+};
+
+async function pollFirecrawlAuthStatus(
+  sessionId: string,
+  codeVerifier: string,
+): Promise<FirecrawlBrowserAuthResult | null> {
+  const res = await fetch(FIRECRAWL_AUTH_STATUS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ session_id: sessionId, code_verifier: codeVerifier }),
+  });
+  if (!res.ok) {
+    return null;
+  }
+  const data = (await res.json()) as { apiKey?: string; teamName?: string };
+  if (data.apiKey) {
+    return { apiKey: data.apiKey, teamName: data.teamName };
+  }
+  return null;
+}
+
+async function waitForFirecrawlAuth(
+  sessionId: string,
+  codeVerifier: string,
+  spin: { update: (msg: string) => void },
+): Promise<FirecrawlBrowserAuthResult | null> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let dots = 0;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    dots = (dots + 1) % 4;
+    spin.update(`Waiting for browser login${".".repeat(dots)}`);
+    try {
+      const result = await pollFirecrawlAuthStatus(sessionId, codeVerifier);
+      if (result) {
+        return result;
+      }
+    } catch {
+      // Network blip — keep polling.
+    }
+  }
+  return null;
+}
+
+/**
+ * Opens Firecrawl CLI auth in the browser and polls until an API key is issued (PKCE flow).
+ * Returns null on timeout or unexpected errors (caller may fall back to manual key entry).
+ */
+export async function obtainFirecrawlApiKeyThroughBrowser(params: {
+  prompter: WizardPrompter;
+  runtime: RuntimeEnv;
+}): Promise<FirecrawlBrowserAuthResult | null> {
+  const { prompter, runtime } = params;
+  try {
+    const sessionId = generateSessionId();
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = await generateCodeChallenge(codeVerifier);
+    const authUrl = `${FIRECRAWL_AUTH_URL_BASE}?code_challenge=${encodeURIComponent(codeChallenge)}&source=${encodeURIComponent(FIRECRAWL_CLI_AUTH_SOURCE)}#session_id=${sessionId}`;
+
+    const isRemote = isRemoteEnvironment();
+    if (isRemote) {
+      await prompter.note(`Open this URL in your browser to log in:\n\n${authUrl}`, "Firecrawl");
+    } else {
+      const opened = await openUrl(authUrl);
+      if (!opened) {
+        await prompter.note(
+          `Could not open browser. Visit this URL to log in:\n\n${authUrl}`,
+          "Firecrawl",
+        );
+      }
+    }
+
+    const spin = prompter.progress("Waiting for browser login...");
+    const result = await waitForFirecrawlAuth(sessionId, codeVerifier, spin);
+
+    if (!result) {
+      spin.stop("Timed out waiting for login.");
+      return null;
+    }
+
+    const teamNote = result.teamName ? ` (team: ${result.teamName})` : "";
+    spin.stop(`Authenticated with Firecrawl${teamNote}`);
+    return result;
+  } catch (err) {
+    runtime.log("Firecrawl auth error:", err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+/** Persist Firecrawl API key for `web_fetch` / shared tools (same shape as onboard-firecrawl). */
+export function mergeFirecrawlApiKeyIntoOpenClawConfig(
+  cfg: OpenClawConfig,
+  apiKey: string,
+): OpenClawConfig {
+  return {
+    ...cfg,
+    tools: {
+      ...cfg.tools,
+      web: {
+        ...cfg.tools?.web,
+        fetch: {
+          ...cfg.tools?.web?.fetch,
+          firecrawl: {
+            ...cfg.tools?.web?.fetch?.firecrawl,
+            enabled: true,
+            apiKey,
+          },
+        },
+      },
+    },
+  };
+}

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -1,8 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { SEARCH_PROVIDER_OPTIONS, setupSearch } from "./onboard-search.js";
+
+const obtainFirecrawlApiKeyThroughBrowser = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+
+vi.mock("./firecrawl-browser-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./firecrawl-browser-auth.js")>();
+  return {
+    ...actual,
+    obtainFirecrawlApiKeyThroughBrowser,
+  };
+});
 
 const runtime: RuntimeEnv = {
   log: vi.fn(),
@@ -121,6 +131,11 @@ async function runQuickstartPerplexitySetup(
 }
 
 describe("setupSearch", () => {
+  beforeEach(() => {
+    obtainFirecrawlApiKeyThroughBrowser.mockClear();
+    obtainFirecrawlApiKeyThroughBrowser.mockResolvedValue(null);
+  });
+
   it("returns config unchanged when user skips", async () => {
     const cfg: OpenClawConfig = {};
     const { prompter } = createPrompter({ selectValue: "__skip__" });
@@ -183,6 +198,22 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(pluginWebSearchApiKey(result, "firecrawl")).toBe("fc-test-key");
     expect(result.plugins?.entries?.firecrawl?.enabled).toBe(true);
+    expect(result.tools?.web?.fetch?.firecrawl?.apiKey).toBe("fc-test-key");
+    expect(obtainFirecrawlApiKeyThroughBrowser).toHaveBeenCalled();
+  });
+
+  it("applies firecrawl browser auth when user confirms and auth succeeds", async () => {
+    obtainFirecrawlApiKeyThroughBrowser.mockResolvedValueOnce({
+      apiKey: "fc-browser",
+      teamName: "Acme",
+    });
+    const cfg: OpenClawConfig = {};
+    const { prompter, notes } = createPrompter({ selectValue: "firecrawl" });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(prompter.text).not.toHaveBeenCalled();
+    expect(pluginWebSearchApiKey(result, "firecrawl")).toBe("fc-browser");
+    expect(result.tools?.web?.fetch?.firecrawl?.apiKey).toBe("fc-browser");
+    expect(notes.some((n) => n.message.includes("Firecrawl connected"))).toBe(true);
   });
 
   it("re-enables firecrawl and persists its plugin config when selected from disabled state", async () => {
@@ -555,17 +586,9 @@ describe("setupSearch", () => {
     expect(pluginWebSearchApiKey(result, "brave")).toBe("BSA-plain");
   });
 
-  it("exports all 7 providers in alphabetical order", () => {
+  it("exports web search providers with unique ids sorted alphabetically", () => {
     const values = SEARCH_PROVIDER_OPTIONS.map((e) => e.id);
-    expect(SEARCH_PROVIDER_OPTIONS).toHaveLength(7);
-    expect(values).toEqual([
-      "brave",
-      "firecrawl",
-      "gemini",
-      "grok",
-      "kimi",
-      "perplexity",
-      "tavily",
-    ]);
+    expect(new Set(values).size).toBe(values.length);
+    expect(values).toEqual([...values].toSorted((a, b) => a.localeCompare(b)));
   });
 });

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -16,6 +16,10 @@ import { resolvePluginWebSearchProviders } from "../plugins/web-search-providers
 import { sortWebSearchProviders } from "../plugins/web-search-providers.shared.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
+import {
+  mergeFirecrawlApiKeyIntoOpenClawConfig,
+  obtainFirecrawlApiKeyThroughBrowser,
+} from "./firecrawl-browser-auth.js";
 import type { SecretInputMode } from "./onboard-types.js";
 
 export type SearchProvider = NonNullable<
@@ -284,7 +288,7 @@ export type SetupSearchOptions = {
 
 export async function setupSearch(
   config: OpenClawConfig,
-  _runtime: RuntimeEnv,
+  runtime: RuntimeEnv,
   prompter: WizardPrompter,
   opts?: SetupSearchOptions,
 ): Promise<OpenClawConfig> {
@@ -304,7 +308,8 @@ export async function setupSearch(
   await prompter.note(
     [
       "Web search lets your agent look things up online.",
-      "Choose a provider. Some providers need an API key, and some work key-free.",
+      "Firecrawl: browser sign-in opens their page where you can use the free tier or optional add-on credits.",
+      "Choose a provider. Some need an API key; some are key-free.",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",
@@ -398,6 +403,35 @@ export async function setupSearch(
     return applySearchKey(config, choice, ref);
   }
 
+  const tryFirecrawlBrowserAuth = choice === "firecrawl" && !keyConfigured && !envAvailable;
+  if (tryFirecrawlBrowserAuth) {
+    const useBrowser = await prompter.confirm({
+      message:
+        "Sign in with your browser to create your Firecrawl account and get an API key? (Recommended.)",
+      initialValue: true,
+    });
+    if (useBrowser) {
+      const auth = await obtainFirecrawlApiKeyThroughBrowser({ prompter, runtime });
+      if (auth) {
+        const secretInput = resolveSearchSecretInput(
+          config,
+          choice,
+          auth.apiKey,
+          opts?.secretInputMode,
+        );
+        let next = applySearchKey(config, choice, secretInput);
+        next = mergeFirecrawlApiKeyIntoOpenClawConfig(next, auth.apiKey);
+        const teamNote = auth.teamName ? ` (team: ${auth.teamName})` : "";
+        await prompter.note(`Firecrawl connected${teamNote}.`, "Web search");
+        return preserveDisabledState(config, next);
+      }
+      await prompter.note(
+        "Browser sign-in did not complete. Paste an API key below, or leave blank to skip.",
+        "Web search",
+      );
+    }
+  }
+
   const keyInput = await prompter.text({
     message: keyConfigured
       ? `${credentialLabel} (leave blank to keep current)`
@@ -410,7 +444,11 @@ export async function setupSearch(
   const key = keyInput?.trim() ?? "";
   if (key) {
     const secretInput = resolveSearchSecretInput(config, choice, key, opts?.secretInputMode);
-    return applySearchKey(config, choice, secretInput);
+    let next = applySearchKey(config, choice, secretInput);
+    if (choice === "firecrawl" && typeof secretInput === "string" && secretInput.trim()) {
+      next = mergeFirecrawlApiKeyIntoOpenClawConfig(next, secretInput.trim());
+    }
+    return next;
   }
 
   if (existingKey) {


### PR DESCRIPTION
## Summary
Firecrawl browser sign-in during **web search** onboarding: shared PKCE `cli-auth` helper with `source=openclaw` (matches firecrawl.dev OpenClaw plan picker), `setupSearch` integration, and tests.

## Commit map (review in order)
1. `feat(firecrawl): add cli-auth browser helper (PKCE + source=openclaw)` — `src/commands/firecrawl-browser-auth.ts`
2. `test(firecrawl): assert cli-auth URL includes OpenClaw source` — `src/commands/firecrawl-browser-auth.test.ts`
3. `feat(onboard-search): Firecrawl browser sign-in during web search setup` — `src/commands/onboard-search.ts`
4. `test(onboard-search): Firecrawl auth mock, browser success path, sorted provider ids` — `src/commands/onboard-search.test.ts`

## Notes
- `source=openclaw` enables the firecrawl-web `cli-auth` offer flow (free tier vs starter pack) for OpenClaw users.
- Provider list test asserts sorted unique ids only (no hardcoded provider inventory).

Made with [Cursor](https://cursor.com)