### PR TITLE
fix: correct ClawHub URL in system prompt and use streaming download in marketplace

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -166,7 +166,7 @@ function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readT
     "Mirror: https://docs.openclaw.ai",
     "Source: https://github.com/openclaw/openclaw",
     "Community: https://discord.com/invite/clawd",
-    "Find new skills: https://clawhub.com",
+    "Find new skills: https://clawhub.ai",
     "For OpenClaw behavior, commands, config, or architecture: consult local docs first.",
     "When diagnosing issues, run `openclaw status` yourself when possible; only ask the user if you lack access (e.g., sandboxed).",
     "",

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
+import { createWriteStream } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -596,7 +599,8 @@ async function downloadUrlToTempFile(url: string): Promise<
   const fileName = path.basename(pathname) || "plugin.tgz";
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
   const targetPath = path.join(tmpDir, fileName);
-  await fs.writeFile(targetPath, Buffer.from(await response.arrayBuffer()));
+  const fileStream = createWriteStream(targetPath);
+  await pipeline(Readable.fromWeb(response.body), fileStream);
   return {
     ok: true,
     path: targetPath,


### PR DESCRIPTION
## Fixes

### #54154 - Wrong ClawHub URL in system prompt
Changed `clawhub.com` → `clawhub.ai` in `src/agents/system-prompt.ts:169`.

Every agent includes this URL in its system prompt. The correct domain is `clawhub.ai` (confirmed by `src/infra/clawhub.ts:8` and `src/plugins/clawhub.ts:336`).

### #54156 - Marketplace download uses excessive memory
Replaced `Buffer.from(await response.arrayBuffer())` with streaming `pipeline(Readable.fromWeb(response.body), createWriteStream())` in `src/plugins/marketplace.ts:599`.

**Before:** A plugin archive of size N required N bytes of heap + Buffer copy (2x memory).  
**After:** Streaming to disk with constant memory usage.

This matches the pattern already used by `src/agents/skills-install-download.ts` and `src/plugins/signal-cli-install.ts`.

### Not included (for separate PR)
- `src/infra/clawhub.ts:581` and `:619` have the same arrayBuffer pattern but also compute SHA-256 integrity hashes, requiring a more careful streaming + hash approach.