### PR TITLE
Fix himalaya move/copy argument order and missing export ID (fixes #9607)

### DIFF
--- a/skills/himalaya/SKILL.md
+++ b/skills/himalaya/SKILL.md
@@ -169,13 +169,13 @@ himalaya message write -H "To:recipient@example.com" -H "Subject:Test" "Message 
 Move to folder:
 
 ```bash
-himalaya message move 42 "Archive"
+himalaya message move "Archive" 42
 ```
 
 Copy to folder:
 
 ```bash
-himalaya message copy 42 "Important"
+himalaya message copy "Important" 42
 ```
 
 ### Delete an Email

--- a/skills/himalaya/references/message-composition.md
+++ b/skills/himalaya/references/message-composition.md
@@ -196,4 +196,4 @@ himalaya message write \
 - The editor opens with a template; fill in headers and body.
 - Save and exit the editor to send; exit without saving to cancel.
 - MML parts are compiled to proper MIME when sending.
-- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.
+- Use `himalaya message export 42 --full` to inspect the raw MIME structure of received emails.


### PR DESCRIPTION
Summary

Problem: message move/message copy docs show wrong argument order (<ID> <FOLDER> instead of <FOLDER> <ID>); message export example is missing required <ID> argument


Why it matters: Users copy-paste these examples and get CLI errors

What changed: 3 lines in skills/himalaya/SKILL.md and skills/himalaya/references/message-composition.md

What did NOT change: No runtime code, no behavior, docs only

Change Type: [x] Docs

Scope: [x] Skills / tool execution

Linked Issue: Closes #9607

Root Cause

Root cause: Incorrect examples in original docs
Missing detection / guardrail: No doc linting for CLI argument order
Prior context: N/A
Why this regressed now: N/A
If unknown, what was ruled out: N/A
Regression Test Plan: N/A
User-visible / Behavior Changes: None (docs only)

Security Impact
New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No

Repro + Verification

Steps: Run himalaya message move "Archive" 42 — works. Run himalaya message move 42 "Archive" — fails.
Expected: Correct syntax matches himalaya CLI spec
Actual: Docs now match correct syntax

Evidence

[x] Verified against himalaya CLI documentation that <FOLDER> precedes <ID>

Human Verification

Verified scenarios: Checked himalaya CLI argument order in source/docs

What you did not verify: Live email account execution

Compatibility / Migration
Backward compatible? Yes
Config/env changes? No
Migration needed? No
Failure Recovery: Revert the 3 changed lines

Risks and Mitigations: None

