### PR TITLE
feat: implement affiliate and referral tracking for monetization

### DIFF
--- a/src/infra/affiliate/referral-manager.ts
+++ b/src/infra/affiliate/referral-manager.ts
@@ -1,0 +1,30 @@
+import { loadJsonFile, saveJsonFile } from "../json-file.js";
+import path from "node:path";
+
+/**
+ * Affiliate and Referral Manager for OpenClaw.
+ * Tracks referral attributions for new user onboarding and skill purchases.
+ */
+export class ReferralManager {
+    private referralPath: string;
+
+    constructor(workspaceDir: string) {
+        this.referralPath = path.join(workspaceDir, "billing", "referrals.json");
+    }
+
+    trackReferral(referringAgentId: string, newUserId: string) {
+        const referrals: any = loadJsonFile(this.referralPath) || {};
+        referrals[newUserId] = {
+            referrer: referringAgentId,
+            timestamp: Date.now(),
+            status: "pending"
+        };
+        saveJsonFile(this.referralPath, referrals);
+        console.info(`[affiliate] Tracked referral from ${referringAgentId} for user ${newUserId}`);
+    }
+
+    getReferrer(userId: string): string | null {
+        const referrals: any = loadJsonFile(this.referralPath) || {};
+        return referrals[userId]?.referrer || null;
+    }
+}


### PR DESCRIPTION
This PR introduces the `ReferralManager`, which allows OpenClaw instances to track marketing attribution and referrals for new users and marketplace transactions (#monetization).

### Changes:
- Added `src/infra/affiliate/referral-manager.ts`.
- Support for persistent referral mapping.
- Lays the groundwork for multi-level marketing (MLM) or simple commission-based agent recruitment networks.

/claim #monetization