### PR TITLE
Adjust Feishu webhook request body limits

### DIFF
--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -13,8 +13,8 @@ export const httpServers = new Map<string, http.Server>();
 export const botOpenIds = new Map<string, string>();
 export const botNames = new Map<string, string>();
 
-export const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
-export const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+export const FEISHU_WEBHOOK_MAX_BODY_BYTES = 64 * 1024;
+export const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 5_000;
 
 type WebhookRateLimitDefaults = {
   windowMs: number;

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -1,3 +1,4 @@
+import { createConnection } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createFeishuClientMockModule,
@@ -34,6 +35,47 @@ import {
   monitorFeishuProvider,
   stopFeishuMonitor,
 } from "./monitor.js";
+
+async function waitForSlowBodyTimeoutResponse(
+  url: string,
+  timeoutMs: number,
+): Promise<{ body: string; elapsedMs: number }> {
+  return await new Promise<{ body: string; elapsedMs: number }>((resolve, reject) => {
+    const target = new URL(url);
+    const startedAt = Date.now();
+    let response = "";
+    const socket = createConnection(
+      {
+        host: target.hostname,
+        port: Number(target.port),
+      },
+      () => {
+        socket.write(`POST ${target.pathname} HTTP/1.1\r\n`);
+        socket.write(`Host: ${target.hostname}\r\n`);
+        socket.write("Content-Type: application/json\r\n");
+        socket.write("Content-Length: 65536\r\n");
+        socket.write("\r\n");
+        socket.write('{"type":"url_verification"');
+      },
+    );
+
+    socket.setEncoding("utf8");
+    socket.on("error", () => {});
+    socket.on("data", (chunk) => {
+      response += chunk;
+      if (response.includes("Request body timeout")) {
+        clearTimeout(failTimer);
+        socket.destroy();
+        resolve({ body: response, elapsedMs: Date.now() - startedAt });
+      }
+    });
+
+    const failTimer = setTimeout(() => {
+      socket.destroy();
+      reject(new Error(`timeout response did not arrive within ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+}
 
 afterEach(() => {
   clearFeishuWebhookRateLimitStateForTest();
@@ -87,6 +129,48 @@ describe("Feishu webhook security hardening", () => {
 
         expect(response.status).toBe(415);
         expect(await response.text()).toBe("Unsupported Media Type");
+      },
+    );
+  });
+
+  it("rejects oversized unsigned webhook bodies with 413 before signature verification", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    await withRunningWebhookMonitor(
+      {
+        accountId: "payload-too-large",
+        path: "/hook-payload-too-large",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ payload: "x".repeat(70 * 1024) }),
+        });
+
+        expect(response.status).toBe(413);
+        expect(await response.text()).toBe("Payload too large");
+      },
+    );
+  });
+
+  it("drops slow-body webhook requests within the tightened pre-auth timeout", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    await withRunningWebhookMonitor(
+      {
+        accountId: "slow-body-timeout",
+        path: "/hook-slow-body-timeout",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const result = await waitForSlowBodyTimeoutResponse(url, 15_000);
+        expect(result.body).toContain("408 Request Timeout");
+        expect(result.body).toContain("Request body timeout");
+        expect(result.elapsedMs).toBeLessThan(12_000);
       },
     );
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the Feishu webhook handler still used the old 1MB/30s body guard before signature verification, so unauthenticated requests could hold server resources much longer than the hardened webhook paths introduced for `GHSA-x4vp-4235-65hg`.
- Why it matters: a remote attacker could send concurrent slow or oversized Feishu webhook POSTs and consume connection and body-buffer resources before authentication failed.
- What changed: Feishu webhook body limits were tightened to `64KB` and `5s`, which automatically hardens both the installed request-body guard and the guarded body read in the webhook transport path.
- What did NOT change (scope boundary): this PR does not refactor Feishu signature verification, rate limiting, or unrelated webhook handlers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the earlier webhook hardening missed the Feishu extension workspace, so its webhook ingress path kept the previous 1MB/30s unauthenticated body budget even though authentication happens only after the body is read.
- Missing detection / guardrail: there was no Feishu-specific regression test proving oversized or slow unauthenticated webhook requests were rejected on the tightened pre-auth budget.
- Prior context (`git blame`, prior PR, issue, or refactor if known): other webhook handlers had already moved to the 64KB/5s pre-auth pattern, but Feishu lives under `extensions/feishu/` and was omitted from that earlier sweep.
- Why this regressed now: this is an incomplete-fix variant rather than a newly introduced bug in Feishu itself.
- If unknown, what was ruled out: the issue is not in Feishu signature verification logic; the exposure exists earlier at the body-limit guard/read boundary.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/monitor.webhook-security.test.ts`
- Scenario the test should lock in: oversized unsigned requests fail with `413` before signature rejection, and slow-body requests receive `408 Request body timeout` well below the old 30-second window.
- Why this is the smallest reliable guardrail: the bug lives at the real HTTP webhook ingress boundary where the server installs the body guard, reads the body, and only then verifies the signature.
- Existing test that already covers this (if any): `extensions/feishu/src/monitor.webhook-e2e.test.ts` already covers signed challenge and dispatch success paths but did not previously cover pre-auth body-limit hardening.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Normal Feishu webhook deliveries should behave the same for typical payloads. Oversized or very slow unauthenticated webhook requests are now rejected much earlier, which reduces exposure to connection/resource exhaustion before authentication.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux host
- Runtime/container: Docker validation container
- Model/provider: N/A
- Integration/channel (if any): Feishu webhook mode
- Relevant config (redacted): `OPENCLAW_TEST_PROFILE=low`

### Steps

1. Build the Docker validation image from the current repo state.
2. Run `pnpm exec oxfmt --check extensions/feishu/src/monitor.state.ts extensions/feishu/src/monitor.webhook-security.test.ts` in the container.
3. Run `OPENCLAW_TEST_PROFILE=low pnpm test -- extensions/feishu/src/monitor.webhook-security.test.ts extensions/feishu/src/monitor.webhook-e2e.test.ts` in the container.
4. Run `pnpm build` in the container.

### Expected

- Formatting passes for the touched Feishu files
- The Feishu security and e2e webhook suites pass
- Oversized unsigned webhook requests are rejected with `413`
- Slow-body Feishu webhook requests receive `408 Request body timeout` on the hardened window rather than lingering toward 30 seconds
- `pnpm build` passes

### Actual

- In-container formatting passed for `extensions/feishu/src/monitor.state.ts` and `extensions/feishu/src/monitor.webhook-security.test.ts`
- In-container `OPENCLAW_TEST_PROFILE=low pnpm test -- extensions/feishu/src/monitor.webhook-security.test.ts extensions/feishu/src/monitor.webhook-e2e.test.ts` passed with `15/15` tests
- In-container `pnpm build` passed after the runtime code change

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified in a Docker validation container that the Feishu webhook path now enforces the tightened body-limit constants, rejects oversized unsigned requests with `413`, returns `408 Request body timeout` for slow-body requests in about 5 seconds, and still passes the signed Feishu e2e webhook scenarios.
- Edge cases checked: oversized unsigned POST, slow-body POST, invalid signature handling, signed challenge handling, and signed dispatch flow.
- What you did **not** verify: I did not run a live public Feishu webhook endpoint against the external Feishu service; validation stayed in the local containerized test harness.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the Feishu webhook constant changes in `extensions/feishu/src/monitor.state.ts` and the companion security regressions in `extensions/feishu/src/monitor.webhook-security.test.ts`.
- Files/config to restore: `extensions/feishu/src/monitor.state.ts`, `extensions/feishu/src/monitor.webhook-security.test.ts`
- Known bad symptoms reviewers should watch for: legitimate small signed Feishu webhook deliveries unexpectedly timing out or being rejected as too large.

## Risks and Mitigations

- Risk: some rare Feishu webhook payload might legitimately exceed the tightened size budget.
  - Mitigation: the fix matches the hardened pre-auth budget already used elsewhere, and signed Feishu e2e flows for challenge and dispatch still pass.
- Risk: the slow-body regression could be flaky if it depends on TCP socket teardown instead of the actual timeout response.
  - Mitigation: the new regression asserts receipt of the `408 Request body timeout` response and checks that it arrives well under the old 30-second window.
