### PR TITLE
fix(whatsapp): restore direct active-listener singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/supervision: stop lock conflicts from crash-looping under launchd and systemd by keeping the duplicate process in a retry wait instead of exiting as a failure while another healthy gateway still owns the lock. Fixes #52922. Thanks @vincentkoc.
 - Gateway/auth: require auth for canvas routes and admin scope for agent session reset, so anonymous canvas access and non-admin reset requests fail closed.
 - Release/install: keep previously released bundled plugins and Control UI assets in published openclaw npm installs, and fail release checks when those shipped artifacts are missing. Thanks @vincentkoc.
+- WhatsApp/outbound sends: keep the active Web listener on a direct process-global symbol so split runtime chunks keep sharing the connected Baileys session and `openclaw message send --channel whatsapp` stops failing after connect. Fixes #52574. Thanks @MonkeyLeeT.
 
 ## 2026.3.22
 

--- a/extensions/whatsapp/src/active-listener.test.ts
+++ b/extensions/whatsapp/src/active-listener.test.ts
@@ -1,8 +1,10 @@
+import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 type ActiveListenerModule = typeof import("./active-listener.js");
 
 const activeListenerModuleUrl = new URL("./active-listener.ts", import.meta.url).href;
+const activeListenerSourcePath = new URL("./active-listener.ts", import.meta.url);
 
 async function importActiveListenerModule(cacheBust: string): Promise<ActiveListenerModule> {
   return (await import(`${activeListenerModuleUrl}?t=${cacheBust}`)) as ActiveListenerModule;
@@ -15,6 +17,14 @@ afterEach(async () => {
 });
 
 describe("active WhatsApp listener singleton", () => {
+  it("keeps the WhatsApp listener on direct globalThis state", () => {
+    const source = fs.readFileSync(activeListenerSourcePath, "utf8");
+
+    expect(source).toContain('Symbol.for("openclaw.whatsapp.activeListenerState")');
+    expect(source).toContain("globalThis");
+    expect(source).not.toContain("resolveGlobalSingleton");
+  });
+
   it("shares listeners across duplicate module instances", async () => {
     const first = await importActiveListenerModule(`first-${Date.now()}`);
     const second = await importActiveListenerModule(`second-${Date.now()}`);

--- a/extensions/whatsapp/src/active-listener.ts
+++ b/extensions/whatsapp/src/active-listener.ts
@@ -1,7 +1,6 @@
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import type { PollInput } from "openclaw/plugin-sdk/media-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
-import { resolveGlobalSingleton } from "openclaw/plugin-sdk/text-runtime";
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
@@ -29,8 +28,10 @@ export type ActiveWebListener = {
   close?: () => Promise<void>;
 };
 
-// Use process-global symbol keys to survive bundler code-splitting and loader
-// cache splits without depending on fragile string property names.
+// WhatsApp shares a live Baileys socket between inbound and outbound runtime
+// chunks. Keep this on a direct globalThis symbol lookup; the generic
+// singleton helper was previously inlined during code-splitting and split the
+// listener state back into per-chunk Maps.
 const WHATSAPP_ACTIVE_LISTENER_STATE_KEY = Symbol.for("openclaw.whatsapp.activeListenerState");
 
 type ActiveListenerState = {
@@ -38,13 +39,14 @@ type ActiveListenerState = {
   current: ActiveWebListener | null;
 };
 
-const state = resolveGlobalSingleton<ActiveListenerState>(
-  WHATSAPP_ACTIVE_LISTENER_STATE_KEY,
-  () => ({
+const g = globalThis as unknown as Record<symbol, ActiveListenerState | undefined>;
+if (!g[WHATSAPP_ACTIVE_LISTENER_STATE_KEY]) {
+  g[WHATSAPP_ACTIVE_LISTENER_STATE_KEY] = {
     listeners: new Map<string, ActiveWebListener>(),
     current: null,
-  }),
-);
+  };
+}
+const state = g[WHATSAPP_ACTIVE_LISTENER_STATE_KEY]!;
 
 function getCurrentListener(): ActiveWebListener | null {
   return state.current;


### PR DESCRIPTION
## Summary

- Problem: WhatsApp outbound sends regressed again after `extensions/whatsapp/src/active-listener.ts` was refactored back to `resolveGlobalSingleton(...)` in `23a6e0ccd3`.
- Why it matters: the inbound monitor and outbound send path can end up reading different listener state, so `openclaw message send --channel whatsapp` fails with `No active WhatsApp Web listener` even while WhatsApp stays linked.
- What changed: restore the direct `globalThis[Symbol.for(...)]` singleton for WhatsApp listener state and add a guardrail test that blocks this file from being rewritten back to `resolveGlobalSingleton`.
- What did NOT change (scope boundary): no other channel singleton logic or generic plugin-sdk helpers changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #52574
- Related #52611
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: WhatsApp is special here because it shares a live Baileys socket across inbound and outbound runtime paths; restoring the generic singleton helper reintroduced a bundle/runtime split risk for that state.
- Missing detection / guardrail: the existing duplicate-module test did not assert the WhatsApp file stayed on the direct global singleton pattern.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `6ae68faf5f` fixed this once, then `23a6e0ccd3` refactored the file back to `resolveGlobalSingleton(...)`.
- Why this regressed now: the refactor tried to unify remaining listener state helpers and removed the WhatsApp-specific carveout.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/active-listener.test.ts`
- Scenario the test should lock in: WhatsApp active listener state must stay on a direct process-global symbol and not regress back to `resolveGlobalSingleton`.
- Why this is the smallest reliable guardrail: the user-visible break came from emitted/runtime behavior, so the safest small guardrail is to pin the WhatsApp-specific implementation choice in source alongside the existing duplicate-module behavior test.
- Existing test that already covers this (if any): the duplicate-module listener-sharing test in the same file.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

WhatsApp outbound sends keep working after the gateway links WhatsApp, instead of failing with `No active WhatsApp Web listener` while inbound traffic still works.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo runtime
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm check`.
2. Run `pnpm build`.
3. Run `pnpm test`.
4. Run `pnpm test -- extensions/whatsapp/src/active-listener.test.ts`.
5. Run `pnpm test -- extensions/whatsapp/src/send.test.ts`.

### Expected

- WhatsApp listener state stays on the direct global singleton.
- Build emits direct `globalThis[Symbol.for(...)]` listener state.
- Tests and full gate stay green.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted WhatsApp listener/send tests, full `pnpm check`, full `pnpm build`, full `pnpm test`, and emitted `dist/active-listener-*.js` shape.
- Edge cases checked: duplicate module instance sharing still works; source guardrail blocks `resolveGlobalSingleton` reintroduction.
- What you did **not** verify: live WhatsApp reconnect against a real linked account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `extensions/whatsapp/src/active-listener.ts`, `extensions/whatsapp/src/active-listener.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: WhatsApp outbound sends failing with `No active WhatsApp Web listener` while inbound traffic still works.

## Risks and Mitigations

- Risk: the new guardrail is structural, not a live runtime E2E.
  - Mitigation: paired it with the existing duplicate-module behavior test, full build, and full suite.
