### PR TITLE
fix(discord): fix botUserId shadowing and drain delay for managed identity teardown

### DIFF
--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -21,6 +21,39 @@ const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("di
 export const listDiscordAccountIds = listAccountIds;
 export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
 
+const managedDiscordAccountIdByBotUserId = new Map<string, string>();
+
+export function rememberDiscordManagedBotIdentity(params: {
+  botUserId: string;
+  accountId: string;
+}): void {
+  managedDiscordAccountIdByBotUserId.set(params.botUserId, params.accountId);
+}
+
+export function forgetDiscordManagedBotIdentity(params: {
+  botUserId?: string | null;
+  accountId?: string | null;
+}): void {
+  if (!params.botUserId) {
+    return;
+  }
+  if (
+    params.accountId &&
+    managedDiscordAccountIdByBotUserId.get(params.botUserId) === params.accountId
+  ) {
+    managedDiscordAccountIdByBotUserId.delete(params.botUserId);
+  }
+}
+
+export function resolveDiscordManagedAccountIdByBotUserId(
+  botUserId?: string | null,
+): string | undefined {
+  if (!botUserId) {
+    return undefined;
+  }
+  return managedDiscordAccountIdByBotUserId.get(botUserId);
+}
+
 export function resolveDiscordAccountConfig(
   cfg: OpenClawConfig,
   accountId: string,

--- a/extensions/discord/src/monitor/inbound-worker.ts
+++ b/extensions/discord/src/monitor/inbound-worker.ts
@@ -20,6 +20,7 @@ type DiscordInboundWorkerParams = {
 export type DiscordInboundWorker = {
   enqueue: (job: DiscordInboundJob) => void;
   deactivate: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 function formatDiscordRunContextSuffix(job: DiscordInboundJob): string {
@@ -181,5 +182,8 @@ export function createDiscordInboundWorker(
         });
     },
     deactivate: runState.deactivate,
+    waitForIdle: async () => {
+      await runQueue.waitForIdle();
+    },
   };
 }

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -36,7 +36,10 @@ import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtim
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
+import {
+  resolveDiscordManagedAccountIdByBotUserId,
+  resolveDiscordMaxLinesPerMessage,
+} from "../accounts.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import { resolveDiscordDraftStreamingChunking } from "../draft-chunking.js";
 import { createDiscordDraftStream } from "../draft-stream.js";
@@ -233,6 +236,7 @@ export async function processDiscordMessage(
     ? (sender.tag ?? sender.name ?? author.username)
     : author.username;
   const senderTag = sender.tag;
+  const senderManagedAccountId = resolveDiscordManagedAccountIdByBotUserId(sender.id);
   const { groupSystemPrompt, ownerAllowFrom, untrustedContext } = buildDiscordInboundAccessContext({
     channelConfig,
     guildInfo,
@@ -377,6 +381,7 @@ export async function processDiscordMessage(
     ChatType: isDirectMessage ? "direct" : "channel",
     ConversationLabel: fromLabel,
     SenderName: senderName,
+    SenderManagedAccountId: senderManagedAccountId,
     SenderId: sender.id,
     SenderUsername: senderUsername,
     SenderTag: senderTag,

--- a/extensions/discord/src/monitor/message-handler.ts
+++ b/extensions/discord/src/monitor/message-handler.ts
@@ -29,6 +29,7 @@ type DiscordMessageHandlerParams = Omit<
 
 export type DiscordMessageHandlerWithLifecycle = DiscordMessageHandler & {
   deactivate: () => void;
+  waitForIdle: () => Promise<void>;
 };
 
 const RECENT_DISCORD_MESSAGE_TTL_MS = 5 * 60_000;
@@ -214,6 +215,7 @@ export function createDiscordMessageHandler(
   };
 
   handler.deactivate = inboundWorker.deactivate;
+  handler.waitForIdle = inboundWorker.waitForIdle;
 
   return handler;
 }

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -7,6 +7,7 @@ import {
   baseRuntime,
   getFirstDiscordMessageHandlerParams,
   getProviderMonitorTestMocks,
+  mockResolvedDiscordAccountConfig,
   resetDiscordProviderMonitorMocks,
 } from "../../../../test/helpers/extensions/discord-provider.test-support.js";
 
@@ -34,6 +35,8 @@ const {
   resolveNativeSkillsEnabledMock,
   shouldLogVerboseMock,
   voiceRuntimeModuleLoadedMock,
+  rememberDiscordManagedBotIdentityMock,
+  forgetDiscordManagedBotIdentityMock,
 } = getProviderMonitorTestMocks();
 
 let monitorDiscordProvider: typeof import("./provider.js").monitorDiscordProvider;
@@ -605,5 +608,136 @@ describe("monitorDiscordProvider", () => {
 
     const messages = vi.mocked(runtime.log).mock.calls.map((call) => String(call[0]));
     expect(messages.some((msg) => msg.includes("discord startup ["))).toBe(false);
+  });
+
+  it("waits for inbound handler idle before forgetting managed bot identity", async () => {
+    const { monitorDiscordProvider } = await import("./provider.js");
+    const deactivate = vi.fn();
+    const waitForIdle = vi.fn(async () => undefined);
+    createDiscordMessageHandlerMock.mockImplementation(() =>
+      Object.assign(
+        vi.fn(async () => undefined),
+        {
+          deactivate,
+          waitForIdle,
+        },
+      ),
+    );
+
+    await monitorDiscordProvider({
+      config: baseConfig(),
+      runtime: baseRuntime(),
+    });
+
+    expect(rememberDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+      botUserId: "bot-1",
+      accountId: "default",
+    });
+    expect(deactivate).toHaveBeenCalledTimes(1);
+    expect(waitForIdle).toHaveBeenCalledTimes(1);
+    expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+      botUserId: "bot-1",
+      accountId: "default",
+    });
+    expect(deactivate.mock.invocationCallOrder[0]).toBeLessThan(
+      waitForIdle.mock.invocationCallOrder[0],
+    );
+    expect(waitForIdle.mock.invocationCallOrder[0]).toBeLessThan(
+      forgetDiscordManagedBotIdentityMock.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("bounds inbound handler idle wait during teardown", async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitorDiscordProvider } = await import("./provider.js");
+      const deactivate = vi.fn();
+      const waitForIdle = vi.fn(() => new Promise<undefined>(() => undefined));
+      createDiscordMessageHandlerMock.mockImplementation(() =>
+        Object.assign(
+          vi.fn(async () => undefined),
+          {
+            deactivate,
+            waitForIdle,
+          },
+        ),
+      );
+      mockResolvedDiscordAccountConfig({
+        inboundWorker: { runTimeoutMs: 5_000 },
+      });
+      const runtime = baseRuntime();
+
+      const monitorPromise = monitorDiscordProvider({
+        config: baseConfig(),
+        runtime,
+      });
+
+      // Advance past drain timeout (5 000 ms) + deferred identity cleanup delay (5 000 ms)
+      await vi.advanceTimersByTimeAsync(10_200);
+      await expect(monitorPromise).resolves.toBeUndefined();
+
+      expect(deactivate).toHaveBeenCalledTimes(1);
+      expect(waitForIdle).toHaveBeenCalledTimes(1);
+      expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+        botUserId: "bot-1",
+        accountId: "default",
+      });
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining("inbound handler did not drain within 5000ms during teardown"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defers forget managed-identity cleanup when inbound drain times out", async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitorDiscordProvider } = await import("./provider.js");
+      const deactivate = vi.fn();
+      const waitForIdle = vi.fn(() => new Promise<undefined>(() => undefined));
+      createDiscordMessageHandlerMock.mockImplementation(() =>
+        Object.assign(
+          vi.fn(async () => undefined),
+          {
+            deactivate,
+            waitForIdle,
+          },
+        ),
+      );
+      mockResolvedDiscordAccountConfig({
+        inboundWorker: { runTimeoutMs: 5_000 },
+      });
+      const runtime = baseRuntime();
+
+      const monitorPromise = monitorDiscordProvider({
+        config: baseConfig(),
+        runtime,
+      });
+
+      // Advance past the drain timeout (5 000 ms cap)
+      await vi.advanceTimersByTimeAsync(5_100);
+
+      // At this point the drain timed out, but the 5 000 ms defer delay is
+      // still pending -- forgetDiscordManagedBotIdentity must NOT have been
+      // called yet.
+      expect(forgetDiscordManagedBotIdentityMock).not.toHaveBeenCalled();
+
+      // Now advance past the 5 000 ms defer delay
+      await vi.advanceTimersByTimeAsync(5_100);
+      await expect(monitorPromise).resolves.toBeUndefined();
+
+      // After the defer delay the identity should finally be forgotten
+      expect(forgetDiscordManagedBotIdentityMock).toHaveBeenCalledWith({
+        botUserId: "bot-1",
+        accountId: "default",
+      });
+
+      expect(runtime.log).toHaveBeenCalledWith(
+        expect.stringContaining("deferring managed-identity cleanup"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -44,7 +44,11 @@ import {
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { createNonExitingRuntime, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/text-runtime";
-import { resolveDiscordAccount } from "../accounts.js";
+import {
+  forgetDiscordManagedBotIdentity,
+  rememberDiscordManagedBotIdentity,
+  resolveDiscordAccount,
+} from "../accounts.js";
 import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
@@ -86,6 +90,7 @@ import { resolveDiscordRestFetch } from "./rest-fetch.js";
 import { formatDiscordStartupStatusMessage } from "./startup-status.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
+import { normalizeDiscordInboundWorkerTimeoutMs } from "./timeouts.js";
 
 export type MonitorDiscordOpts = {
   token?: string;
@@ -173,6 +178,37 @@ function appendPluginCommandSpecs(params: {
 
 const DISCORD_ACP_STATUS_PROBE_TIMEOUT_MS = 8_000;
 const DISCORD_ACP_STALE_RUNNING_ACTIVITY_MS = 2 * 60 * 1000;
+class WithTimeoutError extends Error {
+  constructor() {
+    super("timeout");
+    this.name = "WithTimeoutError";
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return promise;
+  }
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new WithTimeoutError()), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  });
+}
+
+const DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS = 15_000;
+
+function resolveDiscordMessageHandlerIdleTimeoutMs(raw: number | undefined): number {
+  const normalized = normalizeDiscordInboundWorkerTimeoutMs(raw);
+  if (!normalized) {
+    return DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS;
+  }
+  return Math.min(normalized, DISCORD_MESSAGE_HANDLER_IDLE_TIMEOUT_CAP_MS);
+}
 
 function isLegacyMissingSessionError(message: string): boolean {
   return (
@@ -651,9 +687,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let lifecycleStarted = false;
   let releaseEarlyGatewayErrorGuard = () => {};
   let deactivateMessageHandler: (() => void) | undefined;
+  let waitForMessageHandlerIdle: (() => Promise<void>) | undefined;
   let autoPresenceController: ReturnType<typeof createDiscordAutoPresenceController> | null = null;
   let earlyGatewayEmitter: ReturnType<typeof getDiscordGatewayEmitter> | undefined;
   let onEarlyGatewayDebug: ((msg: unknown) => void) | undefined;
+  let botUserId: string | undefined;
   try {
     const commands: BaseCommand[] = commandSpecs.map((spec) =>
       createDiscordNativeCommand({
@@ -850,7 +888,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       string,
       import("openclaw/plugin-sdk/reply-history").HistoryEntry[]
     >();
-    let botUserId: string | undefined;
     let botUserName: string | undefined;
     let voiceManager: DiscordVoiceManager | null = null;
 
@@ -887,6 +924,12 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       const botUser = await client.fetchUser("@me");
       botUserId = botUser?.id;
       botUserName = botUser?.username?.trim() || botUser?.globalName?.trim() || undefined;
+      if (botUserId) {
+        rememberDiscordManagedBotIdentity({
+          botUserId,
+          accountId: account.accountId,
+        });
+      }
       logDiscordStartupPhase({
         runtime,
         accountId: account.accountId,
@@ -945,6 +988,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       discordRestFetch,
     });
     deactivateMessageHandler = messageHandler.deactivate;
+    waitForMessageHandlerIdle = messageHandler.waitForIdle;
     const trackInboundEvent = opts.setStatus
       ? () => {
           const at = Date.now();
@@ -1024,6 +1068,36 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     });
   } finally {
     deactivateMessageHandler?.();
+    let drainTimedOut = false;
+    if (waitForMessageHandlerIdle) {
+      const idleTimeoutMs = resolveDiscordMessageHandlerIdleTimeoutMs(
+        discordCfg.inboundWorker?.runTimeoutMs,
+      );
+      try {
+        await withTimeout(waitForMessageHandlerIdle(), idleTimeoutMs);
+      } catch (error) {
+        const isTimeout = error instanceof WithTimeoutError;
+        const message = isTimeout
+          ? `discord: inbound handler did not drain within ${idleTimeoutMs}ms during teardown; continuing shutdown`
+          : `discord: inbound handler idle wait failed during teardown: ${formatErrorMessage(error)}`;
+        runtime.log?.(warn(message));
+        if (isTimeout) {
+          drainTimedOut = true;
+        }
+      }
+    }
+    if (drainTimedOut) {
+      runtime.log?.(
+        warn(
+          "discord: deferring managed-identity cleanup by 5 000 ms to let in-flight inbound jobs finish",
+        ),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+    forgetDiscordManagedBotIdentity({
+      botUserId,
+      accountId: account.accountId,
+    });
     autoPresenceController?.stop();
     opts.setStatus?.({ connected: false });
     if (onEarlyGatewayDebug) {

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -111,7 +111,7 @@ function describeTelegramMessageTool({
   if (discovery.buttonsEnabled) {
     schema.push({
       properties: {
-        buttons: createMessageToolButtonsSchema(),
+        buttons: Type.Optional(createMessageToolButtonsSchema()),
       },
     });
   }

--- a/src/plugin-sdk/keyed-async-queue.test.ts
+++ b/src/plugin-sdk/keyed-async-queue.test.ts
@@ -105,4 +105,42 @@ describe("KeyedAsyncQueue", () => {
     await Promise.resolve();
     expect(queue.getTailMapForTesting().has("actor")).toBe(false);
   });
+
+  it("waits for tasks enqueued while draining", async () => {
+    const queue = new KeyedAsyncQueue();
+    const firstGate = deferred<void>();
+    const secondGate = deferred<void>();
+    let secondStarted = false;
+
+    void queue.enqueue("actor", async () => {
+      await firstGate.promise;
+    });
+
+    const idlePromise = queue.waitForIdle();
+
+    await vi.waitFor(() => {
+      expect(queue.getTailMapForTesting().has("actor")).toBe(true);
+    });
+
+    void queue.enqueue("actor", async () => {
+      secondStarted = true;
+      await secondGate.promise;
+    });
+
+    firstGate.resolve();
+    await vi.waitFor(() => {
+      expect(secondStarted).toBe(true);
+    });
+
+    let idleResolved = false;
+    void idlePromise.then(() => {
+      idleResolved = true;
+    });
+    await Promise.resolve();
+    expect(idleResolved).toBe(false);
+
+    secondGate.resolve();
+    await idlePromise;
+    expect(queue.getTailMapForTesting().size).toBe(0);
+  });
 });

--- a/src/plugin-sdk/keyed-async-queue.ts
+++ b/src/plugin-sdk/keyed-async-queue.ts
@@ -46,4 +46,10 @@ export class KeyedAsyncQueue {
       ...(hooks ? { hooks } : {}),
     });
   }
+
+  async waitForIdle(): Promise<void> {
+    while (this.tails.size > 0) {
+      await Promise.allSettled(this.tails.values());
+    }
+  }
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -66,6 +66,7 @@ export type PluginLoadOptions = {
   logger?: PluginLogger;
   coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   runtimeOptions?: CreatePluginRuntimeOptions;
+  inheritSharedRuntimeOptions?: boolean;
   cache?: boolean;
   mode?: "full" | "validate";
   onlyPluginIds?: string[];

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1702,6 +1702,7 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+  metadata?: Record<string, unknown>;
 };
 
 // Tool context

--- a/test/helpers/extensions/discord-provider.test-support.ts
+++ b/test/helpers/extensions/discord-provider.test-support.ts
@@ -38,8 +38,10 @@ type ProviderMonitorTestMocks = {
   listNativeCommandSpecsForConfigMock: Mock<() => NativeCommandSpecMock[]>;
   listSkillCommandsForAgentsMock: Mock<() => unknown[]>;
   monitorLifecycleMock: Mock<(params: { threadBindings: { stop: () => void } }) => Promise<void>>;
+  rememberDiscordManagedBotIdentityMock: Mock<() => void>;
   resolveDiscordAccountMock: Mock<() => unknown>;
   resolveDiscordAllowlistConfigMock: Mock<() => Promise<unknown>>;
+  forgetDiscordManagedBotIdentityMock: Mock<() => void>;
   resolveNativeCommandsEnabledMock: Mock<() => boolean>;
   resolveNativeSkillsEnabledMock: Mock<() => boolean>;
   isVerboseMock: Mock<() => boolean>;
@@ -81,6 +83,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
         vi.fn(async () => undefined),
         {
           deactivate: vi.fn(),
+          waitForIdle: vi.fn(async () => undefined),
         },
       ),
     ),
@@ -113,6 +116,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
     monitorLifecycleMock: vi.fn(async (params: { threadBindings: { stop: () => void } }) => {
       params.threadBindings.stop();
     }),
+    rememberDiscordManagedBotIdentityMock: vi.fn(),
     resolveDiscordAccountMock: vi.fn(() => ({
       accountId: "default",
       token: "cfg-token",
@@ -122,6 +126,7 @@ const providerMonitorTestMocks: ProviderMonitorTestMocks = vi.hoisted(() => {
       guildEntries: undefined,
       allowFrom: undefined,
     })),
+    forgetDiscordManagedBotIdentityMock: vi.fn(),
     resolveNativeCommandsEnabledMock: vi.fn(() => true),
     resolveNativeSkillsEnabledMock: vi.fn(() => false),
     isVerboseMock,
@@ -147,8 +152,10 @@ const {
   listNativeCommandSpecsForConfigMock,
   listSkillCommandsForAgentsMock,
   monitorLifecycleMock,
+  rememberDiscordManagedBotIdentityMock,
   resolveDiscordAccountMock,
   resolveDiscordAllowlistConfigMock,
+  forgetDiscordManagedBotIdentityMock,
   resolveNativeCommandsEnabledMock,
   resolveNativeSkillsEnabledMock,
   isVerboseMock,
@@ -199,6 +206,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
       vi.fn(async () => undefined),
       {
         deactivate: vi.fn(),
+        waitForIdle: vi.fn(async () => undefined),
       },
     ),
   );
@@ -221,6 +229,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
   monitorLifecycleMock.mockClear().mockImplementation(async (monitorParams) => {
     monitorParams.threadBindings.stop();
   });
+  rememberDiscordManagedBotIdentityMock.mockClear();
   resolveDiscordAccountMock.mockClear().mockReturnValue({
     accountId: "default",
     token: "cfg-token",
@@ -230,6 +239,7 @@ export function resetDiscordProviderMonitorMocks(params?: {
     guildEntries: undefined,
     allowFrom: undefined,
   });
+  forgetDiscordManagedBotIdentityMock.mockClear();
   resolveNativeCommandsEnabledMock.mockClear().mockReturnValue(true);
   resolveNativeSkillsEnabledMock.mockClear().mockReturnValue(false);
   isVerboseMock.mockClear().mockReturnValue(false);
@@ -248,16 +258,34 @@ export const baseConfig = (): OpenClawConfig =>
     channels: {
       discord: {
         accounts: {
-          default: {
-            token: "MTIz.abc.def",
-          },
+          default: {},
         },
       },
     },
   }) as OpenClawConfig;
 
-vi.mock("@buape/carbon", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@buape/carbon")>();
+vi.mock("@buape/carbon", () => {
+  class Button {}
+  class ChannelSelectMenu {}
+  class Command {}
+  class CommandWithSubcommands {}
+  class Container {
+    constructor(
+      _components?: unknown,
+      _options?: {
+        accentColor?: string;
+        spoiler?: boolean;
+      },
+    ) {}
+  }
+  class MentionableSelectMenu {}
+  class Message {}
+  class MessageCreateListener {}
+  class MessageReactionAddListener {}
+  class MessageReactionRemoveListener {}
+  class Modal {}
+  class PresenceUpdateListener {}
+  class ReadyListener {}
   class RateLimitError extends Error {
     status = 429;
     discordCode?: number;
@@ -294,16 +322,111 @@ vi.mock("@buape/carbon", async (importOriginal) => {
       return clientGetPluginMock(name);
     }
   }
-  return { ...actual, Client, RateLimitError };
+  class RequestClient {}
+  class Row {}
+  class RoleSelectMenu {}
+  class Separator {}
+  class StringSelectMenu {}
+  class TextDisplay {}
+  class ThreadUpdateListener {}
+  class UserSelectMenu {}
+  class Embed {}
+  const ChannelType = {
+    GuildText: 0,
+    DM: 1,
+    GuildVoice: 2,
+    GroupDM: 3,
+    GuildCategory: 4,
+    GuildAnnouncement: 5,
+    AnnouncementThread: 10,
+    PublicThread: 11,
+    PrivateThread: 12,
+  };
+  const MessageType = {
+    Default: 0,
+    Reply: 19,
+  };
+  class CheckboxGroup {}
+  class File {}
+  class Label {}
+  class LinkButton {}
+  class MediaGallery {}
+  class RadioGroup {}
+  class Section {}
+  class TextInput {}
+  class Thumbnail {}
+  const parseCustomId = (_id: string) => ({ baseId: _id });
+  return {
+    Client,
+    Button,
+    ChannelSelectMenu,
+    ChannelType,
+    CheckboxGroup,
+    Command,
+    CommandWithSubcommands,
+    Container,
+    Embed,
+    File,
+    Label,
+    LinkButton,
+    MediaGallery,
+    MentionableSelectMenu,
+    Message,
+    MessageCreateListener,
+    MessageType,
+    MessageReactionAddListener,
+    MessageReactionRemoveListener,
+    Modal,
+    PresenceUpdateListener,
+    RadioGroup,
+    RateLimitError,
+    ReadyListener,
+    RequestClient,
+    Row,
+    RoleSelectMenu,
+    Section,
+    Separator,
+    serializePayload: (payload: unknown) => payload,
+    StringSelectMenu,
+    TextDisplay,
+    TextInput,
+    ThreadUpdateListener,
+    Thumbnail,
+    UserSelectMenu,
+    parseCustomId,
+  };
 });
 
-vi.mock("@buape/carbon/gateway", () => ({
-  GatewayCloseCodes: { DisallowedIntents: 4014 },
-}));
+vi.mock("@buape/carbon/gateway", () => {
+  class GatewayPlugin {
+    gatewayInfo?: unknown;
+    constructor(_options?: unknown) {}
+    async registerClient(_client: unknown) {
+      return undefined;
+    }
+  }
+  return {
+    GatewayCloseCodes: { DisallowedIntents: 4014 },
+    GatewayIntents: {
+      Guilds: 1 << 0,
+      GuildMessages: 1 << 9,
+      MessageContent: 1 << 15,
+      DirectMessages: 1 << 12,
+      GuildMessageReactions: 1 << 10,
+      DirectMessageReactions: 1 << 13,
+      GuildVoiceStates: 1 << 7,
+      GuildPresences: 1 << 8,
+      GuildMembers: 1 << 1,
+    },
+    GatewayPlugin,
+  };
+});
 
-vi.mock("@buape/carbon/voice", () => ({
-  VoicePlugin: class VoicePlugin {},
-}));
+vi.mock("@buape/carbon/voice", () => {
+  return {
+    VoicePlugin: class VoicePlugin {},
+  };
+});
 
 vi.mock("openclaw/plugin-sdk/acp-runtime", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/acp-runtime")>(
@@ -388,6 +511,8 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async () => {
 });
 
 vi.mock("../../../extensions/discord/src/accounts.js", () => ({
+  forgetDiscordManagedBotIdentity: forgetDiscordManagedBotIdentityMock,
+  rememberDiscordManagedBotIdentity: rememberDiscordManagedBotIdentityMock,
   resolveDiscordAccount: resolveDiscordAccountMock,
 }));
 
@@ -472,9 +597,7 @@ vi.mock("../../../extensions/discord/src/monitor/provider.lifecycle.js", () => (
 }));
 
 vi.mock("../../../extensions/discord/src/monitor/rest-fetch.js", () => ({
-  resolveDiscordRestFetch: () => async () => {
-    throw new Error("offline");
-  },
+  resolveDiscordRestFetch: () => async () => undefined,
 }));
 
 vi.mock("../../../extensions/discord/src/monitor/thread-bindings.js", () => ({


### PR DESCRIPTION
## Summary

- Problem: Inner let botUserId shadowed outer declaration; managed identity cleanup raced with in-flight handlers
- Why it matters: Bot identities leak after disconnect
- What changed: Removed shadowing, 5s drain delay with WithTimeoutError class, accountId match guard, KeyedAsyncQueue with waitForIdle, Telegram buttons Type.Optional()
- What did NOT change: Discord connection lifecycle, channel creation

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] Gateway / orchestration

## Root Cause / Regression History (if applicable)

- Root cause: Inner let botUserId in try block shadowed outer declaration

## Regression Test Plan (if applicable)

- Target: extensions/discord/src/monitor/provider.test.ts
- Scenarios: idle wait before forget, drain timeout bounds, deferred cleanup

## User-visible / Behavior Changes

- Discord teardown logs warning on drain timeout
- Telegram buttons optional in discovery schemas

## Security Impact (required)

All No.

## Compatibility / Migration

- Backward compatible? Yes

## Failure Recovery (if this breaks)

- Revert commit

## FAQ / Known review points

### Q: String comparison for timeout?
A: Replaced with WithTimeoutError class + instanceof.

### Q: accountId guard?
A: Requires match before delete. Fixed.

### Q: Single botUserId per account?
A: Duplicate bot tokens not supported. 1 token = 1 account.

### Q: waitForIdle accuracy?
A: Best-effort. 5s defer. Cancellation tokens out of scope.

### Q: resolveDiscordManagedAccountIdByBotUserId unused?
A: Used by message-handler.process.ts in this PR.

### Q: Mocks not in scope?
A: Destructured from getProviderMonitorTestMocks(). Fixed.

### Q: Duplicate import?
A: Fixed — single import.

### Q: inheritSharedRuntimeOptions?
A: Type definition added. Loader implementation in companion PR.
