### PR TITLE
fix(auto-reply): require operator.admin for /stop command

### DIFF
--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -110,7 +110,11 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
   if (params.command.commandBodyNormalized !== "/stop") {
     return null;
   }
-  const unauthorizedStop = requireGatewayClientScopeForInternalChannel(params, "operator.admin");
+  const unauthorizedStop = requireGatewayClientScopeForInternalChannel(params, {
+    label: "/stop",
+    allowedScopes: ["operator.admin"],
+    missingText: "❌ /stop requires operator.admin for gateway clients.",
+  });
   if (unauthorizedStop) {
     return unauthorizedStop;
   }

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -110,7 +110,7 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
   if (params.command.commandBodyNormalized !== "/stop") {
     return null;
   }
-  const unauthorizedStop = rejectUnauthorizedCommand(params, "/stop");
+  const unauthorizedStop = requireGatewayClientScopeForInternalChannel(params, "operator.admin");
   if (unauthorizedStop) {
     return unauthorizedStop;
   }


### PR DESCRIPTION
Fixes a missing authorization check in the `/stop` command handler within the auto-reply module. The command previously relied on a base scope check (`rejectUnauthorizedCommand`) instead of verifying the required elevated scope.

## Root Cause
The `handleStopCommand` function invoked `rejectUnauthorizedCommand` to authorize requests. This does not enforce the `operator.admin` scope requirement necessary for mutating internal commands like session abort, potentially allowing unauthorized users to stop sessions.

## Fix
Replaced `rejectUnauthorizedCommand` with `requireGatewayClientScopeForInternalChannel` to explicitly enforce the `operator.admin` scope.

## Reference
Matches the fix pattern in PR #54097.