### PR TITLE
fix: improve chat send button icon contrast in light theme

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -498,7 +498,7 @@
   border-radius: var(--radius-md);
   border: none;
   background: var(--muted-strong);
-  color: var(--text-strong);
+  color: var(--primary-foreground);
   cursor: pointer;
   flex-shrink: 0;
   transition:


### PR DESCRIPTION
## Summary

- **Problem:** The chat send button icon has insufficient color contrast in light theme (~2.3:1 ratio, fails WCAG AA 4.5:1 minimum). `--text-strong` (#1a1a1e, dark) on `--muted-strong` (#545458, medium gray) produces poor visibility.
- **Why it matters:** Accessibility — users with visual impairments cannot clearly distinguish the send button icon.
- **What changed:** Switched `.chat-send-btn` icon color from `var(--text-strong)` to `var(--primary-foreground)` (#ffffff), achieving ~5.5:1 contrast in light theme and ~3.4:1 in dark theme (meets WCAG 1.4.11 graphical object threshold of 3:1).
- **What did NOT change:** Button background, sizing, hover states, or stop button styling.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Contrast comparison

| Theme | Background | Old icon color | Old ratio | New icon color | New ratio |
|-------|-----------|---------------|-----------|---------------|-----------|
| Light | `#545458` | `#1a1a1e` | ~2.3:1 ✗ | `#ffffff` | ~5.5:1 ✓ |
| Dark  | `#75757d` | `#f4f4f5` | ~4.2:1 ✓ | `#ffffff` | ~3.4:1 ✓ |

Closes #54348