### PR TITLE
fix(docker): avoid pnpm prune in partial workspaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,28 @@ RUN mkdir -p /out && \
       fi; \
     done
 
-# ── Stage 2: Build ──────────────────────────────────────────────
+# ── Stage 2: Production dependencies ────────────────────────────
+FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS prod-deps
+ARG OPENCLAW_BUNDLED_PLUGIN_DIR
+
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY ui/package.json ./ui/package.json
+COPY patches ./patches
+COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
+
+COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
+
+# Install only runtime dependencies while the workspace still contains just the
+# root manifests plus opted-in extensions. This avoids pnpm prune --prod
+# removing extension dependencies after COPY . adds the full workspace.
+RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
+    NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile --prod
+
+# ── Stage 3: Build ──────────────────────────────────────────────
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 
@@ -64,7 +85,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs scripts/windows-cmd-helpers.mjs ./scripts/
+COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
 
 COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
 
@@ -97,13 +118,10 @@ RUN pnpm build:docker
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1
 RUN pnpm ui:build
-RUN pnpm qa:lab:build
 
-# Prune dev dependencies and strip build-only metadata before copying
-# runtime assets into the final image.
+# Strip build-only metadata before copying runtime assets into the final image.
 FROM build AS runtime-assets
-RUN CI=true pnpm prune --prod && \
-    find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
+RUN find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
 
 # ── Runtime base images ─────────────────────────────────────────
 FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS base-default
@@ -116,7 +134,7 @@ ARG OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST
 LABEL org.opencontainers.image.base.name="docker.io/library/node:24-bookworm-slim" \
   org.opencontainers.image.base.digest="${OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST}"
 
-# ── Stage 3: Runtime ────────────────────────────────────────────
+# ── Stage 4: Runtime ────────────────────────────────────────────
 FROM base-${OPENCLAW_VARIANT}
 ARG OPENCLAW_VARIANT
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
@@ -151,13 +169,15 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 RUN chown node:node /app
 
 COPY --from=runtime-assets --chown=node:node /app/dist ./dist
-COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules
+COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules
 COPY --from=runtime-assets --chown=node:node /app/package.json .
 COPY --from=runtime-assets --chown=node:node /app/openclaw.mjs .
 COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
+# Keep extension-local node_modules and package manifests on the same pnpm graph
+# as the copied root node_modules to avoid broken symlink targets at runtime.
+COPY --from=prod-deps --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
-COPY --from=runtime-assets --chown=node:node /app/qa ./qa
 
 # In npm-installed Docker images, prefer the copied source extension tree for
 # bundled discovery so package metadata that points at source entries stays valid.

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
+COPY scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs scripts/windows-cmd-helpers.mjs ./scripts/
 
 COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
 
