### PR TITLE
feat: implement Atomic JSON writes for config and auth stores

### DIFF
--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -18,6 +18,16 @@ export function saveJsonFile(pathname: string, data: unknown) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
-  fs.chmodSync(pathname, 0o600);
+  
+  // Atomic write via temp file and rename
+  const tempPath = `${pathname}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  
+  try {
+    fs.chmodSync(tempPath, 0o600);
+  } catch (e) {
+    // Handle EPERM on Windows-mounted Docker volumes (Fixes #53947)
+  }
+  
+  fs.renameSync(tempPath, pathname);
 }


### PR DESCRIPTION
This PR implements atomic JSON writes by using a temporary file and `renameSync`, preventing configuration or credential corruption during crashes or partial writes (#53969).

### Changes:
- Updated `src/infra/json-file.ts` to use atomic write pattern.
- Includes the chmod EPERM fix for Windows/Docker environments (#53947).
- Ensures that `auth-profiles.json` remains consistent even under high-intensity rotating token writes.

/claim #53969