### PR TITLE
fix(gateway): fix hook dispatch routing and delivery channel resolution

### DIFF
--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -123,6 +123,8 @@ export type MsgContext = {
   /** Explicit owner allowlist overrides (trusted, configuration-derived). */
   OwnerAllowFrom?: Array<string | number>;
   SenderName?: string;
+  /** Provider-managed account id when the inbound sender is one of our configured bot accounts. */
+  SenderManagedAccountId?: string;
   SenderId?: string;
   SenderUsername?: string;
   SenderTag?: string;

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -252,6 +252,7 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
     runtimeOptions: {
       allowGatewaySubagentBinding: true,
     },
+    inheritSharedRuntimeOptions: true,
     logger: {
       info: () => {},
       warn: () => {},

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -171,6 +171,9 @@ describe("message hook mappers", () => {
       channelId: "telegram",
       accountId: "acc-1",
       messageId: "out-1",
+      threadId: "thread-1",
+      sessionKey: "agent:agent-1:telegram:chat:456",
+      agentId: "agent-1",
       isGroup: true,
       groupId: "telegram:chat:456",
     });
@@ -185,6 +188,17 @@ describe("message hook mappers", () => {
       content: "reply",
       success: false,
       error: "network error",
+      metadata: {
+        channel: "telegram",
+        accountId: "acc-1",
+        conversationId: "telegram:chat:456",
+        messageId: "out-1",
+        threadId: "thread-1",
+        sessionKey: "agent:agent-1:telegram:chat:456",
+        agentId: "agent-1",
+        isGroup: true,
+        groupId: "telegram:chat:456",
+      },
     });
     expect(toInternalMessageSentContext(canonical)).toEqual({
       to: "telegram:chat:456",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -28,6 +28,7 @@ export type CanonicalInboundMessageHookContext = {
   messageId?: string;
   senderId?: string;
   senderName?: string;
+  senderManagedAccountId?: string;
   senderUsername?: string;
   senderE164?: string;
   provider?: string;
@@ -52,6 +53,9 @@ export type CanonicalSentMessageHookContext = {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
   isGroup?: boolean;
   groupId?: string;
 };
@@ -97,6 +101,7 @@ export function deriveInboundMessageHookContext(
       ctx.MessageSidLast,
     senderId: ctx.SenderId,
     senderName: ctx.SenderName,
+    senderManagedAccountId: ctx.SenderManagedAccountId,
     senderUsername: ctx.SenderUsername,
     senderE164: ctx.SenderE164,
     provider: ctx.Provider,
@@ -122,6 +127,9 @@ export function buildCanonicalSentMessageHookContext(params: {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
   isGroup?: boolean;
   groupId?: string;
 }): CanonicalSentMessageHookContext {
@@ -134,6 +142,9 @@ export function buildCanonicalSentMessageHookContext(params: {
     accountId: params.accountId,
     conversationId: params.conversationId ?? params.to,
     messageId: params.messageId,
+    threadId: params.threadId,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
     isGroup: params.isGroup,
     groupId: params.groupId,
   };
@@ -296,6 +307,7 @@ export function toPluginMessageReceivedEvent(
       messageId: canonical.messageId,
       senderId: canonical.senderId,
       senderName: canonical.senderName,
+      senderManagedAccountId: canonical.senderManagedAccountId,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,
@@ -312,6 +324,17 @@ export function toPluginMessageSentEvent(
     content: canonical.content,
     success: canonical.success,
     ...(canonical.error ? { error: canonical.error } : {}),
+    metadata: {
+      channel: canonical.channelId,
+      accountId: canonical.accountId,
+      conversationId: canonical.conversationId,
+      messageId: canonical.messageId,
+      threadId: canonical.threadId,
+      sessionKey: canonical.sessionKey,
+      agentId: canonical.agentId,
+      isGroup: canonical.isGroup,
+      groupId: canonical.groupId,
+    },
   };
 }
 
@@ -333,6 +356,7 @@ export function toInternalMessageReceivedContext(
       threadId: canonical.threadId,
       senderId: canonical.senderId,
       senderName: canonical.senderName,
+      senderManagedAccountId: canonical.senderManagedAccountId,
       senderUsername: canonical.senderUsername,
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -19,7 +19,8 @@ const mocks = vi.hoisted(() => ({
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn(() => false),
+    hasHooks: vi.fn<(name: string) => boolean>((_name) => false),
+    runMessageSending: vi.fn(async () => undefined),
     runMessageSent: vi.fn(async () => {}),
   },
 }));
@@ -210,6 +211,8 @@ describe("deliverOutboundPayloads", () => {
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
     hookMocks.runner.hasHooks.mockClear();
     hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSending.mockClear();
+    hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
     hookMocks.runner.runMessageSent.mockClear();
     hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
     internalHookMocks.createInternalHookEvent.mockClear();
@@ -1031,6 +1034,167 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("uses the same resolved sessionKey in message_sending and message_sent", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+      mirror: { sessionKey: "agent:mirror:session", agentId: "mirror-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses replyToId as hook threadId for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendText = vi.fn().mockResolvedValue({ channel: "slack", messageId: "slack-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello" }],
+      replyToId: "1741719181.247349",
+      threadId: null,
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.247349",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.247349",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("uses payload-level replyToId as hook threadId for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+    const sendText = vi.fn().mockResolvedValue({ channel: "slack", messageId: "slack-2" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "slack",
+      to: "C123",
+      payloads: [{ text: "hello", replyToId: "1741719181.999999" }],
+      replyToId: undefined,
+      threadId: null,
+      session: { key: "agent:sender:session", agentId: "sender-agent" },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.999999",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.999999",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back to mirror metadata for message_sending when session is absent", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+      mirror: { sessionKey: "agent:mirror:session", agentId: "mirror-agent" },
+      skipQueue: true,
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          sessionKey: "agent:mirror:session",
+          agentId: "mirror-agent",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
@@ -1245,6 +1409,47 @@ describe("deliverOutboundPayloads", () => {
         error: "downstream failed",
       }),
       expect.objectContaining({ channelId: "whatsapp" }),
+    );
+  });
+
+  it("emits payload-level threadId in message_sent failure metadata for Slack threaded sends", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+    const sendText = vi.fn().mockRejectedValue(new Error("downstream failed"));
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "slack",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "slack",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    await expect(
+      deliverOutboundPayloads({
+        cfg: {},
+        channel: "slack",
+        to: "C123",
+        payloads: [{ text: "hi", replyToId: "1741719181.424242" }],
+        threadId: null,
+        session: { key: "agent:sender:session", agentId: "sender-agent" },
+      }),
+    ).rejects.toThrow("downstream failed");
+
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          threadId: "1741719181.424242",
+          sessionKey: "agent:sender:session",
+          agentId: "sender-agent",
+        }),
+        success: false,
+        error: "downstream failed",
+      }),
+      expect.anything(),
     );
   });
 });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -353,13 +353,23 @@ function createMessageSentEmitter(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  conversationId?: string;
+  agentId?: string;
+  sessionKey?: string;
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
-}): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
+}): {
+  emitMessageSent: (
+    event: MessageSentEvent & { threadId?: string | number; conversationId?: string },
+  ) => void;
+  hasMessageSentHooks: boolean;
+} {
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
   const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
-  const emitMessageSent = (event: MessageSentEvent) => {
+  const emitMessageSent = (
+    event: MessageSentEvent & { threadId?: string | number; conversationId?: string },
+  ) => {
     if (!hasMessageSentHooks && !canEmitInternalHook) {
       return;
     }
@@ -370,8 +380,11 @@ function createMessageSentEmitter(params: {
       error: event.error,
       channelId: params.channel,
       accountId: params.accountId ?? undefined,
-      conversationId: params.to,
+      conversationId: event.conversationId ?? params.conversationId ?? params.to,
       messageId: event.messageId,
+      threadId: event.threadId,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
     });
@@ -408,6 +421,31 @@ function createMessageSentEmitter(params: {
   return { emitMessageSent, hasMessageSentHooks };
 }
 
+function resolveOutboundHookMetadata(params: {
+  channel: Exclude<OutboundChannel, "none">;
+  to: string;
+  conversationId?: string;
+  replyToId?: string | null;
+  threadId?: string | number | null;
+  session?: OutboundSessionContext;
+  mirror?: DeliverOutboundPayloadsCoreParams["mirror"];
+}): {
+  conversationId: string;
+  threadId?: string | number;
+  sessionKey?: string;
+  agentId?: string;
+} {
+  const resolvedThreadId =
+    params.threadId ??
+    (params.channel === "slack" && params.replyToId ? params.replyToId : undefined);
+  return {
+    conversationId: params.conversationId ?? params.to,
+    threadId: resolvedThreadId,
+    sessionKey: params.mirror?.sessionKey ?? params.session?.key,
+    agentId: params.mirror?.agentId ?? params.session?.agentId,
+  };
+}
+
 async function applyMessageSendingHook(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
@@ -416,6 +454,10 @@ async function applyMessageSendingHook(params: {
   to: string;
   channel: Exclude<OutboundChannel, "none">;
   accountId?: string;
+  conversationId?: string;
+  threadId?: string | number | null;
+  sessionKey?: string;
+  agentId?: string;
 }): Promise<{
   cancelled: boolean;
   payload: ReplyPayload;
@@ -436,12 +478,17 @@ async function applyMessageSendingHook(params: {
         metadata: {
           channel: params.channel,
           accountId: params.accountId,
+          conversationId: params.conversationId ?? params.to,
+          threadId: params.threadId ?? undefined,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
           mediaUrls: params.payloadSummary.mediaUrls,
         },
       },
       {
         channelId: params.channel,
         accountId: params.accountId ?? undefined,
+        conversationId: params.conversationId ?? params.to,
       },
     );
     if (sendingResult?.cancel) {
@@ -621,7 +668,16 @@ async function deliverOutboundPayloadsCore(
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler);
   const hookRunner = getGlobalHookRunner();
-  const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
+  const hookMetadata = resolveOutboundHookMetadata({
+    channel,
+    to,
+    conversationId: to,
+    replyToId: params.replyToId,
+    threadId: params.threadId,
+    session: params.session,
+    mirror: params.mirror,
+  });
+  const sessionKeyForInternalHooks = hookMetadata.sessionKey;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
   const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
@@ -629,23 +685,35 @@ async function deliverOutboundPayloadsCore(
     channel,
     to,
     accountId,
+    conversationId: hookMetadata.conversationId,
+    agentId: hookMetadata.agentId,
+    sessionKey: hookMetadata.sessionKey,
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
+  if (hasMessageSentHooks && hookMetadata.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
       {
         channel,
         to,
-        agentId: params.session.agentId,
+        agentId: hookMetadata.agentId,
       },
     );
   }
   for (const payload of normalizedPayloads) {
     let payloadSummary = buildPayloadSummary(payload);
+    let payloadHookMetadata = resolveOutboundHookMetadata({
+      channel,
+      to,
+      conversationId: to,
+      replyToId: payload.replyToId ?? params.replyToId,
+      threadId: params.threadId,
+      session: params.session,
+      mirror: params.mirror,
+    });
     try {
       throwIfAborted(abortSignal);
 
@@ -658,6 +726,10 @@ async function deliverOutboundPayloadsCore(
         to,
         channel,
         accountId,
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
+        sessionKey: payloadHookMetadata.sessionKey,
+        agentId: payloadHookMetadata.agentId,
       });
       if (hookResult.cancelled) {
         continue;
@@ -672,6 +744,15 @@ async function deliverOutboundPayloadsCore(
         audioAsVoice: effectivePayload.audioAsVoice === true ? true : undefined,
         forceDocument: params.forceDocument,
       };
+      payloadHookMetadata = resolveOutboundHookMetadata({
+        channel,
+        to,
+        conversationId: to,
+        replyToId: sendOverrides.replyToId,
+        threadId: sendOverrides.threadId,
+        session: params.session,
+        mirror: params.mirror,
+      });
       if (
         handler.sendPayload &&
         hasReplyPayloadContent({
@@ -685,6 +766,8 @@ async function deliverOutboundPayloadsCore(
           success: true,
           content: payloadSummary.text,
           messageId: delivery.messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -700,6 +783,8 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -726,6 +811,8 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          conversationId: payloadHookMetadata.conversationId,
+          threadId: payloadHookMetadata.threadId,
         });
         continue;
       }
@@ -755,12 +842,16 @@ async function deliverOutboundPayloadsCore(
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
       });
     } catch (err) {
       emitMessageSent({
         success: false,
         content: payloadSummary.text,
         error: err instanceof Error ? err.message : String(err),
+        conversationId: payloadHookMetadata.conversationId,
+        threadId: payloadHookMetadata.threadId,
       });
       if (!params.bestEffort) {
         throw err;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1702,6 +1702,7 @@ export type PluginHookMessageSentEvent = {
   content: string;
   success: boolean;
   error?: string;
+  metadata?: Record<string, string | number | boolean | undefined>;
 };
 
 // Tool context


### PR DESCRIPTION
## Summary

- Problem: Hook dispatch routes incorrectly in multi-channel setups
- Why it matters: Missed hooks and incorrect delivery
- What changed: Fixed message-hook-mappers routing, channel-resolution, delivery logic
- What did NOT change: Hook registration, channel creation

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Root Cause / Regression History (if applicable)

- Root cause: Channel resolution did not account for multi-channel hook dispatch

## User-visible / Behavior Changes

None — internal routing fix.

## Security Impact (required)

All No.

## Compatibility / Migration

- Backward compatible? Yes

## Failure Recovery (if this breaks)

- Revert commit

## FAQ / Known review points

### Q: inheritSharedRuntimeOptions is no-op?
A: Type definition only. Loader implementation in companion PR (#54094).

### Q: Upstream code changes?
A: Upstream code not modified by this PR.
