### PR TITLE
fix(release): add plugin-sdk:check-exports to release:check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
 - Feishu: close WebSocket connections on monitor stop/abort so ghost connections no longer persist, preventing duplicate event processing and resource leaks across restart cycles. (#52844) Thanks @schumilin.
 - Feishu: use the original message `create_time` instead of `Date.now()` for inbound timestamps so offline-retried messages carry the correct authoring time, preventing mis-targeted agent actions on stale instructions. (#52809) Thanks @schumilin.
+- Plugins/SDK: thread `moduleUrl` through plugin-sdk alias resolution so user-installed plugins outside the openclaw directory (e.g. `~/.openclaw/extensions/`) correctly resolve `openclaw/plugin-sdk/*` subpath imports, and gate `plugin-sdk:check-exports` in `release:check`. (#54283) Thanks @xieyongliang.
 
 ## 2026.3.24-beta.2
 

--- a/package.json
+++ b/package.json
@@ -686,7 +686,7 @@
     "protocol:check": "pnpm protocol:gen && pnpm protocol:gen:swift && git diff --exit-code -- dist/protocol.schema.json apps/macos/Sources/OpenClawProtocol/GatewayModels.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
     "protocol:gen": "node --import tsx scripts/protocol-gen.ts",
     "protocol:gen:swift": "node --import tsx scripts/protocol-gen-swift.ts",
-    "release:check": "pnpm config:docs:check && pnpm plugin-sdk:api:check && node scripts/stage-bundled-plugin-runtime-deps.mjs && pnpm ui:build && node --import tsx scripts/release-check.ts",
+    "release:check": "pnpm config:docs:check && pnpm plugin-sdk:check-exports && pnpm plugin-sdk:api:check && node scripts/stage-bundled-plugin-runtime-deps.mjs && pnpm ui:build && node --import tsx scripts/release-check.ts",
     "release:openclaw:npm:check": "node --import tsx scripts/openclaw-npm-release-check.ts",
     "release:openclaw:npm:verify-published": "node --import tsx scripts/openclaw-npm-postpublish-verify.ts",
     "release:plugins:npm:check": "node --import tsx scripts/plugin-npm-release-check.ts",

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -725,7 +725,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
   const getJiti = (modulePath: string) => {
     const tryNative = shouldPreferNativeJiti(modulePath);
-    const aliasMap = buildPluginLoaderAliasMap(modulePath);
+    // Pass loader's moduleUrl so the openclaw root can always be resolved even when
+    // loading external plugins from outside the installation directory (e.g. ~/.openclaw/extensions/).
+    const aliasMap = buildPluginLoaderAliasMap(modulePath, process.argv[1], import.meta.url);
     const cacheKey = JSON.stringify({
       tryNative,
       aliasMap: Object.entries(aliasMap).toSorted(([left], [right]) => left.localeCompare(right)),

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -521,7 +521,9 @@ describe("plugin sdk alias helpers", () => {
     // real openclaw repo root in the test runner environment.
     const loaderModuleUrl = pathToFileURL(path.join(fixture.root, "openclaw.mjs")).href;
 
-    const aliases = withCwd(fixture.root, () =>
+    // Use externalPluginRoot as cwd so process.cwd() fallback cannot accidentally
+    // resolve to the fixture root — only the moduleUrl hint can bridge the gap.
+    const aliases = withCwd(externalPluginRoot, () =>
       withEnv({ NODE_ENV: undefined }, () =>
         buildPluginLoaderAliasMap(
           externalPluginEntry,

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -516,9 +516,8 @@ describe("plugin sdk alias helpers", () => {
     // Simulate loader.ts passing its own import.meta.url as the moduleUrl hint.
     // This covers installations where argv1 does not resolve to the openclaw root
     // (e.g. single-binary distributions or custom process launchers).
-    const loaderModuleUrl = pathToFileURL(
-      path.join(fixture.root, "dist", "plugins", "loader.js"),
-    ).href;
+    // Use openclaw.mjs which is created by createPluginSdkAliasFixture (bin+marker mode).
+    const loaderModuleUrl = pathToFileURL(path.join(fixture.root, "openclaw.mjs")).href;
 
     const aliases = withCwd(externalPluginRoot, () =>
       withEnv({ NODE_ENV: undefined }, () =>

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -498,6 +498,46 @@ describe("plugin sdk alias helpers", () => {
     );
   });
 
+  it("resolves plugin-sdk aliases for user-installed plugins via moduleUrl hint", () => {
+    const fixture = createPluginSdkAliasFixture({
+      srcFile: "channel-runtime.ts",
+      distFile: "channel-runtime.js",
+      packageExports: {
+        "./plugin-sdk/channel-runtime": { default: "./dist/plugin-sdk/channel-runtime.js" },
+      },
+    });
+    const sourceRootAlias = path.join(fixture.root, "src", "plugin-sdk", "root-alias.cjs");
+    fs.writeFileSync(sourceRootAlias, "module.exports = {};\n", "utf-8");
+    const externalPluginRoot = path.join(makeTempDir(), ".openclaw", "extensions", "demo");
+    const externalPluginEntry = path.join(externalPluginRoot, "index.ts");
+    mkdirSafe(externalPluginRoot);
+    fs.writeFileSync(externalPluginEntry, 'export const plugin = "demo";\n', "utf-8");
+
+    // Simulate loader.ts passing its own import.meta.url as the moduleUrl hint.
+    // This covers installations where argv1 does not resolve to the openclaw root
+    // (e.g. single-binary distributions or custom process launchers).
+    const loaderModuleUrl = pathToFileURL(
+      path.join(fixture.root, "dist", "plugins", "loader.js"),
+    ).href;
+
+    const aliases = withCwd(externalPluginRoot, () =>
+      withEnv({ NODE_ENV: undefined }, () =>
+        buildPluginLoaderAliasMap(
+          externalPluginEntry,
+          undefined, // no argv1
+          loaderModuleUrl,
+        ),
+      ),
+    );
+
+    expect(fs.realpathSync(aliases["openclaw/plugin-sdk"] ?? "")).toBe(
+      fs.realpathSync(sourceRootAlias),
+    );
+    expect(fs.realpathSync(aliases["openclaw/plugin-sdk/channel-runtime"] ?? "")).toBe(
+      fs.realpathSync(path.join(fixture.root, "src", "plugin-sdk", "channel-runtime.ts")),
+    );
+  });
+
   it("does not resolve plugin-sdk alias files from cwd fallback when package root is not an OpenClaw root", () => {
     const fixture = createPluginSdkAliasFixture({
       srcFile: "channel-runtime.ts",

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -523,11 +523,15 @@ describe("plugin sdk alias helpers", () => {
 
     // Use externalPluginRoot as cwd so process.cwd() fallback cannot accidentally
     // resolve to the fixture root — only the moduleUrl hint can bridge the gap.
+    // Pass "" for argv1: undefined would trigger the STARTUP_ARGV1 default (the vitest
+    // runner binary, inside the openclaw repo), which resolves before moduleUrl is checked.
+    // An empty string is falsy so resolveTrustedOpenClawRootFromArgvHint returns null,
+    // meaning only the moduleUrl hint can bridge the gap.
     const aliases = withCwd(externalPluginRoot, () =>
       withEnv({ NODE_ENV: undefined }, () =>
         buildPluginLoaderAliasMap(
           externalPluginEntry,
-          undefined, // no argv1
+          "", // explicitly disable argv1 (empty string bypasses STARTUP_ARGV1 default)
           loaderModuleUrl,
         ),
       ),

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -517,9 +517,11 @@ describe("plugin sdk alias helpers", () => {
     // This covers installations where argv1 does not resolve to the openclaw root
     // (e.g. single-binary distributions or custom process launchers).
     // Use openclaw.mjs which is created by createPluginSdkAliasFixture (bin+marker mode).
+    // Use fixture.root as cwd so process.cwd() fallback also resolves to fixture, not the
+    // real openclaw repo root in the test runner environment.
     const loaderModuleUrl = pathToFileURL(path.join(fixture.root, "openclaw.mjs")).href;
 
-    const aliases = withCwd(externalPluginRoot, () =>
+    const aliases = withCwd(fixture.root, () =>
       withEnv({ NODE_ENV: undefined }, () =>
         buildPluginLoaderAliasMap(
           externalPluginEntry,

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -145,11 +145,7 @@ function resolveLoaderPluginSdkPackageRoot(
           cwd,
           moduleUrl: params.moduleUrl,
         })
-      : null) ??
-    // sdk-alias.ts is always compiled into the openclaw package, so import.meta.url
-    // provides a reliable fallback for locating the openclaw root when the plugin
-    // lives outside the installation directory (e.g. ~/.openclaw/extensions/).
-    resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
+      : null);
   return (
     fromCwd ??
     fromExplicitHints ??
@@ -239,10 +235,14 @@ const cachedPluginSdkExportedSubpaths = new Map<string, string[]>();
 const cachedPluginSdkScopedAliasMaps = new Map<string, Record<string, string>>();
 
 export function listPluginSdkExportedSubpaths(
-  params: { modulePath?: string; argv1?: string } = {},
+  params: { modulePath?: string; argv1?: string; moduleUrl?: string } = {},
 ): string[] {
   const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
-  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath, argv1: params.argv1 });
+  const packageRoot = resolveLoaderPluginSdkPackageRoot({
+    modulePath,
+    argv1: params.argv1,
+    moduleUrl: params.moduleUrl,
+  });
   if (!packageRoot) {
     return [];
   }
@@ -256,10 +256,14 @@ export function listPluginSdkExportedSubpaths(
 }
 
 export function resolvePluginSdkScopedAliasMap(
-  params: { modulePath?: string; argv1?: string } = {},
+  params: { modulePath?: string; argv1?: string; moduleUrl?: string } = {},
 ): Record<string, string> {
   const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
-  const packageRoot = resolveLoaderPluginSdkPackageRoot({ modulePath, argv1: params.argv1 });
+  const packageRoot = resolveLoaderPluginSdkPackageRoot({
+    modulePath,
+    argv1: params.argv1,
+    moduleUrl: params.moduleUrl,
+  });
   if (!packageRoot) {
     return {};
   }
@@ -273,7 +277,11 @@ export function resolvePluginSdkScopedAliasMap(
     return cached;
   }
   const aliasMap: Record<string, string> = {};
-  for (const subpath of listPluginSdkExportedSubpaths({ modulePath, argv1: params.argv1 })) {
+  for (const subpath of listPluginSdkExportedSubpaths({
+    modulePath,
+    argv1: params.argv1,
+    moduleUrl: params.moduleUrl,
+  })) {
     const candidateMap = {
       src: path.join(packageRoot, "src", "plugin-sdk", `${subpath}.ts`),
       dist: path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`),
@@ -321,18 +329,20 @@ export function resolveExtensionApiAlias(params: LoaderModuleResolveParams = {})
 export function buildPluginLoaderAliasMap(
   modulePath: string,
   argv1: string | undefined = STARTUP_ARGV1,
+  moduleUrl?: string,
 ): Record<string, string> {
   const pluginSdkAlias = resolvePluginSdkAliasFile({
     srcFile: "root-alias.cjs",
     distFile: "root-alias.cjs",
     modulePath,
     argv1,
+    moduleUrl,
   });
   const extensionApiAlias = resolveExtensionApiAlias({ modulePath });
   return {
     ...(extensionApiAlias ? { "openclaw/extension-api": extensionApiAlias } : {}),
     ...(pluginSdkAlias ? { "openclaw/plugin-sdk": pluginSdkAlias } : {}),
-    ...resolvePluginSdkScopedAliasMap({ modulePath, argv1 }),
+    ...resolvePluginSdkScopedAliasMap({ modulePath, argv1, moduleUrl }),
   };
 }
 

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -145,7 +145,11 @@ function resolveLoaderPluginSdkPackageRoot(
           cwd,
           moduleUrl: params.moduleUrl,
         })
-      : null);
+      : null) ??
+    // sdk-alias.ts is always compiled into the openclaw package, so import.meta.url
+    // provides a reliable fallback for locating the openclaw root when the plugin
+    // lives outside the installation directory (e.g. ~/.openclaw/extensions/).
+    resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
   return (
     fromCwd ??
     fromExplicitHints ??


### PR DESCRIPTION
## Problem

External plugins importing from `openclaw/plugin-sdk/*` subpaths (e.g. `openclaw/plugin-sdk/plugin-entry`, `openclaw/plugin-sdk/provider-auth`, `openclaw/plugin-sdk/provider-onboard`) fail at load time:

```
Error: Cannot find module 'openclaw/plugin-sdk/plugin-entry'
```

Reproduced with `openclaw plugins install --link` on a local `.ts` plugin entry. Affects published `2026.3.23-2`.

## Root Cause

`dist/plugin-sdk/root-alias.cjs` builds a jiti alias map at runtime by reading `package.json` `exports` (`buildPluginSdkAliasMap`). If a subpath is absent from `exports`, jiti cannot resolve it and throws `Cannot find module`.

`scripts/sync-plugin-sdk-exports.mjs` is responsible for syncing `scripts/lib/plugin-sdk-entrypoints.json` (134 entries) into `package.json` exports. A `plugin-sdk:check-exports` script already validates this sync — but it was never wired into `release:check`, so the drift goes undetected until users hit the runtime error at install time.

The published `2026.3.23-2` `package.json` has only 2 `plugin-sdk` exports instead of 134.

## Fix

Add `plugin-sdk:check-exports` to `release:check` so CI fails loudly before publishing if exports are out of sync:

```diff
- "release:check": "pnpm config:docs:check && pnpm plugin-sdk:api:check && ...",
+ "release:check": "pnpm config:docs:check && pnpm plugin-sdk:check-exports && pnpm plugin-sdk:api:check && ...",
```

## Local Verification

```bash
# Simulate the bug (strip plugin-sdk subpath exports from package.json)
# then run:
node scripts/sync-plugin-sdk-exports.mjs --check
# => "plugin-sdk exports out of sync. Run `pnpm plugin-sdk:sync-exports`."
# => exit code 1  ✅ would have blocked the publish

# Restored state:
node scripts/sync-plugin-sdk-exports.mjs --check
# => "plugin-sdk exports synced."
# => exit code 0  ✅
```

## Note

A patch publish of the current release with exports re-synced is also needed to fix users on `2026.3.23-2`, but that is a separate release action. This PR ensures the regression cannot recur.