### PR TITLE
feat: implement automated LogPruner for log rotation and disk maintenance

### DIFF
--- a/src/infra/logging/janitor/log-pruner.ts
+++ b/src/infra/logging/janitor/log-pruner.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Automated Log Pruner.
+ * Cleans up gateway and subagent log files older than X days.
+ */
+export async function pruneOldLogs(logsDir: string, maxAgeDays: number = 7) {
+    console.info(`[janitor] Pruning logs older than ${maxAgeDays} days in ${logsDir}...`);
+    const now = Date.now();
+    const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+
+    try {
+        const files = await fs.readdir(logsDir);
+        for (const file of files) {
+            if (file.endsWith(".log") || file.endsWith(".jsonl")) {
+                const filePath = path.join(logsDir, file);
+                const stats = await fs.stat(filePath);
+                if (now - stats.mtimeMs > maxAgeMs) {
+                    await fs.unlink(filePath);
+                    console.info(`[janitor] Pruned old log file: ${file}`);
+                }
+            }
+        }
+    } catch (e) {
+        console.error("[janitor] Failed to prune logs:", e);
+    }
+}


### PR DESCRIPTION
This PR introduces the `LogPruner`, which automatically removes gateway and agent log files older than a configurable threshold (default 7 days) (#logging).

### Changes:
- Added `src/infra/logging/janitor/log-pruner.ts`.
- Support for background pruning of `.log` and `.jsonl` artifacts.
- Prevents disk-space exhaustion in long-running gateway deployments.

/claim #logging