### PR TITLE
Discord: log rejected native command deploy failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Marketplace/agents: correct the ClawHub skill URL in agent docs and stream marketplace archive downloads to disk so installs avoid excess memory use and fail cleanly on empty responses. (#54160) Thanks @QuinnH496.
 - Discord/config types: add missing `autoArchiveDuration` to `DiscordGuildChannelConfig` so TypeScript config definitions match the existing schema and runtime support. (#43427) Thanks @davidguttman.
 - Docs/IRC: fix five `json55` code-fence typos in the IRC channel examples so Mintlify applies JSON5 syntax highlighting correctly. (#50842) Thanks @Hollychou924.
+- Discord/commands: trim overlong slash-command descriptions to Discord's 100-character limit and map rejected deploy indexes from Discord validation payloads back to command names/descriptions, so deploys stop failing on long descriptions and startup logs identify the rejected commands. (#54118) thanks @huntharo
 
 ## 2026.3.23
 

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -168,4 +168,36 @@ describe("createDiscordNativeCommand option wiring", () => {
 
     expect(respond).toHaveBeenCalledWith([]);
   });
+
+  it("truncates Discord command and option descriptions to Discord's limit", () => {
+    const longDescription = "x".repeat(140);
+    const cfg = {} as ReturnType<typeof loadConfig>;
+    const discordConfig = {} as NonNullable<OpenClawConfig["channels"]>["discord"];
+    const command = createDiscordNativeCommand({
+      command: {
+        name: "longdesc",
+        description: longDescription,
+        acceptsArgs: true,
+        args: [
+          {
+            name: "input",
+            description: longDescription,
+            type: "string",
+            required: false,
+          },
+        ],
+      },
+      cfg,
+      discordConfig,
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+
+    expect(command.description).toHaveLength(100);
+    expect(command.description).toBe("x".repeat(100));
+    expect(requireOption(command, "input").description).toHaveLength(100);
+    expect(requireOption(command, "input").description).toBe("x".repeat(100));
+  });
 });

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -1,6 +1,31 @@
 import { ChannelType } from "discord-api-types/v10";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, loadConfig } from "../../../../src/config/config.js";
+
+const { logVerboseMock } = vi.hoisted(() => ({
+  logVerboseMock: vi.fn(),
+}));
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    createSubsystemLogger: () => ({
+      child: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: loggerWarnMock,
+      debug: vi.fn(),
+    }),
+    logVerbose: logVerboseMock,
+  };
+});
+
 let listNativeCommandSpecs: typeof import("../../../../src/auto-reply/commands-registry.js").listNativeCommandSpecs;
 let createDiscordNativeCommand: typeof import("./native-command.js").createDiscordNativeCommand;
 let createNoopThreadBindingManager: typeof import("./thread-bindings.js").createNoopThreadBindingManager;
@@ -75,6 +100,11 @@ describe("createDiscordNativeCommand option wiring", () => {
     ({ listNativeCommandSpecs } = await import("../../../../src/auto-reply/commands-registry.js"));
     ({ createDiscordNativeCommand } = await import("./native-command.js"));
     ({ createNoopThreadBindingManager } = await import("./thread-bindings.js"));
+  });
+
+  beforeEach(() => {
+    logVerboseMock.mockReset();
+    loggerWarnMock.mockReset();
   });
 
   it("uses autocomplete for /acp action so inline action values are accepted", async () => {
@@ -199,5 +229,11 @@ describe("createDiscordNativeCommand option wiring", () => {
     expect(command.description).toBe("x".repeat(100));
     expect(requireOption(command, "input").description).toHaveLength(100);
     expect(requireOption(command, "input").description).toBe("x".repeat(100));
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("truncating native command description (command:longdesc)"),
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("truncating native command description (command:longdesc arg:input)"),
+    );
   });
 });

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -81,12 +81,26 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
+// Discord application command and option descriptions are limited to 1-100 chars.
+// https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
 const DISCORD_COMMAND_DESCRIPTION_MAX = 100;
 
