### PR TITLE
fix: block non-owner authorized senders from changing /send policy

### DIFF
--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -18,6 +18,7 @@ import {
   isTelegramSurface,
   resolveChannelAccountId,
 } from "./channel-context.js";
+import { rejectNonOwnerCommand, rejectUnauthorizedCommand } from "./command-gates.js";
 import { handleAbortTrigger, handleStopCommand } from "./commands-session-abort.js";
 import { persistSessionEntry } from "./commands-session-store.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -217,11 +218,13 @@ export const handleSendPolicyCommand: CommandHandler = async (params, allowTextC
   if (!sendPolicyCommand.hasCommand) {
     return null;
   }
-  if (!params.command.isAuthorizedSender) {
-    logVerbose(
-      `Ignoring /send from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
+  const unauthorizedResult = rejectUnauthorizedCommand(params, "/send");
+  if (unauthorizedResult) {
+    return unauthorizedResult;
+  }
+  const nonOwnerResult = rejectNonOwnerCommand(params, "/send");
+  if (nonOwnerResult) {
+    return nonOwnerResult;
   }
   if (!sendPolicyCommand.mode) {
     return {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -867,6 +867,101 @@ describe("handleCommands owner gating for privileged show commands", () => {
   });
 });
 
+describe("handleCommands /send owner gating", () => {
+  it("blocks authorized non-owner senders from mutating session send policy", async () => {
+    const params = buildParams("/send off", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = false;
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-send-policy",
+      updatedAt: Date.now(),
+      sendPolicy: "allow",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [params.sessionKey]: sessionEntry,
+    };
+
+    const result = await handleCommands({
+      ...params,
+      sessionEntry,
+      sessionStore,
+    });
+
+    expect(result).toEqual({ shouldContinue: false });
+    expect(sessionEntry.sendPolicy).toBe("allow");
+    expect(sessionStore[params.sessionKey]?.sendPolicy).toBe("allow");
+  });
+
+  it("allows owners to mutate session send policy", async () => {
+    const params = buildParams("/send off", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-send-policy-owner",
+      updatedAt: Date.now(),
+      sendPolicy: "allow",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [params.sessionKey]: sessionEntry,
+    };
+
+    const result = await handleCommands({
+      ...params,
+      sessionEntry,
+      sessionStore,
+    });
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Send policy set to off");
+    expect(sessionEntry.sendPolicy).toBe("deny");
+    expect(sessionStore[params.sessionKey]?.sendPolicy).toBe("deny");
+  });
+
+  it("returns an explicit unauthorized reply for native /send from non-owners", async () => {
+    const params = buildParams(
+      "/send off",
+      {
+        commands: { text: true },
+        channels: { discord: { dm: { enabled: true, policy: "open" } } },
+      } as OpenClawConfig,
+      {
+        Provider: "discord",
+        Surface: "discord",
+        CommandSource: "native",
+      },
+    );
+    params.command.senderIsOwner = false;
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-send-policy-native",
+      updatedAt: Date.now(),
+      sendPolicy: "allow",
+    };
+    const sessionStore: Record<string, SessionEntry> = {
+      [params.sessionKey]: sessionEntry,
+    };
+
+    const result = await handleCommands({
+      ...params,
+      sessionEntry,
+      sessionStore,
+    });
+
+    expect(result).toEqual({
+      shouldContinue: false,
+      reply: { text: "You are not authorized to use this command." },
+    });
+    expect(sessionEntry.sendPolicy).toBe("allow");
+    expect(sessionStore[params.sessionKey]?.sendPolicy).toBe("allow");
+  });
+});
+
 describe("handleCommands /config configWrites gating", () => {
   it("blocks disallowed /config set writes", async () => {
     const cases = [


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/send on|off|inherit` was documented as owner-only, but the handler only checked general command authorization and not owner status.
- Why it matters: a lower-trust participant who was allowed to run commands could still persistently change the current session `sendPolicy`.
- What changed: `/send` now requires owner status by reusing the shared owner-only command gate before any session-state mutation occurs.
- What did NOT change (scope boundary): this PR does not redefine `commands.allowFrom`, owner resolution, or unrelated privileged command surfaces.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `src/auto-reply/reply/commands-session.ts` treated `/send` as if general command authorization were sufficient, even though `/send` is a privileged owner-only command surface.
- Missing detection / guardrail: there was no focused regression proving that `isAuthorizedSender === true` but `senderIsOwner === false` must still be rejected for `/send`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this is the same authorization class as the earlier owner-only command bypasses for `/config` and `/debug`, but it remained unpatched on the `/send` surface.
- Why this regressed now: this is an incomplete-fix variant on an existing owner-only authorization class rather than a newly introduced command feature.
- If unknown, what was ruled out: the bug is not in session persistence itself; the flaw exists at the `/send` command authorization boundary before mutation.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/commands.test.ts`
- Scenario the test should lock in: a non-owner sender who is still command-authorized cannot persist `/send` mutations, while owners still can, and native `/send` gets the standard explicit unauthorized reply.
- Why this is the smallest reliable guardrail: the bug lives in the real command handler path where `buildCommandContext()` output is consumed and session state is mutated.
- Existing test that already covers this (if any): `src/auto-reply/command-auth.owner-default.test.ts` already covered the auth precondition (`senderIsOwner === false` with `isAuthorizedSender === true`) but did not assert `/send` behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Authorized non-owner participants can no longer use `/send on|off|inherit` to change current-session delivery policy. Real owners still can. Native slash-command clients now receive the standard explicit unauthorized message when a non-owner tries `/send`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux host
- Runtime/container: Docker validation container
- Model/provider: N/A
- Integration/channel (if any): auto-reply command handling
- Relevant config (redacted): `OPENCLAW_TEST_PROFILE=low`

### Steps

1. Build the Docker validation image from the current repo state.
2. Run `pnpm exec oxfmt --check src/auto-reply/reply/commands-session.ts src/auto-reply/reply/commands.test.ts` in the container.
3. Run `OPENCLAW_TEST_PROFILE=low pnpm exec vitest run src/auto-reply/reply/commands.test.ts -t "handleCommands /send owner gating"` in the container.
4. Run `OPENCLAW_TEST_PROFILE=low pnpm test -- src/auto-reply/command-auth.owner-default.test.ts src/auto-reply/command-control.test.ts` in the container.
5. Run `pnpm build` in the container.

### Expected

- The touched files pass formatting checks
- Focused `/send` owner-gating regressions pass
- Adjacent auth tests pass
- Build passes
- Authorized non-owners cannot mutate `sessionEntry.sendPolicy`
- Owners can still use `/send` successfully
- Native non-owner `/send` returns `You are not authorized to use this command.`

### Actual

- In-container formatting passed for `src/auto-reply/reply/commands-session.ts` and `src/auto-reply/reply/commands.test.ts`
- In-container focused `/send` regression run passed with `3` targeted tests green
- In-container `OPENCLAW_TEST_PROFILE=low pnpm test -- src/auto-reply/command-auth.owner-default.test.ts src/auto-reply/command-control.test.ts` passed with `41/41` tests
- In-container `pnpm build` passed

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified in a Docker validation container that `/send` now rejects command-authorized non-owners before any session-state mutation, still allows owners to persist `sendPolicy` changes, returns the standard explicit unauthorized message for native non-owner `/send`, and still passes the adjacent owner/auth behavior tests plus build.
- Edge cases checked: text-command non-owner rejection, owner success, native-command explicit unauthorized reply, auth-layer owner-vs-command-authorized distinction.
- What you did **not** verify: I did not run a live end-to-end chat session on each external channel surface; validation stayed in the command-handler test harness plus build.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the `/send` owner gate change in `src/auto-reply/reply/commands-session.ts` and the focused regressions in `src/auto-reply/reply/commands.test.ts`.
- Files/config to restore: `src/auto-reply/reply/commands-session.ts`, `src/auto-reply/reply/commands.test.ts`
- Known bad symptoms reviewers should watch for: legitimate owners unexpectedly losing access to `/send` on text or native command surfaces.

## Risks and Mitigations

- Risk: a legitimate owner flow on a less-common command surface could be accidentally blocked.
  - Mitigation: the fix uses the existing shared owner-only command gate already applied to other privileged commands, and owner success is covered by focused regression tests.
- Risk: unrelated broad `commands.test.ts` failures could obscure the `/send` validation result.
  - Mitigation: the validation explicitly ran the focused `/send` test group, the adjacent auth suites, and a successful full build in-container.

