### PR TITLE
fix: refresh /tools availability when the session model changes

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -136,10 +136,12 @@ describe("handleSendChat", () => {
       }
       throw new Error(`Unexpected request: ${method}`);
     });
+    const onSlashAction = vi.fn();
     const host = makeHost({
       client: { request } as unknown as ChatHost["client"],
       sessionKey: "main",
       chatMessage: "/model gpt-5-mini",
+      onSlashAction,
     });
 
     await handleSendChat(host);
@@ -152,6 +154,7 @@ describe("handleSendChat", () => {
       kind: "qualified",
       value: "openai/gpt-5-mini",
     });
+    expect(onSlashAction).toHaveBeenCalledWith("refresh-tools-effective");
   });
 });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -318,6 +318,7 @@ async function dispatchSlashCommand(
       ...host.chatModelOverrides,
       [targetSessionKey]: result.sessionPatch.modelOverride ?? null,
     };
+    host.onSlashAction?.("refresh-tools-effective");
   }
 
   if (result.action === "refresh") {

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -11,6 +11,7 @@ import {
   resolveChatModelOverrideValue,
   resolveChatModelSelectState,
 } from "./chat-model-select-state.ts";
+import { refreshVisibleToolsEffectiveForCurrentSession } from "./controllers/agents.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
@@ -571,6 +572,7 @@ async function switchChatModel(state: AppViewState, nextModel: string) {
       key: targetSessionKey,
       model: nextModel || null,
     });
+    void refreshVisibleToolsEffectiveForCurrentSession(state);
     await refreshSessionOptions(state);
   } catch (err) {
     // Roll back so the picker reflects the actual server model.

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -22,9 +22,11 @@ import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controlle
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
 import { loadAgentSkills } from "./controllers/agent-skills.ts";
 import {
+  buildToolsEffectiveRequestKey,
   loadAgents,
   loadToolsCatalog,
   loadToolsEffective,
+  refreshVisibleToolsEffectiveForCurrentSession,
   saveAgentsConfig,
 } from "./controllers/agents.ts";
 import { loadChannels } from "./controllers/channels.ts";
@@ -1081,7 +1083,10 @@ export function renderApp(state: AppViewState) {
                         void loadToolsCatalog(state, resolvedAgentId);
                       }
                       if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                        const toolsRequestKey = `${resolvedAgentId}:${state.sessionKey}`;
+                        const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
+                          agentId: resolvedAgentId,
+                          sessionKey: state.sessionKey,
+                        });
                         if (
                           state.toolsEffectiveResultKey !== toolsRequestKey ||
                           state.toolsEffectiveError
@@ -1237,22 +1242,23 @@ export function renderApp(state: AppViewState) {
                     const basePath = ["agents", "list", index, "model"];
                     if (!modelId) {
                       removeConfigFormValue(state, basePath);
-                      return;
-                    }
-                    const entry = Array.isArray(list)
-                      ? (list[index] as { model?: unknown })
-                      : undefined;
-                    const existing = entry?.model;
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                      const next = {
-                        primary: modelId,
-                        ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                      };
-                      updateConfigFormValue(state, basePath, next);
                     } else {
-                      updateConfigFormValue(state, basePath, modelId);
+                      const entry = Array.isArray(list)
+                        ? (list[index] as { model?: unknown })
+                        : undefined;
+                      const existing = entry?.model;
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
+                        const next = {
+                          primary: modelId,
+                          ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
+                        };
+                        updateConfigFormValue(state, basePath, next);
+                      } else {
+                        updateConfigFormValue(state, basePath, modelId);
+                      }
                     }
