### PR TITLE
fix: pass agentId in message CLI so send writes session transcript

### DIFF
--- a/src/commands/message.ts
+++ b/src/commands/message.ts
@@ -10,6 +10,7 @@ import { withProgress } from "../cli/progress.js";
 import { loadConfig } from "../config/config.js";
 import type { OutboundSendDeps } from "../infra/outbound/deliver.js";
 import { runMessageAction } from "../infra/outbound/message-action-runner.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { buildMessageCliJson, formatMessageCliText } from "./message-format.js";
@@ -51,6 +52,7 @@ export async function messageCommand(
   const action = actionMatch as ChannelMessageActionName;
 
   const outboundDeps: OutboundSendDeps = createOutboundSendDeps(deps);
+  const agentId = normalizeAgentId(typeof opts.agent === "string" ? opts.agent : undefined);
 
   const run = async () =>
     await runMessageAction({
@@ -58,6 +60,7 @@ export async function messageCommand(
       action,
       params: opts,
       deps: outboundDeps,
+      agentId,
       gateway: {
         clientName: GATEWAY_CLIENT_NAMES.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,


### PR DESCRIPTION
## Summary

`openclaw message send` delivers the message successfully but never writes to the session transcript. This means the agent has no context of the programmatically sent message when the user replies.

**Root cause:** `messageCommand` calls `runMessageAction` without an `agentId`. Inside `message-action-runner.ts`, `resolvedAgentId` is then `undefined`, which prevents `resolveOutboundSessionRoute` from building an `outboundRoute` or `mirror`. The transcript write in `deliver.ts` only fires when `mirror` is present, so it is skipped entirely.

**Fix:** Derive `agentId` from `opts.agent` (or default `"main"`) and pass it to `runMessageAction`. The agent tool path (`message-tool.ts`) already does this correctly.

## Testing

- [x] `pnpm test -- src/cli/program/message/helpers.test.ts` — 10/10 pass
- [x] `pnpm check` — clean
- [x] `pnpm tsgo` — no errors

Closes #54186