### PR TITLE
fix: correct ClawHub URL in system prompt and use streaming download in marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/docx block ordering: preserve the document tree order from `docx.document.convert` when inserting blocks, fixing heading/paragraph/list misordering in newly written Feishu documents. (#40524) Thanks @TaoXieSZ.
 - Agents/cron: suppress the default heartbeat system prompt for cron-triggered embedded runs even when they target non-cron session keys, so cron tasks stop reading `HEARTBEAT.md` and polluting unrelated threads. (#53152) Thanks @Protocol-zero-0.
 - TUI/chat: preserve pending user messages when a slow local run emits an empty final event, but still defer and flush the needed history reload after the newer active run finishes so silent/tool-only runs do not stay incomplete. (#53130) Thanks @joelnishanth.
+- Marketplace/agents: correct the ClawHub skill URL in agent docs and stream marketplace archive downloads to disk so installs avoid excess memory use and fail cleanly on empty responses. (#54160) Thanks @QuinnH496.
 - Gateway/channels: keep channel startup sequential while isolating per-channel boot failures, so one broken channel no longer blocks later channels from starting. (#54215) Thanks @JonathanJing.
 - Docs/IRC: fix five `json55` code-fence typos in the IRC channel examples so Mintlify applies JSON5 syntax highlighting correctly. (#50842) Thanks @Hollychou924.
 - Telegram/forum topics: recover `#General` topic `1` routing when Telegram omits forum metadata, including native commands, interactive callbacks, inbound message context, and fallback error replies. (#53699) thanks @huntharo

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -41,6 +41,7 @@ describe("marketplace plugins", () => {
   afterEach(() => {
     installPluginFromPathMock.mockReset();
     runCommandWithTimeoutMock.mockReset();
+    vi.unstubAllGlobals();
   });
 
   it("lists plugins from a local marketplace root", async () => {
@@ -211,6 +212,39 @@ describe("marketplace plugins", () => {
       pluginId: "frontend-design",
       marketplacePlugin: "frontend-design",
       marketplaceSource: "owner/repo",
+    });
+  });
+
+  it("returns a structured error for archive downloads with an empty response body", async () => {
+    await withTempDir(async (rootDir) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response(null, { status: 200 })),
+      );
+      await fs.mkdir(path.join(rootDir, ".claude-plugin"), { recursive: true });
+      await fs.writeFile(
+        path.join(rootDir, ".claude-plugin", "marketplace.json"),
+        JSON.stringify({
+          plugins: [
+            {
+              name: "frontend-design",
+              source: "https://example.com/frontend-design.tgz",
+            },
+          ],
+        }),
+      );
+
+      const { installPluginFromMarketplace } = await import("./marketplace.js");
+      const result = await installPluginFromMarketplace({
+        marketplace: path.join(rootDir, ".claude-plugin", "marketplace.json"),
+        plugin: "frontend-design",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error: "failed to download https://example.com/frontend-design.tgz: empty response body",
+      });
+      expect(installPluginFromPathMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
+import { createWriteStream } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -596,7 +599,8 @@ async function downloadUrlToTempFile(url: string): Promise<
   const fileName = path.basename(pathname) || "plugin.tgz";
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
   const targetPath = path.join(tmpDir, fileName);
-  await fs.writeFile(targetPath, Buffer.from(await response.arrayBuffer()));
+  const fileStream = createWriteStream(targetPath);
+  await pipeline(Readable.fromWeb(response.body), fileStream);
   return {
     ok: true,
     path: targetPath,

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs/promises";
 import { createWriteStream } from "node:fs";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { Readable } from "node:stream";
-import { pipeline } from "node:stream/promises";
+import { Writable } from "node:stream";
 import { resolveArchiveKind } from "../infra/archive.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -594,13 +593,16 @@ async function downloadUrlToTempFile(url: string): Promise<
   if (!response.ok) {
     return { ok: false, error: `failed to download ${url}: HTTP ${response.status}` };
   }
+  if (!response.body) {
+    return { ok: false, error: `failed to download ${url}: empty response body` };
+  }
 
   const pathname = new URL(url).pathname;
   const fileName = path.basename(pathname) || "plugin.tgz";
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-marketplace-download-"));
   const targetPath = path.join(tmpDir, fileName);
   const fileStream = createWriteStream(targetPath);
-  await pipeline(Readable.fromWeb(response.body), fileStream);
+  await response.body.pipeTo(Writable.toWeb(fileStream));
   return {
     ok: true,
     path: targetPath,


### PR DESCRIPTION
## Fixes

### #54154 - Wrong ClawHub URL in system prompt
Changed `clawhub.com` → `clawhub.ai` in `src/agents/system-prompt.ts:169`.

The correct domain is `clawhub.ai` (confirmed by `src/infra/clawhub.ts:8` and `src/plugins/clawhub.ts:336`).

### #54156 - Marketplace download uses excessive memory
Replaced `Buffer.from(await response.arrayBuffer())` with streaming `pipeline(Readable.fromWeb(response.body), createWriteStream())` in `src/plugins/marketplace.ts`.

**Before:** Plugin archive of size N requires 2x heap memory (arrayBuffer + Buffer copy).
**After:** Streaming to disk with constant memory usage.

Pattern matches `src/agents/skills-install-download.ts`.