### PR TITLE
fix(gateway): restart sentinel wakes the session after restart and preserves thread routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/restart sentinel: wake the interrupted agent session via heartbeat after restart instead of only sending a best-effort restart note, retry outbound delivery once on transient failure, and preserve explicit thread/topic routing through the wake path so replies land in the correct Telegram topic or Slack thread. (#53940) Thanks @VACInc.
 - Memory/builtin sqlite: cut redundant sync and status query churn by snapshotting file state once per source, reusing sync statements, and consolidating status aggregation reads, which reduces builtin memory overhead on sync/status/doctor-style paths. Thanks @vincentkoc.
 - ACP/direct chats: always deliver a terminal ACP result when final TTS does not yield audio, even if block text already streamed earlier, and skip redundant empty-text final synthesis. (#53692) Thanks @w-sss.
 - Doctor/image generation: seed migrated legacy Nano Banana Google provider config with the `/v1beta` API root and an empty model list so `openclaw doctor --fix` completes and the migrated native Google image path keeps hitting the correct endpoint. (#53757) Thanks @mahopan.

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -26,6 +26,9 @@ const mocks = vi.hoisted(() => ({
   normalizeChannelId: vi.fn((channel: string) => channel),
   resolveOutboundTarget: vi.fn(() => ({ ok: true as const, to: "+15550002" })),
   deliverOutboundPayloads: vi.fn(async () => [{ channel: "whatsapp", messageId: "msg-1" }]),
+  enqueueDelivery: vi.fn(async () => "queue-1"),
+  ackDelivery: vi.fn(async () => {}),
+  failDelivery: vi.fn(async () => {}),
   enqueueSystemEvent: vi.fn(),
   requestHeartbeatNow: vi.fn(),
   logWarn: vi.fn(),
@@ -74,6 +77,12 @@ vi.mock("../infra/outbound/deliver.js", () => ({
   deliverOutboundPayloads: mocks.deliverOutboundPayloads,
 }));
 
+vi.mock("../infra/outbound/delivery-queue.js", () => ({
+  enqueueDelivery: mocks.enqueueDelivery,
+  ackDelivery: mocks.ackDelivery,
+  failDelivery: mocks.failDelivery,
+}));
+
 vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: mocks.enqueueSystemEvent,
 }));
@@ -105,6 +114,10 @@ describe("scheduleRestartSentinelWake", () => {
     });
     mocks.deliverOutboundPayloads.mockReset();
     mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "whatsapp", messageId: "msg-1" }]);
+    mocks.enqueueDelivery.mockReset();
+    mocks.enqueueDelivery.mockResolvedValue("queue-1");
+    mocks.ackDelivery.mockClear();
+    mocks.failDelivery.mockClear();
     mocks.enqueueSystemEvent.mockClear();
     mocks.requestHeartbeatNow.mockClear();
     mocks.logWarn.mockClear();
@@ -122,8 +135,19 @@ describe("scheduleRestartSentinelWake", () => {
         session: { key: "agent:main:main", agentId: "main" },
         deps,
         bestEffort: false,
+        skipQueue: true,
       }),
     );
+    expect(mocks.enqueueDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "whatsapp",
+        to: "+15550002",
+        payloads: [{ text: "restart message" }],
+        bestEffort: false,
+      }),
+    );
+    expect(mocks.ackDelivery).toHaveBeenCalledWith("queue-1");
+    expect(mocks.failDelivery).not.toHaveBeenCalled();
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
       "restart message",
       expect.objectContaining({
@@ -147,7 +171,22 @@ describe("scheduleRestartSentinelWake", () => {
     await vi.runAllTimersAsync();
     await wakePromise;
 
+    expect(mocks.enqueueDelivery).toHaveBeenCalledTimes(1);
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        skipQueue: true,
+      }),
+    );
+    expect(mocks.deliverOutboundPayloads).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        skipQueue: true,
+      }),
+    );
+    expect(mocks.ackDelivery).toHaveBeenCalledWith("queue-1");
+    expect(mocks.failDelivery).not.toHaveBeenCalled();
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
     expect(mocks.requestHeartbeatNow).toHaveBeenCalledTimes(1);
     expect(mocks.logWarn).toHaveBeenCalledWith(
@@ -160,6 +199,22 @@ describe("scheduleRestartSentinelWake", () => {
         maxAttempts: 2,
       }),
     );
