### PR TITLE
feat(gateway): queue inbound messages during drain and recover interrupted turns on restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/superpowers
 
 # Deprecated changelog fragment workflow
 changelog/fragments/
+subagent-resume-worktree

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -19,7 +19,9 @@ import { resolveDiscordPreviewStreamMode } from "openclaw/plugin-sdk/config-runt
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import { writePendingInbound } from "openclaw/plugin-sdk/infra-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { isGatewayDraining } from "openclaw/plugin-sdk/process-runtime";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -33,6 +35,8 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { warn as logWarn } from "openclaw/plugin-sdk/runtime-env";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-runtime";
@@ -54,7 +58,11 @@ import {
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
-import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
+import {
+  resolveDiscordAutoThreadContext,
+  resolveDiscordAutoThreadReplyPlan,
+  resolveDiscordThreadStarter,
+} from "./threading.js";
 import { sendTyping } from "./typing.js";
 
 function sleep(ms: number): Promise<void> {
@@ -126,6 +134,72 @@ export async function processDiscordMessage(
     abortSignal,
   } = ctx;
   if (isProcessAborted(abortSignal)) {
+    return;
+  }
+
+  // Resolve the session key using the same chain as normal message routing so
+  // that drain-captured entries replay into the correct session after restart.
+  // threadKeys and autoThreadContext are computed synchronously here; since
+  // autoThreadContext requires an async Discord API call (thread creation) that
+  // we cannot make during drain, it evaluates to null and its SessionKey slot
+  // falls through to threadKeys.sessionKey ?? baseSessionKey.
+  const drainParentSessionKey = threadParentId
+    ? buildAgentSessionKey({
+        agentId: route.agentId,
+        channel: route.channel,
+        peer: { kind: "channel", id: threadParentId },
+      })
+    : undefined;
+  const drainThreadKeys = resolveThreadSessionKeys({
+    baseSessionKey,
+    threadId: threadChannel ? messageChannelId : undefined,
+    parentSessionKey: drainParentSessionKey,
+    useSuffix: false,
+  });
+  const drainAutoThreadContext = resolveDiscordAutoThreadContext({
+    agentId: route.agentId,
+    channel: route.channel,
+    messageChannelId,
+    // No createdThreadId at drain time — thread creation is skipped during drain.
+    createdThreadId: undefined,
+  });
+
+  // Drain guard: persist authorized messages for replay after restart.
+  // Auth was already verified in the preflight step (message-handler.preflight.ts) —
+  // unauthorized messages return null from preflight and never reach this function.
+  // Only messages that passed DM policy, guild allowlist, channel config, and
+  // member access checks are persisted here.
+  if (isGatewayDraining()) {
+    if (!messageText) {
+      logVerbose("discord: skip drain capture for message " + message.id + " (no routable text)");
+      return;
+    }
+    const stateDir = resolveStateDir(process.env);
+    const drainAccepted = await writePendingInbound(stateDir, {
+      channel: "discord",
+      id: String(message.id ?? Date.now()),
+      accountId,
+      payload: {
+        channelId: messageChannelId,
+        messageId: message.id,
+        text: messageText,
+        senderId: sender.id,
+        senderName: sender.name ?? author.username,
+        isGuild: isGuildMessage,
+        isDirect: isDirectMessage,
+      },
+      capturedAt: Date.now(),
+      sessionKey:
+        boundSessionKey ??
+        drainAutoThreadContext?.SessionKey ??
+        drainThreadKeys.sessionKey ??
+        baseSessionKey,
+    });
+    if (!drainAccepted) {
+      logWarn(
+        `discord: drain capture rejected for message ${message.id} (pending-inbound store at capacity)`,
+      );
+    }
     return;
   }
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,18 +1,12 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
-import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
-import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
-import {
-  createInboundDebouncer,
-  resolveInboundDebounceMs,
-} from "openclaw/plugin-sdk/channel-inbound";
-import {
-  buildCommandsMessagePaginated,
-  buildCommandsPaginationKeyboard,
-  formatModelsAvailableHeader,
-  resolveStoredModelOverride,
-} from "openclaw/plugin-sdk/command-auth";
+import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-runtime";
+import { resolveMentionGatingWithBypass } from "openclaw/plugin-sdk/channel-runtime";
+import { resolveControlCommandGate } from "openclaw/plugin-sdk/channel-runtime";
+import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-runtime";
+import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import { writeConfigFile } from "openclaw/plugin-sdk/config-runtime";
 import {
   loadSessionStore,
@@ -31,12 +25,33 @@ import {
   parsePluginBindingApprovalCustomId,
   resolvePluginConversationBindingApproval,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
+// Drain-queue internals not yet in plugin-sdk — import directly from src.
+import { writePendingInbound } from "openclaw/plugin-sdk/infra-runtime";
 import { dispatchPluginInteractiveHandler } from "openclaw/plugin-sdk/plugin-runtime";
+import { isGatewayDraining } from "openclaw/plugin-sdk/process-runtime";
+import {
+  createInboundDebouncer,
+  resolveInboundDebounceMs,
+} from "openclaw/plugin-sdk/reply-runtime";
+import { buildCommandsPaginationKeyboard } from "openclaw/plugin-sdk/reply-runtime";
+import {
+  buildModelsProviderData,
+  formatModelsAvailableHeader,
+} from "openclaw/plugin-sdk/reply-runtime";
+import { buildMentionRegexes, matchesMentionWithExplicit } from "openclaw/plugin-sdk/reply-runtime";
+import { hasControlCommand } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveStoredModelOverride } from "openclaw/plugin-sdk/reply-runtime";
+import { listSkillCommandsForAgents } from "openclaw/plugin-sdk/reply-runtime";
+import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
+import { warn as logWarn } from "openclaw/plugin-sdk/runtime-env";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
+  firstDefined,
   isSenderAllowed,
   normalizeDmAllowFromWithStore,
   type NormalizedAllowFrom,
@@ -66,6 +81,7 @@ import {
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
   withResolvedTelegramForumFlag,
+  hasBotMention,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import {
@@ -78,6 +94,7 @@ import {
   isTelegramExecApprovalClientEnabled,
   shouldEnableTelegramExecApprovalButtons,
 } from "./exec-approvals.js";
+import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
@@ -108,6 +125,8 @@ export const registerTelegramHandlers = ({
   groupAllowFrom,
   resolveGroupPolicy,
   resolveTelegramGroupConfig,
+  resolveGroupRequireMention,
+  resolveGroupActivation,
   shouldSkipUpdate,
   processMessage,
   logger,
@@ -1706,6 +1725,237 @@ export const registerTelegramHandlers = ({
         if (!dmAuthorized) {
           return;
         }
+      }
+
+      // For DMs that carry only text (no media), enforceTelegramDmAccess did
+      // not run above (it is scoped to media messages).  Apply an equivalent
+      // inline auth gate here so that unauthorized plain-text DM senders are
+      // filtered before we reach the drain guard — they must not be persisted
+      // to the pending-inbound store.  This mirrors the check that
+      // buildTelegramMessageContext performs in the normal (non-drain) path.
+      //
+      // Guard behind drain mode: when NOT draining, the normal path through
+      // processInboundMessage / buildTelegramMessageContext runs
+      // enforceTelegramDmPolicy which handles pairing challenges and other
+      // policy flows.  Firing this short-circuit outside drain mode would
+      // silently drop text-only DMs from senders with dmPolicy: "pairing"
+      // before they ever reach the pairing challenge handler.
+      if (
+        isGatewayDraining() &&
+        !event.isGroup &&
+        !hasInboundMedia(event.msg) &&
+        !hasReplyTargetMedia(event.msg)
+      ) {
+        if (dmPolicy === "disabled") {
+          return;
+        }
+        if (
+          dmPolicy !== "open" &&
+          !isAllowlistAuthorized(effectiveDmAllow, event.senderId, event.senderUsername)
+        ) {
+          return;
+        }
+      }
+
+      // requireTopic gate: mirror buildTelegramMessageContext — DMs without a topic are
+      // blocked when requireTopic=true.  Apply before the drain guard so that messages
+      // that would be dropped in the normal path are never persisted to the pending store.
+      const requireTopicConfig = (groupConfig as TelegramDirectConfig | undefined)?.requireTopic;
+      if (!event.isGroup && requireTopicConfig === true && dmThreadId == null) {
+        logVerbose(`Blocked telegram DM ${event.chatId}: requireTopic=true but no topic present`);
+        return;
+      }
+
+      // Drain guard: only persist messages that passed the auth checks above.
+      // Moved after authorization context, group policy, and DM access checks
+      // so that unauthorized messages are never written to the pending store.
+      if (isGatewayDraining()) {
+        const stateDir = resolveStateDir(process.env);
+        // Resolve the session key now so replay routes to the correct agent-scoped session.
+        // Pass replyThreadId and topicAgentId so topic conversation bindings are applied,
+        // matching the routing parameters used in the normal (non-drain) message path.
+        const drainReplyThreadId = resolvedThreadId ?? dmThreadId;
+        const { route: drainRoute } = resolveTelegramConversationRoute({
+          cfg,
+          accountId,
+          chatId: event.chatId,
+          isGroup: event.isGroup,
+          resolvedThreadId,
+          replyThreadId: drainReplyThreadId,
+          senderId: event.senderId,
+          topicAgentId: topicConfig?.agentId,
+        });
+
+        // Named-account gate: groups with a non-default account require an explicit binding.
+        // Without one, the message would be dropped in buildTelegramMessageContext — mirror
+        // that check here so we never persist messages the session would discard anyway.
+        // DMs use a per-account fallback session key (not dropped), so this is groups-only.
+        const drainIsNamedAccountFallback =
+          drainRoute.accountId !== DEFAULT_ACCOUNT_ID && drainRoute.matchedBy === "default";
+        if (drainIsNamedAccountFallback && event.isGroup) {
+          logVerbose(
+            `Blocked drain: non-default account requires explicit binding for group ${event.chatId}`,
+          );
+          return;
+        }
+
+        // Apply thread-scoped session key for DM topics — mirrors resolveTelegramSessionState.
+        // dmThreadId is already resolved from eventAuthContext above.
+        const drainBaseSessionKey = drainRoute.sessionKey;
+        const drainThreadKeys =
+          dmThreadId != null
+            ? resolveThreadSessionKeys({
+                baseSessionKey: drainBaseSessionKey,
+                threadId: `${event.chatId}:${dmThreadId}`,
+              })
+            : null;
+        const drainSessionKey = drainThreadKeys?.sessionKey ?? drainBaseSessionKey;
+
+        // Mention gate: if the group requires a bot mention, verify the message contains one.
+        // This prevents flooding the pending-inbound store with messages the session would
+        // skip due to mention gating (mirrors buildTelegramMessageContext + resolveTelegramInboundBody).
+        if (event.isGroup) {
+          const activationOverride = resolveGroupActivation({
+            chatId: event.chatId,
+            messageThreadId: resolvedThreadId,
+            sessionKey: drainSessionKey,
+            agentId: drainRoute.agentId,
+          });
+          const baseRequireMention = resolveGroupRequireMention(event.chatId);
+          const drainRequireMention = firstDefined(
+            activationOverride,
+            topicConfig?.requireMention,
+            (groupConfig as TelegramGroupConfig | undefined)?.requireMention,
+            baseRequireMention,
+          );
+          if (drainRequireMention) {
+            const mentionRegexes = buildMentionRegexes(cfg, drainRoute.agentId);
+            const botUsername = event.ctx.me?.username?.toLowerCase();
+            const botId = event.ctx.me?.id;
+            const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
+
+            // Voice preflight: mirror the audio-preflight path from resolveTelegramInboundBody.
+            // In normal processing, a voice-only group message with requireMention=true is
+            // transcribed before mention checking so that a spoken "@bot" can satisfy the gate.
+            // At drain time we cannot transcribe — defer the check to replay by letting the
+            // message through unconditionally when audio preflight would normally apply.
+            const drainHasAudio = Boolean(event.msg.voice ?? event.msg.audio);
+            const drainHasUserText = Boolean(event.msg.text ?? event.msg.caption);
+            const drainDisableAudioPreflight =
+              (topicConfig?.disableAudioPreflight ??
+                (groupConfig as TelegramGroupConfig | undefined)?.disableAudioPreflight) === true;
+            const drainNeedsPreflightTranscription =
+              drainHasAudio &&
+              !drainHasUserText &&
+              mentionRegexes.length > 0 &&
+              !drainDisableAudioPreflight;
+            if (drainNeedsPreflightTranscription) {
+              // Cannot transcribe at drain time — pass through so that replay can do
+              // the audio preflight and apply the mention gate with the transcript.
+              logVerbose(
+                `Drain: deferring mention check for voice-only message in group ${event.chatId} (audio preflight needed)`,
+              );
+            } else {
+              // Mirror the implicit-mention logic from resolveTelegramInboundBody:
+              // a reply to a (non-service) bot message counts as an implicit mention,
+              // matching the normal (non-drain) message processing path.
+              const replyFromId = event.msg.reply_to_message?.from?.id;
+              const replyToBotMessage = botId != null && replyFromId === botId;
+              const isReplyToServiceMessage =
+                replyToBotMessage && isTelegramForumServiceMessage(event.msg.reply_to_message);
+              const implicitMention = replyToBotMessage && !isReplyToServiceMessage;
+              const messageText = event.msg.text ?? event.msg.caption ?? "";
+              const entities = event.msg.entities ?? event.msg.caption_entities ?? [];
+              const hasAnyMention = entities.some((e) => e.type === "mention");
+              const explicitlyMentioned = botUsername
+                ? hasBotMention(event.msg, botUsername)
+                : false;
+              const wasMentioned = matchesMentionWithExplicit({
+                text: messageText,
+                mentionRegexes,
+                explicit: {
+                  hasAnyMention,
+                  isExplicitlyMentioned: explicitlyMentioned,
+                  canResolveExplicit: Boolean(botUsername),
+                },
+              });
+              // Use resolveMentionGatingWithBypass so that slash commands (e.g. /status)
+              // bypass the mention gate even when the bot is not mentioned — matching the
+              // command bypass path in the normal (non-drain) message processing flow.
+              // Derive commandAuthorized via resolveControlCommandGate (matching the
+              // non-drain path in bot-message-context.body.ts) instead of hard-coding true,
+              // so that command access policy is respected even during drain.
+              const allowForCommands = event.isGroup ? effectiveGroupAllow : effectiveDmAllow;
+              const senderAllowedForCommands = isSenderAllowed({
+                allow: allowForCommands,
+                senderId: event.senderId,
+                senderUsername: event.senderUsername,
+              });
+              const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+              const hasControlCommandInMessage = hasControlCommand(messageText, cfg, {
+                botUsername,
+              });
+              const commandGate = resolveControlCommandGate({
+                useAccessGroups,
+                authorizers: [
+                  { configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands },
+                ],
+                allowTextCommands: true,
+                hasControlCommand: hasControlCommandInMessage,
+              });
+              const mentionGate = resolveMentionGatingWithBypass({
+                isGroup: true,
+                requireMention: true,
+                canDetectMention,
+                wasMentioned,
+                implicitMention,
+                hasAnyMention,
+                allowTextCommands: true,
+                hasControlCommand: hasControlCommandInMessage,
+                commandAuthorized: commandGate.commandAuthorized,
+              });
+              if (mentionGate.shouldSkip) {
+                logVerbose(`Blocked drain: requireMention not satisfied for group ${event.chatId}`);
+                return;
+              }
+            }
+          }
+        }
+
+        const drainAccepted = await writePendingInbound(stateDir, {
+          channel: "telegram",
+          // Prefix with accountId to prevent collisions in multi-account deployments where two
+          // bot accounts in the same chat can see the same message_id.
+          id: `${accountId}::${event.chatId}:${event.msg.message_id ?? Date.now()}`,
+          payload: {
+            chatId: event.chatId,
+            messageId: event.msg.message_id,
+            text: event.msg.text ?? event.msg.caption ?? "",
+            senderId: event.senderId,
+            senderUsername: event.senderUsername,
+            isGroup: event.isGroup,
+            date: event.msg.date,
+            // Persist voice/media metadata so replay can recover content that
+            // is only available via file_id (e.g. voice notes, photos).
+            // Without these fields, drained media-only messages are replayed
+            // as "(no text)" and the spoken/visual content is lost.
+            ...(event.msg.voice ? { voice: event.msg.voice } : {}),
+            ...(event.msg.audio ? { audio: event.msg.audio } : {}),
+            ...(event.msg.video ? { video: event.msg.video } : {}),
+            ...(event.msg.video_note ? { video_note: event.msg.video_note } : {}),
+            ...(event.msg.photo?.length ? { photo: event.msg.photo } : {}),
+            ...(event.msg.document ? { document: event.msg.document } : {}),
+            ...(event.msg.sticker ? { sticker: event.msg.sticker } : {}),
+          },
+          capturedAt: Date.now(),
+          sessionKey: drainSessionKey,
+        });
+        if (!drainAccepted) {
+          logWarn(
+            `telegram: drain capture rejected for ${event.chatId}:${event.msg.message_id} (pending-inbound store at capacity)`,
+          );
+        }
+        return; // provider already got 200, no retry needed
       }
 
       await processInboundMessage({

--- a/extensions/telegram/src/bot-handlers.test.ts
+++ b/extensions/telegram/src/bot-handlers.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for drain-time mention gating in Telegram bot handlers.
+ *
+ * Verifies that the drain path uses resolveMentionGatingWithBypass so that
+ * slash commands (e.g. /status) bypass the mention gate in groups with
+ * requireMention:true — matching the behaviour of the normal message path.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Third-party stubs for packages that may lag behind the branch's lockfile ──
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(() => null),
+  getOAuthProviders: vi.fn(() => []),
+}));
+
+// ── Drain / pending-inbound mocks ─────────────────────────────────────────
+const { isGatewayDraining, writePendingInbound } = vi.hoisted(() => ({
+  isGatewayDraining: vi.fn<() => boolean>(() => true),
+  writePendingInbound: vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve()),
+}));
+
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>();
+  return { ...actual, isGatewayDraining };
+});
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/infra-runtime")>();
+  return { ...actual, writePendingInbound };
+});
+
+vi.mock("openclaw/plugin-sdk/state-paths", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/state-paths")>();
+  return { ...actual, resolveStateDir: () => "/tmp/test-state-dir" };
+});
+
+// ── Shared harness (mocks loadConfig, reply, pairing, etc.) ───────────────
+import { getLoadConfigMock, getOnHandler, onSpy } from "./bot.create-telegram-bot.test-harness.js";
+import { createTelegramBot } from "./bot.js";
+
+const loadConfig = getLoadConfigMock();
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeGroupMsgCtx(params: {
+  text: string;
+  fromId?: number;
+  botId?: number;
+  botUsername?: string;
+  replyToBotMessageId?: number;
+  entities?: { type: string; offset: number; length: number }[];
+}) {
+  return {
+    message: {
+      chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+      from: { id: params.fromId ?? 99999, username: "testuser" },
+      text: params.text,
+      date: 1736380800,
+      message_id: 42,
+      ...(params.entities ? { entities: params.entities } : {}),
+      ...(params.replyToBotMessageId !== undefined
+        ? {
+            reply_to_message: {
+              message_id: params.replyToBotMessageId,
+              from: { id: params.botId ?? 7777 },
+            },
+          }
+        : {}),
+    },
+    me: {
+      id: params.botId ?? 7777,
+      username: params.botUsername ?? "openclaw_bot",
+    },
+    getFile: async () => ({ download: async () => new Uint8Array() }),
+  };
+}
+
+function makeGroupVoiceMsgCtx(params: {
+  fromId?: number;
+  botId?: number;
+  botUsername?: string;
+  caption?: string;
+  disableAudioPreflight?: boolean;
+}) {
+  return {
+    message: {
+      chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+      from: { id: params.fromId ?? 99999, username: "testuser" },
+      date: 1736380800,
+      message_id: 43,
+      voice: { file_id: "voice-file-id-001", duration: 5, mime_type: "audio/ogg" },
+      ...(params.caption !== undefined ? { caption: params.caption } : {}),
+    },
+    me: {
+      id: params.botId ?? 7777,
+      username: params.botUsername ?? "openclaw_bot",
+    },
+    getFile: async () => ({ download: async () => new Uint8Array() }),
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("drain-time mention gating", () => {
+  beforeEach(() => {
+    onSpy.mockReset();
+    writePendingInbound.mockReset();
+    isGatewayDraining.mockReturnValue(true);
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: {
+            "*": { requireMention: true, allowFrom: ["*"] },
+          },
+        },
+      },
+    });
+  });
+
+  it("queues group slash command even when bot is not mentioned (command bypass)", async () => {
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    // /status is a known control command — should bypass mention gate
+    await handler(makeGroupMsgCtx({ text: "/status" }));
+
+    expect(writePendingInbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops regular group message when requireMention=true and bot not mentioned", async () => {
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    await handler(makeGroupMsgCtx({ text: "hey everyone" }));
+
+    expect(writePendingInbound).not.toHaveBeenCalled();
+  });
+
+  it("queues group message when bot is explicitly @mentioned", async () => {
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    await handler(
+      makeGroupMsgCtx({
+        text: "@openclaw_bot what is 2+2",
+        entities: [{ type: "mention", offset: 0, length: 14 }],
+      }),
+    );
+
+    expect(writePendingInbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues group message when it is a reply to a bot message (implicit mention)", async () => {
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    await handler(
+      makeGroupMsgCtx({
+        text: "yes please",
+        replyToBotMessageId: 99,
+      }),
+    );
+
+    expect(writePendingInbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not queue anything when gateway is not draining", async () => {
+    isGatewayDraining.mockReturnValue(false);
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    // A slash command — without drain, this goes through normal processing (replySpy),
+    // not writePendingInbound.
+    await handler(makeGroupMsgCtx({ text: "/status" }));
+
+    expect(writePendingInbound).not.toHaveBeenCalled();
+  });
+});
+
+describe("drain-time voice mention preflight", () => {
+  beforeEach(() => {
+    onSpy.mockReset();
+    writePendingInbound.mockReset();
+    isGatewayDraining.mockReturnValue(true);
+    // mentionPatterns are required so that mentionRegexes.length > 0, which
+    // mirrors the needsPreflightTranscription condition from bot-message-context.body.ts:
+    // audio preflight only runs when there are patterns to match in the transcript.
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: {
+            "*": { requireMention: true, allowFrom: ["*"] },
+          },
+        },
+      },
+      messages: {
+        groupChat: {
+          mentionPatterns: ["openclaw"],
+        },
+      },
+    });
+  });
+
+  it("queues voice-only group message even when bot is not mentioned (audio preflight deferred)", async () => {
+    // A voice-only message in a group with requireMention=true has no text/caption
+    // to check for a mention at drain time. The mention check must be deferred to
+    // replay time so the audio can be transcribed first.
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    await handler(makeGroupVoiceMsgCtx({}));
+
+    expect(writePendingInbound).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops regular text group message without mention (gate still enforced for text)", async () => {
+    // Text messages still go through the normal mention gate — only audio-only is bypassed.
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    await handler(makeGroupMsgCtx({ text: "no mention here" }));
+
+    expect(writePendingInbound).not.toHaveBeenCalled();
+  });
+
+  it("voice message with caption is NOT bypassed (caption can be checked for mentions directly)", async () => {
+    // If the voice message has a caption, the caption text is available for mention
+    // checking at drain time — no audio preflight is needed, so the gate applies.
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    // Caption present but does not mention the bot
+    await handler(makeGroupVoiceMsgCtx({ caption: "listen to this" }));
+
+    expect(writePendingInbound).not.toHaveBeenCalled();
+  });
+
+  it("voice message with caption that mentions the bot IS queued", async () => {
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message");
+
+    // Caption explicitly mentions the bot
+    await handler(makeGroupVoiceMsgCtx({ caption: "@openclaw_bot check this out" }));
+
+    expect(writePendingInbound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -115,6 +115,13 @@ export type RegisterTelegramHandlerParams = {
     chatId: string | number,
     messageThreadId?: number,
   ) => { groupConfig?: TelegramGroupConfig; topicConfig?: TelegramTopicConfig };
+  resolveGroupRequireMention: (chatId: string | number) => boolean | undefined;
+  resolveGroupActivation: (params: {
+    chatId: string | number;
+    agentId?: string;
+    messageThreadId?: number;
+    sessionKey?: string;
+  }) => boolean | undefined;
   shouldSkipUpdate: (ctx: TelegramUpdateKeyContext) => boolean;
   processMessage: (
     ctx: TelegramContext,
@@ -202,7 +209,7 @@ async function resolveTelegramCommandAuth(params: {
     isForum,
     messageThreadId,
   });
-  const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
+  const threadParams = buildTelegramThreadParams(threadSpec);
   const groupAllowContext = await resolveTelegramGroupAllowFromContext({
     chatId,
     accountId,
@@ -263,7 +270,10 @@ async function resolveTelegramCommandAuth(params: {
   const sendAuthMessage = async (text: string) => {
     await withTelegramApiErrorLogging({
       operation: "sendMessage",
-      fn: () => bot.api.sendMessage(chatId, text, threadParams),
+      fn: () =>
+        threadParams
+          ? bot.api.sendMessage(chatId, text, threadParams)
+          : bot.api.sendMessage(chatId, text),
     });
     return null;
   };

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1205,7 +1205,7 @@ describe("createTelegramBot", () => {
     expect(replySpy.mock.calls[1]?.[0].SessionKey).toContain("agent:topic-b:");
   });
 
-  it("routes non-default account DMs to the per-account fallback session without explicit bindings", async () => {
+  it("routes non-default account DMs without explicit bindings using per-account session key", async () => {
     loadConfig.mockReturnValue({
       channels: {
         telegram: {
@@ -1234,10 +1234,13 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
+    // Named-account DMs without explicit bindings are allowed through,
+    // routed to a per-account isolated session key (not the agent main key).
+    // Behaviour restored by fix(telegram): restore named-account DM fallback routing.
     expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = replySpy.mock.calls[0]?.[0];
+    const payload = replySpy.mock.calls[0][0];
     expect(payload.AccountId).toBe("opie");
-    expect(payload.SessionKey).toContain("agent:main:telegram:opie:");
+    expect(payload.SessionKey).toBe("agent:main:telegram:opie:direct:999");
   });
 
   it("applies group mention overrides and fallback behavior", async () => {

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -558,6 +558,8 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     groupAllowFrom,
     resolveGroupPolicy,
     resolveTelegramGroupConfig,
+    resolveGroupRequireMention,
+    resolveGroupActivation,
     shouldSkipUpdate,
     processMessage,
     logger,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -108,36 +108,48 @@ async function deliverTextReply(params: {
   progress: DeliveryProgress;
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
-  await sendChunkedTelegramReplyText({
-    chunks: params.chunkText(params.replyText),
-    progress: params.progress,
-    replyToId: params.replyToId,
-    replyToMode: params.replyToMode,
-    replyMarkup: params.replyMarkup,
-    replyQuoteText: params.replyQuoteText,
-    markDelivered,
-    sendChunk: async ({ chunk, replyToMessageId, replyMarkup, replyQuoteText }) => {
-      const messageId = await sendTelegramText(
-        params.bot,
-        params.chatId,
-        chunk.html,
-        params.runtime,
-        {
-          replyToMessageId,
-          replyQuoteText,
-          thread: params.thread,
-          textMode: "html",
-          plainText: chunk.text,
-          linkPreview: params.linkPreview,
-          silent: params.silent,
-          replyMarkup,
-        },
-      );
+  const chunks = params.chunkText(params.replyText);
+  let sentAnyChunk = false;
+  for (let i = 0; i < chunks.length; i += 1) {
+    const chunk = chunks[i];
+    if (!chunk) {
+      continue;
+    }
+    if (!chunk.html?.trim() && !chunk.text?.trim()) {
+      logVerbose("telegram: skipping empty chunk in deliverTextReply");
+      continue;
+    }
+    const shouldAttachButtons = !sentAnyChunk && params.replyMarkup;
+    const replyToForChunk = resolveReplyToForSend({
+      replyToId: params.replyToId,
+      replyToMode: params.replyToMode,
+      progress: params.progress,
+    });
+    const messageId = await sendTelegramText(
+      params.bot,
+      params.chatId,
+      chunk.html,
+      params.runtime,
+      {
+        replyToMessageId: replyToForChunk,
+        replyQuoteText: params.replyQuoteText,
+        thread: params.thread,
+        textMode: "html",
+        plainText: chunk.text,
+        linkPreview: params.linkPreview,
+        silent: params.silent,
+        replyMarkup: shouldAttachButtons ? params.replyMarkup : undefined,
+      },
+    );
+    if (messageId != null) {
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = messageId;
       }
-    },
-  });
+      markReplyApplied(params.progress, replyToForChunk);
+      markDelivered(params.progress);
+      sentAnyChunk = true;
+    }
+  }
   return firstDeliveredMessageId;
 }
 
@@ -155,25 +167,40 @@ async function sendPendingFollowUpText(params: {
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
 }): Promise<void> {
-  await sendChunkedTelegramReplyText({
-    chunks: params.chunkText(params.text),
-    progress: params.progress,
-    replyToId: params.replyToId,
-    replyToMode: params.replyToMode,
-    replyMarkup: params.replyMarkup,
-    markDelivered,
-    sendChunk: async ({ chunk, replyToMessageId, replyMarkup }) => {
-      await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
-        replyToMessageId,
+  const chunks = params.chunkText(params.text);
+  let sentAnyChunk = false;
+  for (let i = 0; i < chunks.length; i += 1) {
+    const chunk = chunks[i];
+    if (!chunk || (!chunk.html?.trim() && !chunk.text?.trim())) {
+      logVerbose("telegram: skipping empty chunk in sendPendingFollowUpText");
+      continue;
+    }
+    const replyToForFollowUp = resolveReplyToForSend({
+      replyToId: params.replyToId,
+      replyToMode: params.replyToMode,
+      progress: params.progress,
+    });
+    const messageId = await sendTelegramText(
+      params.bot,
+      params.chatId,
+      chunk.html,
+      params.runtime,
+      {
+        replyToMessageId: replyToForFollowUp,
         thread: params.thread,
         textMode: "html",
         plainText: chunk.text,
         linkPreview: params.linkPreview,
         silent: params.silent,
-        replyMarkup,
-      });
-    },
-  });
+        replyMarkup: !sentAnyChunk ? params.replyMarkup : undefined,
+      },
+    );
+    if (messageId != null) {
+      markReplyApplied(params.progress, replyToForFollowUp);
+      markDelivered(params.progress);
+      sentAnyChunk = true;
+    }
+  }
 }
 
 function isVoiceMessagesForbidden(err: unknown): boolean {
@@ -205,26 +232,30 @@ async function sendTelegramVoiceFallbackText(opts: {
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = opts.chunkText(opts.text);
-  let appliedReplyTo = false;
+  let sentAnyChunk = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    // Only apply reply reference, quote text, and buttons to the first chunk.
-    const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
+    if (!chunk || (!chunk.html?.trim() && !chunk.text?.trim())) {
+      logVerbose("telegram: skipping empty chunk in sendTelegramVoiceFallbackText");
+      continue;
+    }
+    // Only apply reply reference and buttons to the first sent chunk.
+    const replyToForChunk = !sentAnyChunk ? opts.replyToId : undefined;
     const messageId = await sendTelegramText(opts.bot, opts.chatId, chunk.html, opts.runtime, {
       replyToMessageId: replyToForChunk,
-      replyQuoteText: !appliedReplyTo ? opts.replyQuoteText : undefined,
+      replyQuoteText: !sentAnyChunk ? opts.replyQuoteText : undefined,
       thread: opts.thread,
       textMode: "html",
       plainText: chunk.text,
       linkPreview: opts.linkPreview,
       silent: opts.silent,
-      replyMarkup: !appliedReplyTo ? opts.replyMarkup : undefined,
+      replyMarkup: !sentAnyChunk ? opts.replyMarkup : undefined,
     });
-    if (firstDeliveredMessageId == null) {
-      firstDeliveredMessageId = messageId;
-    }
-    if (replyToForChunk) {
-      appliedReplyTo = true;
+    if (messageId != null) {
+      if (firstDeliveredMessageId == null) {
+        firstDeliveredMessageId = messageId;
+      }
+      sentAnyChunk = true;
     }
   }
   return firstDeliveredMessageId;

--- a/extensions/telegram/src/bot/delivery.send.ts
+++ b/extensions/telegram/src/bot/delivery.send.ts
@@ -1,13 +1,13 @@
 import { type Bot, GrammyError } from "grammy";
 import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { withTelegramApiErrorLogging } from "../api-logging.js";
 import { markdownToTelegramHtml } from "../format.js";
+import { EMPTY_TEXT_ERR_RE } from "../network-errors.js";
 import { buildInlineKeyboard } from "../send.js";
 import { buildTelegramThreadParams, type TelegramThreadSpec } from "./helpers.js";
 
 const PARSE_ERR_RE = /can't parse entities|parse entities|find end of the entity/i;
-const EMPTY_TEXT_ERR_RE = /message text is empty/i;
 const THREAD_NOT_FOUND_RE = /message thread not found/i;
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
@@ -110,7 +110,7 @@ export async function sendTelegramText(
     silent?: boolean;
     replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   },
-): Promise<number> {
+): Promise<number | undefined> {
   const baseParams = buildTelegramSendParams({
     replyToMessageId: opts?.replyToMessageId,
     thread: opts?.thread,
@@ -143,7 +143,8 @@ export async function sendTelegramText(
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
   if (!htmlText.trim()) {
     if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
+      logVerbose("telegram sendMessage skipped: empty formatted text and empty plain fallback");
+      return undefined;
     }
     return await sendPlainFallback();
   }
@@ -171,7 +172,10 @@ export async function sendTelegramText(
     const errText = formatErrorMessage(err);
     if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
       if (!hasFallbackText) {
-        throw err;
+        logVerbose(
+          "telegram sendMessage skipped: Telegram rejected text as empty and no plain fallback available",
+        );
+        return undefined;
       }
       runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
       return await sendPlainFallback();

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1,6 +1,8 @@
 import type { Bot } from "grammy";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
+import { deliverReplies } from "./delivery.js";
+import { sendTelegramText } from "./delivery.send.js";
 
 const { loadWebMedia } = vi.hoisted(() => ({
   loadWebMedia: vi.fn(),
@@ -600,23 +602,138 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("silently skips when formatted and plain fallback text are both empty", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
 
-    await expect(
-      deliverReplies({
-        replies: [{ text: "   " }],
-        chatId: "123",
-        token: "tok",
-        runtime,
-        bot,
-        replyToMode: "off",
-        textLimit: 4000,
-      }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    const result = await deliverReplies({
+      replies: [{ text: "   " }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
     expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.delivered).toBe(false);
+  });
+
+  it("attaches buttons to second chunk when first chunk is empty", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 50,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    // Three chunks: chunk 0 is whitespace-only (skipped), chunks 1+2 are real.
+    // Small textLimit forces paragraph-boundary splitting so "   " is its own chunk.
+    await deliverReplies({
+      replies: [
+        {
+          text: "   \n\nchunk one txt\n\nchunk two txt",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Click me", callback_data: "click" }]],
+            },
+          },
+        },
+      ],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 20,
+    });
+
+    // Chunk 0 (whitespace) is skipped — only 2 sendMessage calls for real content.
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    // First sendMessage call (chunk 1, the first non-empty chunk) should carry reply_markup.
+    expect(sendMessage.mock.calls[0][2]).toEqual(
+      expect.objectContaining({
+        reply_markup: {
+          inline_keyboard: [[{ text: "Click me", callback_data: "click" }]],
+        },
+      }),
+    );
+    // Second sendMessage call (chunk 2) should NOT have reply_markup.
+    expect(sendMessage.mock.calls[1][2]).not.toHaveProperty("reply_markup");
+  });
+
+  it("falls back to plain text when Telegram rejects with 'text must be non-empty' (Mode C)", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn(
+      async (_chatId: string, _text: string, opts?: Record<string, unknown>) => {
+        // HTML send attempt — Telegram rejects with newer error wording
+        if (opts && "parse_mode" in opts) {
+          throw new Error("400: Bad Request: text must be non-empty");
+        }
+        // Plain text fallback succeeds
+        return {
+          message_id: 6,
+          chat: { id: "123" },
+        };
+      },
+    );
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    await deliverReplies({
+      replies: [{ text: "some text" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      thread: { id: 42, scope: "forum" },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    // Second call should be the plain-text fallback without parse_mode
+    expect(sendMessage.mock.calls[1]?.[1]).toBe("some text");
+    expect(sendMessage.mock.calls[1]?.[2]).not.toHaveProperty("parse_mode");
+  });
+
+  it("returns undefined (no throw) when 'text must be non-empty' and no fallback (Mode D)", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn(async () => {
+      throw new Error("400: Bad Request: text must be non-empty");
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    // Call sendTelegramText directly with plainText="" so hasFallbackText is false
+    // while text renders to non-empty HTML
+    const result = await sendTelegramText(bot, "123", "some text", runtime as RuntimeEnv, {
+      plainText: "",
+    });
+
+    // Should return undefined (no throw) — consistent with Mode A pre-send skip
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(result).toBeUndefined();
+  });
+
+  it("does not call markDelivered when sendTelegramText returns undefined (safety net)", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn();
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    // All-whitespace text: sendTelegramText returns undefined (safety net)
+    const result = await deliverReplies({
+      replies: [{ text: "   " }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.delivered).toBe(false);
   });
 
   it("uses reply_to_message_id when quote text is provided", async () => {
@@ -914,6 +1031,35 @@ describe("deliverReplies", () => {
 
     expect(sendMessage).toHaveBeenCalledTimes(1);
     expect(pinChatMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("first chunk empty with replyToMode=first — reply threading applies to first sent chunk, not chunk index 0", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 55,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    // Two chunks: chunk 0 is whitespace-only (will be skipped), chunk 1 has real content.
+    // Use a small textLimit to force chunking at the double newline boundary.
+    const result = await deliverReplies({
+      replies: [{ text: "   \n\nreal content here", replyToId: "999" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "first",
+      textLimit: 20,
+    });
+
+    // Only the real-content chunk should be sent (chunk 0 is empty → skipped)
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    // The reply threading should be applied to the chunk that was actually sent
+    expect(sendMessage.mock.calls[0][2]).toEqual(
+      expect.objectContaining({ reply_to_message_id: 999 }),
+    );
+    expect(result.delivered).toBe(true);
   });
 
   it("rethrows VOICE_MESSAGES_FORBIDDEN when no text fallback is available", async () => {

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -184,6 +184,55 @@ describe("isSafeToRetrySendError", () => {
     const wrapped = Object.assign(new Error("fetch failed"), { cause: root });
     expect(isSafeToRetrySendError(wrapped)).toBe(true);
   });
+
+  it("allows retry for grammY failed-after envelope with pre-connect cause", () => {
+    const root = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+    const envelope = Object.assign(
+      new Error("Network request for 'sendMessage' failed after 3 attempts."),
+      { cause: root },
+    );
+    expect(isSafeToRetrySendError(envelope)).toBe(true);
+  });
+
+  it("allows retry for grammY failed-after envelope with DNS failure cause", () => {
+    const root = Object.assign(new Error("getaddrinfo ENOTFOUND"), { code: "ENOTFOUND" });
+    const envelope = Object.assign(
+      new Error("Network request for 'sendMessage' failed after 2 attempts."),
+      { cause: root },
+    );
+    expect(isSafeToRetrySendError(envelope)).toBe(true);
+  });
+
+  it("does NOT allow retry for grammY failed-after envelope with ECONNRESET cause", () => {
+    const root = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    const envelope = Object.assign(
+      new Error("Network request for 'sendMessage' failed after 2 attempts."),
+      { cause: root },
+    );
+    expect(isSafeToRetrySendError(envelope)).toBe(false);
+  });
+
+  it("does NOT allow retry for grammY failed-after envelope with ETIMEDOUT cause", () => {
+    const root = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const envelope = Object.assign(
+      new Error("Network request for 'sendMessage' failed after 2 attempts."),
+      { cause: root },
+    );
+    expect(isSafeToRetrySendError(envelope)).toBe(false);
+  });
+
+  it("does NOT allow retry for grammY failed-after envelope with no cause", () => {
+    const envelope = new Error("Network request for 'sendMessage' failed after 2 attempts.");
+    expect(isSafeToRetrySendError(envelope)).toBe(false);
+  });
+
+  it("does NOT allow retry for grammY failed-after envelope with unknown cause", () => {
+    const envelope = Object.assign(
+      new Error("Network request for 'sendMessage' failed after 2 attempts."),
+      { cause: new Error("something went wrong") },
+    );
+    expect(isSafeToRetrySendError(envelope)).toBe(false);
+  });
 });
 
 describe("isTelegramServerError", () => {

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -7,6 +7,8 @@ import {
 
 const TELEGRAM_NETWORK_ORIGIN = Symbol("openclaw.telegram.network-origin");
 
+export const EMPTY_TEXT_ERR_RE = /message text is empty|text must be non-empty/i;
+
 const RECOVERABLE_ERROR_CODES = new Set([
   "ECONNRESET",
   "ECONNREFUSED",
@@ -150,6 +152,20 @@ export function isTelegramPollingNetworkError(err: unknown): boolean {
 }
 
 /**
+ * Checks whether any error in the cause chain of `err` has a pre-connect error code.
+ * Used to determine whether a grammY "failed after N attempts" envelope is safe to retry.
+ */
+function hasPreConnectCauseInChain(err: unknown): boolean {
+  for (const candidate of collectTelegramErrorCandidates(err)) {
+    const code = normalizeCode(getErrorCode(candidate));
+    if (code && PRE_CONNECT_ERROR_CODES.has(code)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Returns true if the error is safe to retry for a non-idempotent Telegram send operation
  * (e.g. sendMessage). Only matches errors that are guaranteed to have occurred *before*
  * the request reached Telegram's servers, preventing duplicate message delivery.
@@ -165,6 +181,24 @@ export function isSafeToRetrySendError(err: unknown): boolean {
     const code = normalizeCode(getErrorCode(candidate));
     if (code && PRE_CONNECT_ERROR_CODES.has(code)) {
       return true;
+    }
+    const message = formatErrorMessage(candidate).trim();
+    // Telegram 429 rate-limit: the server explicitly rejected the request before
+    // delivering it; retry_after signals it is safe to retry after the delay.
+    if (/^429\b/.test(message)) {
+      return true;
+    }
+    // grammY envelope error: "Network request for '…' failed after N attempts"
+    // This envelope wraps an underlying cause — we must inspect it to determine
+    // safety. Only treat as safe-to-retry if the root cause is a verifiable
+    // pre-connect failure. ECONNRESET, post-connect timeouts, and unknown causes
+    // could mean Telegram already received the message, so we must NOT retry.
+    if (GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message.toLowerCase())) {
+      if (hasPreConnectCauseInChain(candidate)) {
+        return true;
+      }
+      // Underlying cause is not a pre-connect failure — not safe to retry.
+      continue;
     }
   }
   return false;

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -474,6 +474,49 @@ describe("sendMessageTelegram", () => {
     }
   });
 
+  it("falls back to plain text when Telegram rejects HTML as empty text (Mode E)", async () => {
+    const cases = [
+      {
+        name: "newer 'text must be non-empty' wording",
+        error: new Error("400: Bad Request: text must be non-empty"),
+      },
+      {
+        name: "older 'message text is empty' wording",
+        error: new Error("400: Bad Request: message text is empty"),
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const sendMessage = vi
+        .fn()
+        .mockRejectedValueOnce(testCase.error)
+        .mockResolvedValueOnce({
+          message_id: 99,
+          chat: { id: "123" },
+        });
+      const api = { sendMessage } as unknown as {
+        sendMessage: typeof sendMessage;
+      };
+
+      const res = await sendMessageTelegram("123", ">", {
+        token: "tok",
+        api,
+      });
+
+      expect(sendMessage, testCase.name).toHaveBeenCalledTimes(2);
+      // First call: HTML with parse_mode
+      expect(sendMessage.mock.calls[0]?.[2], testCase.name).toEqual(
+        expect.objectContaining({ parse_mode: "HTML" }),
+      );
+      // Second call: plain text fallback (no parse_mode)
+      expect(sendMessage.mock.calls[1]?.[2], testCase.name).toBeUndefined();
+      expect(sendMessage.mock.calls[1]?.[1], testCase.name).toBe(">");
+      expect(res.messageId, testCase.name).toBe("99");
+
+      sendMessage.mockClear();
+    }
+  });
+
   it("fails when Telegram text send returns no message_id", async () => {
     const sendMessage = vi.fn().mockResolvedValue({
       chat: { id: "123" },

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -32,6 +32,7 @@ import {
   isRecoverableTelegramNetworkError,
   isSafeToRetrySendError,
   isTelegramServerError,
+  EMPTY_TEXT_ERR_RE,
 } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { recordSentMessage } from "./sent-message-cache.js";
@@ -380,6 +381,10 @@ function isTelegramHtmlParseError(err: unknown): boolean {
   return PARSE_ERR_RE.test(formatErrorMessage(err));
 }
 
+function isTelegramEmptyTextError(err: unknown): boolean {
+  return EMPTY_TEXT_ERR_RE.test(formatErrorMessage(err));
+}
+
 function buildTelegramThreadReplyParams(params: {
   targetMessageThreadId?: number;
   messageThreadId?: number;
@@ -423,12 +428,13 @@ async function withTelegramHtmlParseFallback<T>(params: {
   try {
     return await params.requestHtml(params.label);
   } catch (err) {
-    if (!isTelegramHtmlParseError(err)) {
+    if (!isTelegramHtmlParseError(err) && !isTelegramEmptyTextError(err)) {
       throw err;
     }
     if (params.verbose) {
+      const errorKind = isTelegramEmptyTextError(err) ? "empty text" : "HTML parse";
       sendLogger.warn(
-        `telegram ${params.label} failed with HTML parse error, retrying as plain text: ${formatErrorMessage(
+        `telegram ${params.label} failed with ${errorKind} error, retrying as plain text: ${formatErrorMessage(
           err,
         )}`,
       );

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -14,11 +14,13 @@ import {
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import { resolveStateDir } from "../../../config/paths.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import {
   ensureGlobalUndiciEnvProxyDispatcher,
   ensureGlobalUndiciStreamTimeouts,
 } from "../../../infra/net/undici-global-dispatcher.js";
+import { clearActiveTurn, writeActiveTurn } from "../../../infra/pending-inbound-store.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { resolveSignalReactionLevel } from "../../../plugin-sdk/signal.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -2636,6 +2638,29 @@ export async function runEmbeddedAttempt(
       };
       setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
 
+      // Track active turn on disk for crash recovery.
+      // Awaited to guarantee the record is persisted before the run proceeds;
+      // otherwise clearActiveTurn in the finally block can race ahead of the
+      // write on short runs, leaving a ghost active-turn record.
+      if (!params.sessionId?.startsWith("probe-")) {
+        const runtimeChannel = params.messageChannel ?? params.messageProvider ?? "unknown";
+        try {
+          const turnAccepted = await writeActiveTurn(resolveStateDir(process.env), {
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey ?? params.sessionId,
+            channel: runtimeChannel,
+            startedAt: Date.now(),
+          });
+          if (!turnAccepted) {
+            log.warn(
+              `active-turn tracking at capacity: sessionId=${params.sessionId} — crash-recovery for this turn will not be available`,
+            );
+          }
+        } catch (err) {
+          log.warn(`active-turn write failed: sessionId=${params.sessionId} ${String(err)}`);
+        }
+      }
+
       let abortWarnTimer: NodeJS.Timeout | undefined;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
       const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
@@ -3137,6 +3162,16 @@ export async function runEmbeddedAttempt(
           );
         }
         clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+        // Clear active-turn disk record.  Awaited so the clear cannot settle
+        // before a preceding writeActiveTurn on short-lived runs — preventing
+        // ghost active-turn records that trigger false stale-turn recovery.
+        if (!params.sessionId?.startsWith("probe-")) {
+          try {
+            await clearActiveTurn(resolveStateDir(process.env), params.sessionId);
+          } catch (err) {
+            log.warn(`active-turn clear failed: sessionId=${params.sessionId} ${String(err)}`);
+          }
+        }
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -12,10 +12,14 @@ import { ensureOpenClawModelsJson } from "../agents/models-config.js";
 import { resolveModelAsync } from "../agents/pi-embedded-runner/model.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
+import { resolveAnnounceTargetFromKey } from "../agents/tools/sessions-send-helpers.js";
+import { sanitizeInboundSystemTags } from "../auto-reply/reply/inbound-text.js";
+import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
+import { parseSessionThreadInfo } from "../config/sessions/delivery-info.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import {
   clearInternalHooks,
@@ -24,14 +28,23 @@ import {
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import {
+  claimPendingInboundEntries,
+  clearActiveTurn,
+  readActiveTurn,
+  readStaleActiveTurns,
+} from "../infra/pending-inbound-store.js";
+import { enqueueSystemEvent, MAX_EVENTS } from "../infra/system-events.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
+import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/delivery-context.js";
 import { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import {
   scheduleRestartSentinelWake,
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+import { loadSessionEntry } from "./session-utils.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
 
@@ -77,6 +90,12 @@ export async function startGatewaySidecars(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logBrowser: { error: (msg: string) => void };
 }) {
+  // Record the process boot timestamp before any channels start.  Active turns
+  // written by THIS process (startedAt >= processStartedAt) are live — not
+  // stale leftovers from the previous process.  The recovery loop below uses
+  // this to avoid clearing fresh turns that raced ahead of the recovery sweep.
+  const processStartedAt = Date.now();
+
   try {
     const stateDir = resolveStateDir(process.env);
     const sessionDirs = await resolveAgentSessionDirs(stateDir);
@@ -153,6 +172,113 @@ export async function startGatewaySidecars(params: {
     params.logHooks.error(`failed to load hooks: ${String(err)}`);
   }
 
+  // Replay inbound messages captured during the previous drain.
+  // Must run BEFORE startChannels() so queued events are in-memory before any
+  // live inbound message can trigger a turn on the same session — preventing a
+  // race where live messages are processed ahead of drain-captured replays.
+  // enqueueSystemEvent is a pure in-memory operation; no channel infrastructure
+  // is required at this point.
+  try {
+    const stateDir = resolveStateDir(process.env);
+    // Atomically claim (read + clear) pending entries in a single locked
+    // operation.  This prevents a race where a concurrent drain writer
+    // inserts a new entry between reading and clearing — the old separate
+    // readPendingInbound → clearPendingInboundEntries sequence could lose
+    // messages captured in that window.
+    const pending = await claimPendingInboundEntries(stateDir);
+    if (pending.length > 0) {
+      params.log.warn(`replaying ${pending.length} inbound message(s) captured during drain`);
+
+      // Per-session cap: system-event queue holds at most MAX_EVENTS entries.
+      // Sessions with exactly MAX_EVENTS queued entries should replay all of them;
+      // only sessions with MORE than MAX_EVENTS entries should truncate.
+      const REPLAY_CAP_PER_SESSION = MAX_EVENTS;
+
+      // Phase 1: resolve sessionKey and eventText for every entry, collecting by session.
+      type ResolvedEntry = {
+        entry: (typeof pending)[number];
+        sessionKey: string;
+        eventText: string;
+      };
+      const bySession = new Map<string, ResolvedEntry[]>();
+
+      for (const entry of pending) {
+        try {
+          const payload = entry.payload as {
+            chatId?: number | string;
+            channelId?: string;
+            senderId?: string;
+            senderName?: string;
+            senderUsername?: string;
+            text?: string;
+          };
+          // NOTE: senderLabel and textPreview are untrusted user-controlled content
+          // from the original inbound message. Sanitize to prevent prompt injection
+          // via spoofed system tags (e.g. "[System Message]", "System:").
+          const rawSenderLabel =
+            payload.senderName ?? payload.senderUsername ?? payload.senderId ?? "unknown";
+          const senderLabel = sanitizeInboundSystemTags(String(rawSenderLabel));
+          const rawPreview = (payload.text ?? "").slice(0, 200).replace(/\n/g, "\\n");
+          const textPreview = sanitizeInboundSystemTags(String(rawPreview));
+          // Prefer the resolved session key stored at capture time; fall back to
+          // fabricated key for backward compatibility with entries captured before
+          // this change.
+          const sessionKey =
+            entry.sessionKey ??
+            (entry.channel === "telegram"
+              ? `telegram:${payload.chatId ?? "unknown"}`
+              : entry.channel === "discord"
+                ? `discord:channel:${payload.channelId ?? "unknown"}`
+                : `${entry.channel}:unknown`);
+          // Include entry.id in the event text so that two identical messages sent during
+          // a drain window (same text, same sender) are never collapsed by enqueueSystemEvent's
+          // consecutive-duplicate guard.
+          const eventText = `[pending-inbound:${entry.id}] Missed message during restart from ${senderLabel}: "${textPreview || "(no text)"}"`;
+          const list = bySession.get(sessionKey) ?? [];
+          list.push({ entry, sessionKey, eventText });
+          bySession.set(sessionKey, list);
+        } catch (err) {
+          params.log.warn(
+            `pending-inbound: replay failed for ${entry.channel}:${entry.id}: ${String(err)}`,
+          );
+        }
+      }
+
+      // Phase 2: enqueue per-session, capping at REPLAY_CAP_PER_SESSION to avoid silent
+      // truncation when the session accumulates more than MAX_EVENTS during a long drain.
+      for (const [sessionKey, entries] of bySession) {
+        // When a skip notice is needed it consumes one queue slot, so body messages
+        // must be capped at REPLAY_CAP_PER_SESSION - 1 to keep the total ≤ MAX_EVENTS.
+        const hasOverflow = entries.length > REPLAY_CAP_PER_SESSION;
+        const bodyCap = hasOverflow ? REPLAY_CAP_PER_SESSION - 1 : entries.length;
+        const toReplay = entries.slice(entries.length - bodyCap);
+        const skipped = entries.length - toReplay.length;
+
+        if (skipped > 0) {
+          params.log.warn(
+            `pending-inbound: ${skipped} older message(s) trimmed for session ${sessionKey} (queue cap)`,
+          );
+          enqueueSystemEvent(
+            `[pending-inbound] ${skipped} older message${skipped > 1 ? "s" : ""} skipped during restart (queue cap ${MAX_EVENTS})`,
+            { sessionKey },
+          );
+        }
+
+        for (const { entry, eventText } of toReplay) {
+          enqueueSystemEvent(eventText, {
+            sessionKey,
+            contextKey: `pending-inbound:${entry.channel}:${entry.id}`,
+          });
+          params.log.warn(
+            `pending-inbound: replayed ${entry.channel}:${entry.id} → session ${sessionKey}`,
+          );
+        }
+      }
+    }
+  } catch (err) {
+    params.log.warn(`pending-inbound: replay startup failed: ${String(err)}`);
+  }
+
   // Launch configured channels so gateway replies via the surface the message came from.
   // Tests can opt out via OPENCLAW_SKIP_CHANNELS (or legacy OPENCLAW_SKIP_PROVIDERS).
   const skipChannels =
@@ -172,6 +298,98 @@ export async function startGatewaySidecars(params: {
     params.logChannels.info(
       "skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)",
     );
+  }
+
+  // Recover stale active turns — runs that were in-flight when the process died.
+  // Notify the originating session so the user knows to resend.
+  try {
+    const stateDir = resolveStateDir(process.env);
+    const staleTurns = await readStaleActiveTurns(stateDir);
+    if (staleTurns.length > 0) {
+      params.log.warn(
+        `active-turn recovery: found ${staleTurns.length} stale turn(s) from previous process`,
+      );
+      for (const turn of staleTurns) {
+        // Skip turns started by THIS process — they raced ahead of the
+        // recovery loop (channel startup created a new turn before we got
+        // here).  Only turns from the PREVIOUS process are truly stale.
+        if (turn.startedAt >= processStartedAt) {
+          params.log.warn(
+            `active-turn recovery: skipping live turn ${turn.sessionId} (startedAt=${turn.startedAt} >= processStartedAt=${processStartedAt})`,
+          );
+          continue;
+        }
+
+        // Re-validate the current store entry before clearing.  Between the
+        // snapshot (readStaleActiveTurns) and now, a fresh turn could have
+        // been written under the same sessionId — e.g. if a channel handler
+        // started a new turn whose sessionId collides with a stale one.
+        // Only clear if the on-disk entry still has the same startedAt we
+        // saw in the snapshot (i.e. it has NOT been refreshed by this process).
+        const currentEntry = await readActiveTurn(stateDir, turn.sessionId);
+        if (!currentEntry) {
+          // Already cleared by something else — nothing to do.
+          continue;
+        }
+        if (currentEntry.startedAt !== turn.startedAt) {
+          // A fresh turn was written under the same sessionId after our snapshot.
+          // The startedAt guard above already protects against this case when the
+          // new turn's startedAt >= processStartedAt, but a recycled sessionId
+          // whose new startedAt still happens to be < processStartedAt (due to
+          // clock imprecision or test-injected timestamps) would slip through.
+          // Comparing startedAt values is the most reliable way to detect staleness.
+          params.log.warn(
+            `active-turn recovery: skipping refreshed turn ${turn.sessionId} (snapshot startedAt=${turn.startedAt}, current startedAt=${currentEntry.startedAt})`,
+          );
+          continue;
+        }
+
+        // Consume first to prevent infinite retry on crash.
+        await clearActiveTurn(stateDir, turn.sessionId);
+
+        // Skip probe sessions — they are synthetic health-check runs.
+        if (turn.sessionId.startsWith("probe-")) {
+          continue;
+        }
+
+        // Attempt to resolve a delivery target for the session. Sessions without
+        // a resolvable channel target (isolated scheduler sessions, orphaned sessions,
+        // or any session with no channel mapping) are skipped — the originating system
+        // (e.g. a scheduler's drain-retry) handles recovery for those.
+        const { baseSessionKey } = parseSessionThreadInfo(turn.sessionKey);
+        const parsedTarget = resolveAnnounceTargetFromKey(baseSessionKey ?? turn.sessionKey ?? "");
+        const { entry: turnEntry } = loadSessionEntry(turn.sessionKey ?? "");
+        let deliveryCtx = deliveryContextFromSession(turnEntry);
+        if (!deliveryCtx && baseSessionKey && baseSessionKey !== turn.sessionKey) {
+          const { entry: baseEntry } = loadSessionEntry(baseSessionKey);
+          deliveryCtx = deliveryContextFromSession(baseEntry);
+        }
+        const origin = mergeDeliveryContext(deliveryCtx, parsedTarget ?? undefined);
+        const resolvedChannel = origin?.channel ? normalizeChannelId(origin.channel) : null;
+        const resolvedTo = origin?.to;
+        if (!resolvedChannel || !resolvedTo) {
+          continue;
+        }
+
+        try {
+          const recoveryMessage =
+            "⚠️ I was restarted mid-conversation. Please resend your last message.";
+          enqueueSystemEvent(`[active-turn-recovery] ${recoveryMessage}`, {
+            sessionKey: turn.sessionKey,
+            contextKey: `active-turn-recovery:${turn.sessionId}`,
+          });
+          params.log.warn(
+            `active-turn recovery: notified session ${turn.sessionKey} (sessionId=${turn.sessionId}, channel=${turn.channel})`,
+          );
+        } catch (err) {
+          params.log.warn(
+            `active-turn recovery: notify failed for session ${turn.sessionKey}: ${String(err)}`,
+          );
+        }
+      }
+    }
+  } catch (err) {
+    params.log.warn(`active-turn recovery: startup failed: ${String(err)}`);
   }
 
   if (params.cfg.hooks?.internal?.enabled) {

--- a/src/infra/json-files.ts
+++ b/src/infra/json-files.ts
@@ -37,6 +37,16 @@ export async function writeTextAtomic(
     mkdirOptions.mode = options.ensureDirMode;
   }
   await fs.mkdir(path.dirname(filePath), mkdirOptions);
+  // On macOS and some Linux configurations, fs.mkdir({ recursive: true }) may
+  // ignore the mode option.  Explicitly chmod the directory afterward to ensure
+  // it carries the requested permissions regardless of platform behavior.
+  if (typeof options?.ensureDirMode === "number") {
+    try {
+      await fs.chmod(path.dirname(filePath), options.ensureDirMode);
+    } catch {
+      // best-effort; ignore on platforms without chmod
+    }
+  }
   const parentDir = path.dirname(filePath);
   const tmp = `${filePath}.${randomUUID()}.tmp`;
   try {

--- a/src/infra/pending-inbound-store.test.ts
+++ b/src/infra/pending-inbound-store.test.ts
@@ -1,0 +1,795 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearActiveTurn,
+  clearAllActiveTurns,
+  clearPendingInbound,
+  clearPendingInboundEntries,
+  readActiveTurn,
+  readPendingInbound,
+  readStaleActiveTurns,
+  writeActiveTurn,
+  writePendingInbound,
+  type ActiveTurnEntry,
+  type PendingInboundEntry,
+} from "./pending-inbound-store.js";
+
+describe("pending-inbound-store", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pending-inbound-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("write + read round-trip", async () => {
+    const entry: PendingInboundEntry = {
+      channel: "telegram",
+      id: "12345",
+      payload: { chatId: 999, text: "hello" },
+      capturedAt: 1700000000000,
+    };
+
+    await writePendingInbound(stateDir, entry);
+    const result = await readPendingInbound(stateDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(entry);
+  });
+
+  it("dedup: writing same channel:id twice only stores one entry", async () => {
+    const entry1: PendingInboundEntry = {
+      channel: "telegram",
+      id: "100",
+      payload: { text: "first" },
+      capturedAt: 1700000000000,
+    };
+    const entry2: PendingInboundEntry = {
+      channel: "telegram",
+      id: "100",
+      payload: { text: "second" },
+      capturedAt: 1700000001000,
+    };
+
+    await writePendingInbound(stateDir, entry1);
+    await writePendingInbound(stateDir, entry2);
+    const result = await readPendingInbound(stateDir);
+
+    expect(result).toHaveLength(1);
+    // Second write overwrites first
+    expect(result[0].payload).toEqual({ text: "second" });
+    expect(result[0].capturedAt).toBe(1700000001000);
+  });
+
+  it("dedup: multi-account Discord — same message seen by two accounts stored independently", async () => {
+    // Two Discord bot accounts both see the same message (same channel + message id).
+    // Without accountId in the key the second write silently overwrites the first.
+    // With accountId each account's capture gets its own slot.
+    const messageId = "msg-discord-999";
+    const entryAccount1: PendingInboundEntry = {
+      channel: "discord",
+      id: messageId,
+      accountId: "bot-account-A",
+      payload: { text: "from account A", accountId: "bot-account-A" },
+      capturedAt: 1700000000000,
+    };
+    const entryAccount2: PendingInboundEntry = {
+      channel: "discord",
+      id: messageId,
+      accountId: "bot-account-B",
+      payload: { text: "from account B", accountId: "bot-account-B" },
+      capturedAt: 1700000000001,
+    };
+
+    await writePendingInbound(stateDir, entryAccount1);
+    await writePendingInbound(stateDir, entryAccount2);
+    const result = await readPendingInbound(stateDir);
+
+    // Both entries must be retained — different accounts, same message id
+    expect(result).toHaveLength(2);
+    const payloads = result.map((e) => (e.payload as { text: string }).text).toSorted();
+    expect(payloads).toEqual(["from account A", "from account B"]);
+  });
+
+  it("dedup: same Discord message + same account still deduplicates", async () => {
+    // Same bot account capturing the same message twice (e.g. handler called twice)
+    // must still deduplicate to a single entry.
+    const entry1: PendingInboundEntry = {
+      channel: "discord",
+      id: "msg-dup-111",
+      accountId: "bot-account-A",
+      payload: { text: "first capture" },
+      capturedAt: 1700000000000,
+    };
+    const entry2: PendingInboundEntry = {
+      channel: "discord",
+      id: "msg-dup-111",
+      accountId: "bot-account-A",
+      payload: { text: "second capture" },
+      capturedAt: 1700000000100,
+    };
+
+    await writePendingInbound(stateDir, entry1);
+    await writePendingInbound(stateDir, entry2);
+    const result = await readPendingInbound(stateDir);
+
+    expect(result).toHaveLength(1);
+    // Second write overwrites first (same account + same message = same key)
+    expect((result[0].payload as { text: string }).text).toBe("second capture");
+  });
+
+  it("stores multiple entries with different keys", async () => {
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "1",
+      payload: { text: "tg message" },
+      capturedAt: 1700000000000,
+    });
+    await writePendingInbound(stateDir, {
+      channel: "discord",
+      id: "2",
+      payload: { text: "dc message" },
+      capturedAt: 1700000001000,
+    });
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "3",
+      payload: { text: "another tg" },
+      capturedAt: 1700000002000,
+    });
+
+    const result = await readPendingInbound(stateDir);
+    expect(result).toHaveLength(3);
+
+    const channels = result.map((e) => `${e.channel}:${e.id}`).toSorted();
+    expect(channels).toEqual(["discord:2", "telegram:1", "telegram:3"]);
+  });
+
+  it("clear removes file", async () => {
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "1",
+      payload: {},
+      capturedAt: Date.now(),
+    });
+
+    // File exists
+    const before = await readPendingInbound(stateDir);
+    expect(before).toHaveLength(1);
+
+    await clearPendingInbound(stateDir);
+
+    // File removed — read returns empty
+    const after = await readPendingInbound(stateDir);
+    expect(after).toEqual([]);
+  });
+
+  it("read on missing file returns []", async () => {
+    const result = await readPendingInbound(stateDir);
+    expect(result).toEqual([]);
+  });
+
+  it("clear on missing file does not throw", async () => {
+    await expect(clearPendingInbound(stateDir)).resolves.toBeUndefined();
+  });
+
+  it("capturedAt is preserved correctly", async () => {
+    const now = Date.now();
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "42",
+      payload: { text: "test" },
+      capturedAt: now,
+    });
+
+    const result = await readPendingInbound(stateDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].capturedAt).toBe(now);
+  });
+
+  // --- Active Turn tests ---
+
+  it("writeActiveTurn + readStaleActiveTurns round-trip", async () => {
+    const turn: ActiveTurnEntry = {
+      sessionId: "sess-001",
+      sessionKey: "telegram:12345",
+      channel: "telegram",
+      startedAt: 1700000000000,
+    };
+
+    await writeActiveTurn(stateDir, turn);
+    const result = await readStaleActiveTurns(stateDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(turn);
+  });
+
+  it("clearActiveTurn removes entry", async () => {
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-002",
+      sessionKey: "telegram:999",
+      channel: "telegram",
+      startedAt: 1700000000000,
+    });
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-003",
+      sessionKey: "discord:channel:456",
+      channel: "discord",
+      startedAt: 1700000001000,
+    });
+
+    await clearActiveTurn(stateDir, "sess-002");
+    const result = await readStaleActiveTurns(stateDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionId).toBe("sess-003");
+  });
+
+  it("readStaleActiveTurns on missing file returns []", async () => {
+    const result = await readStaleActiveTurns(stateDir);
+    expect(result).toEqual([]);
+  });
+
+  it("scheduler session keys are stored and readable (delivery-target resolution skips them at recovery)", async () => {
+    // Scheduler isolated sessions use keys like "scheduler:jobid:runid".
+    // The store saves them normally — server-startup.ts skips them during
+    // active-turn recovery because no delivery target resolves for these
+    // session keys (they have no channel mapping).
+    const turn: ActiveTurnEntry = {
+      sessionId: "sess-sched-001",
+      sessionKey: "scheduler:abc123:run456",
+      channel: "system",
+      startedAt: 1700000000000,
+    };
+
+    await writeActiveTurn(stateDir, turn);
+    const result = await readStaleActiveTurns(stateDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(turn);
+    expect(result[0].sessionKey).toMatch(/^scheduler:/);
+  });
+
+  it("active turns and pending inbound entries coexist without collision", async () => {
+    // Write a pending inbound entry
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "msg-100",
+      payload: { text: "hello" },
+      capturedAt: 1700000000000,
+    });
+
+    // Write an active turn entry
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-010",
+      sessionKey: "telegram:777",
+      channel: "telegram",
+      startedAt: 1700000001000,
+    });
+
+    // Both should be independently readable
+    const pending = await readPendingInbound(stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe("msg-100");
+
+    const turns = await readStaleActiveTurns(stateDir);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].sessionId).toBe("sess-010");
+
+    // Clearing one does not affect the other
+    await clearActiveTurn(stateDir, "sess-010");
+    const pendingAfter = await readPendingInbound(stateDir);
+    expect(pendingAfter).toHaveLength(1);
+    expect(pendingAfter[0].id).toBe("msg-100");
+
+    const turnsAfter = await readStaleActiveTurns(stateDir);
+    expect(turnsAfter).toEqual([]);
+  });
+
+  // --- Scoped clear functions ---
+
+  it("clearPendingInboundEntries removes entries but preserves active turns", async () => {
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "msg-200",
+      payload: { text: "hello" },
+      capturedAt: 1700000000000,
+    });
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-020",
+      sessionKey: "telegram:888",
+      channel: "telegram",
+      startedAt: 1700000001000,
+    });
+
+    await clearPendingInboundEntries(stateDir);
+
+    const pending = await readPendingInbound(stateDir);
+    expect(pending).toEqual([]);
+
+    // Active turns should still be there
+    const turns = await readStaleActiveTurns(stateDir);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].sessionId).toBe("sess-020");
+  });
+
+  it("clearAllActiveTurns removes turns but preserves inbound entries", async () => {
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "msg-300",
+      payload: { text: "preserved" },
+      capturedAt: 1700000000000,
+    });
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-030",
+      sessionKey: "telegram:999",
+      channel: "telegram",
+      startedAt: 1700000001000,
+    });
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-031",
+      sessionKey: "discord:channel:100",
+      channel: "discord",
+      startedAt: 1700000002000,
+    });
+
+    await clearAllActiveTurns(stateDir);
+
+    const turns = await readStaleActiveTurns(stateDir);
+    expect(turns).toEqual([]);
+
+    // Inbound entries should still be there
+    const pending = await readPendingInbound(stateDir);
+    expect(pending).toHaveLength(1);
+    expect(pending[0].id).toBe("msg-300");
+  });
+
+  it("clearPendingInboundEntries on missing file does not throw", async () => {
+    await expect(clearPendingInboundEntries(stateDir)).resolves.toBeUndefined();
+  });
+
+  it("clearAllActiveTurns on missing file does not throw", async () => {
+    await expect(clearAllActiveTurns(stateDir)).resolves.toBeUndefined();
+  });
+
+  // --- Session key stored at capture time ---
+
+  it("sessionKey is stored and readable on pending inbound entries", async () => {
+    const entry: PendingInboundEntry = {
+      channel: "telegram",
+      id: "msg-400",
+      payload: { text: "with key" },
+      capturedAt: 1700000000000,
+      sessionKey: "agent:main:telegram:direct:12345",
+    };
+
+    await writePendingInbound(stateDir, entry);
+    const result = await readPendingInbound(stateDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionKey).toBe("agent:main:telegram:direct:12345");
+  });
+
+  it("entries without sessionKey remain backward compatible (undefined)", async () => {
+    const entry: PendingInboundEntry = {
+      channel: "telegram",
+      id: "msg-401",
+      payload: { text: "no key" },
+      capturedAt: 1700000000000,
+    };
+
+    await writePendingInbound(stateDir, entry);
+    const result = await readPendingInbound(stateDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionKey).toBeUndefined();
+  });
+
+  // --- Concurrent write safety (lock serialization) ---
+
+  it("concurrent writes do not lose entries (lock serialization)", async () => {
+    // Fire 10 concurrent writes — without locking some would be lost.
+    const writes = Array.from({ length: 10 }, (_, i) =>
+      writePendingInbound(stateDir, {
+        channel: "telegram",
+        id: `concurrent-${i}`,
+        payload: { index: i },
+        capturedAt: 1700000000000 + i,
+      }),
+    );
+    await Promise.all(writes);
+
+    const result = await readPendingInbound(stateDir);
+    expect(result).toHaveLength(10);
+  });
+
+  // --- Bounded store growth (pruning) ---
+
+  it("writePendingInbound rejects new entries when at MAX_PENDING_ENTRIES (200) capacity", async () => {
+    // Write exactly 200 entries to fill the store.
+    for (let i = 0; i < 200; i++) {
+      const accepted = await writePendingInbound(stateDir, {
+        channel: "telegram",
+        id: `fill-${i}`,
+        payload: { index: i },
+        capturedAt: 1700000000000 + i,
+      });
+      expect(accepted).toBe(true);
+    }
+
+    // The 201st entry should be rejected (not silently drop oldest).
+    const rejected = await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "overflow-entry",
+      payload: { index: 200 },
+      capturedAt: 1700000000200,
+    });
+    expect(rejected).toBe(false);
+
+    const result = await readPendingInbound(stateDir);
+    expect(result).toHaveLength(200);
+
+    // All original 200 entries are preserved (none silently dropped).
+    const ids = result.map((e) => e.id).toSorted();
+    expect(ids).not.toContain("overflow-entry");
+    expect(ids).toContain("fill-0"); // oldest is still there
+    expect(ids).toContain("fill-199"); // newest is still there
+  });
+
+  it("writePendingInbound allows dedup overwrites even when at capacity", async () => {
+    // Fill the store to capacity.
+    for (let i = 0; i < 200; i++) {
+      await writePendingInbound(stateDir, {
+        channel: "telegram",
+        id: `fill-${i}`,
+        payload: { index: i },
+        capturedAt: 1700000000000 + i,
+      });
+    }
+
+    // Overwriting an existing key (same channel:id) should succeed even at capacity.
+    const accepted = await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "fill-50",
+      payload: { index: 50, updated: true },
+      capturedAt: 1700000000050,
+    });
+    expect(accepted).toBe(true);
+
+    const result = await readPendingInbound(stateDir);
+    expect(result).toHaveLength(200);
+  });
+
+  it("writeActiveTurn rejects new entries when at MAX_ACTIVE_TURNS (50) capacity", async () => {
+    // Write exactly 50 turns to fill the tracking map.
+    for (let i = 0; i < 50; i++) {
+      const accepted = await writeActiveTurn(stateDir, {
+        sessionId: `sess-fill-${i}`,
+        sessionKey: `telegram:${i}`,
+        channel: "telegram",
+        startedAt: 1700000000000 + i,
+      });
+      expect(accepted).toBe(true);
+    }
+
+    // The 51st entry should be rejected (not evict oldest).
+    const rejected = await writeActiveTurn(stateDir, {
+      sessionId: "sess-overflow",
+      sessionKey: "telegram:overflow",
+      channel: "telegram",
+      startedAt: 1700000000050,
+    });
+    expect(rejected).toBe(false);
+
+    const result = await readStaleActiveTurns(stateDir);
+    expect(result).toHaveLength(50);
+
+    // All original 50 entries are preserved (none silently evicted).
+    const sessionIds = result.map((e) => e.sessionId).toSorted();
+    expect(sessionIds).not.toContain("sess-overflow");
+    expect(sessionIds).toContain("sess-fill-0"); // oldest is still there
+    expect(sessionIds).toContain("sess-fill-49"); // newest is still there
+  });
+
+  it("writeActiveTurn allows overwrites of same sessionId even when at capacity", async () => {
+    // Fill the tracking map to capacity.
+    for (let i = 0; i < 50; i++) {
+      await writeActiveTurn(stateDir, {
+        sessionId: `sess-fill-${i}`,
+        sessionKey: `telegram:${i}`,
+        channel: "telegram",
+        startedAt: 1700000000000 + i,
+      });
+    }
+
+    // Overwriting an existing sessionId should succeed even at capacity.
+    const accepted = await writeActiveTurn(stateDir, {
+      sessionId: "sess-fill-25",
+      sessionKey: "telegram:25",
+      channel: "telegram",
+      startedAt: 1700000099999,
+    });
+    expect(accepted).toBe(true);
+
+    const result = await readStaleActiveTurns(stateDir);
+    expect(result).toHaveLength(50);
+  });
+
+  it("concurrent active turn writes do not lose entries", async () => {
+    const writes = Array.from({ length: 10 }, (_, i) =>
+      writeActiveTurn(stateDir, {
+        sessionId: `sess-concurrent-${i}`,
+        sessionKey: `telegram:${i}`,
+        channel: "telegram",
+        startedAt: 1700000000000 + i,
+      }),
+    );
+    await Promise.all(writes);
+
+    const result = await readStaleActiveTurns(stateDir);
+    expect(result).toHaveLength(10);
+  });
+
+  // --- processStartedAt guard (server-startup recovery filter) ---
+  //
+  // server-startup.ts records processStartedAt = Date.now() before channels
+  // start, then filters readStaleActiveTurns() to skip entries where
+  // startedAt >= processStartedAt (those are live turns from this process,
+  // not stale leftovers from a previous process).  These tests validate
+  // that filtering logic at the data level.
+
+  it("processStartedAt guard: turns before boot are stale, turns at/after boot are live", async () => {
+    const processStartedAt = 1700000005000;
+
+    // Stale turn from previous process (startedAt < processStartedAt)
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-stale-1",
+      sessionKey: "telegram:111",
+      channel: "telegram",
+      startedAt: 1700000000000, // well before boot
+    });
+
+    // Another stale turn, just barely before boot
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-stale-2",
+      sessionKey: "telegram:222",
+      channel: "telegram",
+      startedAt: 1700000004999, // 1ms before boot
+    });
+
+    // Live turn from THIS process (startedAt === processStartedAt)
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-live-1",
+      sessionKey: "telegram:333",
+      channel: "telegram",
+      startedAt: 1700000005000, // exactly at boot
+    });
+
+    // Live turn from THIS process (startedAt > processStartedAt)
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-live-2",
+      sessionKey: "telegram:444",
+      channel: "telegram",
+      startedAt: 1700000006000, // after boot
+    });
+
+    const allTurns = await readStaleActiveTurns(stateDir);
+    expect(allTurns).toHaveLength(4);
+
+    // Apply the same filter that server-startup.ts uses
+    const staleTurns = allTurns.filter((t) => t.startedAt < processStartedAt);
+    const liveTurns = allTurns.filter((t) => t.startedAt >= processStartedAt);
+
+    expect(staleTurns).toHaveLength(2);
+    expect(staleTurns.map((t) => t.sessionId).toSorted()).toEqual(["sess-stale-1", "sess-stale-2"]);
+
+    expect(liveTurns).toHaveLength(2);
+    expect(liveTurns.map((t) => t.sessionId).toSorted()).toEqual(["sess-live-1", "sess-live-2"]);
+  });
+
+  it("processStartedAt guard: all turns before boot are stale (no false positives)", async () => {
+    const processStartedAt = Date.now();
+
+    // Write turns with timestamps in the past
+    for (let i = 0; i < 5; i++) {
+      await writeActiveTurn(stateDir, {
+        sessionId: `sess-old-${i}`,
+        sessionKey: `telegram:${i}`,
+        channel: "telegram",
+        startedAt: processStartedAt - 60_000 + i * 1000, // 60s to 56s ago
+      });
+    }
+
+    const allTurns = await readStaleActiveTurns(stateDir);
+    const staleTurns = allTurns.filter((t) => t.startedAt < processStartedAt);
+
+    expect(staleTurns).toHaveLength(5);
+    // None should be skipped — all are from "previous process"
+    expect(allTurns.filter((t) => t.startedAt >= processStartedAt)).toHaveLength(0);
+  });
+
+  it("processStartedAt guard: all turns after boot are live (no false negatives)", async () => {
+    const processStartedAt = Date.now() - 1000; // boot 1s ago
+
+    // Write turns with timestamps after boot (simulating new turns from this process)
+    for (let i = 0; i < 3; i++) {
+      await writeActiveTurn(stateDir, {
+        sessionId: `sess-new-${i}`,
+        sessionKey: `telegram:${i}`,
+        channel: "telegram",
+        startedAt: processStartedAt + 100 + i * 100, // 100ms to 300ms after boot
+      });
+    }
+
+    const allTurns = await readStaleActiveTurns(stateDir);
+    const liveTurns = allTurns.filter((t) => t.startedAt >= processStartedAt);
+
+    expect(liveTurns).toHaveLength(3);
+    // None should be recovered — all are from "this process"
+    expect(allTurns.filter((t) => t.startedAt < processStartedAt)).toHaveLength(0);
+  });
+
+  // --- readActiveTurn (single-entry re-validation, TOCTOU guard) ---
+
+  it("readActiveTurn returns the entry for an existing sessionId", async () => {
+    const turn: ActiveTurnEntry = {
+      sessionId: "sess-read-001",
+      sessionKey: "telegram:12345",
+      channel: "telegram",
+      startedAt: 1700000010000,
+    };
+    await writeActiveTurn(stateDir, turn);
+
+    const result = await readActiveTurn(stateDir, "sess-read-001");
+    expect(result).toEqual(turn);
+  });
+
+  it("readActiveTurn returns undefined for a non-existent sessionId", async () => {
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-read-002",
+      sessionKey: "telegram:99999",
+      channel: "telegram",
+      startedAt: 1700000010000,
+    });
+
+    const result = await readActiveTurn(stateDir, "sess-read-MISSING");
+    expect(result).toBeUndefined();
+  });
+
+  it("readActiveTurn returns undefined after the entry is cleared", async () => {
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-read-003",
+      sessionKey: "telegram:77777",
+      channel: "telegram",
+      startedAt: 1700000010000,
+    });
+
+    await clearActiveTurn(stateDir, "sess-read-003");
+
+    const result = await readActiveTurn(stateDir, "sess-read-003");
+    expect(result).toBeUndefined();
+  });
+
+  it("readActiveTurn returns undefined on missing file", async () => {
+    const result = await readActiveTurn(stateDir, "sess-read-no-file");
+    expect(result).toBeUndefined();
+  });
+
+  it("readActiveTurn reflects an updated startedAt after a re-write (TOCTOU guard)", async () => {
+    const processStartedAt = 1700000005000;
+
+    // Simulate stale turn from previous process written before snapshot
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-toctou-001",
+      sessionKey: "telegram:111",
+      channel: "telegram",
+      startedAt: 1700000000000, // stale: before processStartedAt
+    });
+
+    // Take snapshot (mirrors readStaleActiveTurns in server-startup)
+    const snapshot = await readStaleActiveTurns(stateDir);
+    expect(snapshot).toHaveLength(1);
+    const snapshotTurn = snapshot[0];
+    expect(snapshotTurn.startedAt).toBeLessThan(processStartedAt);
+
+    // Simulate a fresh turn written under the same sessionId AFTER the snapshot
+    // (e.g. channel handler started a new turn that recycled the sessionId)
+    await writeActiveTurn(stateDir, {
+      sessionId: "sess-toctou-001",
+      sessionKey: "telegram:111",
+      channel: "telegram",
+      startedAt: 1700000010000, // fresh: after processStartedAt
+    });
+
+    // Re-validate by reading the current store entry
+    const current = await readActiveTurn(stateDir, "sess-toctou-001");
+    expect(current).toBeDefined();
+    // startedAt has changed — the recovery loop should skip this entry
+    expect(current!.startedAt).not.toBe(snapshotTurn.startedAt);
+    expect(current!.startedAt).toBe(1700000010000);
+  });
+
+  // --- File permission tests (Aisle Low #3) ---
+
+  it("pending-inbound.json is written with mode 0o600", async () => {
+    await writePendingInbound(stateDir, {
+      channel: "telegram",
+      id: "perm-test-1",
+      payload: { text: "secret" },
+      capturedAt: Date.now(),
+    });
+
+    const filePath = path.join(stateDir, "pending-inbound.json");
+    const stat = await fsp.stat(filePath);
+    // Mask to the low 9 permission bits (strip file type bits)
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("state dir is created with mode 0o700", async () => {
+    // Use a sub-directory that does not yet exist
+    const subDir = path.join(stateDir, "sub-state-dir");
+
+    await writePendingInbound(subDir, {
+      channel: "telegram",
+      id: "perm-test-2",
+      payload: { text: "secret" },
+      capturedAt: Date.now(),
+    });
+
+    const stat = await fsp.stat(subDir);
+    const mode = stat.mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
+  // --- Unhandled rejection guard (P1 inline comment #2912274100) ---
+  //
+  // withInProcessQueue attaches a .finally() cleanup to the internal promise
+  // chain and must suppress the resulting mirror-rejection with .catch(() => {})
+  // to prevent Node.js from emitting an unhandled-rejection event when the
+  // queued operation fails.  This test verifies that a failing write:
+  //   a) rejects the returned promise (caller sees the error), AND
+  //   b) does not leave a dangling unhandled-rejection on the cleanup promise.
+
+  it("failed write rejects the returned promise but does not leak an unhandled rejection", async () => {
+    // Simulate a write failure by making the state dir a file (not a directory),
+    // which causes mkdir/writeFile inside writeJsonAtomic to throw ENOTDIR/EEXIST.
+    const fakeStateDir = path.join(stateDir, "not-a-dir.txt");
+    await fsp.writeFile(fakeStateDir, "I am a file, not a directory", "utf8");
+
+    const unhandledRejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    let caughtError: unknown;
+    try {
+      await writePendingInbound(fakeStateDir, {
+        channel: "telegram",
+        id: "rej-test-1",
+        payload: {},
+        capturedAt: Date.now(),
+      });
+    } catch (err) {
+      caughtError = err;
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+
+    // Caller must see the error
+    expect(caughtError).toBeDefined();
+
+    // Flush the microtask queue so any dangling rejections would fire
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // No unhandled rejections should have escaped
+    expect(unhandledRejections).toHaveLength(0);
+  });
+});

--- a/src/infra/pending-inbound-store.ts
+++ b/src/infra/pending-inbound-store.ts
@@ -1,0 +1,353 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { withFileLock, type FileLockOptions } from "./file-lock.js";
+import { readJsonFile, writeJsonAtomic } from "./json-files.js";
+
+const STORE_FILENAME = "pending-inbound.json";
+
+/** Maximum number of pending inbound entries before oldest are pruned. */
+const MAX_PENDING_ENTRIES = 200;
+
+/** Maximum number of active turn entries before oldest are pruned. */
+const MAX_ACTIVE_TURNS = 50;
+
+/**
+ * In-process operation queue keyed by resolved file path.
+ *
+ * `withFileLock` is reentrant for the same process (it increments a counter
+ * rather than blocking), so concurrent in-process callers can still
+ * read-modify-write the same stale snapshot.  This map serializes operations
+ * on the same file path within the current process by chaining each new
+ * operation onto the previous promise — guaranteeing sequential execution
+ * even when the file lock is already held.
+ *
+ * The cross-process file lock is still acquired inside each operation to
+ * protect against concurrent writes from other processes.
+ */
+const inProcessOpQueue = new Map<string, Promise<void>>();
+
+/**
+ * Serialize an async operation on `filePath` within this process.
+ * Each call chains onto the previous pending operation for the same path,
+ * ensuring sequential read-modify-write even when `withFileLock` is
+ * reentrant.
+ */
+function withInProcessQueue(filePath: string, fn: () => Promise<void>): Promise<void> {
+  const prev = inProcessOpQueue.get(filePath) ?? Promise.resolve();
+  // Chain the new operation.  Use .then(fn, fn) so a rejected predecessor
+  // does not skip this operation (mirrors status-reactions.ts pattern).
+  const next = prev.then(fn, fn);
+  inProcessOpQueue.set(filePath, next);
+  // Clean up the map entry once the chain settles to avoid unbounded growth
+  // for paths that are written once and never again.
+  // Note: next.finally() returns a new promise that mirrors next's rejection.
+  // Without a .catch(), Node 22 would emit an unhandled-rejection event (which
+  // can terminate the gateway) if `next` rejects, e.g. due to a lock timeout
+  // or an atomic-write error.  The rejection is already surfaced to the caller
+  // via the `next` promise that this function returns, so suppressing it on
+  // the cleanup wrapper is correct and safe.
+  next
+    .finally(() => {
+      if (inProcessOpQueue.get(filePath) === next) {
+        inProcessOpQueue.delete(filePath);
+      }
+    })
+    .catch(() => {});
+  return next;
+}
+
+/**
+ * Lock options for pending-inbound-store read-modify-write operations.
+ * Mirrors AUTH_STORE_LOCK_OPTIONS from auth-profiles.
+ */
+const PENDING_INBOUND_LOCK_OPTIONS: FileLockOptions = {
+  retries: {
+    retries: 10,
+    factor: 2,
+    minTimeout: 100,
+    maxTimeout: 10_000,
+    randomize: true,
+  },
+  stale: 30_000,
+};
+
+/**
+ * An inbound message captured during gateway drain.
+ * Stored to disk so it survives restart and can be replayed.
+ */
+export type PendingInboundEntry = {
+  channel: string;
+  id: string;
+  payload: unknown;
+  capturedAt: number;
+  /** Resolved session key at capture time (used for accurate replay routing). */
+  sessionKey?: string;
+  /**
+   * Account identity for channels that support multiple bot accounts watching
+   * the same channel simultaneously (e.g. Discord multi-account setups).
+   * When present, included in the dedup key so each account's capture is
+   * stored independently: `channel:accountId:id` rather than `channel:id`.
+   */
+  accountId?: string;
+};
+
+/**
+ * An active agent turn tracked so we can detect stale runs after restart.
+ * Written at run start, cleared at run end. Any entry surviving a restart
+ * is stale by definition — the process died mid-turn.
+ */
+export type ActiveTurnEntry = {
+  sessionId: string;
+  sessionKey: string;
+  channel: string;
+  startedAt: number;
+};
+
+type PendingInboundFile = {
+  version: 1;
+  entries: Record<string, PendingInboundEntry>;
+  activeTurns?: Record<string, ActiveTurnEntry>;
+};
+
+function storeKey(entry: Pick<PendingInboundEntry, "channel" | "id" | "accountId">): string {
+  return entry.accountId
+    ? `${entry.channel}:${entry.accountId}:${entry.id}`
+    : `${entry.channel}:${entry.id}`;
+}
+
+function resolveStorePath(stateDir: string): string {
+  return path.join(stateDir, STORE_FILENAME);
+}
+
+/**
+ * Append (or overwrite by dedup key) a pending inbound entry.
+ * Uses atomic write (tmp + rename) following the update-offset-store pattern.
+ * Wrapped in a file lock to prevent concurrent read-modify-write races.
+ *
+ * Returns false without writing if the store is already at capacity and the
+ * entry is not a dedup overwrite.  This prevents silent message loss — the
+ * caller can log a warning or take corrective action.
+ */
+export async function writePendingInbound(
+  stateDir: string,
+  entry: PendingInboundEntry,
+): Promise<boolean> {
+  const filePath = resolveStorePath(stateDir);
+  let accepted = true;
+  await withInProcessQueue(filePath, () =>
+    withFileLock(filePath, PENDING_INBOUND_LOCK_OPTIONS, async () => {
+      const existing = await readPendingInboundFile(filePath);
+      const key = storeKey(entry);
+      // Allow dedup overwrites (same key already present) even when at capacity.
+      // Reject genuinely new entries when the store is full to avoid silently
+      // dropping oldest messages that were captured first.
+      if (
+        !(key in existing.entries) &&
+        Object.keys(existing.entries).length >= MAX_PENDING_ENTRIES
+      ) {
+        accepted = false;
+        return;
+      }
+      existing.entries[key] = entry;
+      await writeJsonAtomic(filePath, existing, {
+        mode: 0o600,
+        trailingNewline: true,
+        ensureDirMode: 0o700,
+      });
+    }),
+  );
+  return accepted;
+}
+
+/**
+ * Read all pending inbound entries. Returns [] if the file doesn't exist.
+ */
+export async function readPendingInbound(stateDir: string): Promise<PendingInboundEntry[]> {
+  const filePath = resolveStorePath(stateDir);
+  const data = await readPendingInboundFile(filePath);
+  return Object.values(data.entries);
+}
+
+/**
+ * Atomically claim (read and clear) all pending inbound entries.
+ * Returns the entries that were present and clears them in a single
+ * file-lock-protected operation so that concurrent writers cannot
+ * insert entries between the read and the clear — preventing message loss.
+ */
+export async function claimPendingInboundEntries(stateDir: string): Promise<PendingInboundEntry[]> {
+  const filePath = resolveStorePath(stateDir);
+  let claimed: PendingInboundEntry[] = [];
+  await withInProcessQueue(filePath, () =>
+    withFileLock(filePath, PENDING_INBOUND_LOCK_OPTIONS, async () => {
+      const existing = await readPendingInboundFile(filePath);
+      claimed = Object.values(existing.entries);
+      if (claimed.length === 0) {
+        return; // nothing to claim
+      }
+      existing.entries = {};
+      await writeJsonAtomic(filePath, existing, {
+        mode: 0o600,
+        trailingNewline: true,
+        ensureDirMode: 0o700,
+      });
+    }),
+  );
+  return claimed;
+}
+
+/**
+ * Remove the pending inbound file entirely.
+ * @deprecated Use `clearPendingInboundEntries` or `clearActiveTurns` to avoid
+ * nuking data belonging to the other key.
+ */
+export async function clearPendingInbound(stateDir: string): Promise<void> {
+  const filePath = resolveStorePath(stateDir);
+  try {
+    await fs.unlink(filePath);
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Clear only the `entries` (pending inbound messages), leaving `activeTurns` intact.
+ */
+export async function clearPendingInboundEntries(stateDir: string): Promise<void> {
+  const filePath = resolveStorePath(stateDir);
+  await withInProcessQueue(filePath, () =>
+    withFileLock(filePath, PENDING_INBOUND_LOCK_OPTIONS, async () => {
+      const existing = await readPendingInboundFile(filePath);
+      if (Object.keys(existing.entries).length === 0) {
+        return; // nothing to clear
+      }
+      existing.entries = {};
+      await writeJsonAtomic(filePath, existing, {
+        mode: 0o600,
+        trailingNewline: true,
+        ensureDirMode: 0o700,
+      });
+    }),
+  );
+}
+
+/**
+ * Clear only the `activeTurns` key, leaving pending inbound `entries` intact.
+ */
+export async function clearAllActiveTurns(stateDir: string): Promise<void> {
+  const filePath = resolveStorePath(stateDir);
+  await withInProcessQueue(filePath, () =>
+    withFileLock(filePath, PENDING_INBOUND_LOCK_OPTIONS, async () => {
+      const existing = await readPendingInboundFile(filePath);
+      if (!existing.activeTurns || Object.keys(existing.activeTurns).length === 0) {
+        return; // nothing to clear
+      }
+      existing.activeTurns = {};
+      await writeJsonAtomic(filePath, existing, {
+        mode: 0o600,
+        trailingNewline: true,
+        ensureDirMode: 0o700,
+      });
+    }),
+  );
+}
+
+/**
+ * Upsert an active-turn entry keyed by sessionId.
+ * Wrapped in a file lock to prevent concurrent read-modify-write races.
+ *
+ * Returns false without writing if the tracking map is already at capacity
+ * and the entry is genuinely new (not an overwrite of the same sessionId).
+ * This prevents evicting live active turns that are still running — those
+ * entries are critical for crash-recovery and must not be silently pruned.
+ */
+export async function writeActiveTurn(stateDir: string, entry: ActiveTurnEntry): Promise<boolean> {
+  const filePath = resolveStorePath(stateDir);
+  let accepted = true;
+  await withInProcessQueue(filePath, () =>
+    withFileLock(filePath, PENDING_INBOUND_LOCK_OPTIONS, async () => {
+      const existing = await readPendingInboundFile(filePath);
+      if (!existing.activeTurns) {
+        existing.activeTurns = {};
+      }
+      // Allow overwrites (same sessionId) even when at capacity.
+      // Reject genuinely new entries to avoid evicting live active turns.
+      if (
+        !(entry.sessionId in existing.activeTurns) &&
+        Object.keys(existing.activeTurns).length >= MAX_ACTIVE_TURNS
+      ) {
+        accepted = false;
+        return;
+      }
+      existing.activeTurns[entry.sessionId] = entry;
+      await writeJsonAtomic(filePath, existing, {
+        mode: 0o600,
+        trailingNewline: true,
+        ensureDirMode: 0o700,
+      });
+    }),
+  );
+  return accepted;
+}
+
+/**
+ * Remove an active-turn entry by sessionId.
+ * Wrapped in a file lock to prevent concurrent read-modify-write races.
+ */
+export async function clearActiveTurn(stateDir: string, sessionId: string): Promise<void> {
+  const filePath = resolveStorePath(stateDir);
+  await withInProcessQueue(filePath, () =>
+    withFileLock(filePath, PENDING_INBOUND_LOCK_OPTIONS, async () => {
+      const existing = await readPendingInboundFile(filePath);
+      if (!existing.activeTurns) {
+        return;
+      }
+      delete existing.activeTurns[sessionId];
+      await writeJsonAtomic(filePath, existing, {
+        mode: 0o600,
+        trailingNewline: true,
+        ensureDirMode: 0o700,
+      });
+    }),
+  );
+}
+
+/**
+ * Read all active-turn entries. At startup every surviving entry is stale
+ * (the process died before clearing it). Returns [] if the file or key
+ * doesn't exist.
+ */
+export async function readStaleActiveTurns(stateDir: string): Promise<ActiveTurnEntry[]> {
+  const filePath = resolveStorePath(stateDir);
+  const data = await readPendingInboundFile(filePath);
+  if (!data.activeTurns) {
+    return [];
+  }
+  return Object.values(data.activeTurns);
+}
+
+/**
+ * Read a single active-turn entry by sessionId.
+ * Returns undefined if the entry does not exist.
+ * Use this to re-validate a turn before clearing it, avoiding TOCTOU races
+ * where a fresh turn with the same sessionId is written after a snapshot is taken.
+ */
+export async function readActiveTurn(
+  stateDir: string,
+  sessionId: string,
+): Promise<ActiveTurnEntry | undefined> {
+  const filePath = resolveStorePath(stateDir);
+  const data = await readPendingInboundFile(filePath);
+  return data.activeTurns?.[sessionId];
+}
+
+async function readPendingInboundFile(filePath: string): Promise<PendingInboundFile> {
+  const data = await readJsonFile<PendingInboundFile>(filePath);
+  if (data && data.version === 1 && typeof data.entries === "object" && data.entries !== null) {
+    return data;
+  }
+  return { version: 1, entries: {} };
+}

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -4,11 +4,8 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
 import {
-  drainSystemEventEntries,
   enqueueSystemEvent,
-  hasSystemEvents,
-  isSystemEventContextChanged,
-  peekSystemEventEntries,
+  MAX_EVENTS,
   peekSystemEvents,
   resetSystemEventsForTest,
 } from "./system-events.js";
@@ -72,48 +69,38 @@ describe("system events (session routing)", () => {
     expect(second).toBe(false);
   });
 
-  it("normalizes context keys when checking for context changes", () => {
-    const key = "agent:main:test-context";
-    expect(isSystemEventContextChanged(key, " build:123 ")).toBe(true);
-
-    enqueueSystemEvent("Node connected", {
-      sessionKey: key,
-      contextKey: " BUILD:123 ",
-    });
-
-    expect(isSystemEventContextChanged(key, "build:123")).toBe(false);
-    expect(isSystemEventContextChanged(key, "build:456")).toBe(true);
-    expect(isSystemEventContextChanged(key)).toBe(true);
+  it("MAX_EVENTS is exported and positive", () => {
+    expect(typeof MAX_EVENTS).toBe("number");
+    expect(MAX_EVENTS).toBeGreaterThan(0);
   });
 
-  it("returns cloned event entries and resets duplicate suppression after drain", () => {
-    const key = "agent:main:test-entry-clone";
-    enqueueSystemEvent("Node connected", {
-      sessionKey: key,
-      contextKey: "build:123",
-    });
-
-    const peeked = peekSystemEventEntries(key);
-    expect(hasSystemEvents(key)).toBe(true);
-    expect(peeked).toHaveLength(1);
-    peeked[0].text = "mutated";
-    expect(peekSystemEvents(key)).toEqual(["Node connected"]);
-
-    expect(drainSystemEventEntries(key).map((entry) => entry.text)).toEqual(["Node connected"]);
-    expect(hasSystemEvents(key)).toBe(false);
-
-    expect(enqueueSystemEvent("Node connected", { sessionKey: key })).toBe(true);
-  });
-
-  it("keeps only the newest 20 queued events", () => {
-    const key = "agent:main:test-max-events";
-    for (let index = 1; index <= 22; index += 1) {
-      enqueueSystemEvent(`event ${index}`, { sessionKey: key });
-    }
-
-    expect(peekSystemEvents(key)).toEqual(
-      Array.from({ length: 20 }, (_, index) => `event ${index + 3}`),
+  it("distinct entries with same message text are not deduplicated when text differs", () => {
+    // Simulates the P2 fix: include entry.id in eventText so two identical
+    // messages from the same sender don't collapse into one.
+    const key = "telegram:drain-dedup-test";
+    const first = enqueueSystemEvent(
+      '[pending-inbound:acc::1234:100] Missed message from Alice: "hello"',
+      { sessionKey: key },
     );
+    const second = enqueueSystemEvent(
+      '[pending-inbound:acc::1234:101] Missed message from Alice: "hello"',
+      { sessionKey: key },
+    );
+    expect(first).toBe(true);
+    expect(second).toBe(true); // NOT deduplicated: different entry ids in text
+    expect(peekSystemEvents(key)).toHaveLength(2);
+  });
+
+  it("caps per-session queue at MAX_EVENTS and drops oldest entries on overflow", () => {
+    const key = "telegram:overflow-test";
+    for (let i = 0; i < MAX_EVENTS + 5; i++) {
+      enqueueSystemEvent(`event-${i}`, { sessionKey: key });
+    }
+    const events = peekSystemEvents(key);
+    expect(events).toHaveLength(MAX_EVENTS);
+    // Oldest entries (event-0 through event-4) should have been dropped
+    expect(events[0]).toBe(`event-5`);
+    expect(events[MAX_EVENTS - 1]).toBe(`event-${MAX_EVENTS + 4}`);
   });
 
   it("shares queued events across duplicate module instances", async () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -6,7 +6,7 @@ import { resolveGlobalMap } from "../shared/global-singleton.js";
 
 export type SystemEvent = { text: string; ts: number; contextKey?: string | null };
 
-const MAX_EVENTS = 20;
+export const MAX_EVENTS = 20;
 
 type SessionQueue = {
   queue: SystemEvent[];

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -39,6 +39,7 @@ export * from "../infra/system-events.js";
 export * from "../infra/system-message.ts";
 export * from "../infra/tmp-openclaw-dir.js";
 export * from "../infra/transport-ready.js";
+export * from "../infra/pending-inbound-store.js";
 export * from "../infra/wsl.ts";
 export * from "../utils/fetch-timeout.js";
 export { createRuntimeOutboundDelegates } from "../channels/plugins/runtime-forwarders.js";

--- a/src/plugin-sdk/process-runtime.ts
+++ b/src/plugin-sdk/process-runtime.ts
@@ -1,3 +1,4 @@
 // Public process helpers for plugins that spawn or probe local commands.
 
 export * from "../process/exec.js";
+export { isGatewayDraining } from "../process/command-queue.js";

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -162,6 +162,13 @@ function drainLane(lane: string) {
 }
 
 /**
+ * Returns whether the gateway is currently draining for restart.
+ */
+export function isGatewayDraining(): boolean {
+  return queueState.gatewayDraining;
+}
+
+/**
  * Mark gateway as draining for restart so new enqueues fail fast with
  * `GatewayDrainingError` instead of being silently killed on shutdown.
  */


### PR DESCRIPTION
## Summary

Two complementary fixes that together eliminate silent message loss when the gateway restarts:

**1. Inbound drain queue** — when the gateway starts draining for restart, new inbound messages from Telegram and Discord are captured to a persistent store instead of being rejected with a 503. Acknowledged immediately (200/OK) to the provider. On next startup, captured messages are replayed before the channel pollers resume — so no provider-side retry races and no user messages silently dropped.

**2. Active-turn recovery** — when a turn is interrupted mid-run by a restart, the session receives a system event on next startup prompting the user to resend. Delivery target is resolved from the session store; if no target can be found (scheduler sessions, dead sessions), recovery is skipped silently.

Related: #41547 addresses a related restart race in the session event queue.

Replaces accidentally-closed #41597.