### PR TITLE
fix: pass agentId in CLI message command to enable session transcript writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: trigger timeout recovery compaction before retrying high-context LLM timeouts so embedded runs stop repeating oversized requests. (#46417) thanks @joeykrug.
 - Microsoft Teams/config: accept the existing `welcomeCard`, `groupWelcomeCard`, `promptStarters`, and feedback/reflection keys in strict config validation so already-supported Teams runtime settings stop failing schema checks. (#54679) Thanks @gumclaw.
 - Agents/status: use provider-aware context window lookup for fresh Anthropic 4.6 model overrides so `/status` shows the correct 1.0m window instead of an underreported shared-cache minimum. (#54796) Thanks @neeravmakwana.
+- CLI/message send: write manual `openclaw message send` deliveries into the resolved agent session transcript again by always threading the default CLI agent through outbound mirroring. (#54187) Thanks @KevInTheCloud5617.
 
 ## 2026.3.24
 

--- a/src/commands/message.default-agent.test.ts
+++ b/src/commands/message.default-agent.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/outbound-send-deps.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+let testConfig: Record<string, unknown> = {};
+
+const resolveCommandSecretRefsViaGateway = vi.hoisted(() =>
+  vi.fn(async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    diagnostics: [] as string[],
+  })),
+);
+const runMessageAction = vi.hoisted(() =>
+  vi.fn(async () => ({
+    kind: "send" as const,
+    channel: "telegram" as const,
+    action: "send" as const,
+    to: "123456",
+    handledBy: "core" as const,
+    payload: { ok: true },
+    dryRun: false,
+  })),
+);
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => testConfig,
+  };
+});
+
+vi.mock("../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway,
+}));
+
+vi.mock("../infra/outbound/message-action-runner.js", () => ({
+  runMessageAction,
+}));
+
+describe("messageCommand agent routing", () => {
+  beforeEach(() => {
+    testConfig = {};
+    resolveCommandSecretRefsViaGateway.mockClear();
+    runMessageAction.mockClear();
+  });
+
+  it("passes the resolved default agent id to the outbound runner", async () => {
+    testConfig = {
+      agents: {
+        list: [{ id: "alpha" }, { id: "ops", default: true }],
+      },
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    const { messageCommand } = await import("./message.js");
+
+    await messageCommand(
+      {
+        action: "send",
+        channel: "telegram",
+        target: "123456",
+        message: "hi",
+        json: true,
+      },
+      {} as CliDeps,
+      runtime,
+    );
+
+    expect(runMessageAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "ops",
+      }),
+    );
+  });
+});

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -10,6 +10,7 @@ import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildMessageCliJson, formatMessageCliText } from "./message-format.js";
@@ -52,12 +53,17 @@ export async function messageCommand(
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
+  const agentId = normalizeAgentId(
+    typeof opts.agent === "string" ? opts.agent : cfg.agent?.id,
+  );
+
   const run = async () =>
     await runMessageAction({
       cfg,
       action,
       params: opts,
       deps: outboundDeps,
+      agentId,
       gateway: {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -1,3 +1,4 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   CHANNEL_MESSAGE_ACTION_NAMES,
   type ChannelMessageActionName,
@@ -53,7 +54,9 @@ export async function messageCommand(
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
-  const agentId = normalizeAgentId(typeof opts.agent === "string" ? opts.agent : cfg.agent?.id);
+  const agentId = normalizeAgentId(
+    typeof opts.agent === "string" ? opts.agent : resolveDefaultAgentId(cfg),
+  );
 
   const run = async () =>
     await runMessageAction({

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -53,9 +53,7 @@ export async function messageCommand(
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
-  const agentId = normalizeAgentId(
-    typeof opts.agent === "string" ? opts.agent : cfg.agent?.id,
-  );
+  const agentId = normalizeAgentId(typeof opts.agent === "string" ? opts.agent : cfg.agent?.id);
 
   const run = async () =>
     await runMessageAction({

--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -11,7 +11,6 @@ import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildMessageCliJson, formatMessageCliText } from "./message-format.js";
@@ -54,17 +53,13 @@ export async function messageCommand(
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
 
-  const agentId = normalizeAgentId(
-    typeof opts.agent === "string" ? opts.agent : resolveDefaultAgentId(cfg),
-  );
-
   const run = async () =>
     await runMessageAction({
       cfg,
       action,
       params: opts,
       deps: outboundDeps,
-      agentId,
+      agentId: resolveDefaultAgentId(cfg),
       gateway: {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,


### PR DESCRIPTION
## Summary

Fixes #54186 — `openclaw message send` CLI delivers messages but does not write to the session transcript.

## Root Cause

`messageCommand()` in `src/commands/message.ts` calls `runMessageAction()` without passing `agentId`. The outbound session route resolution in `message-action-runner.ts` is gated on `agentId && !dryRun`, so without an agent ID:

1. `outboundRoute` is `null`
2. The `mirror` object is never constructed
3. `appendAssistantMessageToSessionTranscript()` is never called

The agent tool path (`message-tool.ts`) correctly resolves and passes `agentId` from the session key, which is why transcript writes work when the agent sends messages but not from the CLI.

## Fix

Resolve `agentId` from the config (with `normalizeAgentId`, defaulting to `"main"`) and pass it to `runMessageAction()`. This enables the full outbound session route → mirror → transcript write pipeline for CLI sends across all channels.

## Changes

- `src/commands/message.ts`: Import `normalizeAgentId`, resolve agent ID from `opts.agent` or `cfg.agent?.id`, pass as `agentId` parameter

## Testing

- Verified the code path: with `agentId` set, `resolveOutboundSessionRoute()` resolves the session key, `mirror` is constructed, and `appendAssistantMessageToSessionTranscript()` fires after successful delivery
- Affects all channels equally (Telegram, Discord, WhatsApp, Slack, Signal, etc.) since the fix is at the CLI command layer