-function truncateDiscordCommandDescription(value: string): string {
-  return value.length > DISCORD_COMMAND_DESCRIPTION_MAX
-    ? value.slice(0, DISCORD_COMMAND_DESCRIPTION_MAX)
-    : value;
+function truncateDiscordCommandDescription(params: { value: string; label: string }): string {
+  const { value, label } = params;
+  if (value.length <= DISCORD_COMMAND_DESCRIPTION_MAX) {
+    return value;
+  }
+  log.warn(
+    `discord: truncating native command description (${label}) from ${value.length} to ${DISCORD_COMMAND_DESCRIPTION_MAX}: ${JSON.stringify(value)}`,
+  );
+  return value.slice(0, DISCORD_COMMAND_DESCRIPTION_MAX);
+}
+
+function resolveDiscordCommandLogLabel(command: ChatCommandDefinition): string {
+  if (typeof command.nativeName === "string" && command.nativeName.trim().length > 0) {
+    return command.nativeName;
+  }
+  return command.key;
 }
 
 function resolveDiscordNativeCommandAllowlistAccess(params: {
@@ -131,6 +145,7 @@ function buildDiscordCommandOptions(params: {
   ) => Promise<{ provider?: string; model?: string } | null>;
 }): CommandOptions | undefined {
   const { command, cfg, authorizeChoiceContext, resolveChoiceContext } = params;
+  const commandLabel = resolveDiscordCommandLogLabel(command);
   const args = command.args;
   if (!args || args.length === 0) {
     return undefined;
@@ -140,7 +155,10 @@ function buildDiscordCommandOptions(params: {
     if (arg.type === "number") {
       return {
         name: arg.name,
-        description: truncateDiscordCommandDescription(arg.description),
+        description: truncateDiscordCommandDescription({
+          value: arg.description,
+          label: `command:${commandLabel} arg:${arg.name}`,
+        }),
         type: ApplicationCommandOptionType.Number,
         required,
       };
@@ -148,7 +166,10 @@ function buildDiscordCommandOptions(params: {
     if (arg.type === "boolean") {
       return {
         name: arg.name,
-        description: truncateDiscordCommandDescription(arg.description),
+        description: truncateDiscordCommandDescription({
+          value: arg.description,
+          label: `command:${commandLabel} arg:${arg.name}`,
+        }),
         type: ApplicationCommandOptionType.Boolean,
         required,
       };
@@ -199,7 +220,10 @@ function buildDiscordCommandOptions(params: {
         : undefined;
     return {
       name: arg.name,
-      description: truncateDiscordCommandDescription(arg.description),
+      description: truncateDiscordCommandDescription({
+        value: arg.description,
+        label: `command:${commandLabel} arg:${arg.name}`,
+      }),
       type: ApplicationCommandOptionType.String,
       required,
       choices,
@@ -524,7 +548,10 @@ export function createDiscordNativeCommand(params: {
 
   return new (class extends Command {
     name = command.name;
-    description = truncateDiscordCommandDescription(command.description);
+    description = truncateDiscordCommandDescription({
+      value: command.description,
+      label: `command:${command.name}`,
+    });
     defer = true;
     ephemeral = ephemeralDefault;
     options = options;

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -81,6 +81,13 @@ import { resolveDiscordThreadParentInfo } from "./threading.js";
 
 type DiscordConfig = NonNullable<OpenClawConfig["channels"]>["discord"];
 const log = createSubsystemLogger("discord/native-command");
+const DISCORD_COMMAND_DESCRIPTION_MAX = 100;
+
+function truncateDiscordCommandDescription(value: string): string {
+  return value.length > DISCORD_COMMAND_DESCRIPTION_MAX
+    ? value.slice(0, DISCORD_COMMAND_DESCRIPTION_MAX)
+    : value;
+}
 
 function resolveDiscordNativeCommandAllowlistAccess(params: {
   cfg: OpenClawConfig;
@@ -133,7 +140,7 @@ function buildDiscordCommandOptions(params: {
     if (arg.type === "number") {
       return {
         name: arg.name,
-        description: arg.description,
+        description: truncateDiscordCommandDescription(arg.description),
         type: ApplicationCommandOptionType.Number,
         required,
       };
@@ -141,7 +148,7 @@ function buildDiscordCommandOptions(params: {
     if (arg.type === "boolean") {
       return {
         name: arg.name,
-        description: arg.description,
+        description: truncateDiscordCommandDescription(arg.description),
         type: ApplicationCommandOptionType.Boolean,
         required,
       };
@@ -192,7 +199,7 @@ function buildDiscordCommandOptions(params: {
         : undefined;
     return {
       name: arg.name,
-      description: arg.description,
+      description: truncateDiscordCommandDescription(arg.description),
       type: ApplicationCommandOptionType.String,
       required,
       choices,
@@ -517,7 +524,7 @@ export function createDiscordNativeCommand(params: {
 
   return new (class extends Command {
     name = command.name;
-    description = command.description;
+    description = truncateDiscordCommandDescription(command.description);
     defer = true;
     ephemeral = ephemeralDefault;
     options = options;

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -37,6 +37,7 @@ const {
 } = getProviderMonitorTestMocks();
 
 let monitorDiscordProvider: typeof import("./provider.js").monitorDiscordProvider;
+let providerTesting: typeof import("./provider.js").__testing;
 
 function createConfigWithDiscordAccount(overrides: Record<string, unknown> = {}): OpenClawConfig {
   return {
@@ -129,7 +130,7 @@ describe("monitorDiscordProvider", () => {
     vi.doMock("../token.js", () => ({
       normalizeDiscordToken: (value?: string) => value,
     }));
-    ({ monitorDiscordProvider } = await import("./provider.js"));
+    ({ monitorDiscordProvider, __testing: providerTesting } = await import("./provider.js"));
   });
 
   beforeEach(() => {
@@ -550,6 +551,35 @@ describe("monitorDiscordProvider", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       expect.stringContaining("native command deploy skipped"),
     );
+  });
+
+  it("formats rejected Discord deploy entries with command details", () => {
+    const details = providerTesting.formatDiscordDeployErrorDetails({
+      status: 400,
+      rawBody: {
+        63: ["description"],
+        65: ["description"],
+        66: ["description"],
+        67: ["description"],
+      },
+      deployRequestBody: Array.from({ length: 68 }, (_entry, index) => ({
+        name: `command-${index}`,
+        description: `description-${index}`,
+      })),
+    });
+
+    expect(details).toContain("status=400");
+    expect(details).toContain("rejected=");
+    expect(details).toContain(
+      '#63 fields=description name=command-63 description="description-63"',
+    );
+    expect(details).toContain(
+      '#65 fields=description name=command-65 description="description-65"',
+    );
+    expect(details).toContain(
+      '#66 fields=description name=command-66 description="description-66"',
+    );
+    expect(details).not.toContain("command-67");
   });
 
   it("configures Carbon native deploy by default", async () => {

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -556,11 +556,32 @@ describe("monitorDiscordProvider", () => {
   it("formats rejected Discord deploy entries with command details", () => {
     const details = providerTesting.formatDiscordDeployErrorDetails({
       status: 400,
+      discordCode: 50035,
       rawBody: {
-        63: ["description"],
-        65: ["description"],
-        66: ["description"],
-        67: ["description"],
+        code: 50035,
+        message: "Invalid Form Body",
+        errors: {
+          63: {
+            description: {
+              _errors: [{ code: "BASE_TYPE_MAX_LENGTH", message: "Must be 100 or fewer." }],
+            },
+          },
+          65: {
+            description: {
+              _errors: [{ code: "BASE_TYPE_MAX_LENGTH", message: "Must be 100 or fewer." }],
+            },
+          },
+          66: {
+            description: {
+              _errors: [{ code: "BASE_TYPE_MAX_LENGTH", message: "Must be 100 or fewer." }],
+            },
+          },
+          67: {
+            description: {
+              _errors: [{ code: "BASE_TYPE_MAX_LENGTH", message: "Must be 100 or fewer." }],
+            },
+          },
+        },
       },
       deployRequestBody: Array.from({ length: 68 }, (_entry, index) => ({
         name: `command-${index}`,
@@ -569,6 +590,7 @@ describe("monitorDiscordProvider", () => {
     });
 
     expect(details).toContain("status=400");
+    expect(details).toContain("code=50035");
     expect(details).toContain("rejected=");
     expect(details).toContain(
       '#63 fields=description name=command-63 description="description-63"',

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -312,8 +312,10 @@ async function deployDiscordCommands(params: {
       }
       return result;
     } catch (err) {
+      attachDiscordDeployRequestBody(err, body);
+      const details = formatDiscordDeployErrorDetails(err);
       params.runtime.error?.(
-        `discord startup [${accountId}] deploy-rest:put:error ${Math.max(0, Date.now() - startupStartedAt)}ms path=${path} requestMs=${Date.now() - startedAt} error=${formatErrorMessage(err)}`,
+        `discord startup [${accountId}] deploy-rest:put:error ${Math.max(0, Date.now() - startupStartedAt)}ms path=${path} requestMs=${Date.now() - startedAt} error=${formatErrorMessage(err)}${details}`,
       );
       throw err;
     }
@@ -400,13 +402,100 @@ function logDiscordStartupPhase(params: {
     `discord startup [${params.accountId}] ${params.phase} ${elapsedMs}ms${suffix ? ` ${suffix}` : ""}`,
   );
 }
+
+const DISCORD_DEPLOY_REJECTED_ENTRY_LIMIT = 3;
+
+type DiscordDeployErrorLike = {
+  status?: unknown;
+  discordCode?: unknown;
+  rawBody?: unknown;
+  deployRequestBody?: unknown;
+};
+
+function attachDiscordDeployRequestBody(err: unknown, body: unknown) {
+  if (!err || typeof err !== "object" || body === undefined) {
+    return;
+  }
+  const deployErr = err as DiscordDeployErrorLike;
+  if (deployErr.deployRequestBody === undefined) {
+    deployErr.deployRequestBody = body;
+  }
+}
+
+function stringifyDiscordDeployField(value: unknown): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return inspect(value, { depth: 2, breakLength: 120 });
+  }
+}
+
+function readDiscordDeployRejectedFields(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === "string").slice(0, 6);
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  return Object.keys(value).slice(0, 6);
+}
+
+function formatDiscordRejectedDeployEntries(params: {
+  rawBody: unknown;
+  requestBody: unknown;
+}): string[] {
+  const requestBody = Array.isArray(params.requestBody) ? params.requestBody : null;
+  if (
+    !params.rawBody ||
+    typeof params.rawBody !== "object" ||
+    !requestBody ||
+    requestBody.length === 0
+  ) {
+    return [];
+  }
+  const rawEntries = Object.entries(params.rawBody).filter(([key]) => /^\d+$/.test(key));
+  return rawEntries.slice(0, DISCORD_DEPLOY_REJECTED_ENTRY_LIMIT).flatMap(([key, value]) => {
+    const index = Number.parseInt(key, 10);
+    if (!Number.isFinite(index) || index < 0 || index >= requestBody.length) {
+      return [];
+    }
+    const command = requestBody[index];
+    if (!command || typeof command !== "object") {
+      return [`#${index} fields=${readDiscordDeployRejectedFields(value).join("|") || "unknown"}`];
+    }
+    const payload = command as {
+      name?: unknown;
+      description?: unknown;
+      options?: unknown;
+    };
+    const parts = [
+      `#${index}`,
+      `fields=${readDiscordDeployRejectedFields(value).join("|") || "unknown"}`,
+    ];
+    if (typeof payload.name === "string" && payload.name.trim().length > 0) {
+      parts.push(`name=${payload.name}`);
+    }
+    if (payload.description !== undefined) {
+      parts.push(`description=${stringifyDiscordDeployField(payload.description)}`);
+    }
+    if (Array.isArray(payload.options) && payload.options.length > 0) {
+      parts.push(`options=${payload.options.length}`);
+    }
+    return [parts.join(" ")];
+  });
+}
+
 function formatDiscordDeployErrorDetails(err: unknown): string {
   if (!err || typeof err !== "object") {
     return "";
   }
-  const status = (err as { status?: unknown }).status;
-  const discordCode = (err as { discordCode?: unknown }).discordCode;
-  const rawBody = (err as { rawBody?: unknown }).rawBody;
+  const status = (err as DiscordDeployErrorLike).status;
+  const discordCode = (err as DiscordDeployErrorLike).discordCode;
+  const rawBody = (err as DiscordDeployErrorLike).rawBody;
+  const requestBody = (err as DiscordDeployErrorLike).deployRequestBody;
   const details: string[] = [];
   if (typeof status === "number") {
     details.push(`status=${status}`);
@@ -427,6 +516,10 @@ function formatDiscordDeployErrorDetails(err: unknown): string {
       const trimmed = bodyText.length > maxLen ? `${bodyText.slice(0, maxLen)}...` : bodyText;
       details.push(`body=${trimmed}`);
     }
+  }
+  const rejectedEntries = formatDiscordRejectedDeployEntries({ rawBody, requestBody });
+  if (rejectedEntries.length > 0) {
+    details.push(`rejected=${rejectedEntries.join("; ")}`);
   }
   return details.length > 0 ? ` (${details.join(", ")})` : "";
 }
@@ -1058,4 +1151,5 @@ export const __testing = {
   resolveDefaultGroupPolicy,
   resolveDiscordRestFetch,
   resolveThreadBindingsEnabled: resolveThreadBindingsEnabledForTesting,
+  formatDiscordDeployErrorDetails,
 };

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -443,20 +443,28 @@ function readDiscordDeployRejectedFields(value: unknown): string[] {
   return Object.keys(value).slice(0, 6);
 }
 
+function resolveDiscordRejectedDeployEntriesSource(
+  rawBody: unknown,
+): Record<string, unknown> | null {
+  if (!rawBody || typeof rawBody !== "object") {
+    return null;
+  }
+  const payload = rawBody as { errors?: unknown };
+  const errors = payload.errors && typeof payload.errors === "object" ? payload.errors : undefined;
+  const source = errors ?? rawBody;
+  return source && typeof source === "object" ? (source as Record<string, unknown>) : null;
+}
+
 function formatDiscordRejectedDeployEntries(params: {
   rawBody: unknown;
   requestBody: unknown;
 }): string[] {
   const requestBody = Array.isArray(params.requestBody) ? params.requestBody : null;
-  if (
-    !params.rawBody ||
-    typeof params.rawBody !== "object" ||
-    !requestBody ||
-    requestBody.length === 0
-  ) {
+  const rejectedEntriesSource = resolveDiscordRejectedDeployEntriesSource(params.rawBody);
+  if (!rejectedEntriesSource || !requestBody || requestBody.length === 0) {
     return [];
   }
-  const rawEntries = Object.entries(params.rawBody).filter(([key]) => /^\d+$/.test(key));
+  const rawEntries = Object.entries(rejectedEntriesSource).filter(([key]) => /^\d+$/.test(key));
   return rawEntries.slice(0, DISCORD_DEPLOY_REJECTED_ENTRY_LIMIT).flatMap(([key, value]) => {
     const index = Number.parseInt(key, 10);
     if (!Number.isFinite(index) || index < 0 || index >= requestBody.length) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord native command deploy failures only logged raw numeric rejection indexes like `63` and `65`, which made it hard to tell which commands Discord was rejecting.
- Why it matters: When one Discord-specific limit is exceeded, I need enough logging to identify the offending command without weakening descriptions for every other channel.
- What changed: I now map Discord deploy rejection indexes back to the command payload and log up to three rejected commands with their names/descriptions, and I truncate Discord command/option descriptions to Discord's documented 100-character limit while warning with the exact command or option label that was trimmed.
- What did NOT change (scope boundary): I did not shorten descriptions for non-Discord channels or change general plugin/native command registration behavior outside Discord.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The Discord deploy error path logged Discord's raw validation payload but did not retain the original command body, so numeric rejection keys could not be mapped back to a command name or description. At the same time, Discord command descriptions were passed through unmodified even though Discord caps them at 100 characters.
- Missing detection / guardrail: There was no test ensuring rejected deploy indexes were human-readable, and no guardrail in the Discord command builder for platform-specific description limits.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Existing Discord startup logging already wrapped Carbon's deploy call, but only surfaced `status`, `code`, and raw response body text.
- Why this regressed now: The system started registering a larger set of cross-platform commands, which exposed Discord's stricter description validation without any Discord-specific trimming or useful diagnostics.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/provider.test.ts` and `extensions/discord/src/monitor/native-command.options.test.ts`
- Scenario the test should lock in: Discord deploy error details include the rejected command names/descriptions, and Discord command/option descriptions are truncated with a warning that identifies the affected command or option.
- Why this is the smallest reliable guardrail: Both failures are local to the Discord provider and native command builder and do not require a live Discord connection to validate.
- Existing test that already covers this (if any): None
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Discord startup logs now identify up to three rejected slash commands by name and description when Discord rejects the deploy payload.
- Discord command and option descriptions are truncated to Discord's 100-character limit, and startup logs warn which command or option was trimmed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev environment
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): native Discord commands enabled

### Steps

1. Trigger Discord native command registration with a command payload that exceeds Discord's description limit.
2. Observe the startup deploy error logging and the command descriptions sent through the Discord native command builder.
3. Re-run startup after the fix.

### Expected

- Discord logs identify the rejected command entries clearly enough to find the source command.
- Discord command/option descriptions stay within Discord's 100-character limit.

### Actual

- Before the fix, Discord only logged numeric rejection indexes and raw `description` field failures.
- After the fix, Discord logs the command names/descriptions and trims overlong Discord descriptions before deploy.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified the new provider test maps rejected deploy indexes back to command names/descriptions, the native-command test verifies warning logs include the command and arg labels for truncation, and `pnpm build` passes.
- Edge cases checked: I checked that only Discord descriptions are trimmed and that the rejected-entry formatter caps detail output at three commands.
- What you did **not** verify: I did not run a live Discord deploy against Discord's API in this change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two Discord logging/truncation commits on this branch.
- Files/config to restore: `extensions/discord/src/monitor/provider.ts`, `extensions/discord/src/monitor/provider.test.ts`, `extensions/discord/src/monitor/native-command.ts`, `extensions/discord/src/monitor/native-command.options.test.ts`
- Known bad symptoms reviewers should watch for: Missing Discord command descriptions, missing slash command options, or no truncation warning when overlong descriptions are present.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Discord-only truncation could hide a misconfigured overly long description if warnings are ignored.
  - Mitigation: The startup warning now includes the exact command or option label and the rejected deploy logger includes command names/descriptions.
