### PR TITLE
fix(gateway): isolate channel startup failures to prevent cascade

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -495,8 +495,28 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const startChannels = async () => {
-    for (const plugin of listChannelPlugins()) {
-      await startChannel(plugin.id);
+    const results = await Promise.allSettled(
+      listChannelPlugins().map(async (plugin) => {
+        try {
+          await startChannel(plugin.id);
+        } catch (err) {
+          const message = formatErrorMessage(err);
+          channelLogs[plugin.id].error?.(
+            `[${plugin.id}] channel startup failed: ${message}`,
+          );
+          // Continue with other channels - fault isolation
+        }
+      }),
+    );
+
+    // Log summary of channel startup results
+    const failed = results.filter((r) => r.status === "rejected");
+    if (failed.length > 0) {
+      const total = results.length;
+      const succeeded = total - failed.length;
+      channelLogs.discord?.warn?.(
+        `Channel startup summary: ${succeeded}/${total} channels started successfully`,
+      );
     }
   };
 


### PR DESCRIPTION
## Problem

When one channel (e.g., WhatsApp) fails to start due to missing runtime modules (like `light-runtime-api`), it blocks all subsequent channels (e.g., Discord) from starting. This creates a cascading failure where a single channel issue appears as a total system outage.

### Symptoms
- `channel startup failed: WhatsApp plugin runtime is unavailable: missing light-runtime-api`
- Discord shows as "stopped/disconnected" even though it was never given a chance to start
- Users misdiagnose this as a Discord configuration problem

## Solution

Use `Promise.allSettled` to start channels concurrently with per-channel error isolation:

**Before:**
```typescript
for (const plugin of listChannelPlugins()) {
  await startChannel(plugin.id); // If one throws, loop exits
}
```

**After:**
```typescript
await Promise.allSettled(
  listChannelPlugins().map(async (plugin) => {
    try {
      await startChannel(plugin.id);
    } catch (err) {
      // Log error but continue with other channels
    }
  })
);
```

## Changes

- Start channels concurrently instead of sequentially
- Catch individual channel startup errors without affecting others
- Add startup summary logging for observability

## Testing

- [ ] Configure WhatsApp with missing runtime
- [ ] Verify Discord still starts successfully
- [ ] Check logs show both failure and success

## Related Issues

- P0: WhatsApp runtime exception blocks Discord startup
- P1: Channel status inconsistency (partial fix)

## Backwards Compatibility

- Interface unchanged (`startChannels()` still returns `Promise<void>`)
- Existing error handling in callers continues to work
- Only behavioral change: more channels start successfully when some fail
