### PR TITLE
fix(gateway): tolerate transient pre-hello closes in CLI calls

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -548,6 +548,46 @@ describe("callGateway error details", () => {
     expect(err?.message).toContain("Source: local loopback");
     expect(err?.message).toContain("Bind: loopback");
   });
+  it("waits through a transient pre-hello close when the client later completes hello", async () => {
+    setLocalLoopbackGatewayConfig();
+    vi.useFakeTimers();
+    let healthRequests = 0;
+
+    class ReconnectingStubGatewayClient {
+      constructor(
+        private readonly opts: {
+          onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
+          onClose?: (code: number, reason: string) => void;
+        },
+      ) {}
+
+      async request(method: string) {
+        if (method === "health") {
+          healthRequests += 1;
+          return { ok: true };
+        }
+        return undefined;
+      }
+
+      start() {
+        setTimeout(() => this.opts.onClose?.(1000, ""), 0);
+        setTimeout(() => void this.opts.onHelloOk?.({ features: { methods: ["health"] } }), 1);
+      }
+
+      stop() {}
+    }
+
+    __testing.setCreateGatewayClientForTests(
+      (opts) => new ReconnectingStubGatewayClient(opts as never) as never,
+    );
+
+    const promise = callGateway({ method: "health" });
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(healthRequests).toBe(1);
+  });
+
 
   it("includes connection details on timeout", async () => {
     startMode = "silent";

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -841,6 +841,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
     params;
   return await new Promise<T>((resolve, reject) => {
     let settled = false;
+    let helloOkSeen = false;
     let ignoreClose = false;
     const stop = (err?: Error, value?: T) => {
       if (settled) {
@@ -874,6 +875,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {
+        helloOkSeen = true;
         try {
           ensureGatewaySupportsRequiredMethods({
             requiredMethods: opts.requiredMethods,
@@ -895,6 +897,12 @@ async function executeGatewayRequestWithScopes<T>(params: {
       },
       onClose: (code, reason) => {
         if (settled || ignoreClose) {
+          return;
+        }
+        // Some gateway / ws stacks can emit a transient 1000 close during the initial
+        // pre-hello handshake while the client reconnects immediately. Don't fail one-shot
+        // CLI calls on that specific transient close.
+        if (!helloOkSeen && code === 1000 && reason.trim().length === 0) {
           return;
         }
         ignoreClose = true;

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -8,6 +8,7 @@ const clearDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const loadDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const storeDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const logDebugMock = vi.hoisted(() => vi.fn());
+const logErrorMock = vi.hoisted(() => vi.fn());
 
 type WsEvent = "open" | "message" | "close" | "error";
 type WsEventHandlers = {
@@ -107,6 +108,7 @@ vi.mock("../logger.js", async (importOriginal) => {
   return {
     ...actual,
     logDebug: (...args: unknown[]) => logDebugMock(...args),
+    logError: (...args: unknown[]) => logErrorMock(...args),
   };
 });
 
@@ -408,6 +410,7 @@ describe("GatewayClient connect auth payload", () => {
     wsInstances.length = 0;
     loadDeviceAuthTokenMock.mockReset();
     storeDeviceAuthTokenMock.mockReset();
+    logErrorMock.mockReset();
   });
 
   function connectFrameFrom(ws: MockWebSocket) {
@@ -474,6 +477,22 @@ describe("GatewayClient connect auth payload", () => {
           code: "INVALID_REQUEST",
           message: "unauthorized",
           details,
+        },
+      }),
+    );
+  }
+
+  function emitConnectSuccess(ws: MockWebSocket, connectId: string | undefined) {
+    ws.emitMessage(
+      JSON.stringify({
+        type: "res",
+        id: connectId,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          protocol: 3,
+          server: { version: "test", connId: "conn-1" },
+          features: { methods: ["health"] },
         },
       }),
     );
@@ -646,6 +665,40 @@ describe("GatewayClient connect auth payload", () => {
       deviceToken: "stored-device-token",
     });
     client.stop();
+  });
+
+  it("suppresses transient pre-hello 1000 closes while reconnect succeeds", async () => {
+    vi.useFakeTimers();
+    const onConnectError = vi.fn();
+    const onHelloOk = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onConnectError,
+      onHelloOk,
+    });
+
+    try {
+      const { ws: ws1 } = startClientAndConnect({ client });
+      ws1.emitClose(1000, "");
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.waitFor(() => expect(wsInstances.length).toBe(2));
+
+      const ws2 = getLatestWs();
+      ws2.emitOpen();
+      emitConnectChallenge(ws2, "nonce-2");
+      const secondConnect = connectRequestFrom(ws2);
+      emitConnectSuccess(ws2, secondConnect.id);
+
+      await vi.waitFor(() => expect(onHelloOk).toHaveBeenCalled());
+      expect(onConnectError).not.toHaveBeenCalled();
+      expect(logErrorMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("gateway connect failed: Error: gateway closed (1000):"),
+      );
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+    }
   });
 
   it("does not auto-reconnect on AUTH_TOKEN_MISSING connect failures", async () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -502,6 +502,13 @@ export class GatewayClient {
           this.deviceTokenRetryBudgetUsed = true;
           this.backoffMs = Math.min(this.backoffMs, 250);
         }
+        const isTransientPreHelloClose =
+          this.pendingConnectErrorDetailCode == null &&
+          err instanceof Error &&
+          /^gateway closed \(1000\):\s*$/.test(err.message);
+        if (isTransientPreHelloClose) {
+          return;
+        }
         this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
         const msg = `gateway connect failed: ${String(err)}`;
         if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE) {


### PR DESCRIPTION
## Summary
- track whether the gateway hello handshake has completed before treating a close as fatal
- ignore only the transient pre-hello `1000` close with an empty reason that can occur while the client reconnects
- keep one-shot CLI gateway calls waiting for the reconnect instead of aborting early

## Why this is narrow on purpose
This fixes a specific failure mode seen in one-shot CLI gateway calls: the first socket can close with `1000` and an empty reason before `hello-ok`, while the built-in reconnect succeeds on the next attempt. Today the outer request wrapper treats that first close as terminal and aborts too early.

This PR intentionally does **not** ignore every pre-hello close. It only suppresses the transient `1000` + empty-reason case so real pre-hello failures still surface normally.

## Tradeoffs / limitations
- This is a targeted fix for the observed false-negative path, not a full reconnect-state redesign.
- The transient-close handling is still identified by current close semantics (`1000` + empty reason before `hello-ok`), so there may be other transport-specific transient patterns that need separate treatment.
- A more complete long-term approach would model handshake/reconnect state more explicitly so one-shot callers do not need to infer recoverability from close behavior.

## Testing
- `corepack pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/call.test.ts src/gateway/client.test.ts`
- Added regression coverage for:
  - the one-shot `callGateway(...)` path waiting through a transient pre-hello close
  - `GatewayClient` suppressing the spurious connect-failed log/error while reconnect succeeds
