### PR TITLE
media: fix resource leaks and temp file cleanup in downloadToFile

### DIFF
--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -1,4 +1,6 @@
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
 import JSZip from "jszip";
 import sharp from "sharp";
@@ -450,6 +452,104 @@ describe("media store", () => {
         // Should be UUID-only pattern (legacy behavior)
         expect(saved.id).toMatch(/^[a-f0-9-]{36}\.txt$/);
         expect(saved.id).not.toContain("---");
+      });
+    });
+  });
+
+  describe("downloadToFile resource cleanup", () => {
+    const fakePinnedHostname = {
+      hostname: "example.com",
+      addresses: ["127.0.0.1"],
+      lookup: (() => {}) as never,
+    };
+
+    /** Build a fake HTTP request function that emits a controllable response. */
+    function makeFakeRequest(
+      respondWith: (
+        res: EventEmitter & { statusCode: number; headers: Record<string, string> },
+      ) => void,
+    ) {
+      return (_url: unknown, _opts: unknown, cb: (res: unknown) => void): http.ClientRequest => {
+        const req = new EventEmitter() as EventEmitter & {
+          end: () => void;
+          destroy: (err?: Error) => void;
+        };
+        req.end = () => {
+          const res = Object.assign(new EventEmitter(), {
+            statusCode: 200,
+            headers: { "content-type": "text/plain" } as Record<string, string>,
+            resume: () => {},
+          });
+          cb(res);
+          respondWith(res as never);
+        };
+        req.destroy = (err?: Error) => {
+          req.emit("error", err ?? new Error("destroyed"));
+        };
+        return req as unknown as http.ClientRequest;
+      };
+    }
+
+    afterEach(() => {
+      store.setMediaStoreNetworkDepsForTest();
+    });
+
+    it("cleans up temp file when download exceeds size limit", async () => {
+      await withTempStore(async (store) => {
+        const mediaDir = await store.ensureMediaDir();
+
+        store.setMediaStoreNetworkDepsForTest({
+          httpsRequest: makeFakeRequest((res) => {
+            // Emit a chunk larger than MEDIA_MAX_BYTES to trigger the limit.
+            const huge = Buffer.alloc(store.MEDIA_MAX_BYTES + 1);
+            res.emit("data", huge);
+            res.emit("error", new Error("Media exceeds 5MB limit"));
+            res.emit("end");
+          }) as never,
+          resolvePinnedHostname: async () => fakePinnedHostname,
+        });
+
+        await expect(store.saveMediaSource("https://example.com/big.bin")).rejects.toThrow();
+
+        // Verify no .tmp files remain in the media directory.
+        const entries = await fs.readdir(mediaDir);
+        const tmpFiles = entries.filter((e) => e.endsWith(".tmp"));
+        expect(tmpFiles).toHaveLength(0);
+      });
+    });
+
+    it("cleans up temp file on HTTP error status", async () => {
+      await withTempStore(async (store) => {
+        const mediaDir = await store.ensureMediaDir();
+
+        store.setMediaStoreNetworkDepsForTest({
+          httpsRequest: ((_url: unknown, _opts: unknown, cb: (res: unknown) => void) => {
+            const req = new EventEmitter() as EventEmitter & {
+              end: () => void;
+              destroy: () => void;
+            };
+            req.end = () => {
+              const res = Object.assign(new EventEmitter(), {
+                statusCode: 500,
+                headers: {} as Record<string, string>,
+                resume: () => {},
+              });
+              cb(res);
+            };
+            req.destroy = () => {};
+            return req as unknown as http.ClientRequest;
+          }) as never,
+          resolvePinnedHostname: async () => fakePinnedHostname,
+        });
+
+        await expect(store.saveMediaSource("https://example.com/fail.bin")).rejects.toThrow(
+          "HTTP 500",
+        );
+
+        // Verify no .tmp files remain.
+        const entries = await fs.readdir(mediaDir);
+        const tmpFiles = entries.filter((e) => e.endsWith(".tmp"));
+        expect(tmpFiles).toHaveLength(0);
       });
     });
   });

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -196,22 +196,33 @@ async function downloadToFile(
       return;
     }
     const requestImpl = parsedUrl.protocol === "https:" ? httpsRequestImpl : httpRequestImpl;
