### PR TITLE
Web UI: add heartbeat stop button and fix progress updates

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -272,6 +272,7 @@ public struct OpenClawChatEventPayload: Codable, Sendable {
 public struct OpenClawAgentEventPayload: Codable, Sendable, Identifiable {
     public var id: String { "\(self.runId)-\(self.seq ?? -1)" }
     public let runId: String
+    public let sessionKey: String?
     public let seq: Int?
     public let stream: String
     public let ts: Int?

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -49,6 +49,12 @@ public final class OpenClawChatViewModel {
     @ObservationIgnored
     private nonisolated(unsafe) var pendingRunTimeoutTasks: [String: Task<Void, Never>] = [:]
     private let pendingRunTimeoutMs: UInt64 = 120_000
+    private var assistantStreamText: String?
+    private var syntheticProgressText: String?
+    private var syntheticProgressStartedAtMs: Double?
+    private var syntheticProgressActiveRunId: String?
+    private var syntheticProgressPrimaryToolName: String?
+    private var syntheticProgressLastElapsedBucket: Int?
     // Session switches can overlap in-flight picker patches, so stale completions
     // must compare against the latest request and latest desired value for that session.
     private var nextModelSelectionRequestID: UInt64 = 0
@@ -219,7 +225,7 @@ public final class OpenClawChatViewModel {
         self.healthOK = false
         self.clearPendingRuns(reason: nil)
         self.pendingToolCallsById = [:]
-        self.streamingAssistantText = nil
+        self.resetStreamingState()
         self.sessionId = nil
         defer { self.isLoading = false }
         do {
@@ -492,7 +498,7 @@ public final class OpenClawChatViewModel {
         self.pendingRuns.insert(runId)
         self.armPendingRunTimeout(runId: runId)
         self.pendingToolCallsById = [:]
-        self.streamingAssistantText = nil
+        self.resetStreamingState()
 
         // Optimistically append user message to UI.
         var userContent: [OpenClawChatMessageContent] = [
@@ -897,6 +903,7 @@ public final class OpenClawChatViewModel {
         case let .health(ok):
             self.healthOK = ok
         case .tick:
+            self.refreshSyntheticProgressText(forceElapsedBucketAdvance: false)
             Task { await self.pollHealthIfNeeded(force: false) }
         case let .chat(chat):
             self.handleChatEvent(chat)
@@ -929,7 +936,7 @@ public final class OpenClawChatViewModel {
             // Keep multiple clients in sync: if another client finishes a run for our session, refresh history.
             switch chat.state {
             case "final", "aborted", "error":
-                self.streamingAssistantText = nil
+                self.resetStreamingState()
                 self.pendingToolCallsById = [:]
                 Task { await self.refreshHistoryAfterRun() }
             default:
@@ -949,7 +956,7 @@ public final class OpenClawChatViewModel {
                 self.clearPendingRuns(reason: nil)
             }
             self.pendingToolCallsById = [:]
-            self.streamingAssistantText = nil
+            self.resetStreamingState()
             Task { await self.refreshHistoryAfterRun() }
         default:
             break
@@ -972,15 +979,31 @@ public final class OpenClawChatViewModel {
     }
 
     private func handleAgentEvent(_ evt: OpenClawAgentEventPayload) {
-        if let sessionId, evt.runId != sessionId {
+        let isCurrentPendingRun = self.pendingRuns.contains(evt.runId)
+        let matchesCurrentSession =
+            evt.sessionKey.map {
+                Self.matchesCurrentSessionKey(incoming: $0, current: self.sessionKey)
+            } ?? false
+        let matchesLegacySessionId = self.sessionId.map { $0 == evt.runId } ?? false
+        if !isCurrentPendingRun, !matchesCurrentSession, !matchesLegacySessionId {
             return
         }
 
         switch evt.stream {
         case "assistant":
             if let text = evt.data["text"]?.value as? String {
-                self.streamingAssistantText = text
+                self.assistantStreamText = text
+                if self.syntheticProgressActiveRunId == evt.runId {
+                    self.syntheticProgressActiveRunId = nil
+                    self.syntheticProgressPrimaryToolName = nil
+                    self.syntheticProgressStartedAtMs = nil
+                    self.syntheticProgressLastElapsedBucket = nil
+                    self.syntheticProgressText = nil
+                }
+                self.refreshVisibleStreamingText()
             }
+        case "lifecycle":
+            self.handleLifecycleAgentEvent(evt)
         case "tool":
             guard let phase = evt.data["phase"]?.value as? String else { return }
             guard let name = evt.data["name"]?.value as? String else { return }
@@ -993,12 +1016,106 @@ public final class OpenClawChatViewModel {
                     args: args,
                     startedAt: evt.ts.map(Double.init) ?? Date().timeIntervalSince1970 * 1000,
                     isError: nil)
+                self.startSyntheticProgress(runId: evt.runId, primaryToolName: name, ts: evt.ts)
             } else if phase == "result" {
                 self.pendingToolCallsById[toolCallId] = nil
+                if self.pendingToolCallsById.isEmpty {
+                    self.syntheticProgressPrimaryToolName = nil
+                }
+                self.refreshSyntheticProgressText(forceElapsedBucketAdvance: true)
             }
         default:
             break
         }
+    }
+
+    private func handleLifecycleAgentEvent(_ evt: OpenClawAgentEventPayload) {
+        guard let phase = evt.data["phase"]?.value as? String else { return }
+        switch phase {
+        case "start":
+            self.startSyntheticProgress(runId: evt.runId, primaryToolName: nil, ts: evt.ts)
+        case "end", "error":
+            if self.syntheticProgressActiveRunId == evt.runId || self.pendingRuns.contains(evt.runId) {
+                self.syntheticProgressActiveRunId = nil
+                self.syntheticProgressPrimaryToolName = nil
+                self.syntheticProgressStartedAtMs = nil
+                self.syntheticProgressLastElapsedBucket = nil
+                self.syntheticProgressText = nil
+                self.refreshVisibleStreamingText()
+            }
+        default:
+            break
+        }
+    }
+
+    private func startSyntheticProgress(runId: String, primaryToolName: String?, ts: Int?) {
+        if self.syntheticProgressActiveRunId != runId {
+            self.syntheticProgressActiveRunId = runId
+            self.syntheticProgressStartedAtMs = ts.map(Double.init) ?? Date().timeIntervalSince1970 * 1000
+            self.syntheticProgressLastElapsedBucket = nil
+        }
+        if let primaryToolName, !primaryToolName.isEmpty {
+            self.syntheticProgressPrimaryToolName = primaryToolName
+        }
+        self.refreshSyntheticProgressText(forceElapsedBucketAdvance: true)
+    }
+
+    private func refreshSyntheticProgressText(forceElapsedBucketAdvance: Bool) {
+        guard self.syntheticProgressActiveRunId != nil || !self.pendingToolCallsById.isEmpty else {
+            self.syntheticProgressPrimaryToolName = nil
+            self.syntheticProgressStartedAtMs = nil
+            self.syntheticProgressLastElapsedBucket = nil
+            self.syntheticProgressText = nil
+            self.refreshVisibleStreamingText()
+            return
+        }
+
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        let startedAtMs = self.syntheticProgressStartedAtMs ?? nowMs
+        self.syntheticProgressStartedAtMs = startedAtMs
+        let elapsedSeconds = max(0, Int((nowMs - startedAtMs) / 1000))
+        let elapsedBucket = elapsedSeconds / 15
+        if !forceElapsedBucketAdvance, elapsedBucket == self.syntheticProgressLastElapsedBucket {
+            return
+        }
+        self.syntheticProgressLastElapsedBucket = elapsedBucket
+
+        let toolName = self.syntheticProgressPrimaryToolName ?? self.pendingToolCalls.first?.name
+        var status = "Working"
+        if let toolName, !toolName.isEmpty {
+            status += " while running `\(toolName)`"
+        }
+        if elapsedSeconds >= 15 {
+            status += " (\(elapsedSeconds)s)"
+        }
+        status += "."
+        self.syntheticProgressText = "_\(status)_"
+        self.refreshVisibleStreamingText()
+    }
+
+    private func refreshVisibleStreamingText() {
+        let assistantText = self.assistantStreamText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let syntheticText = self.syntheticProgressText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch (assistantText?.isEmpty == false ? assistantText : nil, syntheticText?.isEmpty == false ? syntheticText : nil) {
+        case let (assistantText?, syntheticText?):
+            self.streamingAssistantText = "\(assistantText)\n\n\(syntheticText)"
+        case let (assistantText?, nil):
+            self.streamingAssistantText = assistantText
+        case let (nil, syntheticText?):
+            self.streamingAssistantText = syntheticText
+        case (nil, nil):
+            self.streamingAssistantText = nil
+        }
+    }
+
+    private func resetStreamingState() {
+        self.assistantStreamText = nil
+        self.syntheticProgressText = nil
+        self.syntheticProgressStartedAtMs = nil
+        self.syntheticProgressActiveRunId = nil
+        self.syntheticProgressPrimaryToolName = nil
+        self.syntheticProgressLastElapsedBucket = nil
+        self.streamingAssistantText = nil
     }
 
     private func refreshHistoryAfterRun() async {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -151,6 +151,7 @@ private func sendMessageAndEmitFinal(
 private func emitAssistantText(
     transport: TestChatTransport,
     runId: String,
+    sessionKey: String? = "main",
     text: String,
     seq: Int = 1)
 {
@@ -158,6 +159,7 @@ private func emitAssistantText(
         .agent(
             OpenClawAgentEventPayload(
                 runId: runId,
+                sessionKey: sessionKey,
                 seq: seq,
                 stream: "assistant",
                 ts: Int(Date().timeIntervalSince1970 * 1000),
@@ -167,12 +169,14 @@ private func emitAssistantText(
 private func emitToolStart(
     transport: TestChatTransport,
     runId: String,
+    sessionKey: String? = "main",
     seq: Int = 2)
 {
     transport.emit(
         .agent(
             OpenClawAgentEventPayload(
                 runId: runId,
+                sessionKey: sessionKey,
                 seq: seq,
                 stream: "tool",
                 ts: Int(Date().timeIntervalSince1970 * 1000),
@@ -433,17 +437,17 @@ extension TestChatTransportState {
         await sendUserMessage(vm)
         try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
 
-        emitAssistantText(transport: transport, runId: sessionId, text: "streaming…")
+        let runId = try #require(await transport.lastSentRunId())
+        emitAssistantText(transport: transport, runId: runId, text: "streaming…")
 
         try await waitUntil("assistant stream visible") {
             await MainActor.run { vm.streamingAssistantText == "streaming…" }
         }
 
-        emitToolStart(transport: transport, runId: sessionId)
+        emitToolStart(transport: transport, runId: runId)
 
         try await waitUntil("tool call pending") { await MainActor.run { vm.pendingToolCalls.count == 1 } }
 
-        let runId = try #require(await transport.lastSentRunId())
         transport.emit(
             .chat(
                 OpenClawChatEventPayload(
@@ -683,8 +687,12 @@ extension TestChatTransportState {
         let (transport, vm) = await makeViewModel(historyResponses: [history, history])
         try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
 
-        emitAssistantText(transport: transport, runId: sessionId, text: "external stream")
-        emitToolStart(transport: transport, runId: sessionId)
+        emitAssistantText(
+            transport: transport,
+            runId: "external-run",
+            sessionKey: "main",
+            text: "external stream")
+        emitToolStart(transport: transport, runId: "external-run", sessionKey: "main")
 
         try await waitUntil("streaming active") {
             await MainActor.run { vm.streamingAssistantText == "external stream" }
@@ -695,6 +703,54 @@ extension TestChatTransportState {
 
         try await waitUntil("streaming cleared") { await MainActor.run { vm.streamingAssistantText == nil } }
         #expect(await MainActor.run { vm.pendingToolCalls.isEmpty })
+    }
+
+    @Test func acceptsAgentEventsForPendingRunsEvenWhenRunIDDiffersFromSessionID() async throws {
+        let sessionId = "sess-main"
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(historyResponses: [history, history])
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "check progress")
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let runId = try #require(await transport.lastSentRunId())
+        #expect(runId != sessionId)
+
+        emitToolStart(transport: transport, runId: runId, sessionKey: "main")
+
+        try await waitUntil("pending tool shows for real run id") {
+            await MainActor.run { vm.pendingToolCalls.count == 1 }
+        }
+        try await waitUntil("synthetic progress visible") {
+            await MainActor.run {
+                vm.streamingAssistantText?.contains("Working while running `demo`.") == true
+            }
+        }
+    }
+
+    @Test func appendsSyntheticProgressToAssistantCommentaryForLongRuns() async throws {
+        let sessionId = "sess-main"
+        let history = historyPayload(sessionId: sessionId)
+        let (transport, vm) = await makeViewModel(historyResponses: [history, history])
+        try await loadAndWaitBootstrap(vm: vm, sessionId: sessionId)
+
+        await sendUserMessage(vm, text: "do the long task")
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+        let runId = try #require(await transport.lastSentRunId())
+
+        emitAssistantText(
+            transport: transport,
+            runId: runId,
+            sessionKey: "main",
+            text: "I’ll keep you updated.")
+        emitToolStart(transport: transport, runId: runId, sessionKey: "main")
+
+        try await waitUntil("assistant text includes synthetic status") {
+            await MainActor.run {
+                vm.streamingAssistantText?.contains("I’ll keep you updated.") == true &&
+                    vm.streamingAssistantText?.contains("Working while running `demo`.") == true
+            }
+        }
     }
 
     @Test func seqGapClearsPendingRunsAndAutoRefreshesHistory() async throws {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -239,7 +239,7 @@ export function buildAgentSystemPrompt(params: {
     browser: "Control web browser",
     canvas: "Present/eval/snapshot the Canvas",
     nodes: "List/describe/notify/camera/screen on paired nodes",
-    cron: "Manage cron jobs and wake events (use for reminders; when scheduling a reminder, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
+    cron: "Manage cron jobs and wake events (use for reminders, milestone tracking, and progress monitoring; when scheduling a reminder or status check, write the systemEvent text as something that will read like a reminder when it fires, and mention that it is a reminder depending on the time gap between setting and firing; include recent context in reminder text if appropriate)",
     message: "Send messages and channel actions",
     gateway: "Restart, apply config, or run updates on the running OpenClaw process",
     agents_list: acpSpawnRuntimeEnabled
@@ -650,6 +650,41 @@ export function buildAgentSystemPrompt(params: {
       "HEARTBEAT_OK",
       'OpenClaw treats a leading/trailing "HEARTBEAT_OK" as a heartbeat ack (and may discard it).',
       'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
+      "",
+    );
+  }
+
+  // Progress monitoring / milestone tracking guidance
+  if (!isMinimal) {
+    const hasCron = availableTools.has("cron");
+    lines.push(
+      "## Progress Updates & Milestone Reporting",
+      "MANDATORY: When the user asks for status updates, progress reports, milestone notifications, or any form of incremental reporting during a task",
+      '(trigger phrases: "give me updates", "status update", "keep me posted", "notify me", "check in", "let me know", "for each X update me", "milestone"),',
+      "you MUST deliver those updates proactively. Do NOT silently complete the entire task and report only at the end.",
+      "",
+      "### Inline updates (sequential/iterative work)",
+      "When processing a list of items or working through steps (e.g., researching issues, reviewing files, completing subtasks):",
+      "- After completing EACH item or milestone, immediately output a visible status update BEFORE moving to the next item",
+      '- Format: "Status update [N/total]: [summary of what was found/completed]"',
+      "- Do NOT batch all tool calls silently — interleave your progress text between tool calls so the user sees real-time updates",
+      "- This is the default behavior whenever the user asks for updates on iterative work",
+      "",
+    );
+    if (hasCron) {
+      lines.push(
+        "### Scheduled updates (long-running/background work)",
+        'When the user asks for time-based periodic updates (e.g., "check every 5 minutes", "update me hourly"), use the cron tool to create temporary scheduled jobs:',
+        '- Use schedule.kind="every" with an appropriate interval (e.g., everyMs: 300000 for 5 minutes)',
+        '- Use payload.kind="agentTurn" with sessionTarget="current" to check progress in the current session context',
+        "- Write the agentTurn message as a clear instruction to check and report on the specific task",
+        '- Set delivery.mode="announce" so the update reaches the user',
+        "- Remove the cron job when the task completes",
+        "",
+      );
+    }
+    lines.push(
+      "Ignoring update requests is a critical failure. Always deliver updates as requested.",
       "",
     );
   }

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -35,6 +35,14 @@ export function getExistingFollowupQueue(key: string): FollowupQueueState | unde
   return FOLLOWUP_QUEUES.get(cleaned);
 }
 
+export function getFollowupQueueSize(key: string): number {
+  const queue = getExistingFollowupQueue(key);
+  if (!queue) {
+    return 0;
+  }
+  return queue.items.length + queue.droppedCount;
+}
+
 export function getFollowupQueue(key: string, settings: QueueSettings): FollowupQueueState {
   const existing = FOLLOWUP_QUEUES.get(key);
   if (existing) {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -110,6 +110,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "sessions.create",
     "sessions.send",
     "sessions.steer",
+    "sessions.activity",
     "sessions.abort",
     "browser.request",
     "push.test",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -190,6 +190,8 @@ import {
   type SecretsResolveResult,
   SecretsResolveParamsSchema,
   SecretsResolveResultSchema,
+  type SessionsActivityParams,
+  SessionsActivityParamsSchema,
   type SessionsAbortParams,
   SessionsAbortParamsSchema,
   type SessionsCompactParams,
@@ -347,6 +349,9 @@ export const validateSessionsMessagesSubscribeParams = ajv.compile<SessionsMessa
 );
 export const validateSessionsMessagesUnsubscribeParams =
   ajv.compile<SessionsMessagesUnsubscribeParams>(SessionsMessagesUnsubscribeParamsSchema);
+export const validateSessionsActivityParams = ajv.compile<SessionsActivityParams>(
+  SessionsActivityParamsSchema,
+);
 export const validateSessionsAbortParams =
   ajv.compile<SessionsAbortParams>(SessionsAbortParamsSchema);
 export const validateSessionsPatchParams =
@@ -522,6 +527,7 @@ export {
   SessionsResolveParamsSchema,
   SessionsCreateParamsSchema,
   SessionsSendParamsSchema,
+  SessionsActivityParamsSchema,
   SessionsAbortParamsSchema,
   SessionsPatchParamsSchema,
   SessionsResetParamsSchema,

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -140,6 +140,7 @@ import {
   SecretsResolveResultSchema,
 } from "./secrets.js";
 import {
+  SessionsActivityParamsSchema,
   SessionsAbortParamsSchema,
   SessionsCompactParamsSchema,
   SessionsCreateParamsSchema,
@@ -215,6 +216,7 @@ export const ProtocolSchemas = {
   SessionsSendParams: SessionsSendParamsSchema,
   SessionsMessagesSubscribeParams: SessionsMessagesSubscribeParamsSchema,
   SessionsMessagesUnsubscribeParams: SessionsMessagesUnsubscribeParamsSchema,
+  SessionsActivityParams: SessionsActivityParamsSchema,
   SessionsAbortParams: SessionsAbortParamsSchema,
   SessionsPatchParams: SessionsPatchParamsSchema,
   SessionsResetParams: SessionsResetParamsSchema,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -86,6 +86,13 @@ export const SessionsMessagesUnsubscribeParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const SessionsActivityParamsSchema = Type.Object(
+  {
+    key: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
 export const SessionsAbortParamsSchema = Type.Object(
   {
     key: NonEmptyString,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -45,6 +45,7 @@ export type SessionsCreateParams = SchemaType<"SessionsCreateParams">;
 export type SessionsSendParams = SchemaType<"SessionsSendParams">;
 export type SessionsMessagesSubscribeParams = SchemaType<"SessionsMessagesSubscribeParams">;
 export type SessionsMessagesUnsubscribeParams = SchemaType<"SessionsMessagesUnsubscribeParams">;
+export type SessionsActivityParams = SchemaType<"SessionsActivityParams">;
 export type SessionsAbortParams = SchemaType<"SessionsAbortParams">;
 export type SessionsPatchParams = SchemaType<"SessionsPatchParams">;
 export type SessionsResetParams = SchemaType<"SessionsResetParams">;

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -191,6 +191,31 @@ describe("agent event handler", () => {
     nowSpy?.mockRestore();
   });
 
+  it("includes assistant delta text in chat delta payloads", () => {
+    const { broadcast, nowSpy, chatRunState, handler } = createHarness({ now: 1_000 });
+    chatRunState.registry.add("run-1", {
+      sessionKey: "session-1",
+      clientRunId: "client-1",
+    });
+    handler({
+      runId: "run-1",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "Hello world", delta: " world" },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(1);
+    const payload = chatCalls[0]?.[1] as {
+      delta?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(payload.delta).toBe(" world");
+    expect(payload.message?.content?.[0]?.text).toBe("Hello world");
+    nowSpy?.mockRestore();
+  });
+
   it("strips inline directives from assistant chat events", () => {
     const { broadcast, nodeSendToSession, nowSpy } = emitRun1AssistantText(
       createHarness({ now: 1_000 }),

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -541,6 +541,7 @@ export function createAgentEventHandler({
       sessionKey,
       seq,
       state: "delta" as const,
+      ...(cleanedDelta ? { delta: cleanedDelta } : {}),
       message: {
         role: "assistant",
         content: [{ type: "text", text: mergedText }],

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -62,6 +62,7 @@ const BASE_METHODS = [
   "sessions.preview",
   "sessions.create",
   "sessions.send",
+  "sessions.activity",
   "sessions.abort",
   "sessions.patch",
   "sessions.reset",

--- a/src/gateway/server-methods/sessions.abort.autonomy.test.ts
+++ b/src/gateway/server-methods/sessions.abort.autonomy.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testState, writeSessionStore } from "../test-helpers.js";
+import { sessionsHandlers } from "./sessions.js";
+
+const queueCleanupMocks = vi.hoisted(() => ({
+  clearSessionQueues: vi.fn<
+    () => {
+      followupCleared: number;
+      laneCleared: number;
+      keys: string[];
+    }
+  >(() => ({ followupCleared: 0, laneCleared: 0, keys: [] })),
+}));
+
+const abortMocks = vi.hoisted(() => ({
+  stopSubagentsForRequester: vi.fn(() => ({ stopped: 0 })),
+}));
+
+const acpManagerMocks = vi.hoisted(() => ({
+  cancelSession: vi.fn(async () => {}),
+}));
+
+vi.mock("../../auto-reply/reply/queue/cleanup.js", async () => {
+  const actual = await vi.importActual<typeof import("../../auto-reply/reply/queue/cleanup.js")>(
+    "../../auto-reply/reply/queue/cleanup.js",
+  );
+  return {
+    ...actual,
+    clearSessionQueues: queueCleanupMocks.clearSessionQueues,
+  };
+});
+
+vi.mock("../../auto-reply/reply/abort.js", async () => {
+  const actual = await vi.importActual<typeof import("../../auto-reply/reply/abort.js")>(
+    "../../auto-reply/reply/abort.js",
+  );
+  return {
+    ...actual,
+    stopSubagentsForRequester: abortMocks.stopSubagentsForRequester,
+  };
+});
+
+vi.mock("../../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    cancelSession: acpManagerMocks.cancelSession,
+  }),
+}));
+
+describe("sessions.abort autonomy stop", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-abort-autonomy-"));
+    testState.sessionStorePath = path.join(tempDir, "sessions.json");
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+      },
+    });
+    queueCleanupMocks.clearSessionQueues.mockReset().mockReturnValue({
+      followupCleared: 2,
+      laneCleared: 1,
+      keys: ["main", "agent:main:main", "sess-main"],
+    });
+    abortMocks.stopSubagentsForRequester.mockReset().mockReturnValue({ stopped: 1 });
+    acpManagerMocks.cancelSession.mockClear();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("disables session-bound cron jobs and reports stopped session work", async () => {
+    const respond = vi.fn();
+    const cronUpdate = vi.fn(async () => ({}));
+
+    await sessionsHandlers["sessions.abort"]({
+      req: { id: "req-sessions-abort-autonomy" } as never,
+      params: { key: "main" },
+      respond,
+      context: {
+        chatAbortControllers: new Map(),
+        getSessionEventSubscriberConnIds: () => new Set(),
+        broadcastToConnIds: vi.fn(),
+        cron: {
+          list: vi.fn(async () => [
+            {
+              id: "job-bound",
+              enabled: true,
+              sessionTarget: "session:agent:main:main",
+              sessionKey: "agent:main:main",
+            },
+            {
+              id: "job-other",
+              enabled: true,
+              sessionTarget: "isolated",
+              sessionKey: "cron:job-other",
+            },
+          ]),
+          update: cronUpdate,
+        },
+        logGateway: { warn: vi.fn() },
+      } as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(cronUpdate).toHaveBeenCalledWith("job-bound", { enabled: false });
+    expect(abortMocks.stopSubagentsForRequester).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      requesterSessionKey: "agent:main:main",
+    });
+    expect(queueCleanupMocks.clearSessionQueues).toHaveBeenCalledWith(["main", "agent:main:main"]);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+        status: "stopped",
+        stopped: true,
+        stoppedSubagents: 1,
+        clearedFollowups: 2,
+        clearedCommands: 1,
+        disabledCronJobIds: ["job-bound"],
+        disabledCronJobs: 1,
+      }),
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2,13 +2,21 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
+import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
   waitForEmbeddedPiRunEnd,
 } from "../../agents/pi-embedded-runner/runs.js";
+import { resolveEmbeddedSessionLane } from "../../agents/pi-embedded.js";
+import {
+  countActiveDescendantRuns,
+  countActiveRunsForSession,
+} from "../../agents/subagent-registry.js";
+import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
+import { getFollowupQueueSize } from "../../auto-reply/reply/queue/state.js";
 import { loadConfig } from "../../config/config.js";
 import {
   loadSessionStore,
@@ -18,6 +26,8 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import type { CronJob } from "../../cron/types.js";
+import { getQueueSize } from "../../process/command-queue.js";
 import {
   normalizeAgentId,
   parseAgentSessionKey,
@@ -27,6 +37,7 @@ import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
+  validateSessionsActivityParams,
   validateSessionsAbortParams,
   validateSessionsCompactParams,
   validateSessionsCreateParams,
@@ -258,6 +269,92 @@ function resolveAbortSessionKey(params: {
     }
   }
   return params.requestedKey;
+}
+
+function resolveSessionQueueKeys(params: {
+  requestedKey: string;
+  canonicalKey: string;
+  sessionId?: string;
+}): string[] {
+  return [
+    ...new Set(
+      [params.requestedKey, params.canonicalKey, params.sessionId].filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      ),
+    ),
+  ];
+}
+
+function isSessionBoundCronJob(job: CronJob, sessionKey: string): boolean {
+  const target = typeof job.sessionTarget === "string" ? job.sessionTarget.trim() : "";
+  const boundTarget = `session:${sessionKey}`;
+  if (target === boundTarget) {
+    return true;
+  }
+  const jobSessionKey = typeof job.sessionKey === "string" ? job.sessionKey.trim() : "";
+  return jobSessionKey === sessionKey;
+}
+
+async function listEnabledSessionBoundCronJobs(params: {
+  context: Pick<GatewayRequestContext, "cron">;
+  canonicalKey: string;
+}): Promise<CronJob[]> {
+  const jobs = await params.context.cron.list({ includeDisabled: true });
+  return jobs.filter((job) => job.enabled && isSessionBoundCronJob(job, params.canonicalKey));
+}
+
+type SessionActivitySummary = {
+  activeRunIds: string[];
+  embeddedRunActive: boolean;
+  followupQueued: number;
+  commandQueued: number;
+  activeSubagentRuns: number;
+  activeDescendantRuns: number;
+  boundCronJobIds: string[];
+  canStop: boolean;
+};
+
+async function collectSessionActivity(params: {
+  context: Pick<GatewayRequestContext, "chatAbortControllers" | "cron">;
+  requestedKey: string;
+  canonicalKey: string;
+  sessionId?: string;
+}): Promise<SessionActivitySummary> {
+  const queueKeys = resolveSessionQueueKeys(params);
+  const activeRunIds: string[] = [];
+  for (const [runId, active] of params.context.chatAbortControllers) {
+    if (active.sessionKey === params.requestedKey || active.sessionKey === params.canonicalKey) {
+      activeRunIds.push(runId);
+    }
+  }
+  const followupQueued = queueKeys.reduce((total, key) => total + getFollowupQueueSize(key), 0);
+  const commandQueued = [
+    ...new Set(queueKeys.map((key) => resolveEmbeddedSessionLane(key))),
+  ].reduce((total, lane) => total + getQueueSize(lane), 0);
+  const activeSubagentRuns = countActiveRunsForSession(params.canonicalKey);
+  const activeDescendantRuns = countActiveDescendantRuns(params.canonicalKey);
+  const boundCronJobIds = (await listEnabledSessionBoundCronJobs(params)).map((job) => job.id);
+  const embeddedRunActive =
+    typeof params.sessionId === "string" && params.sessionId
+      ? isEmbeddedPiRunActive(params.sessionId)
+      : false;
+  return {
+    activeRunIds,
+    embeddedRunActive,
+    followupQueued,
+    commandQueued,
+    activeSubagentRuns,
+    activeDescendantRuns,
+    boundCronJobIds,
+    canStop:
+      activeRunIds.length > 0 ||
+      embeddedRunActive ||
+      followupQueued > 0 ||
+      commandQueued > 0 ||
+      activeSubagentRuns > 0 ||
+      activeDescendantRuns > 0 ||
+      boundCronJobIds.length > 0,
+  };
 }
 
 function hasTrackedActiveSessionRun(params: {
@@ -805,6 +902,40 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       interruptIfActive: true,
     });
   },
+  "sessions.activity": async ({ params, respond, context }) => {
+    if (!assertValidParams(params, validateSessionsActivityParams, "sessions.activity", respond)) {
+      return;
+    }
+    const key = requireSessionKey((params as { key?: unknown }).key, respond);
+    if (!key) {
+      return;
+    }
+    const { entry, canonicalKey } = loadSessionEntry(key);
+    const activity = await collectSessionActivity({
+      context,
+      requestedKey: key,
+      canonicalKey,
+      sessionId: entry?.sessionId,
+    });
+    respond(
+      true,
+      {
+        key,
+        canonicalKey,
+        activeRunCount: activity.activeRunIds.length,
+        activeRunIds: activity.activeRunIds,
+        embeddedRunActive: activity.embeddedRunActive,
+        followupQueued: activity.followupQueued,
+        commandQueued: activity.commandQueued,
+        activeSubagentRuns: activity.activeSubagentRuns,
+        activeDescendantRuns: activity.activeDescendantRuns,
+        boundCronJobCount: activity.boundCronJobIds.length,
+        boundCronJobIds: activity.boundCronJobIds,
+        canStop: activity.canStop,
+      },
+      undefined,
+    );
+  },
   "sessions.abort": async ({ req, params, respond, context, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsAbortParams, "sessions.abort", respond)) {
       return;
@@ -814,7 +945,14 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    const { canonicalKey } = loadSessionEntry(key);
+    const cfg = loadConfig();
+    const { entry, canonicalKey } = loadSessionEntry(key);
+    const activityBefore = await collectSessionActivity({
+      context,
+      requestedKey: key,
+      canonicalKey,
+      sessionId: entry?.sessionId,
+    });
     const abortSessionKey = resolveAbortSessionKey({
       context,
       requestedKey: key,
@@ -822,6 +960,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       runId: typeof p.runId === "string" ? p.runId : undefined,
     });
     let abortedRunId: string | null = null;
+    let abortMeta: Record<string, unknown> | undefined;
+    let abortFailed = false;
     await chatHandlers["chat.abort"]({
       req,
       params: {
@@ -830,6 +970,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       },
       respond: (ok, payload, error, meta) => {
         if (!ok) {
+          abortFailed = true;
           respond(ok, payload, error, meta);
           return;
         }
@@ -842,27 +983,95 @@ export const sessionsHandlers: GatewayRequestHandlers = {
               )
             : [];
         abortedRunId = runIds[0] ?? null;
-        respond(
-          true,
-          {
-            ok: true,
-            abortedRunId,
-            status: abortedRunId ? "aborted" : "no-active-run",
-          },
-          undefined,
-          meta,
-        );
+        abortMeta = meta;
       },
       context,
       client,
       isWebchatConnect,
     });
-    if (abortedRunId) {
+    if (abortFailed) {
+      return;
+    }
+    const queueKeys = resolveSessionQueueKeys({
+      requestedKey: key,
+      canonicalKey,
+      sessionId: entry?.sessionId,
+    });
+    const clearedQueues = clearSessionQueues(queueKeys);
+    const { stopped: stoppedSubagents } = stopSubagentsForRequester({
+      cfg,
+      requesterSessionKey: canonicalKey,
+    });
+
+    let acpCancelRequested = false;
+    if (entry?.acp) {
+      acpCancelRequested = true;
+      try {
+        await getAcpSessionManager().cancelSession({
+          cfg,
+          sessionKey: canonicalKey,
+          reason: "session-abort",
+        });
+      } catch (error) {
+        context.logGateway.warn?.(
+          `sessions.abort: ACP cancel failed for ${canonicalKey}: ${String(error)}`,
+        );
+      }
+    }
+
+    const disabledCronJobIds: string[] = [];
+    for (const job of await listEnabledSessionBoundCronJobs({ context, canonicalKey })) {
+      await context.cron.update(job.id, { enabled: false });
+      disabledCronJobIds.push(job.id);
+    }
+
+    if (activityBefore.embeddedRunActive && entry?.sessionId) {
+      abortEmbeddedPiRun(entry.sessionId);
+      const ended = await waitForEmbeddedPiRunEnd(entry.sessionId, 15_000);
+      if (!ended) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.UNAVAILABLE,
+            `Session ${key} is still active; try again in a moment.`,
+          ),
+        );
+        return;
+      }
+    }
+
+    const stopped =
+      Boolean(abortedRunId) ||
+      clearedQueues.followupCleared > 0 ||
+      clearedQueues.laneCleared > 0 ||
+      stoppedSubagents > 0 ||
+      disabledCronJobIds.length > 0 ||
+      acpCancelRequested ||
+      activityBefore.embeddedRunActive;
+    if (stopped) {
       emitSessionsChanged(context, {
         sessionKey: canonicalKey,
         reason: "abort",
       });
     }
+    respond(
+      true,
+      {
+        ok: true,
+        abortedRunId,
+        status: abortedRunId ? "aborted" : stopped ? "stopped" : "no-active-run",
+        stopped,
+        clearedFollowups: clearedQueues.followupCleared,
+        clearedCommands: clearedQueues.laneCleared,
+        stoppedSubagents,
+        disabledCronJobIds,
+        disabledCronJobs: disabledCronJobIds.length,
+        acpCancelRequested,
+      },
+      undefined,
+      abortMeta,
+    );
   },
   "sessions.patch": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -535,6 +535,28 @@
   background: color-mix(in srgb, var(--danger) 85%, #fff);
 }
 
+.btn--heartbeat-stop svg {
+  color: var(--danger);
+}
+
+.btn--heartbeat-stop:disabled svg {
+  opacity: 0.4;
+}
+
+@keyframes heartbeat-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+}
+
+.btn--heartbeat-stop:not(:disabled) svg {
+  animation: heartbeat-pulse 1.2s ease-in-out infinite;
+}
+
 .slash-menu {
   position: absolute;
   bottom: 100%;

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -29,6 +29,7 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatAttachments: [],
     chatQueue: [],
     chatRunId: null,
+    chatStopping: false,
     chatSending: false,
     lastError: null,
     sessionKey: "agent:main",

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -30,6 +30,7 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatQueue: [],
     chatRunId: null,
     chatStopping: false,
+    chatSessionActivity: null,
     chatSending: false,
     lastError: null,
     sessionKey: "agent:main",

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -23,6 +23,7 @@ export type ChatHost = {
   chatAttachments: ChatAttachment[];
   chatQueue: ChatQueueItem[];
   chatRunId: string | null;
+  chatStopping?: boolean;
   chatSending: boolean;
   lastError?: string | null;
   sessionKey: string;
@@ -41,7 +42,7 @@ export type ChatHost = {
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
 
 export function isChatBusy(host: ChatHost) {
-  return host.chatSending || Boolean(host.chatRunId);
+  return host.chatSending || Boolean(host.chatRunId) || Boolean(host.chatStopping);
 }
 
 export function isChatStopCommand(text: string) {
@@ -336,6 +337,7 @@ async function clearChatHistory(host: ChatHost) {
     host.chatMessages = [];
     host.chatStream = null;
     host.chatRunId = null;
+    host.chatStopping = false;
     await loadChatHistory(host as unknown as OpenClawApp);
   } catch (err) {
     host.lastError = String(err);

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -7,10 +7,11 @@ import { executeSlashCommand } from "./chat/slash-command-executor.ts";
 import { parseSlashCommand } from "./chat/slash-commands.ts";
 import { abortChatRun, loadChatHistory, sendChatMessage } from "./controllers/chat.ts";
 import { loadModels } from "./controllers/models.ts";
+import { loadChatSessionActivity } from "./controllers/session-activity.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import { normalizeBasePath } from "./navigation.ts";
-import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
+import type { ChatModelOverride, ChatSessionActivity, ModelCatalogEntry } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
 
@@ -24,6 +25,7 @@ export type ChatHost = {
   chatQueue: ChatQueueItem[];
   chatRunId: string | null;
   chatStopping?: boolean;
+  chatSessionActivity: ChatSessionActivity | null;
   chatSending: boolean;
   lastError?: string | null;
   sessionKey: string;
@@ -338,7 +340,9 @@ async function clearChatHistory(host: ChatHost) {
     host.chatStream = null;
     host.chatRunId = null;
     host.chatStopping = false;
+    host.chatSessionActivity = null;
     await loadChatHistory(host as unknown as OpenClawApp);
+    await loadChatSessionActivity(host as unknown as OpenClawApp);
   } catch (err) {
     host.lastError = String(err);
   }
@@ -359,6 +363,7 @@ function injectCommandResult(host: ChatHost, content: string) {
 export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: boolean }) {
   await Promise.all([
     loadChatHistory(host as unknown as OpenClawApp),
+    loadChatSessionActivity(host as unknown as OpenClawApp),
     loadSessions(host as unknown as OpenClawApp, {
       activeMinutes: 0,
       limit: 0,

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -135,6 +135,7 @@ function createHost() {
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunId: null,
+    chatStopping: false,
     toolStreamById: new Map(),
     toolStreamOrder: [],
     toolStreamSyncTimer: null,

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -136,6 +136,7 @@ function createHost() {
     chatStreamStartedAt: null,
     chatRunId: null,
     chatStopping: false,
+    chatSessionActivity: null,
     toolStreamById: new Map(),
     toolStreamOrder: [],
     toolStreamSyncTimer: null,

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -98,6 +98,7 @@ function createHost() {
     sessionKey: "main",
     chatRunId: null,
     chatStopping: false,
+    chatSessionActivity: null,
     refreshSessionsAfterChat: new Set<string>(),
     execApprovalQueue: [],
     execApprovalError: null,

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -97,6 +97,7 @@ function createHost() {
     serverVersion: null,
     sessionKey: "main",
     chatRunId: null,
+    chatStopping: false,
     refreshSessionsAfterChat: new Set<string>(),
     execApprovalQueue: [],
     execApprovalError: null,

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -28,6 +28,7 @@ import {
 } from "./controllers/exec-approval.ts";
 import { loadHealthState } from "./controllers/health.ts";
 import { loadNodes } from "./controllers/nodes.ts";
+import { loadChatSessionActivity } from "./controllers/session-activity.ts";
 import { loadSessions, subscribeSessions } from "./controllers/sessions.ts";
 import {
   resolveGatewayErrorDetailCode,
@@ -211,6 +212,7 @@ export function connectGateway(host: GatewayHost) {
       // Any in-flight run's final event was lost during the disconnect window.
       host.chatRunId = null;
       (host as unknown as { chatStopping?: boolean }).chatStopping = false;
+      (host as unknown as { chatSessionActivity?: unknown }).chatSessionActivity = null;
       (host as unknown as { chatStream: string | null }).chatStream = null;
       (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
@@ -375,6 +377,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
 
   if (evt.event === "sessions.changed") {
     void loadSessions(host as unknown as OpenClawApp);
+    void loadChatSessionActivity(host as unknown as OpenClawApp);
     return;
   }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -210,6 +210,7 @@ export function connectGateway(host: GatewayHost) {
       // Reset orphaned chat run state from before disconnect.
       // Any in-flight run's final event was lost during the disconnect window.
       host.chatRunId = null;
+      (host as unknown as { chatStopping?: boolean }).chatStopping = false;
       (host as unknown as { chatStream: string | null }).chatStream = null;
       (host as unknown as { chatStreamStartedAt: number | null }).chatStreamStartedAt = null;
       resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -410,6 +410,16 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     return;
   }
 
+  if (evt.event === "heartbeat") {
+    const payload = evt.payload as { status?: string } | undefined;
+    if (payload?.status) {
+      const heartbeatHost = host as unknown as { heartbeatsEnabled: boolean };
+      // A heartbeat event means heartbeats are running
+      heartbeatHost.heartbeatsEnabled = true;
+    }
+    return;
+  }
+
   if (evt.event === GATEWAY_EVENT_UPDATE_AVAILABLE) {
     const payload = evt.payload as GatewayUpdateAvailableEventPayload | undefined;
     host.updateAvailable = payload?.updateAvailable ?? null;
@@ -431,6 +441,8 @@ export function applySnapshot(host: GatewayHost, hello: GatewayHelloOk) {
   if (snapshot?.health) {
     host.debugHealth = snapshot.health;
     host.healthResult = snapshot.health;
+    const heartbeatHost = host as unknown as { heartbeatsEnabled: boolean };
+    heartbeatHost.heartbeatsEnabled = (snapshot.health.heartbeatSeconds ?? 0) > 0;
   }
   if (snapshot?.sessionDefaults) {
     applySessionDefaults(host, snapshot.sessionDefaults);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -45,6 +45,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatStream = null;
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
   state.chatRunId = null;
+  state.chatStopping = false;
   (state as unknown as OpenClawApp).resetToolStream();
   (state as unknown as OpenClawApp).resetChatScroll();
   state.applySettings({

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -12,6 +12,7 @@ import {
   resolveChatModelSelectState,
 } from "./chat-model-select-state.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
+import { loadChatSessionActivity } from "./controllers/session-activity.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
@@ -490,6 +491,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   state.sessionKey = nextSessionKey;
   state.chatMessage = "";
   state.chatStream = null;
+  state.chatSessionActivity = null;
   // P1: Clear queued chat items from the previous session
   (state as unknown as { chatQueue: unknown[] }).chatQueue = [];
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
@@ -508,6 +510,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
     true,
   );
   void loadChatHistory(state as unknown as ChatState);
+  void loadChatSessionActivity(state as unknown as Parameters<typeof loadChatSessionActivity>[0]);
   void refreshSessionOptions(state);
 }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -70,6 +70,7 @@ import {
 import { loadLogs } from "./controllers/logs.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadPresence } from "./controllers/presence.ts";
+import { loadChatSessionActivity } from "./controllers/session-activity.ts";
 import { deleteSessionsAndRefresh, loadSessions, patchSession } from "./controllers/sessions.ts";
 import {
   installSkill,
@@ -1392,6 +1393,7 @@ export function renderApp(state: AppViewState) {
                   state.chatStreamStartedAt = null;
                   state.chatRunId = null;
                   state.chatStopping = false;
+                  state.chatSessionActivity = null;
                   state.chatQueue = [];
                   state.resetToolStream();
                   state.resetChatScroll();
@@ -1402,6 +1404,7 @@ export function renderApp(state: AppViewState) {
                   });
                   void state.loadAssistantIdentity();
                   void loadChatHistory(state);
+                  void loadChatSessionActivity(state);
                   void refreshChatAvatar(state);
                 },
                 thinkingLevel: state.chatThinkingLevel,
@@ -1427,7 +1430,11 @@ export function renderApp(state: AppViewState) {
                 focusMode: chatFocus,
                 onRefresh: () => {
                   state.resetToolStream();
-                  return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);
+                  return Promise.all([
+                    loadChatHistory(state),
+                    loadChatSessionActivity(state),
+                    refreshChatAvatar(state),
+                  ]);
                 },
                 onToggleFocusMode: () => {
                   if (state.onboarding) {
@@ -1445,7 +1452,12 @@ export function renderApp(state: AppViewState) {
                 attachments: state.chatAttachments,
                 onAttachmentsChange: (next) => (state.chatAttachments = next),
                 onSend: () => state.handleSendChat(),
-                canAbort: Boolean(state.chatRunId || state.chatStopping),
+                canAbort: Boolean(
+                  state.chatRunId || state.chatStopping || state.chatSessionActivity?.canStop,
+                ),
+                abortTitle: state.chatSessionActivity?.canStop
+                  ? "Stop autonomous session tasks"
+                  : undefined,
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
                 onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
@@ -1459,7 +1471,9 @@ export function renderApp(state: AppViewState) {
                     state.chatStream = null;
                     state.chatRunId = null;
                     state.chatStopping = false;
+                    state.chatSessionActivity = null;
                     await loadChatHistory(state);
+                    await loadChatSessionActivity(state);
                   } catch (err) {
                     state.lastError = String(err);
                   }
@@ -1472,12 +1486,14 @@ export function renderApp(state: AppViewState) {
                   state.chatStream = null;
                   state.chatRunId = null;
                   state.chatStopping = false;
+                  state.chatSessionActivity = null;
                   state.applySettings({
                     ...state.settings,
                     sessionKey: state.sessionKey,
                     lastActiveSessionKey: state.sessionKey,
                   });
                   void loadChatHistory(state);
+                  void loadChatSessionActivity(state);
                   void state.loadAssistantIdentity();
                 },
                 onNavigateToAgent: () => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1459,6 +1459,29 @@ export function renderApp(state: AppViewState) {
                   ? "Stop autonomous session tasks"
                   : undefined,
                 onAbort: () => void state.handleAbortChat(),
+                heartbeatsEnabled: state.heartbeatsEnabled,
+                heartbeatStopping: state.heartbeatStopping,
+                onStopHeartbeats: async () => {
+                  if (!state.client || !state.connected || state.heartbeatStopping) {
+                    return;
+                  }
+                  state.heartbeatStopping = true;
+                  try {
+                    // Abort active run if one is in progress
+                    if (state.chatRunId || state.chatSessionActivity?.canStop) {
+                      await state.handleAbortChat();
+                    }
+                    // Also disable the heartbeat system if it's enabled
+                    if (state.heartbeatsEnabled) {
+                      await state.client.request("set-heartbeats", { enabled: false });
+                      state.heartbeatsEnabled = false;
+                    }
+                  } catch (err) {
+                    state.lastError = `Failed to stop: ${String(err)}`;
+                  } finally {
+                    state.heartbeatStopping = false;
+                  }
+                },
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
                 onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
                 onClearHistory: async () => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1391,6 +1391,7 @@ export function renderApp(state: AppViewState) {
                   state.chatStream = null;
                   state.chatStreamStartedAt = null;
                   state.chatRunId = null;
+                  state.chatStopping = false;
                   state.chatQueue = [];
                   state.resetToolStream();
                   state.resetChatScroll();
@@ -1444,7 +1445,7 @@ export function renderApp(state: AppViewState) {
                 attachments: state.chatAttachments,
                 onAttachmentsChange: (next) => (state.chatAttachments = next),
                 onSend: () => state.handleSendChat(),
-                canAbort: Boolean(state.chatRunId),
+                canAbort: Boolean(state.chatRunId || state.chatStopping),
                 onAbort: () => void state.handleAbortChat(),
                 onQueueRemove: (id) => state.removeQueuedMessage(id),
                 onNewSession: () => state.handleSendChat("/new", { restoreDraft: true }),
@@ -1457,6 +1458,7 @@ export function renderApp(state: AppViewState) {
                     state.chatMessages = [];
                     state.chatStream = null;
                     state.chatRunId = null;
+                    state.chatStopping = false;
                     await loadChatHistory(state);
                   } catch (err) {
                     state.lastError = String(err);
@@ -1469,6 +1471,7 @@ export function renderApp(state: AppViewState) {
                   state.chatMessages = [];
                   state.chatStream = null;
                   state.chatRunId = null;
+                  state.chatStopping = false;
                   state.applySettings({
                     ...state.settings,
                     sessionKey: state.sessionKey,

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -13,6 +13,7 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
   return {
     sessionKey: "main",
     chatRunId: null,
+    chatStopping: false,
     chatStream: null,
     chatStreamStartedAt: null,
     chatStreamSegments: [],

--- a/ui/src/ui/app-tool-stream.node.test.ts
+++ b/ui/src/ui/app-tool-stream.node.test.ts
@@ -13,7 +13,6 @@ function createHost(overrides?: Partial<MutableHost>): MutableHost {
   return {
     sessionKey: "main",
     chatRunId: null,
-    chatStopping: false,
     chatStream: null,
     chatStreamStartedAt: null,
     chatStreamSegments: [],

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -278,6 +278,8 @@ export type AppViewState = {
     healthLoading: boolean;
     healthResult: HealthSummary | null;
     healthError: string | null;
+    heartbeatsEnabled: boolean;
+    heartbeatStopping: boolean;
     debugLoading: boolean;
     debugStatus: StatusSummary | null;
     debugHealth: HealthSummary | null;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -22,6 +22,7 @@ import type {
   LogEntry,
   LogLevel,
   ChatModelOverride,
+  ChatSessionActivity,
   ModelCatalogEntry,
   NostrProfile,
   PresenceEntry,
@@ -69,6 +70,7 @@ export type AppViewState = {
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
   chatStopping: boolean;
+  chatSessionActivity: ChatSessionActivity | null;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
   chatAvatarUrl: string | null;

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -68,6 +68,7 @@ export type AppViewState = {
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunId: string | null;
+  chatStopping: boolean;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
   chatAvatarUrl: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -67,6 +67,7 @@ import type {
   AgentsListResult,
   AgentsFilesListResult,
   AgentIdentityResult,
+  ChatSessionActivity,
   ConfigSnapshot,
   ConfigUiHints,
   ChatModelOverride,
@@ -156,6 +157,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
   @state() chatStopping = false;
+  @state() chatSessionActivity: ChatSessionActivity | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
   @state() chatAvatarUrl: string | null = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -155,6 +155,7 @@ export class OpenClawApp extends LitElement {
   @state() chatStream: string | null = null;
   @state() chatStreamStartedAt: number | null = null;
   @state() chatRunId: string | null = null;
+  @state() chatStopping = false;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
   @state() chatAvatarUrl: string | null = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -410,6 +410,9 @@ export class OpenClawApp extends LitElement {
   @state() healthResult: HealthSummary | null = null;
   @state() healthError: string | null = null;
 
+  @state() heartbeatsEnabled = false;
+  @state() heartbeatStopping = false;
+
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;
   @state() debugHealth: HealthSummary | null = null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -16,12 +16,14 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatMessage: "",
     chatMessages: [],
     chatRunId: null,
+    chatStopping: false,
     chatSending: false,
     chatStream: null,
     chatStreamStartedAt: null,
     chatThinkingLevel: null,
     client: null,
     connected: true,
+    ignoredTerminalRunIds: new Set<string>(),
     lastError: null,
     sessionKey: "main",
     ...overrides,
@@ -76,6 +78,41 @@ describe("handleChatEvent", () => {
 
     expect(handleChatEvent(state, payload)).toBe("delta");
     expect(state.chatStream).toBe("Hello");
+  });
+
+  it("merges suffix-style delta updates without clobbering earlier text", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      delta: " world",
+      message: { role: "assistant", content: [{ type: "text", text: " world" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("Hello world");
+  });
+
+  it("ignores stale shorter snapshots after a longer streamed value", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Hello world",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("Hello world");
   });
 
   it("appends final payload from another run without clearing active stream", () => {
@@ -575,6 +612,33 @@ describe("sendChatMessage", () => {
 });
 
 describe("abortChatRun", () => {
+  it("commits the current stream and clears active run state when abort succeeds", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      aborted: true,
+      runIds: ["run-1"],
+    });
+    const state = createState({
+      connected: true,
+      chatRunId: "run-1",
+      chatStream: "Partial answer",
+      chatStreamStartedAt: 100,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const result = await abortChatRun(state);
+
+    expect(result).toBe(true);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+    expect(state.chatStopping).toBe(false);
+    expect(state.chatMessages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Partial answer" }],
+    });
+    expect(state.ignoredTerminalRunIds?.has("run-1")).toBe(true);
+  });
+
   it("formats structured non-auth connect failures for chat abort", async () => {
     // Abort now shares the same structured connect-error formatter as send.
     const request = vi.fn().mockRejectedValue(
@@ -598,6 +662,36 @@ describe("abortChatRun", () => {
       runId: "run-1",
     });
     expect(state.lastError).toContain("device identity required");
+  });
+
+  it("drops a late aborted event after local abort already committed the partial", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      aborted: true,
+      runIds: ["run-1"],
+    });
+    const state = createState({
+      connected: true,
+      chatRunId: "run-1",
+      chatStream: "Partial answer",
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await abortChatRun(state);
+
+    const terminalState = handleChatEvent(state, {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Partial answer" }],
+      },
+    });
+
+    expect(terminalState).toBe("aborted");
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.ignoredTerminalRunIds?.has("run-1")).toBe(false);
   });
 });
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -615,8 +615,8 @@ describe("abortChatRun", () => {
   it("commits the current stream and clears active run state when abort succeeds", async () => {
     const request = vi.fn().mockResolvedValue({
       ok: true,
-      aborted: true,
-      runIds: ["run-1"],
+      abortedRunId: "run-1",
+      stopped: true,
     });
     const state = createState({
       connected: true,
@@ -657,8 +657,8 @@ describe("abortChatRun", () => {
     const result = await abortChatRun(state);
 
     expect(result).toBe(false);
-    expect(request).toHaveBeenCalledWith("chat.abort", {
-      sessionKey: "main",
+    expect(request).toHaveBeenCalledWith("sessions.abort", {
+      key: "main",
       runId: "run-1",
     });
     expect(state.lastError).toContain("device identity required");
@@ -667,8 +667,8 @@ describe("abortChatRun", () => {
   it("drops a late aborted event after local abort already committed the partial", async () => {
     const request = vi.fn().mockResolvedValue({
       ok: true,
-      aborted: true,
-      runIds: ["run-1"],
+      abortedRunId: "run-1",
+      stopped: true,
     });
     const state = createState({
       connected: true,
@@ -692,6 +692,26 @@ describe("abortChatRun", () => {
     expect(terminalState).toBe("aborted");
     expect(state.chatMessages).toHaveLength(1);
     expect(state.ignoredTerminalRunIds?.has("run-1")).toBe(false);
+  });
+
+  it("clears autonomous stop state when the session stop succeeds without an active run", async () => {
+    const request = vi.fn().mockResolvedValue({
+      ok: true,
+      status: "stopped",
+      stopped: true,
+      abortedRunId: null,
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatSessionActivity: { canStop: true },
+    });
+
+    const result = await abortChatRun(state);
+
+    expect(result).toBe(true);
+    expect(request).toHaveBeenCalledWith("sessions.abort", { key: "main" });
+    expect(state.chatSessionActivity).toBeNull();
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -43,8 +43,10 @@ export type ChatState = {
   chatMessage: string;
   chatAttachments: ChatAttachment[];
   chatRunId: string | null;
+  chatStopping?: boolean;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
+  ignoredTerminalRunIds?: Set<string>;
   lastError: string | null;
 };
 
@@ -53,6 +55,7 @@ export type ChatEventPayload = {
   sessionKey: string;
   state: "delta" | "final" | "aborted" | "error";
   message?: unknown;
+  delta?: string;
   errorMessage?: string;
 };
 
@@ -90,6 +93,8 @@ export async function loadChatHistory(state: ChatState) {
     maybeResetToolStream(state);
     state.chatStream = null;
     state.chatStreamStartedAt = null;
+    state.chatStopping = false;
+    state.ignoredTerminalRunIds?.clear();
   } catch (err) {
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];
@@ -160,6 +165,69 @@ function normalizeFinalAssistantMessage(message: unknown): Record<string, unknow
   });
 }
 
+function appendUniqueSuffix(base: string, suffix: string): string {
+  if (!suffix) {
+    return base;
+  }
+  if (!base) {
+    return suffix;
+  }
+  if (base.endsWith(suffix)) {
+    return base;
+  }
+  const maxOverlap = Math.min(base.length, suffix.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    if (base.slice(-overlap) === suffix.slice(0, overlap)) {
+      return base + suffix.slice(overlap);
+    }
+  }
+  return base + suffix;
+}
+
+function mergeAssistantStreamText(params: {
+  currentText: string;
+  nextText: string;
+  nextDelta?: string;
+}) {
+  const { currentText, nextText, nextDelta = "" } = params;
+  if (nextText && currentText) {
+    if (nextText.startsWith(currentText)) {
+      return nextText;
+    }
+    if (currentText.startsWith(nextText) && !nextDelta) {
+      return currentText;
+    }
+  }
+  if (nextDelta) {
+    return appendUniqueSuffix(currentText, nextDelta);
+  }
+  if (!nextText) {
+    return currentText;
+  }
+  return appendUniqueSuffix(currentText, nextText);
+}
+
+function clearActiveRunState(state: ChatState) {
+  state.chatStopping = false;
+  state.chatStream = null;
+  state.chatRunId = null;
+  state.chatStreamStartedAt = null;
+}
+
+function commitStreamTextToHistory(state: ChatState, text: string) {
+  if (!text.trim() || isSilentReplyStream(text)) {
+    return;
+  }
+  state.chatMessages = [
+    ...state.chatMessages,
+    {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      timestamp: Date.now(),
+    },
+  ];
+}
+
 export async function sendChatMessage(
   state: ChatState,
   message: string,
@@ -201,6 +269,7 @@ export async function sendChatMessage(
   ];
 
   state.chatSending = true;
+  state.chatStopping = false;
   state.lastError = null;
   const runId = generateUUID();
   state.chatRunId = runId;
@@ -259,12 +328,30 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
   }
   const runId = state.chatRunId;
   try {
-    await state.client.request(
+    const response = await state.client.request<{
+      ok?: boolean;
+      aborted?: boolean;
+      runIds?: string[];
+    }>(
       "chat.abort",
       runId ? { sessionKey: state.sessionKey, runId } : { sessionKey: state.sessionKey },
     );
+    const abortedRunIds = Array.isArray(response.runIds)
+      ? response.runIds.filter((value): value is string => typeof value === "string")
+      : [];
+    const abortedCurrentRun = Boolean(runId && abortedRunIds.includes(runId));
+    if (abortedCurrentRun) {
+      state.ignoredTerminalRunIds ??= new Set<string>();
+      state.ignoredTerminalRunIds.add(runId);
+      commitStreamTextToHistory(state, state.chatStream ?? "");
+      clearActiveRunState(state);
+      maybeResetToolStream(state);
+      return true;
+    }
+    state.chatStopping = Boolean(runId && response.aborted);
     return true;
   } catch (err) {
+    state.chatStopping = false;
     state.lastError = formatConnectError(err);
     return false;
   }
@@ -276,6 +363,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   }
   if (payload.sessionKey !== state.sessionKey) {
     return null;
+  }
+  if (payload.runId && state.ignoredTerminalRunIds?.has(payload.runId)) {
+    if (payload.state === "final" || payload.state === "aborted" || payload.state === "error") {
+      state.ignoredTerminalRunIds.delete(payload.runId);
+      return payload.state;
+    }
   }
 
   // Final from another run (e.g. sub-agent announce): refresh history to show new message.
@@ -296,51 +389,32 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     const next = extractText(payload.message);
     if (typeof next === "string" && !isSilentReplyStream(next)) {
       const current = state.chatStream ?? "";
-      if (!current || next.length >= current.length) {
-        state.chatStream = next;
-      }
+      state.chatStopping = false;
+      state.chatStream = mergeAssistantStreamText({
+        currentText: current,
+        nextText: next,
+        nextDelta: payload.delta,
+      });
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
     } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
-      state.chatMessages = [
-        ...state.chatMessages,
-        {
-          role: "assistant",
-          content: [{ type: "text", text: state.chatStream }],
-          timestamp: Date.now(),
-        },
-      ];
+      commitStreamTextToHistory(state, state.chatStream);
     }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
+    clearActiveRunState(state);
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
     if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";
-      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
-        state.chatMessages = [
-          ...state.chatMessages,
-          {
-            role: "assistant",
-            content: [{ type: "text", text: streamedText }],
-            timestamp: Date.now(),
-          },
-        ];
-      }
+      commitStreamTextToHistory(state, streamedText);
     }
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
+    clearActiveRunState(state);
   } else if (payload.state === "error") {
-    state.chatStream = null;
-    state.chatRunId = null;
-    state.chatStreamStartedAt = null;
+    clearActiveRunState(state);
     state.lastError = payload.errorMessage ?? "chat error";
   }
   return payload.state;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -44,6 +44,7 @@ export type ChatState = {
   chatAttachments: ChatAttachment[];
   chatRunId: string | null;
   chatStopping?: boolean;
+  chatSessionActivity?: { canStop?: boolean } | null;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   ignoredTerminalRunIds?: Set<string>;
@@ -330,25 +331,24 @@ export async function abortChatRun(state: ChatState): Promise<boolean> {
   try {
     const response = await state.client.request<{
       ok?: boolean;
-      aborted?: boolean;
-      runIds?: string[];
-    }>(
-      "chat.abort",
-      runId ? { sessionKey: state.sessionKey, runId } : { sessionKey: state.sessionKey },
-    );
-    const abortedRunIds = Array.isArray(response.runIds)
-      ? response.runIds.filter((value): value is string => typeof value === "string")
-      : [];
-    const abortedCurrentRun = Boolean(runId && abortedRunIds.includes(runId));
+      abortedRunId?: string | null;
+      status?: string;
+      stopped?: boolean;
+    }>("sessions.abort", runId ? { key: state.sessionKey, runId } : { key: state.sessionKey });
+    const abortedCurrentRun = Boolean(runId && response.abortedRunId === runId);
     if (abortedCurrentRun) {
       state.ignoredTerminalRunIds ??= new Set<string>();
-      state.ignoredTerminalRunIds.add(runId);
+      state.ignoredTerminalRunIds.add(runId!);
       commitStreamTextToHistory(state, state.chatStream ?? "");
       clearActiveRunState(state);
       maybeResetToolStream(state);
+      state.chatSessionActivity = null;
       return true;
     }
-    state.chatStopping = Boolean(runId && response.aborted);
+    state.chatStopping = false;
+    if (response.stopped) {
+      state.chatSessionActivity = null;
+    }
     return true;
   } catch (err) {
     state.chatStopping = false;

--- a/ui/src/ui/controllers/session-activity.ts
+++ b/ui/src/ui/controllers/session-activity.ts
@@ -1,0 +1,27 @@
+import type { GatewayBrowserClient } from "../gateway.ts";
+import type { ChatSessionActivity } from "../types.ts";
+
+export type SessionActivityState = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  sessionKey: string;
+  chatSessionActivity: ChatSessionActivity | null;
+};
+
+export async function loadChatSessionActivity(state: SessionActivityState) {
+  if (!state.client || !state.connected) {
+    state.chatSessionActivity = null;
+    return;
+  }
+  try {
+    const activity = await state.client.request<ChatSessionActivity | undefined>(
+      "sessions.activity",
+      {
+        key: state.sessionKey,
+      },
+    );
+    state.chatSessionActivity = activity ?? null;
+  } catch {
+    state.chatSessionActivity = null;
+  }
+}

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -289,6 +289,12 @@ export const icons = {
   stop: html`
     <svg viewBox="0 0 24 24"><rect width="14" height="14" x="5" y="5" rx="1" /></svg>
   `,
+  heartPulse: html`
+    <svg viewBox="0 0 24 24">
+      <path d="M19.5 12.572 12 20l-7.5-7.428A5 5 0 1 1 12 6.006a5 5 0 1 1 7.5 6.572" />
+      <path d="M5 12h2l2-3 3 6 2-3h5" />
+    </svg>
+  `,
   pin: html`
     <svg viewBox="0 0 24 24">
       <line x1="12" x2="12" y1="17" y2="22" />

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -404,6 +404,21 @@ export type GatewaySessionRow = {
 
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;
 
+export type ChatSessionActivity = {
+  key: string;
+  canonicalKey: string;
+  activeRunCount: number;
+  activeRunIds: string[];
+  embeddedRunActive: boolean;
+  followupQueued: number;
+  commandQueued: number;
+  activeSubagentRuns: number;
+  activeDescendantRuns: number;
+  boundCronJobCount: number;
+  boundCronJobIds: string[];
+  canStop: boolean;
+};
+
 export type SessionsPatchResult = SessionsPatchResultBase<{
   sessionId: string;
   updatedAt?: number;

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -111,6 +111,7 @@ function createChatHeaderState(
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunId: null,
+    chatStopping: false,
     chatQueue: [],
     chatMessages: [],
     chatLoading: false,

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -649,6 +649,33 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("Stop");
   });
 
+  it("shows a secondary stop button for autonomous tasks when chat is idle", () => {
+    const container = document.createElement("div");
+    const onAbort = vi.fn();
+    render(
+      renderChat(
+        createProps({
+          canAbort: true,
+          sending: false,
+          stream: null,
+          onAbort,
+        }),
+      ),
+      container,
+    );
+
+    const stopButton = container.querySelector<HTMLButtonElement>(
+      'button[title="Stop session tasks"]',
+    );
+    const sendButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Send message"]',
+    );
+    expect(stopButton).not.toBeNull();
+    expect(sendButton).not.toBeNull();
+    stopButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
   it("shows sender labels from sanitized gateway messages instead of generic You", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -110,6 +110,9 @@ export type ChatProps = {
   onSplitRatioChange?: (ratio: number) => void;
   onChatScroll?: (event: Event) => void;
   basePath?: string;
+  heartbeatsEnabled?: boolean;
+  heartbeatStopping?: boolean;
+  onStopHeartbeats?: () => void;
 };
 
 const COMPACTION_TOAST_DURATION_MS = 5000;
@@ -1342,6 +1345,22 @@ export function renderChat(props: ChatProps) {
             <button class="btn btn--ghost" @click=${() => exportMarkdown(props)} title="Export" aria-label="Export chat" ?disabled=${props.messages.length === 0}>
               ${icons.download}
             </button>
+
+            ${
+              props.heartbeatsEnabled || isBusy || props.sending
+                ? html`
+                  <button
+                    class="btn btn--ghost btn--heartbeat-stop"
+                    @click=${props.onStopHeartbeats}
+                    title=${props.heartbeatStopping ? "Stopping\u2026" : "Stop"}
+                    aria-label=${props.heartbeatStopping ? "Stopping" : "Stop running task"}
+                    ?disabled=${props.heartbeatStopping || !props.connected}
+                  >
+                    ${icons.heartPulse}
+                  </button>
+                `
+                : nothing
+            }
 
             ${
               canAbort && !(isBusy || props.sending)

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -60,6 +60,7 @@ export type ChatProps = {
   loading: boolean;
   sending: boolean;
   canAbort?: boolean;
+  abortTitle?: string;
   compactionStatus?: CompactionIndicatorStatus | null;
   fallbackStatus?: FallbackIndicatorStatus | null;
   messages: unknown[];
@@ -1343,9 +1344,28 @@ export function renderChat(props: ChatProps) {
             </button>
 
             ${
+              canAbort && !(isBusy || props.sending)
+                ? html`
+                  <button
+                    class="btn btn--ghost"
+                    @click=${props.onAbort}
+                    title=${props.abortTitle ?? "Stop session tasks"}
+                    aria-label=${props.abortTitle ?? "Stop session tasks"}
+                  >
+                    ${icons.stop}
+                  </button>
+                `
+                : nothing
+            }
+            ${
               canAbort && (isBusy || props.sending)
                 ? html`
-                  <button class="chat-send-btn chat-send-btn--stop" @click=${props.onAbort} title="Stop" aria-label="Stop generating">
+                  <button
+                    class="chat-send-btn chat-send-btn--stop"
+                    @click=${props.onAbort}
+                    title="Stop"
+                    aria-label="Stop generating"
+                  >
                     ${icons.stop}
                   </button>
                 `


### PR DESCRIPTION
## Summary
- Add a pulsing heart button to the webchat toolbar that appears when heartbeats are enabled or a task is actively running — clicking it aborts the active run and disables heartbeats via the `set-heartbeats` API
- Fix the agent silently ignoring user requests for milestone/progress updates by adding explicit system prompt instructions that make inline status updates mandatory for iterative tasks and guide the agent to create temp cron jobs for time-based periodic checks

## Changes

### Webchat heartbeat stop button
- **`ui/src/ui/icons.ts`** — Add `heartPulse` icon (Lucide heart-pulse SVG)
- **`ui/src/ui/app.ts`** / **`app-view-state.ts`** — Add `heartbeatsEnabled` and `heartbeatStopping` reactive state
- **`ui/src/ui/app-gateway.ts`** — Derive `heartbeatsEnabled` from `HealthSummary.heartbeatSeconds` on connect; update on `heartbeat` broadcast events
- **`ui/src/ui/views/chat.ts`** — Add heartbeat props to `ChatProps`; render pulsing heart button when heartbeats are enabled or task is busy
- **`ui/src/ui/app-render.ts`** — Wire button to abort active run + call `set-heartbeats` API
- **`ui/src/styles/chat/layout.css`** — Danger-colored icon with pulse animation

### Progress update delivery fix
- **`src/agents/system-prompt.ts`** — Add "Progress Updates & Milestone Reporting" section with:
  - Mandatory inline updates for sequential/iterative work (output status after each item)
  - Cron-based scheduled updates for long-running/background tasks
  - Explicit trigger phrase matching ("give me updates", "status update", "milestone", etc.)
  - Updated cron tool description to mention milestone tracking

## Test plan
- [ ] Start gateway, open webchat UI, verify heart button appears when heartbeats are enabled
- [ ] Send a long-running task, verify heart button appears during active run
- [ ] Click heart button, verify task aborts and heartbeats disable
- [ ] Send iterative task with "give me a status update for each", verify agent outputs inline updates between steps
- [ ] Request time-based updates ("check every 5 minutes"), verify agent creates cron job

🤖 Generated with [Claude Code](https://claude.com/claude-code)