### PR TITLE
fix(daemon): bootstrap stopped service on gateway start

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -206,15 +206,35 @@ export async function runServiceStart(params: {
     return;
   }
   if (!loaded) {
-    await handleServiceNotLoaded({
-      serviceNoun: params.serviceNoun,
-      service: params.service,
-      loaded,
-      renderStartHints: params.renderStartHints,
-      json,
-      emit,
-    });
-    return;
+    // Service was stopped (e.g. `gateway stop` booted out the LaunchAgent).
+    // Attempt a restart, which handles re-bootstrapping the service. Without
+    // this, `start` after `stop` just prints hints and does nothing (#53878).
+    try {
+      const restartResult = await params.service.restart({ env: process.env, stdout });
+      const restartStatus = describeGatewayServiceRestart(params.serviceNoun, restartResult);
+      emit({
+        ok: true,
+        result: restartStatus.daemonActionResult,
+        message: restartStatus.message,
+        service: buildDaemonServiceSnapshot(params.service, true),
+      });
+      if (!json) {
+        defaultRuntime.log(restartStatus.message);
+      }
+      return;
+    } catch {
+      // Bootstrap failed (e.g. plist was deleted, not just booted out).
+      // Fall through to the not-loaded hints.
+      await handleServiceNotLoaded({
+        serviceNoun: params.serviceNoun,
+        service: params.service,
+        loaded,
+        renderStartHints: params.renderStartHints,
+        json,
+        emit,
+      });
+      return;
+    }
   }
   // Pre-flight config validation (#35862)
   {

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -205,6 +205,17 @@ export async function runServiceStart(params: {
   if (loaded === null) {
     return;
   }
+  // Pre-flight config validation (#35862) — run for both loaded and not-loaded
+  // to prevent launching from invalid config in any start path.
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return;
+    }
+  }
   if (!loaded) {
     // Service was stopped (e.g. `gateway stop` booted out the LaunchAgent).
     // Attempt a restart, which handles re-bootstrapping the service. Without
@@ -212,11 +223,12 @@ export async function runServiceStart(params: {
     try {
       const restartResult = await params.service.restart({ env: process.env, stdout });
       const restartStatus = describeGatewayServiceRestart(params.serviceNoun, restartResult);
+      const postLoaded = await params.service.isLoaded({ env: process.env }).catch(() => true);
       emit({
         ok: true,
         result: restartStatus.daemonActionResult,
         message: restartStatus.message,
-        service: buildDaemonServiceSnapshot(params.service, true),
+        service: buildDaemonServiceSnapshot(params.service, postLoaded),
       });
       if (!json) {
         defaultRuntime.log(restartStatus.message);
@@ -233,16 +245,6 @@ export async function runServiceStart(params: {
         json,
         emit,
       });
-      return;
-    }
-  }
-  // Pre-flight config validation (#35862)
-  {
-    const configError = await getConfigValidationError();
-    if (configError) {
-      fail(
-        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
-      );
       return;
     }
   }


### PR DESCRIPTION
lobster-biscuit

Closes #53878

## Problem

On macOS, `openclaw gateway stop` runs `launchctl bootout` which unloads the LaunchAgent. After that, `openclaw gateway start` just prints "not loaded" hints and exits — it never re-bootstraps the service. Only `openclaw gateway install` works, which is wrong for a normal stop/start cycle.

## Root cause

`src/cli/daemon-cli/lifecycle-core.ts:208-217` — `runServiceStart()` calls `handleServiceNotLoaded()` when `isLoaded` returns false. This only prints hints, never calls `service.restart()`.

Meanwhile, `service.restart()` (`restartLaunchAgent` at `launchd.ts:593-603`) already handles the "not loaded" case by calling `bootstrapLaunchAgentOrThrow` to re-register and start the service.

## User impact

`gateway stop` → `gateway start` is broken on macOS. Every macOS user who stops the gateway must run `gateway install` to recover. Breaks expected service lifecycle.

## Fix

When service is not loaded, attempt `service.restart()` first (which handles re-bootstrapping on all platforms). If restart fails (e.g. plist was deleted, not just booted out), fall back to the existing "not loaded" hints.

1 file, +20/-0 net (added restart-attempt block before the existing not-loaded handler).

## How to verify

1. macOS: `openclaw gateway stop`
2. `openclaw gateway start`
3. Before: prints "not loaded" hints. After: bootstraps and starts the gateway.

## Tests

The fix routes through `restartLaunchAgent` which is tested via existing daemon lifecycle tests. The bootstrap path (`bootstrapLaunchAgentOrThrow`) is exercised by the restart flow. No new test needed — this is a call-site routing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)