+    let settled = false;
+    const settle = <T>(fn: (v: T) => void, v: T) => {
+      if (!settled) {
+        settled = true;
+        fn(v);
+      }
+    };
     resolvePinnedHostnameImpl(parsedUrl.hostname)
       .then((pinned) => {
         const req = requestImpl(parsedUrl, { headers, lookup: pinned.lookup }, (res) => {
           // Follow redirects
           if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+            // Consume the redirect response body to free the socket.
+            res.resume();
             const location = res.headers.location;
             if (!location || maxRedirects <= 0) {
-              reject(new Error(`Redirect loop or missing Location header`));
+              settle(reject, new Error(`Redirect loop or missing Location header`));
               return;
             }
             const redirectUrl = new URL(location, url).href;
-            resolve(downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
+            settle(resolve, downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
             return;
           }
           if (!res.statusCode || res.statusCode >= 400) {
-            reject(new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
+            // Consume the error response body to free the socket.
+            res.resume();
+            settle(reject, new Error(`HTTP ${res.statusCode ?? "?"} downloading media`));
             return;
           }
           let total = 0;
@@ -225,26 +236,38 @@ async function downloadToFile(
               sniffLen += chunk.length;
             }
             if (total > MAX_BYTES) {
+              // Destroy the write stream before aborting the request so file
+              // descriptors are released promptly.
+              out.destroy();
               req.destroy(new Error("Media exceeds 5MB limit"));
             }
+          });
+          // Catch response-level errors (e.g. premature close, decompression
+          // failures) that may fire before pipeline wires up its own handler.
+          res.on("error", (err) => {
+            out.destroy();
+            settle(reject, err);
           });
           pipeline(res, out)
             .then(() => {
               const sniffBuffer = Buffer.concat(sniffChunks, Math.min(sniffLen, 16384));
               const rawHeader = res.headers["content-type"];
               const headerMime = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader;
-              resolve({
+              settle(resolve, {
                 headerMime,
                 sniffBuffer,
                 size: total,
               });
             })
-            .catch(reject);
+            .catch((err) => {
+              out.destroy();
+              settle(reject, err);
+            });
         });
-        req.on("error", reject);
+        req.on("error", (err) => settle(reject, err));
         req.end();
       })
-      .catch(reject);
+      .catch((err) => settle(reject, err));
   });
 }
 
@@ -354,9 +377,17 @@ export async function saveMediaSource(
   const baseId = crypto.randomUUID();
   if (looksLikeUrl(source)) {
     const tempDest = path.join(dir, `${baseId}.tmp`);
-    const { headerMime, sniffBuffer, size } = await retryAfterRecreatingDir(dir, () =>
-      downloadToFile(source, tempDest, headers),
-    );
+    let downloadResult: { headerMime?: string; sniffBuffer: Buffer; size: number };
+    try {
+      downloadResult = await retryAfterRecreatingDir(dir, () =>
+        downloadToFile(source, tempDest, headers),
+      );
+    } catch (err) {
+      // Clean up the partial temp file on download failure.
+      await fs.rm(tempDest, { force: true }).catch(() => {});
+      throw err;
+    }
+    const { headerMime, sniffBuffer, size } = downloadResult;
     const mime = await detectMime({
       buffer: sniffBuffer,
       headerMime,


### PR DESCRIPTION
## Summary

- **Fix write stream leak on size-limit abort**: When a download exceeds `MAX_BYTES`, `req.destroy()` was called but the `createWriteStream` was never closed, leaking file descriptors under load
- **Add `res.on('error')` handler**: Response-level errors (premature close, decompression failures) could fire before `pipeline` wired up its own handler, causing unhandled rejections
- **Consume redirect/error response bodies**: Added `res.resume()` on redirect and error status paths to free the underlying socket instead of leaving it hanging
- **Guard against double-settle**: Added a `settled` flag in the Promise executor to prevent resolve/reject from being called multiple times across concurrent error paths
- **Clean up partial `.tmp` files**: `saveMediaSource` now removes the temp file in a `catch` block when `downloadToFile` fails, preventing orphaned partial downloads from accumulating on disk

## Test plan

- [x] Added test: temp file cleanup when download exceeds size limit
- [x] Added test: temp file cleanup on HTTP 500 error status
- [x] All 26 existing `store.test.ts` tests continue to pass
- [x] `pnpm tsgo` — zero type errors
- [x] `pnpm check` — all lint/format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)