### PR TITLE
fix: resolveDeliveryStatus returns not-requested for mode=none cron jobs

### DIFF
--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -151,14 +151,15 @@ describe("CronService persists delivered status", () => {
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 
-  it("persists lastDelivered=false when isolated job explicitly reports not delivered", async () => {
+  it("persists not-requested when mode=none job reports delivered=false", async () => {
     const updated = await runIsolatedJobAndReadState({
       job: buildIsolatedAgentTurnJob("delivered-false"),
       delivered: false,
     });
     expectSuccessfulCronRun(updated);
     expect(updated?.state.lastDelivered).toBe(false);
-    expect(updated?.state.lastDeliveryStatus).toBe("not-delivered");
+    // mode='none' means delivery was never requested — not "not-delivered"
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
     expect(updated?.state.lastDeliveryError).toBeUndefined();
   });
 

--- a/src/cron/service.persists-delivered-status.test.ts
+++ b/src/cron/service.persists-delivered-status.test.ts
@@ -203,6 +203,22 @@ describe("CronService persists delivered status", () => {
     cron.stop();
   });
 
+  it("persists not-requested for webhook mode job with delivered=false", async () => {
+    // mode='webhook' also has requested=false in resolveCronDeliveryPlan (delivery happens
+    // outside dispatchCronDelivery), so delivered=false means not-attempted, not a failure.
+    const updated = await runIsolatedJobAndReadState({
+      job: {
+        ...buildIsolatedAgentTurnJob("webhook-not-delivered"),
+        delivery: { mode: "webhook" as const, to: "https://example.com/hook" },
+      },
+      delivered: false,
+    });
+    expectSuccessfulCronRun(updated);
+    expect(updated?.state.lastDelivered).toBe(false);
+    expect(updated?.state.lastDeliveryStatus).toBe("not-requested");
+    expect(updated?.state.lastDeliveryError).toBeUndefined();
+  });
+
   it("emits delivered in the finished event", async () => {
     let capturedEvent: { jobId: string; delivered?: boolean; deliveryStatus?: string } | undefined;
     await runIsolatedJobAndReadState({

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -255,10 +255,15 @@ function resolveDeliveryStatus(params: { job: CronJob; delivered?: boolean }): C
   if (params.delivered === true) {
     return "delivered";
   }
+  // Treat delivered=false as "not-requested" when delivery was never attempted.
+  // Without this, mode='none' jobs incorrectly report "not-delivered" on run errors.
+  if (!resolveCronDeliveryPlan(params.job).requested) {
+    return "not-requested";
+  }
   if (params.delivered === false) {
     return "not-delivered";
   }
-  return resolveCronDeliveryPlan(params.job).requested ? "unknown" : "not-requested";
+  return "unknown";
 }
 
 function normalizeCronMessageChannel(input: unknown): CronMessageChannel | undefined {


### PR DESCRIPTION
## Summary

`resolveDeliveryStatus` in `src/cron/service/timer.ts` was treating `delivered=false` as `"not-delivered"` even for jobs with `delivery.mode='none'`, where delivery is never attempted.

**Root cause:** `delivered` is initialized to `skipMessagingToolDelivery` (which is `false` for `mode='none'` jobs because `deliveryRequested` is `false`). When the dispatch returns `{ delivered: false }`, `resolveDeliveryStatus` unconditionally returns `"not-delivered"`. This causes any run error on a `mode='none'` job to populate `lastDeliveryError` even though no delivery was attempted.

**Fix:** Move the `!requested` guard before the `delivered === false` check. When delivery was never requested, `delivered=false` means `"not-requested"`, not `"not-delivered"`. The `delivered=true` case is preserved first since a job can still deliver via messaging tool even with `mode='none'`.

**Test update:** The existing test `"persists lastDelivered=false when isolated job explicitly reports not delivered"` was using a `mode='none'` job and asserting `"not-delivered"` — it was asserting the old incorrect behavior. Updated the title and expectation to match the fixed behavior.

## Testing

- [x] `pnpm test -- src/cron/service.persists-delivered-status.test.ts` — 6/6 pass
- [x] `pnpm test -- src/cron/service.delivery-plan.test.ts` — 3/3 pass
- [x] `pnpm test -- src/cron/service.jobs.test.ts` — 35/35 pass
- [x] `pnpm check` — clean

Closes #54188