### PR TITLE
fix: prevent MiniMax reasoning tag leaks (<think>/<final>)

### DIFF
--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -66,7 +66,7 @@ export function stripReasoningTagsFromText(
 
   for (const match of cleaned.matchAll(THINKING_TAG_RE)) {
     const idx = match.index ?? 0;
-    const isClose = match[1] === "/";
+    const isClose = match[1] === "/" || match[0].toLowerCase().includes("final");
 
     if (isInsideCode(idx, codeRegions)) {
       continue;


### PR DESCRIPTION
This PR ensures that MiniMax reasoning content is correctly stripped when `thinkingDefault: "off"` by treating the `<final>` tag as a terminal for the reasoning block (#53956).

### Changes:
- Updated `stripReasoningTagsFromText` logic to treat `<final>` as a closing indicator for thinking segments.
- Prevents raw model thoughts from leaking into the user UI when using MiniMax providers.

/claim #53956