+                    void refreshVisibleToolsEffectiveForCurrentSession(state);
                   },
                   onModelFallbacksChange: (agentId, fallbacks) => {
                     const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -55,7 +55,10 @@ import {
 import type { AppViewState } from "./app-view-state.ts";
 import { normalizeAssistantIdentity } from "./assistant-identity.ts";
 import { exportChatMarkdown } from "./chat/export.ts";
-import { loadToolsEffective as loadToolsEffectiveInternal } from "./controllers/agents.ts";
+import {
+  loadToolsEffective as loadToolsEffectiveInternal,
+  refreshVisibleToolsEffectiveForCurrentSession as refreshVisibleToolsEffectiveForCurrentSessionInternal,
+} from "./controllers/agents.ts";
 import { loadAssistantIdentity as loadAssistantIdentityInternal } from "./controllers/assistant-identity.ts";
 import type { DevicePairingList } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
@@ -486,6 +489,10 @@ export class OpenClawApp extends LitElement {
         case "export":
           exportChatMarkdown(this.chatMessages, this.assistantName);
           break;
+        case "refresh-tools-effective": {
+          void refreshVisibleToolsEffectiveForCurrentSessionInternal(this);
+          break;
+        }
       }
     };
     document.addEventListener("keydown", this.globalKeydownHandler);

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -21,6 +21,25 @@ function createState(): { state: AgentsState; request: ReturnType<typeof vi.fn> 
     toolsEffectiveResultKey: null,
     toolsEffectiveError: null,
     toolsEffectiveResult: null,
+    sessionKey: "main",
+    sessionsResult: {
+      ts: 0,
+      path: "",
+      count: 1,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 0,
+          model: "gpt-5-mini",
+          modelProvider: "openai",
+        },
+      ],
+    },
+    chatModelOverrides: {},
+    chatModelCatalog: [{ id: "gpt-5-mini", name: "GPT-5 Mini", provider: "openai" }],
+    agentsPanel: "overview",
   };
   return { state, request };
 }
@@ -188,7 +207,7 @@ describe("loadToolsEffective", () => {
       sessionKey: "main",
     });
     expect(state.toolsEffectiveResult).toEqual(payload);
