### PR TITLE
fix(gateway): raise default connect challenge timeout

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -121,6 +121,7 @@ export function describeGatewayCloseCode(code: number): string | undefined {
 
 const FORCE_STOP_TERMINATE_GRACE_MS = 250;
 const STOP_AND_WAIT_TIMEOUT_MS = 1_000;
+const DEFAULT_CONNECT_CHALLENGE_TIMEOUT_MS = 5_000;
 
 type PendingStop = {
   ws: WebSocket;
@@ -701,7 +702,7 @@ export class GatewayClient {
     const connectChallengeTimeoutMs =
       typeof rawConnectDelayMs === "number" && Number.isFinite(rawConnectDelayMs)
         ? Math.max(250, Math.min(10_000, rawConnectDelayMs))
-        : 2_000;
+        : DEFAULT_CONNECT_CHALLENGE_TIMEOUT_MS;
     if (this.connectTimer) {
       clearTimeout(this.connectTimer);
     }

--- a/src/gateway/client.watchdog.test.ts
+++ b/src/gateway/client.watchdog.test.ts
@@ -36,6 +36,49 @@ describe("GatewayClient", () => {
     }
   });
 
+  test("uses a 5s default connect-challenge timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const onConnectError = vi.fn();
+      const close = vi.fn();
+      const client = new GatewayClient({ onConnectError });
+      (
+        client as unknown as {
+          ws:
+            | WebSocket
+            | {
+                readyState: number;
+                send: () => void;
+                close: (code: number, reason: string) => void;
+              };
+          queueConnect: () => void;
+        }
+      ).ws = {
+        readyState: WebSocket.OPEN,
+        send: vi.fn(),
+        close,
+      };
+
+      (
+        client as unknown as {
+          queueConnect: () => void;
+        }
+      ).queueConnect();
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(onConnectError).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onConnectError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "gateway connect challenge timeout" }),
+      );
+      expect(close).toHaveBeenCalledWith(1008, "connect challenge timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("closes on missing ticks", async () => {
     const port = await getFreePort();
     wss = new WebSocketServer({ port, host: "127.0.0.1" });


### PR DESCRIPTION
## Summary

The Gateway server default handshake timeout on `main` is already 10s, but `GatewayClient.queueConnect()` still uses a hardcoded 2s default when `connectDelayMs` is not set.

That mismatch makes local loopback clients fail under load with:
- `gateway connect challenge timeout`
- `gateway closed (1000)`
- server-side `handshake timeout` / pre-auth close logs

This PR raises the client default connect-challenge timeout from **2s to 5s** and adds a unit test that locks the new default in place.

## Why

On my host, the Gateway daemon was healthy, but local CLI clients intermittently lost the authenticated connect challenge because the client-side timeout was too short during local pressure. The server was willing to wait longer; the client gave up first.

This is intentionally a narrow fix:
- keep explicit `connectDelayMs` overrides unchanged
- improve the default for the no-override path
- add regression coverage in `client.watchdog.test.ts`

## Validation

Ran:

```bash
corepack pnpm exec vitest run --config vitest.gateway.config.ts \
  src/gateway/client.watchdog.test.ts \
  src/gateway/client.test.ts \
  src/gateway/server.preauth-hardening.test.ts
```

Result: **3 files passed, 30 tests passed**.

## Notes

I saw there are already broader handshake-timeout PRs open. This one is the smaller client-side fix only, with a focused regression test.
