### PR TITLE
feat(auth): add `openclaw models auth clean` command to prune stale auth profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ docs/superpowers
 
 # Deprecated changelog fragment workflow
 changelog/fragments/
+subagent-resume-worktree

--- a/src/agents/auth-profiles/store.legacy-migration.test.ts
+++ b/src/agents/auth-profiles/store.legacy-migration.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for legacy auth.json → auth-profiles.json migration behaviour in
+ * loadAuthProfileStoreForAgent (via loadAgentLocalAuthProfileStore).
+ *
+ * These tests use a real temporary filesystem directory so the migration code
+ * path is exercised end-to-end without mocking file I/O.
+ *
+ * Focus: fix for #2914491523 — with readOnly:true, legacy migration must still
+ * persist auth-profiles.json so that updateAuthProfileStoreWithLock's
+ * ensureAuthStoreFile does not create an empty file that causes toRemove
+ * profiles to go un-removed.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadAgentLocalAuthProfileStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function writeLegacyAuthJson(dir: string, data: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(dir, "auth.json"), JSON.stringify(data));
+}
+
+function readAuthProfilesJson(dir: string): Record<string, unknown> | null {
+  const p = path.join(dir, "auth-profiles.json");
+  if (!fs.existsSync(p)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(p, "utf-8")) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+describe("loadAgentLocalAuthProfileStore – legacy migration with readOnly:true (#2914491523)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "auth-store-migration-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("migrates legacy auth.json to auth-profiles.json even when readOnly:true", () => {
+    writeLegacyAuthJson(tmpDir, {
+      anthropic: { type: "api_key", provider: "anthropic", key: "sk-test" },
+    });
+
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // Profiles should be present in the returned store
+    expect(store.profiles["anthropic:default"]).toBeDefined();
+    expect(store.profiles["anthropic:default"]?.type).toBe("api_key");
+
+    // auth-profiles.json must have been written (migration is unconditional)
+    const migrated = readAuthProfilesJson(tmpDir);
+    expect(migrated).not.toBeNull();
+    expect((migrated as { profiles: Record<string, unknown> }).profiles).toMatchObject({
+      "anthropic:default": { type: "api_key", provider: "anthropic" },
+    });
+
+    // legacy auth.json must have been deleted after successful migration
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
+  });
+
+  it("returns in-memory profiles matching what was in auth.json (readOnly:true)", () => {
+    writeLegacyAuthJson(tmpDir, {
+      openai: { type: "api_key", provider: "openai", key: "sk-openai" },
+      anthropic: { type: "token", provider: "anthropic", token: "tk-anth", expires: 9999999999 },
+    });
+
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // Both legacy profiles should be migrated and visible
+    expect(store.profiles["openai:default"]?.type).toBe("api_key");
+    expect(store.profiles["anthropic:default"]?.type).toBe("token");
+  });
+
+  it("does not create auth-profiles.json when legacy auth.json is absent (readOnly:true)", () => {
+    // No files in tmpDir — nothing to migrate
+    loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    expect(readAuthProfilesJson(tmpDir)).toBeNull();
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
+  });
+
+  it("does not overwrite existing auth-profiles.json body when readOnly:true and no legacy", () => {
+    // Write an existing auth-profiles.json (no auth.json)
+    const existing = {
+      version: 1,
+      profiles: { "anthropic:existing": { type: "api_key", provider: "anthropic", key: "sk-ex" } },
+    };
+    fs.writeFileSync(path.join(tmpDir, "auth-profiles.json"), JSON.stringify(existing));
+
+    // Load with readOnly:true — no legacy present, so no migration; existing file unchanged
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // In-memory store should have the existing profile
+    expect(store.profiles["anthropic:existing"]).toBeDefined();
+
+    // File content should be unchanged (readOnly suppresses external-CLI / OAuth sync)
+    const after = readAuthProfilesJson(tmpDir);
+    expect(after).toEqual(existing);
+  });
+
+  it("migration semantics are preserved when readOnly:false (existing behaviour)", () => {
+    writeLegacyAuthJson(tmpDir, {
+      anthropic: { type: "api_key", provider: "anthropic", key: "sk-test" },
+    });
+
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: false });
+
+    expect(store.profiles["anthropic:default"]).toBeDefined();
+    expect(readAuthProfilesJson(tmpDir)).not.toBeNull();
+    // legacy auth.json should be deleted after migration
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
+  });
+
+  it("ensures updateAuthProfileStoreWithLock sees migrated profiles, not empty store", async () => {
+    // This is the core regression test for #2914491523:
+    // Before the fix, the sequence was:
+    //   1. Probe (readOnly:true) reads legacy profiles into memory but does NOT persist
+    //   2. updateAuthProfileStoreWithLock calls ensureAuthStoreFile → creates empty auth-profiles.json
+    //   3. Write-enabled load inside the lock reads the empty file → returns {}
+    //   4. toRemove profiles were never deleted
+    //
+    // After the fix, step 1 persists the migration, so step 3 reads the migrated profiles.
+    writeLegacyAuthJson(tmpDir, {
+      anthropic: { type: "api_key", provider: "anthropic", key: "sk-legacy" },
+    });
+
+    // Simulate the probe (readOnly:true) — must create auth-profiles.json
+    loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // Simulate what ensureAuthStoreFile does (no-op when file already exists)
+    const authProfilesPath = path.join(tmpDir, "auth-profiles.json");
+    expect(fs.existsSync(authProfilesPath)).toBe(true); // migration created it
+
+    // Simulate the write-enabled load inside the lock (readOnly:false default)
+    const freshStore = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: false });
+
+    // The write-enabled load must see the migrated profiles, not an empty store
+    expect(Object.keys(freshStore.profiles)).toContain("anthropic:default");
+  });
+});

--- a/src/agents/auth-profiles/store.legacy-migration.test.ts
+++ b/src/agents/auth-profiles/store.legacy-migration.test.ts
@@ -5,10 +5,10 @@
  * These tests use a real temporary filesystem directory so the migration code
  * path is exercised end-to-end without mocking file I/O.
  *
- * Focus: fix for #2914491523 — with readOnly:true, legacy migration must still
- * persist auth-profiles.json so that updateAuthProfileStoreWithLock's
- * ensureAuthStoreFile does not create an empty file that causes toRemove
- * profiles to go un-removed.
+ * Focus: fix for #2914491523 — legacy migration (auth.json → auth-profiles.json)
+ * is suppressed when readOnly:true.  The probe call that precedes
+ * updateAuthProfileStoreWithLock uses readOnly:false so migration still runs
+ * before ensureAuthStoreFile can create an empty placeholder.
  */
 
 import fs from "node:fs";
