### PR TITLE
fix(plugins): skip non-provider registrations during snapshot loads

### DIFF
--- a/src/infra/provider-usage.auth.plugin.test.ts
+++ b/src/infra/provider-usage.auth.plugin.test.ts
@@ -4,9 +4,13 @@ const resolveProviderUsageAuthWithPluginMock = vi.fn(
   async (..._args: unknown[]): Promise<unknown> => null,
 );
 
-vi.mock("../plugins/provider-runtime.js", () => ({
-  resolveProviderUsageAuthWithPlugin: resolveProviderUsageAuthWithPluginMock,
-}));
+vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderUsageAuthWithPlugin: resolveProviderUsageAuthWithPluginMock,
+  };
+});
 
 let resolveProviderAuths: typeof import("./provider-usage.auth.js").resolveProviderAuths;
 

--- a/src/infra/provider-usage.load.plugin.test.ts
+++ b/src/infra/provider-usage.load.plugin.test.ts
@@ -3,14 +3,19 @@ import { createProviderUsageFetch } from "../test-utils/provider-usage-fetch.js"
 
 const resolveProviderUsageSnapshotWithPluginMock = vi.fn();
 
-vi.mock("../config/config.js", () => ({
-  loadConfig: () => ({}),
-}));
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return { ...actual, loadConfig: () => ({}) };
+});
 
-vi.mock("../plugins/provider-runtime.js", () => ({
-  resolveProviderUsageSnapshotWithPlugin: (...args: unknown[]) =>
-    resolveProviderUsageSnapshotWithPluginMock(...args),
-}));
+vi.mock("../plugins/provider-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderUsageSnapshotWithPlugin: (...args: unknown[]) =>
+      resolveProviderUsageSnapshotWithPluginMock(...args),
+  };
+});
 
 let loadProviderUsageSummary: typeof import("./provider-usage.load.js").loadProviderUsageSummary;
 

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -993,6 +993,9 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     });
 
     expect(scoped.plugins.find((entry) => entry.id === "command-plugin")?.status).toBe("loaded");
+    // Non-activating loads still run register() with full mode (commands are
+    // registered in the snapshot registry), but they are NOT published to the
+    // global command registry because activate is false.
     expect(scoped.commands.map((entry) => entry.command.name)).toEqual(["pair"]);
     expect(getPluginCommandSpecs("telegram")).toEqual([]);
 
@@ -1118,6 +1121,85 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     expect(() => loadOpenClawPlugins({ activate: false, cache: true })).toThrow(
       "activate:false requires cache:false",
     );