+  });
+
+  it("keeps one queued restart notice when outbound retries are exhausted", async () => {
+    vi.useFakeTimers();
+    mocks.deliverOutboundPayloads
+      .mockRejectedValueOnce(new Error("transport not ready"))
+      .mockRejectedValueOnce(new Error("transport still not ready"));
+
+    const wakePromise = scheduleRestartSentinelWake({ deps: {} as never });
+    await vi.runAllTimersAsync();
+    await wakePromise;
+
+    expect(mocks.enqueueDelivery).toHaveBeenCalledTimes(1);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+    expect(mocks.ackDelivery).not.toHaveBeenCalled();
+    expect(mocks.failDelivery).toHaveBeenCalledWith("queue-1", "transport still not ready");
   });
 
   it("prefers top-level sentinel threadId for wake routing context", async () => {
@@ -195,7 +250,7 @@ describe("scheduleRestartSentinelWake", () => {
       payload: {
         message: "restart message",
       },
-    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
 
     await scheduleRestartSentinelWake({ deps: {} as never });
 

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -124,9 +124,12 @@ describe("scheduleRestartSentinelWake", () => {
         bestEffort: false,
       }),
     );
-    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
-      sessionKey: "agent:main:main",
-    });
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "restart message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
     expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith({
       reason: "wake",
       sessionKey: "agent:main:main",

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -189,4 +189,20 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     );
   });
+
+  it("does not wake the main session when the sentinel has no sessionKey", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        message: "restart message",
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
 });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -161,4 +161,32 @@ describe("scheduleRestartSentinelWake", () => {
       }),
     );
   });
+
+  it("prefers top-level sentinel threadId for wake routing context", async () => {
+    // Legacy or malformed sentinel JSON can still carry a nested threadId.
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+          threadId: "stale-thread",
+        } as never,
+        threadId: "fresh-thread",
+      },
+    } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "restart message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        deliveryContext: expect.objectContaining({
+          threadId: "fresh-thread",
+        }),
+      }),
+    );
+  });
 });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   resolveSessionAgentId: vi.fn(() => "agent-from-key"),
@@ -25,8 +25,10 @@ const mocks = vi.hoisted(() => ({
   })),
   normalizeChannelId: vi.fn((channel: string) => channel),
   resolveOutboundTarget: vi.fn(() => ({ ok: true as const, to: "+15550002" })),
-  deliverOutboundPayloads: vi.fn(async () => []),
+  deliverOutboundPayloads: vi.fn(async () => [{ channel: "whatsapp", messageId: "msg-1" }]),
   enqueueSystemEvent: vi.fn(),
+  requestHeartbeatNow: vi.fn(),
+  logWarn: vi.fn(),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -76,19 +78,84 @@ vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: mocks.enqueueSystemEvent,
 }));
 
+vi.mock("../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: mocks.requestHeartbeatNow,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    warn: mocks.logWarn,
+  })),
+}));
+
 const { scheduleRestartSentinelWake } = await import("./server-restart-sentinel.js");
 
 describe("scheduleRestartSentinelWake", () => {
-  it("forwards session context to outbound delivery", async () => {
-    await scheduleRestartSentinelWake({ deps: {} as never });
+  beforeEach(() => {
+    vi.useRealTimers();
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        deliveryContext: {
+          channel: "whatsapp",
+          to: "+15550002",
+          accountId: "acct-2",
+        },
+      },
+    });
+    mocks.deliverOutboundPayloads.mockReset();
+    mocks.deliverOutboundPayloads.mockResolvedValue([{ channel: "whatsapp", messageId: "msg-1" }]);
+    mocks.enqueueSystemEvent.mockClear();
+    mocks.requestHeartbeatNow.mockClear();
+    mocks.logWarn.mockClear();
+  });
+
+  it("enqueues the sentinel note and wakes the session even when outbound delivery succeeds", async () => {
+    const deps = {} as never;
+
+    await scheduleRestartSentinelWake({ deps });
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "whatsapp",
         to: "+15550002",
         session: { key: "agent:main:main", agentId: "main" },
+        deps,
+        bestEffort: false,
       }),
     );
