### PR TITLE
fix: make log stream height responsive to viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/logs: make the Gateway Logs stream height responsive to the viewport with a minimum height floor, so larger screens can show substantially more log lines without collapsing on shorter viewports. (#53916) Thanks @extrasmall0.
 - ACP/Codex: surface redacted Codex wrapper stderr for generic ACP internal failures and preserve safe Codex model/provider routing in isolated `CODEX_HOME`, making `sessions_spawn(runtime="acp", agentId="codex")` failures actionable. Fixes #80079. (#80718) Thanks @leoge007.
 - ACP: treat rejected timeout config options as best-effort hints so ACP turns continue with adapters that do not support `session/set_config_option` timeout keys. Fixes #81250. (#81603) Thanks @qkal.
 - Cron/Codex: default exact-command scheduled agent turns to lightweight bootstrap context so automation runs the command before loading workspace identity or memory context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/logs: make the Gateway Logs stream height responsive to the viewport with a minimum height floor, so larger screens can show substantially more log lines without collapsing on shorter viewports. (#53916) Thanks @extrasmall0.
 - Image generation/build: write stable runtime alias files into `dist/` and route provider-auth runtime lookups through those aliases so image-generation providers keep resolving auth/runtime modules after rebuilds instead of crashing on missing hashed chunk files.
 - Config/runtime: pin the first successful config load in memory for the running process and refresh that snapshot on successful writes/reloads, so hot paths stop reparsing `openclaw.json` between watcher-driven swaps.
 - Config/legacy cleanup: stop probing obsolete alternate legacy config names and service labels during local config/service detection, while keeping the active `~/.openclaw/openclaw.json` path canonical.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2267,7 +2267,8 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--card);
-  max-height: 500px;
+  max-height: calc(100vh - 280px);
+  min-height: 200px;
   overflow: auto;
   container-type: inline-size;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3404,7 +3404,8 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--card);
-  max-height: 500px;
+  max-height: calc(100vh - 280px);
+  min-height: 200px;
   overflow: auto;
   container-type: inline-size;
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3404,7 +3404,7 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--card);
-  max-height: calc(100vh - 280px);
+  max-height: calc(100vh - 280px); /* top nav + filter bar + page padding + breathing room */
   min-height: 200px;
   overflow: auto;
   container-type: inline-size;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2267,7 +2267,7 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--card);
-  max-height: calc(100vh - 280px);
+  max-height: calc(100vh - 280px); /* top nav + filter bar + page padding + breathing room */
   min-height: 200px;
   overflow: auto;
   container-type: inline-size;


### PR DESCRIPTION
The log viewer's scroll area was capped at `max-height: 500px`, leaving a bunch of unused space on taller screens.

This swaps it for `calc(100vh - 280px)` (with a `min-height: 200px` floor) so the list fills the available vertical space without breaking on smaller viewports.

The 280px offset accounts for the top nav + filter bar + some breathing room — felt right in testing but happy to tweak if needed.

Closes #53881