### PR TITLE
fix(agents): add compaction event observability

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleAutoCompactionEnd, handleAutoCompactionStart } from "./pi-embedded-subscribe.handlers.compaction.js";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+
+vi.mock("../infra/agent-events.js", () => ({
+  emitAgentEvent: vi.fn(),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => undefined),
+}));
+
+function createContext(overrides?: {
+  onAgentEvent?: (event: unknown) => void;
+  compactionCount?: number;
+}): EmbeddedPiSubscribeContext {
+  return {
+    params: {
+      runId: "run-1",
+      config: {},
+      sessionKey: "agent:main:main",
+      onAgentEvent: overrides?.onAgentEvent,
+      session: {
+        messages: [
+          { role: "assistant", usage: { totalTokens: 123 } },
+          { role: "user" },
+        ],
+        sessionFile: "/tmp/session.jsonl",
+      },
+    },
+    state: {
+      compactionInFlight: false,
+    },
+    log: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+    },
+    ensureCompactionPromise: vi.fn(),
+    noteCompactionRetry: vi.fn(),
+    resetForCompactionRetry: vi.fn(),
+    maybeResolveCompactionWait: vi.fn(),
+    incrementCompactionCount: vi.fn(),
+    getCompactionCount: vi.fn(() => overrides?.compactionCount ?? 0),
+  } as unknown as EmbeddedPiSubscribeContext;
+}
+
+describe("compaction event observability", () => {
+  it("emits reason-aware start events and structured start logs", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext({ onAgentEvent, compactionCount: 2 });
+
+    handleAutoCompactionStart(ctx, {
+      type: "auto_compaction_start",
+      reason: "overflow",
+    } as never);
+
+    expect(ctx.state.compactionInFlight).toBe(true);
+    expect(ctx.ensureCompactionPromise).toHaveBeenCalledTimes(1);
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      "embedded run compaction start",
+      expect.objectContaining({
+        event: "embedded_run_compaction_start",
+        reason: "overflow",
+        sessionKey: "agent:main:main",
+        messageCount: 2,
+        consoleMessage:
+          "embedded run compaction start: runId=run-1 reason=overflow sessionKey=agent:main:main",
+      }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: { phase: "start", reason: "overflow" },
+    });
+  });
+
+  it("logs retry compaction failures with sanitized error text and emits end payloads", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext({ onAgentEvent });
+
+    handleAutoCompactionEnd(ctx, {
+      type: "auto_compaction_end",
+      willRetry: true,
+      aborted: false,
+      errorMessage:
+        "x-api-key: sk-abcdefghijklmnopqrstuvwxyz123456\tToo many tokens per day\nrequest id=req_1234567890",
+    } as never);
+
+    expect(ctx.state.compactionInFlight).toBe(false);
+    expect(ctx.noteCompactionRetry).toHaveBeenCalledTimes(1);
+    expect(ctx.resetForCompactionRetry).toHaveBeenCalledTimes(1);
+    expect(ctx.maybeResolveCompactionWait).not.toHaveBeenCalled();
+    expect(ctx.incrementCompactionCount).not.toHaveBeenCalled();
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      "embedded run compaction retry",
+      expect.objectContaining({
+        event: "embedded_run_compaction_retry",
+        completed: false,
+        hasResult: false,
+        wasAborted: false,
+        errorMessage: expect.stringContaining(
+          "x-api-key: *** Too many tokens per day request id=sha256:",
+        ),
+      }),
+    );
+    const warnMeta = vi.mocked(ctx.log.warn).mock.calls[0]?.[1];
+    expect(warnMeta?.consoleMessage).toContain(
+      "embedded run compaction retry: runId=run-1 sessionKey=agent:main:main completed=false hasResult=false aborted=false error=x-api-key: *** Too many tokens per day request id=sha256:",
+    );
+    expect(warnMeta?.consoleMessage).not.toContain("\n");
+    expect(warnMeta?.consoleMessage).not.toContain("\t");
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: expect.objectContaining({
+        phase: "end",
+        willRetry: true,
+        completed: false,
+        errorMessage: expect.stringContaining(
+          "x-api-key: *** Too many tokens per day request id=sha256:",
+        ),
+      }),
+    });
+  });
+
+  it("logs successful compaction completion with completion metadata", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createContext({ onAgentEvent, compactionCount: 3 });
+
+    handleAutoCompactionEnd(ctx, {
+      type: "auto_compaction_end",
+      willRetry: false,
+      aborted: false,
+      result: { ok: true },
+    } as never);
+
+    expect(ctx.state.compactionInFlight).toBe(false);
+    expect(ctx.incrementCompactionCount).toHaveBeenCalledTimes(1);
+    expect(ctx.maybeResolveCompactionWait).toHaveBeenCalledTimes(1);
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      "embedded run compaction end",
+      expect.objectContaining({
+        event: "embedded_run_compaction_end",
+        completed: true,
+        hasResult: true,
+        wasAborted: false,
+        compactionCount: 3,
+        messageCount: 2,
+      }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "compaction",
+      data: {
+        phase: "end",
+        willRetry: false,
+        completed: true,
+        errorMessage: undefined,
+      },
+    });
+  });
+});

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -1,21 +1,41 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import {
+  buildTextObservationFields,
+  sanitizeForConsole,
+} from "./pi-embedded-error-observation.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
-export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+export function handleAutoCompactionStart(
+  ctx: EmbeddedPiSubscribeContext,
+  evt?: AgentEvent & { reason?: unknown },
+) {
   ctx.state.compactionInFlight = true;
   ctx.ensureCompactionPromise();
-  ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
+  const reason = typeof evt?.reason === "string" ? evt.reason : "unknown";
+  const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
+  const safeSessionKey = sanitizeForConsole(ctx.params.sessionKey) ?? "-";
+  const safeReason = sanitizeForConsole(reason) ?? "unknown";
+  ctx.log.warn("embedded run compaction start", {
+    event: "embedded_run_compaction_start",
+    tags: ["compaction", "lifecycle", "auto_compaction_start"],
+    runId: ctx.params.runId,
+    sessionKey: ctx.params.sessionKey,
+    reason,
+    messageCount: ctx.params.session.messages?.length ?? 0,
+    sessionFile: ctx.params.session.sessionFile,
+    consoleMessage: `embedded run compaction start: runId=${safeRunId} reason=${safeReason} sessionKey=${safeSessionKey}`,
+  });
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
-    data: { phase: "start" },
+    data: { phase: "start", reason },
   });
   void ctx.params.onAgentEvent?.({
     stream: "compaction",
-    data: { phase: "start" },
+    data: { phase: "start", reason },
   });
 
   // Run before_compaction plugin hook (fire-and-forget)
