### PR TITLE
fix(extensions): route fetch calls through fetchWithSsrFGuard

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -23297,6 +23297,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.mattermost.accounts.*.allowPrivateNetwork",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.mattermost.accounts.*.baseUrl",
       "kind": "channel",
       "type": "string",
@@ -23817,6 +23827,16 @@
         "number",
         "string"
       ],
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.mattermost.allowPrivateNetwork",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -25407,6 +25427,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.nextcloud-talk.accounts.*.allowPrivateNetwork",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.nextcloud-talk.accounts.*.apiPassword",
       "kind": "channel",
       "type": [
@@ -25988,6 +26018,16 @@
       "path": "channels.nextcloud-talk.allowFrom.*",
       "kind": "channel",
       "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.nextcloud-talk.allowPrivateNetwork",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5639}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5643}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2091,6 +2091,7 @@
 {"recordType":"path","path":"channels.mattermost.accounts.*.actions.reactions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.accounts.*.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.mattermost.accounts.*.allowPrivateNetwork","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.baseUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.accounts.*.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -2139,6 +2140,7 @@
 {"recordType":"path","path":"channels.mattermost.actions.reactions","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.mattermost.allowFrom.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.mattermost.allowPrivateNetwork","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.baseUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Mattermost Base URL","help":"Base URL for your Mattermost server (e.g., https://chat.example.com).","hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.blockStreaming","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.mattermost.blockStreamingCoalesce","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
@@ -2284,6 +2286,7 @@
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.nextcloud-talk.accounts.*.allowPrivateNetwork","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.apiPassword","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.apiPassword.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.apiPassword.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2340,6 +2343,7 @@
 {"recordType":"path","path":"channels.nextcloud-talk.accounts.*.webhookPublicUrl","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.allowFrom","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.allowFrom.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.nextcloud-talk.allowPrivateNetwork","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.apiPassword","kind":"channel","type":["object","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.nextcloud-talk.apiPassword.id","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.nextcloud-talk.apiPassword.provider","kind":"channel","type":"string","required":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -161,7 +161,12 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
         throw new Error(`BlueBubbles ${action} requires serverUrl and password.`);
       }
 
-      const resolved = await runtime.resolveChatGuidForTarget({ baseUrl, password, target });
+      const resolved = await runtime.resolveChatGuidForTarget({
+        baseUrl,
+        password,
+        target,
+        allowPrivateNetwork: account.config.allowPrivateNetwork === true,
+      });
       if (!resolved) {
         throw new Error(`BlueBubbles ${action} failed: chatGuid not found for target.`);
       }

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -19,8 +19,7 @@ import {
   type SsrFPolicy,
 } from "./types.js";
 
-function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy | undefined {
-  if (allowPrivateNetwork === undefined) return undefined;
+function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy {
   return allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
 }
 

--- a/extensions/bluebubbles/src/attachments.ts
+++ b/extensions/bluebubbles/src/attachments.ts
@@ -16,7 +16,13 @@ import {
   buildBlueBubblesApiUrl,
   type BlueBubblesAttachment,
   type BlueBubblesSendTarget,
+  type SsrFPolicy,
 } from "./types.js";
+
+function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy | undefined {
+  if (allowPrivateNetwork === undefined) return undefined;
+  return allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
+}
 
 export type BlueBubblesAttachmentOpts = {
   serverUrl?: string;
@@ -155,7 +161,7 @@ export async function sendBlueBubblesAttachment(params: {
   const fallbackName = wantsVoice ? "Audio Message" : "attachment";
   filename = sanitizeFilename(filename, fallbackName);
   contentType = contentType?.trim() || undefined;
-  const { baseUrl, password, accountId } = resolveAccount(opts);
+  const { baseUrl, password, accountId, allowPrivateNetwork } = resolveAccount(opts);
   const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(accountId);
   const privateApiEnabled = isBlueBubblesPrivateApiStatusEnabled(privateApiStatus);
 
@@ -185,6 +191,7 @@ export async function sendBlueBubblesAttachment(params: {
     password,
     timeoutMs: opts.timeoutMs,
     target,
+    allowPrivateNetwork,
   });
   if (!chatGuid) {
     // For handle targets (phone numbers/emails), auto-create a new DM chat
@@ -194,6 +201,7 @@ export async function sendBlueBubblesAttachment(params: {
         password,
         address: target.address,
         timeoutMs: opts.timeoutMs,
+        allowPrivateNetwork,
       });
       chatGuid = created.chatGuid;
       // If we still don't have a chatGuid, try resolving again (chat was created server-side)
@@ -203,6 +211,7 @@ export async function sendBlueBubblesAttachment(params: {
           password,
           timeoutMs: opts.timeoutMs,
           target,
+          allowPrivateNetwork,
         });
       }
     }
@@ -281,6 +290,7 @@ export async function sendBlueBubblesAttachment(params: {
     boundary,
     parts,
     timeoutMs: opts.timeoutMs ?? 60_000, // longer timeout for file uploads
+    ssrfPolicy: blueBubblesPolicy(allowPrivateNetwork),
   });
 
   await assertMultipartActionOk(res, "attachment send");

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -196,6 +196,7 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount, BlueBu
             baseUrl: account.baseUrl,
             password: account.config.password ?? null,
             timeoutMs,
+            allowPrivateNetwork: account.config.allowPrivateNetwork === true,
           }),
         resolveAccountSnapshot: ({ account, runtime, probe }) => {
           const running = runtime?.running ?? false;

--- a/extensions/bluebubbles/src/chat.ts
+++ b/extensions/bluebubbles/src/chat.ts
@@ -1,10 +1,15 @@
 import crypto from "node:crypto";
 import path from "node:path";
+import type { SsrFPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveBlueBubblesServerAccount } from "./account-resolve.js";
 import { assertMultipartActionOk, postMultipartFormData } from "./multipart.js";
 import { getCachedBlueBubblesPrivateApiStatus } from "./probe.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { blueBubblesFetchWithTimeout, buildBlueBubblesApiUrl } from "./types.js";
+
+function blueBubblesPolicy(allowPrivateNetwork: boolean): SsrFPolicy {
+  return allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
+}
 
 export type BlueBubblesChatOpts = {
   serverUrl?: string;
@@ -41,7 +46,7 @@ async function sendBlueBubblesChatEndpointRequest(params: {
   if (!trimmed) {
     return;
   }
-  const { baseUrl, password, accountId } = resolveAccount(params.opts);
+  const { baseUrl, password, accountId, allowPrivateNetwork } = resolveAccount(params.opts);
   if (getCachedBlueBubblesPrivateApiStatus(accountId) === false) {
     return;
   }
@@ -54,6 +59,7 @@ async function sendBlueBubblesChatEndpointRequest(params: {
     url,
     { method: params.method },
     params.opts.timeoutMs,
+    blueBubblesPolicy(allowPrivateNetwork),
   );
   await assertMultipartActionOk(res, params.action);
 }
@@ -66,7 +72,7 @@ async function sendPrivateApiJsonRequest(params: {
   method: "POST" | "PUT" | "DELETE";
   payload?: unknown;
 }): Promise<void> {
-  const { baseUrl, password, accountId } = resolveAccount(params.opts);
+  const { baseUrl, password, accountId, allowPrivateNetwork } = resolveAccount(params.opts);
   assertPrivateApiEnabled(accountId, params.feature);
   const url = buildBlueBubblesApiUrl({
     baseUrl,
@@ -80,7 +86,12 @@ async function sendPrivateApiJsonRequest(params: {
     request.body = JSON.stringify(params.payload);
   }
 
-  const res = await blueBubblesFetchWithTimeout(url, request, params.opts.timeoutMs);
+  const res = await blueBubblesFetchWithTimeout(
+    url,
+    request,
+    params.opts.timeoutMs,
+    blueBubblesPolicy(allowPrivateNetwork),
+  );
   await assertMultipartActionOk(res, params.action);
 }
 
@@ -282,7 +293,7 @@ export async function setGroupIconBlueBubbles(
     throw new Error("BlueBubbles setGroupIcon requires image buffer");
   }
 
-  const { baseUrl, password, accountId } = resolveAccount(opts);
+  const { baseUrl, password, accountId, allowPrivateNetwork } = resolveAccount(opts);
   assertPrivateApiEnabled(accountId, "setGroupIcon");
   const url = buildBlueBubblesApiUrl({
     baseUrl,
@@ -317,6 +328,7 @@ export async function setGroupIconBlueBubbles(
     boundary,
     parts,
     timeoutMs: opts.timeoutMs ?? 60_000, // longer timeout for file uploads
+    ssrfPolicy: blueBubblesPolicy(allowPrivateNetwork),
   });
 
   await assertMultipartActionOk(res, "setGroupIcon");

--- a/extensions/bluebubbles/src/history.ts
+++ b/extensions/bluebubbles/src/history.ts
@@ -83,11 +83,13 @@ export async function fetchBlueBubblesHistory(
 
   let baseUrl: string;
   let password: string;
+  let allowPrivateNetwork = false;
   try {
-    ({ baseUrl, password } = resolveAccount(opts));
+    ({ baseUrl, password, allowPrivateNetwork } = resolveAccount(opts));
   } catch {
     return { entries: [], resolved: false };
   }
+  const ssrfPolicy = allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
 
   // Try different common API patterns for fetching messages
   const possiblePaths = [
@@ -103,6 +105,7 @@ export async function fetchBlueBubblesHistory(
         url,
         { method: "GET" },
         opts.timeoutMs ?? 10000,
+        ssrfPolicy,
       );
 
       if (!res.ok) {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -938,6 +938,7 @@ export async function processMessage(
           baseUrl,
           password,
           target: resolveTarget,
+          allowPrivateNetwork: account.config.allowPrivateNetwork === true,
         })) ?? undefined;
     }
   }

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -275,6 +275,7 @@ export async function monitorBlueBubblesProvider(
     password: account.config.password,
     accountId: account.accountId,
     timeoutMs: 5000,
+    allowPrivateNetwork: account.config.allowPrivateNetwork === true,
   }).catch(() => null);
   if (serverInfo?.os_version) {
     runtime.log?.(`[${account.accountId}] BlueBubbles server macOS ${serverInfo.os_version}`);

--- a/extensions/bluebubbles/src/multipart.ts
+++ b/extensions/bluebubbles/src/multipart.ts
@@ -1,3 +1,4 @@
+import type { SsrFPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import { blueBubblesFetchWithTimeout } from "./types.js";
 
 export function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
@@ -16,6 +17,7 @@ export async function postMultipartFormData(params: {
   boundary: string;
   parts: Uint8Array[];
   timeoutMs: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<Response> {
   const body = Buffer.from(concatUint8Arrays(params.parts));
   return await blueBubblesFetchWithTimeout(
@@ -28,6 +30,7 @@ export async function postMultipartFormData(params: {
       body,
     },
     params.timeoutMs,
+    params.ssrfPolicy,
   );
 }
 

--- a/extensions/bluebubbles/src/probe.ts
+++ b/extensions/bluebubbles/src/probe.ts
@@ -35,6 +35,7 @@ export async function fetchBlueBubblesServerInfo(params: {
   password?: string | null;
   accountId?: string;
   timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
 }): Promise<BlueBubblesServerInfo | null> {
   const baseUrl = normalizeSecretInputString(params.baseUrl);
   const password = normalizeSecretInputString(params.password);
@@ -48,9 +49,15 @@ export async function fetchBlueBubblesServerInfo(params: {
     return cached.info;
   }
 
+  const ssrfPolicy = params.allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
   const url = buildBlueBubblesApiUrl({ baseUrl, path: "/api/v1/server/info", password });
   try {
-    const res = await blueBubblesFetchWithTimeout(url, { method: "GET" }, params.timeoutMs ?? 5000);
+    const res = await blueBubblesFetchWithTimeout(
+      url,
+      { method: "GET" },
+      params.timeoutMs ?? 5000,
+      ssrfPolicy,
+    );
     if (!res.ok) {
       return null;
     }
@@ -138,6 +145,7 @@ export async function probeBlueBubbles(params: {
   baseUrl?: string | null;
   password?: string | null;
   timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
 }): Promise<BlueBubblesProbe> {
   const baseUrl = normalizeSecretInputString(params.baseUrl);
   const password = normalizeSecretInputString(params.password);
@@ -147,9 +155,15 @@ export async function probeBlueBubbles(params: {
   if (!password) {
     return { ok: false, error: "password not configured" };
   }
+  const probeSsrfPolicy = params.allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
   const url = buildBlueBubblesApiUrl({ baseUrl, path: "/api/v1/ping", password });
   try {
-    const res = await blueBubblesFetchWithTimeout(url, { method: "GET" }, params.timeoutMs);
+    const res = await blueBubblesFetchWithTimeout(
+      url,
+      { method: "GET" },
+      params.timeoutMs,
+      probeSsrfPolicy,
+    );
     if (!res.ok) {
       return { ok: false, status: res.status, error: `HTTP ${res.status}` };
     }

--- a/extensions/bluebubbles/src/reactions.test.ts
+++ b/extensions/bluebubbles/src/reactions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { sendBlueBubblesReaction } from "./reactions.js";
+import { _setFetchGuardForTesting } from "./types.js";
 
 vi.mock("./accounts.js", async () => {
   const { createBlueBubblesAccountsMockModule } = await import("./test-harness.js");
@@ -11,10 +12,34 @@ const mockFetch = vi.fn();
 describe("reactions", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", mockFetch);
+    _setFetchGuardForTesting(async (p) => {
+      const raw = await globalThis.fetch(p.url, p.init);
+      let body: ArrayBuffer;
+      if (typeof raw.arrayBuffer === "function") {
+        body = await raw.arrayBuffer();
+      } else {
+        const text =
+          typeof (raw as { text?: () => Promise<string> }).text === "function"
+            ? await (raw as { text: () => Promise<string> }).text()
+            : typeof (raw as { json?: () => Promise<unknown> }).json === "function"
+              ? JSON.stringify(await (raw as { json: () => Promise<unknown> }).json())
+              : "";
+        body = new TextEncoder().encode(text).buffer;
+      }
+      return {
+        response: new Response(body, {
+          status: (raw as { status?: number }).status ?? 200,
+          headers: (raw as { headers?: HeadersInit }).headers,
+        }),
+        release: async () => {},
+        finalUrl: p.url,
+      };
+    });
     mockFetch.mockReset();
   });
 
   afterEach(() => {
+    _setFetchGuardForTesting(null);
     vi.unstubAllGlobals();
   });
 

--- a/extensions/bluebubbles/src/reactions.test.ts
+++ b/extensions/bluebubbles/src/reactions.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { sendBlueBubblesReaction } from "./reactions.js";
-import { _setFetchGuardForTesting } from "./types.js";
+import { installBlueBubblesFetchTestHooks } from "./test-harness.js";
 
 vi.mock("./accounts.js", async () => {
   const { createBlueBubblesAccountsMockModule } = await import("./test-harness.js");
@@ -8,41 +8,16 @@ vi.mock("./accounts.js", async () => {
 });
 
 const mockFetch = vi.fn();
+const noopPrivateApiStatusMock = {
+  mockReturnValue: () => {},
+};
+
+installBlueBubblesFetchTestHooks({
+  mockFetch,
+  privateApiStatusMock: noopPrivateApiStatusMock,
+});
 
 describe("reactions", () => {
-  beforeEach(() => {
-    vi.stubGlobal("fetch", mockFetch);
-    _setFetchGuardForTesting(async (p) => {
-      const raw = await globalThis.fetch(p.url, p.init);
-      let body: ArrayBuffer;
-      if (typeof raw.arrayBuffer === "function") {
-        body = await raw.arrayBuffer();
-      } else {
-        const text =
-          typeof (raw as { text?: () => Promise<string> }).text === "function"
-            ? await (raw as { text: () => Promise<string> }).text()
-            : typeof (raw as { json?: () => Promise<unknown> }).json === "function"
-              ? JSON.stringify(await (raw as { json: () => Promise<unknown> }).json())
-              : "";
-        body = new TextEncoder().encode(text).buffer;
-      }
-      return {
-        response: new Response(body, {
-          status: (raw as { status?: number }).status ?? 200,
-          headers: (raw as { headers?: HeadersInit }).headers,
-        }),
-        release: async () => {},
-        finalUrl: p.url,
-      };
-    });
-    mockFetch.mockReset();
-  });
-
-  afterEach(() => {
-    _setFetchGuardForTesting(null);
-    vi.unstubAllGlobals();
-  });
-
   describe("sendBlueBubblesReaction", () => {
     async function expectRemovedReaction(emoji: string, expectedReaction = "-love") {
       mockFetch.mockResolvedValueOnce({

--- a/extensions/bluebubbles/src/reactions.ts
+++ b/extensions/bluebubbles/src/reactions.ts
@@ -149,7 +149,7 @@ export async function sendBlueBubblesReaction(params: {
     throw new Error("BlueBubbles reaction requires messageGuid.");
   }
   const reaction = normalizeBlueBubblesReactionInput(params.emoji, params.remove);
-  const { baseUrl, password, accountId } = resolveAccount(params.opts ?? {});
+  const { baseUrl, password, accountId, allowPrivateNetwork } = resolveAccount(params.opts ?? {});
   if (getCachedBlueBubblesPrivateApiStatus(accountId) === false) {
     throw new Error(
       "BlueBubbles reaction requires Private API, but it is disabled on the BlueBubbles server.",
@@ -166,6 +166,7 @@ export async function sendBlueBubblesReaction(params: {
     reaction,
     partIndex: typeof params.partIndex === "number" ? params.partIndex : 0,
   };
+  const ssrfPolicy = allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
   const res = await blueBubblesFetchWithTimeout(
     url,
     {
@@ -174,6 +175,7 @@ export async function sendBlueBubblesReaction(params: {
       body: JSON.stringify(payload),
     },
     params.opts?.timeoutMs,
+    ssrfPolicy,
   );
   if (!res.ok) {
     const errorText = await res.text();

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -17,8 +17,7 @@ import {
   type SsrFPolicy,
 } from "./types.js";
 
-function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy | undefined {
-  if (allowPrivateNetwork === undefined) return undefined;
+function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy {
   return allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
 }
 

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -14,7 +14,13 @@ import {
   blueBubblesFetchWithTimeout,
   buildBlueBubblesApiUrl,
   type BlueBubblesSendTarget,
+  type SsrFPolicy,
 } from "./types.js";
+
+function blueBubblesPolicy(allowPrivateNetwork: boolean | undefined): SsrFPolicy | undefined {
+  if (allowPrivateNetwork === undefined) return undefined;
+  return allowPrivateNetwork ? { allowPrivateNetwork: true } : {};
+}
 
 export type BlueBubblesSendOpts = {
   serverUrl?: string;
@@ -194,6 +200,7 @@ async function queryChats(params: {
   timeoutMs?: number;
   offset: number;
   limit: number;
+  allowPrivateNetwork?: boolean;
 }): Promise<BlueBubblesChatRecord[]> {
   const url = buildBlueBubblesApiUrl({
     baseUrl: params.baseUrl,
@@ -212,6 +219,7 @@ async function queryChats(params: {
       }),
     },
     params.timeoutMs,
+    blueBubblesPolicy(params.allowPrivateNetwork),
   );
   if (!res.ok) {
     return [];
@@ -226,6 +234,7 @@ export async function resolveChatGuidForTarget(params: {
   password: string;
   timeoutMs?: number;
   target: BlueBubblesSendTarget;
+  allowPrivateNetwork?: boolean;
 }): Promise<string | null> {
   if (params.target.kind === "chat_guid") {
     return params.target.chatGuid;
@@ -246,6 +255,7 @@ export async function resolveChatGuidForTarget(params: {
       timeoutMs: params.timeoutMs,
       offset,
       limit,
+      allowPrivateNetwork: params.allowPrivateNetwork,
     });
     if (chats.length === 0) {
       break;
@@ -325,6 +335,7 @@ export async function createChatForHandle(params: {
   address: string;
   message?: string;
   timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
 }): Promise<{ chatGuid: string | null; messageId: string }> {
   const url = buildBlueBubblesApiUrl({
     baseUrl: params.baseUrl,
@@ -344,6 +355,7 @@ export async function createChatForHandle(params: {
       body: JSON.stringify(payload),
     },
     params.timeoutMs,
+    blueBubblesPolicy(params.allowPrivateNetwork),
   );
   if (!res.ok) {
     const errorText = await res.text();
@@ -407,6 +419,7 @@ async function createNewChatWithMessage(params: {
   address: string;
   message: string;
   timeoutMs?: number;
+  allowPrivateNetwork?: boolean;
 }): Promise<BlueBubblesSendResult> {
   const result = await createChatForHandle({
     baseUrl: params.baseUrl,
@@ -414,6 +427,7 @@ async function createNewChatWithMessage(params: {
     address: params.address,
     message: params.message,
     timeoutMs: params.timeoutMs,
+    allowPrivateNetwork: params.allowPrivateNetwork,
   });
   return { messageId: result.messageId };
 }
@@ -450,6 +464,7 @@ export async function sendMessageBlueBubbles(
     throw new Error("BlueBubbles password is required");
   }
   const privateApiStatus = getCachedBlueBubblesPrivateApiStatus(account.accountId);
+  const allowPrivateNetwork = account.config.allowPrivateNetwork === true;
 
   const target = resolveBlueBubblesSendTarget(to);
   const chatGuid = await resolveChatGuidForTarget({
@@ -457,6 +472,7 @@ export async function sendMessageBlueBubbles(
     password,
     timeoutMs: opts.timeoutMs,
     target,
+    allowPrivateNetwork,
   });
   if (!chatGuid) {
     // If target is a phone number/handle and no existing chat found,
@@ -468,6 +484,7 @@ export async function sendMessageBlueBubbles(
         address: target.address,
         message: strippedText,
         timeoutMs: opts.timeoutMs,
+        allowPrivateNetwork,
       });
     }
     throw new Error(
@@ -523,6 +540,7 @@ export async function sendMessageBlueBubbles(
       body: JSON.stringify(payload),
     },
     opts.timeoutMs,
+    blueBubblesPolicy(allowPrivateNetwork),
   );
   if (!res.ok) {
     const errorText = await res.text();

--- a/extensions/bluebubbles/src/test-harness.ts
+++ b/extensions/bluebubbles/src/test-harness.ts
@@ -1,5 +1,6 @@
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, vi } from "vitest";
+import { _setFetchGuardForTesting } from "./types.js";
 
 export const BLUE_BUBBLES_PRIVATE_API_STATUS = {
   enabled: true,
@@ -69,6 +70,31 @@ export function installBlueBubblesFetchTestHooks(params: {
 }) {
   beforeEach(() => {
     vi.stubGlobal("fetch", params.mockFetch);
+    // Replace the SSRF guard with a passthrough that delegates to the mocked global.fetch,
+    // wrapping the result in a real Response so callers can call .arrayBuffer() on it.
+    _setFetchGuardForTesting(async (p) => {
+      const raw = await globalThis.fetch(p.url, p.init);
+      let body: ArrayBuffer;
+      if (typeof raw.arrayBuffer === "function") {
+        body = await raw.arrayBuffer();
+      } else {
+        const text =
+          typeof (raw as { text?: () => Promise<string> }).text === "function"
+            ? await (raw as { text: () => Promise<string> }).text()
+            : typeof (raw as { json?: () => Promise<unknown> }).json === "function"
+              ? JSON.stringify(await (raw as { json: () => Promise<unknown> }).json())
+              : "";
+        body = new TextEncoder().encode(text).buffer;
+      }
+      return {
+        response: new Response(body, {
+          status: (raw as { status?: number }).status ?? 200,
+          headers: (raw as { headers?: HeadersInit }).headers,
+        }),
+        release: async () => {},
+        finalUrl: p.url,
+      };
+    });
     params.mockFetch.mockReset();
     params.privateApiStatusMock.mockReset?.();
     params.privateApiStatusMock.mockClear?.();
@@ -76,6 +102,7 @@ export function installBlueBubblesFetchTestHooks(params: {
   });
 
   afterEach(() => {
+    _setFetchGuardForTesting(null);
     vi.unstubAllGlobals();
   });
 }

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -1,5 +1,7 @@
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/setup";
 
+export type { SsrFPolicy } from "openclaw/plugin-sdk/infra-runtime";
 export type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/setup";
 
 export type BlueBubblesGroupConfig = {
@@ -126,11 +128,36 @@ export function buildBlueBubblesApiUrl(params: {
   return url.toString();
 }
 
+// Overridable guard for testing; production code uses fetchWithSsrFGuard.
+let _fetchGuard = fetchWithSsrFGuard;
+
+/** @internal Replace the SSRF fetch guard in tests. */
+export function _setFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
+  _fetchGuard = impl ?? fetchWithSsrFGuard;
+}
+
 export async function blueBubblesFetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs = DEFAULT_TIMEOUT_MS,
-) {
+  ssrfPolicy?: SsrFPolicy,
+): Promise<Response> {
+  if (ssrfPolicy !== undefined) {
+    // Use SSRF-guarded fetch; buffer the body so the dispatcher can be released
+    // before the caller reads the response (API responses are small JSON payloads).
+    const { response, release } = await _fetchGuard({
+      url,
+      init,
+      timeoutMs,
+      policy: ssrfPolicy,
+      auditContext: "bluebubbles-api",
+    });
+    // Null-body status codes per Fetch spec — Response constructor rejects a body for these.
+    const isNullBody = response.status === 204 || response.status === 304;
+    const bodyBytes = isNullBody ? null : await response.arrayBuffer();
+    await release();
+    return new Response(bodyBytes, { status: response.status, headers: response.headers });
+  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {

--- a/extensions/bluebubbles/src/types.ts
+++ b/extensions/bluebubbles/src/types.ts
@@ -153,10 +153,17 @@ export async function blueBubblesFetchWithTimeout(
       auditContext: "bluebubbles-api",
     });
     // Null-body status codes per Fetch spec — Response constructor rejects a body for these.
-    const isNullBody = response.status === 204 || response.status === 304;
-    const bodyBytes = isNullBody ? null : await response.arrayBuffer();
-    await release();
-    return new Response(bodyBytes, { status: response.status, headers: response.headers });
+    const isNullBody =
+      response.status === 101 ||
+      response.status === 204 ||
+      response.status === 205 ||
+      response.status === 304;
+    try {
+      const bodyBytes = isNullBody ? null : await response.arrayBuffer();
+      return new Response(bodyBytes, { status: response.status, headers: response.headers });
+    } finally {
+      await release();
+    }
   }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -2,13 +2,22 @@ import { Type } from "@sinclair/typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { createChannelReplyPipeline } from "../runtime-api.js";
-const { sendMessageMattermostMock } = vi.hoisted(() => ({
+const { sendMessageMattermostMock, mockFetchGuard } = vi.hoisted(() => ({
   sendMessageMattermostMock: vi.fn(),
+  mockFetchGuard: vi.fn(async (p: { url: string; init?: RequestInit }) => {
+    const response = await globalThis.fetch(p.url, p.init);
+    return { response, release: async () => {}, finalUrl: p.url };
+  }),
 }));
 
 vi.mock("./mattermost/send.js", () => ({
   sendMessageMattermost: sendMessageMattermostMock,
 }));
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return { ...original, fetchWithSsrFGuard: mockFetchGuard };
+});
 
 import { mattermostPlugin } from "./channel.js";
 import { resetMattermostReactionBotUserCacheForTests } from "./mattermost/reactions.js";

--- a/extensions/mattermost/src/config-schema.ts
+++ b/extensions/mattermost/src/config-schema.ts
@@ -84,6 +84,8 @@ const MattermostAccountSchemaBase = z
         allowedSourceIps: z.array(z.string()).optional(),
       })
       .optional(),
+    /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for self-hosted Mattermost on LAN/VPN. */
+    allowPrivateNetwork: z.boolean().optional(),
     /** Retry configuration for DM channel creation */
     dmChannelRetry: DmChannelRetrySchema,
   })

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -107,9 +107,14 @@ export function createMattermostClient(params: {
       init,
       auditContext: "mattermost-api",
     });
-    const bodyBytes = NULL_BODY_STATUSES.has(response.status) ? null : await response.arrayBuffer();
-    await release();
-    return new Response(bodyBytes, { status: response.status, headers: response.headers });
+    try {
+      const bodyBytes = NULL_BODY_STATUSES.has(response.status)
+        ? null
+        : await response.arrayBuffer();
+      return new Response(bodyBytes, { status: response.status, headers: response.headers });
+    } finally {
+      await release();
+    }
   };
 
   const fetchImpl = externalFetchImpl ?? guardedFetchImpl;

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -78,6 +78,8 @@ export function createMattermostClient(params: {
   baseUrl: string;
   botToken: string;
   fetchImpl?: typeof fetch;
+  /** Allow requests to private/internal IPs (self-hosted/LAN deployments). */
+  allowPrivateNetwork?: boolean;
 }): MattermostClient {
   const baseUrl = normalizeMattermostBaseUrl(params.baseUrl);
   if (!baseUrl) {
@@ -106,6 +108,7 @@ export function createMattermostClient(params: {
       url,
       init,
       auditContext: "mattermost-api",
+      policy: params.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
     });
     try {
       const bodyBytes = NULL_BODY_STATUSES.has(response.status)

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -1,8 +1,12 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/infra-runtime";
+
 export type MattermostClient = {
   baseUrl: string;
   apiBaseUrl: string;
   token: string;
   request: <T>(path: string, init?: RequestInit) => Promise<T>;
+  /** Guarded fetch implementation; use in place of raw fetch for outbound requests. */
+  fetchImpl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 };
 
 export type MattermostUser = {
@@ -81,7 +85,34 @@ export function createMattermostClient(params: {
   }
   const apiBaseUrl = `${baseUrl}/api/v4`;
   const token = params.botToken.trim();
-  const fetchImpl = params.fetchImpl ?? fetch;
+  // When no custom fetchImpl is provided (production path), use an SSRF-guarded wrapper
+  // that validates the target URL before making the request (DNS rebinding protection etc.).
+  // A custom fetchImpl is accepted for testing and special cases.
+  const externalFetchImpl = params.fetchImpl;
+
+  // Guarded fetch adapter: calls fetchWithSsrFGuard and returns a plain Response.
+  // Body is buffered before releasing the dispatcher so callers get a complete Response.
+  // Null-body status codes per Fetch spec — Response constructor rejects a body for these.
+  const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+
+  const guardedFetchImpl: typeof fetch = async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const { response, release } = await fetchWithSsrFGuard({
+      url,
+      init,
+      auditContext: "mattermost-api",
+    });
+    const bodyBytes = NULL_BODY_STATUSES.has(response.status) ? null : await response.arrayBuffer();
+    await release();
+    return new Response(bodyBytes, { status: response.status, headers: response.headers });
+  };
+
+  const fetchImpl = externalFetchImpl ?? guardedFetchImpl;
 
   const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
     const url = buildMattermostApiUrl(baseUrl, path);
@@ -110,7 +141,7 @@ export function createMattermostClient(params: {
     return (await res.text()) as T;
   };
 
-  return { baseUrl, apiBaseUrl, token, request };
+  return { baseUrl, apiBaseUrl, token, request, fetchImpl };
 }
 
 export async function fetchMattermostMe(client: MattermostClient): Promise<MattermostUser> {
@@ -513,7 +544,7 @@ export async function uploadMattermostFile(
   form.append("files", blob, fileName);
   form.append("channel_id", params.channelId);
 
-  const res = await fetch(`${client.apiBaseUrl}/files`, {
+  const res = await client.fetchImpl(`${client.apiBaseUrl}/files`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${client.token}`,

--- a/extensions/mattermost/src/mattermost/directory.ts
+++ b/extensions/mattermost/src/mattermost/directory.ts
@@ -24,7 +24,11 @@ function buildClient(params: {
   if (!account.enabled || !account.botToken || !account.baseUrl) {
     return null;
   }
-  return createMattermostClient({ baseUrl: account.baseUrl, botToken: account.botToken });
+  return createMattermostClient({
+    baseUrl: account.baseUrl,
+    botToken: account.botToken,
+    allowPrivateNetwork: account.config?.allowPrivateNetwork === true,
+  });
 }
 
 /**

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -263,7 +263,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     );
   }
 
-  const client = createMattermostClient({ baseUrl, botToken });
+  const client = createMattermostClient({
+    baseUrl,
+    botToken,
+    allowPrivateNetwork: account.config?.allowPrivateNetwork === true,
+  });
   const botUser = await fetchMattermostMe(client);
   const botUserId = botUser.id;
   const botUsername = botUser.username?.trim() || undefined;

--- a/extensions/mattermost/src/mattermost/reactions.ts
+++ b/extensions/mattermost/src/mattermost/reactions.ts
@@ -81,6 +81,7 @@ async function runMattermostReaction(
     baseUrl,
     botToken,
     fetchImpl: params.fetchImpl,
+    allowPrivateNetwork: resolved.config?.allowPrivateNetwork === true,
   });
 
   const cacheKey = `${baseUrl}:${botToken}`;

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -128,13 +128,17 @@ export function parseMattermostTarget(raw: string): MattermostTarget {
   return { kind: "channel", id: trimmed };
 }
 
-async function resolveBotUser(baseUrl: string, token: string): Promise<MattermostUser> {
+async function resolveBotUser(
+  baseUrl: string,
+  token: string,
+  allowPrivateNetwork?: boolean,
+): Promise<MattermostUser> {
   const key = cacheKey(baseUrl, token);
   const cached = botUserCache.get(key);
   if (cached) {
     return cached;
   }
-  const client = createMattermostClient({ baseUrl, botToken: token });
+  const client = createMattermostClient({ baseUrl, botToken: token, allowPrivateNetwork });
   const user = await fetchMattermostMe(client);
   botUserCache.set(key, user);
   return user;
@@ -144,6 +148,7 @@ async function resolveUserIdByUsername(params: {
   baseUrl: string;
   token: string;
   username: string;
+  allowPrivateNetwork?: boolean;
 }): Promise<string> {
   const { baseUrl, token, username } = params;
   const key = `${cacheKey(baseUrl, token)}::${username.toLowerCase()}`;
@@ -151,7 +156,11 @@ async function resolveUserIdByUsername(params: {
   if (cached?.id) {
     return cached.id;
   }
-  const client = createMattermostClient({ baseUrl, botToken: token });
+  const client = createMattermostClient({
+    baseUrl,
+    botToken: token,
+    allowPrivateNetwork: params.allowPrivateNetwork,
+  });
   const user = await fetchMattermostUserByUsername(client, username);
   userByNameCache.set(key, user);
   return user.id;
@@ -161,6 +170,7 @@ async function resolveChannelIdByName(params: {
   baseUrl: string;
   token: string;
   name: string;
+  allowPrivateNetwork?: boolean;
 }): Promise<string> {
   const { baseUrl, token, name } = params;
   const key = `${cacheKey(baseUrl, token)}::channel::${name.toLowerCase()}`;
@@ -168,7 +178,11 @@ async function resolveChannelIdByName(params: {
   if (cached) {
     return cached;
   }
-  const client = createMattermostClient({ baseUrl, botToken: token });
+  const client = createMattermostClient({
+    baseUrl,
+    botToken: token,
+    allowPrivateNetwork: params.allowPrivateNetwork,
+  });
   const me = await fetchMattermostMe(client);
   const teams = await fetchMattermostUserTeams(client, me.id);
   for (const team of teams) {
@@ -189,6 +203,7 @@ type ResolveTargetChannelIdParams = {
   target: MattermostTarget;
   baseUrl: string;
   token: string;
+  allowPrivateNetwork?: boolean;
   dmRetryOptions?: CreateDmChannelRetryOptions;
   logger?: { debug?: (msg: string) => void; warn?: (msg: string) => void };
 };
@@ -227,6 +242,7 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
       baseUrl: params.baseUrl,
       token: params.token,
       name: params.target.name,
+      allowPrivateNetwork: params.allowPrivateNetwork,
     });
   }
   const userId = params.target.id
@@ -235,16 +251,18 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
         baseUrl: params.baseUrl,
         token: params.token,
         username: params.target.username ?? "",
+        allowPrivateNetwork: params.allowPrivateNetwork,
       });
   const dmKey = `${cacheKey(params.baseUrl, params.token)}::dm::${userId}`;
   const cachedDm = dmChannelCache.get(dmKey);
   if (cachedDm) {
     return cachedDm;
   }
-  const botUser = await resolveBotUser(params.baseUrl, params.token);
+  const botUser = await resolveBotUser(params.baseUrl, params.token, params.allowPrivateNetwork);
   const client = createMattermostClient({
     baseUrl: params.baseUrl,
     botToken: params.token,
+    allowPrivateNetwork: params.allowPrivateNetwork,
   });
 
   const channel = await createMattermostDirectChannelWithRetry(client, [botUser.id, userId], {
@@ -270,6 +288,7 @@ type MattermostSendContext = {
   token: string;
   baseUrl: string;
   channelId: string;
+  allowPrivateNetwork?: boolean;
 };
 
 async function resolveMattermostSendContext(
@@ -319,10 +338,12 @@ async function resolveMattermostSendContext(
     : undefined;
   const dmRetryOptions = mergeDmRetryOptions(accountRetryConfig, opts.dmRetryOptions);
 
+  const allowPrivateNetwork = account.config.allowPrivateNetwork === true;
   const channelId = await resolveTargetChannelId({
     target,
     baseUrl,
     token,
+    allowPrivateNetwork,
     dmRetryOptions,
     logger: core.logging.shouldLogVerbose() ? logger : undefined,
   });
@@ -333,6 +354,7 @@ async function resolveMattermostSendContext(
     token,
     baseUrl,
     channelId,
+    allowPrivateNetwork,
   };
 }
 
@@ -350,12 +372,10 @@ export async function sendMessageMattermost(
 ): Promise<MattermostSendResult> {
   const core = getCore();
   const logger = core.logging.getChildLogger({ module: "mattermost" });
-  const { cfg, accountId, token, baseUrl, channelId } = await resolveMattermostSendContext(
-    to,
-    opts,
-  );
+  const { cfg, accountId, token, baseUrl, channelId, allowPrivateNetwork } =
+    await resolveMattermostSendContext(to, opts);
 
-  const client = createMattermostClient({ baseUrl, botToken: token });
+  const client = createMattermostClient({ baseUrl, botToken: token, allowPrivateNetwork });
   let props = opts.props;
   if (!props && Array.isArray(opts.buttons) && opts.buttons.length > 0) {
     setInteractionSecret(accountId, token);

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -260,6 +260,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
     const client = createMattermostClient({
       baseUrl: account.baseUrl ?? "",
       botToken: account.botToken ?? "",
+      allowPrivateNetwork: account.config?.allowPrivateNetwork === true,
     });
 
     const auth = await authorizeSlashInvocation({

--- a/extensions/mattermost/src/mattermost/target-resolution.ts
+++ b/extensions/mattermost/src/mattermost/target-resolution.ts
@@ -79,7 +79,11 @@ export async function resolveMattermostOpaqueTarget(params: {
     return { kind: "channel", id: input, to: `channel:${input}` };
   }
 
-  const client = createMattermostClient({ baseUrl, botToken: token });
+  const client = createMattermostClient({
+    baseUrl,
+    botToken: token,
+    allowPrivateNetwork: account?.config?.allowPrivateNetwork === true,
+  });
   try {
     await fetchMattermostUser(client, input);
     mattermostOpaqueTargetCache.set(key, true);

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -86,6 +86,8 @@ export type MattermostAccountConfig = {
      */
     allowedSourceIps?: string[];
   };
+  /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for self-hosted Mattermost on LAN/VPN. */
+  allowPrivateNetwork?: boolean;
   /** Retry configuration for DM channel creation */
   dmChannelRetry?: {
     /** Maximum number of retry attempts (default: 3) */

--- a/extensions/nextcloud-talk/src/config-schema.ts
+++ b/extensions/nextcloud-talk/src/config-schema.ts
@@ -43,6 +43,8 @@ export const NextcloudTalkAccountSchemaBase = z
     groupAllowFrom: z.array(z.string()).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     rooms: z.record(z.string(), NextcloudTalkRoomSchema.optional()).optional(),
+    /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for self-hosted Nextcloud on LAN/VPN. */
+    allowPrivateNetwork: z.boolean().optional(),
     ...ReplyRuntimeConfigSchemaShape,
   })
   .strict();

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -105,6 +105,7 @@ export async function resolveNextcloudTalkRoomKind(params: {
         },
       },
       auditContext: "nextcloud-talk.room-info",
+      policy: account.config?.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
     });
     try {
       if (!response.ok) {

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -1,3 +1,4 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveNextcloudTalkAccount } from "./accounts.js";
 import { stripNextcloudTalkTargetPrefix } from "./normalize.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
@@ -101,69 +102,77 @@ export async function sendMessageNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${roomToken}/message`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body: bodyStr,
     },
-    body: bodyStr,
+    auditContext: "nextcloud-talk-send",
   });
 
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => "");
-    const status = response.status;
-    let errorMsg = `Nextcloud Talk send failed (${status})`;
+  try {
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      const status = response.status;
+      let errorMsg = `Nextcloud Talk send failed (${status})`;
 
-    if (status === 400) {
-      errorMsg = `Nextcloud Talk: bad request - ${errorBody || "invalid message format"}`;
-    } else if (status === 401) {
-      errorMsg = "Nextcloud Talk: authentication failed - check bot secret";
-    } else if (status === 403) {
-      errorMsg = "Nextcloud Talk: forbidden - bot may not have permission in this room";
-    } else if (status === 404) {
-      errorMsg = `Nextcloud Talk: room not found (token=${roomToken})`;
-    } else if (errorBody) {
-      errorMsg = `Nextcloud Talk send failed: ${errorBody}`;
+      if (status === 400) {
+        errorMsg = `Nextcloud Talk: bad request - ${errorBody || "invalid message format"}`;
+      } else if (status === 401) {
+        errorMsg = "Nextcloud Talk: authentication failed - check bot secret";
+      } else if (status === 403) {
+        errorMsg = "Nextcloud Talk: forbidden - bot may not have permission in this room";
+      } else if (status === 404) {
+        errorMsg = `Nextcloud Talk: room not found (token=${roomToken})`;
+      } else if (errorBody) {
+        errorMsg = `Nextcloud Talk send failed: ${errorBody}`;
+      }
+
+      throw new Error(errorMsg);
     }
 
-    throw new Error(errorMsg);
-  }
-
-  let messageId = "unknown";
-  let timestamp: number | undefined;
-  try {
-    const data = (await response.json()) as {
-      ocs?: {
-        data?: {
-          id?: number | string;
-          timestamp?: number;
+    let messageId = "unknown";
+    let timestamp: number | undefined;
+    try {
+      const data = (await response.json()) as {
+        ocs?: {
+          data?: {
+            id?: number | string;
+            timestamp?: number;
+          };
         };
       };
-    };
-    if (data.ocs?.data?.id != null) {
-      messageId = String(data.ocs.data.id);
+      if (data.ocs?.data?.id != null) {
+        messageId = String(data.ocs.data.id);
+      }
+      if (typeof data.ocs?.data?.timestamp === "number") {
+        timestamp = data.ocs.data.timestamp;
+      }
+    } catch {
+      // Response parsing failed, but message was sent.
     }
-    if (typeof data.ocs?.data?.timestamp === "number") {
-      timestamp = data.ocs.data.timestamp;
+
+    if (opts.verbose) {
+      console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
     }
-  } catch {
-    // Response parsing failed, but message was sent.
+
+    getNextcloudTalkRuntime().channel.activity.record({
+      channel: "nextcloud-talk",
+      accountId: account.accountId,
+      direction: "outbound",
+    });
+
+    return { messageId, roomToken, timestamp };
+  } finally {
+    await release();
   }
-
-  if (opts.verbose) {
-    console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
-  }
-
-  getNextcloudTalkRuntime().channel.activity.record({
-    channel: "nextcloud-talk",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
-
-  return { messageId, roomToken, timestamp };
 }
 
 export async function sendReactionNextcloudTalk(
@@ -184,21 +193,29 @@ export async function sendReactionNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${normalizedToken}/reaction/${messageId}`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body,
     },
-    body,
+    auditContext: "nextcloud-talk-reaction",
   });
 
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => "");
-    throw new Error(`Nextcloud Talk reaction failed: ${response.status} ${errorBody}`.trim());
-  }
+  try {
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new Error(`Nextcloud Talk reaction failed: ${response.status} ${errorBody}`.trim());
+    }
 
-  return { ok: true };
+    return { ok: true };
+  } finally {
+    await release();
+  }
 }

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -115,6 +115,7 @@ export async function sendMessageNextcloudTalk(
       body: bodyStr,
     },
     auditContext: "nextcloud-talk-send",
+    policy: account.config?.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
   });
 
   try {
@@ -206,6 +207,7 @@ export async function sendReactionNextcloudTalk(
       body,
     },
     auditContext: "nextcloud-talk-reaction",
+    policy: account.config?.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
   });
 
   try {

--- a/extensions/nextcloud-talk/src/setup.test.ts
+++ b/extensions/nextcloud-talk/src/setup.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSendCfgThreadingRuntime,
   expectProvidedCfgSkipsRuntimeLoad,
@@ -38,6 +38,7 @@ const hoisted = vi.hoisted(() => ({
     random: "r",
     signature: "s",
   })),
+  mockFetchGuard: vi.fn(),
 }));
 
 vi.mock("./monitor.js", async () => {
@@ -65,6 +66,14 @@ vi.mock("./signature.js", async (importOriginal) => {
   return {
     ...actual,
     generateNextcloudTalkSignature: hoisted.generateNextcloudTalkSignature,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    fetchWithSsrFGuard: hoisted.mockFetchGuard,
   };
 });
 
@@ -415,14 +424,23 @@ describe("resolveNextcloudTalkAccount", () => {
 describe("nextcloud-talk send cfg threading", () => {
   const fetchMock = vi.fn<typeof fetch>();
 
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    // Wire the SSRF guard mock to delegate to the global fetch mock
+    hoisted.mockFetchGuard.mockImplementation(async (p: { url: string; init?: RequestInit }) => {
+      const response = await globalThis.fetch(p.url, p.init);
+      return { response, release: async () => {}, finalUrl: p.url };
+    });
+  });
+
   afterEach(() => {
     fetchMock.mockReset();
+    hoisted.mockFetchGuard.mockReset();
     vi.unstubAllGlobals();
   });
 
   it("uses provided cfg for sendMessage and skips runtime loadConfig", async () => {
     const cfg = { source: "provided" } as const;
-    vi.stubGlobal("fetch", fetchMock);
     hoisted.resolveNextcloudTalkAccount.mockReturnValue({
       accountId: "default",
       baseUrl: "https://nextcloud.example.com",
@@ -459,7 +477,6 @@ describe("nextcloud-talk send cfg threading", () => {
   it("falls back to runtime cfg for sendReaction when cfg is omitted", async () => {
     const runtimeCfg = { source: "runtime" } as const;
     hoisted.loadConfig.mockReturnValueOnce(runtimeCfg);
-    vi.stubGlobal("fetch", fetchMock);
     hoisted.resolveNextcloudTalkAccount.mockReturnValue({
       accountId: "default",
       baseUrl: "https://nextcloud.example.com",

--- a/extensions/nextcloud-talk/src/types.ts
+++ b/extensions/nextcloud-talk/src/types.ts
@@ -75,6 +75,8 @@ export type NextcloudTalkAccountConfig = {
   responsePrefix?: string;
   /** Media upload max size in MB. */
   mediaMaxMb?: number;
+  /** Allow fetching from private/internal IP addresses (e.g. localhost). Required for self-hosted Nextcloud on LAN/VPN. */
+  allowPrivateNetwork?: boolean;
 };
 
 export type NextcloudTalkConfig = {

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,4 +1,10 @@
-import { definePluginEntry, type OpenClawConfig, type OpenClawPluginApi } from "./api.js";
+import {
+  definePluginEntry,
+  fetchWithSsrFGuard,
+  ssrfPolicyFromAllowPrivateNetwork,
+  type OpenClawConfig,
+  type OpenClawPluginApi,
+} from "./api.js";
 
 type ThreadOwnershipConfig = {
   forwarderUrl?: string;
@@ -89,24 +95,35 @@ export default definePluginEntry({
       if (mentionedThreads.has(`${channelId}:${threadTs}`)) return;
 
       try {
-        const resp = await fetch(`${forwarderUrl}/api/v1/ownership/${channelId}/${threadTs}`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ agent_id: agentId }),
-          signal: AbortSignal.timeout(3000),
+        // The forwarder is an internal service (e.g. a Docker container); allow private-network
+        // access but pin DNS so DNS-rebinding attacks cannot pivot to a different internal host.
+        const { response: resp, release } = await fetchWithSsrFGuard({
+          url: `${forwarderUrl}/api/v1/ownership/${channelId}/${threadTs}`,
+          init: {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ agent_id: agentId }),
+          },
+          timeoutMs: 3000,
+          policy: ssrfPolicyFromAllowPrivateNetwork(true),
+          auditContext: "thread-ownership",
         });
 
-        if (resp.ok) {
-          return;
+        try {
+          if (resp.ok) {
+            return;
+          }
+          if (resp.status === 409) {
+            const body = (await resp.json()) as { owner?: string };
+            api.logger.info?.(
+              `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
+            );
+            return { cancel: true };
+          }
+          api.logger.warn?.(`thread-ownership: unexpected status ${resp.status}, allowing send`);
+        } finally {
+          await release();
         }
-        if (resp.status === 409) {
-          const body = (await resp.json()) as { owner?: string };
-          api.logger.info?.(
-            `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
-          );
-          return { cancel: true };
-        }
-        api.logger.warn?.(`thread-ownership: unexpected status ${resp.status}, allowing send`);
       } catch (err) {
         api.logger.warn?.(
           `thread-ownership: ownership check failed (${String(err)}), allowing send`,

--- a/src/plugin-sdk/thread-ownership.ts
+++ b/src/plugin-sdk/thread-ownership.ts
@@ -4,3 +4,5 @@
 export { definePluginEntry } from "./plugin-entry.js";
 export type { OpenClawConfig } from "../config/config.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";
+export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export { ssrfPolicyFromAllowPrivateNetwork } from "./ssrf-policy.js";


### PR DESCRIPTION
## Summary

- Replace raw `fetch()` with `fetchWithSsrFGuard` in BlueBubbles, Mattermost, Nextcloud Talk, and Thread Ownership extensions so outbound requests go through the shared DNS-pinning and network-policy layer
- Thread `allowPrivateNetwork` from account config through all BlueBubbles fetch call sites (send, chat, reactions, history, probe, attachments, multipart)
- Add `guardedFetchImpl` wrapper in Mattermost `createMattermostClient` with body buffering and null-body status handling (204/304)
- Wrap Nextcloud Talk `sendMessage` and `sendReaction` with guarded fetch and try/finally release
- Expose `fetchWithSsrFGuard` and `ssrfPolicyFromAllowPrivateNetwork` on the thread-ownership plugin SDK surface

## Test plan

- [x] `pnpm build` passes (no `INEFFECTIVE_DYNAMIC_IMPORT` warnings)
- [x] `pnpm test -- extensions/bluebubbles` — 322 tests pass
- [x] `pnpm test -- extensions/mattermost` — all tests pass
- [x] `pnpm test -- extensions/nextcloud-talk` — all tests pass  
- [x] `pnpm test -- extensions/thread-ownership` — all tests pass
- [x] `pnpm format` clean
- [x] Pre-existing lint errors on `main` only (unrelated `src/plugins/` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)