### PR TITLE
feat: implement background janitor for stale artifact cleanup

### DIFF
--- a/src/infra/remediation/cleanup/artifact-janitor.ts
+++ b/src/infra/remediation/cleanup/artifact-janitor.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Cleanup Janitor for temporary artifacts.
+ * Removes stale .tmp files and orphaned lockfiles during startup.
+ */
+export async function cleanupStaleArtifacts(rootDirs: string[]) {
+    console.info("[janitor] Cleaning up stale temporary artifacts...");
+    
+    for (const dir of rootDirs) {
+        try {
+            const files = await fs.readdir(dir);
+            for (const file of files) {
+                if (file.includes(".tmp-") || file.endsWith(".lock")) {
+                    const fullPath = path.join(dir, file);
+                    const stats = await fs.stat(fullPath);
+                    
+                    // If file is older than 1 hour, it's likely orphaned
+                    if (Date.now() - stats.mtimeMs > 3600000) {
+                        await fs.unlink(fullPath);
+                        console.info(`[janitor] Removed stale artifact: ${file}`);
+                    }
+                }
+            }
+        } catch (e) {
+            // Directory likely doesn't exist or is inaccessible
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces an `ArtifactJanitor`, which automatically identifies and removes orphaned `.tmp` files and stale lockfiles left behind by crashed processes or incomplete writes (#cleanup).

### Changes:
- Added `src/infra/remediation/cleanup/artifact-janitor.ts`.
- Support for age-based detection of temporary files.
- Improves system hygiene and prevents lockfile contention on gateway restart.

/claim #cleanup