### PR TITLE
fix: Discord: avoid blocking on oversized inbound media

### DIFF
--- a/extensions/matrix/src/matrix/sdk/read-response-with-limit.ts
+++ b/extensions/matrix/src/matrix/sdk/read-response-with-limit.ts
@@ -37,6 +37,10 @@ async function readChunkWithIdleTimeout(
   });
 }
 
+function cancelReaderWithoutAwait(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  void reader.cancel().catch(() => undefined);
+}
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
@@ -74,9 +78,7 @@ export async function readResponseWithLimit(
       if (value?.length) {
         total += value.length;
         if (total > maxBytes) {
-          try {
-            await reader.cancel();
-          } catch {}
+          cancelReaderWithoutAwait(reader);
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -1,6 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
-import { normalizeGoogleApiBaseUrl } from "../infra/google-api-base-url.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   buildAnthropicVertexProvider,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -2,7 +2,6 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ModelDefinitionConfig } from "../../config/types.js";
-import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import {
   clearProviderRuntimeHookCache,
   prepareProviderDynamicModel,

--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -53,6 +53,41 @@ describe("readResponseWithLimit", () => {
     ).rejects.toThrow("custom: 10 > 5");
   });
 
+  it("does not wait for reader cancel before rejecting oversized payloads", async () => {
+    const cancel = vi.fn(() => new Promise<void>(() => {}));
+    const releaseLock = vi.fn();
+    const reader = {
+      read: vi.fn().mockResolvedValueOnce({
+        done: false,
+        value: new Uint8Array([1, 2, 3, 4, 5]),
+      }),
+      cancel,
+      releaseLock,
+    };
+    const res = {
+      body: {
+        getReader: () => reader,
+      },
+    } as unknown as Response;
+
+    const outcome = await Promise.race([
+      readResponseWithLimit(res, 4).then(
+        () => "resolved",
+        (err: unknown) => {
+          expect(String(err)).toMatch(/too large/i);
+          return "rejected";
+        },
+      ),
+      new Promise<"timeout">((resolve) => {
+        setTimeout(() => resolve("timeout"), 50);
+      }),
+    ]);
+
+    expect(outcome).toBe("rejected");
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+  });
+
   it("times out when no new chunk arrives before idle timeout", async () => {
     vi.useFakeTimers();
     try {

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -37,6 +37,10 @@ async function readChunkWithIdleTimeout(
   });
 }
 
+function cancelReaderWithoutAwait(reader: ReadableStreamDefaultReader<Uint8Array>): void {
+  void reader.cancel().catch(() => undefined);
+}
+
 type ReadResponsePrefixResult = {
   buffer: Buffer;
   size: number;
@@ -90,9 +94,7 @@ async function readResponsePrefix(
         }
         size = nextTotal;
         truncated = true;
-        try {
-          await reader.cancel();
-        } catch {}
+        cancelReaderWithoutAwait(reader);
         break;
       }
       chunks.push(value);


### PR DESCRIPTION
AI-assisted: Yes
Testing: Targeted unit test only (`pnpm test -- src/media/read-response-with-limit.test.ts`)

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Oversized Discord inbound attachments could leave the affected inbound channel stuck after the download crossed the configured media size limit.
- Why it matters: After one large image, later messages in the same channel could stop being processed until the gateway was restarted.
- What changed: The shared bounded-response reader now cancels overflowed streams without awaiting `reader.cancel()`, a regression test locks in the non-returning cancel case, and the matching Matrix helper now uses the same non-blocking overflow cleanup.
- What did NOT change (scope boundary): This does not raise media limits, change attachment storage behavior, or change outbound media handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54112
- Related N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `readResponseWithLimit()` awaited `reader.cancel()` on max-bytes overflow. If the underlying stream did not resolve cancel promptly, the inbound job stayed pending.
- Missing detection / guardrail: No regression test covered an overflow path where `reader.cancel()` never resolves.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Discord inbound attachment downloads flow through `fetchRemoteMedia()` into the shared bounded-response reader. The same await-on-cancel pattern also existed in the Matrix SDK copy of that helper.
- Why this regressed now: Large Discord attachments are a common way to hit the overflow branch because Discord inbound media defaults to 8 MB in this path.
- If unknown, what was ruled out: Not a normal HTTP fetch failure path, not media persistence, and not the per-channel queue implementation itself.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/media/read-response-with-limit.test.ts`
- Scenario the test should lock in: Reject immediately on overflow even if `reader.cancel()` never resolves.
- Why this is the smallest reliable guardrail: The bug is in the shared overflow reader logic, so a focused unit test hits the exact stuck path without needing a live Discord setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Oversized Discord inbound attachments now fail fast instead of potentially leaving the affected inbound channel unresponsive.
- No user-facing config or default changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord inbound attachments
- Relevant config (redacted): Default Discord inbound media limit (`channels.discord.mediaMaxMb = 8`)

### Steps

1. Send an image attachment larger than the configured Discord inbound media limit to a Discord channel where OpenClaw is active.
2. Let the inbound media download cross the overflow path in the bounded response reader.
3. Send another message in the same channel.

### Expected

- The oversized attachment should fail gracefully.
- The same channel should continue processing later inbound messages without a restart.

### Actual

- Before this change, the overflow path could leave the channel's inbound processing stuck until the gateway was restarted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm test -- src/media/read-response-with-limit.test.ts`, including the new regression case where `cancel()` never resolves.
- Edge cases checked: In-limit reads, overflow reads, custom overflow errors, and idle timeout behavior.
- What you did **not** verify: I did not run a live end-to-end Discord repro against a real gateway session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR or restore the previous overflow cancellation behavior in the bounded-response reader helpers.
- Files/config to restore: `src/media/read-response-with-limit.ts`, `extensions/matrix/src/matrix/sdk/read-response-with-limit.ts`
- Known bad symptoms reviewers should watch for: Unexpected regressions in bounded media downloads or attachment reads that now abort earlier than expected.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The shared Matrix helper was updated alongside the Discord path without a live Matrix repro.
  - Mitigation: The change is a direct equivalent of the shared fix, preserves overflow semantics, and only removes the blocking wait on cancel.
- Risk: This PR also removes two pre-existing unused imports that were already failing lint on `main`.
  - Mitigation: Those lines are behavior-free cleanup only and were required to let the repo checks pass for this branch.
