### PR TITLE
Tests: isolate security audit home skill resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Runtime/install: lower the supported Node 22 floor to `22.14+` while continuing to recommend Node 24, so npm installs and self-updates do not strand Node 22.14 users on older releases.
 - CLI/update: preflight the target npm package `engines.node` before `openclaw update` runs a global package install, so outdated Node runtimes fail with a clear upgrade message instead of attempting an unsupported latest release.
+- Tests/security audit: isolate audit-test home and personal skill resolution so local `~/.agents/skills` installs no longer make maintainer prep runs fail nondeterministically. (#54473) thanks @huntharo
 
 ## 2026.3.24-beta.1
 

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -5,7 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { saveExecApprovals } from "../infra/exec-approvals.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import { createPathResolutionEnv, withEnvAsync } from "../test-utils/env.js";
 import {
   collectInstalledSkillsCodeSafetyFindings,
   collectPluginsCodeSafetyFindings,
@@ -19,6 +19,15 @@ const windowsAuditEnv = {
   USERNAME: "Tester",
   USERDOMAIN: "DESKTOP-TEST",
 };
+const pathResolutionEnvKeys = [
+  "HOME",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "OPENCLAW_HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+] as const;
 const execDockerRawUnavailable: NonNullable<SecurityAuditOptions["execDockerRawFn"]> = async () => {
   return {
     stdout: Buffer.alloc(0),
@@ -271,7 +280,10 @@ describe("security audit", () => {
   let sharedCodeSafetyWorkspaceDir = "";
   let sharedExtensionsStateDir = "";
   let sharedInstallMetadataStateDir = "";
-  let previousOpenClawHome: string | undefined;
+  let isolatedHome = "";
+  let homedirSpy: { mockRestore(): void } | undefined;
+  const previousPathResolutionEnv: Partial<Record<(typeof pathResolutionEnvKeys)[number], string>> =
+    {};
 
   const makeTmpDir = async (label: string) => {
     const dir = path.join(fixtureRoot, `case-${caseId++}-${label}`);
@@ -353,9 +365,19 @@ description: test skill
 
   beforeAll(async () => {
     fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-security-audit-"));
-    previousOpenClawHome = process.env.OPENCLAW_HOME;
-    process.env.OPENCLAW_HOME = path.join(fixtureRoot, "home");
-    await fs.mkdir(process.env.OPENCLAW_HOME, { recursive: true, mode: 0o700 });
+    isolatedHome = path.join(fixtureRoot, "home");
+    const isolatedEnv = createPathResolutionEnv(isolatedHome, { OPENCLAW_HOME: isolatedHome });
+    for (const key of pathResolutionEnvKeys) {
+      previousPathResolutionEnv[key] = process.env[key];
+      const value = isolatedEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(isolatedHome);
+    await fs.mkdir(isolatedHome, { recursive: true, mode: 0o700 });
     channelSecurityRoot = path.join(fixtureRoot, "channel-security");
     await fs.mkdir(channelSecurityRoot, { recursive: true, mode: 0o700 });
     sharedChannelSecurityStateDir = path.join(channelSecurityRoot, "state-shared");
@@ -376,10 +398,14 @@ description: test skill
   });
 
   afterAll(async () => {
-    if (previousOpenClawHome === undefined) {
-      delete process.env.OPENCLAW_HOME;
-    } else {
-      process.env.OPENCLAW_HOME = previousOpenClawHome;
+    homedirSpy?.mockRestore();
+    for (const key of pathResolutionEnvKeys) {
+      const value = previousPathResolutionEnv[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
     if (!fixtureRoot) {
       return;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `src/security/audit.test.ts` resolved installed skills from my real home directory during test setup, so the suite could scan `~/.agents/skills/*` instead of only its fixture data.
- Why it matters: `$prepare-pr` gates can fail based on whatever skills a maintainer happens to have installed locally, which makes the audit test nondeterministic and unrelated to the repo under test.
- What changed: I isolated the audit test's home/path-resolution environment and stubbed `os.homedir()` so installed-skill discovery stays inside the test fixture.
- What did NOT change (scope boundary): I did not change production audit behavior; runtime deep audit still scans managed and personal installed skills on purpose.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #54118
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the audit test only changed `OPENCLAW_HOME`, but installed-skill discovery also uses the module-level `CONFIG_DIR` constant and `os.homedir()` for `~/.agents/skills`, so the test still saw real home-installed skills.
- Missing detection / guardrail: the test asserted on specific finding content without first forcing all home/path resolution into an isolated fixture.
- Prior context (`git blame`, prior PR, issue, or refactor if known): observed while running `$prepare-pr` for [#54118](https://github.com/openclaw/openclaw/pull/54118).
- Why this regressed now: local skill installs under `~/.agents/skills/last30days` introduced additional critical findings that the test was never meant to see.
- If unknown, what was ruled out: not a production audit regression; the runtime scanner is intentionally capable of scanning installed personal skills.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/security/audit.test.ts`
- Scenario the test should lock in: the code-safety audit test should only report findings from its fixture workspace/state, even when the developer has managed or personal skills installed in their real home directory.
- Why this is the smallest reliable guardrail: the failure came from test harness path resolution, not from a wider integration boundary.
- Existing test that already covers this (if any): the existing `evaluates code-safety findings` case now covers it once the harness is isolated.
- If no new test is added, why not: I reused the existing case and fixed its setup instead of adding a duplicate.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): local home directory had personal skills installed under `/Users/huntharo/.agents/skills`

### Steps

1. Install one or more personal skills under `/Users/huntharo/.agents/skills`, including a skill with code-safety findings such as `last30days`.
2. Run `$prepare-pr` on an unrelated PR until it reaches `pnpm test`, or run `pnpm test -- src/security/audit.test.ts -t "evaluates code-safety findings"` before this fix.
3. Observe that the audit test inspects home-installed skills instead of only the fixture skill tree.

### Expected

- The test only scans the fixture workspace/state it created for itself.

### Actual

- The test scanned a personal installed skill from `/Users/huntharo/.agents/skills/last30days` and reported those findings in the same run.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Sanitized example from the observed failure mode while preparing another PR:

```text
TITLE: Skill "last30days" contains dangerous code patterns
DETAIL: Found 5 critical issue(s) in 115 scanned file(s) under /Users/huntharo/.agents/skills/last30days:
  - [env-harvesting] Environment variable access combined with network send — possible credential harvesting (vendor/package/dist/lib/runtime-query-ids.js:50)
  - [env-harvesting] Environment variable access combined with network send — possible credential harvesting (vendor/package/dist/lib/twitter-client-base.js:38)
  - [env-harvesting] Environment variable access combined with network send — possible credential harvesting (vendor/package/dist/lib/twitter-client-news.js:24)
  - [env-harvesting] Environment variable access combined with network send — possible credential harvesting (scripts/lib/vendor/bird-search/lib/runtime-query-ids.js:50)
  - [env-harvesting] Environment variable access combined with network send — possible credential harvesting (scripts/lib/vendor/bird-search/lib/twitter-client-base.js:38)
```

Passing after this change:

```text
$ pnpm test -- src/security/audit.test.ts
Test Files  1 passed (1)
Tests       73 passed (73)

$ pnpm check
...passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I ran `pnpm test -- src/security/audit.test.ts`, `pnpm test -- src/security/audit.test.ts -t "evaluates code-safety findings"`, and `pnpm check`.
- Edge cases checked: I reproduced that the underlying installed-skill scan still finds `/Users/huntharo/.agents/skills/last30days` outside the isolated test harness, which confirms this PR only fixes test isolation.
- What you did **not** verify: I did not run the full `pnpm test` suite again for this standalone PR.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Tests: isolate audit home skill resolution`.
- Files/config to restore: `src/security/audit.test.ts`
- Known bad symptoms reviewers should watch for: audit tests unexpectedly scanning real home-installed skills again on developer machines.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the test could still read a path resolved before the isolation hooks run.
  - Mitigation: the setup now overrides both the path-resolution env vars and `os.homedir()` in `beforeAll`, and restores them in `afterAll`.
