### PR TITLE
fix: honor authHeader provider config by injecting Authorization Bear…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - `/context detail` now compares the tracked prompt estimate with cached context usage and surfaces untracked provider/runtime overhead when present. (#28391) thanks @ImLukeF.
 - Gateway/session reset: emit the typed `before_reset` hook for gateway `/new` and `/reset`, preserving reset-hook behavior even when the previous transcript has already been archived. (#53872) thanks @VACInc
 - Plugins/commands: pass the active host `sessionKey` into plugin command contexts, and include `sessionId` when it is already available from the active session entry, so bundled and third-party commands can resolve the current conversation reliably. (#59044) Thanks @jalehman.
+- Agents/auth: honor `models.providers.*.authHeader` for pi embedded runner model requests by injecting `Authorization: Bearer <apiKey>` when requested. (#54390) Thanks @lndyzwdxhs.
 
 ## 2026.4.2
 
@@ -590,7 +591,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/outbound errors: preserve actionable 403 membership/block/kick details and treat `bot not a member` as a permanent delivery failure so Telegram sends stop retrying doomed chats. (#53635) Thanks @w-sss.
 - Telegram/photos: preflight Telegram photo dimension and aspect-ratio rules, and fall back to document sends when image metadata is invalid or unavailable so photo uploads stop failing with `PHOTO_INVALID_DIMENSIONS`. (#52545) Thanks @hnshah.
 - Slack/runtime defaults: trim Slack DM reply overhead, restore Codex auto transport, and tighten Slack/web-search runtime defaults around DM preview threading, cache scoping, warning dedupe, and explicit web-search opt-in. (#53957) Thanks @vincentkoc.
-- Agents/auth: honor `models.providers.*.authHeader` for pi embedded runner model requests by injecting `Authorization: Bearer <apiKey>` when requested. (#54390) Thanks @lndyzwdxhs.
 - Security/gateway config: block agent `config.apply` and `config.patch` writes to `tools.exec.ask` and `tools.exec.security` so gateway config tools cannot silently disable exec approvals or broaden exec security.
 - Security/chat provenance: require `operator.admin` for system provenance injection so `chat.send` callers cannot spoof ACP-only provenance through client identity metadata.
 - Security/exec approvals: treat `/usr/bin/script` as a transparent wrapper during trust-plan resolution and allow-always persistence so wrapper registration cannot broaden exec approvals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -590,6 +590,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/outbound errors: preserve actionable 403 membership/block/kick details and treat `bot not a member` as a permanent delivery failure so Telegram sends stop retrying doomed chats. (#53635) Thanks @w-sss.
 - Telegram/photos: preflight Telegram photo dimension and aspect-ratio rules, and fall back to document sends when image metadata is invalid or unavailable so photo uploads stop failing with `PHOTO_INVALID_DIMENSIONS`. (#52545) Thanks @hnshah.
 - Slack/runtime defaults: trim Slack DM reply overhead, restore Codex auto transport, and tighten Slack/web-search runtime defaults around DM preview threading, cache scoping, warning dedupe, and explicit web-search opt-in. (#53957) Thanks @vincentkoc.
+- Agents/auth: honor `models.providers.*.authHeader` for pi embedded runner model requests by injecting `Authorization: Bearer <apiKey>` when requested. (#54390) Thanks @lndyzwdxhs.
 - Security/gateway config: block agent `config.apply` and `config.patch` writes to `tools.exec.ask` and `tools.exec.security` so gateway config tools cannot silently disable exec approvals or broaden exec security.
 - Security/chat provenance: require `operator.admin` for system provenance injection so `chat.send` callers cannot spoof ACP-only provenance through client identity metadata.
 - Security/exec approvals: treat `/usr/bin/script` as a transparent wrapper during trust-plan resolution and allow-always persistence so wrapper registration cannot broaden exec approvals.

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -10,6 +10,7 @@ import {
   NON_ENV_SECRETREF_MARKER,
 } from "./model-auth-markers.js";
 import {
+  applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
   hasUsableCustomProviderApiKey,
   requireApiKey,
@@ -707,5 +708,178 @@ describe("applyLocalNoAuthHeaderOverride", () => {
 
     expect(capturedAuthorization).toBeNull();
     expect(capturedXTest).toBe("1");
+  });
+});
+
+describe("applyAuthHeaderOverride", () => {
+  const baseModel: Model<"openai-completions"> = {
+    id: "gemini-3.1-flash-lite-preview",
+    name: "gemini-3.1-flash-lite-preview",
+    api: "openai-completions" as const,
+    provider: "google",
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+    reasoning: false,
+    input: ["text"] as ("text" | "image")[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 131072,
+    maxTokens: 8192,
+  };
+
+  it("injects Authorization Bearer header when authHeader is true", () => {
+    const result = applyAuthHeaderOverride(
+      baseModel,
+      { apiKey: "test-api-key", source: "env", mode: "api-key" },
+      {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+              api: "openai-completions",
+              authHeader: true,
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.headers).toEqual({ Authorization: "Bearer test-api-key" });
+  });
+
+  it("preserves existing model headers when injecting Authorization", () => {
+    const result = applyAuthHeaderOverride(
+      { ...baseModel, headers: { "X-Custom": "value" } },
+      { apiKey: "test-api-key", source: "env", mode: "api-key" },
+      {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+              api: "openai-completions",
+              authHeader: true,
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.headers).toEqual({
+      "X-Custom": "value",
+      Authorization: "Bearer test-api-key",
+    });
+  });
+
+  it("returns model unchanged when authHeader is not set", () => {
+    const result = applyAuthHeaderOverride(
+      baseModel,
+      { apiKey: "test-api-key", source: "env", mode: "api-key" },
+      {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(result).toBe(baseModel);
+  });
+
+  it("returns model unchanged when authHeader is false", () => {
+    const result = applyAuthHeaderOverride(
+      baseModel,
+      { apiKey: "test-api-key", source: "env", mode: "api-key" },
+      {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+              api: "openai-completions",
+              authHeader: false,
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(result).toBe(baseModel);
+  });
+
+  it("returns model unchanged when no API key is available", () => {
+    const result = applyAuthHeaderOverride(baseModel, null, {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+            api: "openai-completions",
+            authHeader: true,
+            models: [],
+          },
+        },
+      },
+    });
+
+    expect(result).toBe(baseModel);
+  });
+
+  it("returns model unchanged when provider config is missing", () => {
+    const result = applyAuthHeaderOverride(
+      baseModel,
+      { apiKey: "test-api-key", source: "env", mode: "api-key" },
+      undefined,
+    );
+
+    expect(result).toBe(baseModel);
+  });
+
+  it("rejects synthetic marker API keys", () => {
+    const result = applyAuthHeaderOverride(
+      baseModel,
+      { apiKey: CUSTOM_LOCAL_AUTH_MARKER, source: "synthetic", mode: "api-key" },
+      {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+              api: "openai-completions",
+              authHeader: true,
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(result).toBe(baseModel);
+  });
+
+  it("strips existing authorization header case-insensitively before injection", () => {
+    const result = applyAuthHeaderOverride(
+      { ...baseModel, headers: { authorization: "old-value", "X-Custom": "keep" } },
+      { apiKey: "test-api-key", source: "env", mode: "api-key" },
+      {
+        models: {
+          providers: {
+            google: {
+              baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+              api: "openai-completions",
+              authHeader: true,
+              models: [],
+            },
+          },
+        },
+      },
+    );
+
+    expect(result.headers).toEqual({
+      "X-Custom": "keep",
+      Authorization: "Bearer test-api-key",
+    });
   });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -586,3 +586,48 @@ export function applyLocalNoAuthHeaderOverride<T extends Model<Api>>(
     headers,
   };
 }
+
+/**
+ * When the provider config sets `authHeader: true`, inject an explicit
+ * `Authorization: Bearer <apiKey>` header into the model so downstream SDKs
+ * (e.g. `@google/genai`) send credentials via the standard HTTP Authorization
+ * header instead of vendor-specific headers like `x-goog-api-key`.
+ *
+ * This is a no-op when `authHeader` is not `true`, when no API key is
+ * available, or when the API key is a synthetic marker (e.g. local-server
+ * placeholders) rather than a real credential.
+ */
+export function applyAuthHeaderOverride<T extends Model<Api>>(
+  model: T,
+  auth: ResolvedProviderAuth | null | undefined,
+  cfg: OpenClawConfig | undefined,
+): T {
+  if (!auth?.apiKey) {
+    return model;
+  }
+  // Reject synthetic marker values that are not real credentials.
+  if (isNonSecretApiKeyMarker(auth.apiKey)) {
+    return model;
+  }
+  const providerConfig = resolveProviderConfig(cfg, model.provider);
+  if (!providerConfig?.authHeader) {
+    return model;
+  }
+
+  // Strip any existing authorization header (case-insensitive) before
+  // injecting the canonical one so we don't produce a comma-joined value.
+  const headers: Record<string, string> = {};
+  if (model.headers) {
+    for (const [key, value] of Object.entries(model.headers)) {
+      if (key.toLowerCase() !== "authorization") {
+        headers[key] = value;
+      }
+    }
+  }
+  headers.Authorization = `Bearer ${auth.apiKey}`;
+
+  return {
+    ...model,
+    headers,
+  };
+}

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -259,6 +259,7 @@ export async function loadCompactHooksHarness(): Promise<{
   }));
 
   vi.doMock("../model-auth.js", () => ({
+    applyAuthHeaderOverride: vi.fn((model: unknown) => model),
     applyLocalNoAuthHeaderOverride: vi.fn((model: unknown) => model),
     getApiKeyForModel: vi.fn(async () => ({ apiKey: "test", mode: "env" })),
     resolveModelAuthMode: vi.fn(() => "env"),

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -44,6 +44,7 @@ import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../d
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
 import {
+  applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
   getApiKeyForModel,
   resolveModelAuthMode,
@@ -328,6 +329,7 @@ export async function compactEmbeddedPiSessionDirect(
   }
   let runtimeModel = model;
   let apiKeyInfo: Awaited<ReturnType<typeof getApiKeyForModel>> | null = null;
+  let hasRuntimeAuthExchange = false;
   try {
     apiKeyInfo = await getApiKeyForModel({
       model: runtimeModel,
@@ -365,6 +367,7 @@ export async function compactEmbeddedPiSessionDirect(
         runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
       }
       const runtimeApiKey = preparedAuth?.apiKey ?? apiKeyInfo.apiKey;
+      hasRuntimeAuthExchange = Boolean(preparedAuth?.apiKey);
       if (!runtimeApiKey) {
         throw new Error(`Provider "${runtimeModel.provider}" runtime auth returned no apiKey.`);
       }
@@ -439,11 +442,18 @@ export async function compactEmbeddedPiSessionDirect(
       modelContextWindow: runtimeModel.contextWindow,
       defaultTokens: DEFAULT_CONTEXT_TOKENS,
     });
-    const effectiveModel = applyLocalNoAuthHeaderOverride(
-      ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
-        ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
-        : runtimeModel,
-      apiKeyInfo,
+    const effectiveModel = applyAuthHeaderOverride(
+      applyLocalNoAuthHeaderOverride(
+        ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
+          ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
+          : runtimeModel,
+        apiKeyInfo,
+      ),
+      // Skip header injection when runtime auth exchange produced a
+      // different credential — the SDK reads the exchanged token from
+      // authStorage automatically.
+      hasRuntimeAuthExchange ? null : apiKeyInfo,
+      params.config,
     );
 
     const runAbortController = new AbortController();

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -35,6 +35,7 @@ type InlineProviderConfig = {
   api?: ModelDefinitionConfig["api"];
   models?: ModelDefinitionConfig[];
   headers?: unknown;
+  authHeader?: boolean;
 };
 
 type ProviderRuntimeHooks = {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -412,6 +412,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
   }));
 
   vi.doMock("../model-auth.js", () => ({
+    applyAuthHeaderOverride: vi.fn((model: unknown) => model),
     applyLocalNoAuthHeaderOverride: vi.fn((model: unknown) => model),
     ensureAuthProfileStore: vi.fn(() => ({})),
     getApiKeyForModel: mockedGetApiKeyForModel,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -31,6 +31,7 @@ import {
   consumeLiveSessionModelSwitch,
 } from "../live-model-switch.js";
 import {
+  applyAuthHeaderOverride,
   applyLocalNoAuthHeaderOverride,
   ensureAuthProfileStore,
   type ResolvedProviderAuth,
@@ -518,7 +519,15 @@ export async function runEmbeddedPiAgent(
             disableTools: params.disableTools,
             provider,
             modelId,
-            model: applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+            model: applyAuthHeaderOverride(
+              applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
+              // When runtime auth exchange produced a different credential
+              // (runtimeAuthState is set), the exchanged token lives in
+              // authStorage and the SDK will pick it up automatically.
+              // Skip header injection to avoid leaking the pre-exchange key.
+              runtimeAuthState ? null : apiKeyInfo,
+              params.config,
+            ),
             authProfileId: lastProfileId,
             authProfileIdSource: lockedProfileId ? "user" : "auto",
             authStorage,


### PR DESCRIPTION
## Summary

- Problem: The `authHeader: true` provider config flag was defined in the schema, validated, and documented, but **never implemented at runtime**. No code path ever read or acted on this flag.
- Why it matters: Users who set `authHeader: true` (e.g. for Google's OpenAI-compatible endpoint) expected credentials to be sent via `Authorization: Bearer <key>`, but the flag was silently ignored.
- What changed: Added `applyAuthHeaderOverride()` that reads the provider's `authHeader` flag and injects `Authorization: Bearer <apiKey>` into model headers before they reach downstream SDKs. Wired into both the main run and compaction code paths.
- What did NOT change (scope boundary): No changes to config schema, SDK packages, extension code, or existing auth resolution logic. The `authHeader: false` and unset cases behave identically to before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54175
- [x] This PR fixes a bug

## Root Cause / Regression History (if applicable)

- Root cause: `InlineProviderConfig` type in `src/agents/pi-embedded-runner/model.ts` omitted the `authHeader` field, so the flag was silently dropped during model resolution. No code path ever checked or acted on the flag.
- Missing detection / guardrail: No unit test verified that `authHeader: true` produces an `Authorization` header on the model object.
- Prior context: The `authHeader` field has existed in `ModelProviderConfig` since the type was first created (`bcbfb357be`, 2026-01-14). The MiniMax commit (`60bb475355`, 2026-02-26) set `authHeader: true` in provider config but only wired up the config side — no runtime behavior was ever implemented.
- **Not a regression**: Despite the issue being labeled as a regression (v2026.3.22 → v2026.3.23-2), git history confirms `authHeader` was never functional in any version. The reporter likely observed a different change in behavior (e.g. switching to Google's OpenAI-compatible endpoint) that surfaced this pre-existing gap.
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-auth.test.ts`
- Scenario the test should lock in: When `authHeader: true` is set on a provider config, `applyAuthHeaderOverride()` must inject `Authorization: Bearer <apiKey>` into model headers. When `authHeader` is unset/false or no API key exists, the model must be returned unchanged.
- Why this is the smallest reliable guardrail: Unit tests on the override function directly validate the header injection logic without requiring a full model resolution or network call.
- Existing test that already covers this (if any): None — this is entirely new coverage.
- If no new test is added, why not: 6 new tests added covering positive and negative cases.

## User-visible / Behavior Changes

When `models.providers.*.authHeader` is set to `true`, OpenClaw now sends the API key as `Authorization: Bearer <key>` in HTTP headers for all model requests to that provider. Previously the flag was silently ignored in all versions.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — the same API key is sent, just via a different HTTP header when explicitly requested by the user.
- New/changed network calls? No — same endpoints, different header format only when user opts in.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 10.0.22631 (reported), macOS (verified)
- Runtime/container: Node.js v24.14.0
- Model/provider: google/gemini-3.1-flash-lite-preview
- Relevant config (redacted):
```json
"models.providers.google": {
  "baseUrl": "https://generativelanguage.googleapis.com/v1beta/openai",
  "api": "openai-completions",
  "authHeader": true
}
```

### Steps

1. Configure Google provider with `authHeader: true` and `api: "openai-completions"`
2. Send a message to the model
3. Observe the outbound HTTP request headers

### Expected

- Request includes `Authorization: Bearer <api-key>` header

### Actual (before fix)

- `authHeader: true` had no effect; auth was sent via the SDK's default mechanism (e.g. `x-goog-api-key` header for Google GenAI SDK)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

6 new unit tests in `src/agents/model-auth.test.ts` verify the `applyAuthHeaderOverride` function handles all cases correctly (positive injection, header preservation, no-op for unset/false/missing-key/missing-config).

## Human Verification (required)

- Verified scenarios: All 6 new unit tests pass; all 31 tests in `model-auth.test.ts` pass; compact hooks tests (24) pass; overflow compaction tests (21) pass; `pnpm check` passes (format, lint, typecheck, all custom lints).
- Edge cases checked: `authHeader: false`, `authHeader` unset, no API key, no provider config, existing model headers preserved when injecting Authorization.
- What you did **not** verify: End-to-end test with a real Google API key against the OpenAI-compatible endpoint (requires live credentials).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `authHeader: true` from provider config or revert the commit.
- Files/config to restore: `src/agents/model-auth.ts`, `src/agents/pi-embedded-runner/model.ts`, `run.ts`, `compact.ts`
- Known bad symptoms reviewers should watch for: Duplicate Authorization headers if a provider's SDK also injects one; should not happen since the header is set before SDK processing and SDKs typically check for existing Authorization headers.

## Risks and Mitigations

- Risk: If a downstream SDK (e.g. OpenAI) also generates Authorization from the apiKey parameter, there could be duplicate headers.
  - Mitigation: The OpenAI SDK uses `defaultHeaders` which the injected Authorization would override. The Google GenAI SDK checks for existing Authorization headers and skips its own auth injection. Both SDKs handle this correctly.