@@ -40,7 +60,12 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
 
 export function handleAutoCompactionEnd(
   ctx: EmbeddedPiSubscribeContext,
-  evt: AgentEvent & { willRetry?: unknown; result?: unknown; aborted?: unknown },
+  evt: AgentEvent & {
+    willRetry?: unknown;
+    result?: unknown;
+    aborted?: unknown;
+    errorMessage?: unknown;
+  },
 ) {
   ctx.state.compactionInFlight = false;
   const willRetry = Boolean(evt.willRetry);
@@ -50,25 +75,56 @@ export function handleAutoCompactionEnd(
   // and context was trimmed — the counter must reflect that.  (#38905)
   const hasResult = evt.result != null;
   const wasAborted = Boolean(evt.aborted);
+  const completed = hasResult && !wasAborted;
+  const errorMessage =
+    typeof evt.errorMessage === "string"
+      ? sanitizeForConsole(buildTextObservationFields(evt.errorMessage).textPreview)
+      : undefined;
+  const safeRunId = sanitizeForConsole(ctx.params.runId) ?? "-";
+  const safeSessionKey = sanitizeForConsole(ctx.params.sessionKey) ?? "-";
+  const errorConsoleSuffix = errorMessage ? ` error=${errorMessage}` : "";
   if (hasResult && !wasAborted) {
     ctx.incrementCompactionCount?.();
   }
   if (willRetry) {
     ctx.noteCompactionRetry();
     ctx.resetForCompactionRetry();
-    ctx.log.debug(`embedded run compaction retry: runId=${ctx.params.runId}`);
+    ctx.log.warn("embedded run compaction retry", {
+      event: "embedded_run_compaction_retry",
+      tags: ["compaction", "lifecycle", "auto_compaction_end", "retry"],
+      runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
+      hasResult,
+      completed,
+      wasAborted,
+      errorMessage,
+      consoleMessage: `embedded run compaction retry: runId=${safeRunId} sessionKey=${safeSessionKey} completed=${completed} hasResult=${hasResult} aborted=${wasAborted}${errorConsoleSuffix}`,
+    });
   } else {
     ctx.maybeResolveCompactionWait();
     clearStaleAssistantUsageOnSessionMessages(ctx);
+    ctx.log.warn("embedded run compaction end", {
+      event: "embedded_run_compaction_end",
+      tags: ["compaction", "lifecycle", "auto_compaction_end"],
+      runId: ctx.params.runId,
+      sessionKey: ctx.params.sessionKey,
+      hasResult,
+      completed,
+      wasAborted,
+      errorMessage,
+      compactionCount: ctx.getCompactionCount(),
+      messageCount: ctx.params.session.messages?.length ?? 0,
+      consoleMessage: `embedded run compaction end: runId=${safeRunId} sessionKey=${safeSessionKey} completed=${completed} hasResult=${hasResult} aborted=${wasAborted} willRetry=${willRetry}${errorConsoleSuffix}`,
+    });
   }
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: { phase: "end", willRetry, completed, errorMessage },
   });
   void ctx.params.onAgentEvent?.({
     stream: "compaction",
-    data: { phase: "end", willRetry, completed: hasResult && !wasAborted },
+    data: { phase: "end", willRetry, completed, errorMessage },
   });
 
   // Run after_compaction plugin hook (fire-and-forget)

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -51,7 +51,7 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         handleAgentStart(ctx);
         return;
       case "auto_compaction_start":
-        handleAutoCompactionStart(ctx);
+        handleAutoCompactionStart(ctx, evt as never);
         return;
       case "auto_compaction_end":
         handleAutoCompactionEnd(ctx, evt as never);


### PR DESCRIPTION
## Summary

This PR improves embedded compaction observability by exposing clearer start/end details for auto-compaction attempts.

## What changes

- include `reason` on compaction start events
- include `completed`, `hasResult`, `willRetry`, and sanitized `errorMessage` on compaction end events
- add focused tests around compaction event payloads

## Why

When compaction is triggered during overflow recovery, the current logs and events make it hard to distinguish:

- compaction never started
- compaction started but failed
- compaction produced no result
- compaction is about to retry
- compaction actually completed

This is especially painful in fallback / rate-limit scenarios, where operators may otherwise see repeated compaction attempts without enough signal to tell whether the system is making progress.

## Scope

This PR intentionally does **not** change:

- compaction UX / notification policy
- model fallback policy
- `/status` compactionCount reconciliation

Those are better handled separately and already have related upstream discussion.
