### PR TITLE
fix(ui): hydrate default agent model editor from object-shaped defaults

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -95,7 +95,7 @@ import {
   resolveAgentConfig,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
-  resolveModelPrimary,
+  resolveModelConfigForFallbackEdit,
   sortLocaleStrings,
 } from "./views/agents-utils.ts";
 import { renderChat } from "./views/chat.ts";
@@ -1264,58 +1264,27 @@ export function renderApp(state: AppViewState) {
                     const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
                     const currentConfig = getCurrentConfigValue();
                     const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
-                    const effectivePrimary =
-                      resolveModelPrimary(resolvedConfig.entry?.model) ??
-                      resolveModelPrimary(resolvedConfig.defaults?.model);
                     const effectiveFallbacks = resolveEffectiveModelFallbacks(
                       resolvedConfig.entry?.model,
                       resolvedConfig.defaults?.model,
                     );
+                    const existingModel = resolvedConfig.entry?.model;
+                    const nextModel = resolveModelConfigForFallbackEdit({
+                      existingModel,
+                      nextFallbacks: normalized,
+                      hadEffectiveFallbacks: (effectiveFallbacks?.length ?? 0) > 0,
+                    });
                     const index =
-                      normalized.length > 0
-                        ? effectivePrimary
-                          ? ensureAgentIndex(agentId)
-                          : -1
-                        : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
-                          ? ensureAgentIndex(agentId)
-                          : -1;
+                      nextModel === null ? findAgentIndex(agentId) : ensureAgentIndex(agentId);
                     if (index < 0) {
                       return;
                     }
-                    const list = (
-                      getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null
-                    )?.agents?.list;
                     const basePath = ["agents", "list", index, "model"];
-                    const entry = Array.isArray(list)
-                      ? (list[index] as { model?: unknown })
-                      : undefined;
-                    const existing = entry?.model;
-                    const resolvePrimary = () => {
-                      if (typeof existing === "string") {
-                        return existing.trim() || null;
-                      }
-                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                        const primary = (existing as { primary?: unknown }).primary;
-                        if (typeof primary === "string") {
-                          const trimmed = primary.trim();
-                          return trimmed || null;
-                        }
-                      }
-                      return null;
-                    };
-                    const primary = resolvePrimary() ?? effectivePrimary;
-                    if (normalized.length === 0) {
-                      if (primary) {
-                        updateConfigFormValue(state, basePath, primary);
-                      } else {
-                        removeConfigFormValue(state, basePath);
-                      }
-                      return;
+                    if (nextModel === null) {
+                      removeConfigFormValue(state, basePath);
+                    } else {
+                      updateConfigFormValue(state, basePath, nextModel);
                     }
-                    if (!primary) {
-                      return;
-                    }
-                    updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
                   },
                   onSetDefault: (agentId) => {
                     if (!configValue) {

--- a/ui/src/ui/views/agents-overview.test.ts
+++ b/ui/src/ui/views/agents-overview.test.ts
@@ -3,14 +3,18 @@ import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import { renderAgentOverview } from "./agents-panels-overview.ts";
 
-function renderOverview(configForm: Record<string, unknown>) {
+function renderOverview(params: {
+  configForm: Record<string, unknown>;
+  agentId?: string;
+  defaultId?: string;
+}) {
   const container = document.createElement("div");
   render(
     renderAgentOverview({
-      agent: { id: "main", name: "Main" } as never,
+      agent: { id: params.agentId ?? "main", name: "Main" } as never,
       basePath: "",
-      defaultId: "main",
-      configForm,
+      defaultId: params.defaultId ?? "main",
+      configForm: params.configForm,
       agentFilesList: null,
       agentIdentity: null,
       agentIdentityLoading: false,
@@ -33,17 +37,19 @@ function renderOverview(configForm: Record<string, unknown>) {
 describe("renderAgentOverview", () => {
   it("hydrates the default-model selector from object-shaped defaults.model", async () => {
     const container = renderOverview({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai-codex/gpt-5.4",
+      configForm: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4",
+            },
+            models: {
+              "google/gemini-2.5-pro": { alias: "gemini" },
+              "openai-codex/gpt-5.4": {},
+            },
           },
-          models: {
-            "google/gemini-2.5-pro": { alias: "gemini" },
-            "openai-codex/gpt-5.4": {},
-          },
+          list: [{ id: "main" }],
         },
-        list: [{ id: "main" }],
       },
     });
     await Promise.resolve();
@@ -55,18 +61,20 @@ describe("renderAgentOverview", () => {
 
   it("shows inherited default-model fallbacks for the default agent editor", async () => {
     const container = renderOverview({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai-codex/gpt-5.4",
-            fallbacks: ["google/gemini-2.5-pro"],
+      configForm: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4",
+              fallbacks: ["google/gemini-2.5-pro"],
+            },
+            models: {
+              "google/gemini-2.5-pro": { alias: "gemini" },
+              "openai-codex/gpt-5.4": {},
+            },
           },
-          models: {
-            "google/gemini-2.5-pro": { alias: "gemini" },
-            "openai-codex/gpt-5.4": {},
-          },
+          list: [{ id: "main" }],
         },
-        list: [{ id: "main" }],
       },
     });
     await Promise.resolve();
@@ -76,5 +84,31 @@ describe("renderAgentOverview", () => {
     );
 
     expect(chips).toContain("google/gemini-2.5-pro");
+  });
+
+  it("keeps the inherit option selected for non-default agents without an explicit model", async () => {
+    const container = renderOverview({
+      agentId: "other",
+      defaultId: "main",
+      configForm: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4",
+            },
+            models: {
+              "google/gemini-2.5-pro": { alias: "gemini" },
+              "openai-codex/gpt-5.4": {},
+            },
+          },
+          list: [{ id: "other" }],
+        },
+      },
+    });
+    await Promise.resolve();
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+
+    expect(modelSelect?.value).toBe("");
   });
 });

--- a/ui/src/ui/views/agents-overview.test.ts
+++ b/ui/src/ui/views/agents-overview.test.ts
@@ -53,6 +53,7 @@ describe("renderAgentOverview", () => {
       },
     });
     await Promise.resolve();
