### PR TITLE
feat(tts): add discord to opus voice-bubble channels

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -231,7 +231,7 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for opus channels (telegram/feishu/whatsapp/matrix) and mp3 for others", () => {
+    it("selects opus for opus channels (telegram/feishu/whatsapp/matrix/discord) and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
@@ -272,10 +272,10 @@ describe("tts", () => {
         {
           channel: "discord",
           expected: {
-            openai: "mp3",
-            elevenlabs: "mp3_44100_128",
-            extension: ".mp3",
-            voiceCompatible: false,
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
           },
         },
       ] as const;

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -518,7 +518,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio */
-const OPUS_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
+const OPUS_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix", "discord"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && OPUS_CHANNELS.has(channelId)) {


### PR DESCRIPTION
## Summary

Add `discord` to the `OPUS_CHANNELS` set so TTS audio is delivered as native voice messages (with waveform visualization) instead of generic file attachments.

## Problem

When OpenClaw sends TTS audio on Discord, it arrives as a regular `.mp3` file attachment with a basic play button. Discord has supported native voice messages since April 2023, which display with a waveform UI — but the TTS pipeline was sending MP3 to Discord instead of Opus.

## Solution

One-line change: add `"discord"` to the `OPUS_CHANNELS` set in `src/tts/tts.ts`.

This makes the TTS pipeline:
1. Generate Opus audio (instead of MP3) for Discord
2. Set `voiceCompatible: true`, which triggers `audioAsVoice: true`
3. Route through the existing `sendVoiceMessageDiscord` function (which already sets the `IS_VOICE_MESSAGE` flag 8192)

The entire voice message delivery infrastructure for Discord already existed — it just wasn't being triggered because Discord wasn't in the opus channels set.

## Changes

- `src/tts/tts.ts`: Added `"discord"` to `OPUS_CHANNELS`
- `src/tts/tts.test.ts`: Updated test expectations for Discord from MP3 to Opus

## Testing

- All 27 existing TTS tests pass
- Updated the Discord test case to expect Opus output format

Closes #44633