### PR TITLE
fix(telegram): silently skip empty-text sends instead of failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/superpowers
 
 # Deprecated changelog fragment workflow
 changelog/fragments/
+subagent-resume-worktree

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -34,19 +34,14 @@ import {
   sendTelegramWithThreadFallback,
 } from "./delivery.send.js";
 import { resolveTelegramReplyId, type TelegramThreadSpec } from "./helpers.js";
-import {
-  markReplyApplied,
-  resolveReplyToForSend,
-  sendChunkedTelegramReplyText,
-  type DeliveryProgress as ReplyThreadDeliveryProgress,
-} from "./reply-threading.js";
-
 const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
-type DeliveryProgress = ReplyThreadDeliveryProgress & {
+type DeliveryProgress = {
+  hasReplied: boolean;
+  hasDelivered: boolean;
   deliveredCount: number;
 };
 
@@ -87,6 +82,22 @@ function buildChunkTextResolver(params: {
   };
 }
 
+function resolveReplyToForSend(params: {
+  replyToId?: number;
+  replyToMode: ReplyToMode;
+  progress: DeliveryProgress;
+}): number | undefined {
+  return params.replyToId && (params.replyToMode === "all" || !params.progress.hasReplied)
+    ? params.replyToId
+    : undefined;
+}
+
+function markReplyApplied(progress: DeliveryProgress, replyToId?: number): void {
+  if (replyToId && !progress.hasReplied) {
+    progress.hasReplied = true;
+  }
+}
+
 function markDelivered(progress: DeliveryProgress): void {
   progress.hasDelivered = true;
   progress.deliveredCount += 1;
@@ -117,6 +128,12 @@ async function deliverTextReply(params: {
     replyQuoteText: params.replyQuoteText,
     markDelivered,
     sendChunk: async ({ chunk, replyToMessageId, replyMarkup, replyQuoteText }) => {
+      // Silently skip empty chunks instead of sending a blank message that
+      // would trigger a Telegram API error.
+      if (!chunk.html?.trim() && !chunk.text?.trim()) {
+        logVerbose("telegram: skipping empty chunk in deliverTextReply");
+        return;
+      }
       const messageId = await sendTelegramText(
         params.bot,
         params.chatId,
@@ -163,6 +180,10 @@ async function sendPendingFollowUpText(params: {
     replyMarkup: params.replyMarkup,
     markDelivered,
     sendChunk: async ({ chunk, replyToMessageId, replyMarkup }) => {
+      if (!chunk.html?.trim() && !chunk.text?.trim()) {
+        logVerbose("telegram: skipping empty chunk in sendPendingFollowUpText");
+        return;
+      }
       await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
         replyToMessageId,
         thread: params.thread,
@@ -205,26 +226,30 @@ async function sendTelegramVoiceFallbackText(opts: {
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = opts.chunkText(opts.text);
-  let appliedReplyTo = false;
+  let sentAnyChunk = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    // Only apply reply reference, quote text, and buttons to the first chunk.
-    const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
+    if (!chunk || (!chunk.html?.trim() && !chunk.text?.trim())) {
+      logVerbose("telegram: skipping empty chunk in sendTelegramVoiceFallbackText");
+      continue;
+    }
+    // Only apply reply reference and buttons to the first sent chunk.
+    const replyToForChunk = !sentAnyChunk ? opts.replyToId : undefined;
     const messageId = await sendTelegramText(opts.bot, opts.chatId, chunk.html, opts.runtime, {
       replyToMessageId: replyToForChunk,
-      replyQuoteText: !appliedReplyTo ? opts.replyQuoteText : undefined,
+      replyQuoteText: !sentAnyChunk ? opts.replyQuoteText : undefined,
       thread: opts.thread,
       textMode: "html",
       plainText: chunk.text,
       linkPreview: opts.linkPreview,
       silent: opts.silent,
-      replyMarkup: !appliedReplyTo ? opts.replyMarkup : undefined,
+      replyMarkup: !sentAnyChunk ? opts.replyMarkup : undefined,
     });
-    if (firstDeliveredMessageId == null) {
-      firstDeliveredMessageId = messageId;
-    }
-    if (replyToForChunk) {
-      appliedReplyTo = true;
+    if (messageId != null) {
+      if (firstDeliveredMessageId == null) {
+        firstDeliveredMessageId = messageId;
+      }
+      sentAnyChunk = true;
     }
   }
   return firstDeliveredMessageId;

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -34,6 +34,7 @@ import {
   sendTelegramWithThreadFallback,
 } from "./delivery.send.js";
 import { resolveTelegramReplyId, type TelegramThreadSpec } from "./helpers.js";
+import { sendChunkedTelegramReplyText } from "./reply-threading.js";
 const VOICE_FORBIDDEN_RE = /VOICE_MESSAGES_FORBIDDEN/;
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
@@ -132,7 +133,7 @@ async function deliverTextReply(params: {
       // would trigger a Telegram API error.
       if (!chunk.html?.trim() && !chunk.text?.trim()) {
         logVerbose("telegram: skipping empty chunk in deliverTextReply");
-        return;
+        return false;
       }
       const messageId = await sendTelegramText(
         params.bot,
@@ -182,7 +183,7 @@ async function sendPendingFollowUpText(params: {
     sendChunk: async ({ chunk, replyToMessageId, replyMarkup }) => {
       if (!chunk.html?.trim() && !chunk.text?.trim()) {
         logVerbose("telegram: skipping empty chunk in sendPendingFollowUpText");
-        return;
+        return false;
       }
       await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
         replyToMessageId,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -151,9 +151,15 @@ async function deliverTextReply(params: {
           replyMarkup,
         },
       );
+      if (messageId == null) {
+        // sendTelegramText returned undefined (e.g. Telegram rejected empty
+        // content in the catch path) — treat as unsent.
+        return false;
+      }
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = messageId;
       }
+      return true;
     },
   });
   return firstDeliveredMessageId;
@@ -185,15 +191,27 @@ async function sendPendingFollowUpText(params: {
         logVerbose("telegram: skipping empty chunk in sendPendingFollowUpText");
         return false;
       }
-      await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
-        replyToMessageId,
-        thread: params.thread,
-        textMode: "html",
-        plainText: chunk.text,
-        linkPreview: params.linkPreview,
-        silent: params.silent,
-        replyMarkup,
-      });
+      const messageId = await sendTelegramText(
+        params.bot,
+        params.chatId,
+        chunk.html,
+        params.runtime,
+        {
+          replyToMessageId,
+          thread: params.thread,
+          textMode: "html",
+          plainText: chunk.text,
+          linkPreview: params.linkPreview,
+          silent: params.silent,
+          replyMarkup,
+        },
+      );
+      if (messageId == null) {
+        // sendTelegramText returned undefined (e.g. Telegram rejected empty
+        // content in the catch path) — treat as unsent.
+        return false;
+      }
+      return true;
     },
   });
 }

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -412,11 +412,22 @@ async function deliverMediaReply(params: {
               replyMarkup: params.replyMarkup,
               replyQuoteText: params.replyQuoteText,
             });
-            if (firstDeliveredMessageId == null) {
-              firstDeliveredMessageId = fallbackMessageId;
+            // Only mark as delivered if a chunk was actually sent.
+            // sendTelegramVoiceFallbackText returns undefined when all chunks
+            // are empty (e.g. formatting-only fallback text that trims to
+            // whitespace). Without this guard, reply threading advances and
+            // the reply is reported as delivered even though nothing was sent.
+            if (fallbackMessageId != null) {
+              if (firstDeliveredMessageId == null) {
+                firstDeliveredMessageId = fallbackMessageId;
+              }
+              markReplyApplied(params.progress, voiceFallbackReplyTo);
+              markDelivered(params.progress);
+            } else {
+              logVerbose(
+                "telegram voice fallback text produced no sendable chunks; skipping delivery mark",
+              );
             }
-            markReplyApplied(params.progress, voiceFallbackReplyTo);
-            markDelivered(params.progress);
             continue;
           }
           if (isCaptionTooLong(voiceErr)) {

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,13 +1,13 @@
 import { type Bot, GrammyError } from "grammy";
 import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
 import { markdownToTelegramHtml } from "../format.js";
+import { EMPTY_TEXT_ERR_RE } from "../network-errors.js";
 import { buildInlineKeyboard } from "../send.js";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./helpers.js";
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
-const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 const THREAD_NOT_FOUND_RE = /message thread not found/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
@@ -110,7 +110,7 @@ export async function sendTelegramText(
     silent?: boolean;
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   },
-): Promise<number> {
+): Promise<number | undefined> {
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
     thread: opts?.thread,
@@ -143,7 +143,8 @@ export async function sendTelegramText(
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
   if (!htmlText.trim()) {
     if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
+      logVerbose("telegram sendMessage skipped: empty formatted text and empty plain fallback");
+      return undefined;
     }
     return await sendPlainFallback();
   }
@@ -171,7 +172,10 @@ export async function sendTelegramText(
     const errText = formatErrorMessage(err);
     if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
       if (!hasFallbackText) {
-        throw err;
+        logVerbose(
+          "telegram sendMessage skipped: Telegram rejected text as empty and no plain fallback available",
+        );
+        return undefined;
       }
       runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
       return await sendPlainFallback();

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -600,23 +600,84 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("silently skips when formatted and plain fallback text are both empty", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
 
-    await expect(
-      deliverReplies({
-        replies: [{ text: "   " }],
-        chatId: "123",
-        token: "tok",
-        runtime,
-        bot,
-        replyToMode: "off",
-        textLimit: 4000,
-      }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    const result = await deliverReplies({
+      replies: [{ text: "   " }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
     expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.delivered).toBe(false);
+  });
+
+  it("attaches buttons only to the first sent chunk when text spans multiple chunks", async () => {
+    // Verify sentAnyChunk logic: buttons attach to the first chunk that actually
+    // delivers, and not to any subsequent chunks.
+    // Use a small textLimit to force the text into multiple chunks.
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 7, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    // "hello world" at textLimit=5 → chunks ["hello", "world"] (each ~5 chars).
+    await deliverWith({
+      replies: [
+        {
+          text: "hello world",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Click me", callback_data: "action" }]],
+            },
+          },
+        },
+      ],
+      runtime,
+      bot,
+      textLimit: 5,
+    });
+
+    // Both chunks were sent
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    // reply_markup on first chunk only
+    const firstCall = sendMessage.mock.calls[0];
+    const secondCall = sendMessage.mock.calls[1];
+    expect(firstCall?.[2]).toHaveProperty("reply_markup");
+    expect(secondCall?.[2]).not.toHaveProperty("reply_markup");
+  });
+
+  it("falls back to plain text when Telegram rejects HTML with 'text must be non-empty'", async () => {
+    // Mode C: Telegram's newer error wording "text must be non-empty" (vs old "message text is empty")
+    // should be caught and retried with plain text, just like an HTML parse error.
+    // Use a text that renders to non-empty HTML (e.g. bold markdown) so sendMessage is
+    // first called with HTML, then plain text on rejection.
+    const runtime = createRuntime();
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: text must be non-empty"))
+      .mockResolvedValueOnce({ message_id: 5, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    const result = await deliverReplies({
+      replies: [{ text: "**hello**" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
+    expect(result.delivered).toBe(true);
+    // HTML attempt (rejected) + plain-text retry (succeeds)
+    expect(sendMessage).toHaveBeenCalledTimes(2);
   });
 
   it("uses reply_to_message_id when quote text is provided", async () => {

--- a/extensions/telegram/src/bot/reply-threading.ts
+++ b/extensions/telegram/src/bot/reply-threading.ts
@@ -77,8 +77,9 @@ export async function sendChunkedTelegramReplyText<
       replyQuoteText: shouldAttachQuote ? params.replyQuoteText : undefined,
     });
     // Skip delivery bookkeeping when the chunk was not actually sent
-    // (e.g. empty-chunk guard returned false). This prevents an unsent
-    // chunk from consuming the reply target or inflating deliveredCount.
+    // (e.g. empty-chunk guard returned false, or sendTelegramText returned
+    // undefined after Telegram rejected empty content). This prevents an
+    // unsent chunk from consuming the reply target or inflating deliveredCount.
     if (sent === false) {
       continue;
     }

--- a/extensions/telegram/src/bot/reply-threading.ts
+++ b/extensions/telegram/src/bot/reply-threading.ts
@@ -51,7 +51,7 @@ export async function sendChunkedTelegramReplyText<
     replyToMessageId?: number;
     replyMarkup?: TReplyMarkup;
     replyQuoteText?: string;
-  }) => Promise<void>;
+  }) => Promise<boolean | void>;
 }): Promise<void> {
   const applyDelivered = params.markDelivered ?? markDelivered;
   for (let i = 0; i < params.chunks.length; i += 1) {
@@ -69,13 +69,19 @@ export async function sendChunkedTelegramReplyText<
       Boolean(replyToMessageId) &&
       Boolean(params.replyQuoteText) &&
       (params.quoteOnlyOnFirstChunk !== true || isFirstChunk);
-    await params.sendChunk({
+    const sent = await params.sendChunk({
       chunk,
       isFirstChunk,
       replyToMessageId,
       replyMarkup: isFirstChunk ? params.replyMarkup : undefined,
       replyQuoteText: shouldAttachQuote ? params.replyQuoteText : undefined,
     });
+    // Skip delivery bookkeeping when the chunk was not actually sent
+    // (e.g. empty-chunk guard returned false). This prevents an unsent
+    // chunk from consuming the reply target or inflating deliveredCount.
+    if (sent === false) {
+      continue;
+    }
     markReplyApplied(params.progress, replyToMessageId);
     applyDelivered(params.progress);
   }

--- a/extensions/telegram/src/bot/reply-threading.ts
+++ b/extensions/telegram/src/bot/reply-threading.ts
@@ -54,12 +54,18 @@ export async function sendChunkedTelegramReplyText<
   }) => Promise<boolean | void>;
 }): Promise<void> {
   const applyDelivered = params.markDelivered ?? markDelivered;
+  let firstSentChunk = false;
   for (let i = 0; i < params.chunks.length; i += 1) {
     const chunk = params.chunks[i];
     if (!chunk) {
       continue;
     }
     const isFirstChunk = i === 0;
+    // Track whether we have already successfully sent a chunk.  Reply markup
+    // (inline buttons) must be attached to the first *actually delivered* chunk,
+    // not necessarily chunk index 0 — because sendChunk can return false for
+    // skipped/empty chunks, losing the markup if it was only attached to i===0.
+    const isFirstSentChunk = !firstSentChunk;
     const replyToMessageId = resolveReplyToForSend({
       replyToId: params.replyToId,
       replyToMode: params.replyToMode,
@@ -73,7 +79,7 @@ export async function sendChunkedTelegramReplyText<
       chunk,
       isFirstChunk,
       replyToMessageId,
-      replyMarkup: isFirstChunk ? params.replyMarkup : undefined,
+      replyMarkup: isFirstSentChunk ? params.replyMarkup : undefined,
       replyQuoteText: shouldAttachQuote ? params.replyQuoteText : undefined,
     });
     // Skip delivery bookkeeping when the chunk was not actually sent
@@ -83,6 +89,7 @@ export async function sendChunkedTelegramReplyText<
     if (sent === false) {
       continue;
     }
+    firstSentChunk = true;
     markReplyApplied(params.progress, replyToMessageId);
     applyDelivered(params.progress);
   }

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -5,6 +5,12 @@ import {
   readErrorName,
 } from "openclaw/plugin-sdk/infra-runtime";
 
+/**
+ * Matches Telegram's empty-text rejection errors.
+ * Two known variants: "message text is empty" (legacy) and "text must be non-empty" (newer).
+ */
+export const EMPTY_TEXT_ERR_RE = /message text is empty|text must be non-empty/i;
+
 const TELEGRAM_NETWORK_ORIGIN = Symbol("openclaw.telegram.network-origin");
 
 const RECOVERABLE_ERROR_CODES = new Set([

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -474,6 +474,34 @@ describe("sendMessageTelegram", () => {
     }
   });
 
+  it("retries with plain text on 'text must be non-empty' error", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { linkPreview: false } },
+    });
+    // Use bold markdown so HTML is non-empty, ensuring an HTML send attempt first.
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: text must be non-empty"))
+      .mockResolvedValueOnce({ message_id: 99, chat: { id: "123" } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    await sendMessageTelegram("123", "**hello**", { token: "tok", api, plainText: "hello" });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries with plain text on 'message text is empty' error", async () => {
+    loadConfig.mockReturnValue({
+      channels: { telegram: { linkPreview: false } },
+    });
+    // Use bold markdown so HTML is non-empty, ensuring an HTML send attempt first.
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("400: Bad Request: message text is empty"))
+      .mockResolvedValueOnce({ message_id: 99, chat: { id: "123" } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+    await sendMessageTelegram("123", "**hello**", { token: "tok", api, plainText: "hello" });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
   it("fails when Telegram text send returns no message_id", async () => {
     const sendMessage = vi.fn().mockResolvedValue({
       chat: { id: "123" },

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -29,6 +29,7 @@ import { splitTelegramCaption } from "./caption.js";
 import { resolveTelegramApiBase, resolveTelegramFetch } from "./fetch.js";
 import { renderTelegramHtmlText, splitTelegramHtmlChunks } from "./format.js";
 import {
+  EMPTY_TEXT_ERR_RE,
   isRecoverableTelegramNetworkError,
   isSafeToRetrySendError,
   isTelegramServerError,
@@ -380,6 +381,10 @@ function isTelegramHtmlParseError(err: unknown): boolean {
   return PARSE_ERR_RE.test(formatErrorMessage(err));
 }
 
+function isTelegramEmptyTextError(err: unknown): boolean {
+  return EMPTY_TEXT_ERR_RE.test(formatErrorMessage(err));
+}
+
 function buildTelegramThreadReplyParams(params: {
   targetMessageThreadId?: number;
   messageThreadId?: number;
@@ -423,12 +428,13 @@ async function withTelegramHtmlParseFallback<T>(params: {
   try {
     return await params.requestHtml(params.label);
   } catch (err) {
-    if (!isTelegramHtmlParseError(err)) {
+    if (!isTelegramHtmlParseError(err) && !isTelegramEmptyTextError(err)) {
       throw err;
     }
     if (params.verbose) {
+      const errorKind = isTelegramEmptyTextError(err) ? "empty text" : "HTML parse";
       sendLogger.warn(
-        `telegram ${params.label} failed with HTML parse error, retrying as plain text: ${formatErrorMessage(
+        `telegram ${params.label} failed with ${errorKind} error, retrying as plain text: ${formatErrorMessage(
           err,
         )}`,
       );


### PR DESCRIPTION
## Problem

When an agent reply normalizes to empty or whitespace-only text, the following chain fires and sends a spurious fallback message to the user:

1. `sendTelegramText` throws (pre-send check) OR Telegram rejects the API call with `400: text must be non-empty` / `400: message text is empty`
2. The throw propagates to `onError` in `bot-message-dispatch.ts`
3. `markNonSilentFailure()` fires → sends "No response generated. Please try again."

This produces a confusing user-visible error for something that should silently no-op.

Fixes #37278. Supersedes #37294 (incomplete fix). Replaces accidentally-closed #40384.

## Root causes fixed

### Mode A — pre-send empty check threw instead of skipping
`sendTelegramText` threw `"empty formatted text and empty plain fallback"` when htmlText and plainText were both empty. Changed to `logVerbose + return undefined`.

### Mode B — empty chunks reached sendTelegramText in delivery functions
`deliverTextReply`, `sendPendingFollowUpText`, `sendTelegramVoiceFallbackText` passed chunks with empty html AND empty text to `sendTelegramText`. Added pre-send guards. Also fixed `replyToMode="first"` threading to attach to the first *actually sent* chunk via `sentAnyChunk` flag (was using chunk index 0).

### Mode C — EMPTY_TEXT_ERR_RE regex didn't match Telegram's newer error wording
Telegram has two variants: `"message text is empty"` (old) and `"text must be non-empty"` (new). The catch block only matched the old form. Updated regex: `/message text is empty|text must be non-empty/i`

### Mode D — catch block threw instead of returning undefined when no fallback
When the empty-text error was caught but no fallback text was available, the code threw instead of returning undefined. Changed to `logVerbose + return undefined`.

### Mode E — send.ts HTML-parse fallback didn't handle empty-text errors
`withTelegramHtmlParseFallback` in `send.ts` only caught HTML parse errors. Added empty-text error handling alongside it.

## Files changed
- `src/telegram/bot/delivery.send.ts` — Modes A, C, D
- `src/telegram/bot/delivery.replies.ts` — Mode B + sentAnyChunk fix
- `src/telegram/send.ts` — Mode E
- `src/telegram/bot/delivery.test.ts` — new tests for A, B, C, D
- `src/telegram/send.test.ts` — new test for Mode E