-    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith("restart message", {
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith({
+      reason: "wake",
+      sessionKey: "agent:main:main",
+    });
+    expect(mocks.logWarn).not.toHaveBeenCalled();
+  });
+
+  it("retries outbound delivery once and logs a warning without dropping the agent wake", async () => {
+    vi.useFakeTimers();
+    mocks.deliverOutboundPayloads
+      .mockRejectedValueOnce(new Error("transport not ready"))
+      .mockResolvedValueOnce([{ channel: "whatsapp", messageId: "msg-2" }]);
+
+    const wakePromise = scheduleRestartSentinelWake({ deps: {} as never });
+    await vi.runAllTimersAsync();
+    await wakePromise;
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.requestHeartbeatNow).toHaveBeenCalledTimes(1);
+    expect(mocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("retrying in 750ms"),
+      expect.objectContaining({
+        channel: "whatsapp",
+        to: "+15550002",
+        sessionKey: "agent:main:main",
+        attempt: 1,
+        maxAttempts: 2,
+      }),
+    );
   });
 });

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -112,7 +112,7 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
 
   if (!sessionKey) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
-    enqueueRestartSentinelWake(message, mainSessionKey, wakeDeliveryContext);
+    enqueueSystemEvent(message, { sessionKey: mainSessionKey });
     return;
   }
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -21,8 +21,20 @@ const log = createSubsystemLogger("gateway/restart-sentinel");
 const OUTBOUND_RETRY_DELAY_MS = 750;
 const OUTBOUND_MAX_ATTEMPTS = 2;
 
-function enqueueRestartSentinelWake(message: string, sessionKey: string) {
-  enqueueSystemEvent(message, { sessionKey });
+function enqueueRestartSentinelWake(
+  message: string,
+  sessionKey: string,
+  deliveryContext?: {
+    channel?: string;
+    to?: string;
+    accountId?: string;
+    threadId?: string | number;
+  },
+) {
+  enqueueSystemEvent(message, {
+    sessionKey,
+    ...(deliveryContext ? { deliveryContext } : {}),
+  });
   requestHeartbeatNow({ reason: "wake", sessionKey });
 }
 
@@ -91,14 +103,18 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const sessionKey = payload.sessionKey?.trim();
   const message = formatRestartSentinelMessage(payload);
   const summary = summarizeRestartSentinel(payload);
+  const wakeDeliveryContext = mergeDeliveryContext(
+    payload.deliveryContext,
+    payload.threadId != null ? { threadId: payload.threadId } : undefined,
+  );
 
   if (!sessionKey) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
-    enqueueRestartSentinelWake(message, mainSessionKey);
+    enqueueRestartSentinelWake(message, mainSessionKey, wakeDeliveryContext);
     return;
   }
 
-  enqueueRestartSentinelWake(message, sessionKey);
+  enqueueRestartSentinelWake(message, sessionKey, wakeDeliveryContext);
 
   const { baseSessionKey, threadId: sessionThreadId } = parseSessionThreadInfo(sessionKey);
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -3,6 +3,7 @@ import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/delivery-info.js";
+import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
@@ -12,10 +13,76 @@ import {
   summarizeRestartSentinel,
 } from "../infra/restart-sentinel.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/delivery-context.js";
 import { loadSessionEntry } from "./session-utils.js";
 