+    await Promise.resolve();
 
     const modelSelect = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
 
@@ -77,6 +78,7 @@ describe("renderAgentOverview", () => {
         },
       },
     });
+    await Promise.resolve();
     await Promise.resolve();
 
     const chips = Array.from(container.querySelectorAll(".chip")).map((node) =>
@@ -105,6 +107,91 @@ describe("renderAgentOverview", () => {
         },
       },
     });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+
+    expect(modelSelect?.value).toBe("");
+  });
+
+  it("re-syncs the live select value when switching from an explicit model to inherit-default", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgentOverview({
+        agent: { id: "main", name: "Main" } as never,
+        basePath: "",
+        defaultId: "main",
+        configForm: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "openai-codex/gpt-5.4",
+              },
+              models: {
+                "google/gemini-2.5-pro": { alias: "gemini" },
+                "openai-codex/gpt-5.4": {},
+              },
+            },
+            list: [{ id: "main" }],
+          },
+        },
+        agentFilesList: null,
+        agentIdentity: null,
+        agentIdentityLoading: false,
+        agentIdentityError: null,
+        configLoading: false,
+        configSaving: false,
+        configDirty: false,
+        modelCatalog: [],
+        onConfigReload: () => undefined,
+        onConfigSave: () => undefined,
+        onModelChange: () => undefined,
+        onModelFallbacksChange: () => undefined,
+        onSelectPanel: () => undefined,
+      }),
+      container,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    render(
+      renderAgentOverview({
+        agent: { id: "other", name: "Other" } as never,
+        basePath: "",
+        defaultId: "main",
+        configForm: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "openai-codex/gpt-5.4",
+              },
+              models: {
+                "google/gemini-2.5-pro": { alias: "gemini" },
+                "openai-codex/gpt-5.4": {},
+              },
+            },
+            list: [{ id: "other" }],
+          },
+        },
+        agentFilesList: null,
+        agentIdentity: null,
+        agentIdentityLoading: false,
+        agentIdentityError: null,
+        configLoading: false,
+        configSaving: false,
+        configDirty: false,
+        modelCatalog: [],
+        onConfigReload: () => undefined,
+        onConfigSave: () => undefined,
+        onModelChange: () => undefined,
+        onModelFallbacksChange: () => undefined,
+        onSelectPanel: () => undefined,
+      }),
+      container,
+    );
+    await Promise.resolve();
     await Promise.resolve();
 
     const modelSelect = container.querySelector<HTMLSelectElement>(".agent-model-fields select");

--- a/ui/src/ui/views/agents-overview.test.ts
+++ b/ui/src/ui/views/agents-overview.test.ts
@@ -198,4 +198,40 @@ describe("renderAgentOverview", () => {
 
     expect(modelSelect?.value).toBe("");
   });
