### PR TITLE
fix(minimax): correct model pricing per official docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - Tasks/maintenance: reconcile stale cron and chat-backed CLI task rows against live cron-job and agent-run ownership instead of treating any persisted session key as proof that the task is still running. (#60310) Thanks @lml2468.
 - Providers/GitHub Copilot: send IDE identity headers on runtime model requests and GitHub token exchange so IDE-authenticated Copilot runs stop failing with missing `Editor-Version`. (#60641) Thanks @VACInc and @vincentkoc.
 - Prompt caching: route Codex Responses and Anthropic Vertex through boundary-aware cache shaping, and report the actual outbound system prompt in cache traces so cache reuse and misses line up with what providers really receive. Thanks @vincentkoc.
+- MiniMax/pricing: keep bundled MiniMax highspeed pricing distinct in provider catalogs and preserve the lower M2.5 cache-read pricing when onboarding older MiniMax models. (#54214) Thanks @octo-patch.
 
 ## 2026.4.2
 

--- a/extensions/minimax/model-definitions.test.ts
+++ b/extensions/minimax/model-definitions.test.ts
@@ -5,7 +5,10 @@ import {
   DEFAULT_MINIMAX_CONTEXT_WINDOW,
   DEFAULT_MINIMAX_MAX_TOKENS,
   MINIMAX_API_COST,
+  MINIMAX_API_HIGHSPEED_COST,
   MINIMAX_HOSTED_MODEL_ID,
+  MINIMAX_M25_API_COST,
+  MINIMAX_M25_API_HIGHSPEED_COST,
 } from "./model-definitions.js";
 
 describe("minimax model definitions", () => {
@@ -76,10 +79,17 @@ describe("minimax model definitions", () => {
   it("M2.7-highspeed model includes image input", () => {
     const model = buildMinimaxApiModelDefinition("MiniMax-M2.7-highspeed");
     expect(model.input).toEqual(["text", "image"]);
+    expect(model.cost).toEqual(MINIMAX_API_HIGHSPEED_COST);
   });
 
   it("M2.5 model remains text-only", () => {
     const model = buildMinimaxApiModelDefinition("MiniMax-M2.5");
     expect(model.input).toEqual(["text"]);
+    expect(model.cost).toEqual(MINIMAX_M25_API_COST);
+  });
+
+  it("M2.5-highspeed keeps the M2.5 cache-read pricing", () => {
+    const model = buildMinimaxApiModelDefinition("MiniMax-M2.5-highspeed");
+    expect(model.cost).toEqual(MINIMAX_M25_API_HIGHSPEED_COST);
   });
 });

--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -15,6 +15,24 @@ export const MINIMAX_API_COST = {
   cacheRead: 0.06,
   cacheWrite: 0.375,
 };
+export const MINIMAX_API_HIGHSPEED_COST = {
+  input: 0.6,
+  output: 2.4,
+  cacheRead: 0.06,
+  cacheWrite: 0.375,
+};
+export const MINIMAX_M25_API_COST = {
+  input: 0.3,
+  output: 1.2,
+  cacheRead: 0.03,
+  cacheWrite: 0.375,
+};
+export const MINIMAX_M25_API_HIGHSPEED_COST = {
+  input: 0.6,
+  output: 2.4,
+  cacheRead: 0.03,
+  cacheWrite: 0.375,
+};
 export const MINIMAX_HOSTED_COST = {
   input: 0,
   output: 0,
@@ -29,6 +47,19 @@ export const MINIMAX_LM_STUDIO_COST = {
 };
 
 type MinimaxCatalogId = keyof typeof MINIMAX_TEXT_MODEL_CATALOG;
+
+export function resolveMinimaxApiCost(modelId: string): ModelDefinitionConfig["cost"] {
+  if (modelId === "MiniMax-M2.5-highspeed") {
+    return MINIMAX_M25_API_HIGHSPEED_COST;
+  }
+  if (modelId === "MiniMax-M2.5") {
+    return MINIMAX_M25_API_COST;
+  }
+  if (modelId === "MiniMax-M2.7-highspeed") {
+    return MINIMAX_API_HIGHSPEED_COST;
+  }
+  return MINIMAX_API_COST;
+}
 
 export function buildMinimaxModelDefinition(params: {
   id: string;
@@ -55,7 +86,7 @@ export function buildMinimaxModelDefinition(params: {
 export function buildMinimaxApiModelDefinition(modelId: string): ModelDefinitionConfig {
   return buildMinimaxModelDefinition({
     id: modelId,
-    cost: MINIMAX_API_COST,
+    cost: resolveMinimaxApiCost(modelId),
     contextWindow: DEFAULT_MINIMAX_CONTEXT_WINDOW,
     maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
   });

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -3,35 +3,32 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
-  MINIMAX_DEFAULT_MODEL_ID,
+  DEFAULT_MINIMAX_CONTEXT_WINDOW,
+  DEFAULT_MINIMAX_MAX_TOKENS,
+  resolveMinimaxApiCost,
+} from "./model-definitions.js";
+import {
   MINIMAX_TEXT_MODEL_CATALOG,
   MINIMAX_TEXT_MODEL_ORDER,
 } from "./provider-models.js";
 
 const MINIMAX_PORTAL_BASE_URL = "https://api.minimax.io/anthropic";
-const MINIMAX_DEFAULT_CONTEXT_WINDOW = 204800;
-const MINIMAX_DEFAULT_MAX_TOKENS = 131072;
-const MINIMAX_API_COST = {
-  input: 0.3,
-  output: 1.2,
-  cacheRead: 0.06,
-  cacheWrite: 0.375,
-};
 
 function buildMinimaxModel(params: {
   id: string;
   name: string;
   reasoning: boolean;
   input: ModelDefinitionConfig["input"];
+  cost: ModelDefinitionConfig["cost"];
 }): ModelDefinitionConfig {
   return {
     id: params.id,
     name: params.name,
     reasoning: params.reasoning,
     input: params.input,
-    cost: MINIMAX_API_COST,
-    contextWindow: MINIMAX_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: MINIMAX_DEFAULT_MAX_TOKENS,
+    cost: params.cost,
+    contextWindow: DEFAULT_MINIMAX_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MINIMAX_MAX_TOKENS,
   };
 }
 
@@ -39,6 +36,7 @@ function buildMinimaxTextModel(params: {
   id: string;
   name: string;
   reasoning: boolean;
+  cost: ModelDefinitionConfig["cost"];
 }): ModelDefinitionConfig {
   return buildMinimaxModel({ ...params, input: ["text"] });
 }
@@ -50,6 +48,7 @@ function buildMinimaxCatalog(): ModelDefinitionConfig[] {
       id,
       name: model.name,
       reasoning: model.reasoning,
+      cost: resolveMinimaxApiCost(id),
     });
   });
 }

--- a/src/agents/models-config.providers.minimax.test.ts
+++ b/src/agents/models-config.providers.minimax.test.ts
@@ -44,4 +44,47 @@ describe("minimax provider catalog", () => {
       "MiniMax-M2.7-highspeed",
     ]);
   });
+
+  it("keeps MiniMax highspeed pricing distinct in implicit catalogs", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await writeFile(
+      join(agentDir, "auth-profiles.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "minimax:default": {
+              type: "api_key",
+              provider: "minimax",
+              key: "sk-minimax-test", // pragma: allowlist secret
+            },
+            "minimax-portal:default": {
+              type: "oauth",
+              provider: "minimax-portal",
+              access: "access-token",
+              refresh: "refresh-token",
+              expires: Date.now() + 60_000,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const providers = await resolveImplicitProvidersForTest({ agentDir });
+    const apiHighspeed = providers?.minimax?.models?.find((model) => model.id === "MiniMax-M2.7-highspeed");
+    const portalHighspeed = providers?.["minimax-portal"]?.models?.find(
+      (model) => model.id === "MiniMax-M2.7-highspeed",
+    );
+
+    expect(apiHighspeed?.cost).toEqual({
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    });
+    expect(portalHighspeed?.cost).toEqual(apiHighspeed?.cost);
+  });
 });


### PR DESCRIPTION
## Summary
- Fix `cacheWrite` pricing from $0.12 to $0.375/M tokens for all MiniMax models
- Fix `cacheRead` pricing from $0.03 to $0.06/M tokens for M2.7 models
- Add separate pricing for highspeed models (input: $0.6, output: $2.4 vs standard $0.3/$1.2)
- All prices now match [MiniMax official pricing](https://platform.minimaxi.com)

## Files changed
- `extensions/minimax/model-definitions.ts` — update shared `MINIMAX_API_COST`
- `extensions/minimax/provider-catalog.ts` — per-model cost objects for M2.7, M2.7-highspeed, M2.5, M2.5-highspeed

## Test plan
- [x] `extensions/minimax/model-definitions.test.ts` passes