### PR TITLE
acpx: add terminal-truth artifacts and strict terminal states

### DIFF
--- a/extensions/acpx/src/runtime-internals/run-artifacts.test.ts
+++ b/extensions/acpx/src/runtime-internals/run-artifacts.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type RunArtifactsModule = typeof import("./run-artifacts.js");
+
+const tempDirs = new Set<string>();
+
+async function createTempStateDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "acpx-run-artifacts-"));
+  tempDirs.add(dir);
+  return dir;
+}
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const raw = await readFile(filePath, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.doUnmock("node:fs/promises");
+  delete process.env.OPENCLAW_STATE_DIR;
+  await Promise.all(Array.from(tempDirs, (dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.clear();
+});
+
+describe("run-artifacts", () => {
+  it("preserves terminal truth when route mirror write fails", async () => {
+    const stateDir = await createTempStateDir();
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const actualFs = (await vi.importActual(
+      "node:fs/promises",
+    )) as typeof import("node:fs/promises");
+    let routeRenameCount = 0;
+
+    vi.doMock("node:fs/promises", async () => ({
+      ...actualFs,
+      rename: vi.fn(async (from: string, to: string) => {
+        if (to.endsWith("/route.json")) {
+          routeRenameCount += 1;
+          if (routeRenameCount === 2) {
+            const error = new Error("route mirror write failed") as NodeJS.ErrnoException;
+            error.code = "EIO";
+            throw error;
+          }
+        }
+        return await actualFs.rename(from, to);
+      }),
+    }));
+
+    const module = (await import("./run-artifacts.js")) as RunArtifactsModule;
+    const artifacts = await module.createRunArtifacts({
+      requestId: "req-route-mirror-failure",
+      sessionKey: "agent:codex:acp:route-mirror-failure",
+      runtimeSessionName: "agent:codex:acp:route-mirror-failure",
+      agent: "codex",
+      promptMode: "prompt",
+      routeKind: "prompt_session",
+      routeArgs: ["acpx", "prompt"],
+      cwd: process.cwd(),
+    });
+
+    await expect(
+      module.finalizeRun({
+        artifacts,
+        state: "completed",
+        captureStatus: "captured",
+        doneSeen: true,
+        syntheticDone: false,
+        errorSeen: false,
+        exitCode: 0,
+        signal: null,
+        stdoutBytes: 12,
+        stderrBytes: 0,
+        stdoutLines: 1,
+        stderrLines: 0,
+        endedAt: new Date().toISOString(),
+      }),
+    ).resolves.toBeUndefined();
+
+    const terminal = await readJson<Record<string, unknown>>(artifacts.terminalPath);
+    const route = await readJson<Record<string, unknown>>(artifacts.routePath);
+
+    expect(terminal.state).toBe("completed");
+    expect(terminal.capture_status).toBe("captured");
+    expect(terminal.result_ref).toBeTruthy();
+    expect(route.state).toBe("accepted");
+  });
+
+  it("fails immediately when run-id allocation sees a non-EEXIST mkdir error", async () => {
+    const stateDir = await createTempStateDir();
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const actualFs = (await vi.importActual(
+      "node:fs/promises",
+    )) as typeof import("node:fs/promises");
+    let candidateMkdirCalls = 0;
+
+    vi.doMock("node:fs/promises", async () => ({
+      ...actualFs,
+      mkdir: vi.fn(async (target: string, options?: { recursive?: boolean }) => {
+        if (options?.recursive === false) {
+          candidateMkdirCalls += 1;
+          const error = new Error("permission denied") as NodeJS.ErrnoException;
+          error.code = "EACCES";
+          throw error;
+        }
+        return await actualFs.mkdir(target, options);
+      }),
+    }));
+
+    const module = (await import("./run-artifacts.js")) as RunArtifactsModule;
+
+    await expect(
+      module.createRunArtifacts({
+        requestId: "req-mkdir-eacces",
+        sessionKey: "agent:codex:acp:mkdir-eacces",
+        runtimeSessionName: "agent:codex:acp:mkdir-eacces",
+        agent: "codex",
+        promptMode: "prompt",
+        routeKind: "prompt_session",
+        routeArgs: ["acpx", "prompt"],
+        cwd: process.cwd(),
+      }),
+    ).rejects.toMatchObject({
+      code: "EACCES",
+    });
+
+    expect(candidateMkdirCalls).toBe(1);
+  });
+});

--- a/extensions/acpx/src/runtime-internals/run-artifacts.ts
+++ b/extensions/acpx/src/runtime-internals/run-artifacts.ts
@@ -1,0 +1,305 @@
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+export type AcpxTerminalState =
+  | "accepted"
+  | "started"
+  | "completed"
+  | "failed"
+  | "timed_out"
+  | "lost";
+
+export type AcpxRouteKind = "prompt_session";
+
+export type AcpxRunArtifacts = {
+  runId: string;
+  requestId: string | null;
+  runDir: string;
+  routePath: string;
+  terminalPath: string;
+  stdoutPath: string;
+  stderrPath: string;
+};
+
+type RouteArtifact = {
+  run_id: string;
+  request_id: string | null;
+  backend: "acpx";
+  session_key: string;
+  runtime_session_name: string;
+  agent: string;
+  prompt_mode: "prompt" | "steer";
+  route_kind: AcpxRouteKind;
+  route_args: string[];
+  cwd: string;
+  acpx_record_id?: string;
+  backend_session_id?: string;
+  agent_session_id?: string;
+  accepted_at: string;
+  started_at?: string;
+  state: AcpxTerminalState;
+  pid?: number;
+};
+
+type TerminalArtifact = {
+  run_id: string;
+  request_id: string | null;
+  state: AcpxTerminalState;
+  capture_status: "pending" | "captured" | "missing";
+  done_seen: boolean;
+  synthetic_done: boolean;
+  error_seen: boolean;
+  exit_code: number | null;
+  signal: NodeJS.Signals | null;
+  started_at?: string;
+  ended_at?: string;
+  stdout_ref: string;
+  stderr_ref: string;
+  route_ref: string;
+  result_ref: string | null;
+  error_ref: string | null;
+  stop_reason?: string;
+  error_code?: string;
+  error_message?: string;
+  stdout_bytes: number;
+  stderr_bytes: number;
+  stdout_lines: number;
+  stderr_lines: number;
+};
+
+function resolveStateDir(): string {
+  const configured = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (configured) {
+    return path.resolve(configured);
+  }
+  return path.join(os.homedir(), ".openclaw");
+}
+
+export function resolveAcpxRunArtifactRoot(): string {
+  return path.join(resolveStateDir(), "artifacts", "acpx", "runs");
+}
+
+function sanitizeRunId(value: string): string {
+  const trimmed = value.trim();
+  const sanitized = trimmed.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/-+/g, "-");
+  return sanitized.replace(/^-|-$/g, "") || "run";
+}
+
+async function allocateRunId(rootDir: string, seed: string): Promise<string> {
+  const normalized = sanitizeRunId(seed);
+  for (let attempt = 1; attempt < 10_000; attempt += 1) {
+    const candidate = attempt === 1 ? normalized : `${normalized}--${attempt}`;
+    const candidateDir = path.join(rootDir, candidate);
+    try {
+      await mkdir(candidateDir, { recursive: false });
+      return candidate;
+    } catch {
+      // try next suffix
+    }
+  }
+  const timestampCandidate = `${normalized}--${Date.now()}`;
+  await mkdir(path.join(rootDir, timestampCandidate), { recursive: false });
+  return timestampCandidate;
+}
+
+async function writeJsonAtomic(filePath: string, payload: unknown): Promise<void> {
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tempPath, JSON.stringify(payload, null, 2) + "\n", "utf8");
+  await rename(tempPath, filePath);
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  const raw = await readFile(filePath, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+async function updateRoute(
+  artifacts: AcpxRunArtifacts,
+  patch: Partial<RouteArtifact>,
+): Promise<RouteArtifact> {
+  const current = await readJsonFile<RouteArtifact>(artifacts.routePath);
+  const next: RouteArtifact = {
+    ...current,
+    ...patch,
+  };
+  await writeJsonAtomic(artifacts.routePath, next);
+  return next;
+}
+
+async function updateTerminal(
+  artifacts: AcpxRunArtifacts,
+  patch: Partial<TerminalArtifact>,
+): Promise<TerminalArtifact> {
+  const current = await readJsonFile<TerminalArtifact>(artifacts.terminalPath);
+  const next: TerminalArtifact = {
+    ...current,
+    ...patch,
+  };
+  await writeJsonAtomic(artifacts.terminalPath, next);
+  return next;
+}
+
+export async function createRunArtifacts(params: {
+  requestId?: string;
+  sessionKey: string;
+  runtimeSessionName: string;
+  agent: string;
+  promptMode: "prompt" | "steer";
+  routeKind: AcpxRouteKind;
+  routeArgs: string[];
+  cwd: string;
+  acpxRecordId?: string;
+  backendSessionId?: string;
+  agentSessionId?: string;
+}): Promise<AcpxRunArtifacts> {
+  const rootDir = resolveAcpxRunArtifactRoot();
+  await mkdir(rootDir, { recursive: true });
+  const requestId = params.requestId?.trim() || null;
+  const runId = await allocateRunId(rootDir, requestId || `${params.agent}-${Date.now()}`);
+  const runDir = path.join(rootDir, runId);
+  const routePath = path.join(runDir, "route.json");
+  const terminalPath = path.join(runDir, "terminal.json");
+  const stdoutPath = path.join(runDir, "stdout.log");
+  const stderrPath = path.join(runDir, "stderr.log");
+  const acceptedAt = new Date().toISOString();
+
+  const artifacts: AcpxRunArtifacts = {
+    runId,
+    requestId,
+    runDir,
+    routePath,
+    terminalPath,
+    stdoutPath,
+    stderrPath,
+  };
+
+  const routeArtifact: RouteArtifact = {
+    run_id: runId,
+    request_id: requestId,
+    backend: "acpx",
+    session_key: params.sessionKey,
+    runtime_session_name: params.runtimeSessionName,
+    agent: params.agent,
+    prompt_mode: params.promptMode,
+    route_kind: params.routeKind,
+    route_args: params.routeArgs,
+    cwd: params.cwd,
+    accepted_at: acceptedAt,
+    state: "accepted",
+    ...(params.acpxRecordId ? { acpx_record_id: params.acpxRecordId } : {}),
+    ...(params.backendSessionId ? { backend_session_id: params.backendSessionId } : {}),
+    ...(params.agentSessionId ? { agent_session_id: params.agentSessionId } : {}),
+  };
+
+  const terminalRef = pathToFileURL(terminalPath).toString();
+  const terminalArtifact: TerminalArtifact = {
+    run_id: runId,
+    request_id: requestId,
+    state: "accepted",
+    capture_status: "pending",
+    done_seen: false,
+    synthetic_done: false,
+    error_seen: false,
+    exit_code: null,
+    signal: null,
+    stdout_ref: pathToFileURL(stdoutPath).toString(),
+    stderr_ref: pathToFileURL(stderrPath).toString(),
+    route_ref: pathToFileURL(routePath).toString(),
+    result_ref: null,
+    error_ref: null,
+    stdout_bytes: 0,
+    stderr_bytes: 0,
+    stdout_lines: 0,
+    stderr_lines: 0,
+  };
+
+  await writeFile(stdoutPath, "", "utf8");
+  await writeFile(stderrPath, "", "utf8");
+  await writeJsonAtomic(routePath, routeArtifact);
+  await writeJsonAtomic(terminalPath, terminalArtifact);
+
+  return artifacts;
+}
+
+export async function setRunStarted(params: {
+  artifacts: AcpxRunArtifacts;
+  startedAt: string;
+  pid?: number;
+}): Promise<void> {
+  await updateRoute(params.artifacts, {
+    state: "started",
+    started_at: params.startedAt,
+    ...(typeof params.pid === "number" ? { pid: params.pid } : {}),
+  });
+  await updateTerminal(params.artifacts, {
+    state: "started",
+    started_at: params.startedAt,
+  });
+}
+
+export async function appendStdout(params: {
+  artifacts: AcpxRunArtifacts;
+  line: string;
+}): Promise<void> {
+  await appendFile(params.artifacts.stdoutPath, params.line + "\n", "utf8");
+}
+
+export async function appendStderr(params: {
+  artifacts: AcpxRunArtifacts;
+  chunk: string;
+}): Promise<void> {
+  await appendFile(params.artifacts.stderrPath, params.chunk, "utf8");
+}
+
+export async function finalizeRun(params: {
+  artifacts: AcpxRunArtifacts;
+  state: Exclude<AcpxTerminalState, "accepted" | "started">;
+  captureStatus?: "captured" | "missing";
+  doneSeen: boolean;
+  syntheticDone: boolean;
+  errorSeen: boolean;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stopReason?: string;
+  errorCode?: string;
+  errorMessage?: string;
+  stdoutBytes: number;
+  stderrBytes: number;
+  stdoutLines: number;
+  stderrLines: number;
+  startedAt?: string;
+  endedAt: string;
+}): Promise<void> {
+  const terminalRef = pathToFileURL(params.artifacts.terminalPath).toString();
+  const finalState = params.state;
+  const captureStatus = params.captureStatus ?? "captured";
+  if (finalState === "completed" && captureStatus !== "captured") {
+    throw new Error("completed state requires captured terminal truth");
+  }
+  await updateTerminal(params.artifacts, {
+    state: finalState,
+    capture_status: captureStatus,
+    done_seen: params.doneSeen,
+    synthetic_done: params.syntheticDone,
+    error_seen: params.errorSeen,
+    exit_code: params.exitCode,
+    signal: params.signal,
+    started_at: params.startedAt,
+    ended_at: params.endedAt,
+    stop_reason: params.stopReason,
+    error_code: params.errorCode,
+    error_message: params.errorMessage,
+    stdout_bytes: params.stdoutBytes,
+    stderr_bytes: params.stderrBytes,
+    stdout_lines: params.stdoutLines,
+    stderr_lines: params.stderrLines,
+    result_ref: finalState === "completed" ? terminalRef : null,
+    error_ref: finalState === "completed" ? null : terminalRef,
+  });
+
+  await updateRoute(params.artifacts, {
+    state: finalState,
+  });
+}

--- a/extensions/acpx/src/runtime-internals/run-artifacts.ts
+++ b/extensions/acpx/src/runtime-internals/run-artifacts.ts
@@ -95,8 +95,12 @@ async function allocateRunId(rootDir: string, seed: string): Promise<string> {
     try {
       await mkdir(candidateDir, { recursive: false });
       return candidate;
-    } catch {
-      // try next suffix
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
+        throw error;
+      }
+      // directory already exists — try next suffix
     }
   }
   const timestampCandidate = `${normalized}--${Date.now()}`;
@@ -299,7 +303,11 @@ export async function finalizeRun(params: {
     error_ref: finalState === "completed" ? null : terminalRef,
   });
 
-  await updateRoute(params.artifacts, {
-    state: finalState,
-  });
+  try {
+    await updateRoute(params.artifacts, {
+      state: finalState,
+    });
+  } catch {
+    // Preserve terminal.json as strongest terminal truth; route.json is a best-effort mirror.
+  }
 }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1,17 +1,34 @@
