### PR TITLE
fix(telegram): skip DM access check for bot's own messages

### DIFF
--- a/extensions/telegram/src/dm-access.test.ts
+++ b/extensions/telegram/src/dm-access.test.ts
@@ -77,6 +77,60 @@ describe("enforceTelegramDmAccess", () => {
     expect(allowed).toBe(false);
   });
 
+  it("keeps disabled policy authoritative for bot-originated DMs", async () => {
+    const allowed = await enforceTelegramDmAccess({
+      isGroup: false,
+      dmPolicy: "disabled",
+      msg: createDmMessage({
+        from: {
+          id: 999,
+          is_bot: true,
+          first_name: "OpenClaw",
+          username: "openclaw_bot",
+        },
+      }),
+      chatId: 42,
+      effectiveDmAllow: normalizeAllowFrom([]),
+      accountId: "main",
+      bot: {
+        botInfo: { id: 999 },
+        api: { sendMessage: vi.fn(async () => undefined) },
+      } as never,
+      logger: { info: vi.fn() },
+    });
+
+    expect(allowed).toBe(false);
+  });
+
+  it("allows the bot's own messages under pairing policy", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+
+    const allowed = await enforceTelegramDmAccess({
+      isGroup: false,
+      dmPolicy: "pairing",
+      msg: createDmMessage({
+        from: {
+          id: 999,
+          is_bot: true,
+          first_name: "OpenClaw",
+          username: "openclaw_bot",
+        },
+      }),
+      chatId: 42,
+      effectiveDmAllow: normalizeAllowFrom([]),
+      accountId: "main",
+      bot: {
+        botInfo: { id: 999 },
+        api: { sendMessage },
+      } as never,
+      logger: { info: vi.fn() },
+    });
+
+    expect(allowed).toBe(true);
+    expect(createChannelPairingChallengeIssuerMock).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("allows DMs for allowlisted senders under pairing policy", async () => {
     const allowed = await enforceTelegramDmAccess({
       isGroup: false,

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -60,6 +60,11 @@ export async function enforceTelegramDmAccess(params: {
   if (dmPolicy === "disabled") {
     return false;
   }
+  // Allow self-originated messages (bot's own pinned_message notifications, etc.)
+  // but only AFTER the disabled-policy check so disabled remains authoritative.
+  if (msg.from?.is_bot && msg.from.id === bot.botInfo.id) {
+    return true;
+  }
   if (dmPolicy === "open") {
     return true;
   }


### PR DESCRIPTION
## Summary

Fixes #54339

When a Telegram bot sends a message in a DM conversation, the bot's own message gets processed by `enforceTelegramDmAccess` and triggers a spurious pairing request because the bot's user ID isn't in the `allowFrom` list.

- Add an early `msg.from?.is_bot` guard in `enforceTelegramDmAccess` to skip DM policy checks for bot-originated messages
- This matches the existing pattern used in the reaction handler (`bot-handlers.runtime.ts`) which already filters bot messages with `if (user?.is_bot) return;`

## Test plan

- [x] Added test: bot messages with `is_bot: true` return `allowed = true` without issuing a pairing challenge
- [x] All 5 existing + new `dm-access.test.ts` tests pass
- [x] `pnpm check` passes (lint, format, type-check, boundary checks)