+  });
+
+  it("skips register() side-effects but collects providers when activate:false (snapshot load)", () => {
+    useNoBundledPlugins();
+    const registerCalls: string[] = [];
+    // Using a global to track calls since the plugin runs in a separate module scope via jiti,
+    // but CommonJS module.exports closures can capture the array reference.
+    (globalThis as Record<string, unknown>).__snapshot_register_calls = registerCalls;
+    try {
+      const plugin = writePlugin({
+        id: "snapshot-provider-plugin",
+        filename: "snapshot-provider-plugin.cjs",
+        body: `module.exports = {
+        id: "snapshot-provider-plugin",
+        register(api) {
+          const calls = globalThis.__snapshot_register_calls;
+          if (calls) calls.push("register:" + api.registrationMode);
+          api.registerProvider({
+            id: "snapshot-test-provider",
+            label: "Snapshot Test",
+            auth: [],
+          });
+          api.registerTool({
+            name: "snapshot-tool",
+            description: "tool that should not appear in snapshot loads",
+            parameters: { type: "object", properties: {} },
+            execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+          });
+        },
+      };`,
+      });
+
+      const snapshot = loadOpenClawPlugins({
+        cache: false,
+        activate: false,
+        providerOnly: true,
+        workspaceDir: plugin.dir,
+        config: {
+          plugins: {
+            load: { paths: [plugin.file] },
+            allow: ["snapshot-provider-plugin"],
+          },
+        },
+        onlyPluginIds: ["snapshot-provider-plugin"],
+      });
+
+      // Plugin was loaded and registered.
+      expect(
+        snapshot.plugins.find((entry) => entry.id === "snapshot-provider-plugin")?.status,
+      ).toBe("loaded");
+      // Provider is collected — this is the whole point of snapshot provider loads.
+      expect(snapshot.providers.map((entry) => entry.provider.id)).toEqual([
+        "snapshot-test-provider",
+      ]);
+      // Tools are NOT registered in provider-only mode.
+      expect(snapshot.tools).toEqual([]);
+      // register() was called with provider-only mode.
+      expect(registerCalls).toEqual(["register:provider-only"]);
+
+      // Verify full activation still works for the same plugin.
+      registerCalls.length = 0;
+      const full = loadOpenClawPlugins({
+        cache: false,
+        workspaceDir: plugin.dir,
+        config: {
+          plugins: {
+            load: { paths: [plugin.file] },
+            allow: ["snapshot-provider-plugin"],
+          },
+        },
+        onlyPluginIds: ["snapshot-provider-plugin"],
+      });
+
+      expect(full.providers.map((entry) => entry.provider.id)).toEqual(["snapshot-test-provider"]);
+      expect(full.tools.some((entry) => entry.names.includes("snapshot-tool"))).toBe(true);
+      expect(registerCalls).toEqual(["register:full"]);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__snapshot_register_calls;
+    }
   });
 
   it("re-initializes global hook runner when serving registry from cache", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -76,6 +76,13 @@ export type PluginLoadOptions = {
    */
   preferSetupRuntimeForChannelPlugins?: boolean;
   activate?: boolean;
+  /**
+   * When true, downgrade "full" registration to "provider-only" so plugins
+   * skip expensive tool, hook, command, and channel registration. Only
+   * provider registration methods remain active. Use this for provider
+   * resolution paths that don't need full plugin capabilities.
+   */
+  providerOnly?: boolean;
   throwOnLoadError?: boolean;
 };
 
@@ -185,6 +192,7 @@ function buildCacheKey(params: {
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
   runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
+  providerOnly?: boolean;
 }): string {
   const { roots, loadPaths } = resolvePluginCacheInputs({
     workspaceDir: params.workspaceDir,
@@ -215,7 +223,7 @@ function buildCacheKey(params: {
     ...params.plugins,
     installs,
     loadPaths,
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${params.runtimeSubagentMode ?? "default"}::${params.providerOnly ? "provider-only" : "full"}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -700,6 +708,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         : options.runtimeOptions?.subagent
           ? "explicit"
           : "default",
+    providerOnly: options.providerOnly === true,
   });
   const cacheEnabled = options.cache !== false;
   if (cacheEnabled) {
@@ -952,7 +961,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       });
     };
 
-    const registrationMode = enableState.enabled
+    const baseRegistrationMode = enableState.enabled
       ? !validateOnly &&
         shouldLoadChannelPluginInSetupRuntime({
           manifestChannels: manifestRecord.channels,
@@ -968,6 +977,19 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       : includeSetupOnlyChannelPlugins && !validateOnly && manifestRecord.channels.length > 0
         ? "setup-only"
         : null;
+
+    // When providerOnly is set, downgrade "full" to "provider-only" so plugins
+    // skip expensive tool, hook, command, and channel registration. This is
+    // used by resolvePluginProviders which only needs provider metadata.
+    // Note: !shouldActivate alone is NOT sufficient — channel setup snapshot
+    // loads also use activate:false but need registerChannel to work.
+    // Note: "setup-runtime" is intentionally not downgraded here; channel
+    // plugins in setup-runtime mode do not register providers regardless, so
+    // this is a pre-existing limitation rather than a regression.
+    const registrationMode =
+      options.providerOnly && baseRegistrationMode === "full"
+        ? "provider-only"
+        : baseRegistrationMode;
 
     if (!registrationMode) {
       record.status = "disabled";
@@ -1044,7 +1066,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     // Fast-path bundled memory plugins that are guaranteed disabled by slot policy.
     // This avoids opening/importing heavy memory plugin modules that will never register.
     if (
-      registrationMode === "full" &&
+      (registrationMode === "full" || registrationMode === "provider-only") &&
       candidate.origin === "bundled" &&
       manifestRecord.kind === "memory"
     ) {
@@ -1162,7 +1184,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       memorySlotMatched = true;
     }
 
-    if (registrationMode === "full") {
+    if (registrationMode === "full" || registrationMode === "provider-only") {
       const memoryDecision = resolveMemorySlotDecision({
         id: record.id,
         kind: record.kind,

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -61,6 +61,7 @@ export function resolvePluginProviders(params: {
     onlyPluginIds: params.onlyPluginIds,
     cache: params.cache ?? false,
     activate: params.activate ?? false,
+    providerOnly: !(params.activate ?? false),
     logger: createPluginLoaderLogger(log),
   });
 

--- a/src/plugins/providers.ts
+++ b/src/plugins/providers.ts
@@ -1,8 +1,18 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  withBundledPluginAllowlistCompat,
+  withBundledPluginEnablementCompat,
+} from "./bundled-compat.js";
 import { hasExplicitPluginConfig } from "./config-state.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
+import { loadOpenClawPlugins } from "./loader.js";
+import { createPluginLoaderLogger } from "./logger.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import type { ProviderPlugin } from "./types.js";
+
+const log = createSubsystemLogger("plugins");
 
 export function withBundledProviderVitestCompat(params: {
   config: PluginLoadOptions["config"];
@@ -110,4 +120,61 @@ export function resolveNonBundledProviderPluginIds(params: {
     )
     .map((plugin) => plugin.id)
     .toSorted((left, right) => left.localeCompare(right));
+}
+
+export function resolvePluginProviders(params: {
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  /** Use an explicit env when plugin roots should resolve independently from process.env. */
+  env?: PluginLoadOptions["env"];
+  bundledProviderAllowlistCompat?: boolean;
+  bundledProviderVitestCompat?: boolean;
+  onlyPluginIds?: string[];
+  activate?: boolean;
+  cache?: boolean;
+}): ProviderPlugin[] {
+  const bundledProviderCompatPluginIds =
+    params.bundledProviderAllowlistCompat || params.bundledProviderVitestCompat
+      ? resolveBundledProviderCompatPluginIds({
+          config: params.config,
+          workspaceDir: params.workspaceDir,
+          env: params.env,
+          onlyPluginIds: params.onlyPluginIds,
+        })
+      : [];
+  const maybeAllowlistCompat = params.bundledProviderAllowlistCompat
+    ? withBundledPluginAllowlistCompat({
+        config: params.config,
+        pluginIds: bundledProviderCompatPluginIds,
+      })
+    : params.config;
+  const maybeVitestCompat = params.bundledProviderVitestCompat
+    ? withBundledProviderVitestCompat({
+        config: maybeAllowlistCompat,
+        pluginIds: bundledProviderCompatPluginIds,
+        env: params.env,
+      })
+    : maybeAllowlistCompat;
+  const config =
+    params.bundledProviderAllowlistCompat || params.bundledProviderVitestCompat
+      ? withBundledPluginEnablementCompat({
+          config: maybeVitestCompat,
+          pluginIds: bundledProviderCompatPluginIds,
+        })
+      : maybeVitestCompat;
+  const registry = loadOpenClawPlugins({
+    config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    onlyPluginIds: params.onlyPluginIds,
+    cache: params.cache ?? false,
+    activate: params.activate ?? false,
+    providerOnly: !(params.activate ?? false),
+    logger: createPluginLoaderLogger(log),
+  });
+
+  return registry.providers.map((entry) => ({
+    ...entry.provider,
+    pluginId: entry.pluginId,
+  }));
 }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -903,23 +903,28 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
           : () => {},
       registerHttpRoute:
         registrationMode === "full" ? (params) => registerHttpRoute(record, params) : () => {},
-      registerChannel: (registration) => registerChannel(record, registration, registrationMode),
+      registerChannel:
+        registrationMode === "provider-only"
+          ? () => {}
+          : (registration) => registerChannel(record, registration, registrationMode),
       registerProvider:
-        registrationMode === "full" ? (provider) => registerProvider(record, provider) : () => {},
+        registrationMode === "full" || registrationMode === "provider-only"
+          ? (provider) => registerProvider(record, provider)
+          : () => {},
       registerSpeechProvider:
-        registrationMode === "full"
+        registrationMode === "full" || registrationMode === "provider-only"
           ? (provider) => registerSpeechProvider(record, provider)
           : () => {},
       registerMediaUnderstandingProvider:
-        registrationMode === "full"
+        registrationMode === "full" || registrationMode === "provider-only"
           ? (provider) => registerMediaUnderstandingProvider(record, provider)
           : () => {},
       registerImageGenerationProvider:
-        registrationMode === "full"
+        registrationMode === "full" || registrationMode === "provider-only"
           ? (provider) => registerImageGenerationProvider(record, provider)
           : () => {},
       registerWebSearchProvider:
-        registrationMode === "full"
+        registrationMode === "full" || registrationMode === "provider-only"
           ? (provider) => registerWebSearchProvider(record, provider)
           : () => {},
       registerGatewayMethod:

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1308,7 +1308,7 @@ export type OpenClawPluginModule =
   | OpenClawPluginDefinition
   | ((api: OpenClawPluginApi) => void | Promise<void>);
 
-export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime";
+export type PluginRegistrationMode = "full" | "setup-only" | "setup-runtime" | "provider-only";
 
 /** Main registration API injected into native plugin entry files. */
 export type OpenClawPluginApi = {


### PR DESCRIPTION
## Summary
- Adds providerOnly mode, included in buildCacheKey
- Test mocks use importOriginal pattern
- Restored scoped.commands assertion, added try/finally for globalThis cleanup
## Change Type
- [x] Bug fix
## Scope
- [x] Gateway / orchestration
## Security Impact
All No.
## FAQ
### Q: provider-only breaks full-guard plugins?
A: Standard register() pattern does not use registrationMode guard. setup-runtime limitation documented in comment.
### Q: providerOnly in buildCacheKey?
A: Prevents cache pollution between provider-only and full loads.
### Q: importOriginal pattern in test mocks?
A: Auto-includes new upstream exports without explicit stubs. Avoids repeated CI breakage from upstream additions.
### Q: Duplicate resolvePluginProviders in providers.ts and providers.runtime.ts?
A: Intentional. Different call sites import from different modules.
### Q: Removed assertion in loader.test.ts?
A: Restored — scoped.commands assertion verifies commands are still collected in non-activating loads.
### Q: globalThis cleanup on test failure?
A: Wrapped in try/finally to ensure __snapshot_register_calls is cleaned up even if assertions throw.