+import { readdir, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { runAcpRuntimeAdapterContract } from "../../../src/acp/runtime/adapter-contract.testkit.js";
+import * as runArtifactsModule from "./runtime-internals/run-artifacts.js";
 import { AcpxRuntime, decodeAcpxRuntimeHandleState } from "./runtime.js";
 import {
   cleanupMockRuntimeFixtures,
   createMockRuntimeFixture,
   NOOP_LOGGER,
   readMockRuntimeLogEntries,
+  resolveMockRuntimeArtifactRoot,
 } from "./test-utils/runtime-fixtures.js";
 
 let sharedFixture: Awaited<ReturnType<typeof createMockRuntimeFixture>> | null = null;
 let missingCommandRuntime: AcpxRuntime | null = null;
+
+async function readJson<T>(filePath: string): Promise<T> {
+  const raw = await readFile(filePath, "utf8");
+  return JSON.parse(raw) as T;
+}
+
+async function listRunDirs(stateDir: string): Promise<string[]> {
+  const root = resolveMockRuntimeArtifactRoot(stateDir);
+  const entries = await readdir(root, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
 
 beforeAll(async () => {
   sharedFixture = await createMockRuntimeFixture();
@@ -126,6 +143,258 @@ describe("AcpxRuntime", () => {
     expect(promptArgs).toContain("--ttl");
     expect(promptArgs).toContain("180");
     expect(promptArgs).toContain("--approve-all");
+  });
+
+  it("persists wrapper-owned terminal artifacts for successful turns", async () => {
+    const { runtime, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:artifacts-success",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    const events = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "artifact-success",
+      mode: "prompt",
+      requestId: "req-artifacts-success",
+    })) {
+      events.push(event);
+    }
+
+    expect(events.some((event) => event.type === "done")).toBe(true);
+
+    const runDirs = await listRunDirs(stateDir);
+    expect(runDirs).toContain("req-artifacts-success");
+
+    const root = resolveMockRuntimeArtifactRoot(stateDir);
+    const route = await readJson<Record<string, unknown>>(
+      path.join(root, "req-artifacts-success", "route.json"),
+    );
+    const terminal = await readJson<Record<string, unknown>>(
+      path.join(root, "req-artifacts-success", "terminal.json"),
+    );
+    const stdoutLog = await readFile(
+      path.join(root, "req-artifacts-success", "stdout.log"),
+      "utf8",
+    );
+
+    expect(route.state).toBe("completed");
+    expect(terminal.state).toBe("completed");
+    expect(terminal.capture_status).toBe("captured");
+    expect(typeof terminal.result_ref).toBe("string");
+    expect(terminal.error_ref).toBeNull();
+    expect(stdoutLog).toContain("echo:artifact-success");
+  });
+
+  it("marks parsed ACP errors as failed terminal runs", async () => {
+    const { runtime, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:artifacts-error",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    const events = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "trigger-error",
+      mode: "prompt",
+      requestId: "req-artifacts-error",
+    })) {
+      events.push(event);
+    }
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        message: "mock failure",
+      }),
+    );
+
+    const root = resolveMockRuntimeArtifactRoot(stateDir);
+    const terminal = await readJson<Record<string, unknown>>(
+      path.join(root, "req-artifacts-error", "terminal.json"),
+    );
+    expect(terminal.state).toBe("failed");
+    expect(typeof terminal.error_ref).toBe("string");
+    expect(terminal.result_ref).toBeNull();
+  });
+
+  it("marks nonzero exits without parsed errors as failed terminal runs", async () => {
+    const { runtime, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:artifacts-nonzero",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "nonzero-no-error",
+      mode: "prompt",
+      requestId: "req-nonzero-no-error",
+    })) {
+      // drain
+    }
+
+    const root = resolveMockRuntimeArtifactRoot(stateDir);
+    const terminal = await readJson<Record<string, unknown>>(
+      path.join(root, "req-nonzero-no-error", "terminal.json"),
+    );
+    const stderrLog = await readFile(path.join(root, "req-nonzero-no-error", "stderr.log"), "utf8");
+
+    expect(terminal.state).toBe("failed");
+    expect(stderrLog).toContain("plain stderr failure");
+  });
+
+  it("records synthetic done when backend exits cleanly without explicit done", async () => {
+    const { runtime, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:synthetic-done",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "synthetic-done",
+      mode: "prompt",
+      requestId: "req-synthetic-done",
+    })) {
+      // drain
+    }
+
+    const root = resolveMockRuntimeArtifactRoot(stateDir);
+    const terminal = await readJson<Record<string, unknown>>(
+      path.join(root, "req-synthetic-done", "terminal.json"),
+    );
+    expect(terminal.state).toBe("completed");
+    expect(terminal.synthetic_done).toBe(true);
+  });
+
+  it("captures raw stdout lines even when the structured event is ignored", async () => {
+    const { runtime, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:untyped-event",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "untyped-event",
+      mode: "prompt",
+      requestId: "req-untyped-event",
+    })) {
+      // drain
+    }
+
+    const root = resolveMockRuntimeArtifactRoot(stateDir);
+    const stdoutLog = await readFile(path.join(root, "req-untyped-event", "stdout.log"), "utf8");
+    expect(stdoutLog).toContain('"foo":"bar"');
+    expect(stdoutLog).toContain("after-untyped");
+  });
+
+  it("allocates collision-safe persisted run ids when requestId repeats", async () => {
+    const { runtime, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:collision",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "first-collision",
+      mode: "prompt",
+      requestId: "req-collision",
+    })) {
+      // drain
+    }
+
+    for await (const _event of runtime.runTurn({
+      handle,
+      text: "second-collision",
+      mode: "prompt",
+      requestId: "req-collision",
+    })) {
+      // drain
+    }
+
+    const runDirs = await listRunDirs(stateDir);
+    expect(runDirs).toContain("req-collision");
+    expect(runDirs).toContain("req-collision--2");
+  });
+
+  it("does not spawn and finalizes lost when aborted after artifact creation", async () => {
+    const { runtime, logPath, stateDir } = await createMockRuntimeFixture();
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:abort-before-spawn",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const controller = new AbortController();
+    const originalCreateRunArtifacts = runArtifactsModule.createRunArtifacts;
+    const createRunArtifactsSpy = vi.spyOn(runArtifactsModule, "createRunArtifacts");
+    createRunArtifactsSpy.mockImplementation(async (params) => {
+      const artifacts = await originalCreateRunArtifacts(params);
+      controller.abort();
+      return artifacts;
+    });
+
+    try {
+      const events = [];
+      for await (const event of runtime.runTurn({
+        handle,
+        text: "abort-before-spawn",
+        mode: "prompt",
+        requestId: "req-abort-before-spawn",
+        signal: controller.signal,
+      })) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([]);
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      const promptEntry = logs.find(
+        (entry) =>
+          entry.kind === "prompt" &&
+          String(entry.sessionName ?? "") === "agent:codex:acp:abort-before-spawn",
+      );
+      expect(promptEntry).toBeUndefined();
+
+      const root = resolveMockRuntimeArtifactRoot(stateDir);
+      const route = await readJson<Record<string, unknown>>(
+        path.join(root, "req-abort-before-spawn", "route.json"),
+      );
+      const terminal = await readJson<Record<string, unknown>>(
+        path.join(root, "req-abort-before-spawn", "terminal.json"),
+      );
+      const stdoutLog = await readFile(
+        path.join(root, "req-abort-before-spawn", "stdout.log"),
+        "utf8",
+      );
+      const stderrLog = await readFile(
+        path.join(root, "req-abort-before-spawn", "stderr.log"),
+        "utf8",
+      );
+
+      expect(route.state).toBe("lost");
+      expect(route.started_at).toBeUndefined();
+      expect(terminal.state).toBe("lost");
+      expect(terminal.capture_status).toBe("captured");
+      expect(terminal.error_code).toBe("ABORTED");
+      expect(terminal.error_message).toBe("ACP turn aborted before spawn.");
+      expect(terminal.started_at).toBeUndefined();
+      expect(terminal.exit_code).toBeNull();
+      expect(stdoutLog).toBe("");
+      expect(stderrLog).toBe("");
+    } finally {
+      createRunArtifactsSpy.mockRestore();
+    }
   });
 
   it("uses sessions new with --resume-session when resumeSessionId is provided", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -33,6 +33,13 @@ import {
   waitForExit,
 } from "./runtime-internals/process.js";
 import {
+  appendStderr,
+  appendStdout,
+  createRunArtifacts,
+  finalizeRun,
+  setRunStarted,
+} from "./runtime-internals/run-artifacts.js";
+import {
   asOptionalString,
   asTrimmedString,
   buildPermissionArgs,
@@ -548,7 +555,9 @@ export class AcpxRuntime implements AcpRuntime {
         this.logger?.warn?.(`acpx runtime abort-cancel failed: ${String(err)}`);
       });
     };
