### PR TITLE
fix(skill-creator): default to workspace skills directory to prevent data loss on upgrade

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -268,28 +268,43 @@ Skip this step only if the skill being developed already exists, and iteration o
 
 When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
 
+**Important: Always create skills in your workspace directory, NOT in the global OpenClaw installation.** Skills created in the global `node_modules/openclaw/skills/` directory will be lost when you upgrade OpenClaw.
+
 Usage:
 
 ```bash
-scripts/init_skill.py <skill-name> --path <output-directory> [--resources scripts,references,assets] [--examples]
+scripts/init_skill.py <skill-name> [--path <output-directory>] [--resources scripts,references,assets] [--examples]
 ```
 
 Examples:
 
 ```bash
-scripts/init_skill.py my-skill --path skills/public
-scripts/init_skill.py my-skill --path skills/public --resources scripts,references
-scripts/init_skill.py my-skill --path skills/public --resources scripts --examples
+# Create in default workspace skills directory (~/.openclaw/workspace/skills/)
+scripts/init_skill.py my-skill
+
+# Create in default workspace with resources
+scripts/init_skill.py my-skill --resources scripts,references
+
+# Create in default workspace with resources and examples
+scripts/init_skill.py my-skill --resources scripts --examples
+
+# Create in a custom directory (use absolute paths to avoid confusion)
+scripts/init_skill.py my-skill --path /absolute/path/to/skills
+scripts/init_skill.py my-skill --path ~/.openclaw/workspace/skills
 ```
 
 The script:
 
-- Creates the skill directory at the specified path
+- Creates the skill directory at the specified path (defaults to workspace skills directory if `--path` is omitted)
 - Generates a SKILL.md template with proper frontmatter and TODO placeholders
 - Optionally creates resource directories based on `--resources`
 - Optionally adds example files when `--examples` is set
 
 After initialization, customize the SKILL.md and add resources as needed. If you used `--examples`, replace or delete placeholder files.
+
+**Default behavior:** When `--path` is not specified, the skill is created in:
+- `~/.openclaw/workspace/skills/<skill-name>/` (default)
+- Or `$OPENCLAW_WORKSPACE_DIR/skills/<skill-name>/` if the environment variable is set
 
 ### Step 4: Edit the Skill
 

--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -3,16 +3,22 @@
 Skill Initializer - Creates a new skill from template
 
 Usage:
-    init_skill.py <skill-name> --path <path> [--resources scripts,references,assets] [--examples]
+    init_skill.py <skill-name> [--path <path>] [--resources scripts,references,assets] [--examples]
 
 Examples:
-    init_skill.py my-new-skill --path skills/public
-    init_skill.py my-new-skill --path skills/public --resources scripts,references
-    init_skill.py my-api-helper --path skills/private --resources scripts --examples
+    init_skill.py my-new-skill                                    # Creates in workspace skills directory
+    init_skill.py my-new-skill --path /absolute/path/to/skills    # Creates in specified directory
+    init_skill.py my-new-skill --path ~/.openclaw/workspace/skills --resources scripts,references
+    init_skill.py my-api-helper --resources scripts --examples
     init_skill.py custom-skill --path /custom/location
+
+When --path is not specified, the skill is created in the OpenClaw workspace skills directory:
+- Defaults to ~/.openclaw/workspace/skills/<skill-name>
+- Respects OPENCLAW_WORKSPACE_DIR environment variable if set
 """
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -317,12 +323,41 @@ def init_skill(skill_name, path, resources, include_examples):
     return skill_dir
 
 
+def resolve_default_skills_dir():
+    """
+    Resolve the default skills directory for the OpenClaw workspace.
+    
+    Priority:
+    1. OPENCLAW_WORKSPACE_DIR env var + /skills
+    2. ~/.openclaw/workspace/skills (default)
+    
+    Returns the absolute path to the skills directory.
+    """
+    # Check for workspace directory override
+    workspace_dir = os.environ.get("OPENCLAW_WORKSPACE_DIR", "").strip()
+    if not workspace_dir:
+        # Default workspace directory
+        home = os.path.expanduser("~")
+        workspace_dir = os.path.join(home, ".openclaw", "workspace")
+    else:
+        # Expand tilde in env var (e.g., "~/.openclaw/workspace")
+        workspace_dir = os.path.expanduser(workspace_dir)
+    
+    skills_dir = os.path.join(workspace_dir, "skills")
+    return os.path.abspath(skills_dir)
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Create a new skill directory with a SKILL.md template.",
     )
     parser.add_argument("skill_name", help="Skill name (normalized to hyphen-case)")
-    parser.add_argument("--path", required=True, help="Output directory for the skill")
+    parser.add_argument(
+        "--path",
+        required=False,
+        default=None,
+        help="Output directory for the skill (default: workspace skills directory)",
+    )
     parser.add_argument(
         "--resources",
         default="",
@@ -354,7 +389,12 @@ def main():
         print("[ERROR] --examples requires --resources to be set.")
         sys.exit(1)
 
-    path = args.path
+    # Resolve path: use provided --path or default to workspace skills directory
+    if args.path:
+        path = args.path
+    else:
+        path = resolve_default_skills_dir()
+        print(f"[INFO] No --path specified, using default workspace skills directory: {path}")
 
     print(f"Initializing skill: {skill_name}")
     print(f"   Location: {path}")


### PR DESCRIPTION
## Problem

When using the `skill-creator` skill to automatically generate a new skill, skills were being created in the global `node_modules/openclaw/skills/` directory instead of the user's workspace directory (`~/.openclaw/workspace/skills/`).

This is a critical issue because:
1. Skills created in the global directory are lost when upgrading OpenClaw via `npm install -g openclaw@latest`
2. Users expect their custom skills to persist across upgrades
3. The global `node_modules` directory is not the appropriate location for user-created content

## Root Cause

The `init_skill.py` script required a `--path` argument, and the skill-creator SKILL.md documentation showed examples with relative paths like `skills/public`. When the agent executed this command, the relative path was resolved against the current working directory, which was often the global OpenClaw installation directory.

## Solution

1. **Make `--path` optional**: The `init_skill.py` script now defaults to the workspace skills directory when `--path` is not specified.

2. **Smart default path resolution**: Added `resolve_default_skills_dir()` function that:
   - Defaults to `~/.openclaw/workspace/skills/`
   - Respects the `OPENCLAW_WORKSPACE_DIR` environment variable if set

3. **Updated documentation**: Enhanced SKILL.md with:
   - Clear warning about NOT creating skills in global node_modules
   - Examples showing the new default behavior
   - Explicit guidance to use absolute paths for custom locations

## Changes

- `skills/skill-creator/scripts/init_skill.py`: Make `--path` optional, add default path resolution
- `skills/skill-creator/SKILL.md`: Add warnings and updated examples

## Testing

The changes maintain backward compatibility:
- Existing usage with `--path` continues to work as before
- New default behavior safely directs skills to the workspace directory
- Respects environment variable overrides for advanced configurations