-export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
+const log = createSubsystemLogger("gateway/restart-sentinel");
+const OUTBOUND_RETRY_DELAY_MS = 750;
+const OUTBOUND_MAX_ATTEMPTS = 2;
+
+function enqueueRestartSentinelWake(message: string, sessionKey: string) {
+  enqueueSystemEvent(message, { sessionKey });
+  requestHeartbeatNow({ reason: "wake", sessionKey });
+}
+
+async function waitForOutboundRetry(delayMs: number) {
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
+}
+
+async function deliverRestartSentinelNotice(params: {
+  deps: CliDeps;
+  cfg: ReturnType<typeof loadSessionEntry>["cfg"];
+  sessionKey: string;
+  summary: string;
+  message: string;
+  channel: string;
+  to: string;
+  accountId?: string;
+  replyToId?: string;
+  threadId?: string;
+  session: ReturnType<typeof buildOutboundSessionContext>;
+}) {
+  for (let attempt = 1; attempt <= OUTBOUND_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const results = await deliverOutboundPayloads({
+        cfg: params.cfg,
+        channel: params.channel,
+        to: params.to,
+        accountId: params.accountId,
+        replyToId: params.replyToId,
+        threadId: params.threadId,
+        payloads: [{ text: params.message }],
+        session: params.session,
+        deps: params.deps,
+        bestEffort: false,
+      });
+      if (results.length > 0) {
+        return;
+      }
+      throw new Error("outbound delivery returned no results");
+    } catch (err) {
+      const retrying = attempt < OUTBOUND_MAX_ATTEMPTS;
+      const suffix = retrying ? `; retrying in ${OUTBOUND_RETRY_DELAY_MS}ms` : "";
+      log.warn(`${params.summary}: outbound delivery failed${suffix}: ${String(err)}`, {
+        channel: params.channel,
+        to: params.to,
+        sessionKey: params.sessionKey,
+        attempt,
+        maxAttempts: OUTBOUND_MAX_ATTEMPTS,
+      });
+      if (!retrying) {
+        return;
+      }
+      await waitForOutboundRetry(OUTBOUND_RETRY_DELAY_MS);
+    }
+  }
+}
+
+export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const sentinel = await consumeRestartSentinel();
   if (!sentinel) {
     return;
@@ -27,9 +94,11 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
 
   if (!sessionKey) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
-    enqueueSystemEvent(message, { sessionKey: mainSessionKey });
+    enqueueRestartSentinelWake(message, mainSessionKey);
     return;
   }
+
+  enqueueRestartSentinelWake(message, sessionKey);
 
   const { baseSessionKey, threadId: sessionThreadId } = parseSessionThreadInfo(sessionKey);
 
@@ -54,7 +123,6 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   const channel = channelRaw ? normalizeChannelId(channelRaw) : null;
   const to = origin?.to;
   if (!channel || !to) {
-    enqueueSystemEvent(message, { sessionKey });
     return;
   }
 
@@ -66,7 +134,6 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
     mode: "implicit",
   });
   if (!resolved.ok) {
-    enqueueSystemEvent(message, { sessionKey });
     return;
   }
 
@@ -88,21 +155,19 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
     sessionKey,
   });
 
-  try {
-    await deliverOutboundPayloads({
-      cfg,
-      channel,
-      to: resolved.to,
-      accountId: origin?.accountId,
-      replyToId,
-      threadId: resolvedThreadId,
-      payloads: [{ text: message }],
-      session: outboundSession,
-      bestEffort: true,
-    });
-  } catch (err) {
-    enqueueSystemEvent(`${summary}\n${String(err)}`, { sessionKey });
-  }
+  await deliverRestartSentinelNotice({
+    deps: params.deps,
+    cfg,
+    sessionKey,
+    summary,
+    message,
+    channel,
+    to: resolved.to,
+    accountId: origin?.accountId,
+    replyToId,
+    threadId: resolvedThreadId,
+    session: outboundSession,
+  });
 }
 
 export function shouldWakeFromRestartSentinel() {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -5,6 +5,7 @@ import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/delivery-info.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
+import { ackDelivery, enqueueDelivery, failDelivery } from "../infra/outbound/delivery-queue.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import {
@@ -58,6 +59,18 @@ async function deliverRestartSentinelNotice(params: {
   threadId?: string;
   session: ReturnType<typeof buildOutboundSessionContext>;
 }) {
+  const payloads = [{ text: params.message }];
+  // Persist one recoverable notice across the whole retry loop so a transient
+  // failure does not leave behind a stale duplicate queue entry.
+  const queueId = await enqueueDelivery({
+    channel: params.channel,
+    to: params.to,
+    accountId: params.accountId,
+    replyToId: params.replyToId,
+    threadId: params.threadId,
+    payloads,
+    bestEffort: false,
+  }).catch(() => null);
   for (let attempt = 1; attempt <= OUTBOUND_MAX_ATTEMPTS; attempt += 1) {
     try {
       const results = await deliverOutboundPayloads({
@@ -67,12 +80,16 @@ async function deliverRestartSentinelNotice(params: {
         accountId: params.accountId,
         replyToId: params.replyToId,
         threadId: params.threadId,
-        payloads: [{ text: params.message }],
+        payloads,
         session: params.session,
         deps: params.deps,
         bestEffort: false,
+        skipQueue: true,
       });
       if (results.length > 0) {
+        if (queueId) {
+          await ackDelivery(queueId).catch(() => {});
+        }
         return;
       }
       throw new Error("outbound delivery returned no results");
@@ -87,6 +104,13 @@ async function deliverRestartSentinelNotice(params: {
         maxAttempts: OUTBOUND_MAX_ATTEMPTS,
       });
       if (!retrying) {
+        if (queueId) {
+          await failDelivery(queueId, err instanceof Error ? err.message : String(err)).catch(
+            () => {
+              // Best-effort queue bookkeeping.
+            },
+          );
+        }
         return;
       }
       await waitForOutboundRetry(OUTBOUND_RETRY_DELAY_MS);

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -104,8 +104,10 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const message = formatRestartSentinelMessage(payload);
   const summary = summarizeRestartSentinel(payload);
   const wakeDeliveryContext = mergeDeliveryContext(
-    payload.deliveryContext,
-    payload.threadId != null ? { threadId: payload.threadId } : undefined,
+    payload.threadId != null
+      ? { ...payload.deliveryContext, threadId: payload.threadId }
+      : payload.deliveryContext,
+    undefined,
   );
 
   if (!sessionKey) {

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as replyModule from "../auto-reply/reply.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
   seedMainSessionStore,
@@ -228,5 +230,64 @@ describe("Ghost reminder bug (issue #13317)", () => {
     expect(calledCtx?.Provider).toBe("exec-event");
     expect(calledCtx?.Body).toContain("Handle the result internally");
     expect(sendTelegram).not.toHaveBeenCalled();
+  });
+
+  it("routes wake-triggered heartbeat replies using queued system-event delivery context", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100155462274",
+      });
+      replySpy.mockResolvedValue({ text: "Restart complete" });
+      enqueueSystemEvent("Gateway restart ok", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100155462274",
+          threadId: 42,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "wake",
+        deps: {
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "-100155462274",
+        "Restart complete",
+        expect.objectContaining({ messageThreadId: 42 }),
+      );
+    });
   });
 });

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -290,4 +290,71 @@ describe("Ghost reminder bug (issue #13317)", () => {
       );
     });
   });
