### PR TITLE
fix: close sandbox media root bypass for mediaUrl/fileUrl aliases

### DIFF
--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -253,7 +253,7 @@ describe("message action media helpers", () => {
     expect(mediaArgs.filename).toBe("pic.png");
 
     const fileArgs: Record<string, unknown> = {
-      fileUrl: "file:///workspace/docs/report.pdf",
+      fileUrl: "https://example.com/docs/report.pdf",
     };
     await hydrateAttachmentParamsForAction({
       cfg,

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -185,6 +185,87 @@ describe("message action media helpers", () => {
     }
   });
 
+  maybeIt("normalizes mediaUrl and fileUrl sandbox media params", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-alias-"));
+    try {
+      const args: Record<string, unknown> = {
+        mediaUrl: " file:///workspace/assets/photo.png ",
+        fileUrl: "/workspace/docs/report.pdf",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot: ` ${sandboxRoot} `,
+        },
+      });
+
+      expect(args).toMatchObject({
+        mediaUrl: path.join(sandboxRoot, "assets", "photo.png"),
+        fileUrl: path.join(sandboxRoot, "docs", "report.pdf"),
+      });
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
+  maybeIt(
+    "keeps remote HTTP mediaUrl and fileUrl aliases unchanged under sandbox normalization",
+    async () => {
+      const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-remote-alias-"));
+      try {
+        const args: Record<string, unknown> = {
+          mediaUrl: "https://example.com/assets/photo.png?sig=1",
+          fileUrl: "https://example.com/docs/report.pdf?sig=2",
+        };
+
+        await normalizeSandboxMediaParams({
+          args,
+          mediaPolicy: {
+            mode: "sandbox",
+            sandboxRoot,
+          },
+        });
+
+        expect(args).toMatchObject({
+          mediaUrl: "https://example.com/assets/photo.png?sig=1",
+          fileUrl: "https://example.com/docs/report.pdf?sig=2",
+        });
+      } finally {
+        await fs.rm(sandboxRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("uses mediaUrl and fileUrl aliases when inferring attachment filenames", async () => {
+    const mediaArgs: Record<string, unknown> = {
+      mediaUrl: "https://example.com/pic.png",
+    };
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "slack",
+      args: mediaArgs,
+      action: "sendAttachment",
+      dryRun: true,
+      mediaPolicy: { mode: "host" },
+    });
+    expect(mediaArgs.filename).toBe("pic.png");
+
+    const fileArgs: Record<string, unknown> = {
+      fileUrl: "file:///workspace/docs/report.pdf",
+    };
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "slack",
+      args: fileArgs,
+      action: "sendAttachment",
+      dryRun: true,
+      mediaPolicy: { mode: "host" },
+    });
+    expect(fileArgs.filename).toBe("report.pdf");
+  });
+
   it("falls back to extension-based attachment names for remote-host file URLs", async () => {
     const args: Record<string, unknown> = {
       media: "file://attacker/share/photo.png",

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -10,6 +10,27 @@ import { readBooleanParam as readBooleanParamShared } from "../../plugin-sdk/boo
 
 export const readBooleanParam = readBooleanParamShared;
 
+const SANDBOX_MEDIA_PARAM_KEYS = ["media", "path", "filePath", "mediaUrl", "fileUrl"] as const;
+
+function readMediaParam(
+  args: Record<string, unknown>,
+  key: (typeof SANDBOX_MEDIA_PARAM_KEYS)[number],
+): string | undefined {
+  return readStringParam(args, key, { trim: false });
+}
+
+function readAttachmentMediaHint(args: Record<string, unknown>): string | undefined {
+  return readMediaParam(args, "media") ?? readMediaParam(args, "mediaUrl");
+}
+
+function readAttachmentFileHint(args: Record<string, unknown>): string | undefined {
+  return (
+    readMediaParam(args, "path") ??
+    readMediaParam(args, "filePath") ??
+    readMediaParam(args, "fileUrl")
+  );
+}
+
 function resolveAttachmentMaxBytes(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
@@ -190,9 +211,8 @@ export async function normalizeSandboxMediaParams(params: {
 }): Promise<void> {
   const sandboxRoot =
     params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.sandboxRoot.trim() : undefined;
-  const mediaKeys: Array<"media" | "path" | "filePath"> = ["media", "path", "filePath"];
-  for (const key of mediaKeys) {
-    const raw = readStringParam(params.args, key, { trim: false });
+  for (const key of SANDBOX_MEDIA_PARAM_KEYS) {
+    const raw = readMediaParam(params.args, key);
     if (!raw) {
       continue;
     }
@@ -242,10 +262,8 @@ async function hydrateAttachmentActionPayload(params: {
   allowMessageCaptionFallback?: boolean;
   mediaPolicy: AttachmentMediaPolicy;
 }): Promise<void> {
-  const mediaHint = readStringParam(params.args, "media", { trim: false });
-  const fileHint =
-    readStringParam(params.args, "path", { trim: false }) ??
-    readStringParam(params.args, "filePath", { trim: false });
+  const mediaHint = readAttachmentMediaHint(params.args);
+  const fileHint = readAttachmentFileHint(params.args);
   const contentTypeParam =
     readStringParam(params.args, "contentType") ?? readStringParam(params.args, "mimeType");
 

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -56,6 +56,7 @@ const runDrySend = (params: {
 async function expectSandboxMediaRewrite(params: {
   sandboxDir: string;
   media?: string;
+  mediaField?: "media" | "mediaUrl" | "fileUrl";
   message?: string;
   expectedRelativePath: string;
 }) {
@@ -64,7 +65,11 @@ async function expectSandboxMediaRewrite(params: {
     actionParams: {
       channel: "slack",
       target: "#C12345678",
-      ...(params.media ? { media: params.media } : {}),
+      ...(params.media
+        ? {
+            [params.mediaField ?? "media"]: params.media,
+          }
+        : {}),
       ...(params.message ? { message: params.message } : {}),
     },
     sandboxRoot: params.sandboxDir,
@@ -196,6 +201,7 @@ describe("runMessageAction media behavior", () => {
     async function expectRejectsLocalAbsolutePathWithoutSandbox(params: {
       action: "sendAttachment" | "setGroupIcon";
       target: string;
+      mediaField?: "media" | "mediaUrl" | "fileUrl";
       message?: string;
       tempPrefix: string;
     }) {
@@ -209,7 +215,7 @@ describe("runMessageAction media behavior", () => {
         const actionParams: Record<string, unknown> = {
           channel: "bluebubbles",
           target: params.target,
-          media: outsidePath,
+          [params.mediaField ?? "media"]: outsidePath,
         };
         if (params.message) {
           actionParams.message = params.message;
@@ -271,6 +277,24 @@ describe("runMessageAction media behavior", () => {
           expectedPath: path.join("data", "pic.png"),
         },
         {
+          name: "sendAttachment mediaUrl rewrite",
+          action: "sendAttachment" as const,
+          target: "+15551234567",
+          mediaField: "mediaUrl" as const,
+          media: "./data/pic.png",
+          message: "caption",
+          expectedPath: path.join("data", "pic.png"),
+        },
+        {
+          name: "sendAttachment fileUrl rewrite",
+          action: "sendAttachment" as const,
+          target: "+15551234567",
+          mediaField: "fileUrl" as const,
+          media: "/workspace/files/report.pdf",
+          message: "caption",
+          expectedPath: path.join("files", "report.pdf"),
+        },
+        {
           name: "setGroupIcon rewrite",
           action: "setGroupIcon" as const,
           target: "group:123",
@@ -286,7 +310,7 @@ describe("runMessageAction media behavior", () => {
             params: {
               channel: "bluebubbles",
               target: testCase.target,
-              media: testCase.media,
+              [testCase.mediaField ?? "media"]: testCase.media,
               ...(testCase.message ? { message: testCase.message } : {}),
             },
             sandboxRoot: sandboxDir,
@@ -308,6 +332,20 @@ describe("runMessageAction media behavior", () => {
           target: "+15551234567",
           message: "caption",
           tempPrefix: "msg-attachment-",
+        },
+        {
+          action: "sendAttachment" as const,
+          target: "+15551234567",
+          mediaField: "mediaUrl" as const,
+          message: "caption",
+          tempPrefix: "msg-attachment-media-url-",
+        },
+        {
+          action: "sendAttachment" as const,
+          target: "+15551234567",
+          mediaField: "fileUrl" as const,
+          message: "caption",
+          tempPrefix: "msg-attachment-file-url-",
         },
         {
           action: "setGroupIcon" as const,
@@ -337,25 +375,43 @@ describe("runMessageAction media behavior", () => {
       setActivePluginRegistry(createTestRegistry([]));
     });
 
-    it.each(["/etc/passwd", "file:///etc/passwd"])(
-      "rejects out-of-sandbox media reference: %s",
-      async (media) => {
-        await withSandbox(async (sandboxDir) => {
-          await expect(
-            runDrySend({
-              cfg: slackConfig,
-              actionParams: {
-                channel: "slack",
-                target: "#C12345678",
-                media,
-                message: "",
-              },
-              sandboxRoot: sandboxDir,
-            }),
-          ).rejects.toThrow(/sandbox/i);
-        });
+    it.each([
+      {
+        name: "media absolute path",
+        mediaField: "media" as const,
+        media: "/etc/passwd",
       },
-    );
+      {
+        name: "mediaUrl absolute path",
+        mediaField: "mediaUrl" as const,
+        media: "/etc/passwd",
+      },
+      {
+        name: "mediaUrl file URL",
+        mediaField: "mediaUrl" as const,
+        media: "file:///etc/passwd",
+      },
+      {
+        name: "fileUrl file URL",
+        mediaField: "fileUrl" as const,
+        media: "file:///etc/passwd",
+      },
+    ])("rejects out-of-sandbox media reference: $name", async ({ mediaField, media }) => {
+      await withSandbox(async (sandboxDir) => {
+        await expect(
+          runDrySend({
+            cfg: slackConfig,
+            actionParams: {
+              channel: "slack",
+              target: "#C12345678",
+              [mediaField]: media,
+              message: "",
+            },
+            sandboxRoot: sandboxDir,
+          }),
+        ).rejects.toThrow(/sandbox/i);
+      });
+    });
 
     it("rejects data URLs in media params", async () => {
       await expect(
@@ -380,6 +436,20 @@ describe("runMessageAction media behavior", () => {
           expectedRelativePath: path.join("data", "file.txt"),
         },
         {
+          name: "relative mediaUrl path",
+          mediaField: "mediaUrl" as const,
+          media: "./data/file.txt",
+          message: "",
+          expectedRelativePath: path.join("data", "file.txt"),
+        },
+        {
+          name: "/workspace fileUrl path",
+          mediaField: "fileUrl" as const,
+          media: "/workspace/data/file.txt",
+          message: "",
+          expectedRelativePath: path.join("data", "file.txt"),
+        },
+        {
           name: "/workspace media path",
           media: "/workspace/data/file.txt",
           message: "",
@@ -390,17 +460,74 @@ describe("runMessageAction media behavior", () => {
           message: "Hello\nMEDIA: ./data/note.ogg",
           expectedRelativePath: path.join("data", "note.ogg"),
         },
-      ]) {
+      ] as const) {
         await withSandbox(async (sandboxDir) => {
           await expectSandboxMediaRewrite({
             sandboxDir,
             media: testCase.media,
+            mediaField: testCase.mediaField,
             message: testCase.message,
             expectedRelativePath: testCase.expectedRelativePath,
           });
         });
       }
     });
+
+    it("prefers media over mediaUrl when both aliases are present", async () => {
+      await withSandbox(async (sandboxDir) => {
+        const result = await runDrySend({
+          cfg: slackConfig,
+          actionParams: {
+            channel: "slack",
+            target: "#C12345678",
+            media: "./data/primary.txt",
+            mediaUrl: "./data/secondary.txt",
+            message: "",
+          },
+          sandboxRoot: sandboxDir,
+        });
+
+        expect(result.kind).toBe("send");
+        if (result.kind !== "send") {
+          throw new Error("expected send result");
+        }
+        expect(result.sendResult?.mediaUrl).toBe(path.join(sandboxDir, "data", "primary.txt"));
+      });
+    });
+
+    it.each([
+      {
+        name: "mediaUrl",
+        mediaField: "mediaUrl" as const,
+      },
+      {
+        name: "fileUrl",
+        mediaField: "fileUrl" as const,
+      },
+    ])(
+      "keeps remote HTTP $name aliases unchanged under sandbox validation",
+      async ({ mediaField }) => {
+        await withSandbox(async (sandboxDir) => {
+          const remoteUrl = "https://example.com/files/report.pdf?sig=1";
+          const result = await runDrySend({
+            cfg: slackConfig,
+            actionParams: {
+              channel: "slack",
+              target: "#C12345678",
+              [mediaField]: remoteUrl,
+              message: "",
+            },
+            sandboxRoot: sandboxDir,
+          });
+
+          expect(result.kind).toBe("send");
+          if (result.kind !== "send") {
+            throw new Error("expected send result");
+          }
+          expect(result.sendResult?.mediaUrl).toBe(remoteUrl);
+        });
+      },
+    );
 
     it("allows media paths under preferred OpenClaw tmp root", async () => {
       const tmpRoot = resolvePreferredOpenClawTmpDir();

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { jsonResult } from "../../agents/tools/common.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.js";
@@ -58,6 +59,7 @@ describe("runMessageAction plugin dispatch", () => {
     afterEach(() => {
       setActivePluginRegistry(createTestRegistry([]));
       vi.clearAllMocks();
+      vi.unstubAllEnvs();
     });
 
     it("dispatches messageId/chatId-based Feishu actions through the shared runner", async () => {
@@ -114,6 +116,9 @@ describe("runMessageAction plugin dispatch", () => {
     });
 
     it("routes execution context ids into plugin handleAction", async () => {
+      const stateDir = path.join("/tmp", "openclaw-plugin-dispatch-media-roots");
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
       await runMessageAction({
         cfg: {
           channels: {
@@ -148,6 +153,7 @@ describe("runMessageAction plugin dispatch", () => {
           sessionKey: "agent:alpha:main",
           sessionId: "session-123",
           agentId: "alpha",
+          mediaLocalRoots: expect.arrayContaining([path.join(stateDir, "workspace-alpha")]),
           toolContext: expect.objectContaining({
             currentChannelId: "chat:oc_123",
             currentThreadTs: "thread-456",

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -117,6 +117,7 @@ describe("runMessageAction plugin dispatch", () => {
 
     it("routes execution context ids into plugin handleAction", async () => {
       const stateDir = path.join("/tmp", "openclaw-plugin-dispatch-media-roots");
+      const expectedWorkspaceRoot = path.resolve(stateDir, "workspace-alpha");
       vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
 
       await runMessageAction({
@@ -153,7 +154,7 @@ describe("runMessageAction plugin dispatch", () => {
           sessionKey: "agent:alpha:main",
           sessionId: "session-123",
           agentId: "alpha",
-          mediaLocalRoots: expect.arrayContaining([path.join(stateDir, "workspace-alpha")]),
+          mediaLocalRoots: expect.arrayContaining([expectedWorkspaceRoot]),
           toolContext: expect.objectContaining({
             currentChannelId: "chat:oc_123",
             currentThreadTs: "thread-456",

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -457,9 +457,6 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     preferComponents: true,
   });
 
-  if (!readStringParam(params, "media", { trim: false }) && mediaHint) {
-    params.media = mediaHint;
-  }
   const mediaUrl = readStringParam(params, "media", { trim: false });
   if (
     !hasReplyPayloadContent(

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -258,6 +258,7 @@ type ResolvedActionContext = {
   cfg: OpenClawConfig;
   params: Record<string, unknown>;
   channel: ChannelId;
+  mediaLocalRoots: readonly string[];
   accountId?: string | null;
   dryRun: boolean;
   gateway?: MessageActionRunnerGateway;
@@ -382,8 +383,10 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   // Support media, path, and filePath parameters for attachments
   const mediaHint =
     readStringParam(params, "media", { trim: false }) ??
+    readStringParam(params, "mediaUrl", { trim: false }) ??
     readStringParam(params, "path", { trim: false }) ??
-    readStringParam(params, "filePath", { trim: false });
+    readStringParam(params, "filePath", { trim: false }) ??
+    readStringParam(params, "fileUrl", { trim: false });
   const hasButtons = Array.isArray(params.buttons) && params.buttons.length > 0;
   const hasCard = params.card != null && typeof params.card === "object";
   const hasComponents = params.components != null && typeof params.components === "object";
@@ -454,6 +457,9 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     preferComponents: true,
   });
 
+  if (!readStringParam(params, "media", { trim: false }) && mediaHint) {
+    params.media = mediaHint;
+  }
   const mediaUrl = readStringParam(params, "media", { trim: false });
   if (
     !hasReplyPayloadContent(
@@ -620,7 +626,18 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
 }
 
 async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal, agentId } = ctx;
+  const {
+    cfg,
+    params,
+    channel,
+    mediaLocalRoots,
+    accountId,
+    dryRun,
+    gateway,
+    input,
+    abortSignal,
+    agentId,
+  } = ctx;
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
   if (dryRun) {
@@ -644,6 +661,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     action,
     cfg,
     params,
+    mediaLocalRoots,
     accountId: accountId ?? undefined,
     requesterSenderId: input.requesterSenderId ?? undefined,
     sessionKey: input.sessionKey,
@@ -753,6 +771,7 @@ export async function runMessageAction(
       cfg,
       params,
       channel,
+      mediaLocalRoots,
       accountId,
       dryRun,
       gateway,
@@ -768,6 +787,7 @@ export async function runMessageAction(
       cfg,
       params,
       channel,
+      mediaLocalRoots,
       accountId,
       dryRun,
       gateway,
@@ -780,6 +800,7 @@ export async function runMessageAction(
     cfg,
     params,
     channel,
+    mediaLocalRoots,
     accountId,
     dryRun,
     gateway,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: sandbox media enforcement normalized `media`, `path`, and `filePath`, but missed the `mediaUrl` and `fileUrl` aliases that real message-tool and plugin flows also accept.
- Why it matters: a sandboxed agent could route local file paths through unchecked aliases and avoid the intended sandbox path rewrite boundary.
- Secondary gap: plugin-owned non-`send` / `poll` actions were dispatched without `mediaLocalRoots`, even though the shared plugin action context supports that field.
- What changed: sandbox normalization and attachment hydration now cover `mediaUrl` / `fileUrl`, generic `send` treats those aliases consistently, and plugin-owned actions now receive forwarded `mediaLocalRoots`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: outbound sandbox media normalization used an incomplete alias set, so `mediaUrl` and `fileUrl` skipped `resolveSandboxedMediaSource(...)` even though they participate in real outbound/plugin media flows.
- Missing detection / guardrail: there was no focused regression proving that `mediaUrl` / `fileUrl` must be treated exactly like `media` / `path` / `filePath` under sandbox policy.
- Secondary regression class: plugin-owned actions had a shared context field for `mediaLocalRoots`, but `handlePluginAction(...)` failed to forward it, creating inconsistent media-root behavior compared with plugin-handled `send` / `poll` flows.
- Why this regressed now: this is an incomplete-fix / incomplete-coverage variant in the outbound media boundary rather than a newly introduced feature.
- If unknown, what was ruled out: the bug is not in channel target resolution or message routing; the failure is at the media source normalization and dispatch-context boundaries.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests or files:
  - `src/infra/outbound/message-action-params.test.ts`
  - `src/infra/outbound/message-action-runner.media.test.ts`
  - `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- Scenario the tests should lock in:
  - sandboxed `mediaUrl` / `fileUrl` inputs are rejected or rewritten just like existing checked media keys
  - plugin-owned attachment actions cannot bypass sandboxing through those aliases
  - plugin-owned actions receive the scoped `mediaLocalRoots` context
- Why this is the smallest reliable guardrail: the bug lives in the real outbound message-action runner and shared param helpers, not in a single channel plugin implementation.

## User-visible / Behavior Changes

Sandboxed message-tool callers can no longer pass local media paths through `mediaUrl` or `fileUrl` to avoid sandbox enforcement. Plugin-owned actions now see the same scoped `mediaLocalRoots` context already used by plugin-handled `send` / `poll` flows.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - This patch narrows local file access for sandboxed outbound media handling by ensuring alias keys and plugin-owned actions honor the intended sandbox/root restrictions.

## Repro + Verification

### Environment

- OS: Linux host
- Runtime/container: Docker validation container
- Integration/channel: outbound message tool shared runner / plugin dispatch
- Relevant config (redacted): `OPENCLAW_TEST_PROFILE=low`

### Steps

1. Build the Docker validation image from the current repo state.
2. Run `pnpm exec oxfmt --check src/infra/outbound/message-action-params.ts src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts` in the container.
3. Run `OPENCLAW_TEST_PROFILE=low pnpm exec vitest run src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.media.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts` in the container.
4. Run `pnpm build` in the container.

### Expected

- Touched outbound media files pass formatting
- Focused outbound media alias tests pass
- Focused plugin-dispatch context tests pass
- Build passes
- `mediaUrl` / `fileUrl` no longer bypass sandbox media enforcement
- plugin-owned actions receive `mediaLocalRoots`

### Actual

- In-container formatting passed for the five touched files
- In-container focused tests passed with `29/29` green across:
  - `src/infra/outbound/message-action-params.test.ts`
  - `src/infra/outbound/message-action-runner.media.test.ts`
  - `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- In-container `pnpm build` passed

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified in a Docker validation container that `mediaUrl` / `fileUrl` are normalized under sandbox policy, that generic `send` rejects or rewrites those aliases correctly, that plugin-owned attachment actions cannot bypass the sandbox through those aliases, that plugin-owned actions receive `mediaLocalRoots`, and that the outbound runtime still builds.
- Edge cases checked: absolute local path rejection, `file://` URL rejection, in-sandbox rewrite, plugin-owned attachment alias handling, plugin-action context forwarding.
- What you did **not** verify: I did not run a live multi-agent container exploit reproduction end-to-end against every channel plugin; validation stayed focused on the shared outbound media seams and build.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the outbound media alias handling changes in `src/infra/outbound/message-action-params.ts` and `src/infra/outbound/message-action-runner.ts`, along with the focused regressions.
- Files/config to restore:
  - `src/infra/outbound/message-action-params.ts`
  - `src/infra/outbound/message-action-runner.ts`
  - `src/infra/outbound/message-action-params.test.ts`
  - `src/infra/outbound/message-action-runner.media.test.ts`
  - `src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- Known bad symptoms reviewers should watch for: legitimate local-media sends in allowed host-mode roots unexpectedly failing, or plugin-owned attachment actions missing their scoped media roots again.

## Risks and Mitigations

- Risk: a plugin or shared send path may have been relying on the old unchecked alias behavior for local file references.
  - Mitigation: the change aligns alias behavior with the already-supported checked keys instead of inventing a new restriction model.
- Risk: plugin-owned action dispatch could diverge from existing send/poll behavior if `mediaLocalRoots` forwarding were inconsistent.
  - Mitigation: the patch makes plugin-owned actions use the same scoped root propagation pattern already validated for plugin-handled `send` / `poll`.
