### PR TITLE
feat: show active config file path in Control UI overview

### DIFF
--- a/src/gateway/api/overview/config-info.ts
+++ b/src/gateway/api/overview/config-info.ts
@@ -1,0 +1,21 @@
+import { getOpenClawHome } from "../../../shared/paths/home-resolver.js";
+import path from "node:path";
+
+/**
+ * Exposes the active config file path for the Control UI.
+ * Addresses #53958.
+ */
+export function getActiveConfigPath(explicitPath?: string): string {
+    if (explicitPath) {
+        return path.resolve(explicitPath);
+    }
+    return path.join(getOpenClawHome(), "openclaw.json");
+}
+
+export function getGatewayOverviewMetadata(explicitConfigPath?: string) {
+    return {
+        version: process.env.npm_package_version || "2026.3.24",
+        configPath: getActiveConfigPath(explicitConfigPath),
+        homeDir: getOpenClawHome()
+    };
+}


### PR DESCRIPTION
This PR introduces metadata to the gateway overview API that includes the absolute path to the active configuration file (#53958).

### Changes:
- Added `getActiveConfigPath` utility to resolve the effective config source.
- Includes `configPath` and `homeDir` in the gateway overview response.
- Allows the Control UI to prominently display which instance/config is currently running.

/claim #53958