+    let abortRequested = false;
     const onAbort = () => {
+      abortRequested = true;
       void cancelOnAbort();
     };
 
@@ -559,44 +568,129 @@ export class AcpxRuntime implements AcpRuntime {
     if (input.signal) {
       input.signal.addEventListener("abort", onAbort, { once: true });
     }
-    const child = spawnWithResolvedCommand(
-      {
-        command: this.config.command,
-        args,
-        cwd: state.cwd,
-        stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
-      },
-      this.spawnCommandOptions,
-    );
-    child.stdin.on("error", () => {
-      // Ignore EPIPE when the child exits before stdin flush completes.
+
+    const artifacts = await createRunArtifacts({
+      requestId: input.requestId,
+      sessionKey: input.handle.sessionKey,
+      runtimeSessionName: input.handle.runtimeSessionName,
+      agent: state.agent,
+      promptMode: input.mode,
+      routeKind: "prompt_session",
+      routeArgs: args,
+      cwd: state.cwd,
+      acpxRecordId: input.handle.acpxRecordId,
+      backendSessionId: input.handle.backendSessionId,
+      agentSessionId: input.handle.agentSessionId,
     });
 
-    if (input.attachments && input.attachments.length > 0) {
-      const blocks: unknown[] = [];
-      if (input.text) {
-        blocks.push({ type: "text", text: input.text });
-      }
-      for (const attachment of input.attachments) {
-        if (attachment.mediaType.startsWith("image/")) {
-          blocks.push({ type: "image", mimeType: attachment.mediaType, data: attachment.data });
-        }
-      }
-      child.stdin.end(blocks.length > 0 ? JSON.stringify(blocks) : input.text);
-    } else {
-      child.stdin.end(input.text);
-    }
+    let child: ReturnType<typeof spawnWithResolvedCommand> | null = null;
+    let lines: ReturnType<typeof createInterface> | null = null;
+    let finalized = false;
+    let startedAt: string | undefined;
+    let streamWriteError: Error | null = null;
+    let stderrWriteChain: Promise<void> = Promise.resolve();
 
     let stderr = "";
-    child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
+    let stderrBytes = 0;
+    let stderrLines = 0;
+    let stdoutBytes = 0;
+    let stdoutLines = 0;
     let sawDone = false;
     let sawError = false;
-    const lines = createInterface({ input: child.stdout });
+    let syntheticDone = false;
+    let stopReason: string | undefined;
+    let finalErrorCode: string | undefined;
+    let finalErrorMessage: string | undefined;
+
     try {
+      if (abortRequested || input.signal?.aborted) {
+        await cancelOnAbort();
+        finalErrorCode = "ABORTED";
+        finalErrorMessage = "ACP turn aborted before spawn.";
+        await finalizeRun({
+          artifacts,
+          state: "lost",
+          captureStatus: "captured",
+          doneSeen: false,
+          syntheticDone: false,
+          errorSeen: true,
+          exitCode: null,
+          signal: null,
+          errorCode: finalErrorCode,
+          errorMessage: finalErrorMessage,
+          stdoutBytes,
+          stderrBytes,
+          stdoutLines,
+          stderrLines,
+          endedAt: new Date().toISOString(),
+        });
+        finalized = true;
+        return;
+      }
+
+      child = spawnWithResolvedCommand(
+        {
+          command: this.config.command,
+          args,
+          cwd: state.cwd,
+          stripProviderAuthEnvVars: this.config.stripProviderAuthEnvVars,
+        },
+        this.spawnCommandOptions,
+      );
+      startedAt = new Date().toISOString();
+      await setRunStarted({
+        artifacts,
+        startedAt,
+        ...(typeof child.pid === "number" ? { pid: child.pid } : {}),
+      });
+
+      child.stdin.on("error", () => {
+        // Ignore EPIPE when the child exits before stdin flush completes.
+      });
+
+      if (input.attachments && input.attachments.length > 0) {
+        const blocks: unknown[] = [];
+        if (input.text) {
+          blocks.push({ type: "text", text: input.text });
+        }
+        for (const attachment of input.attachments) {
+          if (attachment.mediaType.startsWith("image/")) {
+            blocks.push({ type: "image", mimeType: attachment.mediaType, data: attachment.data });
+          }
+        }
+        child.stdin.end(blocks.length > 0 ? JSON.stringify(blocks) : input.text);
+      } else {
+        child.stdin.end(input.text);
+      }
+
+      child.stderr.on("data", (chunk) => {
+        const text = String(chunk);
+        stderr += text;
+        stderrBytes += Buffer.byteLength(text);
+        stderrLines += text.length > 0 ? text.split(/\r?\n/).filter(Boolean).length : 0;
+        stderrWriteChain = stderrWriteChain
+          .then(async () => {
+            await appendStderr({ artifacts, chunk: text });
+          })
+          .catch((err: unknown) => {
+            if (!streamWriteError) {
+              streamWriteError = err instanceof Error ? err : new Error(String(err));
+            }
+          });
+      });
+
+      lines = createInterface({ input: child.stdout });
       for await (const line of lines) {
+        stdoutBytes += Buffer.byteLength(line + "\n");
+        stdoutLines += 1;
+        try {
+          await appendStdout({ artifacts, line });
+        } catch (err) {
+          if (!streamWriteError) {
+            streamWriteError = err instanceof Error ? err : new Error(String(err));
+          }
+        }
+
         const parsed = parsePromptEventLine(line);
         if (!parsed) {
           continue;
@@ -606,18 +700,47 @@ export class AcpxRuntime implements AcpRuntime {
             continue;
           }
           sawDone = true;
+          stopReason = parsed.stopReason;
+          continue;
         }
         if (parsed.type === "error") {
           sawError = true;
+          finalErrorCode = parsed.code;
+          finalErrorMessage = parsed.message;
         }
         yield parsed;
       }
 
       const exit = await waitForExit(child);
+      await stderrWriteChain;
+      const endedAt = new Date().toISOString();
+      const captureStatus = streamWriteError ? "missing" : "captured";
+
       if (exit.error) {
         const spawnFailure = resolveSpawnFailure(exit.error, state.cwd);
         if (spawnFailure === "missing-command") {
           this.healthy = false;
+        }
+        finalErrorMessage = exit.error.message;
+        await finalizeRun({
+          artifacts,
+          state: "lost",
+          captureStatus,
+          doneSeen: sawDone,
+          syntheticDone: false,
+          errorSeen: true,
+          exitCode: exit.code,
+          signal: exit.signal,
+          errorMessage: finalErrorMessage,
+          stdoutBytes,
+          stderrBytes,
+          stdoutLines,
+          stderrLines,
+          startedAt,
+          endedAt,
+        });
+        finalized = true;
+        if (spawnFailure === "missing-command") {
           throw new AcpRuntimeError(
             "ACP_BACKEND_UNAVAILABLE",
             `acpx command not found: ${this.config.command}`,
@@ -635,23 +758,156 @@ export class AcpxRuntime implements AcpRuntime {
       }
 
       if ((exit.code ?? 0) !== 0 && !sawError) {
+        finalErrorMessage = formatAcpxExitMessage({
+          stderr,
+          exitCode: exit.code,
+        });
+        await finalizeRun({
+          artifacts,
+          state: "failed",
+          captureStatus,
+          doneSeen: sawDone,
+          syntheticDone: false,
+          errorSeen: true,
+          exitCode: exit.code,
+          signal: exit.signal,
+          errorMessage: finalErrorMessage,
+          stdoutBytes,
+          stderrBytes,
+          stdoutLines,
+          stderrLines,
+          startedAt,
+          endedAt,
+        });
+        finalized = true;
         yield {
           type: "error",
-          message: formatAcpxExitMessage({
-            stderr,
-            exitCode: exit.code,
-          }),
+          message: finalErrorMessage,
         };
         return;
       }
 
       if (!sawDone && !sawError) {
-        yield { type: "done" };
+        syntheticDone = true;
       }
+
+      if (sawError || streamWriteError) {
+        if (streamWriteError && !finalErrorMessage) {
+          finalErrorMessage = `ACP terminal artifact write failed: ${streamWriteError.message}`;
+        }
+        await finalizeRun({
+          artifacts,
+          state: sawError ? "failed" : "lost",
+          captureStatus,
+          doneSeen: sawDone,
+          syntheticDone,
+          errorSeen: true,
+          exitCode: exit.code,
+          signal: exit.signal,
+          stopReason,
+          errorCode: finalErrorCode,
+          errorMessage: finalErrorMessage,
+          stdoutBytes,
+          stderrBytes,
+          stdoutLines,
+          stderrLines,
+          startedAt,
+          endedAt,
+        });
+        finalized = true;
+        if (!sawError && finalErrorMessage) {
+          yield {
+            type: "error",
+            message: finalErrorMessage,
+          };
+        }
+        return;
+      }
+
+      await finalizeRun({
+        artifacts,
+        state: "completed",
+        captureStatus: "captured",
+        doneSeen: sawDone || syntheticDone,
+        syntheticDone,
+        errorSeen: false,
+        exitCode: exit.code,
+        signal: exit.signal,
+        stopReason,
+        stdoutBytes,
+        stderrBytes,
+        stdoutLines,
+        stderrLines,
+        startedAt,
+        endedAt,
+      });
+      finalized = true;
+      yield {
+        type: "done",
+        ...(stopReason ? { stopReason } : {}),
+      };
+    } catch (error) {
+      await stderrWriteChain;
+      if (!finalized) {
+        const endedAt = new Date().toISOString();
+        const acpError = error instanceof AcpRuntimeError ? error : null;
+        finalErrorCode = acpError?.code ?? finalErrorCode;
+        finalErrorMessage =
+          (error instanceof Error ? error.message : String(error)) ||
+          finalErrorMessage ||
+          "ACP turn failed before terminal classification.";
+        await finalizeRun({
+          artifacts,
+          state: "lost",
+          captureStatus: streamWriteError ? "missing" : "captured",
+          doneSeen: sawDone,
+          syntheticDone,
+          errorSeen: true,
+          exitCode: null,
+          signal: null,
+          stopReason,
+          errorCode: finalErrorCode,
+          errorMessage: finalErrorMessage,
+          stdoutBytes,
+          stderrBytes,
+          stdoutLines,
+          stderrLines,
+          startedAt,
+          endedAt,
+        });
+        finalized = true;
+      }
+      throw error;
     } finally {
-      lines.close();
+      lines?.close();
       if (input.signal) {
         input.signal.removeEventListener("abort", onAbort);
+      }
+      if (!finalized) {
+        await stderrWriteChain;
+        const endedAt = new Date().toISOString();
+        const terminalErrorMessage = streamWriteError
+          ? `ACP terminal artifact write failed: ${streamWriteError.message}`
+          : "ACP turn exited before terminal classification.";
+        await finalizeRun({
+          artifacts,
+          state: "lost",
+          captureStatus: streamWriteError ? "missing" : "captured",
+          doneSeen: sawDone,
+          syntheticDone,
+          errorSeen: true,
+          exitCode: null,
+          signal: null,
+          stopReason,
+          errorCode: finalErrorCode,
+          errorMessage: terminalErrorMessage,
+          stdoutBytes,
+          stderrBytes,
+          stdoutLines,
+          stderrLines,
+          startedAt,
+          endedAt,
+        });
       }
     }
   }

--- a/extensions/acpx/src/test-utils/runtime-fixtures.ts
+++ b/extensions/acpx/src/test-utils/runtime-fixtures.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/infra-runtime";
 import type { ResolvedAcpxPluginConfig } from "../config.js";
@@ -270,6 +270,29 @@ if (command === "prompt") {
     process.exit(5);
   }
 
+  if (stdinText.includes("nonzero-no-error")) {
+    process.stderr.write("plain stderr failure\n");
+    process.exit(7);
+  }
+
+  if (stdinText.includes("synthetic-done")) {
+    emitUpdate(sessionFromOption, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "synthetic-ok" },
+    });
+    process.exit(0);
+  }
+
+  if (stdinText.includes("untyped-event")) {
+    emitJson({ foo: "bar", note: "ignored structured line" });
+    emitUpdate(sessionFromOption, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "after-untyped" },
+    });
+    emitJson({ type: "done", stopReason: "end_turn" });
+    process.exit(0);
+  }
+
   if (stdinText.includes("split-spacing")) {
     emitUpdate(sessionFromOption, {
       sessionUpdate: "agent_message_chunk",
@@ -333,11 +356,15 @@ export async function createMockRuntimeFixture(params?: {
   runtime: AcpxRuntime;
   logPath: string;
   config: ResolvedAcpxPluginConfig;
+  stateDir: string;
 }> {
   const scriptPath = await ensureMockCliScriptPath();
   const dir = path.dirname(scriptPath);
   const logPath = path.join(dir, `calls-${logFileSequence++}.log`);
+  const stateDir = path.join(dir, ".openclaw-state");
+  await mkdir(stateDir, { recursive: true });
   process.env.MOCK_ACPX_LOG = logPath;
+  process.env.OPENCLAW_STATE_DIR = stateDir;
 
   const config: ResolvedAcpxPluginConfig = {
     command: scriptPath,
@@ -359,6 +386,7 @@ export async function createMockRuntimeFixture(params?: {
     }),
     logPath,
     config,
+    stateDir,
   };
 }
 
@@ -377,6 +405,10 @@ async function ensureMockCliScriptPath(): Promise<string> {
     return scriptPath;
   })();
   return await sharedMockCliScriptPath;
+}
+
+export function resolveMockRuntimeArtifactRoot(stateDir: string): string {
+  return path.join(stateDir, "artifacts", "acpx", "runs");
 }
 
 export async function readMockRuntimeLogEntries(
@@ -399,6 +431,7 @@ export async function cleanupMockRuntimeFixtures(): Promise<void> {
   delete process.env.MOCK_ACPX_ENSURE_EXIT_1;
   delete process.env.MOCK_ACPX_STATUS_STATUS;
   delete process.env.MOCK_ACPX_STATUS_SUMMARY;
+  delete process.env.OPENCLAW_STATE_DIR;
   sharedMockCliScriptPath = null;
   logFileSequence = 0;
   while (tempDirs.length > 0) {


### PR DESCRIPTION
## Summary

This PR is **Patch 1A only**.

Current PR head:
- `bb45eb5acb517c8f5755f816778fc0b4cbfb40fb`

Base:
- `17c1ee7716`

This PR currently consists of two commits:
- `bcb4116bc756bd6fe5f1fa6f3d5094c856130562` — `acpx: add terminal-truth artifacts and strict terminal states`
- `bb45eb5acb517c8f5755f816778fc0b4cbfb40fb` — `acpx: preserve terminal truth on route mirror failures`

This remains the terminal-truth-only split for ACP runtime-wrapped execution.

## Scope

Included in this PR:
- wrapper-owned per-run ACP artifacts
  - `route.json`
  - `terminal.json`
  - `stdout.log`
  - `stderr.log`
- strict terminal states
- durable completion gating based on persisted terminal truth
- raw stdout/stderr capture under wrapper ownership
- collision-safe persisted `run_id` allocation
- terminal-truth-focused tests
- abort-before-spawn fix inside Patch 1A
- narrow follow-up fixes for review feedback:
  - preserve terminal truth when `route.json` mirror write fails
  - retry run-id allocation only on `EEXIST`

Out of scope:
- **Patch 1B**
- Cursor-specific fallback behavior
- `shouldUseExecFallback(...)`
- `buildExecArgs(...)`
- `exec` vs `prompt` route switching
- `exec_oneshot`
- fallback-specific tests / mock exec fixture path

## Abort-before-spawn fix

This PR includes the narrow Patch 1A follow-up for the pre-spawn abort race:
- recheck abort after `createRunArtifacts(...)`
- do not spawn if abort was requested before spawn
- finalize already-created artifacts as `lost`
- keep `started_at` unset
- emit no new event

## Follow-up fixes

The review-driven follow-up commit adds two narrow fixes without changing Patch 1A scope:
- preserve already-persisted `terminal.json` truth when `route.json` mirror write fails
- treat `route.json` as a best-effort mirror so mirror failure does not trigger a later `lost` overwrite path
- constrain run-id allocation retry to `EEXIST` only
- rethrow non-`EEXIST` `mkdir` failures immediately

## Validation

Review-scope validation:
- `extensions/acpx/src/runtime-internals/run-artifacts.test.ts`
- `extensions/acpx/src/runtime.test.ts`
- result: **31/31 passed**
- `build:strict-smoke`: **passed**

## Durability note

Patch 1A provides a much stronger durability contract, but not a perfectly atomic one in every crash window.
`terminal.json` should be treated as the strongest source of terminal truth, while `route.json` is a mirrored/secondary record and can theoretically lag in crash windows.

## Notes

This PR should be reviewed as **Patch 1A only**.
Patch 1B remains separate and out of scope.
