### PR TITLE
fix(slack): skip block-path send when HEARTBEAT_OK shouldSkip is true

### DIFF
--- a/extensions/slack/src/monitor/replies.heartbeat.test.ts
+++ b/extensions/slack/src/monitor/replies.heartbeat.test.ts
@@ -62,6 +62,58 @@ describe("deliverReplies HEARTBEAT_OK safety-net", () => {
     expect(sendMock).toHaveBeenCalledWith("C123", "Hello, how can I help?", expect.any(Object));
   });
 
+  it("skips block-path message entirely when HEARTBEAT_OK shouldSkip is true", async () => {
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "HEARTBEAT_OK",
+            channelData: {
+              slack: {
+                blocks: [
+                  {
+                    type: "rich_text",
+                    elements: [
+                      {
+                        type: "rich_text_section",
+                        elements: [{ type: "text", text: "HEARTBEAT_OK" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }),
+    );
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("delivers block-path message when text has HEARTBEAT_OK mixed with real content", async () => {
+    await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "HEARTBEAT_OK Here is a real reply",
+            channelData: {
+              slack: {
+                blocks: [
+                  { type: "section", text: { type: "mrkdwn", text: "Here is a real reply" } },
+                ],
+              },
+            },
+          },
+        ],
+      }),
+    );
+    expect(sendMock).toHaveBeenCalledWith(
+      "C123",
+      expect.not.stringContaining("HEARTBEAT_OK"),
+      expect.objectContaining({ blocks: expect.any(Array) }),
+    );
+  });
+
   it("still delivers media when HEARTBEAT_OK text is stripped", async () => {
     await deliverReplies(
       baseParams({

--- a/extensions/slack/src/monitor/replies.heartbeat.test.ts
+++ b/extensions/slack/src/monitor/replies.heartbeat.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMock = vi.fn();
+vi.mock("../send.js", () => ({
+  sendMessageSlack: (...args: unknown[]) => sendMock(...args),
+}));
+
+import { deliverReplies } from "./replies.js";
+
+function baseParams(overrides?: Record<string, unknown>) {
+  return {
+    replies: [{ text: "hello" }],
+    target: "C123",
+    token: "xoxb-test",
+    runtime: { log: () => {}, error: () => {}, exit: () => {} },
+    textLimit: 4000,
+    replyToMode: "off" as const,
+    ...overrides,
+  };
+}
+
+describe("deliverReplies HEARTBEAT_OK safety-net", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue(undefined);
+  });
+
+  it("strips messages that are exactly 'HEARTBEAT_OK'", async () => {
+    await deliverReplies(baseParams({ replies: [{ text: "HEARTBEAT_OK" }] }));
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("strips messages that are 'HEARTBEAT_OK' with surrounding whitespace", async () => {
+    await deliverReplies(baseParams({ replies: [{ text: "  HEARTBEAT_OK  " }] }));
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("strips HEARTBEAT_OK from messages with surrounding content", async () => {
+    await deliverReplies(
+      baseParams({ replies: [{ text: "HEARTBEAT_OK Here is some other text" }] }),
+    );
+    expect(sendMock).toHaveBeenCalledWith(
+      "C123",
+      expect.not.stringContaining("HEARTBEAT_OK"),
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages containing the word 'heartbeat'", async () => {
+    await deliverReplies(
+      baseParams({ replies: [{ text: "The heartbeat check passed successfully" }] }),
+    );
+    expect(sendMock).toHaveBeenCalledWith(
+      "C123",
+      "The heartbeat check passed successfully",
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages", async () => {
+    await deliverReplies(baseParams({ replies: [{ text: "Hello, how can I help?" }] }));
+    expect(sendMock).toHaveBeenCalledWith("C123", "Hello, how can I help?", expect.any(Object));
+  });
+
+  it("still delivers media when HEARTBEAT_OK text is stripped", async () => {
+    await deliverReplies(
+      baseParams({
+        replies: [{ text: "HEARTBEAT_OK", mediaUrls: ["https://example.com/image.png"] }],
+      }),
+    );
+    expect(sendMock).toHaveBeenCalled();
+  });
+});

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -64,7 +64,10 @@ export async function deliverReplies(params: {
       let effectiveText = trimmed;
       if (effectiveText && effectiveText.includes(HEARTBEAT_TOKEN)) {
         const stripped = stripHeartbeatToken(effectiveText, { mode: "message" });
-        effectiveText = stripped.shouldSkip ? "" : stripped.text;
+        if (stripped.shouldSkip) {
+          continue;
+        }
+        effectiveText = stripped.text;
       }
       await sendMessageSlack(params.target, effectiveText, {
         token: params.token,

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -6,7 +6,12 @@ import {
 import type { ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-runtime";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  HEARTBEAT_TOKEN,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  stripHeartbeatToken,
+} from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { parseSlackBlocksInput } from "../blocks-input.js";
@@ -55,7 +60,13 @@ export async function deliverReplies(params: {
       if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
-      await sendMessageSlack(params.target, trimmed, {
+      // Safety-net: strip stray HEARTBEAT_OK tokens that escaped upstream normalization.
+      let effectiveText = trimmed;
+      if (effectiveText && effectiveText.includes(HEARTBEAT_TOKEN)) {
+        const stripped = stripHeartbeatToken(effectiveText, { mode: "message" });
+        effectiveText = stripped.shouldSkip ? "" : stripped.text;
+      }
+      await sendMessageSlack(params.target, effectiveText, {
         token: params.token,
         threadTs,
         accountId: params.accountId,
@@ -74,6 +85,14 @@ export async function deliverReplies(params: {
             const trimmed = value.trim();
             if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
               return [];
+            }
+            // Safety-net: strip stray HEARTBEAT_OK tokens that escaped upstream normalization.
+            if (trimmed.includes(HEARTBEAT_TOKEN)) {
+              const stripped = stripHeartbeatToken(trimmed, { mode: "message" });
+              if (stripped.shouldSkip) {
+                return [];
+              }
+              return [stripped.text];
             }
             return [trimmed];
           }

--- a/extensions/slack/src/outbound-adapter.heartbeat.test.ts
+++ b/extensions/slack/src/outbound-adapter.heartbeat.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner: vi.fn().mockReturnValue(null),
+}));
+
+import { slackOutbound } from "./outbound-adapter.js";
+
+function requireSendText() {
+  const sendText = slackOutbound.sendText;
+  if (!sendText) {
+    throw new Error("slackOutbound.sendText unavailable");
+  }
+  return sendText;
+}
+
+function baseSendParams(text: string, extra?: Record<string, unknown>) {
+  const sendSlack = vi.fn().mockResolvedValue({ messageId: "m1", channelId: "C123" });
+  return {
+    params: {
+      cfg: {},
+      to: "C123",
+      text,
+      accountId: "default",
+      deps: { sendSlack },
+      ...extra,
+    },
+    sendSlack,
+  };
+}
+
+describe("slack outbound HEARTBEAT_OK safety-net", () => {
+  it("strips messages that are exactly 'HEARTBEAT_OK'", async () => {
+    const { params, sendSlack } = baseSendParams("HEARTBEAT_OK");
+    const result = await requireSendText()(params);
+    expect(sendSlack).not.toHaveBeenCalled();
+    expect(result.channel).toBe("slack");
+  });
+
+  it("strips messages that are 'HEARTBEAT_OK' with surrounding whitespace", async () => {
+    const { params, sendSlack } = baseSendParams("  HEARTBEAT_OK  ");
+    const result = await requireSendText()(params);
+    expect(sendSlack).not.toHaveBeenCalled();
+    expect(result.channel).toBe("slack");
+  });
+
+  it("strips HEARTBEAT_OK from messages with surrounding content", async () => {
+    const { params, sendSlack } = baseSendParams("HEARTBEAT_OK Here is some other text");
+    await requireSendText()(params);
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      expect.not.stringContaining("HEARTBEAT_OK"),
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages containing the word 'heartbeat'", async () => {
+    const { params, sendSlack } = baseSendParams("The heartbeat check passed successfully");
+    await requireSendText()(params);
+    expect(sendSlack).toHaveBeenCalledWith(
+      "C123",
+      "The heartbeat check passed successfully",
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT strip normal messages", async () => {
+    const { params, sendSlack } = baseSendParams("Hello, how can I help?");
+    await requireSendText()(params);
+    expect(sendSlack).toHaveBeenCalledWith("C123", "Hello, how can I help?", expect.any(Object));
+  });
+});

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -17,6 +17,7 @@ import {
   sendPayloadMediaSequenceAndFinalize,
   sendTextMediaPayload,
 } from "openclaw/plugin-sdk/reply-payload";
+import { HEARTBEAT_TOKEN, stripHeartbeatToken } from "openclaw/plugin-sdk/reply-runtime";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { buildSlackInteractiveBlocks, type SlackBlock } from "./blocks-render.js";
 import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
@@ -108,8 +109,22 @@ async function sendSlackOutboundMessage(params: {
     };
   }
 
+  // Safety-net: strip stray HEARTBEAT_OK tokens that escaped upstream normalization.
+  let finalText = hookResult.text;
+  if (finalText.includes(HEARTBEAT_TOKEN)) {
+    const stripped = stripHeartbeatToken(finalText, { mode: "message" });
+    if (stripped.shouldSkip && !params.mediaUrl) {
+      return {
+        messageId: "heartbeat-stripped",
+        channelId: params.to,
+        meta: { heartbeatStripped: true },
+      };
+    }
+    finalText = stripped.text;
+  }
+
   const slackIdentity = resolveSlackSendIdentity(params.identity);
-  const result = await send(params.to, hookResult.text, {
+  const result = await send(params.to, finalText, {
     cfg: params.cfg,
     threadTs,
     accountId: params.accountId ?? undefined,

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -5,6 +5,7 @@ import {
   abortEmbeddedPiRun,
   clearActiveEmbeddedRun,
   getActiveEmbeddedRunSnapshot,
+  queueEmbeddedPiMessage,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
   waitForActiveEmbeddedRuns,
@@ -139,5 +140,61 @@ describe("pi-embedded runner run registry", () => {
 
     clearActiveEmbeddedRun("session-snapshot", handle);
     expect(getActiveEmbeddedRunSnapshot("session-snapshot")).toBeUndefined();
+  });
+});
+
+describe("queueEmbeddedPiMessage", () => {
+  afterEach(() => {
+    __testing.resetActiveEmbeddedRuns();
+  });
+
+  function createQueueableHandle(
+    overrides: { isCompacting?: boolean; isStreaming?: boolean } = {},
+  ): RunHandle & { queueMessageSpy: ReturnType<typeof vi.fn> } {
+    const queueMessageSpy = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+    return {
+      queueMessage: queueMessageSpy,
+      isStreaming: () => overrides.isStreaming ?? true,
+      isCompacting: () => overrides.isCompacting ?? false,
+      abort: () => {},
+      queueMessageSpy,
+    };
+  }
+
+  it("returns false when no active run exists for the session", () => {
+    const result = queueEmbeddedPiMessage("no-such-session", "hello");
+    expect(result).toBe(false);
+  });
+
+  it("queues message when session is active but NOT streaming (original bug case)", () => {
+    // Simulates the between-turns state that was previously blocked by the
+    // removed isStreaming guard.
+    const handle = createQueueableHandle({ isStreaming: false });
+    setActiveEmbeddedRun("session-not-streaming", handle);
+
+    const result = queueEmbeddedPiMessage("session-not-streaming", "steer message");
+
+    expect(result).toBe(true);
+    expect(handle.queueMessageSpy).toHaveBeenCalledWith("steer message");
+  });
+
+  it("returns false when session is active but compacting", () => {
+    const handle = createQueueableHandle({ isCompacting: true });
+    setActiveEmbeddedRun("session-compacting", handle);
+
+    const result = queueEmbeddedPiMessage("session-compacting", "steer message");
+
+    expect(result).toBe(false);
+    expect(handle.queueMessageSpy).not.toHaveBeenCalled();
+  });
+
+  it("queues message when session is active and streaming (not compacting)", () => {
+    const handle = createQueueableHandle();
+    setActiveEmbeddedRun("session-streaming", handle);
+
+    const result = queueEmbeddedPiMessage("session-streaming", "steer message");
+
+    expect(result).toBe(true);
+    expect(handle.queueMessageSpy).toHaveBeenCalledWith("steer message");
   });
 });

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -44,10 +44,6 @@ export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean
     diag.debug(`queue message failed: sessionId=${sessionId} reason=no_active_run`);
     return false;
   }
-  if (!handle.isStreaming()) {
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=not_streaming`);
-    return false;
-  }
   if (handle.isCompacting()) {
     diag.debug(`queue message failed: sessionId=${sessionId} reason=compacting`);
     return false;

--- a/src/auto-reply/reply/agent-runner.steer-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner.steer-guard.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the steer guard in runReplyAgent — verifies that steer mode
+ * message injection uses `isActive` (not `isStreaming`) to decide whether
+ * to inject a steer message into an already-running agent session.
+ *
+ * Covers the fix for issue #48003 / PR #52351.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+const runEmbeddedPiAgentMock = vi.fn();
+const runCliAgentMock = vi.fn();
+const runWithModelFallbackMock = vi.fn();
+const queueEmbeddedPiMessageMock = vi.fn();
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(),
+  getOAuthProviders: vi.fn().mockReturnValue([]),
+  refreshOAuthApiKey: vi.fn(),
+}));
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string) => Promise<unknown>;
+  }) => runWithModelFallbackMock(params),
+}));
+
+vi.mock("../../agents/pi-embedded.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/pi-embedded.js")>(
+    "../../agents/pi-embedded.js",
+  );
+  return {
+    ...actual,
+    queueEmbeddedPiMessage: (...args: unknown[]) => queueEmbeddedPiMessageMock(...args),
+    runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
+  };
+});
+
+vi.mock("../../agents/cli-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("../../agents/cli-runner.js")>(
+    "../../agents/cli-runner.js",
+  );
+  return {
+    ...actual,
+    runCliAgent: (params: unknown) => runCliAgentMock(params),
+  };
+});
+
+vi.mock("../../runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../runtime.js")>("../../runtime.js");
+  return {
+    ...actual,
+    defaultRuntime: {
+      ...actual.defaultRuntime,
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
+  };
+});
+
+vi.mock("./queue.js", async () => {
+  const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
+  return {
+    ...actual,
+    enqueueFollowupRun: vi.fn(),
+    scheduleFollowupDrain: vi.fn(),
+  };
+});
+
+const loadCronStoreMock = vi.fn();
+vi.mock("../../cron/store.js", async () => {
+  const actual = await vi.importActual<typeof import("../../cron/store.js")>("../../cron/store.js");
+  return {
+    ...actual,
+    loadCronStore: (...args: unknown[]) => loadCronStoreMock(...args),
+  };
+});
+
+import { runReplyAgent } from "./agent-runner.js";
+
+type RunWithModelFallbackParams = {
+  provider: string;
+  model: string;
+  run: (provider: string, model: string) => Promise<unknown>;
+};
+
+beforeEach(() => {
+  runEmbeddedPiAgentMock.mockClear();
+  runCliAgentMock.mockClear();
+  runWithModelFallbackMock.mockClear();
+  queueEmbeddedPiMessageMock.mockClear();
+  loadCronStoreMock.mockClear();
+  loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+
+  runWithModelFallbackMock.mockImplementation(
+    async ({ provider, model, run }: RunWithModelFallbackParams) => ({
+      result: await run(provider, model),
+      provider,
+      model,
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("runReplyAgent steer mode message injection", () => {
+  function createSteerRun(params: {
+    shouldSteer: boolean;
+    isActive: boolean;
+    isStreaming?: boolean;
+    shouldFollowup?: boolean;
+    queueEmbeddedResult?: boolean;
+  }) {
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "webchat",
+      OriginatingTo: "session:steer",
+      AccountId: "primary",
+      MessageSid: "msg-steer",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "steer" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "steer this",
+      summaryLine: "steer this",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session-steer",
+        sessionKey: "main",
+        messageProvider: "webchat",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: { enabled: false, allowed: false, defaultLevel: "off" },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    queueEmbeddedPiMessageMock.mockReturnValue(params.queueEmbeddedResult ?? false);
+
+    return {
+      promise: runReplyAgent({
+        commandBody: "steer this",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: params.shouldSteer,
+        shouldFollowup: params.shouldFollowup ?? false,
+        isActive: params.isActive,
+        isStreaming: params.isStreaming ?? false,
+        typing,
+        sessionCtx,
+        defaultModel: "anthropic/claude",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      }),
+      typing,
+    };
+  }
+
+  it("injects steer message when shouldSteer=true AND isActive=true", async () => {
+    const { promise, typing } = createSteerRun({
+      shouldSteer: true,
+      isActive: true,
+      queueEmbeddedResult: true,
+    });
+
+    const result = await promise;
+
+    expect(queueEmbeddedPiMessageMock).toHaveBeenCalledWith("session-steer", "steer this");
+    // When steered successfully and shouldFollowup=false, returns undefined (early exit).
+    expect(result).toBeUndefined();
+    expect(typing.cleanup).toHaveBeenCalled();
+  });
+
+  it("does NOT inject steer message when shouldSteer=true AND isActive=false", async () => {
+    // When isActive is false, the steer guard is skipped entirely and the
+    // agent proceeds to a full run.
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const { promise } = createSteerRun({
+      shouldSteer: true,
+      isActive: false,
+    });
+
+    const result = await promise;
+
+    expect(queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  it("does NOT inject steer message when shouldSteer=false", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const { promise } = createSteerRun({
+      shouldSteer: false,
+      isActive: true,
+    });
+
+    await promise;
+
+    expect(queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -98,7 +98,7 @@ export async function runReplyAgent(params: {
     shouldSteer,
     shouldFollowup,
     isActive,
-    isStreaming,
+    isStreaming: _isStreaming,
     opts,
     typing,
     sessionEntry,
@@ -193,7 +193,7 @@ export async function runReplyAgent(params: {
     }
   };
 
-  if (shouldSteer && isStreaming) {
+  if (shouldSteer && isActive) {
     const steered = queueEmbeddedPiMessage(followupRun.run.sessionId, followupRun.prompt);
     if (steered && !shouldFollowup) {
       await touchActiveSessionEntry();


### PR DESCRIPTION
Fixes op-3p6: HEARTBEAT_OK leak where block path skips text but still sends Slack blocks.

When `stripped.shouldSkip` is true on the block path, the message was still being sent with original Slack blocks containing HEARTBEAT_OK as rich_text. Added `continue` after the shouldSkip check to skip the send entirely.

## Changes
- Skip block-path send when HEARTBEAT_OK shouldSkip is true
- HEARTBEAT_OK responses no longer appear in Slack channels or DMs
- Existing non-heartbeat block messages unaffected

Follow-up to op-na9 / GitHub #52370

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>