-    expect(state.toolsEffectiveResultKey).toBe("main:main");
+    expect(state.toolsEffectiveResultKey).toBe("main:main:model=openai/gpt-5-mini");
     expect(state.toolsEffectiveError).toBeNull();
     expect(state.toolsEffectiveLoading).toBe(false);
   });

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -1,5 +1,17 @@
+import { resolveAgentIdFromSessionKey } from "../../../../src/routing/session-key.js";
+import {
+  resolveChatModelOverride,
+  resolvePreferredServerChatModelValue,
+} from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
-import type { AgentsListResult, ToolsCatalogResult, ToolsEffectiveResult } from "../types.ts";
+import type {
+  AgentsListResult,
+  ChatModelOverride,
+  ModelCatalogEntry,
+  SessionsListResult,
+  ToolsCatalogResult,
+  ToolsEffectiveResult,
+} from "../types.ts";
 import { saveConfig } from "./config.ts";
 import type { ConfigState } from "./config.ts";
 import {
@@ -23,6 +35,11 @@ export type AgentsState = {
   toolsEffectiveResultKey?: string | null;
   toolsEffectiveError: string | null;
   toolsEffectiveResult: ToolsEffectiveResult | null;
+  sessionKey?: string;
+  sessionsResult?: SessionsListResult | null;
+  chatModelOverrides?: Record<string, ChatModelOverride | null>;
+  chatModelCatalog?: ModelCatalogEntry[];
+  agentsPanel?: "overview" | "files" | "tools" | "skills" | "channels" | "cron";
 };
 
 export type AgentsConfigSaveState = AgentsState & ConfigState;
@@ -107,7 +124,10 @@ export async function loadToolsEffective(
 ) {
   const resolvedAgentId = params.agentId.trim();
   const resolvedSessionKey = params.sessionKey.trim();
-  const requestKey = `${resolvedAgentId}:${resolvedSessionKey}`;
+  const requestKey = buildToolsEffectiveRequestKey(state, {
+    agentId: resolvedAgentId,
+    sessionKey: resolvedSessionKey,
+  });
   if (!state.client || !state.connected || !resolvedAgentId || !resolvedSessionKey) {
     return;
   }
@@ -150,6 +170,70 @@ export async function loadToolsEffective(
       state.toolsEffectiveLoading = false;
     }
   }
+}
+
+export function resetToolsEffectiveState(state: AgentsState) {
+  state.toolsEffectiveResult = null;
+  state.toolsEffectiveResultKey = null;
+  state.toolsEffectiveError = null;
+  state.toolsEffectiveLoading = false;
+  state.toolsEffectiveLoadingKey = null;
+}
+
+export function buildToolsEffectiveRequestKey(
+  state: Pick<AgentsState, "sessionsResult" | "chatModelOverrides" | "chatModelCatalog">,
+  params: { agentId: string; sessionKey: string },
+): string {
+  const resolvedAgentId = params.agentId.trim();
+  const resolvedSessionKey = params.sessionKey.trim();
+  const modelKey = resolveEffectiveToolsModelKey(state, resolvedSessionKey);
+  return `${resolvedAgentId}:${resolvedSessionKey}:model=${modelKey || "(default)"}`;
+}
+
+export function refreshVisibleToolsEffectiveForCurrentSession(
+  state: AgentsState,
+): Promise<void> | undefined {
+  const resolvedSessionKey = state.sessionKey?.trim();
+  if (!resolvedSessionKey || state.agentsPanel !== "tools" || !state.agentsSelectedId) {
+    return;
+  }
+  const sessionAgentId = resolveAgentIdFromSessionKey(resolvedSessionKey);
+  if (!sessionAgentId || state.agentsSelectedId !== sessionAgentId) {
+    return;
+  }
+  return loadToolsEffective(state, {
+    agentId: sessionAgentId,
+    sessionKey: resolvedSessionKey,
+  });
+}
+
+function resolveEffectiveToolsModelKey(
+  state: Pick<AgentsState, "sessionsResult" | "chatModelOverrides" | "chatModelCatalog">,
+  sessionKey: string,
+): string {
+  const resolvedSessionKey = sessionKey.trim();
+  if (!resolvedSessionKey) {
+    return "";
+  }
+  const catalog = state.chatModelCatalog ?? [];
+  const cachedOverride = state.chatModelOverrides?.[resolvedSessionKey];
+  const defaults = state.sessionsResult?.defaults;
+  const defaultModel = resolvePreferredServerChatModelValue(
+    defaults?.model,
+    defaults?.modelProvider,
+    catalog,
+  );
+  if (cachedOverride === null) {
+    return defaultModel;
+  }
+  if (cachedOverride) {
+    return resolveChatModelOverride(cachedOverride, catalog).value;
+  }
+  const activeRow = state.sessionsResult?.sessions?.find((row) => row.key === resolvedSessionKey);
+  if (activeRow?.model) {
+    return resolvePreferredServerChatModelValue(activeRow.model, activeRow.modelProvider, catalog);
+  }
+  return defaultModel;
 }
 
 export async function saveAgentsConfig(state: AgentsConfigSaveState) {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -77,6 +77,13 @@ function createChatHeaderState(
     if (method === "models.list") {
       return { models: catalog };
     }
+    if (method === "tools.effective") {
+      return {
+        agentId: "main",
+        profile: "coding",
+        groups: [],
+      };
+    }
     throw new Error(`Unexpected request: ${method}`);
   });
   const state = {
@@ -120,6 +127,13 @@ function createChatHeaderState(
     basePath: "",
     hello: null,
     agentsList: null,
+    agentsPanel: "overview",
+    agentsSelectedId: null,
+    toolsEffectiveLoading: false,
+    toolsEffectiveLoadingKey: null,
+    toolsEffectiveResultKey: null,
+    toolsEffectiveError: null,
+    toolsEffectiveResult: null,
     applySettings(next: AppViewState["settings"]) {
       state.settings = next;
     },
@@ -802,6 +816,42 @@ describe("chat view", () => {
     expect(request).not.toHaveBeenCalledWith("chat.history", expect.anything());
     expect(state.sessionsResult?.sessions[0]?.model).toBe("gpt-5-mini");
     expect(state.sessionsResult?.sessions[0]?.modelProvider).toBe("openai");
+    vi.unstubAllGlobals();
+  });
+
+  it("reloads effective tools after a chat-header model switch for the active tools panel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+      } satisfies Partial<Response>),
+    );
+    const { state, request } = createChatHeaderState();
+    state.agentsPanel = "tools";
+    state.agentsSelectedId = "main";
+    state.toolsEffectiveResultKey = "main:main";
+    state.toolsEffectiveResult = {
+      agentId: "main",
+      profile: "coding",
+      groups: [],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(
+      'select[data-chat-model-select="true"]',
+    );
+    expect(modelSelect).not.toBeNull();
+
+    modelSelect!.value = "openai/gpt-5-mini";
+    modelSelect!.dispatchEvent(new Event("change", { bubbles: true }));
+    await flushTasks();
+
+    expect(request).toHaveBeenCalledWith("tools.effective", {
+      agentId: "main",
+      sessionKey: "main",
+    });
+    expect(state.toolsEffectiveResultKey).toBe("main:main:model=openai/gpt-5-mini");
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the Control UI cached `tools.effective` results by `agentId + sessionKey`, so a model change in the same session could reuse stale runtime tool availability.
- Why it matters: effective tool exposure is model-sensitive, so `/tools` and the "Available Right Now" panel could show the wrong inventory after switching models.
- What changed: the UI now keys effective-tool results by `agentId + sessionKey + effective model`, and the runtime model-switch paths reuse a shared refresh helper for the visible Tools panel.
- What did NOT change (scope boundary): gateway/runtime tool resolution logic and model compatibility rules stayed the same; this PR only fixes UI cache invalidation and refresh behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the effective-tools refresh guard only compared `agentId + sessionKey`, but `tools.effective` is also a function of the session's effective model.
- Missing detection / guardrail: there was no test covering a model switch in the same session while reusing the same Tools panel/session key.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this follows the runtime-effective `/tools` work that moved the UI off catalog guesses and onto `tools.effective`.
- Why this regressed now: once the UI started trusting the runtime-effective result, the old coarse cache key became incorrect for model-sensitive tool exposure.
- If unknown, what was ruled out: ruled out gateway/runtime resolver bugs; the stale behavior came from client-side request-key reuse.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`, `ui/src/ui/app-chat.test.ts`, `ui/src/ui/controllers/agents.test.ts`
- Scenario the test should lock in: switching the session model should force a fresh `tools.effective` request and produce a model-aware cache key for the same `agentId + sessionKey`.
- Why this is the smallest reliable guardrail: the bug lives in UI state/cache handling, and these focused tests exercise the exact model-switch entry points without needing a full browser/channel environment.
- Existing test that already covers this (if any): none covered model changes against the effective-tools cache key before this PR.
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- After changing the current session model, the Control UI Tools panel refreshes "Available Right Now" instead of reusing stale availability for the prior model.
- Reopening the Tools panel after a same-session model switch no longer reuses the old effective-tools result.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm/vitest
- Model/provider: example session switch from `openai/gpt-5` to `openai/gpt-5-mini`
- Integration/channel (if any): Control UI / web chat header + `/model`
- Relevant config (redacted): active session owned by the selected agent, Tools panel open or reopened after model switch

### Steps

1. Open the Control UI Tools panel for the current session's agent.
2. Change the session model via the chat header picker or `/model`.
3. Observe whether the Tools panel reuses the previous `tools.effective` result or reloads.

### Expected

- The effective-tools request key changes with the session model, and the Tools panel reloads the runtime inventory.

### Actual

- Before this fix, the guard reused the stale `agentId + sessionKey` result and could skip reloading after a model switch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the focused UI/controller tests that cover the chat header model picker, `/model`, and effective-tools request-key behavior.
- Edge cases checked: same session key with a different model; cached override vs. server/default model fallback in the request key.
- What you did **not** verify: manual browser/channel interaction outside the focused local test suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit to restore the previous session-key-only refresh behavior.
- Files/config to restore: `ui/src/ui/controllers/agents.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/app-render.helpers.ts`, `ui/src/ui/app-chat.ts`, `ui/src/ui/app.ts`
- Known bad symptoms reviewers should watch for: stale or wrong "Available Right Now" inventory after changing models in the same session.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the UI-side effective-model key could diverge from the server's final resolved model in an edge case.
  - Mitigation: the key prefers in-flight overrides, then session row data, then defaults, matching the UI's own model-selection resolution path and covered by focused tests.