+
+  it("shows the inherited primary in the summary when an entry only overrides fallbacks", async () => {
+    const container = renderOverview({
+      agentId: "other",
+      defaultId: "main",
+      configForm: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai-codex/gpt-5.4",
+            },
+            models: {
+              "google/gemini-2.5-pro": { alias: "gemini" },
+              "openai-codex/gpt-5.4": {},
+            },
+          },
+          list: [
+            {
+              id: "other",
+              model: {
+                fallbacks: ["google/gemini-2.5-pro"],
+              },
+            },
+          ],
+        },
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const modelValue = Array.from(container.querySelectorAll(".agent-kv")).find((node) =>
+      node.textContent?.includes("Primary Model"),
+    )?.lastElementChild?.textContent;
+
+    expect(modelValue?.trim()).toBe("openai-codex/gpt-5.4 (+1 fallback)");
+  });
 });

--- a/ui/src/ui/views/agents-overview.test.ts
+++ b/ui/src/ui/views/agents-overview.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderAgentOverview } from "./agents-panels-overview.ts";
+
+function renderOverview(configForm: Record<string, unknown>) {
+  const container = document.createElement("div");
+  render(
+    renderAgentOverview({
+      agent: { id: "main", name: "Main" } as never,
+      basePath: "",
+      defaultId: "main",
+      configForm,
+      agentFilesList: null,
+      agentIdentity: null,
+      agentIdentityLoading: false,
+      agentIdentityError: null,
+      configLoading: false,
+      configSaving: false,
+      configDirty: false,
+      modelCatalog: [],
+      onConfigReload: () => undefined,
+      onConfigSave: () => undefined,
+      onModelChange: () => undefined,
+      onModelFallbacksChange: () => undefined,
+      onSelectPanel: () => undefined,
+    }),
+    container,
+  );
+  return container;
+}
+
+describe("renderAgentOverview", () => {
+  it("hydrates the default-model selector from object-shaped defaults.model", async () => {
+    const container = renderOverview({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.4",
+          },
+          models: {
+            "google/gemini-2.5-pro": { alias: "gemini" },
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    await Promise.resolve();
+
+    const modelSelect = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+
+    expect(modelSelect?.value).toBe("openai-codex/gpt-5.4");
+  });
+
+  it("shows inherited default-model fallbacks for the default agent editor", async () => {
+    const container = renderOverview({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.4",
+            fallbacks: ["google/gemini-2.5-pro"],
+          },
+          models: {
+            "google/gemini-2.5-pro": { alias: "gemini" },
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    });
+    await Promise.resolve();
+
+    const chips = Array.from(container.querySelectorAll(".chip")).map((node) =>
+      node.textContent?.replace("×", "").trim(),
+    );
+
+    expect(chips).toContain("google/gemini-2.5-pro");
+  });
+});

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -12,7 +12,7 @@ import {
   parseFallbackList,
   resolveAgentConfig,
   resolveEffectiveModelFallbacks,
-  resolveModelLabel,
+  resolveEffectiveModelLabel,
   resolveModelPrimary,
 } from "./agents-utils.ts";
 import type { AgentsPanel } from "./agents.ts";
@@ -54,10 +54,8 @@ export function renderAgentOverview(params: {
     agentFilesList && agentFilesList.agentId === agent.id ? agentFilesList.workspace : null;
   const workspace =
     workspaceFromFiles || config.entry?.workspace || config.defaults?.workspace || "default";
-  const model = config.entry?.model
-    ? resolveModelLabel(config.entry?.model)
-    : resolveModelLabel(config.defaults?.model);
-  const defaultModel = resolveModelLabel(config.defaults?.model);
+  const model = resolveEffectiveModelLabel(config.entry?.model, config.defaults?.model);
+  const defaultModel = resolveEffectiveModelLabel(undefined, config.defaults?.model);
   const entryPrimary = resolveModelPrimary(config.entry?.model);
   const defaultPrimary =
     resolveModelPrimary(config.defaults?.model) ||

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -10,7 +10,7 @@ import {
   normalizeModelValue,
   parseFallbackList,
   resolveAgentConfig,
-  resolveModelFallbacks,
+  resolveEffectiveModelFallbacks,
   resolveModelLabel,
   resolveModelPrimary,
 } from "./agents-utils.ts";
@@ -62,11 +62,15 @@ export function renderAgentOverview(params: {
     resolveModelPrimary(config.defaults?.model) ||
     (defaultModel !== "-" ? normalizeModelValue(defaultModel) : null);
   const effectivePrimary = entryPrimary ?? defaultPrimary ?? null;
-  const modelFallbacks = resolveModelFallbacks(config.entry?.model);
-  const fallbackChips = modelFallbacks ?? [];
   const skillFilter = Array.isArray(config.entry?.skills) ? config.entry?.skills : null;
   const skillCount = skillFilter?.length ?? null;
   const isDefault = Boolean(params.defaultId && agent.id === params.defaultId);
+  const selectedPrimary = isDefault ? (effectivePrimary ?? "") : (entryPrimary ?? "");
+  const modelFallbacks = resolveEffectiveModelFallbacks(
+    config.entry?.model,
+    config.defaults?.model,
+  );
+  const fallbackChips = modelFallbacks ?? [];
   const disabled = !configForm || configLoading || configSaving;
 
   const removeChip = (index: number) => {
@@ -127,7 +131,6 @@ export function renderAgentOverview(params: {
           <label class="field">
             <span>Primary model${isDefault ? " (default)" : ""}</span>
             <select
-              .value=${isDefault ? (effectivePrimary ?? "") : (entryPrimary ?? "")}
               ?disabled=${disabled}
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
@@ -135,15 +138,20 @@ export function renderAgentOverview(params: {
               ${
                 isDefault
                   ? html`
-                      <option value="">Not set</option>
+                      <option value="" ?selected=${selectedPrimary === ""}>Not set</option>
                     `
                   : html`
-                      <option value="">
+                      <option value="" ?selected=${selectedPrimary === ""}>
                         ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
                       </option>
                     `
               }
-              ${buildModelOptions(configForm, effectivePrimary ?? undefined, params.modelCatalog)}
+              ${buildModelOptions(
+                configForm,
+                effectivePrimary ?? undefined,
+                params.modelCatalog,
+                selectedPrimary || null,
+              )}
             </select>
           </label>
           <div class="field">

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -131,6 +132,16 @@ export function renderAgentOverview(params: {
           <label class="field">
             <span>Primary model${isDefault ? " (default)" : ""}</span>
             <select
+              ${ref((el) => {
+                if (!(el instanceof HTMLSelectElement)) {
+                  return;
+                }
+                queueMicrotask(() => {
+                  if (el.isConnected && el.value !== selectedPrimary) {
+                    el.value = selectedPrimary;
+                  }
+                });
+              })}
               ?disabled=${disabled}
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}

--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -150,7 +150,7 @@ export function renderAgentOverview(params: {
                 configForm,
                 effectivePrimary ?? undefined,
                 params.modelCatalog,
-                selectedPrimary || null,
+                selectedPrimary,
               )}
             </select>
           </label>

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -4,6 +4,7 @@ import {
   resolveConfiguredCronModelSuggestions,
   resolveAgentAvatarUrl,
   resolveEffectiveModelFallbacks,
+  resolveEffectiveModelLabel,
   resolveModelConfigForFallbackEdit,
   sortLocaleStrings,
 } from "./agents-utils.ts";
@@ -45,6 +46,30 @@ describe("resolveEffectiveModelFallbacks", () => {
     };
 
     expect(resolveEffectiveModelFallbacks(entryModel, defaultModel)).toEqual([]);
+  });
+});
+
+describe("resolveEffectiveModelLabel", () => {
+  it("shows the inherited primary when an entry only overrides fallbacks", () => {
+    expect(
+      resolveEffectiveModelLabel(
+        {
+          fallbacks: ["google/gemini-2.5-flash"],
+        },
+        {
+          primary: "openai/gpt-5.4",
+        },
+      ),
+    ).toBe("openai/gpt-5.4 (+1 fallback)");
+  });
+
+  it("shows inherited fallback counts on top of the effective primary", () => {
+    expect(
+      resolveEffectiveModelLabel(undefined, {
+        primary: "openai/gpt-5.4",
+        fallbacks: ["google/gemini-2.5-flash"],
+      }),
+    ).toBe("openai/gpt-5.4 (+1 fallback)");
   });
 });
 

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -4,6 +4,7 @@ import {
   resolveConfiguredCronModelSuggestions,
   resolveAgentAvatarUrl,
   resolveEffectiveModelFallbacks,
+  resolveModelConfigForFallbackEdit,
   sortLocaleStrings,
 } from "./agents-utils.ts";
 
@@ -88,6 +89,85 @@ describe("resolveConfiguredCronModelSuggestions", () => {
     expect(resolveConfiguredCronModelSuggestions({ agents: { defaults: { model: "" } } })).toEqual(
       [],
     );
+  });
+});
+
+describe("resolveModelConfigForFallbackEdit", () => {
+  it("keeps an explicit string primary when adding fallback overrides", () => {
+    expect(
+      resolveModelConfigForFallbackEdit({
+        existingModel: "openai/gpt-5.4",
+        nextFallbacks: ["google/gemini-2.5-flash"],
+        hadEffectiveFallbacks: false,
+      }),
+    ).toEqual({
+      primary: "openai/gpt-5.4",
+      fallbacks: ["google/gemini-2.5-flash"],
+    });
+  });
+
+  it("supports fallback-only overrides when no explicit primary exists", () => {
+    expect(
+      resolveModelConfigForFallbackEdit({
+        existingModel: undefined,
+        nextFallbacks: ["google/gemini-2.5-flash"],
+        hadEffectiveFallbacks: false,
+      }),
+    ).toEqual({
+      fallbacks: ["google/gemini-2.5-flash"],
+    });
+  });
+
+  it("keeps an explicit empty override when clearing inherited fallbacks", () => {
+    expect(
+      resolveModelConfigForFallbackEdit({
+        existingModel: undefined,
+        nextFallbacks: [],
+        hadEffectiveFallbacks: true,
+      }),
+    ).toEqual({
+      fallbacks: [],
+    });
+  });
+
+  it("keeps the explicit primary when clearing fallback overrides", () => {
+    expect(
+      resolveModelConfigForFallbackEdit({
+        existingModel: {
+          primary: "openai/gpt-5.4",
+          fallbacks: ["google/gemini-2.5-flash"],
+        },
+        nextFallbacks: [],
+        hadEffectiveFallbacks: true,
+      }),
+    ).toEqual({
+      primary: "openai/gpt-5.4",
+      fallbacks: [],
+    });
+  });
+
+  it("preserves explicit empty fallback arrays even without inherited fallbacks", () => {
+    expect(
+      resolveModelConfigForFallbackEdit({
+        existingModel: {
+          fallbacks: [],
+        },
+        nextFallbacks: [],
+        hadEffectiveFallbacks: false,
+      }),
+    ).toEqual({
+      fallbacks: [],
+    });
+  });
+
+  it("removes the model config when nothing explicit remains", () => {
+    expect(
+      resolveModelConfigForFallbackEdit({
+        existingModel: undefined,
+        nextFallbacks: [],
+        hadEffectiveFallbacks: false,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -426,6 +426,38 @@ export function resolveEffectiveModelFallbacks(
   return resolveModelFallbacks(entryModel) ?? resolveModelFallbacks(defaultModel);
 }
 
+export function resolveModelConfigForFallbackEdit(params: {
+  existingModel?: unknown;
+  nextFallbacks: string[];
+  hadEffectiveFallbacks: boolean;
+}): string | { primary?: string; fallbacks?: string[] } | null {
+  const hasExplicitFallbacks =
+    !!params.existingModel &&
+    typeof params.existingModel === "object" &&
+    !Array.isArray(params.existingModel) &&
+    Array.isArray((params.existingModel as { fallbacks?: unknown }).fallbacks);
+  const explicitPrimary = (() => {
+    if (typeof params.existingModel === "string") {
+      const trimmed = params.existingModel.trim();
+      return trimmed || null;
+    }
+    return resolveModelPrimary(params.existingModel);
+  })();
+  const normalizedFallbacks = params.nextFallbacks.map((entry) => entry.trim()).filter(Boolean);
+
+  if (normalizedFallbacks.length > 0) {
+    return explicitPrimary
+      ? { primary: explicitPrimary, fallbacks: normalizedFallbacks }
+      : { fallbacks: normalizedFallbacks };
+  }
+
+  if (params.hadEffectiveFallbacks || hasExplicitFallbacks) {
+    return explicitPrimary ? { primary: explicitPrimary, fallbacks: [] } : { fallbacks: [] };
+  }
+
+  return explicitPrimary;
+}
+
 function addModelId(target: Set<string>, value: unknown) {
   if (typeof value !== "string") {
     return;

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -576,6 +576,7 @@ export function buildModelOptions(
   configForm: Record<string, unknown> | null,
   current?: string | null,
   catalog?: ModelCatalogEntry[],
+  selected?: string | null,
 ) {
   const seen = new Set<string>();
   const options: ConfiguredModelOption[] = [];
@@ -608,7 +609,12 @@ export function buildModelOptions(
   if (options.length === 0) {
     return nothing;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  const selectedValue = selected ?? current ?? null;
+  return options.map(
+    (option) => html`<option value=${option.value} ?selected=${option.value === selectedValue}>
+      ${option.label}
+    </option>`,
+  );
 }
 
 type CompiledPattern =

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -330,9 +330,7 @@ export function buildAgentContext(
     agentFilesList && agentFilesList.agentId === agent.id ? agentFilesList.workspace : null;
   const workspace =
     workspaceFromFiles || config.entry?.workspace || config.defaults?.workspace || "default";
-  const modelLabel = config.entry?.model
-    ? resolveModelLabel(config.entry?.model)
-    : resolveModelLabel(config.defaults?.model);
+  const modelLabel = resolveEffectiveModelLabel(config.entry?.model, config.defaults?.model);
   const identityName =
     agentIdentity?.name?.trim() ||
     agent.identity?.name?.trim() ||
@@ -368,6 +366,16 @@ export function resolveModelLabel(model?: unknown): string {
     }
   }
   return "-";
+}
+
+export function resolveEffectiveModelLabel(entryModel?: unknown, defaultModel?: unknown): string {
+  const primary = resolveModelPrimary(entryModel) ?? resolveModelPrimary(defaultModel);
+  if (!primary) {
+    const entryLabel = resolveModelLabel(entryModel);
+    return entryLabel !== "-" ? entryLabel : resolveModelLabel(defaultModel);
+  }
+  const fallbacks = resolveEffectiveModelFallbacks(entryModel, defaultModel);
+  return fallbacks?.length ? `${primary} (+${fallbacks.length} fallback)` : primary;
 }
 
 export function normalizeModelValue(label: string): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
       "extensions/**/*.test.ts",
       "test/**/*.test.ts",
       "ui/src/ui/app-chat.test.ts",
+      "ui/src/ui/views/agents-overview.test.ts",
       "ui/src/ui/views/agents-utils.test.ts",
       "ui/src/ui/views/channels.test.ts",
       "ui/src/ui/views/chat.test.ts",

--- a/vitest.unit-paths.mjs
+++ b/vitest.unit-paths.mjs
@@ -4,6 +4,7 @@ export const unitTestIncludePatterns = [
   "src/**/*.test.ts",
   "test/**/*.test.ts",
   "ui/src/ui/app-chat.test.ts",
+  "ui/src/ui/views/agents-overview.test.ts",
   "ui/src/ui/views/agents-utils.test.ts",
   "ui/src/ui/views/channels.test.ts",
   "ui/src/ui/views/chat.test.ts",


### PR DESCRIPTION
## Summary

Fixes #54252.

The Agents page had two inconsistent hydration paths for the default agent editor when `agents.defaults.model` was configured as an object.

This patch makes the editor reuse the same effective primary/fallback resolution that the summary already uses, so the editable form now stays aligned with the runtime/config display.

## What Changed

- hydrate the default-agent primary model selector from the resolved effective model instead of letting the `<select>` fall back to an empty/default browser state
- show inherited `agents.defaults.model.fallbacks` chips in the editor when the selected agent is the default agent and has no entry-level override
- add a focused jsdom regression test that covers the object-shaped `agents.defaults.model` payload from the issue
- register the new UI regression test in the normal Vitest include list so it runs in the standard unit lane

## Root Cause

The overview summary already handled object-shaped model config correctly, but the editable form diverged in two places:

- fallback chips only read `entry.model`, so the default agent editor rendered inherited fallbacks as blank
- the primary-model `<select>` relied on property assignment instead of explicit option selection, so object-shaped defaults could leave the control with an empty value and the browser could visually fall through to another configured option

## Testing

- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-54252-vitest-include.json pnpm exec vitest run --config /private/tmp/openclaw-54252/vitest.unit.config.ts`
- include file contents: `ui/src/ui/views/agents-overview.test.ts`, `ui/src/ui/views/agents-utils.test.ts`
- result: 2 files / 13 tests passed

## Base

- rebased onto latest GitHub-green `main` commit before opening: `8b80690a1a90a5dcd61fe86e141fdde19c7a45c5`

## Notes

- AI-assisted, reviewed locally