+
+  it("does not reuse stale turn-source routing for isolated wake runs", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "-100155462274",
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100155462274",
+      });
+      replySpy.mockResolvedValue({ text: "Restart complete" });
+      enqueueSystemEvent("Gateway restart ok", {
+        sessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "-100999999999",
+          threadId: 42,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        reason: "wake",
+        deps: {
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          SessionKey: `${sessionKey}:heartbeat`,
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram.mock.calls[0]?.[0]).toBe("-100155462274");
+      const options = sendTelegram.mock.calls[0]?.[2] as { messageThreadId?: number } | undefined;
+      expect(options?.messageThreadId).toBeUndefined();
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -80,7 +80,7 @@ import {
   resolveHeartbeatDeliveryTarget,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
-import { peekSystemEventEntries } from "./system-events.js";
+import { peekSystemEventEntries, resolveSystemEventDeliveryContext } from "./system-events.js";
 
 export type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
@@ -398,6 +398,7 @@ type HeartbeatSkipReason = "empty-heartbeat-file";
 type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
+  turnSourceDeliveryContext: ReturnType<typeof resolveSystemEventDeliveryContext>;
   hasTaggedCronEvents: boolean;
   shouldInspectPendingEvents: boolean;
   skipReason?: HeartbeatSkipReason;
@@ -427,6 +428,7 @@ async function resolveHeartbeatPreflight(params: {
     params.forcedSessionKey,
   );
   const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
   );
@@ -441,6 +443,7 @@ async function resolveHeartbeatPreflight(params: {
     ...reasonFlags,
     session,
     pendingEventEntries,
+    turnSourceDeliveryContext,
     hasTaggedCronEvents,
     shouldInspectPendingEvents,
   } satisfies Omit<HeartbeatPreflight, "skipReason">;
@@ -598,7 +601,12 @@ export async function runHeartbeatOnce(opts: {
     runStorePath = cronSession.storePath;
   }
 
-  const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });
+  const delivery = resolveHeartbeatDeliveryTarget({
+    cfg,
+    entry,
+    heartbeat,
+    turnSource: preflight.turnSourceDeliveryContext,
+  });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
     log.warn("heartbeat: unknown accountId", {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -605,7 +605,11 @@ export async function runHeartbeatOnce(opts: {
     cfg,
     entry,
     heartbeat,
-    turnSource: preflight.turnSourceDeliveryContext,
+    // Isolated heartbeat runs drain system events from their dedicated
+    // `:heartbeat` session, not from the base session we peek during preflight.
+    // Reusing base-session turnSource routing here can pin later isolated runs
+    // to stale channels/threads because that base-session event context remains queued.
+    turnSource: useIsolatedSession ? undefined : preflight.turnSourceDeliveryContext,
   });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -645,6 +645,52 @@ describe("resolveSessionDeliveryTarget", () => {
     expect(resolved.to).toBe("-10063448508");
     expect(resolved.threadId).toBe(1008013);
   });
+
+  it("prefers turn-scoped routing over mutable session routing for target=last", () => {
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg: {},
+      entry: {
+        sessionId: "sess-heartbeat-turn-source",
+        updatedAt: 1,
+        lastChannel: "slack",
+        lastTo: "U_WRONG",
+      },
+      heartbeat: {
+        target: "last",
+      },
+      turnSource: {
+        channel: "telegram",
+        to: "-100123",
+        threadId: 42,
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("-100123");
+    expect(resolved.threadId).toBe(42);
+  });
+
+  it("merges partial turn-scoped metadata with the stored session route for target=last", () => {
+    const resolved = resolveHeartbeatDeliveryTarget({
+      cfg: {},
+      entry: {
+        sessionId: "sess-heartbeat-turn-source-partial",
+        updatedAt: 1,
+        lastChannel: "telegram",
+        lastTo: "-100123",
+      },
+      heartbeat: {
+        target: "last",
+      },
+      turnSource: {
+        threadId: 42,
+      },
+    });
+
+    expect(resolved.channel).toBe("telegram");
+    expect(resolved.to).toBe("-100123");
+    expect(resolved.threadId).toBe(42);
+  });
 });
 
 describe("resolveSessionDeliveryTarget — cross-channel reply guard (#24152)", () => {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -6,7 +6,11 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
-import { deliveryContextFromSession } from "../../utils/delivery-context.js";
+import {
+  deliveryContextFromSession,
+  mergeDeliveryContext,
+  type DeliveryContext,
+} from "../../utils/delivery-context.js";
 import type {
   DeliverableMessageChannel,
   GatewayMessageChannel,
@@ -162,8 +166,16 @@ export function resolveSessionDeliveryTarget(params: {
 
   const mode = params.mode ?? (explicitTo ? "explicit" : "implicit");
   const accountId = channel && channel === lastChannel ? lastAccountId : undefined;
+  const hasTurnSourceThreadId =
+    params.turnSourceThreadId != null && params.turnSourceThreadId !== "";
   const threadId =
-    mode !== "heartbeat" && channel && channel === lastChannel ? lastThreadId : undefined;
+    channel && channel === lastChannel
+      ? mode === "heartbeat"
+        ? hasTurnSourceThreadId
+          ? params.turnSourceThreadId
+          : undefined
+        : lastThreadId
+      : undefined;
 
   const resolvedThreadId = explicitThreadId ?? threadId;
   return {
@@ -254,6 +266,7 @@ export function resolveHeartbeatDeliveryTarget(params: {
   cfg: OpenClawConfig;
   entry?: SessionEntry;
   heartbeat?: AgentDefaultsConfig["heartbeat"];
+  turnSource?: DeliveryContext;
 }): OutboundTarget {
   const { cfg, entry } = params;
   const heartbeat = params.heartbeat ?? cfg.agents?.defaults?.heartbeat;
@@ -277,11 +290,28 @@ export function resolveHeartbeatDeliveryTarget(params: {
     });
   }
 
+  const resolvedTurnSource =
+    target === "last"
+      ? mergeDeliveryContext(params.turnSource, deliveryContextFromSession(entry))
+      : undefined;
+
   const resolvedTarget = resolveSessionDeliveryTarget({
     entry,
     requestedChannel: target === "last" ? "last" : target,
     explicitTo: heartbeat?.to,
     mode: "heartbeat",
+    turnSourceChannel:
+      resolvedTurnSource?.channel && isDeliverableMessageChannel(resolvedTurnSource.channel)
+        ? resolvedTurnSource.channel
+        : undefined,
+    turnSourceTo: resolvedTurnSource?.to,
+    turnSourceAccountId: resolvedTurnSource?.accountId,
+    // Only pass threadId from an explicit turn source (e.g., restart sentinel's
+    // delivery context). Do NOT fall back to session-stored threadId here —
+    // heartbeat mode intentionally drops inherited thread IDs to avoid replying
+    // in stale threads (e.g., Slack thread_ts). The sentinel's delivery context
+    // carries the correct topic/thread ID when present.
+    turnSourceThreadId: params.turnSource?.threadId,
   });
 
   const heartbeatAccountId = heartbeat?.accountId?.trim();

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -11,6 +11,7 @@ import {
   peekSystemEventEntries,
   peekSystemEvents,
   resetSystemEventsForTest,
+  resolveSystemEventDeliveryContext,
 } from "./system-events.js";
 
 type SystemEventsModule = typeof import("./system-events.js");
@@ -103,6 +104,38 @@ describe("system events (session routing)", () => {
     expect(hasSystemEvents(key)).toBe(false);
 
     expect(enqueueSystemEvent("Node connected", { sessionKey: key })).toBe(true);
+  });
+
+  it("resolves the newest effective delivery context from queued events", () => {
+    const key = "agent:main:test-delivery-context";
+    enqueueSystemEvent("Restarted", {
+      sessionKey: key,
+      deliveryContext: {
+        channel: " telegram ",
+        to: " -100123 ",
+      },
+    });
+    enqueueSystemEvent("Thread route", {
+      sessionKey: key,
+      deliveryContext: {
+        threadId: " 42 ",
+      },
+    });
+
+    const events = peekSystemEventEntries(key);
+    const resolved = resolveSystemEventDeliveryContext(events);
+    events[0].deliveryContext!.to = "mutated";
+
+    expect(resolved).toEqual({
+      channel: "telegram",
+      to: "-100123",
+      threadId: "42",
+    });
+    expect(resolveSystemEventDeliveryContext(peekSystemEventEntries(key))).toEqual({
+      channel: "telegram",
+      to: "-100123",
+      threadId: "42",
+    });
   });
 
   it("keeps only the newest 20 queued events", () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -3,8 +3,18 @@
 // events ephemeral. Events are session-scoped and require an explicit key.
 
 import { resolveGlobalMap } from "../shared/global-singleton.js";
+import {
+  mergeDeliveryContext,
+  normalizeDeliveryContext,
+  type DeliveryContext,
+} from "../utils/delivery-context.js";
 
-export type SystemEvent = { text: string; ts: number; contextKey?: string | null };
+export type SystemEvent = {
+  text: string;
+  ts: number;
+  contextKey?: string | null;
+  deliveryContext?: DeliveryContext;
+};
 
 const MAX_EVENTS = 20;
 
@@ -21,6 +31,7 @@ const queues = resolveGlobalMap<string, SessionQueue>(SYSTEM_EVENT_QUEUES_KEY);
 type SystemEventOptions = {
   sessionKey: string;
   contextKey?: string | null;
+  deliveryContext?: DeliveryContext;
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -61,6 +72,13 @@ function getOrCreateSessionQueue(sessionKey: string): SessionQueue {
   return created;
 }
 
+function cloneSystemEvent(event: SystemEvent): SystemEvent {
+  return {
+    ...event,
+    ...(event.deliveryContext ? { deliveryContext: { ...event.deliveryContext } } : {}),
+  };
+}
+
 export function isSystemEventContextChanged(
   sessionKey: string,
   contextKey?: string | null,
@@ -78,6 +96,7 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
     return false;
   }
   const normalizedContextKey = normalizeContextKey(options?.contextKey);
+  const normalizedDeliveryContext = normalizeDeliveryContext(options?.deliveryContext);
   entry.lastContextKey = normalizedContextKey;
   if (entry.lastText === cleaned) {
     return false;
@@ -87,6 +106,7 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
     text: cleaned,
     ts: Date.now(),
     contextKey: normalizedContextKey,
+    deliveryContext: normalizedDeliveryContext,
   });
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
@@ -100,7 +120,7 @@ export function drainSystemEventEntries(sessionKey: string): SystemEvent[] {
   if (!entry || entry.queue.length === 0) {
     return [];
   }
-  const out = entry.queue.slice();
+  const out = entry.queue.map(cloneSystemEvent);
   entry.queue.length = 0;
   entry.lastText = null;
   entry.lastContextKey = null;
@@ -113,7 +133,7 @@ export function drainSystemEvents(sessionKey: string): string[] {
 }
 
 export function peekSystemEventEntries(sessionKey: string): SystemEvent[] {
-  return getSessionQueue(sessionKey)?.queue.map((event) => ({ ...event })) ?? [];
+  return getSessionQueue(sessionKey)?.queue.map(cloneSystemEvent) ?? [];
 }
 
 export function peekSystemEvents(sessionKey: string): string[] {
@@ -122,6 +142,16 @@ export function peekSystemEvents(sessionKey: string): string[] {
 
 export function hasSystemEvents(sessionKey: string) {
   return (getSessionQueue(sessionKey)?.queue.length ?? 0) > 0;
+}
+
+export function resolveSystemEventDeliveryContext(
+  events: readonly SystemEvent[],
+): DeliveryContext | undefined {
+  let resolved: DeliveryContext | undefined;
+  for (const event of events) {
+    resolved = mergeDeliveryContext(event.deliveryContext, resolved);
+  }
+  return resolved;
 }
 
 export function resetSystemEventsForTest() {


### PR DESCRIPTION
## Summary

- Problem: restart sentinel could send a restart note without actually waking the interrupted session.
- Why it matters: after restart, the in-progress session could stall instead of continuing.
- What changed: startup restart-sentinel handling now queues a system event, requests an immediate wake for that session, and preserves explicit thread/topic routing through the wake-triggered reply path.
- What did NOT change (scope boundary): no config changes, no heartbeat schedule changes, no broad routing rewrite outside restart-sentinel wake handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Memory / storage
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #27584
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the restart-sentinel path was refactored into direct outbound delivery, which no longer guaranteed an agent turn for the interrupted session.
- Missing detection / guardrail: no test covered "startup consumes restart sentinel and wakes the original session."
- Prior context (`git blame`, prior PR, issue, or refactor if known): `refactor: unify outbound session context wiring` plus earlier restart-sentinel routing/thread fixes.
- Why this regressed now: restart note delivery survived, but session wake did not.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-restart-sentinel.test.ts`, `src/infra/heartbeat-runner.ghost-reminder.test.ts`, `src/infra/outbound/targets.test.ts`, `src/infra/system-events.test.ts`
- Scenario the test should lock in: startup restart-sentinel handling wakes the original session and preserves thread/topic routing.
- Why this is the smallest reliable guardrail: it covers the exact startup -> wake -> routing seam without full restart E2E.
- Existing test that already covers this (if any): partial coverage only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- After restart, restart sentinel now wakes the interrupted session instead of only sending a best-effort restart note.
- Wake-triggered replies preserve explicit thread/topic routing.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22, pnpm
- Model/provider: N/A
- Integration/channel (if any): restart sentinel + heartbeat wake routing
- Relevant config (redacted): `agents.defaults.heartbeat.target=last`

### Steps

1. Consume a restart sentinel on startup for a session with delivery context.
2. Trigger the wake path for that session.
3. Verify the reply routes back to the original thread/topic.

### Expected

- The interrupted session wakes after restart and replies in the original thread/topic.

### Actual

- Before: restart note could be sent without waking the session.
- After: session wakes and thread/topic routing is preserved.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted restart-sentinel, heartbeat-runner, outbound-target, and system-event tests pass; `pnpm build` passes.
- Edge cases checked: retry does not drop the wake; partial turn-scoped metadata still preserves thread/topic routing.
- What you did **not** verify: full live restart E2E against a real gateway/channel.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR
- Files/config to restore: `src/gateway/server-restart-sentinel.ts`, `src/infra/system-events.ts`, `src/infra/outbound/targets.ts`, `src/infra/heartbeat-runner.ts`
- Known bad symptoms reviewers should watch for: restart note appears but the session still does not continue, or replies land in the wrong thread/topic

## Risks and Mitigations

- Risk:
  - Retried outbound restart notifications could duplicate the note in some transport failure modes.
- Mitigation:
  - Retry is capped, and session wake no longer depends on outbound success.
