### PR TITLE
fix: add 60s timeout to MiniMax VLM fetch call

### DIFF
--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -85,6 +85,7 @@ export async function minimaxUnderstandImage(params: {
       "Content-Type": "application/json",
       "MM-API-Source": "OpenClaw",
     },
+    signal: AbortSignal.timeout(60_000),
     body: JSON.stringify({
       prompt,
       image_url: imageDataUrl,


### PR DESCRIPTION
## Problem
`minimax-vlm.ts` line 81: the VLM image analysis fetch has no timeout, causing sessions to hang indefinitely when the MiniMax API is slow. Other vision/model API calls in the codebase (ollama, opencode-zen, chutes) already use timeouts.

## Fix
Add `signal: AbortSignal.timeout(60_000)` to the fetch call. 60s accounts for large base64 image uploads while preventing infinite hangs.

## Changes
- 1 file, 1 line added

Fixes #54139