### PR TITLE
Plugins: enforce terminal hook decision semantics for tool/message guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/ports: parse Docker Compose-style `OPENCLAW_GATEWAY_PORT` host publish values correctly without reviving the legacy `CLAWDBOT_GATEWAY_PORT` override. (#44083) Thanks @bebule.
 - Feishu/MSTeams message tool: keep provider-native `card` payloads optional in merged tool schemas so media-only sends stop failing validation before channel runtime dispatch. (#53715) Thanks @lndyzwdxhs.
 - Feishu/startup: keep `requireMention` enforcement strict when bot identity startup probes fail, raise the startup bot-info timeout to 30s, and add cancellable background identity recovery so mention-gated groups recover without noisy fallback. (#43788) Thanks @lefarcen.
+- Plugins: enforce terminal hook decision semantics for tool/message guards (#54241) Thanks @joshavant.
 
 ## 2026.3.23
 

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -92,6 +92,13 @@ These run inside the agent loop or gateway pipeline:
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.
 
+Hook decision rules for outbound/tool guards:
+
+- `before_tool_call`: `{ block: true }` is terminal and stops lower-priority handlers.
+- `before_tool_call`: `{ block: false }` is a no-op and does not clear a prior block.
+- `message_sending`: `{ cancel: true }` is terminal and stops lower-priority handlers.
+- `message_sending`: `{ cancel: false }` is a no-op and does not clear a prior cancel.
+
 See [Plugin hooks](/plugins/architecture#provider-runtime-hooks) for the hook API and registration details.
 
 ## Streaming + partial replies

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -144,6 +144,15 @@ A single plugin can register any number of capabilities via the `api` object:
 
 For the full registration API, see [SDK Overview](/plugins/sdk-overview#registration-api).
 
+Hook guard semantics to keep in mind:
+
+- `before_tool_call`: `{ block: true }` is terminal and stops lower-priority handlers.
+- `before_tool_call`: `{ block: false }` is treated as no decision.
+- `message_sending`: `{ cancel: true }` is terminal and stops lower-priority handlers.
+- `message_sending`: `{ cancel: false }` is treated as no decision.
+
+See [SDK Overview hook decision semantics](/plugins/sdk-overview#hook-decision-semantics) for details.
+
 ## Registering agent tools
 
 Tools are typed functions the LLM can call. They can be required (always

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -152,6 +152,13 @@ methods:
 | `api.on(hookName, handler, opts?)`           | Typed lifecycle hook          |
 | `api.onConversationBindingResolved(handler)` | Conversation binding callback |
 
+### Hook decision semantics
+
+- `before_tool_call`: returning `{ block: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
+- `before_tool_call`: returning `{ block: false }` is treated as no decision (same as omitting `block`), not as an override.
+- `message_sending`: returning `{ cancel: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
+- `message_sending`: returning `{ cancel: false }` is treated as no decision (same as omitting `cancel`), not as an override.
+
 ### API object fields
 
 | Field                    | Type                      | Description                                               |

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -258,6 +258,15 @@ Common registration methods:
 | `registerContextEngine`              | Context engine       |
 | `registerService`                    | Background service   |
 
+Hook guard behavior for typed lifecycle hooks:
+
+- `before_tool_call`: `{ block: true }` is terminal; lower-priority handlers are skipped.
+- `before_tool_call`: `{ block: false }` is a no-op and does not clear an earlier block.
+- `message_sending`: `{ cancel: true }` is terminal; lower-priority handlers are skipped.
+- `message_sending`: `{ cancel: false }` is a no-op and does not clear an earlier cancel.
+
+For full typed hook behavior, see [SDK Overview](/plugins/sdk-overview#hook-decision-semantics).
+
 ## Related
 
 - [Building Plugins](/plugins/building-plugins) — create your own plugin

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -4,7 +4,9 @@ import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
-import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { addTestHook, createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import type { PluginHookRegistration } from "../plugins/types.js";
 
 type ToolDefinitionAdapterModule = typeof import("./pi-tool-definition-adapter.js");
 type PiToolsAbortModule = typeof import("./pi-tools.abort.js");
@@ -39,6 +41,12 @@ beforeEach(async () => {
 
 type BeforeToolCallHandlerMock = ReturnType<typeof vi.fn>;
 
+type BeforeToolCallHookInstall = {
+  pluginId: string;
+  priority?: number;
+  handler: BeforeToolCallHandlerMock;
+};
+
 function installBeforeToolCallHook(params?: {
   enabled?: boolean;
   runBeforeToolCallImpl?: (...args: unknown[]) => unknown;
@@ -52,6 +60,21 @@ function installBeforeToolCallHook(params?: {
   }
   initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_tool_call", handler }]));
   return handler;
+}
+
+function installBeforeToolCallHooks(hooks: BeforeToolCallHookInstall[]): void {
+  resetGlobalHookRunner();
+  const registry = createEmptyPluginRegistry();
+  for (const hook of hooks) {
+    addTestHook({
+      registry,
+      pluginId: hook.pluginId,
+      hookName: "before_tool_call",
+      handler: hook.handler as PluginHookRegistration["handler"],
+      priority: hook.priority,
+    });
+  }
+  initializeGlobalHookRunner(registry);
 }
 
 describe("before_tool_call hook integration", () => {
@@ -119,6 +142,28 @@ describe("before_tool_call hook integration", () => {
     await expect(
       tool.execute("call-3", { cmd: "rm -rf /" }, undefined, extensionContext),
     ).rejects.toThrow("blocked");
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("does not execute lower-priority hooks after block=true", async () => {
+    const high = vi.fn().mockResolvedValue({ block: true, blockReason: "blocked-high" });
+    const low = vi.fn().mockResolvedValue({ params: { shouldNotApply: true } });
+    installBeforeToolCallHooks([
+      { pluginId: "high", priority: 100, handler: high },
+      { pluginId: "low", priority: 0, handler: low },
+    ]);
+
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "exec", execute } as any);
+    const extensionContext = {} as Parameters<typeof tool.execute>[3];
+
+    await expect(
+      tool.execute("call-stop", { cmd: "rm -rf /" }, undefined, extensionContext),
+    ).rejects.toThrow("blocked-high");
+
+    expect(high).toHaveBeenCalledTimes(1);
+    expect(low).not.toHaveBeenCalled();
     expect(execute).not.toHaveBeenCalled();
   });
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -7,7 +7,11 @@ import {
   whatsappOutbound,
 } from "../../../test/channel-outbounds.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { createHookRunner } from "../../plugins/hooks.js";
+import { addTestHook } from "../../plugins/hooks.test-helpers.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import type { PluginHookRegistration } from "../../plugins/types.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { createIMessageTestPlugin } from "../../test-utils/imessage-test-plugin.js";
@@ -19,8 +23,11 @@ const mocks = vi.hoisted(() => ({
 }));
 const hookMocks = vi.hoisted(() => ({
   runner: {
-    hasHooks: vi.fn(() => false),
-    runMessageSent: vi.fn(async () => {}),
+    hasHooks: vi.fn<(_hookName?: string) => boolean>(() => false),
+    runMessageSending: vi.fn<(event: unknown, ctx: unknown) => Promise<unknown>>(
+      async () => undefined,
+    ),
+    runMessageSent: vi.fn<(event: unknown, ctx: unknown) => Promise<void>>(async () => {}),
   },
 }));
 const internalHookMocks = vi.hoisted(() => ({
@@ -210,6 +217,8 @@ describe("deliverOutboundPayloads", () => {
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
     hookMocks.runner.hasHooks.mockClear();
     hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSending.mockClear();
+    hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
     hookMocks.runner.runMessageSent.mockClear();
     hookMocks.runner.runMessageSent.mockResolvedValue(undefined);
     internalHookMocks.createInternalHookEvent.mockClear();
@@ -1029,6 +1038,48 @@ describe("deliverOutboundPayloads", () => {
       expect.objectContaining({ to: "+1555", content: "hello", success: true }),
       expect.objectContaining({ channelId: "whatsapp" }),
     );
+  });
+
+  it("short-circuits lower-priority message_sending hooks after cancel=true", async () => {
+    const hookRegistry = createEmptyPluginRegistry();
+    const high = vi.fn().mockResolvedValue({ cancel: true, content: "blocked" });
+    const low = vi.fn().mockResolvedValue({ cancel: false, content: "override" });
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "high",
+      hookName: "message_sending",
+      handler: high as PluginHookRegistration["handler"],
+      priority: 100,
+    });
+    addTestHook({
+      registry: hookRegistry,
+      pluginId: "low",
+      hookName: "message_sending",
+      handler: low as PluginHookRegistration["handler"],
+      priority: 0,
+    });
+    const realRunner = createHookRunner(hookRegistry);
+    hookMocks.runner.hasHooks.mockImplementation((hookName?: string) =>
+      realRunner.hasHooks((hookName ?? "") as never),
+    );
+    hookMocks.runner.runMessageSending.mockImplementation((event, ctx) =>
+      realRunner.runMessageSending(event as never, ctx as never),
+    );
+
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { sendWhatsApp },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledTimes(1);
+    expect(high).toHaveBeenCalledTimes(1);
+    expect(low).not.toHaveBeenCalled();
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
   });
 
   it("emits message_sent success for sendPayload deliveries", async () => {

--- a/src/infra/outbound/format.test.ts
+++ b/src/infra/outbound/format.test.ts
@@ -1,9 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildOutboundDeliveryJson,
   formatGatewaySummary,
   formatOutboundDeliverySummary,
 } from "./format.js";
+
+const getChannelPluginMock = vi.hoisted(() => vi.fn((_channel: unknown) => undefined));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: getChannelPluginMock,
+}));
 
 describe("formatOutboundDeliverySummary", () => {
   it("formats fallback and provider-specific detail variants", () => {

--- a/src/plugins/hooks.security.test.ts
+++ b/src/plugins/hooks.security.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { addTestHook } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type {
+  PluginHookBeforeToolCallResult,
+  PluginHookMessageSendingResult,
+  PluginHookRegistration,
+} from "./types.js";
+
+function addBeforeToolCallHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: () => PluginHookBeforeToolCallResult | Promise<PluginHookBeforeToolCallResult>,
+  priority?: number,
+) {
+  addTestHook({
+    registry,
+    pluginId,
+    hookName: "before_tool_call",
+    handler: handler as PluginHookRegistration["handler"],
+    priority,
+  });
+}
+
+function addMessageSendingHook(
+  registry: PluginRegistry,
+  pluginId: string,
+  handler: () => PluginHookMessageSendingResult | Promise<PluginHookMessageSendingResult>,
+  priority?: number,
+) {
+  addTestHook({
+    registry,
+    pluginId,
+    hookName: "message_sending",
+    handler: handler as PluginHookRegistration["handler"],
+    priority,
+  });
+}
+
+const toolEvent = { toolName: "bash", params: { command: "echo hello" } };
+const toolCtx = { toolName: "bash" };
+const messageEvent = { to: "user-1", content: "hello" };
+const messageCtx = { channelId: "telegram" };
+
+describe("before_tool_call terminal block semantics", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("keeps block=true when a lower-priority hook returns block=false", async () => {
+    addBeforeToolCallHook(registry, "high", () => ({ block: true, blockReason: "dangerous" }), 100);
+    addBeforeToolCallHook(registry, "low", () => ({ block: false }), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("dangerous");
+  });
+
+  it("treats explicit block=false as no-op when no prior hook blocked", async () => {
+    addBeforeToolCallHook(registry, "single", () => ({ block: false }), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBeUndefined();
+  });
+
+  it("treats passive handler output as no-op for prior block", async () => {
+    addBeforeToolCallHook(registry, "high", () => ({ block: true, blockReason: "blocked" }), 100);
+    addBeforeToolCallHook(registry, "passive", () => ({}), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("blocked");
+  });
+
+  it("short-circuits lower-priority hooks after block=true", async () => {
+    const high = vi.fn().mockReturnValue({ block: true, blockReason: "stop" });
+    const low = vi.fn().mockReturnValue({ params: { injected: true } });
+    addBeforeToolCallHook(registry, "high", high, 100);
+    addBeforeToolCallHook(registry, "low", low, 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(high).toHaveBeenCalledTimes(1);
+    expect(low).not.toHaveBeenCalled();
+  });
+
+  it("preserves deterministic same-priority registration order when terminal hook runs first", async () => {
+    const first = vi.fn().mockReturnValue({ block: true, blockReason: "first" });
+    const second = vi.fn().mockReturnValue({ block: true, blockReason: "second" });
+    addBeforeToolCallHook(registry, "first", first, 50);
+    addBeforeToolCallHook(registry, "second", second, 50);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("first");
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("stops before lower-priority throwing hooks when catchErrors is false", async () => {
+    addBeforeToolCallHook(registry, "high", () => ({ block: true, blockReason: "guard" }), 100);
+    const low = vi.fn().mockImplementation(() => {
+      throw new Error("should not run");
+    });
+    addBeforeToolCallHook(registry, "low", low, 10);
+
+    const runner = createHookRunner(registry, { catchErrors: false });
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(low).not.toHaveBeenCalled();
+  });
+
+  it("respects block from a middle hook in a multi-handler chain", async () => {
+    const low = vi.fn().mockReturnValue({ block: false });
+    addBeforeToolCallHook(registry, "high-passive", () => ({}), 100);
+    addBeforeToolCallHook(
+      registry,
+      "middle-block",
+      () => ({ block: true, blockReason: "mid" }),
+      50,
+    );
+    addBeforeToolCallHook(registry, "low-false", low, 0);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforeToolCall(toolEvent, toolCtx);
+
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("mid");
+    expect(low).not.toHaveBeenCalled();
+  });
+});
+
+describe("message_sending terminal cancel semantics", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  it("keeps cancel=true when a lower-priority hook returns cancel=false", async () => {
+    addMessageSendingHook(registry, "high", () => ({ cancel: true, content: "guarded" }), 100);
+    addMessageSendingHook(registry, "low", () => ({ cancel: false, content: "override" }), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.cancel).toBe(true);
+    expect(result?.content).toBe("guarded");
+  });
+
+  it("treats explicit cancel=false as no-op when no prior hook canceled", async () => {
+    addMessageSendingHook(registry, "single", () => ({ cancel: false }), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.cancel).toBeUndefined();
+  });
+
+  it("treats passive handler output as no-op for prior cancel", async () => {
+    addMessageSendingHook(registry, "high", () => ({ cancel: true }), 100);
+    addMessageSendingHook(registry, "passive", () => ({}), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.cancel).toBe(true);
+  });
+
+  it("short-circuits lower-priority hooks after cancel=true", async () => {
+    const high = vi.fn().mockReturnValue({ cancel: true, content: "guarded" });
+    const low = vi.fn().mockReturnValue({ cancel: false, content: "mutated" });
+    addMessageSendingHook(registry, "high", high, 100);
+    addMessageSendingHook(registry, "low", low, 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.cancel).toBe(true);
+    expect(result?.content).toBe("guarded");
+    expect(high).toHaveBeenCalledTimes(1);
+    expect(low).not.toHaveBeenCalled();
+  });
+
+  it("preserves deterministic same-priority registration order for non-terminal merges", async () => {
+    addMessageSendingHook(registry, "first", () => ({ content: "first" }), 50);
+    addMessageSendingHook(registry, "second", () => ({ content: "second" }), 50);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.content).toBe("second");
+  });
+
+  it("stops before lower-priority throwing hooks when catchErrors is false", async () => {
+    addMessageSendingHook(registry, "high", () => ({ cancel: true }), 100);
+    const low = vi.fn().mockImplementation(() => {
+      throw new Error("should not run");
+    });
+    addMessageSendingHook(registry, "low", low, 10);
+
+    const runner = createHookRunner(registry, { catchErrors: false });
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.cancel).toBe(true);
+    expect(low).not.toHaveBeenCalled();
+  });
+
+  it("allows lower-priority cancel when higher-priority hooks are non-terminal", async () => {
+    addMessageSendingHook(registry, "high-passive", () => ({ content: "rewritten" }), 100);
+    addMessageSendingHook(registry, "low-cancel", () => ({ cancel: true }), 10);
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runMessageSending(messageEvent, messageCtx);
+
+    expect(result?.cancel).toBe(true);
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -114,6 +114,13 @@ export type HookRunnerOptions = {
   catchErrors?: boolean;
 };
 
+type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
+  mergeResults?: (accumulated: TResult | undefined, next: TResult) => TResult;
+  shouldStop?: (result: TResult) => boolean;
+  terminalLabel?: string;
+  onTerminal?: (params: { hookName: K; pluginId: string; result: TResult }) => void;
+};
+
 export type PluginTargetedInboundClaimOutcome =
   | {
       status: "handled";
@@ -160,20 +167,25 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   const logger = options.logger;
   const catchErrors = options.catchErrors ?? true;
 
+  const firstDefined = <T>(prev: T | undefined, next: T | undefined): T | undefined => prev ?? next;
+  const lastDefined = <T>(prev: T | undefined, next: T | undefined): T | undefined => next ?? prev;
+  const stickyTrue = (prev?: boolean, next?: boolean): true | undefined =>
+    prev === true || next === true ? true : undefined;
+
   const mergeBeforeModelResolve = (
     acc: PluginHookBeforeModelResolveResult | undefined,
     next: PluginHookBeforeModelResolveResult,
   ): PluginHookBeforeModelResolveResult => ({
     // Keep the first defined override so higher-priority hooks win.
-    modelOverride: acc?.modelOverride ?? next.modelOverride,
-    providerOverride: acc?.providerOverride ?? next.providerOverride,
+    modelOverride: firstDefined(acc?.modelOverride, next.modelOverride),
+    providerOverride: firstDefined(acc?.providerOverride, next.providerOverride),
   });
 
   const mergeBeforePromptBuild = (
     acc: PluginHookBeforePromptBuildResult | undefined,
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
-    systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
+    systemPrompt: lastDefined(acc?.systemPrompt, next.systemPrompt),
     prependContext: concatOptionalTextSegments({
       left: acc?.prependContext,
       right: next.prependContext,
@@ -270,7 +282,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     hookName: K,
     event: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[0],
     ctx: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
-    mergeResults?: (accumulated: TResult | undefined, next: TResult) => TResult,
+    policy: ModifyingHookPolicy<K, TResult> = {},
   ): Promise<TResult | undefined> {
     const hooks = getHooksForName(registry, hookName);
     if (hooks.length === 0) {
@@ -288,10 +300,19 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
         )(event, ctx);
 
         if (handlerResult !== undefined && handlerResult !== null) {
-          if (mergeResults && result !== undefined) {
-            result = mergeResults(result, handlerResult);
+          if (policy.mergeResults) {
+            result = policy.mergeResults(result, handlerResult);
           } else {
             result = handlerResult;
+          }
+          if (result && policy.shouldStop?.(result)) {
+            const terminalLabel = policy.terminalLabel ? ` ${policy.terminalLabel}` : "";
+            const priority = hook.priority ?? 0;
+            logger?.debug?.(
+              `[hooks] ${hookName}${terminalLabel} decided by ${hook.pluginId} (priority=${priority}); skipping remaining handlers`,
+            );
+            policy.onTerminal?.({ hookName, pluginId: hook.pluginId, result });
+            break;
           }
         }
       } catch (err) {
@@ -434,7 +455,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "before_model_resolve",
       event,
       ctx,
-      mergeBeforeModelResolve,
+      { mergeResults: mergeBeforeModelResolve },
     );
   }
 
@@ -450,7 +471,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "before_prompt_build",
       event,
       ctx,
-      mergeBeforePromptBuild,
+      { mergeResults: mergeBeforePromptBuild },
     );
   }
 
@@ -466,10 +487,12 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "before_agent_start",
       event,
       ctx,
-      (acc, next) => ({
-        ...mergeBeforePromptBuild(acc, next),
-        ...mergeBeforeModelResolve(acc, next),
-      }),
+      {
+        mergeResults: (acc, next) => ({
+          ...mergeBeforePromptBuild(acc, next),
+          ...mergeBeforeModelResolve(acc, next),
+        }),
+      },
     );
   }
 
@@ -604,10 +627,19 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "message_sending",
       event,
       ctx,
-      (acc, next) => ({
-        content: next.content ?? acc?.content,
-        cancel: next.cancel ?? acc?.cancel,
-      }),
+      {
+        mergeResults: (acc, next) => {
+          if (acc?.cancel === true) {
+            return acc;
+          }
+          return {
+            content: lastDefined(acc?.content, next.content),
+            cancel: stickyTrue(acc?.cancel, next.cancel),
+          };
+        },
+        shouldStop: (result) => result.cancel === true,
+        terminalLabel: "cancel=true",
+      },
     );
   }
 
@@ -639,11 +671,20 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "before_tool_call",
       event,
       ctx,
-      (acc, next) => ({
-        params: next.params ?? acc?.params,
-        block: next.block ?? acc?.block,
-        blockReason: next.blockReason ?? acc?.blockReason,
-      }),
+      {
+        mergeResults: (acc, next) => {
+          if (acc?.block === true) {
+            return acc;
+          }
+          return {
+            params: lastDefined(acc?.params, next.params),
+            block: stickyTrue(acc?.block, next.block),
+            blockReason: lastDefined(acc?.blockReason, next.blockReason),
+          };
+        },
+        shouldStop: (result) => result.block === true,
+        terminalLabel: "block=true",
+      },
     );
   }
 
@@ -832,7 +873,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "subagent_spawning",
       event,
       ctx,
-      mergeSubagentSpawningResult,
+      { mergeResults: mergeSubagentSpawningResult },
     );
   }
 
@@ -848,7 +889,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       "subagent_delivery_target",
       event,
       ctx,
-      mergeSubagentDeliveryTargetResult,
+      { mergeResults: mergeSubagentDeliveryTargetResult },
     );
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `before_tool_call` and `message_sending` merged hook outputs with nullish-coalescing semantics, so a lower-priority handler returning explicit `false` could clear a higher-priority deny/cancel decision.
- Why it matters: security and policy hooks could be silently neutralized, and downstream hooks still executed even after a deny/cancel decision was reached.
- What changed: reimplemented hook reduction with explicit policy semantics in `hooks.ts` so `block: true` and `cancel: true` are terminal, explicit `false` is treated as no-op, and lower-priority handlers are skipped once terminal state is reached.
- What changed: added dedicated regression tests and integration-path assertions, and updated plugin docs to document the decision contract.
- What did NOT change (scope boundary): no changelog edits, no config-key changes, no auth/token/network behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #53848
- Related (original PR): https://github.com/openclaw/openclaw/pull/53848
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: merge lambdas in `src/plugins/hooks.ts` used `next.block ?? acc?.block` / `next.cancel ?? acc?.cancel`, so an explicit `false` from a lower-priority hook overrode an earlier `true`.
- Missing detection / guardrail: no targeted regression suite covering explicit-false override and terminal short-circuit behavior for these hooks.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this PR is a from-scratch reimplementation of #53848 with expanded guardrails and tests.
- Why this regressed now: hook semantics were based on generic nullish merge behavior instead of deny/cancel terminal policy semantics.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/plugins/hooks.security.test.ts`
  - `src/agents/pi-tools.before-tool-call.integration.e2e.test.ts`
  - `src/infra/outbound/deliver.test.ts`
- Scenario the test should lock in: once a higher-priority hook sets `block: true` or `cancel: true`, lower-priority hooks cannot clear it with explicit `false` and are not executed.
- Why this is the smallest reliable guardrail: unit tests validate merge/terminal policy directly, while integration tests validate behavior in real tool-call and outbound-delivery call paths.
- Existing test that already covers this (if any): existing hook wiring tests still cover non-terminal paths; this PR adds missing terminal semantics coverage.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Plugin behavior change: explicit `{ block: false }` can no longer clear an earlier `{ block: true }` in `before_tool_call`.
- Plugin behavior change: explicit `{ cancel: false }` can no longer clear an earlier `{ cancel: true }` in `message_sending`.
- Runtime behavior change: after terminal deny/cancel is reached, lower-priority handlers for those hooks are skipped.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - Risk addressed: lower-priority plugins could previously neutralize prior deny/cancel decisions.
  - Mitigation: terminal decision semantics now prevent clear/override and short-circuit further handlers.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): outbound channel delivery + tool execution paths
- Relevant config (redacted): default local test config

### Steps

1. Register two hooks for `before_tool_call` or `message_sending` with priorities 100 and 0.
2. Return `{ block: true }` / `{ cancel: true }` from high-priority hook and `{ block: false }` / `{ cancel: false }` from low-priority hook.
3. Execute hook path through runner/integration call path.

### Expected

- Final decision remains denied/cancelled, and low-priority hook does not execute after terminal decision.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification commands:

- `pnpm test -- src/plugins/hooks.security.test.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/infra/outbound/deliver.test.ts`
- `pnpm test`
- `pnpm build`
- `pnpm check`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - terminal sticky behavior for `before_tool_call` and `message_sending`
  - explicit `false` treated as no-op
  - lower-priority handler short-circuit after terminal decision
  - integration-path behavior in tool-call and outbound-delivery flows
- Edge cases checked:
  - same-priority deterministic behavior
  - multi-handler chains
  - `catchErrors: false` does not bypass terminal short-circuit
- What you did **not** verify:
  - external third-party plugin ecosystems outside local test coverage

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No (intentional behavior correction for plugins that relied on explicit `false` overrides)
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Possibly for affected plugins
- If yes, exact upgrade steps:
  1. Remove explicit `{ block: false }` / `{ cancel: false }` override patterns.
  2. Move allow/exception logic to higher-priority hooks or pre-decision checks.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits in this PR (core runner policy + tests/docs) or restore previous merge lambdas in `src/plugins/hooks.ts`.
- Files/config to restore: `src/plugins/hooks.ts`.
- Known bad symptoms reviewers should watch for: third-party plugins that depended on downstream unblocking may stop unblocking.

## Risks and Mitigations

- Risk: plugin behavior changes for handlers relying on explicit-false overrides or downstream side-effect hooks after terminal decisions.
  - Mitigation: explicit docs updates, scoped integration tests, and straightforward revert boundary in `hooks.ts`.
