### PR TITLE
fix(daemon): add headless server hints to systemd unavailable error

### DIFF
--- a/src/daemon/systemd-hints.test.ts
+++ b/src/daemon/systemd-hints.test.ts
@@ -28,6 +28,8 @@ describe("renderSystemdUnavailableHints", () => {
   it("renders generic Linux recovery hints outside WSL", () => {
     expect(renderSystemdUnavailableHints()).toEqual([
       "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "On a headless server (SSH/no desktop session): run `loginctl enable-linger` to persist your systemd user session across logins.",
+      "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
     ]);
   });

--- a/src/daemon/systemd-hints.ts
+++ b/src/daemon/systemd-hints.ts
@@ -24,6 +24,8 @@ export function renderSystemdUnavailableHints(options: { wsl?: boolean } = {}): 
   }
   return [
     "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+    "On a headless server (SSH/no desktop session): run `loginctl enable-linger` to persist your systemd user session across logins.",
+    "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
     `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
   ];
 }


### PR DESCRIPTION
## Summary

- Adds `loginctl enable-linger` and `XDG_RUNTIME_DIR` recovery hints to the non-WSL systemd unavailable error path in `renderSystemdUnavailableHints`
- Users on headless/SSH servers now see actionable steps instead of the generic "install/enable systemd" message
- Updates the snapshot test to match the new hint lines

## Changes

**`src/daemon/systemd-hints.ts`**
```
+ "On a headless server (SSH/no desktop session): run `loginctl enable-linger` to persist your systemd user session across logins.",
+ "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
```

## Test plan

- [x] `pnpm test src/daemon/systemd-hints.test.ts` passes
- [ ] Verify on a headless Linux server: `openclaw gateway status` shows the new hints when systemd user services are unavailable

Fixes #11805

🤖 Generated with [Claude Code](https://claude.com/claude-code)