@@ -48,26 +48,23 @@ describe("loadAgentLocalAuthProfileStore – legacy migration with readOnly:true
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("migrates legacy auth.json to auth-profiles.json even when readOnly:true", () => {
+  it("does not write auth-profiles.json or delete auth.json when readOnly:true", () => {
     writeLegacyAuthJson(tmpDir, {
       anthropic: { type: "api_key", provider: "anthropic", key: "sk-test" },
     });
 
     const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
 
-    // Profiles should be present in the returned store
+    // Profiles should be present in the returned in-memory store
     expect(store.profiles["anthropic:default"]).toBeDefined();
     expect(store.profiles["anthropic:default"]?.type).toBe("api_key");
 
-    // auth-profiles.json must have been written (migration is unconditional)
+    // auth-profiles.json must NOT have been written (migration suppressed when readOnly:true)
     const migrated = readAuthProfilesJson(tmpDir);
-    expect(migrated).not.toBeNull();
-    expect((migrated as { profiles: Record<string, unknown> }).profiles).toMatchObject({
-      "anthropic:default": { type: "api_key", provider: "anthropic" },
-    });
+    expect(migrated).toBeNull();
 
-    // legacy auth.json must have been deleted after successful migration
-    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
+    // legacy auth.json must NOT have been deleted (readOnly suppresses all file writes)
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(true);
   });
 
   it("returns in-memory profiles matching what was in auth.json (readOnly:true)", () => {
@@ -123,27 +120,29 @@ describe("loadAgentLocalAuthProfileStore – legacy migration with readOnly:true
     expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
   });
 
-  it("ensures updateAuthProfileStoreWithLock sees migrated profiles, not empty store", async () => {
-    // This is the core regression test for #2914491523:
-    // Before the fix, the sequence was:
-    //   1. Probe (readOnly:true) reads legacy profiles into memory but does NOT persist
-    //   2. updateAuthProfileStoreWithLock calls ensureAuthStoreFile → creates empty auth-profiles.json
-    //   3. Write-enabled load inside the lock reads the empty file → returns {}
-    //   4. toRemove profiles were never deleted
+  it("ensures updateAuthProfileStoreWithLock sees migrated profiles, not empty store", () => {
+    // Regression test for #2914491523.
+    // The correct fix is to probe with readOnly:false so migration runs before
+    // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty placeholder.
     //
-    // After the fix, step 1 persists the migration, so step 3 reads the migrated profiles.
+    // This test validates the readOnly:true probe behaviour (no writes) and confirms
+    // that a subsequent readOnly:false load still migrates correctly from the
+    // untouched auth.json.
     writeLegacyAuthJson(tmpDir, {
       anthropic: { type: "api_key", provider: "anthropic", key: "sk-legacy" },
     });
 
-    // Simulate the probe (readOnly:true) — must create auth-profiles.json
+    // Simulate a readOnly:true probe — must NOT create auth-profiles.json
     loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
 
-    // Simulate what ensureAuthStoreFile does (no-op when file already exists)
     const authProfilesPath = path.join(tmpDir, "auth-profiles.json");
-    expect(fs.existsSync(authProfilesPath)).toBe(true); // migration created it
+    // readOnly probe leaves the filesystem untouched
+    expect(fs.existsSync(authProfilesPath)).toBe(false);
+    // auth.json still present — not deleted by readOnly probe
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(true);
 
     // Simulate the write-enabled load inside the lock (readOnly:false default)
+    // — it still sees auth.json and performs the migration
     const freshStore = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: false });
 
     // The write-enabled load must see the migrated profiles, not an empty store

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -540,7 +540,7 @@ export function loadAuthProfileStoreForSecretsRuntime(agentDir?: string): AuthPr
 
 export function ensureAuthProfileStore(
   agentDir?: string,
-  options?: { allowKeychainPrompt?: boolean },
+  options?: { allowKeychainPrompt?: boolean; readOnly?: boolean },
 ): AuthProfileStore {
   const runtimeStore = resolveRuntimeAuthProfileStore(agentDir);
   if (runtimeStore) {
@@ -571,7 +571,7 @@ export function ensureAuthProfileStore(
  */
 export function loadAgentLocalAuthProfileStore(
   agentDir?: string,
-  options?: { allowKeychainPrompt?: boolean },
+  options?: { allowKeychainPrompt?: boolean; readOnly?: boolean },
 ): AuthProfileStore {
   return loadAuthProfileStoreForAgent(agentDir, options);
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -504,9 +504,9 @@ function loadAuthProfileStoreForAgent(
 
   // Legacy migration (auth.json → auth-profiles.json) is suppressed when the
   // caller passes readOnly:true (dry-run or probe-mode loads that must not write).
-  // For actual cleanup calls the probe is loaded with readOnly:false, so migration
-  // still runs and auth-profiles.json is created before updateAuthProfileStoreWithLock's
-  // ensureAuthStoreFile can create an empty placeholder.  (#2914491523, #2914711181)
+  // auth-clean.ts probes readOnly:true, then performs a separate readOnly:false
+  // load after guards pass to trigger migration before updateAuthProfileStoreWithLock's
+  // ensureAuthStoreFile can create an empty placeholder. (#2914491523, #2914711181, #2915530629)
   const shouldMigrateLegacy = !readOnly && !forceReadOnly && legacy !== null;
   // External-CLI / OAuth extras are still suppressed during read-only probes.
   const shouldPersistExtras = !readOnly && !forceReadOnly && (mergedOAuth || syncedCli);

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -501,15 +501,26 @@ function loadAuthProfileStoreForAgent(
   // Keep external CLI credentials visible in runtime even during read-only loads.
   const syncedCli = syncExternalCliCredentialsTimed(store, { log: !readOnly });
   const forceReadOnly = process.env.OPENCLAW_AUTH_STORE_READONLY === "1";
-  const shouldWrite = !readOnly && !forceReadOnly && (legacy !== null || mergedOAuth || syncedCli);
-  if (shouldWrite) {
+
+  // Legacy migration (auth.json → auth-profiles.json) persists unconditionally,
+  // even when readOnly:true.  The readOnly flag suppresses updates to EXISTING
+  // auth-profiles.json (external CLI sync, OAuth merge) but must NOT suppress the
+  // one-time creation of auth-profiles.json from legacy auth.json.  Without this,
+  // updateAuthProfileStoreWithLock's ensureAuthStoreFile creates an empty
+  // auth-profiles.json, the subsequent write-enabled load finds it and returns an
+  // empty store, and toRemove profiles are never actually deleted.  (#2914491523)
+  const shouldMigrateLegacy = !forceReadOnly && legacy !== null;
+  // External-CLI / OAuth extras are still suppressed during read-only probes.
+  const shouldPersistExtras = !readOnly && !forceReadOnly && (mergedOAuth || syncedCli);
+
+  if (shouldMigrateLegacy || shouldPersistExtras) {
     saveJsonFile(authPath, store);
   }
 
   // PR #368: legacy auth.json could get re-migrated from other agent dirs,
   // overwriting fresh OAuth creds with stale tokens (fixes #363). Delete only
   // after we've successfully written auth-profiles.json.
-  if (shouldWrite && legacy !== null) {
+  if (shouldMigrateLegacy) {
     const legacyPath = resolveLegacyAuthStorePath(agentDir);
     try {
       fs.unlinkSync(legacyPath);

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -560,6 +560,22 @@ export function ensureAuthProfileStore(
   return merged;
 }
 
+/**
+ * Load only the agent-local auth profile store, without merging with the main
+ * agent store. Use this when computing which profiles to delete: the clean
+ * command's write target is the agent-local file only, so profile IDs that
+ * exist exclusively in the main store must never appear in toRemove.
+ *
+ * Unlike ensureAuthProfileStore, this function does NOT merge the main store
+ * into the result for non-default agents.
+ */
+export function loadAgentLocalAuthProfileStore(
+  agentDir?: string,
+  options?: { allowKeychainPrompt?: boolean },
+): AuthProfileStore {
+  return loadAuthProfileStoreForAgent(agentDir, options);
+}
+
 export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string): void {
   const authPath = resolveAuthStorePath(agentDir);
   const profiles = Object.fromEntries(

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -19,6 +19,13 @@ type RejectedCredentialEntry = { key: string; reason: CredentialRejectReason };
 type LoadAuthProfileStoreOptions = {
   allowKeychainPrompt?: boolean;
   readOnly?: boolean;
+  /**
+   * When true, skip the main-agent inheritance fallback that clones main profiles
+   * into a subagent directory when the subagent has no auth-profiles.json.
+   * Use for the pre-lock migration trigger in auth-clean to avoid materialising
+   * main credentials in the subagent file before cleanup (scope bleed).
+   */
+  skipInheritance?: boolean;
 };
 
 const AUTH_PROFILE_TYPES = new Set<AuthProfileCredential["type"]>(["api_key", "oauth", "token"]);
@@ -473,8 +480,11 @@ function loadAuthProfileStoreForAgent(
     return asStore;
   }
 
-  // Fallback: inherit auth-profiles from main agent if subagent has none
-  if (agentDir && !readOnly) {
+  // Fallback: inherit auth-profiles from main agent if subagent has none.
+  // Skipped when skipInheritance:true (e.g. auth-clean pre-lock migration trigger)
+  // to prevent materialising main credentials in the subagent file before cleanup
+  // runs — that would cause scope bleed and a misleading no-op clean. (#2915653312)
+  if (agentDir && !readOnly && !options?.skipInheritance) {
     const mainAuthPath = resolveAuthStorePath(); // without agentDir = main
     const mainRaw = loadJsonFile(mainAuthPath);
     const mainStore = coerceAuthStore(mainRaw);
@@ -590,7 +600,7 @@ export function ensureAuthProfileStore(
  */
 export function loadAgentLocalAuthProfileStore(
   agentDir?: string,
-  options?: { allowKeychainPrompt?: boolean; readOnly?: boolean },
+  options?: LoadAuthProfileStoreOptions,
 ): AuthProfileStore {
   return loadAuthProfileStoreForAgent(agentDir, options);
 }

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -123,6 +123,14 @@ function writeCachedAuthProfileStore(
 
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
+  /**
+   * When true, load only the agent-local store inside the lock instead of the
+   * merged (main + agent-local) view returned by ensureAuthProfileStore.
+   * Use for non-default agents when the write target is the agent-local file
+   * only, to prevent main-store profiles from being written into that file
+   * (credential scope bleed).
+   */
+  agentLocalOnly?: boolean;
   updater: (store: AuthProfileStore) => boolean;
 }): Promise<AuthProfileStore | null> {
   const authPath = resolveAuthStorePath(params.agentDir);
@@ -133,7 +141,9 @@ export async function updateAuthProfileStoreWithLock(params: {
       // Locked writers must reload from disk, not from any runtime snapshot.
       // Otherwise a live gateway can overwrite fresher CLI/config-auth writes
       // with stale in-memory auth state during usage/cooldown updates.
-      const store = loadAuthProfileStoreForAgent(params.agentDir);
+      const store = params.agentLocalOnly
+        ? loadAgentLocalAuthProfileStore(params.agentDir)
+        : loadAuthProfileStoreForAgent(params.agentDir);
       const shouldSave = params.updater(store);
       if (shouldSave) {
         saveAuthProfileStore(store, params.agentDir);

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -502,14 +502,12 @@ function loadAuthProfileStoreForAgent(
   const syncedCli = syncExternalCliCredentialsTimed(store, { log: !readOnly });
   const forceReadOnly = process.env.OPENCLAW_AUTH_STORE_READONLY === "1";
 
-  // Legacy migration (auth.json → auth-profiles.json) persists unconditionally,
-  // even when readOnly:true.  The readOnly flag suppresses updates to EXISTING
-  // auth-profiles.json (external CLI sync, OAuth merge) but must NOT suppress the
-  // one-time creation of auth-profiles.json from legacy auth.json.  Without this,
-  // updateAuthProfileStoreWithLock's ensureAuthStoreFile creates an empty
-  // auth-profiles.json, the subsequent write-enabled load finds it and returns an
-  // empty store, and toRemove profiles are never actually deleted.  (#2914491523)
-  const shouldMigrateLegacy = !forceReadOnly && legacy !== null;
+  // Legacy migration (auth.json → auth-profiles.json) is suppressed when the
+  // caller passes readOnly:true (dry-run or probe-mode loads that must not write).
+  // For actual cleanup calls the probe is loaded with readOnly:false, so migration
+  // still runs and auth-profiles.json is created before updateAuthProfileStoreWithLock's
+  // ensureAuthStoreFile can create an empty placeholder.  (#2914491523, #2914711181)
+  const shouldMigrateLegacy = !readOnly && !forceReadOnly && legacy !== null;
   // External-CLI / OAuth extras are still suppressed during read-only probes.
   const shouldPersistExtras = !readOnly && !forceReadOnly && (mergedOAuth || syncedCli);
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -4,6 +4,7 @@ import {
   modelsAliasesListCommand,
   modelsAliasesRemoveCommand,
   modelsAuthAddCommand,
+  modelsAuthCleanCommand,
   modelsAuthLoginCommand,
   modelsAuthOrderClearCommand,
   modelsAuthOrderGetCommand,
@@ -371,6 +372,27 @@ export function registerModelsCli(program: Command) {
             provider: "github-copilot",
             method: "device",
             yes: Boolean(opts.yes),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("clean")
+    .description(
+      "Remove stale profiles from auth-profiles.json that are not configured in openclaw.json",
+    )
+    .option("--agent <id>", "Agent id to clean (default: main)")
+    .option("--dry-run", "Preview removals without writing changes")
+    .option("--json", "Output as JSON")
+    .action((opts) => {
+      runModelsCommand(async () => {
+        await modelsAuthCleanCommand(
+          {
+            agent: opts.agent as string | undefined,
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json),
           },
           defaultRuntime,
         );

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -383,14 +383,16 @@ export function registerModelsCli(program: Command) {
     .description(
       "Remove stale profiles from auth-profiles.json that are not configured in openclaw.json",
     )
-    .option("--agent <id>", "Agent id to clean (default: main)")
+    .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--dry-run", "Preview removals without writing changes")
     .option("--json", "Output as JSON")
-    .action((opts) => {
-      runModelsCommand(async () => {
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
+      await runModelsCommand(async () => {
         await modelsAuthCleanCommand(
           {
-            agent: opts.agent as string | undefined,
+            agent,
             dryRun: Boolean(opts.dryRun),
             json: Boolean(opts.json),
           },

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -31,3 +31,5 @@ export { modelsListCommand, modelsStatusCommand } from "./models/list.js";
 export { modelsScanCommand } from "./models/scan.js";
 export { modelsSetCommand } from "./models/set.js";
 export { modelsSetImageCommand } from "./models/set-image.js";
+
+export { modelsAuthCleanCommand } from "./models/auth-clean.js";

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -630,4 +630,46 @@ describe("modelsAuthCleanCommand", () => {
     // The sanitized prefix (before the stripped \n) should still appear
     expect(runtime.logs.some((line) => line.includes("anthropic:legit"))).toBe(true);
   });
+
+  it("strips private CSI escape sequences (e.g. cursor hide) from profile IDs", async () => {
+    // Private CSI sequences like \x1b[?25l (cursor hide) contain a '?' parameter
+    // prefix not matched by the old [0-9;]* pattern — they must be stripped.
+    const maliciousId = "anthropic:\x1b[?25lhidden\x1b[?25h";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // Private CSI sequences must be stripped
+    expect(combined).not.toContain("\x1b[?25l");
+    expect(combined).not.toContain("\x1b[?25h");
+    // The non-escape text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("hidden");
+  });
+
+  it("strips OSC escape sequences (e.g. window title) from profile IDs", async () => {
+    // OSC sequences like \x1b]0;title\x07 set terminal window titles; they are
+    // not matched by CSI-only patterns and must be stripped to prevent injection.
+    const maliciousId = "anthropic:\x1b]0;injected-title\x07name";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // OSC sequence must be stripped
+    expect(combined).not.toContain("\x1b]0;");
+    expect(combined).not.toContain("\x07");
+    // The non-escape text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("name");
+  });
 });

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -20,6 +20,9 @@ vi.mock("../../agents/agent-scope.js", () => ({
 
 vi.mock("../../agents/auth-profiles.js", () => ({
   ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+}));
+
+vi.mock("../../agents/auth-profiles/store.js", () => ({
   updateAuthProfileStoreWithLock: mocks.updateAuthProfileStoreWithLock,
 }));
 
@@ -37,12 +40,13 @@ const { modelsAuthCleanCommand } = await import("./auth-clean.js");
 
 function makeRuntime(): RuntimeEnv & { logs: string[] } {
   const logs: string[] = [];
-  return {
+  const runtime = {
     logs,
-    log: vi.fn((msg: string) => logs.push(msg)),
+    log: (msg: string) => { logs.push(msg); },
     error: vi.fn(),
     exit: vi.fn(),
   };
+  return runtime as unknown as RuntimeEnv & { logs: string[] };
 }
 
 function makeCfg(

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -248,25 +248,33 @@ describe("modelsAuthCleanCommand", () => {
   it("probe uses readOnly:true; migration trigger uses readOnly:false after guards pass (non-default agent)", async () => {
     // #2915530629: same as default agent path — probe is always readOnly:true;
     // migration trigger uses readOnly:false after guards pass. (#2914491523, #2914711181)
+    // #2915653312: migration trigger must also pass skipInheritance:true so that
+    // the main-agent fallback inside loadAuthProfileStoreForAgent is suppressed —
+    // without it, a subagent with no local store would clone main credentials
+    // before cleanup, causing scope bleed and a misleading no-op.
     const store = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+    const workerAgentDir = "/home/user/.openclaw/agents/worker/agent";
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
     mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
-    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    mocks.resolveAgentDir.mockReturnValueOnce(workerAgentDir);
     mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
     captureUpdater(store);
 
     await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime()); // no dryRun
 
-    // Probe call: readOnly:true (always, even for non-dryRun)
+    // Probe call: readOnly:true (always, even for non-dryRun); agentDir is the
+    // worker-specific path, not the main agent path.
     expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
-      expect.any(String),
+      workerAgentDir,
       expect.objectContaining({ readOnly: true }),
     );
-    // Migration trigger call: readOnly:false (after guards pass, before lock)
+    // Migration trigger call: readOnly:false (after guards pass, before lock).
+    // Must pass skipInheritance:true to prevent the main-agent fallback from
+    // cloning main profiles into the worker file before cleanup. (#2915653312)
     expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({ readOnly: false }),
+      workerAgentDir,
+      expect.objectContaining({ readOnly: false, skipInheritance: true }),
     );
   });
 

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+// ---- hoisted mocks ---------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  resolveDefaultAgentId: vi.fn(() => "main"),
+  resolveAgentDir: vi.fn((_cfg: unknown, _id: unknown) => "/home/user/.openclaw/agents/main/agent"),
+  ensureAuthProfileStore: vi.fn(),
+  updateAuthProfileStoreWithLock: vi.fn(),
+  loadModelsConfig: vi.fn(),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+  resolveAgentDir: mocks.resolveAgentDir,
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  updateAuthProfileStoreWithLock: mocks.updateAuthProfileStoreWithLock,
+}));
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./shared.js", () => ({
+  resolveKnownAgentId: vi.fn(() => null),
+}));
+
+// ---- helpers ----------------------------------------------------------------
+
+const { modelsAuthCleanCommand } = await import("./auth-clean.js");
+
+function makeRuntime(): RuntimeEnv & { logs: string[] } {
+  const logs: string[] = [];
+  return {
+    logs,
+    log: vi.fn((msg: string) => logs.push(msg)),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function makeCfg(
+  profileIds: string[] = ["anthropic:me.com", "anthropic:gmail"],
+  orderIds: string[] = [],
+): OpenClawConfig {
+  const profiles: Record<string, { provider: string; mode: string }> = {};
+  for (const id of profileIds) {
+    const provider = id.split(":")[0] ?? "anthropic";
+    profiles[id] = { provider, mode: "token" };
+  }
+  const order: Record<string, string[]> = {};
+  if (orderIds.length > 0) {
+    order["anthropic"] = orderIds;
+  }
+  return { auth: { profiles, ...(orderIds.length > 0 ? { order } : {}) } } as OpenClawConfig;
+}
+
+function makeStore(
+  profileIds: string[],
+  extras: Partial<AuthProfileStore> = {},
+): AuthProfileStore {
+  const profiles: AuthProfileStore["profiles"] = {};
+  for (const id of profileIds) {
+    const provider = id.split(":")[0] ?? "anthropic";
+    profiles[id] = { type: "token", provider, token: `sk-${id}` };
+  }
+  return { version: 1, profiles, ...extras };
+}
+
+/**
+ * Capture what the updater closure does when called with a given store.
+ * updateAuthProfileStoreWithLock calls params.updater(freshStore) internally;
+ * this helper simulates that so we can inspect mutations.
+ */
+function captureUpdater(storeSeed: AuthProfileStore): {
+  result: AuthProfileStore;
+  returned: boolean;
+} {
+  let captured: AuthProfileStore | undefined;
+  let returned = false;
+
+  mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+    async (params: { updater: (s: AuthProfileStore) => boolean }) => {
+      const clone = structuredClone(storeSeed);
+      returned = params.updater(clone);
+      captured = clone;
+      return returned ? clone : null;
+    },
+  );
+
+  return { get result() { return captured!; }, get returned() { return returned; } };
+}
+
+// ---- tests ------------------------------------------------------------------
+
+describe("modelsAuthCleanCommand", () => {
+  it("removes stale profiles from profiles, usageStats, and lastGood", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail", "anthropic:manual"], {
+      usageStats: {
+        "anthropic:manual": { lastUsed: 1000, errorCount: 1 },
+        "anthropic:me.com": { lastUsed: 2000, errorCount: 0 },
+      },
+      lastGood: { anthropic: "anthropic:manual" },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:manual");
+    expect(capture.result.profiles).toHaveProperty("anthropic:me.com");
+    expect(capture.result.profiles).toHaveProperty("anthropic:gmail");
+    expect(capture.result.usageStats).not.toHaveProperty("anthropic:manual");
+    expect(capture.result.usageStats).toHaveProperty("anthropic:me.com");
+    expect(capture.result.lastGood).not.toHaveProperty("anthropic");
+  });
+
+  it("removes stale ids from order and deletes the key when the array becomes empty", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"], {
+      order: { anthropic: ["anthropic:manual"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // key deleted because filtered list became empty
+    expect(capture.result.order).not.toHaveProperty("anthropic");
+  });
+
+  it("keeps a non-empty order array when only some ids are stale", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail", "anthropic:manual"], {
+      order: { anthropic: ["anthropic:me.com", "anthropic:manual"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    expect(capture.result.order?.["anthropic"]).toEqual(["anthropic:me.com"]);
+  });
+
+  it("--dry-run does not call updateAuthProfileStoreWithLock", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({ dryRun: true }, makeRuntime());
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("--dry-run logs the plan without writing", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    expect(combined).toContain("anthropic:manual");
+    expect(combined).toContain("dry run");
+  });
+
+  it("does nothing when all store profiles are configured", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("treats profiles referenced in auth.order as configured (not stale)", async () => {
+    // anthropic:legacy is in auth.order but not in auth.profiles — should be preserved
+    const store = makeStore(["anthropic:me.com", "anthropic:legacy"]);
+
+    const cfg = makeCfg(["anthropic:me.com"], ["anthropic:me.com", "anthropic:legacy"]);
+    mocks.loadModelsConfig.mockResolvedValue(cfg);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // Nothing stale — updateAuthProfileStoreWithLock should not be called
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("throws when openclaw.json has no configured auth and store has profiles", async () => {
+    const store = makeStore(["anthropic:me.com"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await expect(modelsAuthCleanCommand({}, makeRuntime())).rejects.toThrow(
+      /no configured auth profiles/i,
+    );
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("--dry-run with no configured auth logs warning instead of throwing", async () => {
+    const store = makeStore(["anthropic:me.com"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toMatch(/warning/i);
+  });
+
+  it("--json emits plan object then {ok, removed} result after write", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ json: true }, runtime);
+
+    expect(runtime.logs.length).toBe(2);
+    const plan = JSON.parse(runtime.logs[0]!);
+    const result = JSON.parse(runtime.logs[1]!);
+
+    expect(plan).toMatchObject({ toRemove: ["anthropic:manual"], dryRun: false });
+    expect(result).toMatchObject({ ok: true, removed: 1 });
+  });
+
+  it("--json --dry-run emits only the plan object", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ json: true, dryRun: true }, runtime);
+
+    expect(runtime.logs.length).toBe(1);
+    const plan = JSON.parse(runtime.logs[0]!);
+    expect(plan).toMatchObject({ toRemove: ["anthropic:manual"], dryRun: true });
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("reports actualRemoved from inside the lock, not the pre-lock estimate", async () => {
+    // Simulate gateway concurrently removing anthropic:manual before lock acquired
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+    const storeAtLockTime = makeStore(["anthropic:me.com"]); // manual already gone
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    // updater receives the already-cleaned store
+    mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+      async (params: { updater: (s: AuthProfileStore) => boolean }) => {
+        const clone = structuredClone(storeAtLockTime);
+        params.updater(clone);
+        return clone; // something returned = success
+      },
+    );
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // actualRemoved should be 0 (nothing was there to delete under the lock)
+    expect(runtime.logs.join("\n")).toContain("Removed 0 stale profile(s)");
+  });
+
+  it("throws when updateAuthProfileStoreWithLock returns null (lock busy)", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    mocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null);
+
+    await expect(modelsAuthCleanCommand({}, makeRuntime())).rejects.toThrow(/lock busy/i);
+  });
+});

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -100,6 +100,10 @@ function captureUpdater(storeSeed: AuthProfileStore): {
 // ---- tests ------------------------------------------------------------------
 
 describe("modelsAuthCleanCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("removes stale profiles from profiles, usageStats, and lastGood", async () => {
     const store = makeStore(["anthropic:me.com", "anthropic:gmail", "anthropic:manual"], {
       usageStats: {
@@ -135,8 +139,8 @@ describe("modelsAuthCleanCommand", () => {
 
     await modelsAuthCleanCommand({}, makeRuntime());
 
-    // key deleted because filtered list became empty
-    expect(capture.result.order).not.toHaveProperty("anthropic");
+    // order key deleted entirely because filtered list became empty
+    expect(capture.result.order).toBeUndefined();
   });
 
   it("keeps a non-empty order array when only some ids are stale", async () => {

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -219,11 +219,12 @@ describe("modelsAuthCleanCommand", () => {
     expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
   });
 
-  it("always passes readOnly:true to ensureAuthProfileStore even when not dry-run (default agent)", async () => {
-    // P2 (#2914164081): store was previously loaded readOnly:false before the empty-config
-    // safety guard ran, causing unwanted write side-effects (external CLI sync, legacy migration).
-    // The probe load must always be read-only; the write-enabled load is deferred to
-    // updateAuthProfileStoreWithLock which only runs when cleanup actually proceeds.
+  it("passes readOnly:false to ensureAuthProfileStore when not dry-run (default agent)", async () => {
+    // #2914711181: the probe for actual cleanup must use readOnly:false so legacy
+    // auth.json → auth-profiles.json migration runs before
+    // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty
+    // placeholder (which would cause the write-enabled load inside the lock to
+    // return an empty store and skip all removals).
     const store = makeStore(["anthropic:me.com", "anthropic:stale"]);
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
@@ -234,14 +235,12 @@ describe("modelsAuthCleanCommand", () => {
 
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ readOnly: true }),
+      expect.objectContaining({ readOnly: false }),
     );
   });
 
-  it("always passes readOnly:true to loadAgentLocalAuthProfileStore even when not dry-run (non-default agent)", async () => {
-    // P2 (#2914199338): for non-dry non-main-agent runs, the store was loaded readOnly:false
-    // before any validation, triggering write side-effects before guards were checked.
-    // The probe load must always be read-only regardless of dry-run or agent type.
+  it("passes readOnly:false to loadAgentLocalAuthProfileStore when not dry-run (non-default agent)", async () => {
+    // #2914711181: same as above for non-default agent path.
     const store = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
@@ -254,7 +253,7 @@ describe("modelsAuthCleanCommand", () => {
 
     expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ readOnly: true }),
+      expect.objectContaining({ readOnly: false }),
     );
   });
 

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -564,6 +564,36 @@ describe("modelsAuthCleanCommand", () => {
     );
   });
 
+  it("non-main agent: pre-lock readOnly:false migration trigger passes agent-specific agentDir, not main path (#2915653312)", async () => {
+    // Guard: the pre-lock readOnly:false migration trigger must explicitly pass the
+    // agent-specific agentDir to loadAgentLocalAuthProfileStore — not the default
+    // (main) path and not undefined.  Without the explicit agentDir, the call
+    // resolves to the main agent's auth-profiles.json and cleanup silently operates
+    // on the wrong store (scope bleed, misleading no-op). (#2915653312)
+    const workerAgentDir = "/home/user/.openclaw/agents/worker/agent";
+    const mainAgentDir = "/home/user/.openclaw/agents/main/agent"; // default mock value
+    const store = makeStore(["anthropic:worker-profile", "anthropic:worker-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:worker-profile"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce(workerAgentDir);
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime());
+
+    // Every call to loadAgentLocalAuthProfileStore must use the worker-specific
+    // agentDir — never the main agent dir and never undefined (which would also
+    // resolve to the main dir).
+    const calls = mocks.loadAgentLocalAuthProfileStore.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [dir] of calls) {
+      expect(dir).toBe(workerAgentDir);
+      expect(dir).not.toBe(mainAgentDir);
+      expect(dir).not.toBeUndefined();
+    }
+  });
+
   it("default agent: does not set agentLocalOnly on updateAuthProfileStoreWithLock", async () => {
     // Default agent uses the merged store (ensureAuthProfileStore path) — no agentLocalOnly.
     const store = makeStore(["anthropic:me.com", "anthropic:stale"]);

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -420,4 +420,146 @@ describe("modelsAuthCleanCommand", () => {
     // ensureAuthProfileStore should not have been called for profile-set computation
     expect(mocks.ensureAuthProfileStore).not.toHaveBeenCalled();
   });
+
+  // ---- Fix: agent media profiles without top-level tools.media (P1 #2912273297) ----
+
+  it("collects agent-level media profiles even when cfg.tools.media is absent", async () => {
+    // Arrange: no top-level tools.media, but one agent override references a profile.
+    // Without the fix, collectMediaProfileIds() returned early on !media and the
+    // agent-level profile was treated as stale and added to toRemove.
+    const store = makeStore(["anthropic:me.com", "anthropic:media-agent"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({
+      ...makeCfg(["anthropic:me.com"]),
+      // Deliberately omit tools.media at the top level
+      agents: {
+        list: [
+          {
+            id: "worker",
+            tools: {
+              media: {
+                models: [{ model: "gpt-4o", profile: "anthropic:media-agent" }],
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // anthropic:media-agent is in an agent's tools.media override — must be kept
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("collects agent preferredProfile references without top-level tools.media", async () => {
+    // preferredProfile (not just profile) must also be picked up from agent overrides
+    const store = makeStore(["anthropic:me.com", "anthropic:preferred-agent"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({
+      ...makeCfg(["anthropic:me.com"]),
+      agents: {
+        list: [
+          {
+            id: "worker",
+            tools: {
+              media: {
+                image: {
+                  models: [{ model: "gpt-4o", preferredProfile: "anthropic:preferred-agent" }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  // ---- Fix: agentLocalOnly prevents credential scope bleed (Aisle High) ----
+
+  it("non-default agent: passes agentLocalOnly:true to updateAuthProfileStoreWithLock", async () => {
+    // Ensures the write path uses agent-local-only loading, preventing main-store
+    // profiles from being persisted into the agent-local auth-profiles.json file.
+    const agentLocalStore = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(agentLocalStore);
+    captureUpdater(agentLocalStore);
+
+    await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime());
+
+    expect(mocks.updateAuthProfileStoreWithLock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentLocalOnly: true }),
+    );
+  });
+
+  it("default agent: does not set agentLocalOnly on updateAuthProfileStoreWithLock", async () => {
+    // Default agent uses the merged store (ensureAuthProfileStore path) — no agentLocalOnly.
+    const store = makeStore(["anthropic:me.com", "anthropic:stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    const call = mocks.updateAuthProfileStoreWithLock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call?.agentLocalOnly).toBeFalsy();
+  });
+
+  // ---- Fix: sanitize ANSI escape codes in profile ID output (Aisle Low) ----
+
+  it("strips ANSI escape sequences from profile IDs in --dry-run output", async () => {
+    // A profile ID containing an ANSI color sequence must not reach the terminal raw.
+    const maliciousId = "anthropic:\x1b[31mred\x1b[0m";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // ANSI escape sequences must be stripped
+    expect(combined).not.toContain("\x1b[31m");
+    expect(combined).not.toContain("\x1b[0m");
+    // The non-malicious text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("red");
+  });
+
+  it("strips newlines from profile IDs in --dry-run output to prevent log forging", async () => {
+    // A profile ID "anthropic:legit\nINJECTED LINE" must not produce a separate
+    // log entry that starts with "INJECTED LINE" (i.e., must not forge a new line).
+    // After sanitization the \n is removed and the injected text is concatenated
+    // to the profile ID rather than appearing as a standalone forged log entry.
+    const maliciousId = "anthropic:legit\nINJECTED LINE";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    // No log call should start with the injected text (that would mean log forging)
+    for (const line of runtime.logs) {
+      expect(line).not.toMatch(/^\s*INJECTED LINE/);
+    }
+    // The sanitized prefix (before the stripped \n) should still appear
+    expect(runtime.logs.some((line) => line.includes("anthropic:legit"))).toBe(true);
+  });
 });

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -219,12 +219,12 @@ describe("modelsAuthCleanCommand", () => {
     expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
   });
 
-  it("passes readOnly:false to ensureAuthProfileStore when not dry-run (default agent)", async () => {
-    // #2914711181: the probe for actual cleanup must use readOnly:false so legacy
-    // auth.json → auth-profiles.json migration runs before
+  it("probe uses readOnly:true; migration trigger uses readOnly:false after guards pass (default agent)", async () => {
+    // #2915530629: probe must always use readOnly:true — never open a write-capable
+    // store before guards pass. After guards pass, a separate write-enabled call
+    // (readOnly:false) triggers legacy auth.json migration before
     // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty
-    // placeholder (which would cause the write-enabled load inside the lock to
-    // return an empty store and skip all removals).
+    // placeholder. (#2914491523, #2914711181)
     const store = makeStore(["anthropic:me.com", "anthropic:stale"]);
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
@@ -233,14 +233,21 @@ describe("modelsAuthCleanCommand", () => {
 
     await modelsAuthCleanCommand({}, makeRuntime()); // no dryRun
 
+    // Probe call: readOnly:true (always, even for non-dryRun)
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+    // Migration trigger call: readOnly:false (after guards pass, before lock)
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ readOnly: false }),
     );
   });
 
-  it("passes readOnly:false to loadAgentLocalAuthProfileStore when not dry-run (non-default agent)", async () => {
-    // #2914711181: same as above for non-default agent path.
+  it("probe uses readOnly:true; migration trigger uses readOnly:false after guards pass (non-default agent)", async () => {
+    // #2915530629: same as default agent path — probe is always readOnly:true;
+    // migration trigger uses readOnly:false after guards pass. (#2914491523, #2914711181)
     const store = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
@@ -251,6 +258,12 @@ describe("modelsAuthCleanCommand", () => {
 
     await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime()); // no dryRun
 
+    // Probe call: readOnly:true (always, even for non-dryRun)
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+    // Migration trigger call: readOnly:false (after guards pass, before lock)
     expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ readOnly: false }),

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   updateAuthProfileStoreWithLock: vi.fn(),
   loadAgentLocalAuthProfileStore: vi.fn(),
   loadModelsConfig: vi.fn(),
-  resolveKnownAgentId: vi.fn(() => null),
+  resolveKnownAgentId: vi.fn<() => string | null>(() => null),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -219,6 +219,45 @@ describe("modelsAuthCleanCommand", () => {
     expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
   });
 
+  it("always passes readOnly:true to ensureAuthProfileStore even when not dry-run (default agent)", async () => {
+    // P2 (#2914164081): store was previously loaded readOnly:false before the empty-config
+    // safety guard ran, causing unwanted write side-effects (external CLI sync, legacy migration).
+    // The probe load must always be read-only; the write-enabled load is deferred to
+    // updateAuthProfileStoreWithLock which only runs when cleanup actually proceeds.
+    const store = makeStore(["anthropic:me.com", "anthropic:stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime()); // no dryRun
+
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+  });
+
+  it("always passes readOnly:true to loadAgentLocalAuthProfileStore even when not dry-run (non-default agent)", async () => {
+    // P2 (#2914199338): for non-dry non-main-agent runs, the store was loaded readOnly:false
+    // before any validation, triggering write side-effects before guards were checked.
+    // The probe load must always be read-only regardless of dry-run or agent type.
+    const store = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime()); // no dryRun
+
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+  });
+
   it("keeps profiles referenced only in store.order (not in cfg.auth.profiles or cfg.auth.order)", async () => {
     // anthropic:store-override is in store.order (set via 'models auth order set')
     // but NOT in openclaw.json auth.profiles or auth.order — must be treated as kept

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -141,33 +141,40 @@ describe("modelsAuthCleanCommand", () => {
     expect(capture.result.lastGood).not.toHaveProperty("anthropic");
   });
 
-  it("removes stale ids from order and deletes the key when the array becomes empty", async () => {
+  it("keeps profile referenced only in store.order even when not in cfg", async () => {
+    // anthropic:manual is in store.profiles and store.order, but NOT in cfg.
+    // The fix ensures store.order-referenced profiles are treated as configured (kept).
     const store = makeStore(["anthropic:me.com", "anthropic:manual"], {
       order: { anthropic: ["anthropic:manual"] },
     });
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
     mocks.ensureAuthProfileStore.mockReturnValue(store);
-    const capture = captureUpdater(store);
 
-    await modelsAuthCleanCommand({}, makeRuntime());
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
 
-    // order key deleted entirely because filtered list became empty
-    expect(capture.result.order).toBeUndefined();
+    // manual is kept because it's in store.order — no write needed
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
   });
 
-  it("keeps a non-empty order array when only some ids are stale", async () => {
+  it("keeps all store.order-referenced profiles alongside cfg-configured ones", async () => {
+    // anthropic:manual is in store.order (set via 'models auth order set') but not in cfg.
+    // It must be protected, so nothing is stale and the lock is never acquired.
     const store = makeStore(["anthropic:me.com", "anthropic:gmail", "anthropic:manual"], {
       order: { anthropic: ["anthropic:me.com", "anthropic:manual"] },
     });
 
     mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
     mocks.ensureAuthProfileStore.mockReturnValue(store);
-    const capture = captureUpdater(store);
 
-    await modelsAuthCleanCommand({}, makeRuntime());
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
 
-    expect(capture.result.order?.["anthropic"]).toEqual(["anthropic:me.com"]);
+    // All three profiles are kept (me.com/gmail via cfg, manual via store.order)
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
   });
 
   it("--dry-run does not call updateAuthProfileStoreWithLock", async () => {
@@ -179,6 +186,71 @@ describe("modelsAuthCleanCommand", () => {
     await modelsAuthCleanCommand({ dryRun: true }, makeRuntime());
 
     expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("--dry-run passes readOnly:true to ensureAuthProfileStore (default agent)", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({ dryRun: true }, makeRuntime());
+
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+  });
+
+  it("--dry-run passes readOnly:true to loadAgentLocalAuthProfileStore (non-default agent)", async () => {
+    const store = makeStore(["anthropic:me.com"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({ agent: "worker", dryRun: true }, makeRuntime());
+
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("keeps profiles referenced only in store.order (not in cfg.auth.profiles or cfg.auth.order)", async () => {
+    // anthropic:store-override is in store.order (set via 'models auth order set')
+    // but NOT in openclaw.json auth.profiles or auth.order — must be treated as kept
+    const store = makeStore(["anthropic:me.com", "anthropic:store-override"], {
+      order: { anthropic: ["anthropic:me.com", "anthropic:store-override"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // Both profiles are kept — no stale entries — lock not acquired
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("removes profiles not in cfg or store.order even when store.order exists", async () => {
+    // anthropic:manual is in neither cfg nor store.order — should be removed
+    // anthropic:store-override is in store.order — should be kept
+    const store = makeStore(["anthropic:me.com", "anthropic:store-override", "anthropic:manual"], {
+      order: { anthropic: ["anthropic:me.com", "anthropic:store-override"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:manual");
+    expect(capture.result.profiles).toHaveProperty("anthropic:me.com");
+    expect(capture.result.profiles).toHaveProperty("anthropic:store-override");
   });
 
   it("--dry-run logs the plan without writing", async () => {

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/config.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 // ---- hoisted mocks ---------------------------------------------------------
@@ -10,7 +10,9 @@ const mocks = vi.hoisted(() => ({
   resolveAgentDir: vi.fn((_cfg: unknown, _id: unknown) => "/home/user/.openclaw/agents/main/agent"),
   ensureAuthProfileStore: vi.fn(),
   updateAuthProfileStoreWithLock: vi.fn(),
+  loadAgentLocalAuthProfileStore: vi.fn(),
   loadModelsConfig: vi.fn(),
+  resolveKnownAgentId: vi.fn(() => null),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
@@ -24,6 +26,7 @@ vi.mock("../../agents/auth-profiles.js", () => ({
 
 vi.mock("../../agents/auth-profiles/store.js", () => ({
   updateAuthProfileStoreWithLock: mocks.updateAuthProfileStoreWithLock,
+  loadAgentLocalAuthProfileStore: mocks.loadAgentLocalAuthProfileStore,
 }));
 
 vi.mock("./load-config.js", () => ({
@@ -31,7 +34,7 @@ vi.mock("./load-config.js", () => ({
 }));
 
 vi.mock("./shared.js", () => ({
-  resolveKnownAgentId: vi.fn(() => null),
+  resolveKnownAgentId: mocks.resolveKnownAgentId,
 }));
 
 // ---- helpers ----------------------------------------------------------------
@@ -42,7 +45,9 @@ function makeRuntime(): RuntimeEnv & { logs: string[] } {
   const logs: string[] = [];
   const runtime = {
     logs,
-    log: (msg: string) => { logs.push(msg); },
+    log: (msg: string) => {
+      logs.push(msg);
+    },
     error: vi.fn(),
     exit: vi.fn(),
   };
@@ -65,10 +70,7 @@ function makeCfg(
   return { auth: { profiles, ...(orderIds.length > 0 ? { order } : {}) } } as OpenClawConfig;
 }
 
-function makeStore(
-  profileIds: string[],
-  extras: Partial<AuthProfileStore> = {},
-): AuthProfileStore {
+function makeStore(profileIds: string[], extras: Partial<AuthProfileStore> = {}): AuthProfileStore {
   const profiles: AuthProfileStore["profiles"] = {};
   for (const id of profileIds) {
     const provider = id.split(":")[0] ?? "anthropic";
@@ -98,7 +100,14 @@ function captureUpdater(storeSeed: AuthProfileStore): {
     },
   );
 
-  return { get result() { return captured!; }, get returned() { return returned; } };
+  return {
+    get result() {
+      return captured!;
+    },
+    get returned() {
+      return returned;
+    },
+  };
 }
 
 // ---- tests ------------------------------------------------------------------
@@ -249,8 +258,8 @@ describe("modelsAuthCleanCommand", () => {
     await modelsAuthCleanCommand({ json: true }, runtime);
 
     expect(runtime.logs.length).toBe(2);
-    const plan = JSON.parse(runtime.logs[0]!);
-    const result = JSON.parse(runtime.logs[1]!);
+    const plan = JSON.parse(runtime.logs[0]);
+    const result = JSON.parse(runtime.logs[1]);
 
     expect(plan).toMatchObject({ toRemove: ["anthropic:manual"], dryRun: false });
     expect(result).toMatchObject({ ok: true, removed: 1 });
@@ -266,7 +275,7 @@ describe("modelsAuthCleanCommand", () => {
     await modelsAuthCleanCommand({ json: true, dryRun: true }, runtime);
 
     expect(runtime.logs.length).toBe(1);
-    const plan = JSON.parse(runtime.logs[0]!);
+    const plan = JSON.parse(runtime.logs[0]);
     expect(plan).toMatchObject({ toRemove: ["anthropic:manual"], dryRun: true });
     expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
   });
@@ -303,5 +312,40 @@ describe("modelsAuthCleanCommand", () => {
     mocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null);
 
     await expect(modelsAuthCleanCommand({}, makeRuntime())).rejects.toThrow(/lock busy/i);
+  });
+
+  it("non-default agent: excludes main-only profiles from toRemove", async () => {
+    // The agent-local store has agent-profile (configured) and agent-stale (not configured).
+    // The merged view returned by ensureAuthProfileStore also includes main-only-profile,
+    // which exists only in the main store and is NOT configured.
+    // toRemove must contain only agent-stale (from the agent-local store),
+    // NOT main-only-profile (which lives in the main store and must not be touched).
+    const agentLocalStore = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+    const mergedStore = makeStore([
+      "anthropic:agent-profile",
+      "anthropic:agent-stale",
+      "anthropic:main-only-profile", // exists in main store only, not agent-local
+    ]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    // Non-default agent: resolveKnownAgentId returns "worker", default is "main"
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    // ensureAuthProfileStore is NOT called for non-default agents (loadAgentLocalAuthProfileStore is)
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(agentLocalStore);
+    // The updater receives the merged store (simulating what updateAuthProfileStoreWithLock
+    // would pass in production after calling ensureAuthProfileStore internally).
+    const capture = captureUpdater(mergedStore);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ agent: "worker" }, runtime);
+
+    // toRemove was computed from agentLocalStore only: ["anthropic:agent-stale"]
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:agent-stale");
+    expect(capture.result.profiles).toHaveProperty("anthropic:agent-profile");
+    // main-only-profile was never in toRemove, so the updater left it intact
+    expect(capture.result.profiles).toHaveProperty("anthropic:main-only-profile");
+    // ensureAuthProfileStore should not have been called for profile-set computation
+    expect(mocks.ensureAuthProfileStore).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -519,6 +519,36 @@ describe("modelsAuthCleanCommand", () => {
     expect(call?.agentLocalOnly).toBeFalsy();
   });
 
+  it("non-main agent as configured default: agentLocalOnly:true even when agentId === defaultAgentId", async () => {
+    // Regression: when a config sets a non-main agent as default (e.g. agents.list[0].default=true
+    // with id "custom-agent"), the old code used (agentId === defaultAgentId) which was true,
+    // disabling agentLocalOnly and causing main-store profiles to be written into the agent-local
+    // file (scope bleed). The fix compares resolved agentDir paths against the main agent
+    // directory instead of comparing agentId strings.
+    const agentLocalStore = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    // "custom-agent" is the configured default (not the main agent)
+    mocks.resolveDefaultAgentId.mockReturnValueOnce("custom-agent");
+    // No --agent flag: resolveKnownAgentId returns null (default mock) → agentId = "custom-agent"
+    // First resolveAgentDir call: agentDir for "custom-agent"
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/custom-agent/agent");
+    // Second resolveAgentDir call: mainAgentDir for DEFAULT_AGENT_ID ("main")
+    // falls through to default mock → "/home/user/.openclaw/agents/main/agent"
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(agentLocalStore);
+    captureUpdater(agentLocalStore);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // agentLocalOnly must be true: custom-agent's dir != main agent dir
+    expect(mocks.updateAuthProfileStoreWithLock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentLocalOnly: true }),
+    );
+    // loadAgentLocalAuthProfileStore must be used, NOT ensureAuthProfileStore
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalled();
+    expect(mocks.ensureAuthProfileStore).not.toHaveBeenCalled();
+  });
+
   // ---- Fix: sanitize ANSI escape codes in profile ID output (Aisle Low) ----
 
   it("strips ANSI escape sequences from profile IDs in --dry-run output", async () => {

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -638,6 +638,64 @@ describe("modelsAuthCleanCommand", () => {
     expect(mocks.ensureAuthProfileStore).not.toHaveBeenCalled();
   });
 
+  // ---- Fix: preserve store-fallback profiles (P2 #2928322204) ----
+
+  it("preserves store-only profiles whose provider has no explicitly-configured profile", async () => {
+    // "openai:default" is a store-fallback: it lives only in the store, the provider
+    // "openai" has NO entry in auth.profiles, auth.order, or tools.media.
+    // Meanwhile "anthropic:me.com" IS configured, so configuredProfiles.size > 0
+    // and the empty-config guard does not trigger.  Without the fix, openai:default
+    // would be wrongly added to toRemove.
+    const store = makeStore(["anthropic:me.com", "openai:default"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // openai:default is a store-fallback: its provider has no configured profiles
+    // → should be preserved, nothing to clean
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("still removes stale profiles when the same provider has configured profiles", async () => {
+    // "anthropic:manual" is in the store but NOT configured. Its provider "anthropic"
+    // already has a configured profile ("anthropic:me.com"), so anthropic:manual is
+    // genuinely stale (not a store-fallback) and should be removed.
+    const store = makeStore(["anthropic:me.com", "anthropic:manual", "openai:default"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // anthropic:manual removed (provider has configured profiles)
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:manual");
+    // openai:default kept (provider has no configured profiles — store-fallback)
+    expect(capture.result.profiles).toHaveProperty("openai:default");
+    expect(capture.result.profiles).toHaveProperty("anthropic:me.com");
+  });
+
+  it("preserves multiple store-fallback profiles from different unconfigured providers", async () => {
+    // Both "openai:default" and "google:default" are store-fallback entries —
+    // their providers have no configured profiles.
+    const store = makeStore(["anthropic:me.com", "openai:default", "google:default"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // Both fallback profiles preserved — nothing to clean
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
   // ---- Fix: sanitize ANSI escape codes in profile ID output (Aisle Low) ----
 
   it("strips ANSI escape sequences from profile IDs in --dry-run output", async () => {

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -1,0 +1,113 @@
+import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  ensureAuthProfileStore,
+  updateAuthProfileStoreWithLock,
+} from "../../agents/auth-profiles.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { shortenHomePath } from "../../utils.js";
+import { loadModelsConfig } from "./load-config.js";
+import { resolveKnownAgentId } from "./shared.js";
+
+/**
+ * Remove stale profiles from auth-profiles.json that are no longer present in
+ * openclaw.json auth.profiles. Prevents ghost profiles (e.g. anthropic:manual,
+ * anthropic:user-me.com) from accumulating and silently corrupting auth order.
+ *
+ * Fixes: https://github.com/openclaw/openclaw/issues/41634
+ */
+export async function modelsAuthCleanCommand(
+  opts: { agent?: string; dryRun?: boolean; json?: boolean },
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const cfg = await loadModelsConfig({ commandName: "models auth clean", runtime });
+  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? resolveDefaultAgentId(cfg);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const authStorePath = shortenHomePath(`${agentDir}/auth-profiles.json`);
+
+  // Collect profile ids that are explicitly configured in openclaw.json auth.profiles
+  const configuredProfiles = new Set<string>(
+    Object.keys(cfg.auth?.profiles ?? {}).map((id) => id.trim()).filter(Boolean),
+  );
+
+  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const storeProfileIds = Object.keys(store.profiles);
+
+  const toRemove = storeProfileIds.filter((id) => !configuredProfiles.has(id));
+  const toKeep = storeProfileIds.filter((id) => configuredProfiles.has(id));
+
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        {
+          agentId,
+          agentDir,
+          authStorePath,
+          configuredProfiles: [...configuredProfiles],
+          storeProfiles: storeProfileIds,
+          toRemove,
+          toKeep,
+          dryRun: opts.dryRun ?? false,
+        },
+        null,
+        2,
+      ),
+    );
+    if (opts.dryRun || toRemove.length === 0) return;
+  } else {
+    runtime.log(`Agent:      ${agentId}`);
+    runtime.log(`Auth file:  ${authStorePath}`);
+    runtime.log(`Configured: ${[...configuredProfiles].join(", ") || "(none)"}`);
+    runtime.log(`In store:   ${storeProfileIds.join(", ") || "(none)"}`);
+  }
+
+  if (toRemove.length === 0) {
+    if (!opts.json) runtime.log("Nothing to clean up.");
+    return;
+  }
+
+  if (!opts.json) {
+    runtime.log(`\nProfiles to remove (${toRemove.length}):`);
+    for (const id of toRemove) runtime.log(`  - ${id}`);
+    runtime.log(`Profiles to keep (${toKeep.length}):`);
+    for (const id of toKeep) runtime.log(`  + ${id}`);
+  }
+
+  if (opts.dryRun) {
+    if (!opts.json) runtime.log("\n(dry run -- no changes written)");
+    return;
+  }
+
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    updater: (freshStore) => {
+      let removed = 0;
+      for (const id of toRemove) {
+        if (id in freshStore.profiles) {
+          delete freshStore.profiles[id];
+          removed++;
+        }
+      }
+      // Drop removed ids from the order array as well
+      for (const provider of Object.keys(freshStore.order ?? {})) {
+        const existing = freshStore.order[provider];
+        if (Array.isArray(existing)) {
+          freshStore.order[provider] = existing.filter((id) => !toRemove.includes(id));
+        }
+      }
+      // Drop removed ids from usageStats
+      for (const id of toRemove) {
+        delete freshStore.usageStats?.[id];
+      }
+      return removed > 0;
+    },
+  });
+
+  if (!updated) {
+    throw new Error("Failed to update auth-profiles.json (lock busy or no changes needed).");
+  }
+
+  if (!opts.json) {
+    runtime.log(`\nRemoved ${toRemove.length} stale profile(s). Restart the gateway to apply.`);
+  }
+}

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -117,7 +117,11 @@ export async function modelsAuthCleanCommand(
     configuredProfiles.add(id);
   }
 
-  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: opts.dryRun === true };
+  // Load the store read-only for inspection: this probe read collects storeProfileIds
+  // and storeOrder only.  The write-enabled load happens inside updateAuthProfileStoreWithLock
+  // (which only runs when cleanup actually proceeds) — so readOnly:true is correct here
+  // regardless of whether this is a dry-run or not.
+  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: true };
   const store = isMainAgentDir
     ? ensureAuthProfileStore(agentDir, storeLoadOpts)
     : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
 import {
@@ -6,6 +7,7 @@ import {
 } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import type { MediaToolsConfig, MediaUnderstandingModelConfig } from "../../config/types.tools.js";
+import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
 import { loadModelsConfig } from "./load-config.js";
@@ -84,11 +86,15 @@ export async function modelsAuthCleanCommand(
   const agentDir = resolveAgentDir(cfg, agentId);
   const authStorePath = shortenHomePath(`${agentDir}/auth-profiles.json`);
 
-  // For non-default agents, ensureAuthProfileStore returns a merged (main + agent-local)
-  // view. toRemove must be derived from the agent-local-only profile set because the
-  // write via updateAuthProfileStoreWithLock targets only the agent-local file. Profiles
-  // that exist exclusively in the main store must never appear in toRemove.
-  const isDefaultAgent = agentId === defaultAgentId;
+  // Determine whether agentDir resolves to the main agent directory.
+  // We compare resolved paths rather than checking (agentId === defaultAgentId) because
+  // a config may designate a non-main agent as the configured default.  In that case
+  // agentId === defaultAgentId would be true even though the write target is not the
+  // main agent file — incorrectly disabling agentLocalOnly and causing main-store
+  // profiles to be persisted into the agent-local auth-profiles.json (scope bleed).
+  // Comparing resolved paths against the main agent directory handles this correctly.
+  const mainAgentDir = resolveAgentDir(cfg, DEFAULT_AGENT_ID);
+  const isMainAgentDir = path.resolve(agentDir) === path.resolve(mainAgentDir);
 
   // Collect profile ids that are explicitly configured: union of auth.profiles keys,
   // ids referenced in auth.order, and ids pinned in tools.media model entries.
@@ -112,7 +118,7 @@ export async function modelsAuthCleanCommand(
   }
 
   const storeLoadOpts = { allowKeychainPrompt: false, readOnly: opts.dryRun === true };
-  const store = isDefaultAgent
+  const store = isMainAgentDir
     ? ensureAuthProfileStore(agentDir, storeLoadOpts)
     : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);
 
@@ -231,12 +237,12 @@ export async function modelsAuthCleanCommand(
 
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
-    // For non-default agents the write target is the agent-local file only.
+    // For non-main agent directories the write target is the agent-local file only.
     // Setting agentLocalOnly ensures the store loaded inside the lock is the
     // agent-local view (not the merged main+agent view returned by
     // ensureAuthProfileStore), which prevents main-store profiles from being
     // written into the agent-local file (credential scope bleed).
-    agentLocalOnly: !isDefaultAgent,
+    agentLocalOnly: !isMainAgentDir,
     updater: (freshStore: AuthProfileStore) => {
       let mutated = false;
 

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -30,17 +30,18 @@ function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>
     }
   }
 
+  // Scan top-level tools.media if present.
   const media = cfg.tools?.media;
-  if (!media) {
-    return ids;
+  if (media) {
+    addFromModels(media.models);
+    addFromModels(media.image?.models);
+    addFromModels(media.audio?.models);
+    addFromModels(media.video?.models);
   }
 
-  addFromModels(media.models);
-  addFromModels(media.image?.models);
-  addFromModels(media.audio?.models);
-  addFromModels(media.video?.models);
-
-  // Also cover per-agent tool overrides
+  // Always scan per-agent tool overrides, even when cfg.tools.media is absent.
+  // Agent-level overrides may reference profiles not present at the top level;
+  // skipping them would cause those profiles to be treated as stale and wrongly pruned.
   for (const agent of cfg.agents?.list ?? []) {
     const agentMedia = (agent as { tools?: { media?: MediaToolsConfig } }).tools?.media;
     if (!agentMedia) {
@@ -53,6 +54,16 @@ function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>
   }
 
   return ids;
+}
+
+/**
+ * Sanitize a profile ID string for safe output in terminal/log messages.
+ * Strips ANSI/VT escape sequences and newlines to prevent terminal injection
+ * (log forging) via maliciously crafted profile IDs.
+ */
+function sanitizeProfileId(id: string): string {
+  // eslint-disable-next-line no-control-regex
+  return id.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "").replace(/[\r\n]/g, "");
 }
 
 /**
@@ -149,7 +160,7 @@ export async function modelsAuthCleanCommand(
         runtime.log(
           "Warning: openclaw.json has no configured profiles. All store profiles would be removed.",
         );
-        runtime.log(`In store: ${storeProfileIds.join(", ")}`);
+        runtime.log(`In store: ${storeProfileIds.map(sanitizeProfileId).join(", ")}`);
         runtime.log("(dry run -- no changes written)");
       }
       return;
@@ -183,8 +194,10 @@ export async function modelsAuthCleanCommand(
   } else {
     runtime.log(`Agent:      ${agentId}`);
     runtime.log(`Auth file:  ${authStorePath}`);
-    runtime.log(`Configured: ${[...configuredProfiles].join(", ") || "(none)"}`);
-    runtime.log(`In store:   ${storeProfileIds.join(", ") || "(none)"}`);
+    runtime.log(
+      `Configured: ${[...configuredProfiles].map(sanitizeProfileId).join(", ") || "(none)"}`,
+    );
+    runtime.log(`In store:   ${storeProfileIds.map(sanitizeProfileId).join(", ") || "(none)"}`);
   }
 
   if (toRemove.length === 0) {
@@ -197,11 +210,11 @@ export async function modelsAuthCleanCommand(
   if (!opts.json) {
     runtime.log(`\nProfiles to remove (${toRemove.length}):`);
     for (const id of toRemove) {
-      runtime.log(`  - ${id}`);
+      runtime.log(`  - ${sanitizeProfileId(id)}`);
     }
     runtime.log(`Profiles to keep (${toKeep.length}):`);
     for (const id of toKeep) {
-      runtime.log(`  + ${id}`);
+      runtime.log(`  + ${sanitizeProfileId(id)}`);
     }
   }
 
@@ -218,6 +231,12 @@ export async function modelsAuthCleanCommand(
 
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
+    // For non-default agents the write target is the agent-local file only.
+    // Setting agentLocalOnly ensures the store loaded inside the lock is the
+    // agent-local view (not the merged main+agent view returned by
+    // ensureAuthProfileStore), which prevents main-store profiles from being
+    // written into the agent-local file (credential scope bleed).
+    agentLocalOnly: !isDefaultAgent,
     updater: (freshStore: AuthProfileStore) => {
       let mutated = false;
 

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -60,12 +60,24 @@ function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>
 
 /**
  * Sanitize a profile ID string for safe output in terminal/log messages.
- * Strips ANSI/VT escape sequences and newlines to prevent terminal injection
+ * Strips ALL terminal escape sequences and newlines to prevent terminal injection
  * (log forging) via maliciously crafted profile IDs.
+ *
+ * Handles:
+ *   - Standard CSI:  ESC [ ... final        e.g. \x1b[31m, \x1b[1;32m
+ *   - Private CSI:   ESC [ ? ... final       e.g. \x1b[?25l (cursor hide)
+ *   - OSC:           ESC ] ... BEL/ST        e.g. \x1b]0;title\x07
+ *   - DCS/SOS/PM/APC: ESC P/X/^/_ ... ST   e.g. \x1bPdata\x1b\\
+ *   - Other Fe:      ESC <single char>       e.g. \x1bc (RIS reset)
  */
 function sanitizeProfileId(id: string): string {
-  // eslint-disable-next-line no-control-regex
-  return id.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "").replace(/[\r\n]/g, "");
+  return id
+    .replace(
+      // eslint-disable-next-line no-control-regex
+      /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|[\s\S])/g,
+      "",
+    )
+    .replace(/[\r\n]/g, "");
 }
 
 /**

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -130,15 +130,11 @@ export async function modelsAuthCleanCommand(
   }
 
   // Load the store for inspection (collect storeProfileIds and storeOrder).
-  // During dry-run: readOnly:true — no writes of any kind, including legacy migration.
-  // During actual cleanup: readOnly:false — allows the one-time legacy auth.json →
-  // auth-profiles.json migration to persist before updateAuthProfileStoreWithLock's
-  // ensureAuthStoreFile can create an empty placeholder (which would cause the
-  // write-enabled load inside the lock to find an empty store and skip all removals).
-  // The write-enabled load for profile mutations is still deferred to
-  // updateAuthProfileStoreWithLock; this probe only triggers migration when needed.
-  // (#2914491523, #2914711181)
-  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: opts.dryRun === true };
+  // Probe phase is always readOnly:true — a write-capable store must never be opened
+  // before guards pass and cleanup is confirmed to proceed. A separate write-enabled
+  // load is deferred to after all guards pass (see below) to trigger legacy migration.
+  // (#2914491523, #2914711181, #2915530629)
+  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: true };
   const store = isMainAgentDir
     ? ensureAuthProfileStore(agentDir, storeLoadOpts)
     : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);
@@ -250,6 +246,19 @@ export async function modelsAuthCleanCommand(
       runtime.log("\n(dry run -- no changes written)");
     }
     return;
+  }
+
+  // Trigger legacy auth.json → auth-profiles.json migration with a write-enabled
+  // load now that all guards have passed and cleanup is confirmed to proceed.
+  // The probe above used readOnly:true (suppressing migration writes); running a
+  // readOnly:false load here ensures the legacy store is persisted before
+  // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty
+  // placeholder (which would cause the lock-internal load to see an empty store
+  // and skip all profile removals). (#2914491523, #2914711181)
+  if (isMainAgentDir) {
+    ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false, readOnly: false });
+  } else {
+    loadAgentLocalAuthProfileStore(agentDir, { allowKeychainPrompt: false, readOnly: false });
   }
 
   // Track actual removals inside the lock (concurrent gateway writes may have

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -1,7 +1,10 @@
 import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
+import {
+  loadAgentLocalAuthProfileStore,
+  updateAuthProfileStoreWithLock,
+} from "../../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
-import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store.js";
 import type { MediaToolsConfig, MediaUnderstandingModelConfig } from "../../config/types.tools.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
@@ -18,13 +21,19 @@ function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>
 
   function addFromModels(models: MediaUnderstandingModelConfig[] | undefined): void {
     for (const m of models ?? []) {
-      if (m.profile) ids.add(m.profile);
-      if (m.preferredProfile) ids.add(m.preferredProfile);
+      if (m.profile) {
+        ids.add(m.profile);
+      }
+      if (m.preferredProfile) {
+        ids.add(m.preferredProfile);
+      }
     }
   }
 
   const media = cfg.tools?.media;
-  if (!media) return ids;
+  if (!media) {
+    return ids;
+  }
 
   addFromModels(media.models);
   addFromModels(media.image?.models);
@@ -34,7 +43,9 @@ function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>
   // Also cover per-agent tool overrides
   for (const agent of cfg.agents?.list ?? []) {
     const agentMedia = (agent as { tools?: { media?: MediaToolsConfig } }).tools?.media;
-    if (!agentMedia) continue;
+    if (!agentMedia) {
+      continue;
+    }
     addFromModels(agentMedia.models);
     addFromModels(agentMedia.image?.models);
     addFromModels(agentMedia.audio?.models);
@@ -57,10 +68,16 @@ export async function modelsAuthCleanCommand(
   runtime: RuntimeEnv,
 ): Promise<void> {
   const cfg = await loadModelsConfig({ commandName: "models auth clean", runtime });
-  const agentId =
-    resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? resolveDefaultAgentId(cfg);
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? defaultAgentId;
   const agentDir = resolveAgentDir(cfg, agentId);
   const authStorePath = shortenHomePath(`${agentDir}/auth-profiles.json`);
+
+  // For non-default agents, ensureAuthProfileStore returns a merged (main + agent-local)
+  // view. toRemove must be derived from the agent-local-only profile set because the
+  // write via updateAuthProfileStoreWithLock targets only the agent-local file. Profiles
+  // that exist exclusively in the main store must never appear in toRemove.
+  const isDefaultAgent = agentId === defaultAgentId;
 
   // Collect profile ids that are explicitly configured: union of auth.profiles keys,
   // ids referenced in auth.order, and ids pinned in tools.media model entries.
@@ -73,7 +90,9 @@ export async function modelsAuthCleanCommand(
   for (const ids of Object.values(cfg.auth?.order ?? {})) {
     if (Array.isArray(ids)) {
       for (const id of ids) {
-        if (typeof id === "string" && id.trim()) configuredProfiles.add(id.trim());
+        if (typeof id === "string" && id.trim()) {
+          configuredProfiles.add(id.trim());
+        }
       }
     }
   }
@@ -81,7 +100,9 @@ export async function modelsAuthCleanCommand(
     configuredProfiles.add(id);
   }
 
-  const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+  const store = isDefaultAgent
+    ? ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false })
+    : loadAgentLocalAuthProfileStore(agentDir, { allowKeychainPrompt: false });
   const storeProfileIds = Object.keys(store.profiles);
 
   const toRemove = storeProfileIds.filter((id) => !configuredProfiles.has(id));
@@ -137,7 +158,9 @@ export async function modelsAuthCleanCommand(
         2,
       ),
     );
-    if (opts.dryRun || toRemove.length === 0) return;
+    if (opts.dryRun || toRemove.length === 0) {
+      return;
+    }
   } else {
     runtime.log(`Agent:      ${agentId}`);
     runtime.log(`Auth file:  ${authStorePath}`);
@@ -146,19 +169,27 @@ export async function modelsAuthCleanCommand(
   }
 
   if (toRemove.length === 0) {
-    if (!opts.json) runtime.log("Nothing to clean up.");
+    if (!opts.json) {
+      runtime.log("Nothing to clean up.");
+    }
     return;
   }
 
   if (!opts.json) {
     runtime.log(`\nProfiles to remove (${toRemove.length}):`);
-    for (const id of toRemove) runtime.log(`  - ${id}`);
+    for (const id of toRemove) {
+      runtime.log(`  - ${id}`);
+    }
     runtime.log(`Profiles to keep (${toKeep.length}):`);
-    for (const id of toKeep) runtime.log(`  + ${id}`);
+    for (const id of toKeep) {
+      runtime.log(`  + ${id}`);
+    }
   }
 
   if (opts.dryRun) {
-    if (!opts.json) runtime.log("\n(dry run -- no changes written)");
+    if (!opts.json) {
+      runtime.log("\n(dry run -- no changes written)");
+    }
     return;
   }
 

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -255,10 +255,20 @@ export async function modelsAuthCleanCommand(
   // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty
   // placeholder (which would cause the lock-internal load to see an empty store
   // and skip all profile removals). (#2914491523, #2914711181)
+  //
+  // For non-main agents, skipInheritance:true prevents the main-agent fallback
+  // inside loadAuthProfileStoreForAgent from cloning main profiles into the
+  // subagent file when auth-profiles.json is absent.  Without it, a subagent
+  // with no local store would materialise main credentials before cleanup and
+  // skip the intended legacy migration, causing scope bleed. (#2915653312)
   if (isMainAgentDir) {
     ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false, readOnly: false });
   } else {
-    loadAgentLocalAuthProfileStore(agentDir, { allowKeychainPrompt: false, readOnly: false });
+    loadAgentLocalAuthProfileStore(agentDir, {
+      allowKeychainPrompt: false,
+      readOnly: false,
+      skipInheritance: true,
+    });
   }
 
   // Track actual removals inside the lock (concurrent gateway writes may have

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -100,9 +100,28 @@ export async function modelsAuthCleanCommand(
     configuredProfiles.add(id);
   }
 
+  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: opts.dryRun === true };
   const store = isDefaultAgent
-    ? ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false })
-    : loadAgentLocalAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+    ? ensureAuthProfileStore(agentDir, storeLoadOpts)
+    : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);
+
+  // Also keep profiles referenced in store.order (per-agent overrides set via
+  // 'models auth order set'). These are not reflected in cfg.auth.order or
+  // cfg.auth.profiles, so they would be incorrectly treated as stale without
+  // this step.
+  const storeOrder = store.order;
+  if (storeOrder) {
+    for (const ids of Object.values(storeOrder)) {
+      if (Array.isArray(ids)) {
+        for (const id of ids) {
+          if (typeof id === "string" && id.trim()) {
+            configuredProfiles.add(id.trim());
+          }
+        }
+      }
+    }
+  }
+
   const storeProfileIds = Object.keys(store.profiles);
 
   const toRemove = storeProfileIds.filter((id) => !configuredProfiles.has(id));

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -117,11 +117,16 @@ export async function modelsAuthCleanCommand(
     configuredProfiles.add(id);
   }
 
-  // Load the store read-only for inspection: this probe read collects storeProfileIds
-  // and storeOrder only.  The write-enabled load happens inside updateAuthProfileStoreWithLock
-  // (which only runs when cleanup actually proceeds) — so readOnly:true is correct here
-  // regardless of whether this is a dry-run or not.
-  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: true };
+  // Load the store for inspection (collect storeProfileIds and storeOrder).
+  // During dry-run: readOnly:true — no writes of any kind, including legacy migration.
+  // During actual cleanup: readOnly:false — allows the one-time legacy auth.json →
+  // auth-profiles.json migration to persist before updateAuthProfileStoreWithLock's
+  // ensureAuthStoreFile can create an empty placeholder (which would cause the
+  // write-enabled load inside the lock to find an empty store and skip all removals).
+  // The write-enabled load for profile mutations is still deferred to
+  // updateAuthProfileStoreWithLock; this probe only triggers migration when needed.
+  // (#2914491523, #2914711181)
+  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: opts.dryRun === true };
   const store = isMainAgentDir
     ? ensureAuthProfileStore(agentDir, storeLoadOpts)
     : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -3,7 +3,6 @@ import {
   ensureAuthProfileStore,
   updateAuthProfileStoreWithLock,
 } from "../../agents/auth-profiles.js";
-import { normalizeProviderId } from "../../agents/model-selection.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
 import { loadModelsConfig } from "./load-config.js";
@@ -11,8 +10,9 @@ import { resolveKnownAgentId } from "./shared.js";
 
 /**
  * Remove stale profiles from auth-profiles.json that are no longer present in
- * openclaw.json auth.profiles. Prevents ghost profiles (e.g. anthropic:manual,
- * anthropic:user-me.com) from accumulating and silently corrupting auth order.
+ * openclaw.json auth.profiles or auth.order. Prevents ghost profiles (e.g.
+ * anthropic:manual, anthropic:user-me.com) from accumulating and silently
+ * corrupting auth order.
  *
  * Fixes: https://github.com/openclaw/openclaw/issues/41634
  */
@@ -21,20 +21,65 @@ export async function modelsAuthCleanCommand(
   runtime: RuntimeEnv,
 ): Promise<void> {
   const cfg = await loadModelsConfig({ commandName: "models auth clean", runtime });
-  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? resolveDefaultAgentId(cfg);
+  const agentId =
+    resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const authStorePath = shortenHomePath(`${agentDir}/auth-profiles.json`);
 
-  // Collect profile ids that are explicitly configured in openclaw.json auth.profiles
+  // Collect profile ids that are explicitly configured: union of auth.profiles keys
+  // and any ids referenced in auth.order (which may exist only in the store, not in
+  // auth.profiles, and are still valid active profiles).
   const configuredProfiles = new Set<string>(
-    Object.keys(cfg.auth?.profiles ?? {}).map((id) => id.trim()).filter(Boolean),
+    Object.keys(cfg.auth?.profiles ?? {})
+      .map((id) => id.trim())
+      .filter(Boolean),
   );
+  for (const ids of Object.values(cfg.auth?.order ?? {})) {
+    if (Array.isArray(ids)) {
+      for (const id of ids) {
+        if (typeof id === "string" && id.trim()) configuredProfiles.add(id.trim());
+      }
+    }
+  }
 
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
   const storeProfileIds = Object.keys(store.profiles);
 
   const toRemove = storeProfileIds.filter((id) => !configuredProfiles.has(id));
   const toKeep = storeProfileIds.filter((id) => configuredProfiles.has(id));
+
+  // Safety guard: refuse to wipe everything when openclaw.json has no auth
+  // config at all (e.g. profiles and order both absent/empty). This avoids
+  // accidentally nuking a store-only setup. Require --dry-run to inspect.
+  if (configuredProfiles.size === 0 && storeProfileIds.length > 0) {
+    if (opts.dryRun) {
+      if (opts.json) {
+        runtime.log(
+          JSON.stringify(
+            {
+              warning:
+                "No profiles configured in openclaw.json auth.profiles or auth.order. All store profiles would be removed. Pass --force to proceed.",
+              storeProfiles: storeProfileIds,
+              dryRun: true,
+            },
+            null,
+            2,
+          ),
+        );
+      } else {
+        runtime.log(
+          "Warning: openclaw.json has no configured profiles. All store profiles would be removed.",
+        );
+        runtime.log(`In store: ${storeProfileIds.join(", ")}`);
+        runtime.log("(dry run -- no changes written)");
+      }
+      return;
+    }
+    throw new Error(
+      "openclaw.json has no configured auth profiles (auth.profiles and auth.order are both empty). " +
+        "Run with --dry-run to inspect, or add profiles to openclaw.json before cleaning.",
+    );
+  }
 
   if (opts.json) {
     runtime.log(
@@ -78,36 +123,79 @@ export async function modelsAuthCleanCommand(
     return;
   }
 
+  // Track actual removals inside the lock (concurrent gateway writes may have
+  // already cleaned some ids between our initial read and lock acquisition).
+  let actualRemoved = 0;
+
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
     updater: (freshStore) => {
-      let removed = 0;
+      let mutated = false;
+
+      // Remove stale profiles
       for (const id of toRemove) {
         if (id in freshStore.profiles) {
           delete freshStore.profiles[id];
-          removed++;
+          actualRemoved++;
+          mutated = true;
         }
       }
-      // Drop removed ids from the order array as well
-      for (const provider of Object.keys(freshStore.order ?? {})) {
-        const existing = freshStore.order[provider];
-        if (Array.isArray(existing)) {
-          freshStore.order[provider] = existing.filter((id) => !toRemove.includes(id));
+
+      // Prune removed ids from the order map; delete the key entirely when
+      // the filtered list becomes empty (an empty array overrides config with
+      // no candidates, which breaks provider auth resolution).
+      const order = freshStore.order;
+      if (order) {
+        for (const provider of Object.keys(order)) {
+          const existing = order[provider];
+          if (Array.isArray(existing)) {
+            const filtered = existing.filter((id) => !toRemove.includes(id));
+            if (filtered.length !== existing.length) {
+              mutated = true;
+              if (filtered.length > 0) {
+                order[provider] = filtered;
+              } else {
+                delete order[provider];
+              }
+            }
+          }
+        }
+        if (Object.keys(order).length === 0) {
+          delete freshStore.order;
         }
       }
-      // Drop removed ids from usageStats
-      for (const id of toRemove) {
-        delete freshStore.usageStats?.[id];
+
+      // Prune removed ids from usageStats
+      if (freshStore.usageStats) {
+        for (const id of toRemove) {
+          if (id in freshStore.usageStats) {
+            delete freshStore.usageStats[id];
+            mutated = true;
+          }
+        }
       }
-      return removed > 0;
+
+      // Prune removed ids from lastGood (provider -> profileId map)
+      if (freshStore.lastGood) {
+        for (const [provider, profileId] of Object.entries(freshStore.lastGood)) {
+          if (toRemove.includes(profileId)) {
+            delete freshStore.lastGood[provider];
+            mutated = true;
+          }
+        }
+      }
+
+      return mutated;
     },
   });
 
   if (!updated) {
-    throw new Error("Failed to update auth-profiles.json (lock busy or no changes needed).");
+    throw new Error("Failed to update auth-profiles.json (lock busy).");
   }
 
-  if (!opts.json) {
-    runtime.log(`\nRemoved ${toRemove.length} stale profile(s). Restart the gateway to apply.`);
+  if (opts.json) {
+    runtime.log(JSON.stringify({ ok: true, removed: actualRemoved }, null, 2));
+  } else {
+    runtime.log(`\nRemoved ${actualRemoved} stale profile(s). Restart the gateway to apply.`);
   }
 }

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -1,18 +1,54 @@
 import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import {
-  ensureAuthProfileStore,
-  updateAuthProfileStoreWithLock,
-} from "../../agents/auth-profiles.js";
+import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store.js";
+import type { MediaToolsConfig, MediaUnderstandingModelConfig } from "../../config/types.tools.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { shortenHomePath } from "../../utils.js";
 import { loadModelsConfig } from "./load-config.js";
 import { resolveKnownAgentId } from "./shared.js";
 
 /**
+ * Collect all auth profile ids referenced in tools.media config
+ * (top-level models array + per-media-type image/audio/video models).
+ * These are consumed by resolveProviderExecutionAuth and must not be pruned.
+ */
+function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>>): Set<string> {
+  const ids = new Set<string>();
+
+  function addFromModels(models: MediaUnderstandingModelConfig[] | undefined): void {
+    for (const m of models ?? []) {
+      if (m.profile) ids.add(m.profile);
+      if (m.preferredProfile) ids.add(m.preferredProfile);
+    }
+  }
+
+  const media = cfg.tools?.media;
+  if (!media) return ids;
+
+  addFromModels(media.models);
+  addFromModels(media.image?.models);
+  addFromModels(media.audio?.models);
+  addFromModels(media.video?.models);
+
+  // Also cover per-agent tool overrides
+  for (const agent of cfg.agents?.list ?? []) {
+    const agentMedia = (agent as { tools?: { media?: MediaToolsConfig } }).tools?.media;
+    if (!agentMedia) continue;
+    addFromModels(agentMedia.models);
+    addFromModels(agentMedia.image?.models);
+    addFromModels(agentMedia.audio?.models);
+    addFromModels(agentMedia.video?.models);
+  }
+
+  return ids;
+}
+
+/**
  * Remove stale profiles from auth-profiles.json that are no longer present in
- * openclaw.json auth.profiles or auth.order. Prevents ghost profiles (e.g.
- * anthropic:manual, anthropic:user-me.com) from accumulating and silently
- * corrupting auth order.
+ * openclaw.json auth.profiles, auth.order, or tools.media model entries.
+ * Prevents ghost profiles (e.g. anthropic:manual, anthropic:user-me.com) from
+ * accumulating and silently corrupting auth order.
  *
  * Fixes: https://github.com/openclaw/openclaw/issues/41634
  */
@@ -26,9 +62,9 @@ export async function modelsAuthCleanCommand(
   const agentDir = resolveAgentDir(cfg, agentId);
   const authStorePath = shortenHomePath(`${agentDir}/auth-profiles.json`);
 
-  // Collect profile ids that are explicitly configured: union of auth.profiles keys
-  // and any ids referenced in auth.order (which may exist only in the store, not in
-  // auth.profiles, and are still valid active profiles).
+  // Collect profile ids that are explicitly configured: union of auth.profiles keys,
+  // ids referenced in auth.order, and ids pinned in tools.media model entries.
+  // All three sets represent actively-used credentials that must not be pruned.
   const configuredProfiles = new Set<string>(
     Object.keys(cfg.auth?.profiles ?? {})
       .map((id) => id.trim())
@@ -40,6 +76,9 @@ export async function modelsAuthCleanCommand(
         if (typeof id === "string" && id.trim()) configuredProfiles.add(id.trim());
       }
     }
+  }
+  for (const id of collectMediaProfileIds(cfg)) {
+    configuredProfiles.add(id);
   }
 
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
@@ -129,7 +168,7 @@ export async function modelsAuthCleanCommand(
 
   const updated = await updateAuthProfileStoreWithLock({
     agentDir,
-    updater: (freshStore) => {
+    updater: (freshStore: AuthProfileStore) => {
       let mutated = false;
 
       // Remove stale profiles

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -75,7 +75,7 @@ function sanitizeProfileId(id: string): string {
   return id
     .replace(
       // eslint-disable-next-line no-control-regex
-      /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|[\s\S])/g,
+      /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|[\s\S]?)/g,
       "",
     )
     .replace(/[\r\n]/g, "");
@@ -139,6 +139,11 @@ export async function modelsAuthCleanCommand(
   const store = isMainAgentDir
     ? ensureAuthProfileStore(agentDir, storeLoadOpts)
     : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);
+
+  // Snapshot config-only profile IDs BEFORE adding store-derived ones.
+  // The empty-config safety guard must gate on config-derived IDs only;
+  // store.order IDs must NOT inflate the count and bypass the guard.
+  const configOnlyProfileIds = new Set(configuredProfiles);
 
   // Also keep profiles referenced in store.order (per-agent overrides set via
   // 'models auth order set'). These are not reflected in cfg.auth.order or
@@ -213,7 +218,9 @@ export async function modelsAuthCleanCommand(
   // Safety guard: refuse to wipe everything when openclaw.json has no auth
   // config at all (e.g. profiles and order both absent/empty). This avoids
   // accidentally nuking a store-only setup. Require --dry-run to inspect.
-  if (configuredProfiles.size === 0 && storeProfileIds.length > 0) {
+  // Gate on configOnlyProfileIds (config-derived IDs only) so that store.order
+  // IDs cannot inflate the count and bypass the guard.
+  if (configOnlyProfileIds.size === 0 && storeProfileIds.length > 0) {
     if (opts.dryRun) {
       if (opts.json) {
         runtime.log(

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -262,7 +262,14 @@ export async function modelsAuthCleanCommand(
   // accidentally nuking a store-only setup. Require --dry-run to inspect.
   // Gate on configOnlyProfileIds (config-derived IDs only) so that store.order
   // IDs cannot inflate the count and bypass the guard.
-  if (configOnlyProfileIds.size === 0 && storeProfileIds.length > 0) {
+  // When providers are explicitly disabled via `auth.order.<provider>: []`,
+  // there IS clear intent to clean up — the guard should not fire even if
+  // no configured profile IDs exist (#2950578522).
+  if (
+    configOnlyProfileIds.size === 0 &&
+    explicitlyDisabledProviders.size === 0 &&
+    storeProfileIds.length > 0
+  ) {
     if (opts.dryRun) {
       if (opts.json) {
         runtime.log(

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -184,9 +184,18 @@ export async function modelsAuthCleanCommand(
     }
   }
   // 2) Provider keys in cfg.auth.order (keys are provider identifiers).
-  for (const providerKey of Object.keys(cfg.auth?.order ?? {})) {
+  //    Also track providers explicitly disabled via an empty order array so the
+  //    drift guard does not preserve their stale profiles.
+  const explicitlyDisabledProviders = new Set<string>();
+  for (const [providerKey, orderValue] of Object.entries(cfg.auth?.order ?? {})) {
     if (providerKey.trim()) {
       configuredProviders.add(normalizeProviderIdForAuth(providerKey.trim()));
+      // An explicitly empty array means the provider is intentionally disabled.
+      // Runtime (resolveAuthProfileOrder) skips empty-order providers entirely,
+      // so their store profiles are stale and should be pruned.
+      if (Array.isArray(orderValue) && orderValue.length === 0) {
+        explicitlyDisabledProviders.add(normalizeProviderIdForAuth(providerKey.trim()));
+      }
     }
   }
   // 3) Fall back to store-matched providers for profiles referenced by
@@ -220,17 +229,27 @@ export async function modelsAuthCleanCommand(
       return false;
     }
     // Store-fallback: this profile's provider has no explicitly-configured profile,
-    // so it is the sole credential source for that provider.  Preserve it.
+    // so it is the sole credential source for that provider.  Preserve it —
+    // unless the provider is explicitly disabled via an empty auth.order array,
+    // in which case its profiles are stale and should be pruned.
     const cred = store.profiles[id];
-    if (cred && !configuredProviders.has(normalizeProviderIdForAuth(cred.provider))) {
+    if (
+      cred &&
+      !configuredProviders.has(normalizeProviderIdForAuth(cred.provider)) &&
+      !explicitlyDisabledProviders.has(normalizeProviderIdForAuth(cred.provider))
+    ) {
       return false;
     }
     // Drift guard: the provider appears in config, but none of its configured
     // profile IDs actually exist in the store.  The store profile is the only
     // working credential — preserve it so the provider isn't left with nothing.
+    // Exception: providers explicitly disabled via an empty auth.order array
+    // should have their profiles pruned even if no configured IDs exist in
+    // the store — the empty order means the provider is intentionally off.
     if (
       cred &&
-      !configuredProvidersWithStorePresence.has(normalizeProviderIdForAuth(cred.provider))
+      !configuredProvidersWithStorePresence.has(normalizeProviderIdForAuth(cred.provider)) &&
+      !explicitlyDisabledProviders.has(normalizeProviderIdForAuth(cred.provider))
     ) {
       return false;
     }

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -236,7 +236,7 @@ export async function modelsAuthCleanCommand(
     }
     return true;
   });
-  const toKeep = storeProfileIds.filter((id) => configuredProfiles.has(id));
+  const toKeep = storeProfileIds.filter((id) => !toRemove.includes(id));
 
   // Safety guard: refuse to wipe everything when openclaw.json has no auth
   // config at all (e.g. profiles and order both absent/empty). This avoids

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -201,6 +201,20 @@ export async function modelsAuthCleanCommand(
 
   const storeProfileIds = Object.keys(store.profiles);
 
+  // Build the set of providers that have at least one configured profile ID
+  // actually present in the store.  If no configured ID for a provider exists
+  // in the store, that provider is in "store-only fallback mode" and its store
+  // profiles must be preserved — deleting them would leave the provider with
+  // no credentials at all (resolveAuthProfileOrder falls back to store
+  // profiles when configured IDs are missing).
+  const configuredProvidersWithStorePresence = new Set<string>();
+  for (const profileId of configuredProfiles) {
+    const cred = store.profiles[profileId];
+    if (cred) {
+      configuredProvidersWithStorePresence.add(normalizeProviderIdForAuth(cred.provider));
+    }
+  }
+
   const toRemove = storeProfileIds.filter((id) => {
     if (configuredProfiles.has(id)) {
       return false;
@@ -209,6 +223,15 @@ export async function modelsAuthCleanCommand(
     // so it is the sole credential source for that provider.  Preserve it.
     const cred = store.profiles[id];
     if (cred && !configuredProviders.has(normalizeProviderIdForAuth(cred.provider))) {
+      return false;
+    }
+    // Drift guard: the provider appears in config, but none of its configured
+    // profile IDs actually exist in the store.  The store profile is the only
+    // working credential — preserve it so the provider isn't left with nothing.
+    if (
+      cred &&
+      !configuredProvidersWithStorePresence.has(normalizeProviderIdForAuth(cred.provider))
+    ) {
       return false;
     }
     return true;

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -167,7 +167,26 @@ export async function modelsAuthCleanCommand(
   // Detect them by collecting the set of providers that already have at least one
   // explicitly-configured profile.  Any store profile whose provider is NOT in that
   // set is a store-fallback entry and must be kept.
+  // Compute configured providers from the config itself — not from what
+  // exists in store.profiles.  This ensures a provider counts as "configured"
+  // even when its profile IDs are missing from the store (drifted setups),
+  // allowing stale store entries for that provider to be pruned correctly.
   const configuredProviders = new Set<string>();
+  // 1) Providers declared in cfg.auth.profiles (each entry has a .provider).
+  for (const profile of Object.values(cfg.auth?.profiles ?? {})) {
+    if (profile && typeof profile.provider === "string") {
+      configuredProviders.add(normalizeProviderIdForAuth(profile.provider));
+    }
+  }
+  // 2) Provider keys in cfg.auth.order (keys are provider identifiers).
+  for (const providerKey of Object.keys(cfg.auth?.order ?? {})) {
+    if (providerKey.trim()) {
+      configuredProviders.add(normalizeProviderIdForAuth(providerKey.trim()));
+    }
+  }
+  // 3) Fall back to store-matched providers for profiles referenced by
+  //    store.order or tools.media (these don't carry a .provider field
+  //    themselves, so we still need the store lookup for them).
   for (const profileId of configuredProfiles) {
     const cred = store.profiles[profileId];
     if (cred) {

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -6,6 +6,7 @@ import {
   updateAuthProfileStoreWithLock,
 } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { normalizeProviderIdForAuth } from "../../agents/model-selection.js";
 import type { MediaToolsConfig, MediaUnderstandingModelConfig } from "../../config/types.tools.js";
 import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -156,9 +157,38 @@ export async function modelsAuthCleanCommand(
     }
   }
 
+  // Preserve store-fallback profiles: profiles that exist only in the store
+  // (no corresponding entry in auth.profiles, auth.order, or tools.media) but serve
+  // as active fallback credentials for their provider via resolveAuthProfileOrder's
+  // fallback to listProfilesForProvider.  When at least one *other* provider has a
+  // configured profile, the empty-config safety guard above does not fire, and these
+  // store-only profiles would be incorrectly removed.
+  //
+  // Detect them by collecting the set of providers that already have at least one
+  // explicitly-configured profile.  Any store profile whose provider is NOT in that
+  // set is a store-fallback entry and must be kept.
+  const configuredProviders = new Set<string>();
+  for (const profileId of configuredProfiles) {
+    const cred = store.profiles[profileId];
+    if (cred) {
+      configuredProviders.add(normalizeProviderIdForAuth(cred.provider));
+    }
+  }
+
   const storeProfileIds = Object.keys(store.profiles);
 
-  const toRemove = storeProfileIds.filter((id) => !configuredProfiles.has(id));
+  const toRemove = storeProfileIds.filter((id) => {
+    if (configuredProfiles.has(id)) {
+      return false;
+    }
+    // Store-fallback: this profile's provider has no explicitly-configured profile,
+    // so it is the sole credential source for that provider.  Preserve it.
+    const cred = store.profiles[id];
+    if (cred && !configuredProviders.has(normalizeProviderIdForAuth(cred.provider))) {
+      return false;
+    }
+    return true;
+  });
   const toKeep = storeProfileIds.filter((id) => configuredProfiles.has(id));
 
   // Safety guard: refuse to wipe everything when openclaw.json has no auth

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -250,7 +250,7 @@ export async function modelsAuthCleanCommand(
           JSON.stringify(
             {
               warning:
-                "No profiles configured in openclaw.json auth.profiles or auth.order. All store profiles would be removed. Pass --force to proceed.",
+                "No profiles configured in openclaw.json auth.profiles or auth.order. All store profiles would be removed. Configure auth profiles in openclaw.json before cleaning.",
               storeProfiles: storeProfileIds,
               dryRun: true,
             },


### PR DESCRIPTION
Fixes #41634

Adds `openclaw models auth clean` which removes stale/unconfigured profiles from `auth-profiles.json` without requiring the gateway to be stopped.

- Reads profiles from `auth-profiles.json`
- Compares against IDs configured in `openclaw.json auth.profiles`
- Removes unconfigured entries via `updateAuthProfileStoreWithLock`
- Prunes stale IDs from `order` array and `usageStats`
- `--dry-run` flag to preview
- `--json` flag for scripting
- `--agent` flag to target non-default agent

Replaces accidentally-closed #41640.