### PR TITLE
fix(talk-voice): enforce operator.admin scope on /voice set config writes

### DIFF
--- a/extensions/talk-voice/index.test.ts
+++ b/extensions/talk-voice/index.test.ts
@@ -247,6 +247,26 @@ describe("talk-voice plugin", () => {
     expect(result.text).toContain("voice-a");
   });
 
+  it("rejects /voice set from webchat channel with no scopes (TUI/internal)", async () => {
+    const { command, runtime } = createHarness({
+      talk: {
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            apiKey: "sk-eleven",
+          },
+        },
+      },
+    });
+    vi.mocked(runtime.tts.listVoices).mockResolvedValue([{ id: "voice-a", name: "Claudia" }]);
+
+    // gatewayClientScopes omitted — simulates internal webchat session without scopes
+    const result = await command.handler(createCommandContext("set Claudia", "webchat"));
+
+    expect(result.text).toContain("requires operator.admin");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
   it("allows /voice set from non-gateway channels without scope check", async () => {
     const { command, runtime } = createHarness({
       talk: {

--- a/extensions/talk-voice/index.test.ts
+++ b/extensions/talk-voice/index.test.ts
@@ -27,12 +27,17 @@ function createHarness(config: Record<string, unknown>) {
   return { command, runtime };
 }
 
-function createCommandContext(args: string, channel: string = "discord") {
+function createCommandContext(
+  args: string,
+  channel: string = "discord",
+  gatewayClientScopes?: string[],
+) {
   return {
     args,
     channel,
     channelId: channel,
     isAuthorizedSender: true,
+    gatewayClientScopes,
     commandBody: args ? `/voice ${args}` : "/voice",
     config: {},
     requestConversationBinding: vi.fn(),
@@ -198,6 +203,67 @@ describe("talk-voice plugin", () => {
         },
       },
     });
+  });
+
+  it("rejects /voice set from gateway client with only operator.write scope", async () => {
+    const { command, runtime } = createHarness({
+      talk: {
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            apiKey: "sk-eleven",
+          },
+        },
+      },
+    });
+    vi.mocked(runtime.tts.listVoices).mockResolvedValue([{ id: "voice-a", name: "Claudia" }]);
+
+    const result = await command.handler(
+      createCommandContext("set Claudia", "webchat", ["operator.write"]),
+    );
+
+    expect(result.text).toContain("requires operator.admin");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("allows /voice set from gateway client with operator.admin scope", async () => {
+    const { command, runtime } = createHarness({
+      talk: {
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            apiKey: "sk-eleven",
+          },
+        },
+      },
+    });
+    vi.mocked(runtime.tts.listVoices).mockResolvedValue([{ id: "voice-a", name: "Claudia" }]);
+
+    const result = await command.handler(
+      createCommandContext("set Claudia", "webchat", ["operator.admin"]),
+    );
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalled();
+    expect(result.text).toContain("voice-a");
+  });
+
+  it("allows /voice set from non-gateway channels without scope check", async () => {
+    const { command, runtime } = createHarness({
+      talk: {
+        provider: "elevenlabs",
+        providers: {
+          elevenlabs: {
+            apiKey: "sk-eleven",
+          },
+        },
+      },
+    });
+    vi.mocked(runtime.tts.listVoices).mockResolvedValue([{ id: "voice-a", name: "Claudia" }]);
+
+    const result = await command.handler(createCommandContext("set Claudia", "telegram"));
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalled();
+    expect(result.text).toContain("voice-a");
   });
 
   it("returns provider lookup errors cleanly", async () => {

--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -168,11 +168,7 @@ export default definePluginEntry({
           // Without this check, a caller with only operator.write could bypass the
           // admin-only config.patch RPC by reaching writeConfigFile indirectly
           // through chat.send → /voice set.
-          if (
-            ctx.channel === "webchat" &&
-            Array.isArray(ctx.gatewayClientScopes) &&
-            !ctx.gatewayClientScopes.includes("operator.admin")
-          ) {
+          if (ctx.channel === "webchat" && !ctx.gatewayClientScopes?.includes("operator.admin")) {
             return { text: `⚠️ ${commandLabel} set requires operator.admin for gateway clients.` };
           }
 

--- a/extensions/talk-voice/index.ts
+++ b/extensions/talk-voice/index.ts
@@ -164,6 +164,18 @@ export default definePluginEntry({
         }
 
         if (action === "set") {
+          // Persistent config writes require operator.admin for gateway clients.
+          // Without this check, a caller with only operator.write could bypass the
+          // admin-only config.patch RPC by reaching writeConfigFile indirectly
+          // through chat.send → /voice set.
+          if (
+            ctx.channel === "webchat" &&
+            Array.isArray(ctx.gatewayClientScopes) &&
+            !ctx.gatewayClientScopes.includes("operator.admin")
+          ) {
+            return { text: `⚠️ ${commandLabel} set requires operator.admin for gateway clients.` };
+          }
+
           const query = tokens.slice(1).join(" ").trim();
           if (!query) {
             return { text: `Usage: ${commandLabel} set <voiceId|name>` };


### PR DESCRIPTION
## Summary

- `/voice set` now checks for `operator.admin` gateway client scope before persisting Talk voice config via `writeConfigFile`
- Gateway clients with only `operator.write` are rejected with a clear error message
- Non-gateway channels (Telegram, Discord, etc.) are unaffected since they use identity-based auth

## Context

The gateway's scope model classifies persistent config mutations as admin-only actions (`config.patch` requires `operator.admin`). However, the `/voice set` command was persisting config to disk without enforcing the same scope requirement when reached indirectly through `chat.send`. This aligns the `/voice set` sink with the same privilege boundary that direct config mutation RPCs already enforce.

## Test plan

- [x] Added test: gateway client with `operator.write` is rejected on `/voice set`
- [x] Added test: gateway client with `operator.admin` can still `/voice set`
- [x] Added test: non-gateway channels bypass scope check (existing behavior preserved)
- [x] All existing talk-voice tests pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)