### PR TITLE
fix(agents): correct ClawHub URL in system prompt (clawhub.com → clawhub.ai)

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -179,7 +179,7 @@ function buildDocsSection(params: { docsPath?: string; isMinimal: boolean; readT
     "Mirror: https://docs.openclaw.ai",
     "Source: https://github.com/openclaw/openclaw",
     "Community: https://discord.com/invite/clawd",
-    "Find new skills: https://clawhub.com",
+    "Find new skills: https://clawhub.ai",
     "For OpenClaw behavior, commands, config, or architecture: consult local docs first.",
     "When diagnosing issues, run `openclaw status` yourself when possible; only ask the user if you lack access (e.g., sandboxed).",
     "",


### PR DESCRIPTION
## Summary

Fixes #54154

The agent system prompt was pointing to `https://clawhub.com` instead of the correct `https://clawhub.ai`. This URL appears in every agent's system prompt documentation section.

## Changes

- `src/agents/system-prompt.ts`: Change `clawhub.com` to `clawhub.ai`

## Verification

- [x] Code follows the project's style guidelines (oxfmt passes)
- [x] The correct URL `https://clawhub.ai` is used consistently throughout the codebase:
  - `src/infra/clawhub.ts:8`: `const DEFAULT_CLAWHUB_URL = "https://clawhub.ai";`
  - `src/plugins/clawhub.ts:336`: `"https://clawhub.ai",`

## Test Plan

- [ ] Start an agent and verify the system prompt contains the correct URL