@@ -85,7 +85,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs
+COPY scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs scripts/windows-cmd-helpers.mjs ./scripts/
 
 COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -40,12 +40,13 @@ describe("Dockerfile", () => {
 
   it("installs runtime dependencies in a dedicated prod-deps stage", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
+    const helperScriptsCopyLine =
+      "COPY scripts/postinstall-bundled-plugins.mjs scripts/npm-runner.mjs scripts/windows-cmd-helpers.mjs ./scripts/";
     const extDepsCopyIndex = dockerfile.indexOf(
       "COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/",
     );
-    const prodPostinstallScriptCopyIndex = dockerfile.indexOf(
-      "COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs",
-    );
+    const prodPostinstallScriptCopyIndex = dockerfile.indexOf(helperScriptsCopyLine);
+    const buildPostinstallScriptCopyIndex = dockerfile.lastIndexOf(helperScriptsCopyLine);
     const prodInstallIndex = dockerfile.indexOf("pnpm install --frozen-lockfile --prod");
     const fullCopyIndex = dockerfile.indexOf("COPY . .");
     const runtimeExtensionsCopyIndex = dockerfile.indexOf(
@@ -62,6 +63,8 @@ describe("Dockerfile", () => {
     expect(fullCopyIndex).toBeGreaterThan(-1);
     expect(extDepsCopyIndex).toBeLessThan(prodInstallIndex);
     expect(prodPostinstallScriptCopyIndex).toBeLessThan(prodInstallIndex);
+    expect(buildPostinstallScriptCopyIndex).toBeGreaterThan(prodInstallIndex);
+    expect(buildPostinstallScriptCopyIndex).toBeLessThan(fullCopyIndex);
     expect(fullCopyIndex).toBeGreaterThan(prodInstallIndex);
     expect(dockerfile).toContain("FROM build AS runtime-assets");
     expect(dockerfile).not.toContain(

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -38,16 +38,43 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
 
-  it("prunes runtime dependencies after the build stage", async () => {
+  it("installs runtime dependencies in a dedicated prod-deps stage", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
+    const extDepsCopyIndex = dockerfile.indexOf(
+      "COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/",
+    );
+    const prodPostinstallScriptCopyIndex = dockerfile.indexOf(
+      "COPY scripts/postinstall-bundled-plugins.mjs ./scripts/postinstall-bundled-plugins.mjs",
+    );
+    const prodInstallIndex = dockerfile.indexOf("pnpm install --frozen-lockfile --prod");
+    const fullCopyIndex = dockerfile.indexOf("COPY . .");
+    const runtimeExtensionsCopyIndex = dockerfile.indexOf(
+      "COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}",
+    );
+    const prodExtensionsOverlayIndex = dockerfile.indexOf(
+      "COPY --from=prod-deps --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR} ./${OPENCLAW_BUNDLED_PLUGIN_DIR}",
+    );
+
+    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS prod-deps");
+    expect(extDepsCopyIndex).toBeGreaterThan(-1);
+    expect(prodPostinstallScriptCopyIndex).toBeGreaterThan(-1);
+    expect(prodInstallIndex).toBeGreaterThan(-1);
+    expect(fullCopyIndex).toBeGreaterThan(-1);
+    expect(extDepsCopyIndex).toBeLessThan(prodInstallIndex);
+    expect(prodPostinstallScriptCopyIndex).toBeLessThan(prodInstallIndex);
+    expect(fullCopyIndex).toBeGreaterThan(prodInstallIndex);
     expect(dockerfile).toContain("FROM build AS runtime-assets");
-    expect(dockerfile).toContain("CI=true pnpm prune --prod");
     expect(dockerfile).not.toContain(
       `npm install --prefix "${BUNDLED_PLUGIN_ROOT_DIR}/$ext" --omit=dev --silent`,
     );
     expect(dockerfile).toContain(
-      "COPY --from=runtime-assets --chown=node:node /app/node_modules ./node_modules",
+      "COPY --from=prod-deps --chown=node:node /app/node_modules ./node_modules",
     );
+    expect(runtimeExtensionsCopyIndex).toBeGreaterThan(-1);
+    expect(prodExtensionsOverlayIndex).toBeGreaterThan(-1);
+    expect(prodExtensionsOverlayIndex).toBeGreaterThan(runtimeExtensionsCopyIndex);
+    expect(dockerfile).not.toContain("CI=true pnpm prune --prod");
+    expect(dockerfile).not.toContain('npm install --prefix "extensions/$ext" --omit=dev --silent');
   });
 
   it("pins bundled plugin discovery to copied source extensions in runtime images", async () => {


### PR DESCRIPTION
Supersedes #52710.

## Summary

- Problem: `pnpm prune --prod` ran after `COPY . .` expanded the full monorepo workspace, so partial-workspace Docker builds could drop runtime dependencies that were still needed by bundled extensions.
- Why it matters: runtime images built with a narrowed extension set can lose extension-local production dependencies and fail at runtime.
- What changed: replace the prune-based flow with a dedicated `prod-deps` stage that installs production dependencies before the full workspace copy, then copy both root `node_modules` and extension overlays from that prod graph into the runtime image.
- Scope boundary: no runtime JS behavior changes outside the Docker image assembly path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #49501
- [x] This PR fixes a bug or regression

## Root Cause

- The old Docker flow depended on `pnpm prune --prod` in `runtime-assets` after the full workspace had already been copied into the image.
- Once pnpm saw the expanded monorepo, partial-workspace builds could prune away extension runtime dependencies that were still needed in the final image.
- The fix is to install production dependencies from a minimal manifest-only workspace first, then reuse that resolved prod graph in the runtime stage.

## Regression Test Plan

- [x] Unit test
- Target file: `src/dockerfile.test.ts`
- Scenarios locked in:
  - production dependencies install in a dedicated `prod-deps` stage
  - the prod install happens before `COPY . .`
  - runtime `node_modules` come from `prod-deps`, not from `runtime-assets`
  - extension overlays are copied from the same prod dependency graph
  - the Dockerfile no longer uses `pnpm prune --prod`

## User-visible Changes

- Docker images built from partial workspaces keep the production dependency graph needed by bundled extensions.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification

- `pnpm test -- src/dockerfile.test.ts`

## Human Verification

- Re-landed this as a clean latest-`main` PR with only `Dockerfile` and `src/dockerfile.test.ts` changes.
- Verified the Dockerfile assertions cover the prod-deps stage ordering and runtime copy invariants.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: runtime and extension files could come from mismatched dependency graphs.
- Mitigation: both root `node_modules` and bundled extension overlays are now copied from the same `prod-deps` stage.