### PR TITLE
fix(gateway): propagate AbortController signal on HTTP client disconnect

### DIFF
--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -106,3 +106,35 @@ export function setSseHeaders(res: ServerResponse) {
   res.setHeader("Connection", "keep-alive");
   res.flushHeaders?.();
 }
+
+export function watchClientDisconnect(
+  req: IncomingMessage,
+  res: ServerResponse,
+  abortController: AbortController,
+  onDisconnect?: () => void,
+) {
+  const sockets = Array.from(
+    new Set(
+      [req.socket, res.socket].filter(
+        (socket): socket is NonNullable<typeof socket> => socket !== null,
+      ),
+    ),
+  );
+  if (sockets.length === 0) {
+    return () => {};
+  }
+  const handleClose = () => {
+    onDisconnect?.();
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+  };
+  for (const socket of sockets) {
+    socket.on("close", handleClose);
+  }
+  return () => {
+    for (const socket of sockets) {
+      socket.off("close", handleClose);
+    }
+  };
+}

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -881,4 +882,109 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       await server.close({ reason: "openai token auth owner test done" });
     }
   });
+
+  it("aborts agent command when streaming client disconnects", { timeout: 15_000 }, async () => {
+    const port = enabledPort;
+    let serverAbortSignal: AbortSignal | undefined;
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(
+      (opts: unknown) =>
+        new Promise<undefined>((resolve) => {
+          const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+          serverAbortSignal = signal;
+          if (signal?.aborted) {
+            resolve(undefined);
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+        }),
+    );
+
+    const clientReq = http.request({
+      hostname: "127.0.0.1",
+      port,
+      path: "/v1/chat/completions",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer secret",
+      },
+    });
+    clientReq.on("error", () => {});
+    clientReq.end(
+      JSON.stringify({
+        stream: true,
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    });
+
+    clientReq.destroy();
+
+    await vi.waitFor(
+      () => {
+        expect(serverAbortSignal?.aborted).toBe(true);
+      },
+      { timeout: 5_000, interval: 50 },
+    );
+  });
+
+  it(
+    "aborts agent command when non-streaming client disconnects",
+    { timeout: 15_000 },
+    async () => {
+      const port = enabledPort;
+      let serverAbortSignal: AbortSignal | undefined;
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce(
+        (opts: unknown) =>
+          new Promise<undefined>((resolve) => {
+            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            serverAbortSignal = signal;
+            if (signal?.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+          }),
+      );
+
+      const clientReq = http.request({
+        hostname: "127.0.0.1",
+        port,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer secret",
+        },
+      });
+      clientReq.on("error", () => {});
+      clientReq.end(
+        JSON.stringify({
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(agentCommand).toHaveBeenCalledTimes(1);
+      });
+
+      clientReq.destroy();
+
+      await vi.waitFor(
+        () => {
+          expect(serverAbortSignal?.aborted).toBe(true);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+    },
+  );
 });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -515,7 +515,7 @@ export async function handleOpenAiHttpRequest(
     // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
     // before we reach this point. ServerResponse stays alive until the response is written,
     // so its `close` event reliably fires on premature client disconnect.
-    res.on("close", () => {
+    res.on("cabortController.signal.abortedlose", () => {
       if (!abortController.signal.aborted) {
         abortController.abort();
       }
@@ -640,10 +640,10 @@ export async function handleOpenAiHttpRequest(
         });
       }
     } catch (err) {
-      logWarn(`openai-compat: streaming chat completion failed: ${String(err)}`);
-      if (closed) {
+      if (closed || abortController.signal.aborted) {
         return;
       }
+      logWarn(`openai-compat: streaming chat completion failed: ${String(err)}`);
       writeAssistantContentChunk(res, {
         runId,
         model,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -112,6 +112,7 @@ function buildAgentCommandInput(params: {
   runId: string;
   messageChannel: string;
   senderIsOwner: boolean;
+  abortSignal?: AbortSignal;
 }) {
   return {
     message: params.prompt.message,
@@ -125,6 +126,7 @@ function buildAgentCommandInput(params: {
     bestEffortDeliver: false as const,
     senderIsOwner: params.senderIsOwner,
     allowModelOverride: true as const,
+    abortSignal: params.abortSignal,
   };
 }
 
@@ -493,6 +495,7 @@ export async function handleOpenAiHttpRequest(
 
   const runId = `chatcmpl_${randomUUID()}`;
   const deps = createDefaultDeps();
+  const abortController = new AbortController();
   const commandInput = buildAgentCommandInput({
     prompt: {
       message: prompt.message,
@@ -503,12 +506,26 @@ export async function handleOpenAiHttpRequest(
     sessionKey,
     runId,
     messageChannel,
+    abortSignal: abortController.signal,
     senderIsOwner,
   });
 
   if (!stream) {
+    // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
+    // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
+    // before we reach this point. ServerResponse stays alive until the response is written,
+    // so its `close` event reliably fires on premature client disconnect.
+    res.on("close", () => {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    });
     try {
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+
+      if (abortController.signal.aborted) {
+        return true;
+      }
 
       const content = resolveAgentResponseText(result);
 
@@ -527,6 +544,9 @@ export async function handleOpenAiHttpRequest(
         usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
       });
     } catch (err) {
+      if (abortController.signal.aborted) {
+        return true;
+      }
       logWarn(`openai-compat: chat completion failed: ${String(err)}`);
       sendJson(res, 500, {
         error: { message: "internal error", type: "api_error" },
@@ -581,7 +601,16 @@ export async function handleOpenAiHttpRequest(
     }
   });
 
-  req.on("close", () => {
+  // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
+  // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
+  // before we reach this point. ServerResponse stays alive until the response is written,
+  // so its `close` event reliably fires on premature client disconnect.
+  res.on("close", () => {
+    // Only abort on genuine client disconnect; when we called res.end()
+    // ourselves, closed is already true so we skip the abort.
+    if (!closed) {
+      abortController.abort();
+    }
     closed = true;
     unsubscribe();
   });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -25,7 +25,7 @@ import {
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
+import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   resolveGatewayRequestContext,
@@ -511,15 +511,7 @@ export async function handleOpenAiHttpRequest(
   });
 
   if (!stream) {
-    // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
-    // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
-    // before we reach this point. ServerResponse stays alive until the response is written,
-    // so its `close` event reliably fires on premature client disconnect.
-    res.on("close", () => {
-      if (!abortController.signal.aborted) {
-        abortController.abort();
-      }
-    });
+    const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
     try {
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
 
@@ -551,6 +543,8 @@ export async function handleOpenAiHttpRequest(
       sendJson(res, 500, {
         error: { message: "internal error", type: "api_error" },
       });
+    } finally {
+      stopWatchingDisconnect();
     }
     return true;
   }
@@ -560,6 +554,7 @@ export async function handleOpenAiHttpRequest(
   let wroteRole = false;
   let sawAssistantDelta = false;
   let closed = false;
+  let stopWatchingDisconnect = () => {};
 
   const unsubscribe = onAgentEvent((evt) => {
     if (evt.runId !== runId) {
@@ -594,6 +589,7 @@ export async function handleOpenAiHttpRequest(
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
         closed = true;
+        stopWatchingDisconnect();
         unsubscribe();
         writeDone(res);
         res.end();
@@ -601,16 +597,7 @@ export async function handleOpenAiHttpRequest(
     }
   });
 
-  // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
-  // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
-  // before we reach this point. ServerResponse stays alive until the response is written,
-  // so its `close` event reliably fires on premature client disconnect.
-  res.on("close", () => {
-    // Only abort on genuine client disconnect; when we called res.end()
-    // ourselves, closed is already true so we skip the abort.
-    if (!closed) {
-      abortController.abort();
-    }
+  stopWatchingDisconnect = watchClientDisconnect(req, res, abortController, () => {
     closed = true;
     unsubscribe();
   });
@@ -658,6 +645,7 @@ export async function handleOpenAiHttpRequest(
     } finally {
       if (!closed) {
         closed = true;
+        stopWatchingDisconnect();
         unsubscribe();
         writeDone(res);
         res.end();

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -515,7 +515,7 @@ export async function handleOpenAiHttpRequest(
     // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
     // before we reach this point. ServerResponse stays alive until the response is written,
     // so its `close` event reliably fires on premature client disconnect.
-    res.on("cabortController.signal.abortedlose", () => {
+    res.on("close", () => {
       if (!abortController.signal.aborted) {
         abortController.abort();
       }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -1169,4 +1170,109 @@ describe("OpenResponses HTTP API (e2e)", () => {
       await capServer.close({ reason: "responses url cap hardening test done" });
     }
   });
+
+  it("aborts agent command when streaming client disconnects", { timeout: 15_000 }, async () => {
+    const port = enabledPort;
+    let serverAbortSignal: AbortSignal | undefined;
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(
+      (opts: unknown) =>
+        new Promise<undefined>((resolve) => {
+          const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+          serverAbortSignal = signal;
+          if (signal?.aborted) {
+            resolve(undefined);
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+        }),
+    );
+
+    const clientReq = http.request({
+      hostname: "127.0.0.1",
+      port,
+      path: "/v1/responses",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer secret",
+      },
+    });
+    clientReq.on("error", () => {});
+    clientReq.end(
+      JSON.stringify({
+        stream: true,
+        model: "openclaw",
+        input: "hi",
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    });
+
+    clientReq.destroy();
+
+    await vi.waitFor(
+      () => {
+        expect(serverAbortSignal?.aborted).toBe(true);
+      },
+      { timeout: 5_000, interval: 50 },
+    );
+  });
+
+  it(
+    "aborts agent command when non-streaming client disconnects",
+    { timeout: 15_000 },
+    async () => {
+      const port = enabledPort;
+      let serverAbortSignal: AbortSignal | undefined;
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce(
+        (opts: unknown) =>
+          new Promise<undefined>((resolve) => {
+            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            serverAbortSignal = signal;
+            if (signal?.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+          }),
+      );
+
+      const clientReq = http.request({
+        hostname: "127.0.0.1",
+        port,
+        path: "/v1/responses",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: "Bearer secret",
+        },
+      });
+      clientReq.on("error", () => {});
+      clientReq.end(
+        JSON.stringify({
+          model: "openclaw",
+          input: "hi",
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(agentCommand).toHaveBeenCalledTimes(1);
+      });
+
+      clientReq.destroy();
+
+      await vi.waitFor(
+        () => {
+          expect(serverAbortSignal?.aborted).toBe(true);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+    },
+  );
 });

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -34,7 +34,7 @@ import { wrapExternalContent } from "../security/external-content.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
+import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   getBearerToken,
@@ -684,15 +684,7 @@ export async function handleOpenResponsesHttpRequest(
       : undefined;
 
   if (!stream) {
-    // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
-    // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
-    // before we reach this point. ServerResponse stays alive until the response is written,
-    // so its `close` event reliably fires on premature client disconnect.
-    res.on("close", () => {
-      if (!abortController.signal.aborted) {
-        abortController.abort();
-      }
-    });
+    const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -802,6 +794,8 @@ export async function handleOpenResponsesHttpRequest(
       });
       rememberResponseSession();
       sendJson(res, 500, response);
+    } finally {
+      stopWatchingDisconnect();
     }
     return true;
   }
@@ -816,6 +810,7 @@ export async function handleOpenResponsesHttpRequest(
   let sawAssistantDelta = false;
   let closed = false;
   let unsubscribe = () => {};
+  let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
 
@@ -832,6 +827,7 @@ export async function handleOpenResponsesHttpRequest(
     const usage = finalUsage;
 
     closed = true;
+    stopWatchingDisconnect();
     unsubscribe();
 
     writeSseEvent(res, {
@@ -960,16 +956,7 @@ export async function handleOpenResponsesHttpRequest(
     }
   });
 
-  // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
-  // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
-  // before we reach this point. ServerResponse stays alive until the response is written,
-  // so its `close` event reliably fires on premature client disconnect.
-  res.on("close", () => {
-    // Only abort on genuine client disconnect; when we called res.end()
-    // ourselves, closed is already true so we skip the abort.
-    if (!closed) {
-      abortController.abort();
-    }
+  stopWatchingDisconnect = watchClientDisconnect(req, res, abortController, () => {
     closed = true;
     unsubscribe();
   });
@@ -1076,6 +1063,7 @@ export async function handleOpenResponsesHttpRequest(
           usage,
         });
         closed = true;
+        stopWatchingDisconnect();
         unsubscribe();
         rememberResponseSession();
         writeSseEvent(res, { type: "response.completed", response: incompleteResponse });

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1113,10 +1113,10 @@ export async function handleOpenResponsesHttpRequest(
         });
       }
     } catch (err) {
-      logWarn(`openresponses: streaming response failed: ${String(err)}`);
-      if (closed) {
+      if (closed || abortController.signal.aborted) {
         return;
       }
+      logWarn(`openresponses: streaming response failed: ${String(err)}`);
 
       finalUsage = finalUsage ?? createEmptyUsage();
       const errorResponse = createResponseResource({

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -407,6 +407,7 @@ async function runResponsesAgentCommand(params: {
   messageChannel: string;
   senderIsOwner: boolean;
   deps: ReturnType<typeof createDefaultDeps>;
+  abortSignal?: AbortSignal;
 }) {
   return agentCommandFromIngress(
     {
@@ -423,6 +424,7 @@ async function runResponsesAgentCommand(params: {
       bestEffortDeliver: false,
       senderIsOwner: params.senderIsOwner,
       allowModelOverride: true,
+      abortSignal: params.abortSignal,
     },
     defaultRuntime,
     params.deps,
@@ -675,12 +677,22 @@ export async function handleOpenResponsesHttpRequest(
     storeResponseSession(responseId, sessionKey, responseSessionScope);
   const outputItemId = `msg_${randomUUID()}`;
   const deps = createDefaultDeps();
+  const abortController = new AbortController();
   const streamParams =
     typeof payload.max_output_tokens === "number"
       ? { maxTokens: payload.max_output_tokens }
       : undefined;
 
   if (!stream) {
+    // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
+    // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
+    // before we reach this point. ServerResponse stays alive until the response is written,
+    // so its `close` event reliably fires on premature client disconnect.
+    res.on("close", () => {
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    });
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -694,7 +706,12 @@ export async function handleOpenResponsesHttpRequest(
         messageChannel,
         senderIsOwner,
         deps,
+        abortSignal: abortController.signal,
       });
+
+      if (abortController.signal.aborted) {
+        return true;
+      }
 
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
       const usage = extractUsageFromResult(result);
@@ -772,6 +789,9 @@ export async function handleOpenResponsesHttpRequest(
       rememberResponseSession();
       sendJson(res, 200, response);
     } catch (err) {
+      if (abortController.signal.aborted) {
+        return true;
+      }
       logWarn(`openresponses: non-stream response failed: ${String(err)}`);
       const response = createResponseResource({
         id: responseId,
@@ -940,7 +960,16 @@ export async function handleOpenResponsesHttpRequest(
     }
   });
 
-  req.on("close", () => {
+  // Listen on `res` instead of `req` because handleGatewayPostJsonEndpoint has already
+  // consumed the request body, causing IncomingMessage to auto-destroy and emit `close`
+  // before we reach this point. ServerResponse stays alive until the response is written,
+  // so its `close` event reliably fires on premature client disconnect.
+  res.on("close", () => {
+    // Only abort on genuine client disconnect; when we called res.end()
+    // ourselves, closed is already true so we skip the abort.
+    if (!closed) {
+      abortController.abort();
+    }
     closed = true;
     unsubscribe();
   });
@@ -959,6 +988,7 @@ export async function handleOpenResponsesHttpRequest(
         messageChannel,
         senderIsOwner,
         deps,
+        abortSignal: abortController.signal,
       });
 
       finalUsage = extractUsageFromResult(result);


### PR DESCRIPTION
## Summary

- Problem: The `/v1/chat/completions` and `/v1/responses` HTTP endpoints do not cancel the underlying agent execution when a client disconnects. The close handler only sets a `closed` flag and unsubscribes from agent events, but never aborts the in-flight LLM call.
- Why it matters: When an HTTP client disconnects mid-request, the backend continues running the full LLM turn, wasting tokens, compute, and holding resources unnecessarily.
- What changed: Created an `AbortController` in each handler (both streaming and non-streaming paths) and pass `abortController.signal` through to `agentCommandFromIngress`. On client disconnect (`res.on("close")`), the controller is aborted, which propagates cancellation to the agent runtime via the existing `abortSignal` plumbing (`acpManager.runTurn({ signal })`). Used `res.on("close")` instead of `req.on("close")` because the request body is fully consumed by `handleGatewayPostJsonEndpoint` before the abort listener is registered, and `IncomingMessage` auto-destroys after EOF in modern Node.js.
- What did NOT change (scope boundary): No changes to the agent runtime, ACP manager, WebSocket handlers, or any other endpoint. The `AbortSignal` infrastructure was already in place; this PR only wires it into the two HTTP endpoints that were missing it.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: The WebSocket chat handler (`src/gateway/server-methods/chat.ts`) already implements this pattern correctly; this PR brings HTTP endpoints to parity.
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The `/v1/chat/completions` and `/v1/responses` HTTP handlers were originally implemented without `AbortController` integration. The `abortSignal` parameter on `AgentCommandOpts` existed but was never wired in from these HTTP code paths.
- Missing detection / guardrail: No tests verified that client disconnection propagated an abort signal to the agent command layer for HTTP endpoints.
- Prior context: The WebSocket chat handler (`server-methods/chat.ts:1367`) was implemented with proper abort support from the start; the HTTP endpoints were added later without this consideration.
- Why this regressed now: This was never implemented, not a regression from a prior change.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/openai-http.test.ts`, `src/gateway/openresponses-http.test.ts`
- Scenario the test should lock in: When an HTTP client disconnects mid-request (both streaming and non-streaming), the `abortSignal` passed to `agentCommandFromIngress` must transition to aborted state.
- Why this is the smallest reliable guardrail: The tests mock the agent command to observe the abort signal directly, using `http.request` + `req.destroy()` to simulate client disconnection. This isolates the exact behavior without requiring a full agent runtime.
- Existing test that already covers this (if any): None for HTTP; WebSocket abort tests exist in `server.chat.gateway-server-chat-b.test.ts`.
- If no new test is added, why not: N/A — 4 new tests added.

## User-visible / Behavior Changes

When an HTTP client disconnects from `/v1/chat/completions` or `/v1/responses` (streaming or non-streaming), the backend now cancels the in-flight LLM call instead of letting it run to completion. This reduces wasted tokens and frees resources faster.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / pnpm
- Model/provider: Any (mock in tests)
- Integration/channel (if any): HTTP gateway endpoints
- Relevant config (redacted): default local test config

### Steps

1. Start the gateway with HTTP endpoints enabled.
2. Send a streaming or non-streaming request to `/v1/chat/completions` or `/v1/responses`.
3. Disconnect the client before the response completes.

### Expected

- The agent command receives an aborted signal and stops processing.

### Actual

- Before fix: the agent command continues running to completion, wasting resources.
- After fix: matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification commands:

- `pnpm test -- src/gateway/openai-http.test.ts` (6/6 passed)
- `pnpm test -- src/gateway/openresponses-http.test.ts` (14/14 passed)
- `pnpm format` (clean)

## Human Verification (required)

- Verified scenarios: streaming and non-streaming abort propagation for both `/v1/chat/completions` and `/v1/responses`; all pre-existing tests still pass.
- Edge cases checked: `res.on("close")` vs `req.on("close")` — verified that `req.on("close")` does NOT fire reliably after body consumption in modern Node.js due to `IncomingMessage` auto-destroy; switched to `res.on("close")` which fires when the underlying TCP connection closes.
- What you did **not** verify: full `pnpm test` suite run; live integration with real LLM provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; the abort signal is simply ignored if not passed.
- Files/config to restore: `src/gateway/openai-http.ts`, `src/gateway/openresponses-http.ts`.
- Known bad symptoms reviewers should watch for: If `res.on("close")` fires prematurely (before response is sent), it could abort requests that should complete. This would manifest as incomplete or missing responses.

## Risks and Mitigations

- Risk: `res.on("close")` might fire after a successful response is fully sent, calling `abortController.abort()` on an already-completed operation.
  - Mitigation: Aborting an already-completed `AbortController` is a no-op. The agent command has already returned by that point, so the signal is harmless.
