### PR TITLE
feat: implement usage-based quotas for hosted instances

### DIFF
--- a/src/infra/billing/quota-manager.ts
+++ b/src/infra/billing/quota-manager.ts
@@ -1,0 +1,32 @@
+import { loadJsonFile, saveJsonFile } from "../json-file.js";
+import path from "node:path";
+
+/**
+ * Usage Quota Manager for OpenClaw.
+ * Enables usage-based billing and token caps for hosted agent instances.
+ */
+export class QuotaManager {
+    private quotaPath: string;
+
+    constructor(workspaceDir: string) {
+        this.quotaPath = path.join(workspaceDir, "billing", "quotas.json");
+    }
+
+    checkQuota(userId: string, requestedTokens: number): boolean {
+        const quotas: any = loadJsonFile(this.quotaPath) || {};
+        const userQuota = quotas[userId] || { limit: 100000, used: 0 };
+        
+        if (userQuota.used + requestedTokens > userQuota.limit) {
+            console.warn(`[billing] User ${userId} exceeded token quota.`);
+            return false;
+        }
+        return true;
+    }
+
+    recordUsage(userId: string, tokens: number) {
+        const quotas: any = loadJsonFile(this.quotaPath) || {};
+        if (!quotas[userId]) quotas[userId] = { limit: 100000, used: 0 };
+        quotas[userId].used += tokens;
+        saveJsonFile(this.quotaPath, quotas);
+    }
+}


### PR DESCRIPTION
This PR introduces the `QuotaManager`, enabling hosts to set token limits and track usage for different users (#monetization).

### Changes:
- Added `src/infra/billing/quota-manager.ts`.
- Support for per-user token caps and usage recording.
- Foundation for commercial "Agent-as-a-Service" hosting models.

/claim #monetization