### PR TITLE
feat(plugins): expose runId in agent hook context

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -270,6 +270,7 @@ export async function runEmbeddedPiAgent(
       let legacyBeforeAgentStartResult: PluginHookBeforeAgentStartResult | undefined;
       const hookRunner = getGlobalHookRunner();
       const hookCtx = {
+        runId: params.runId,
         agentId: workspaceResolution.agentId,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2741,6 +2741,7 @@ export async function runEmbeddedAttempt(
           },
         );
         const hookCtx = {
+          runId: params.runId,
           agentId: hookAgentId,
           sessionKey: params.sessionKey,
           sessionId: params.sessionId,
@@ -2873,6 +2874,7 @@ export async function runEmbeddedAttempt(
                   imagesCount: imageResult.images.length,
                 },
                 {
+                  runId: params.runId,
                   agentId: hookAgentId,
                   sessionKey: params.sessionKey,
                   sessionId: params.sessionId,
@@ -3103,6 +3105,7 @@ export async function runEmbeddedAttempt(
                 durationMs: Date.now() - promptStartedAt,
               },
               {
+                runId: params.runId,
                 agentId: hookAgentId,
                 sessionKey: params.sessionKey,
                 sessionId: params.sessionId,
@@ -3165,6 +3168,7 @@ export async function runEmbeddedAttempt(
               usage: getUsageTotals(),
             },
             {
+              runId: params.runId,
               agentId: hookAgentId,
               sessionKey: params.sessionKey,
               sessionId: params.sessionId,

--- a/src/plugins/hooks.before-agent-start.test.ts
+++ b/src/plugins/hooks.before-agent-start.test.ts
@@ -175,4 +175,24 @@ describe("before_agent_start hook merger", () => {
     expect(result?.modelOverride).toBe("llama3.3:8b");
     expect(result?.providerOverride).toBe("ollama");
   });
+
+  it("passes runId through the agent context to hook handlers", async () => {
+    const registry = createEmptyPluginRegistry();
+    let capturedCtx: typeof stubCtx | undefined;
+    addTestHook({
+      registry,
+      pluginId: "ctx-spy",
+      hookName: "before_agent_start",
+      handler: ((_event: unknown, ctx: typeof stubCtx) => {
+        capturedCtx = ctx;
+        return {};
+      }) as PluginHookRegistration["handler"],
+    });
+
+    const runner = createHookRunner(registry);
+    await runner.runBeforeAgentStart({ prompt: "test" }, stubCtx);
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx?.runId).toBe("test-run-id");
+  });
 });

--- a/src/plugins/hooks.test-helpers.ts
+++ b/src/plugins/hooks.test-helpers.ts
@@ -56,6 +56,7 @@ export function createMockPluginRegistry(
 }
 
 export const TEST_PLUGIN_AGENT_CTX: PluginHookAgentContext = {
+  runId: "test-run-id",
   agentId: "test-agent",
   sessionKey: "test-session",
   sessionId: "test-session-id",

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1478,6 +1478,8 @@ export const isPromptInjectionHookName = (hookName: PluginHookName): boolean =>
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
+  /** Unique identifier for this agent run. */
+  runId?: string;
   agentId?: string;
   sessionKey?: string;
   sessionId?: string;


### PR DESCRIPTION
## Summary

- Problem: Plugins cannot identify which agent run triggered a hook event
- Why it matters: Multi-agent orchestration plugins need to correlate hook events with specific agent executions (e.g., abort stale runs)
- What changed: Added `runId` to `AgentHookContext` type, propagated through agent runner and gateway agent handler
- What did NOT change: Hook dispatch logic, existing hook behavior, hook registration

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #52411

## Root Cause / Regression History (if applicable)

N/A — new feature.

## Regression Test Plan (if applicable)

N/A — additive type change with no behavioral regression risk.

## User-visible / Behavior Changes

Plugins receiving agent hook events now see `runId` in the context object. No breaking changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; no config changes needed
- Known bad symptoms: TypeScript compile errors if runId is removed from hook context type

## Risks and Mitigations

None — additive type change only.