### PR TITLE
fix(discord): prevent uncaught gateway errors from crashing the process

### DIFF
--- a/extensions/discord/src/monitor.gateway.ts
+++ b/extensions/discord/src/monitor.gateway.ts
@@ -33,10 +33,12 @@ export async function waitForDiscordGatewayStop(
         return;
       }
       settled = true;
-      cleanup();
       try {
         gateway?.disconnect?.();
       } finally {
+        // remove listeners after disconnect so late "error" events emitted
+        // during disconnect are still handled instead of becoming uncaught
+        cleanup();
         resolve();
       }
     };
@@ -45,10 +47,10 @@ export async function waitForDiscordGatewayStop(
         return;
       }
       settled = true;
-      cleanup();
       try {
         gateway?.disconnect?.();
       } finally {
+        cleanup();
         reject(err);
       }
     };

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -420,6 +420,13 @@ export async function runDiscordGatewayLifecycle(params: {
     }
   } finally {
     lifecycleStopping = true;
+    // attach a safety listener before releasing other listeners so that late
+    // "error" events emitted by Carbon during teardown do not become uncaught
+    // exceptions and crash the entire gateway process.
+    const suppressLateError = (err: unknown) => {
+      params.runtime.error?.(danger(`discord: suppressed late gateway error: ${String(err)}`));
+    };
+    gatewayEmitter?.on("error", suppressLateError);
     params.releaseEarlyGatewayErrorGuard?.();
     unregisterGateway(params.accountId);
     stopGatewayLogging();

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -442,5 +442,6 @@ export async function runDiscordGatewayLifecycle(params: {
       await params.execApprovalsHandler.stop();
     }
     params.threadBindings.stop();
+    gatewayEmitter?.removeListener("error", suppressLateError);
   }
 }


### PR DESCRIPTION
## Summary

- Move `cleanup()` after `disconnect()` in `waitForDiscordGatewayStop` so the error listener remains active during disconnect — prevents late "error" events from becoming uncaught exceptions
- Add a safety error listener in the `runDiscordGatewayLifecycle` finally block to suppress late errors emitted by Carbon during teardown

Fixes the `Uncaught exception: Error: Max reconnect attempts (0) reached after code 1006` crash that kills the entire gateway process (including Telegram, Slack, etc.) when a Discord WebSocket drops and reconnection fails.

Related: #18410, #14703, #21099, #20714

## Root cause

When the Carbon gateway emits an "error" event on its EventEmitter during disconnect or teardown, no listener is attached:

1. `waitForDiscordGatewayStop` calls `cleanup()` (removes error listener) **before** `disconnect()` — if disconnect triggers another error, it's unhandled
2. The lifecycle `finally` block releases the early gateway error guard, leaving no error listener on the emitter for any late errors

In Node.js, an EventEmitter "error" event with no listener throws an uncaught exception, crashing the process.

## Test plan

- [ ] Verify gateway survives Discord WebSocket disconnection (code 1006) without crashing
- [ ] Verify late gateway errors during teardown are logged but suppressed
- [ ] Verify other channels (Telegram, Slack) remain operational when Discord reconnection fails