### PR TITLE
fix(browser): prevent cross-origin images from disappearing in CDP sc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,6 +433,11 @@ Docs: https://docs.openclaw.ai
 - Security/bash stop: route `/bash stop` through the hardened process-tree killer so invalid or attacker-influenced SIGKILL targets cannot escape the intended bash-session scope.
 - Security/installer: hide staged project `.npmrc` files during skill and package installs so npm registry and git settings inside the stage directory cannot hijack trusted installs.
 - Channels/QQ Bot: add QQ Bot as a bundled first-party channel plugin for the official QQ Bot API, including multi-account setup, SecretRef-aware credentials, QQ-specific slash commands, media send/receive support, and bundled-channel integration fixes for config schema, version/help surfaces, and local media delivery.
+- Agents/tool-call repair: recover malformed Kimi/OpenRouter tool-call argument streams when provider preambles appear before JSON payloads, and fail closed on non-tool leading text so fragment strings do not leak into filesystem path arguments during sub-agent runs. (#56560) Thanks @Originalwhite.
+- Agents/cooldowns: scope rate-limit cooldowns per model so one 429 no longer blocks every model on the same auth profile, replace the exponential 1 min → 1 h escalation with a stepped 30 s / 1 min / 5 min ladder, and surface a user-facing countdown message when all models are rate-limited. (#49834) Thanks @kiranvk-2011.
+- Config/web fetch: allow the documented `tools.web.fetch.maxResponseBytes` setting in runtime schema validation so valid configs no longer fail with unrecognized-key errors. (#53401) Thanks @erhhung.
+- Message tool/buttons: keep the shared `buttons` schema optional in merged tool definitions so plain `action=send` calls stop failing validation when no buttons are provided. (#54418) Thanks @adzendo.
+- Browser/screenshot: use `fromSurface: false` in raw CDP screenshots to avoid a Chromium compositor bug that drops cross-origin image textures (QR codes, CDN assets), and preserve pre-existing device emulation state across full-page viewport expansion. (#54358) Thanks @FMLS.
 
 ## 2026.3.23
 

--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedBrowserProfile } from "./config.js";
+import { shouldUsePlaywrightForScreenshot } from "./profile-capabilities.js";
+
+const sentMessages = vi.hoisted(() => {
+  const msgs: Array<{ method: string; params?: Record<string, unknown> }> = [];
+  return msgs;
+});
+
+// Tracks whether emulation has been cleared so post-clear Runtime.evaluate
+// can return different values for the "emulated tab" vs "non-emulated tab" tests.
+const mockState = vi.hoisted(() => ({
+  emulationCleared: false,
+  emulatedTab: true,
+  viewport: { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 } as Record<string, unknown>,
+  naturalViewport: { w: 1920, h: 1080, dpr: 1 },
+}));
+
+vi.mock("./cdp.helpers.js", () => ({
+  withCdpSocket: vi.fn(async (_wsUrl: string, fn: (send: unknown) => Promise<unknown>) => {
+    const send = (method: string, params?: Record<string, unknown>) => {
+      sentMessages.push({ method, params });
+      if (method === "Page.captureScreenshot") {
+        return Promise.resolve({ data: "AAAA" });
+      }
+      if (method === "Page.getLayoutMetrics") {
+        return Promise.resolve({
+          cssContentSize: { width: 1200, height: 3000 },
+          contentSize: { width: 1200, height: 3000 },
+        });
+      }
+      if (method === "Emulation.clearDeviceMetricsOverride") {
+        mockState.emulationCleared = true;
+        return Promise.resolve({});
+      }
+      if (method === "Emulation.setDeviceMetricsOverride") {
+        mockState.emulationCleared = false;
+        return Promise.resolve({});
+      }
+      if (method === "Runtime.evaluate") {
+        if (mockState.emulationCleared && mockState.emulatedTab) {
+          return Promise.resolve({
+            result: {
+              value: mockState.naturalViewport,
+            },
+          });
+        }
+        return Promise.resolve({
+          result: {
+            value: mockState.viewport,
+          },
+        });
+      }
+      return Promise.resolve({});
+    };
+    return fn(send);
+  }),
+  appendCdpPath: vi.fn(),
+  fetchJson: vi.fn(),
+  isLoopbackHost: vi.fn(),
+  isWebSocketUrl: vi.fn(),
+}));
+
+vi.mock("./navigation-guard.js", () => ({
+  assertBrowserNavigationAllowed: vi.fn(),
+  withBrowserNavigationPolicy: vi.fn(() => ({})),
+}));
+
+const localProfile: ResolvedBrowserProfile = {
+  name: "openclaw",
+  cdpUrl: "http://127.0.0.1:18800",
+  cdpPort: 18800,
+  cdpHost: "127.0.0.1",
+  cdpIsLoopback: true,
+  color: "#FF4500",
+  driver: "openclaw",
+  attachOnly: false,
+};
+
+let captureScreenshot: typeof import("./cdp.js").captureScreenshot;
+
+beforeEach(async () => {
+  sentMessages.length = 0;
+  mockState.emulationCleared = false;
+  mockState.emulatedTab = true;
+  mockState.viewport = { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 };
+  mockState.naturalViewport = { w: 1920, h: 1080, dpr: 1 };
+  vi.resetModules();
+  ({ captureScreenshot } = await import("./cdp.js"));
+});
+
+describe("CDP screenshot params", () => {
+  it("viewport screenshot uses fromSurface: false without clip or emulation override", async () => {
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", format: "png" });
+
+    const call = sentMessages.find((m) => m.method === "Page.captureScreenshot");
+    expect(call).toBeDefined();
+    expect(call!.params).toMatchObject({
+      format: "png",
+      fromSurface: false,
+      captureBeyondViewport: true,
+    });
+    expect(call!.params).not.toHaveProperty("clip");
+
+    const emulationCalls = sentMessages.filter(
+      (m) => m.method === "Emulation.setDeviceMetricsOverride",
+    );
+    expect(emulationCalls).toHaveLength(0);
+  });
+
+  it("fullPage on emulated tab: clears, detects drift, re-applies saved emulation", async () => {
+    mockState.emulatedTab = true;
+
+    await captureScreenshot({
+      wsUrl: "ws://localhost:9222/devtools/page/X",
+      format: "png",
+      fullPage: true,
+    });
+
+    const setCalls = sentMessages.filter((m) => m.method === "Emulation.setDeviceMetricsOverride");
+    expect(setCalls.length).toBe(2);
+
+    // Expand: uses saved DPR, mobile defaults to false
+    expect(setCalls[0]!.params).toMatchObject({
+      width: 1200,
+      height: 3000,
+      deviceScaleFactor: 2,
+      mobile: false,
+    });
+
+    // Clear is called first in the finally block
+    const clearCall = sentMessages.find((m) => m.method === "Emulation.clearDeviceMetricsOverride");
+    expect(clearCall).toBeDefined();
+
+    // Viewport drifted after clear → re-apply saved dimensions
+    expect(setCalls[1]!.params).toMatchObject({
+      width: 800,
+      height: 600,
+      deviceScaleFactor: 2,
+      mobile: false,
+      screenWidth: 800,
+      screenHeight: 600,
+    });
+  });
+
+  it("fullPage on non-emulated tab: clears and does NOT re-apply emulation", async () => {
+    mockState.emulatedTab = false;
+    mockState.viewport = { w: 1920, h: 1080, dpr: 1, sw: 1920, sh: 1080 };
+    mockState.naturalViewport = { w: 1920, h: 1080, dpr: 1 };
+
+    await captureScreenshot({
+      wsUrl: "ws://localhost:9222/devtools/page/X",
+      format: "png",
+      fullPage: true,
+    });
+
+    const setCalls = sentMessages.filter((m) => m.method === "Emulation.setDeviceMetricsOverride");
+    // Only the expand call — no re-apply after clear
+    expect(setCalls).toHaveLength(1);
+
+    const clearCall = sentMessages.find((m) => m.method === "Emulation.clearDeviceMetricsOverride");
+    expect(clearCall).toBeDefined();
+  });
+
+  it("fullPage viewport dimensions never shrink below current innerWidth/Height", async () => {
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X", fullPage: true });
+
+    const expandCall = sentMessages.find((m) => m.method === "Emulation.setDeviceMetricsOverride");
+    expect(expandCall).toBeDefined();
+    expect(Number(expandCall!.params!.width)).toBeGreaterThanOrEqual(800);
+    expect(Number(expandCall!.params!.height)).toBeGreaterThanOrEqual(600);
+  });
+});
+
+describe("shouldUsePlaywrightForScreenshot routing", () => {
+  it("returns false for a normal viewport screenshot with wsUrl", () => {
+    expect(shouldUsePlaywrightForScreenshot({ profile: localProfile, wsUrl: "ws://x" })).toBe(
+      false,
+    );
+  });
+
+  it("returns true when wsUrl is missing", () => {
+    expect(shouldUsePlaywrightForScreenshot({ profile: localProfile })).toBe(true);
+  });
+
+  it("returns true when ref is specified", () => {
+    expect(
+      shouldUsePlaywrightForScreenshot({ profile: localProfile, wsUrl: "ws://x", ref: "btn-1" }),
+    ).toBe(true);
+  });
+
+  it("returns true when element is specified", () => {
+    expect(
+      shouldUsePlaywrightForScreenshot({
+        profile: localProfile,
+        wsUrl: "ws://x",
+        element: "#submit",
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -66,17 +66,50 @@ export async function captureScreenshot(opts: {
   return await withCdpSocket(opts.wsUrl, async (send) => {
     await send("Page.enable");
 
-    let clip: { x: number; y: number; width: number; height: number; scale: number } | undefined;
+    // For full-page captures, temporarily expand the viewport to the content
+    // size so the entire page is within the viewport bounds.  We save the
+    // current viewport state and restore it after capture so pre-existing
+    // device emulation (mobile width, DPR, touch) is not lost.
+    let savedVp: { w: number; h: number; dpr: number; sw: number; sh: number } | undefined;
     if (opts.fullPage) {
       const metrics = (await send("Page.getLayoutMetrics")) as {
         cssContentSize?: { width?: number; height?: number };
         contentSize?: { width?: number; height?: number };
       };
       const size = metrics?.cssContentSize ?? metrics?.contentSize;
-      const width = Number(size?.width ?? 0);
-      const height = Number(size?.height ?? 0);
-      if (width > 0 && height > 0) {
-        clip = { x: 0, y: 0, width, height, scale: 1 };
+      const contentWidth = Number(size?.width ?? 0);
+      const contentHeight = Number(size?.height ?? 0);
+      if (contentWidth > 0 && contentHeight > 0) {
+        const vpResult = (await send("Runtime.evaluate", {
+          expression:
+            "({ w: window.innerWidth, h: window.innerHeight, dpr: window.devicePixelRatio, sw: screen.width, sh: screen.height })",
+          returnByValue: true,
+        })) as {
+          result?: {
+            value?: { w?: number; h?: number; dpr?: number; sw?: number; sh?: number };
+          };
+        };
+        const v = vpResult?.result?.value;
+        const currentW = Number(v?.w ?? 0);
+        const currentH = Number(v?.h ?? 0);
+        savedVp = {
+          w: currentW,
+          h: currentH,
+          dpr: Number(v?.dpr ?? 1),
+          sw: Number(v?.sw ?? currentW),
+          sh: Number(v?.sh ?? currentH),
+        };
+        // mobile: false is the safe default — CDP provides no way to query
+        // the active mobile flag, and inferring from navigator.maxTouchPoints
+        // would false-positive on touch-enabled desktops.
+        await send("Emulation.setDeviceMetricsOverride", {
+          width: Math.ceil(Math.max(currentW, contentWidth)),
+          height: Math.ceil(Math.max(currentH, contentHeight)),
+          deviceScaleFactor: savedVp.dpr,
+          mobile: false,
+          screenWidth: savedVp.sw,
+          screenHeight: savedVp.sh,
+        });
       }
     }
 
@@ -84,19 +117,55 @@ export async function captureScreenshot(opts: {
     const quality =
       format === "jpeg" ? Math.max(0, Math.min(100, Math.round(opts.quality ?? 85))) : undefined;
 
-    const result = (await send("Page.captureScreenshot", {
-      format,
-      ...(quality !== undefined ? { quality } : {}),
-      fromSurface: true,
-      captureBeyondViewport: true,
-      ...(clip ? { clip } : {}),
-    })) as { data?: string };
+    try {
+      // fromSurface: false avoids a Chromium compositor bug where cross-origin
+      // image textures are lost when fromSurface: true + captureBeyondViewport: true
+      // extends the capture surface (see https://issues.chromium.org/40760789).
+      const result = (await send("Page.captureScreenshot", {
+        format,
+        ...(quality !== undefined ? { quality } : {}),
+        fromSurface: false,
+        captureBeyondViewport: true,
+      })) as { data?: string };
 
-    const base64 = result?.data;
-    if (!base64) {
-      throw new Error("Screenshot failed: missing data");
+      const base64 = result?.data;
+      if (!base64) {
+        throw new Error("Screenshot failed: missing data");
+      }
+      return Buffer.from(base64, "base64");
+    } finally {
+      if (savedVp) {
+        // Clear the temporary viewport expansion first.  If the tab had
+        // prior device emulation the clear will change the viewport back to
+        // the browser's natural dimensions — detect that and re-apply the
+        // saved emulation so the tab's original state is preserved.
+        await send("Emulation.clearDeviceMetricsOverride").catch(() => {});
+        try {
+          const postResult = (await send("Runtime.evaluate", {
+            expression:
+              "({ w: window.innerWidth, h: window.innerHeight, dpr: window.devicePixelRatio })",
+            returnByValue: true,
+          })) as { result?: { value?: { w?: number; h?: number; dpr?: number } } };
+          const p = postResult?.result?.value;
+          if (
+            Number(p?.w) !== savedVp.w ||
+            Number(p?.h) !== savedVp.h ||
+            Number(p?.dpr) !== savedVp.dpr
+          ) {
+            await send("Emulation.setDeviceMetricsOverride", {
+              width: savedVp.w,
+              height: savedVp.h,
+              deviceScaleFactor: savedVp.dpr,
+              mobile: false,
+              screenWidth: savedVp.sw,
+              screenHeight: savedVp.sh,
+            });
+          }
+        } catch {
+          // Best-effort restoration; ignore failures in the cleanup path.
+        }
+      }
     }
-    return Buffer.from(base64, "base64");
   });
 }
 


### PR DESCRIPTION
以下是更新后的 PR 说明：

---

## Summary

- **Problem:** CDP `Page.captureScreenshot` with `fromSurface: true` + `captureBeyondViewport: true` triggers a Chromium compositor bug where cross-origin image textures are lost when extending the capture surface. This causes QR codes, CDN-hosted images, and other cross-origin resources to appear as blank in screenshots.
- **Why it matters:** Browser agents frequently screenshot pages with cross-origin images (login QR codes, third-party embeds, CDN assets). The blank images degrade agent vision and decision-making.
- **What changed:** Switch the Raw CDP screenshot path to `fromSurface: false` so cross-origin images are rendered via the software path instead of the compositor surface. For full-page captures, temporarily expand the viewport to the content size via `Emulation.setDeviceMetricsOverride` (width only increases, never decreases, to avoid triggering responsive breakpoints), then restore after capture. Added seam tests and a changelog entry.
- **What did NOT change (scope boundary):** The Playwright screenshot path is unaffected. Chrome MCP and existing-session paths are unaffected. The `fullPage` option, routing logic (`shouldUsePlaywrightForScreenshot`), and public API shape are all preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

None

## Root Cause / Regression History (if applicable)

- **Root cause:** When `fromSurface: true` + `captureBeyondViewport: true`, Chrome's compositor creates an extended capture surface. During this extension, GPU texture references for cross-origin images are not properly transferred to the new surface, resulting in blank areas in the screenshot. `fromSurface: false` bypasses the compositor and uses a software rendering path that does not lose cross-origin textures.
- **Missing detection / guardrail:** All existing screenshot tests are mock-level unit tests that do not exercise the actual CDP `Page.captureScreenshot` call, so the visual regression was never caught.
- **Prior context:** The Raw CDP screenshot path was introduced on 12-20 as a fallback for environments without Playwright. It used `fromSurface: true` + `captureBeyondViewport: true` as the Chrome defaults without awareness of this compositor bug.
- **Why this regressed now:** This is a latent bug present since the Raw CDP path was added. It surfaces on any page with cross-origin images.
- **If unknown, what was ruled out:** N/A — root cause is confirmed through systematic parameter testing across 8 combinations of `fromSurface` and `captureBeyondViewport`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/browser/cdp.screenshot-params.test.ts`
- **Scenario the test should lock in:**
  - Viewport screenshots use `fromSurface: false, captureBeyondViewport: true` with no clip and no viewport override
  - Full-page screenshots call `Emulation.setDeviceMetricsOverride` (width >= current innerWidth), then `fromSurface: false, captureBeyondViewport: true` with no clip, then `Emulation.clearDeviceMetricsOverride`
  - `shouldUsePlaywrightForScreenshot` routing is unchanged (no fullPage condition)
- **Why this is the smallest reliable guardrail:** The seam tests deterministically assert the CDP param shape and the viewport-expand sequence without requiring a real browser.
- **Existing test that already covers this (if any):** None existed prior to this PR.

## User-visible / Behavior Changes

- Cross-origin images (QR codes, CDN images, third-party embeds) now appear correctly in Raw CDP screenshots (both viewport and full-page) instead of blank.
- Full-page screenshots remain on the Raw CDP path (no rerouting to Playwright). The viewport is temporarily expanded to the content size before capture and restored after.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu, headless) and macOS
- Runtime/container: Node 22, Chrome 145/146 headless
- Model/provider: N/A (browser infrastructure)
- Integration/channel (if any): Browser control service
- Relevant config (redacted): `browser.headless: true`, `browser.extraArgs: ["--window-size=1920,1080"]`

### Steps

1. Launch Chrome with `--remote-debugging-port`
2. Navigate to `https://passport.weibo.com/sso/signin` (has a cross-origin QR code from `v2.qr.weibo.cn`)
3. Call `Page.captureScreenshot` with `fromSurface: true` (before fix)
4. Call `Page.captureScreenshot` with `fromSurface: false` (after fix)

### Expected

QR code image visible in the screenshot.

### Actual

- Before fix: QR code area is blank.
- After fix: QR code is visible.

## Evidence

Tested with a standalone CDP screenshot script across 8 parameter combinations on both local headed Chrome and remote headless Chrome. Key results:

| `fromSurface` | `captureBeyondViewport` | QR code |
|:---:|:---:|:---:|
| true | true (before) | blank |
| true | false | visible |
| **false** | **true (after)** | **visible** |
| false | false | visible |

Full-page screenshot with viewport expansion verified on remote headless Linux (Chrome 145, ozone headless, `--window-size=1920,1080`): Weibo homepage captured at 930x4242 with all cross-origin images intact.

Viewport expansion uses `Math.max(currentInnerWidth, contentWidth)` to prevent shrinking — verified against the Weibo login page where a 3-pixel drop from 780 to 765 would otherwise trigger a 768px responsive breakpoint and hide the QR code.

New seam tests added in `src/browser/cdp.screenshot-params.test.ts` (7 tests):
- Asserts viewport screenshot params (`fromSurface: false`, `captureBeyondViewport: true`, no clip, no viewport override)
- Asserts full-page screenshot expands viewport via `Emulation.setDeviceMetricsOverride` and restores via `clearDeviceMetricsOverride`
- Asserts viewport width never shrinks below current `innerWidth`
- Asserts `shouldUsePlaywrightForScreenshot` routing behavior (unchanged)

## Human Verification (required)

- **Verified scenarios:** Viewport screenshot with cross-origin QR code; full-page screenshot with viewport expansion on long pages; full-page screenshot on responsive login page (768px breakpoint); headless Linux + headed macOS.
- **Edge cases checked:** Responsive pages near media query breakpoints (768px, verified `Math.max` prevents width shrinkage); pages with canvas/WebGL content; cross-origin images from multiple different domains.
- **What you did not verify:** Extremely tall pages (>10000px) where viewport expansion might hit Chrome's internal size limits.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (recommended: `browser.extraArgs: ["--window-size=1920,1080"]` for headless deployments to ensure a large default viewport)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/browser/cdp.ts` to restore `fromSurface: true` and the original clip-based full-page logic.
- Files/config to restore: `src/browser/cdp.ts`
- Known bad symptoms reviewers should watch for: Full-page screenshots on very tall pages may trigger page reflow if the content height greatly exceeds the current viewport; screenshots via the Raw CDP path may render differently from the compositor surface for pages with advanced GPU effects.

## Risks and Mitigations

- **Risk:** `fromSurface: false` uses a software rendering path that may differ subtly from the compositor surface for advanced GPU effects (WebGL shaders, CSS compositing).
  - **Mitigation:** Modern Chrome (100+) handles canvas and standard WebGL correctly via the software path. The cross-origin image fix is a higher priority than pixel-perfect GPU fidelity for the Raw CDP fallback path.

- **Risk:** Viewport expansion for full-page captures may trigger page reflow on very tall or responsive pages.
  - **Mitigation:** Width is only increased (never decreased) via `Math.max(currentInnerWidth, contentWidth)`, preventing horizontal responsive breakpoint regressions. The viewport is restored in a `finally` block after capture. Verified against a 768px breakpoint edge case where a 3-pixel difference would have hidden content.

### Additional context from Chromium / CDP docs

This change is consistent with known limitations in Chromium's screenshot pipeline:

- **Chrome DevTools Protocol docs** mark `Page.captureScreenshot.captureBeyondViewport` as **Experimental**.
  Official docs:
  - https://chromedevtools.github.io/devtools-protocol/tot/Page/
  - https://chromedevtools.github.io/devtools-protocol/1-3/Page/

- **Chromium issue tracker** has an existing issue stating that `captureBeyondViewport` does not behave as documented:
  - **Issue 40760789** — *"the CDP captureBeyondViewport parameter does not work"*
    https://issues.chromium.org/40760789

- This area also has prior upstream history around screenshot clipping / viewport-bounded capture behavior:
  - **Chromium issue 1003629**
    referenced from Puppeteer discussion: https://github.com/puppeteer/puppeteer/issues/5080

Using `fromSurface: false` sidesteps the compositor texture-loss bug entirely, while the viewport expansion approach preserves full-page capture without depending on the experimental `captureBeyondViewport` behavior.