### PR TITLE
fix(gateway): isolate channel startup failures to prevent cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/docx block ordering: preserve the document tree order from `docx.document.convert` when inserting blocks, fixing heading/paragraph/list misordering in newly written Feishu documents. (#40524) Thanks @TaoXieSZ.
 - Agents/cron: suppress the default heartbeat system prompt for cron-triggered embedded runs even when they target non-cron session keys, so cron tasks stop reading `HEARTBEAT.md` and polluting unrelated threads. (#53152) Thanks @Protocol-zero-0.
 - TUI/chat: preserve pending user messages when a slow local run emits an empty final event, but still defer and flush the needed history reload after the newer active run finishes so silent/tool-only runs do not stay incomplete. (#53130) Thanks @joelnishanth.
+- Gateway/channels: keep channel startup sequential while isolating per-channel boot failures, so one broken channel no longer blocks later channels from starting. (#54215) Thanks @JonathanJing.
 - Docs/IRC: fix five `json55` code-fence typos in the IRC channel examples so Mintlify applies JSON5 syntax highlighting correctly. (#50842) Thanks @Hollychou924.
 - Telegram/forum topics: recover `#General` topic `1` routing when Telegram omits forum metadata, including native commands, interactive callbacks, inbound message context, and fallback error replies. (#53699) thanks @huntharo
 - Discord/config types: add missing `autoArchiveDuration` to `DiscordGuildChannelConfig` so TypeScript config definitions match the existing schema and runtime support. (#43427) Thanks @davidguttman.

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -41,12 +41,15 @@ type TestAccount = {
 };
 
 function createTestPlugin(params?: {
+  id?: ChannelId;
+  order?: number;
   account?: TestAccount;
   startAccount?: NonNullable<ChannelPlugin<TestAccount>["gateway"]>["startAccount"];
   includeDescribeAccount?: boolean;
   resolveAccount?: ChannelPlugin<TestAccount>["config"]["resolveAccount"];
   isConfigured?: ChannelPlugin<TestAccount>["config"]["isConfigured"];
 }): ChannelPlugin<TestAccount> {
+  const id = params?.id ?? "discord";
   const account = params?.account ?? { enabled: true, configured: true };
   const includeDescribeAccount = params?.includeDescribeAccount !== false;
   const config: ChannelPlugin<TestAccount>["config"] = {
@@ -67,13 +70,14 @@ function createTestPlugin(params?: {
     gateway.startAccount = params.startAccount;
   }
   return {
-    id: "discord",
+    id,
     meta: {
-      id: "discord",
-      label: "Discord",
-      selectionLabel: "Discord",
-      docsPath: "/channels/discord",
+      id,
+      label: id,
+      selectionLabel: id,
+      docsPath: `/channels/${id}`,
       blurb: "test stub",
+      ...(params?.order === undefined ? {} : { order: params.order }),
     },
     capabilities: { chatTypes: ["direct"] },
     config,
@@ -89,13 +93,15 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve: resolvePromise };
 }
 
-function installTestRegistry(plugin: ChannelPlugin<TestAccount>) {
+function installTestRegistry(...plugins: ChannelPlugin<TestAccount>[]) {
   const registry = createEmptyPluginRegistry();
-  registry.channels.push({
-    pluginId: plugin.id,
-    source: "test",
-    plugin,
-  });
+  for (const plugin of plugins) {
+    registry.channels.push({
+      pluginId: plugin.id,
+      source: "test",
+      plugin,
+    });
+  }
   setActivePluginRegistry(registry);
 }
 
@@ -103,11 +109,17 @@ function createManager(options?: {
   channelRuntime?: PluginRuntime["channel"];
   resolveChannelRuntime?: () => PluginRuntime["channel"];
   loadConfig?: () => Record<string, unknown>;
+  channelIds?: ChannelId[];
 }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
   const channelLogs = { discord: log } as Record<ChannelId, SubsystemLogger>;
   const runtime = runtimeForLogger(log);
   const channelRuntimeEnvs = { discord: runtime } as unknown as Record<ChannelId, RuntimeEnv>;
+  const channelIds = options?.channelIds ?? ["discord"];
+  for (const channelId of channelIds) {
+    channelLogs[channelId] ??= log.child(channelId);
+    channelRuntimeEnvs[channelId] ??= runtime;
+  }
   return createChannelManager({
     loadConfig: () => options?.loadConfig?.() ?? {},
     channelLogs,
@@ -266,6 +278,23 @@ describe("server-channels auto restart", () => {
 
     expect(resolveChannelRuntime).toHaveBeenCalledTimes(1);
     expect(startAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues starting later channels after one startup failure", async () => {
+    const failingStart = vi.fn(async () => {
+      throw new Error("missing runtime");
+    });
+    const succeedingStart = vi.fn(async () => {});
+    installTestRegistry(
+      createTestPlugin({ id: "discord", order: 1, startAccount: failingStart }),
+      createTestPlugin({ id: "slack", order: 2, startAccount: succeedingStart }),
+    );
+    const manager = createManager({ channelIds: ["discord", "slack"] });
+
+    await expect(manager.startChannels()).resolves.toBeUndefined();
+
+    expect(failingStart).toHaveBeenCalledTimes(1);
+    expect(succeedingStart).toHaveBeenCalledTimes(1);
   });
 
   it("reuses plugin account resolution for health monitor overrides", () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -495,45 +495,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const startChannels = async () => {
-    const plugins = listChannelPlugins();
-    const failedPlugins: Array<{ id: string; error: string }> = [];
-
-    await Promise.allSettled(
-      plugins.map(async (plugin) => {
-        try {
-          await startChannel(plugin.id);
-        } catch (err) {
-          try {
-            const message = formatErrorMessage(err);
-            channelLogs[plugin.id]?.error?.(
-              `[${plugin.id}] channel startup failed: ${message}`,
-            );
-            failedPlugins.push({ id: plugin.id, error: message });
-          } catch (innerErr) {
-            // Secondary failure during error formatting or logging; ignore
-            failedPlugins.push({
-              id: plugin.id,
-              error: `Internal logging error: ${String(innerErr)}`,
-            });
-          }
-        }
-      }),
-    );
-
-    // Log summary of channel startup results
-    if (failedPlugins.length > 0) {
-      const total = plugins.length;
-      const succeeded = total - failedPlugins.length;
-      
-      // No general logger is available here; use the first succeeded channel's logger,
-      // falling back to the first plugin's logger if all failed.
-      const firstSucceededId = plugins.find((p) => !failedPlugins.some((f) => f.id === p.id))?.id;
-      const targetChannelId = (firstSucceededId ?? plugins[0]?.id) as ChannelId;
-      const log = channelLogs[targetChannelId];
-      
-      log?.warn?.(
-        `Channel startup summary: ${succeeded}/${total} channels started successfully (${failedPlugins.length} failed: ${failedPlugins.map((p) => p.id).join(", ")})`,
-      );
+    for (const plugin of listChannelPlugins()) {
+      try {
+        await startChannel(plugin.id);
+      } catch (err) {
+        channelLogs[plugin.id]?.error?.(
+          `[${plugin.id}] channel startup failed: ${formatErrorMessage(err)}`,
+        );
+      }
     }
   };
 

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -495,8 +495,45 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   };
 
   const startChannels = async () => {
-    for (const plugin of listChannelPlugins()) {
-      await startChannel(plugin.id);
+    const plugins = listChannelPlugins();
+    const failedPlugins: Array<{ id: string; error: string }> = [];
+
+    await Promise.allSettled(
+      plugins.map(async (plugin) => {
+        try {
+          await startChannel(plugin.id);
+        } catch (err) {
+          try {
+            const message = formatErrorMessage(err);
+            channelLogs[plugin.id]?.error?.(
+              `[${plugin.id}] channel startup failed: ${message}`,
+            );
+            failedPlugins.push({ id: plugin.id, error: message });
+          } catch (innerErr) {
+            // Secondary failure during error formatting or logging; ignore
+            failedPlugins.push({
+              id: plugin.id,
+              error: `Internal logging error: ${String(innerErr)}`,
+            });
+          }
+        }
+      }),
+    );
+
+    // Log summary of channel startup results
+    if (failedPlugins.length > 0) {
+      const total = plugins.length;
+      const succeeded = total - failedPlugins.length;
+      
+      // No general logger is available here; use the first succeeded channel's logger,
+      // falling back to the first plugin's logger if all failed.
+      const firstSucceededId = plugins.find((p) => !failedPlugins.some((f) => f.id === p.id))?.id;
+      const targetChannelId = (firstSucceededId ?? plugins[0]?.id) as ChannelId;
+      const log = channelLogs[targetChannelId];
+      
+      log?.warn?.(
+        `Channel startup summary: ${succeeded}/${total} channels started successfully (${failedPlugins.length} failed: ${failedPlugins.map((p) => p.id).join(", ")})`,
+      );
     }
   };
 


### PR DESCRIPTION
## Problem

When one channel (e.g., WhatsApp) fails to start due to missing runtime modules (like `light-runtime-api`), it blocks all subsequent channels (e.g., Discord) from starting. This creates a cascading failure where a single channel issue appears as a total system outage.

### Symptoms
- `channel startup failed: WhatsApp plugin runtime is unavailable: missing light-runtime-api`
- Discord shows as "stopped/disconnected" even though it was never given a chance to start
- Users misdiagnose this as a Discord configuration problem

## Solution

Use `Promise.allSettled` to start channels concurrently with per-channel error isolation:

**Before:**
```typescript
for (const plugin of listChannelPlugins()) {
  await startChannel(plugin.id); // If one throws, loop exits
}
```

**After:**
```typescript
await Promise.allSettled(
  listChannelPlugins().map(async (plugin) => {
    try {
      await startChannel(plugin.id);
    } catch (err) {
      // Log error but continue with other channels
    }
  })
);
```

## Changes

- Start channels concurrently instead of sequentially
- Catch individual channel startup errors without affecting others
- Add startup summary logging for observability

## Testing

- [ ] Configure WhatsApp with missing runtime
- [ ] Verify Discord still starts successfully
- [ ] Check logs show both failure and success

## Related Issues

- P0: WhatsApp runtime exception blocks Discord startup
- P1: Channel status inconsistency (partial fix)

## Backwards Compatibility

- Interface unchanged (`startChannels()` still returns `Promise<void>`)
- Existing error handling in callers continues to work
- Only behavioral change: more channels start successfully when some fail
