### PR TITLE
fix(whatsapp): reply-to-bot detection with WhatsApp LID identifiers

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/group-gating.ts
@@ -127,14 +127,19 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
     conversationId: params.conversationId,
   });
   const requireMention = activation !== "always";
-  const selfJid = params.msg.selfJid?.replace(/:\\d+/, "");
-  const replySenderJid = params.msg.replyToSenderJid?.replace(/:\\d+/, "");
+  const selfJid = params.msg.selfJid?.replace(/:\d+/, "");
+  const selfLid = params.msg.selfLid?.replace(/:\d+/, "");
+  const replySenderJid = params.msg.replyToSenderJid?.replace(/:\d+/, "");
   const selfE164 = params.msg.selfE164 ? normalizeE164(params.msg.selfE164) : null;
   const replySenderE164 = params.msg.replyToSenderE164
     ? normalizeE164(params.msg.replyToSenderE164)
     : null;
+  // Detect reply-to-bot: compare JIDs, LIDs, and E.164 numbers.
+  // WhatsApp may report the quoted message sender as either a phone JID
+  // (xxxxx@s.whatsapp.net) or a LID (xxxxx@lid), so we compare both.
   const implicitMention = Boolean(
     (selfJid && replySenderJid && selfJid === replySenderJid) ||
+    (selfLid && replySenderJid && selfLid === replySenderJid) ||
     (selfE164 && replySenderE164 && selfE164 === replySenderE164),
   );
   const mentionGate = resolveMentionGating({

--- a/extensions/whatsapp/src/inbound/extract.ts
+++ b/extensions/whatsapp/src/inbound/extract.ts
@@ -108,7 +108,38 @@ function extractMessage(message: proto.IMessage | undefined): proto.IMessage | u
 }
 
 function unwrapMessage(message: proto.IMessage | undefined): proto.IMessage | undefined {
-  const normalized = normalizeMessage(message);
+  let normalized = normalizeMessage(message);
+  if (!normalized) {
+    return undefined;
+  }
+  // Generic FutureProofMessage unwrap for wrappers that Baileys'
+  // normalizeMessageContent doesn't handle yet (e.g. botInvokeMessage,
+  // groupMentionedMessage). These wrappers have shape { message: IMessage }.
+  // Iterate up to 3 times to handle nested wrappers.
+  for (let i = 0; i < 3; i++) {
+    const contentType = getMessageContentType(normalized);
+    if (!contentType) {
+      break;
+    }
+    const value = (normalized as Record<string, unknown>)[contentType];
+    if (
+      value &&
+      typeof value === "object" &&
+      "message" in value &&
+      (value as { message?: unknown }).message &&
+      typeof (value as { message: unknown }).message === "object"
+    ) {
+      const inner = normalizeMessage((value as { message: proto.IMessage }).message);
+      if (inner) {
+        const innerType = getMessageContentType(inner);
+        if (innerType && innerType !== contentType) {
+          normalized = inner;
+          continue;
+        }
+      }
+    }
+    break;
+  }
   return normalized;
 }
 
@@ -145,12 +176,21 @@ function extractContextInfo(message: proto.IMessage | undefined): proto.IContext
     if (!value || typeof value !== "object") {
       continue;
     }
-    if (!("contextInfo" in value)) {
-      continue;
+    if ("contextInfo" in value) {
+      const candidateContext = (value as { contextInfo?: proto.IContextInfo }).contextInfo;
+      if (candidateContext) {
+        return candidateContext;
+      }
     }
-    const candidateContext = (value as { contextInfo?: proto.IContextInfo }).contextInfo;
-    if (candidateContext) {
-      return candidateContext;
+    // FutureProofMessage wrapper: dig into .message to find contextInfo
+    if ("message" in value) {
+      const inner = (value as { message?: proto.IMessage }).message;
+      if (inner) {
+        const innerCtx = extractContextInfo(inner);
+        if (innerCtx) {
+          return innerCtx;
+        }
+      }
     }
   }
   return undefined;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -82,10 +82,11 @@ export async function monitorWebInbox(options: {
   // Bot's own LID (Linked Identity) — needed for reply-to-bot detection
   // when contextInfo.participant returns a LID instead of a phone JID.
   // Baileys 7 rc9 does not expose lid on sock.user, so read from creds file.
-  const selfLid = (() => {
+  const selfLid = await (async () => {
     try {
-      const credsPath = path.join(options.authDir ?? "", "creds.json");
-      const creds = JSON.parse(fs.readFileSync(credsPath, "utf-8"));
+      const credsPath = path.join(options.authDir, "creds.json");
+      const raw = await fs.promises.readFile(credsPath, "utf-8");
+      const creds = JSON.parse(raw) as { me?: { lid?: string } };
       return creds?.me?.lid ?? undefined;
     } catch {
       return (sock.user as { lid?: string } | undefined)?.lid ?? undefined;

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -77,6 +77,9 @@ export async function monitorWebInbox(options: {
 
   const selfJid = sock.user?.id;
   const selfE164 = selfJid ? jidToE164(selfJid) : null;
+  // Bot's own LID (Linked Identity) — needed for reply-to-bot detection
+  // when contextInfo.participant returns a LID instead of a phone JID.
+  const selfLid = (sock.user as { lid?: string } | undefined)?.lid ?? undefined;
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
     buildKey: (msg) => {
@@ -416,6 +419,7 @@ export async function monitorWebInbox(options: {
       groupParticipants: inbound.groupParticipants,
       mentionedJids: mentionedJids ?? undefined,
       selfJid,
+      selfLid,
       selfE164,
       fromMe: Boolean(msg.key?.fromMe),
       location: enriched.location ?? undefined,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { AnyMessageContent, proto, WAMessage } from "@whiskeysockets/baileys";
 import { DisconnectReason, isJidGroup } from "@whiskeysockets/baileys";
 import { createInboundDebouncer, formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
@@ -79,7 +81,16 @@ export async function monitorWebInbox(options: {
   const selfE164 = selfJid ? jidToE164(selfJid) : null;
   // Bot's own LID (Linked Identity) — needed for reply-to-bot detection
   // when contextInfo.participant returns a LID instead of a phone JID.
-  const selfLid = (sock.user as { lid?: string } | undefined)?.lid ?? undefined;
+  // Baileys 7 rc9 does not expose lid on sock.user, so read from creds file.
+  const selfLid = (() => {
+    try {
+      const credsPath = path.join(options.authDir ?? "", "creds.json");
+      const creds = JSON.parse(fs.readFileSync(credsPath, "utf-8"));
+      return creds?.me?.lid ?? undefined;
+    } catch {
+      return (sock.user as { lid?: string } | undefined)?.lid ?? undefined;
+    }
+  })();
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
     buildKey: (msg) => {

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -30,6 +30,7 @@ export type WebInboundMessage = {
   groupParticipants?: string[];
   mentionedJids?: string[];
   selfJid?: string | null;
+  selfLid?: string | null;
   selfE164?: string | null;
   fromMe?: boolean;
   location?: NormalizedLocation;


### PR DESCRIPTION
## Summary

Fixes the long-standing issue where replying to the bot's message in a WhatsApp group did not trigger a response.

**Root cause:** WhatsApp's LID (Linked Identity) system uses `xxxxx@lid` identifiers instead of phone-based JIDs (`xxxxx@s.whatsapp.net`). When a user replies to the bot's message, `contextInfo.participant` reports the original sender as a LID, but the bot's `selfJid` is a phone JID — the two never match, so `implicitMention` is always `false`.

**Two bugs stacked together:**

1. **FutureProofMessage wrapper** — WhatsApp wraps reply-to-bot messages in `botInvokeMessage` (a FutureProofMessage envelope). Baileys' `normalizeMessageContent` does not unwrap this type, so `contextInfo` (carrying reply metadata) is silently lost. Fixed by adding generic FutureProofMessage unwrapping in `extractContextInfo`.

2. **LID vs phone JID mismatch** — Even when `contextInfo` is present, the quoted sender is a LID while `selfJid` is a phone JID. Fixed by reading the bot's own LID from `creds.me.lid` and comparing `selfLid === replySenderJid` alongside the existing JID and E.164 comparisons.

### Changes

- `extensions/whatsapp/src/inbound/extract.ts` — Generic FutureProofMessage unwrap in `unwrapMessage` + recursive `contextInfo` extraction
- `extensions/whatsapp/src/auto-reply/monitor/group-gating.ts` — Add `selfLid` to the implicit mention comparison chain
- `extensions/whatsapp/src/inbound/monitor.ts` — Read `selfLid` from Baileys auth state, pass through to enriched message
- `extensions/whatsapp/src/inbound/types.ts` — Add `selfLid` field to `WebInboundMessage`

## Test plan
- [x] In a WhatsApp group with `requireMention` enabled, reply to the bot's text message without @mentioning — bot now responds
- [x] Verify @mention still works as before
- [x] Verify DM replies still work
- [x] Verify non-reply messages in groups are still gated by mention requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)