### PR TITLE
fix(telegram): resolve channel-level token fallthrough for binding-created accountIds

### DIFF
--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -476,6 +476,39 @@ describe("telegramPlugin duplicate token guard", () => {
     expect(await telegramPlugin.config.isConfigured!(alertsAccount, cfg)).toBe(true);
   });
 
+  // Regression: https://github.com/openclaw/openclaw/issues/53876
+  // Single-bot setup with channel-level token should report configured.
+  it("reports configured for single-bot setup with channel-level token", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "single-bot-token",
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveAccount(cfg, "default");
+    expect(await telegramPlugin.config.isConfigured!(account, cfg)).toBe(true);
+  });
+
+  // Regression: https://github.com/openclaw/openclaw/issues/53876
+  // Binding-created non-default accountId in single-bot setup should report configured.
+  it("reports configured for binding-created accountId in single-bot setup", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "single-bot-token",
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveAccount(cfg, "bot-main");
+    expect(account.token).toBe("single-bot-token");
+    expect(await telegramPlugin.config.isConfigured!(account, cfg)).toBe(true);
+  });
+
   it("does not crash startup when a resolved account token is undefined", async () => {
     const { monitorTelegramProvider, probeTelegram } = installGatewayRuntime({
       probeOk: false,

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -529,6 +529,44 @@ describe("telegramPlugin duplicate token guard", () => {
     expect(telegramPlugin.config.unconfiguredReason?.(account, cfg)).toContain("unknown accountId");
   });
 
+  // Regression: multi-bot guard must use full normalization (same as resolveTelegramToken)
+  // so that account keys like "Carey Notifications" resolve to "carey-notifications".
+  it("multi-bot guard normalizes account keys with spaces and mixed case", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "channel-level-token",
+          enabled: true,
+          accounts: {
+            "Carey Notifications": { botToken: "carey-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    // "carey-notifications" is the normalized form of "Carey Notifications"
+    const account = resolveAccount(cfg, "carey-notifications");
+    expect(await telegramPlugin.config.isConfigured!(account, cfg)).toBe(true);
+  });
+
+  // Regression: configured_unavailable token (e.g. unreadable tokenFile) should
+  // NOT be reported as configured — runtime would fail to authenticate.
+  it("reports not configured when token is configured_unavailable", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          tokenFile: "/nonexistent/path/to/token",
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveAccount(cfg, "default");
+    // tokenFile is configured but file doesn't exist → configured_unavailable
+    expect(await telegramPlugin.config.isConfigured!(account, cfg)).toBe(false);
+    expect(telegramPlugin.config.unconfiguredReason?.(account, cfg)).toContain("unavailable");
+  });
+
   it("does not crash startup when a resolved account token is undefined", async () => {
     const { monitorTelegramProvider, probeTelegram } = installGatewayRuntime({
       probeOk: false,

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -509,6 +509,26 @@ describe("telegramPlugin duplicate token guard", () => {
     expect(await telegramPlugin.config.isConfigured!(account, cfg)).toBe(true);
   });
 
+  // Regression: multi-bot guard — unknown binding-created accountId in multi-bot
+  // setup must NOT be reported as configured, matching resolveTelegramToken behaviour.
+  it("reports not configured for unknown binding-created accountId in multi-bot setup", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "channel-level-token",
+          enabled: true,
+          accounts: {
+            knownBot: { botToken: "known-bot-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = resolveAccount(cfg, "unknownBot");
+    expect(await telegramPlugin.config.isConfigured!(account, cfg)).toBe(false);
+    expect(telegramPlugin.config.unconfiguredReason?.(account, cfg)).toContain("unknown accountId");
+  });
+
   it("does not crash startup when a resolved account token is undefined", async () => {
     const { monitorTelegramProvider, probeTelegram } = installGatewayRuntime({
       probeOk: false,

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -4,6 +4,7 @@ import {
   createScopedChannelConfigAdapter,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createChannelPluginBase } from "openclaw/plugin-sdk/core";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import {
   buildChannelConfigSchema,
   getChatChannelMeta,
@@ -17,6 +18,7 @@ import {
   listTelegramAccountIds,
   resolveDefaultTelegramAccountId,
   resolveTelegramAccount,
+  resolveTelegramAccountConfig,
   type ResolvedTelegramAccount,
 } from "./accounts.js";
 
@@ -54,6 +56,36 @@ export function formatDuplicateTelegramTokenReason(params: {
     `Duplicate Telegram bot token: account "${params.accountId}" shares a token with ` +
     `account "${params.ownerAccountId}". Keep one owner account per bot token.`
   );
+}
+
+/**
+ * Returns true when the runtime token resolver (`resolveTelegramToken`) would
+ * block channel-level fallthrough for the given accountId.  This mirrors the
+ * guard in `token.ts` so that status-check functions (`isConfigured`,
+ * `unconfiguredReason`, `describeAccount`) stay consistent with the gateway
+ * runtime behaviour.
+ *
+ * The guard fires when:
+ *   1. The accountId is not the default account, AND
+ *   2. The config has an explicit `accounts` section with entries, AND
+ *   3. The accountId is not found in that `accounts` section.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/53876
+ */
+function isBlockedByMultiBotGuard(cfg: OpenClawConfig, accountId: string): boolean {
+  if (normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID) {
+    return false;
+  }
+  const accounts = cfg.channels?.telegram?.accounts;
+  const hasConfiguredAccounts =
+    !!accounts &&
+    typeof accounts === "object" &&
+    !Array.isArray(accounts) &&
+    Object.keys(accounts).length > 0;
+  if (!hasConfiguredAccounts) {
+    return false;
+  }
+  return !resolveTelegramAccountConfig(cfg, accountId);
 }
 
 export const telegramConfigAdapter = createScopedChannelConfigAdapter<ResolvedTelegramAccount>({
@@ -102,6 +134,9 @@ export function createTelegramPluginBase(params: {
         // This ensures binding-created accountIds that inherit the channel-level
         // token are correctly detected as configured.
         // See: https://github.com/openclaw/openclaw/issues/53876
+        if (isBlockedByMultiBotGuard(cfg, account.accountId)) {
+          return false;
+        }
         const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
         if (!inspected.configured) {
           return false;
@@ -109,6 +144,9 @@ export function createTelegramPluginBase(params: {
         return !findTelegramTokenOwnerAccountId({ cfg, accountId: account.accountId });
       },
       unconfiguredReason: (account, cfg) => {
+        if (isBlockedByMultiBotGuard(cfg, account.accountId)) {
+          return `not configured: unknown accountId "${account.accountId}" in multi-bot setup`;
+        }
         const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
         if (!inspected.configured) {
           return "not configured";
@@ -126,6 +164,15 @@ export function createTelegramPluginBase(params: {
         });
       },
       describeAccount: (account, cfg) => {
+        if (isBlockedByMultiBotGuard(cfg, account.accountId)) {
+          return {
+            accountId: account.accountId,
+            name: account.name,
+            enabled: account.enabled,
+            configured: false,
+            tokenSource: "none" as const,
+          };
+        }
         const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
         return {
           accountId: account.accountId,

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -1,3 +1,4 @@
+import { resolveNormalizedAccountEntry } from "openclaw/plugin-sdk/account-resolution";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import {
   adaptScopedAccountAccessor,
@@ -18,7 +19,6 @@ import {
   listTelegramAccountIds,
   resolveDefaultTelegramAccountId,
   resolveTelegramAccount,
-  resolveTelegramAccountConfig,
   type ResolvedTelegramAccount,
 } from "./accounts.js";
 
@@ -85,7 +85,10 @@ function isBlockedByMultiBotGuard(cfg: OpenClawConfig, accountId: string): boole
   if (!hasConfiguredAccounts) {
     return false;
   }
-  return !resolveTelegramAccountConfig(cfg, accountId);
+  // Use resolveNormalizedAccountEntry (same as resolveTelegramToken in token.ts)
+  // instead of resolveAccountEntry to handle keys that require full normalization
+  // (e.g. "Carey Notifications" → "carey-notifications").
+  return !resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
 }
 
 export const telegramConfigAdapter = createScopedChannelConfigAdapter<ResolvedTelegramAccount>({
@@ -138,7 +141,10 @@ export function createTelegramPluginBase(params: {
           return false;
         }
         const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
-        if (!inspected.configured) {
+        // Gate on actually available token, not just "configured" — the latter
+        // includes "configured_unavailable" (unreadable tokenFile, unresolved
+        // SecretRef) which would pass here but fail at runtime.
+        if (!inspected.token?.trim()) {
           return false;
         }
         return !findTelegramTokenOwnerAccountId({ cfg, accountId: account.accountId });
@@ -148,7 +154,10 @@ export function createTelegramPluginBase(params: {
           return `not configured: unknown accountId "${account.accountId}" in multi-bot setup`;
         }
         const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
-        if (!inspected.configured) {
+        if (!inspected.token?.trim()) {
+          if (inspected.tokenStatus === "configured_unavailable") {
+            return `not configured: token ${inspected.tokenSource} is configured but unavailable`;
+          }
           return "not configured";
         }
         const ownerAccountId = findTelegramTokenOwnerAccountId({
@@ -179,7 +188,7 @@ export function createTelegramPluginBase(params: {
           name: account.name,
           enabled: account.enabled,
           configured:
-            inspected.configured &&
+            !!inspected.token?.trim() &&
             !findTelegramTokenOwnerAccountId({ cfg, accountId: account.accountId }),
           tokenSource: inspected.tokenSource,
         };

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -97,13 +97,20 @@ export function createTelegramPluginBase(params: {
     config: {
       ...telegramConfigAdapter,
       isConfigured: (account, cfg) => {
-        if (!account.token?.trim()) {
+        // Use inspectTelegramAccount for a complete token resolution that includes
+        // channel-level fallback paths not available in resolveTelegramAccount.
+        // This ensures binding-created accountIds that inherit the channel-level
+        // token are correctly detected as configured.
+        // See: https://github.com/openclaw/openclaw/issues/53876
+        const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
+        if (!inspected.configured) {
           return false;
         }
         return !findTelegramTokenOwnerAccountId({ cfg, accountId: account.accountId });
       },
       unconfiguredReason: (account, cfg) => {
-        if (!account.token?.trim()) {
+        const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
+        if (!inspected.configured) {
           return "not configured";
         }
         const ownerAccountId = findTelegramTokenOwnerAccountId({
@@ -118,15 +125,18 @@ export function createTelegramPluginBase(params: {
           ownerAccountId,
         });
       },
-      describeAccount: (account, cfg) => ({
-        accountId: account.accountId,
-        name: account.name,
-        enabled: account.enabled,
-        configured:
-          Boolean(account.token?.trim()) &&
-          !findTelegramTokenOwnerAccountId({ cfg, accountId: account.accountId }),
-        tokenSource: account.tokenSource,
-      }),
+      describeAccount: (account, cfg) => {
+        const inspected = inspectTelegramAccount({ cfg, accountId: account.accountId });
+        return {
+          accountId: account.accountId,
+          name: account.name,
+          enabled: account.enabled,
+          configured:
+            inspected.configured &&
+            !findTelegramTokenOwnerAccountId({ cfg, accountId: account.accountId }),
+          tokenSource: inspected.tokenSource,
+        };
+      },
     },
     setup: params.setup,
   }) as Pick<

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -236,6 +236,42 @@ describe("resolveTelegramToken", () => {
       /channels\.telegram\.botToken: unresolved SecretRef/i,
     );
   });
+
+  // Regression: https://github.com/openclaw/openclaw/issues/53876
+  // Binding-created accountIds should inherit the channel-level token in
+  // single-bot setups (no accounts section).
+  it("falls through to channel-level token for binding-created accountId without accounts section", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "channel-level-token",
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    const res = resolveTelegramToken(cfg, { accountId: "bot-main" });
+    expect(res.token).toBe("channel-level-token");
+    expect(res.source).toBe("config");
+  });
+
+  it("still blocks fallthrough for unknown accountId when accounts section exists", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "wrong-bot-token",
+          accounts: {
+            knownBot: { botToken: "known-bot-token" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const res = resolveTelegramToken(cfg, { accountId: "unknownBot" });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
+  });
 });
 
 describe("telegram update offset store", () => {

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -39,13 +39,28 @@ export function resolveTelegramToken(
   );
 
   // When a non-default accountId is explicitly specified but not found in config,
-  // return empty immediately — do NOT fall through to channel-level defaults,
-  // which would silently route the message via the wrong bot's token.
+  // decide whether to fall through to channel-level defaults based on whether
+  // the config has an explicit accounts section (multi-bot setup).
+  //
+  // Multi-bot: accounts section exists with entries → block fallthrough to prevent
+  // routing via the wrong bot's token.
+  //
+  // Single-bot: no accounts section (or empty) → allow fallthrough so that
+  // binding-created accountIds inherit the channel-level token.
+  // See: https://github.com/openclaw/openclaw/issues/53876
   if (accountId !== DEFAULT_ACCOUNT_ID && !accountCfg) {
-    opts.logMissingFile?.(
-      `channels.telegram.accounts: unknown accountId "${accountId}" — not found in config, refusing channel-level fallback`,
-    );
-    return { token: "", source: "none" };
+    const accounts = telegramCfg?.accounts;
+    const hasConfiguredAccounts =
+      !!accounts &&
+      typeof accounts === "object" &&
+      !Array.isArray(accounts) &&
+      Object.keys(accounts).length > 0;
+    if (hasConfiguredAccounts) {
+      opts.logMissingFile?.(
+        `channels.telegram.accounts: unknown accountId "${accountId}" — not found in config, refusing channel-level fallback`,
+      );
+      return { token: "", source: "none" };
+    }
   }
 
   const accountTokenFile = accountCfg?.tokenFile?.trim();


### PR DESCRIPTION
## Summary

Fixes #53876 — Telegram channel shows "not configured" after upgrading from
v2026.3.13 to v2026.3.22/v2026.3.23.

## Root Cause

Two interrelated bugs introduced in the v2026.3.22 refactor:

1. **`resolveTelegramToken`** unconditionally blocked channel-level token
   fallthrough for ALL non-default accountIds not found in the `accounts`
   config section. This broke single-bot setups where agent bindings create
   non-default accountIds that should legitimately inherit the channel-level
   token.

2. **`isConfigured`/`unconfiguredReason`/`describeAccount`** relied on the
   account object from `resolveAccount` (which uses `resolveTelegramToken`)
   for token detection, instead of `inspectTelegramAccount` which correctly
   handles all fallback paths. This caused a disconnect: `channels list`
   showed "configured" while the gateway reported "not configured".

## Changes

### `extensions/telegram/src/token.ts`

- Changed the non-default accountId guard to only block fallthrough when
  the config has an explicit `accounts` section (multi-bot setup)
- In single-bot setups (no `accounts` section), binding-created accountIds
  now correctly inherit the channel-level token

### `extensions/telegram/src/shared.ts`

- `isConfigured`, `unconfiguredReason`, and `describeAccount` now use
  `inspectTelegramAccount` for complete token resolution that includes
  channel-level fallback paths
- This ensures consistency between CLI (`channels list`) and gateway
  runtime behavior

### `extensions/telegram/src/token.test.ts`

- Added regression test for binding-created accountId fallthrough
- Added regression test confirming multi-bot guard still blocks correctly

### `extensions/telegram/src/channel.test.ts`

- Added regression test for `isConfigured` with single-bot channel-level token
- Added regression test for `isConfigured` with binding-created accountId

## Test Results

All 59 Telegram tests pass (17 token + 15 channel + 23 accounts +
4 account-inspect).