### PR TITLE
Adjust CLI backend environment handling before spawn

### DIFF
--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -102,6 +102,10 @@ function createManagedRun(exit: MockRunExit, pid = 1234) {
 }
 
 describe("runCliAgent with process supervisor", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   beforeEach(async () => {
     supervisorSpawnMock.mockClear();
     enqueueSystemEventMock.mockClear();
@@ -155,6 +159,112 @@ describe("runCliAgent with process supervisor", () => {
     expect(input.noOutputTimeoutMs).toBeGreaterThanOrEqual(1_000);
     expect(input.replaceExistingScope).toBe(true);
     expect(input.scopeKey).toContain("thread-123");
+  });
+
+  it("sanitizes dangerous backend env overrides before spawn", async () => {
+    vi.stubEnv("PATH", "/usr/bin:/bin");
+    vi.stubEnv("HOME", "/tmp/trusted-home");
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "codex-cli": {
+                env: {
+                  NODE_OPTIONS: "--require ./malicious.js",
+                  LD_PRELOAD: "/tmp/pwn.so",
+                  PATH: "/tmp/evil",
+                  HOME: "/tmp/evil-home",
+                  SAFE_KEY: "ok",
+                },
+              },
+            },
+          },
+        },
+      } satisfies OpenClawConfig,
+      prompt: "hi",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+      timeoutMs: 1_000,
+      runId: "run-env-sanitized",
+      cliSessionId: "thread-123",
+    });
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+      env?: Record<string, string | undefined>;
+    };
+    expect(input.env?.SAFE_KEY).toBe("ok");
+    expect(input.env?.PATH).toBe("/usr/bin:/bin");
+    expect(input.env?.HOME).toBe("/tmp/trusted-home");
+    expect(input.env?.NODE_OPTIONS).toBeUndefined();
+    expect(input.env?.LD_PRELOAD).toBeUndefined();
+  });
+
+  it("applies clearEnv after sanitizing backend env overrides", async () => {
+    vi.stubEnv("PATH", "/usr/bin:/bin");
+    vi.stubEnv("SAFE_CLEAR", "from-base");
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "codex-cli": {
+                env: {
+                  SAFE_KEEP: "keep-me",
+                },
+                clearEnv: ["SAFE_CLEAR"],
+              },
+            },
+          },
+        },
+      } satisfies OpenClawConfig,
+      prompt: "hi",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+      timeoutMs: 1_000,
+      runId: "run-clear-env",
+      cliSessionId: "thread-123",
+    });
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+      env?: Record<string, string | undefined>;
+    };
+    expect(input.env?.SAFE_KEEP).toBe("keep-me");
+    expect(input.env?.SAFE_CLEAR).toBeUndefined();
   });
 
   it("prepends bootstrap warnings to the CLI prompt body", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
@@ -296,7 +297,11 @@ export async function runCliAgent(params: {
         }
 
         const env = (() => {
-          const next = { ...process.env, ...backend.env };
+          const next = sanitizeHostExecEnv({
+            baseEnv: process.env,
+            overrides: backend.env,
+            blockPathOverrides: true,
+          });
           for (const key of backend.clearEnv ?? []) {
             delete next[key];
           }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `runCliAgent()` in `src/agents/cli-runner.ts` merged `backend.env` directly into the child-process environment, so workspace-configured `cliBackends.*.env` values could inject dangerous execution variables into spawned CLI backends.
- Why it matters: blocked variables such as `NODE_OPTIONS`, `LD_PRELOAD`, or override-only sensitive keys like `HOME` could influence the spawned tool process in ways the host env security policy is supposed to prevent.
- What changed: the runner now constructs the child env with `sanitizeHostExecEnv({ baseEnv: process.env, overrides: backend.env, blockPathOverrides: true })`, then applies the existing `clearEnv` deletions.
- What did NOT change (scope boundary): this PR does not redesign CLI backend config merging, change the sanitizer policy itself, or alter unrelated backend/provider behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the child-process env was assembled at the runner boundary with a raw object spread instead of the existing host exec env sanitizer, so untrusted backend config overrides bypassed policy enforcement.
- Missing detection / guardrail: there was no runner-level regression test asserting that dangerous `cliBackends.*.env` values are removed before `supervisor.spawn(...)` receives the env.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the repo already had `sanitizeHostExecEnv()` and dedicated policy tests in `src/infra/host-env-security.ts` and `src/infra/host-env-security.test.ts`, but this runner path had not been wired through that helper.
- Why this regressed now: this appears to be an incomplete adoption of the existing env security boundary rather than a newly introduced sanitizer regression.
- If unknown, what was ruled out: the vulnerability does not require changes to `src/agents/cli-backends.ts`, because that file only merges config data and does not directly spawn processes.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/cli-runner.test.ts`
- Scenario the test should lock in: dangerous backend env overrides are absent from the env passed to `supervisor.spawn(...)`, safe keys still survive, trusted inherited values remain pinned when blocked overrides are requested, and `clearEnv` still deletes keys after sanitization.
- Why this is the smallest reliable guardrail: the trust boundary is the runner's final spawn env assembly, so this file can assert the exact env object that reaches process creation without requiring external CLI binaries.
- Existing test that already covers this (if any): `src/infra/host-env-security.test.ts` already covers the sanitizer policy itself, but not the runner integration point.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Users with normal backend env overrides should see no behavior change for safe keys. Workspace-configured backend env values that target blocked execution-sensitive keys are now ignored before the CLI backend process is spawned.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: the command execution surface is hardened, not expanded; untrusted backend env values now flow through the existing host exec env policy before process spawn.

## Repro + Verification

### Environment

- OS: Linux host
- Runtime/container: Docker validation container
- Model/provider: `codex-cli`
- Integration/channel (if any): N/A
- Relevant config (redacted): `OPENCLAW_TEST_PROFILE=low`

### Steps

1. Build the validation container and install repo dependencies inside it.
2. Run `pnpm exec oxfmt --check src/agents/cli-runner.ts src/agents/cli-runner.test.ts` in the container.
3. Run `pnpm build` in the same container.
4. Run `OPENCLAW_TEST_PROFILE=low pnpm test -- src/agents/cli-runner.test.ts` and `OPENCLAW_TEST_PROFILE=low pnpm test -- src/infra/host-env-security.test.ts` in the same container.

### Expected

- Formatting check passes for the touched files
- `pnpm build` passes in-container
- `src/agents/cli-runner.test.ts` passes
- `src/infra/host-env-security.test.ts` passes
- Dangerous backend env override keys do not appear in the env passed to `supervisor.spawn(...)`
- Safe keys remain available and `clearEnv` behavior still works

### Actual

- In-container formatting check passed for `src/agents/cli-runner.ts` and `src/agents/cli-runner.test.ts`
- In-container `pnpm build` passed
- In-container `src/agents/cli-runner.test.ts` passed with `8/8` tests
- In-container `src/infra/host-env-security.test.ts` passed with `18/18` tests

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified in a Docker validation container that the runner now sanitizes backend env overrides before spawn, the focused runner regressions pass, the sanitizer test suite still passes, and the repo build remains green.
- Edge cases checked: blocked override keys (`NODE_OPTIONS`, `LD_PRELOAD`), protected inherited values (`PATH`, `HOME`), surviving safe override keys, and post-sanitization `clearEnv` deletion behavior.
- What you did **not** verify: I did not run a live external CLI backend binary or a full end-to-end agent session beyond the mocked runner boundary tests.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the env-construction change in `src/agents/cli-runner.ts` and the companion regression additions in `src/agents/cli-runner.test.ts`.
- Files/config to restore: `src/agents/cli-runner.ts`, `src/agents/cli-runner.test.ts`
- Known bad symptoms reviewers should watch for: safe backend env keys missing unexpectedly, `clearEnv` no longer removing keys, or dangerous override keys appearing in the env given to `supervisor.spawn(...)`.

## Risks and Mitigations

- Risk: sanitizing at the runner boundary could accidentally drop env keys that some safe backend configurations expect.
  - Mitigation: the fix reuses the existing repo-wide host exec env policy rather than inventing a new blocklist, and the new runner test confirms safe keys still pass through.
- Risk: changing the env assembly order could break existing backend `clearEnv` behavior.
  - Mitigation: a focused runner regression verifies `clearEnv` still applies after the sanitized env is created.
