### PR TITLE
fix(gateway): tolerate transient pre-hello closes in CLI calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/CLI: tolerate transient pre-hello WebSocket closes only when they are clean `1000` closes with an empty reason, so one-shot CLI calls can survive immediate reconnects without hiding real close failures. Carries forward #54475. Thanks @ruanrrn.
 - CLI/update: scope packaged Node compile caches by OpenClaw version and install metadata, so global installs no longer reuse stale compiled chunks after package updates. Thanks @pashpashpash.
 - Plugin SDK/testing: lazy-load TypeScript from the plugin test-contract runtime and add release checks for critical SDK contract entrypoint imports and bundle size, so published packages fail preflight before shipping ESM-incompatible or oversized contract helpers. Thanks @vincentkoc.
 - Channels/Microsoft Teams: treat configured `19:...@thread.tacv2` and legacy `19:...@thread.skype` team/channel IDs as already resolved during startup, avoiding false `channels unresolved` warnings while preserving Graph name lookup for display-name entries. Fixes #74683. Thanks @dseravalli.
@@ -242,16 +243,16 @@ Docs: https://docs.openclaw.ai
 - WhatsApp/reliability: publish real transport-liveness into WhatsApp channel status and force earlier reconnects on silent transport stalls, so quiet healthy sessions stay connected while wedged sockets recover before the later remote 408 path. (#72656) Thanks @Sathvik-1007.
 - Core/channels: tighten selected runtime, media, and plugin edge-case handling while preserving existing behavior. Thanks @jesse-merhi.
 - Channels/WhatsApp: strip leaked plural tool-call XML wrappers on every WhatsApp-visible outbound path and keep channel error payloads out of WhatsApp chats. (#71830) Thanks @rubencu.
-- Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
-- Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
-- Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
-- Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
-- Auto-reply/subagents: reject `/focus` from leaf subagents and scope fallback target resolution to the requesting subagent's children, so subagents cannot bind conversations outside their control boundary. (#73613) Thanks @drobison00.
-- Gateway/startup: skip inherited workspace startup memory for sandboxed spawned sessions without real-workspace write access, so `/new` no longer preloads host workspace memory into isolated child runs. (#73611) Thanks @drobison00.
-- Agents/tool policy: validate caller group IDs against session or spawned context before applying group-scoped tool policies or persisting gateway group metadata, so forged group IDs cannot unlock more permissive tools. (#73720) Thanks @mmaps.
-- Commands: keep channel-prefixed owner allowlist entries scoped to matching providers so webchat command contexts cannot inherit external channel owners. Thanks @zsxsoft.
-- Auth/device pairing: bound bootstrap handoff token issuance, redemption, and approved pairing baselines to the documented per-role scope allowlist, so bootstrap approvals cannot persistently grant `operator.admin`, `operator.pairing`, or `node.exec` scopes. Thanks @eleqtrizit.
-- Providers/GitHub Copilot: support the GUI/RPC wizard device-code auth flow so onboarding from non-TTY clients (gateway RPC bridge, GUI wizards) completes instead of returning empty profiles. Dangerous-state handling now distinguishes `access_denied` and `expired_token` from transport errors. (#73290) Thanks @indierawk2k2.
+- Gateway/CLI: tolerate transient pre-hello WebSocket closes only when they are clean `1000` closes with an empty reason, so one-shot CLI calls can survive immediate reconnects without hiding real close failures. Carries forward #54475. Thanks @ruanrrn.
+- CLI/update: scope packaged Node compile caches by OpenClaw version and install metadata, so global installs no longer reuse stale compiled chunks after package updates. Thanks @pashpashpash.
+- Plugin SDK/testing: lazy-load TypeScript from the plugin test-contract runtime and add release checks for critical SDK contract entrypoint imports and bundle size, so published packages fail preflight before shipping ESM-incompatible or oversized contract helpers. Thanks @vincentkoc.
+- Channels/Microsoft Teams: treat configured `19:...@thread.tacv2` and legacy `19:...@thread.skype` team/channel IDs as already resolved during startup, avoiding false `channels unresolved` warnings while preserving Graph name lookup for display-name entries. Fixes #74683. Thanks @dseravalli.
+- CLI/browser: preserve parent flags while lazy-loading browser subcommands, so `openclaw browser --json open` and `openclaw browser --json tabs` keep machine-readable output after reparsing. Fixes #74574. Thanks @devintegeritsm.
+- Plugins/runtime-deps: add `openclaw plugins deps` inspection and repair with script-free package-manager defaults shared across plugin installers, so operators can repair missing bundled runtime deps without corrupting JSON output or blocking unrelated conflict-free deps. Thanks @vincentkoc.
+- Agents/output: strip internal `[tool calls omitted]` replay placeholders from user-facing replies while preserving visible reply whitespace. Fixes #74573. Thanks @blaspat.
+- Providers/Google Vertex: route authorized_user ADC credentials through OpenClaw's REST transport so Docker installs using gcloud application-default credentials no longer crash in the Google SDK before requests are sent. Fixes #74628. Thanks @frankhal2001-design.
+- Agents/sessions: emit a terminal lifecycle backstop when embedded timeout/error turns return without `agent_end`, so Gateway sessions no longer stay stuck in `running` after failover surfaces a timeout. Fixes #74607. Thanks @millerc79.
+- Gateway/diagnostics: include stuck-session reason hints and recovery skip causes in warnings, so operators can tell whether a lane is waiting on active work, queued work, or stale bookkeeping. Thanks @vincentkoc.
 
 ## 2026.4.27
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -921,7 +921,6 @@ describe("callGateway error details", () => {
     expect(healthRequests).toBe(1);
   });
 
-
   it("includes connection details on timeout", async () => {
     startMode = "silent";
     setLocalLoopbackGatewayConfig();

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -921,6 +921,49 @@ describe("callGateway error details", () => {
     expect(healthRequests).toBe(1);
   });
 
+  it("rejects pre-hello 1000 closes when the reason is non-empty", async () => {
+    startMode = "close";
+    closeCode = 1000;
+    closeReason = "going away";
+    setLocalLoopbackGatewayConfig();
+
+    await expect(callGateway({ method: "health" })).rejects.toThrow(
+      "gateway closed (1000 normal closure): going away",
+    );
+  });
+
+  it("rejects empty 1000 closes after hello starts request execution", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    class PostHelloCloseStubGatewayClient {
+      constructor(
+        private readonly opts: {
+          onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
+          onClose?: (code: number, reason: string) => void;
+        },
+      ) {}
+
+      async request() {
+        return await new Promise(() => {});
+      }
+
+      start() {
+        void this.opts.onHelloOk?.({ features: { methods: ["health"] } });
+        this.opts.onClose?.(1000, "");
+      }
+
+      stop() {}
+    }
+
+    __testing.setCreateGatewayClientForTests(
+      (opts) => new PostHelloCloseStubGatewayClient(opts as never) as never,
+    );
+
+    await expect(callGateway({ method: "health" })).rejects.toThrow(
+      "gateway closed (1000 normal closure): no close reason",
+    );
+  });
+
   it("includes connection details on timeout", async () => {
     startMode = "silent";
     setLocalLoopbackGatewayConfig();

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -881,6 +881,46 @@ describe("callGateway error details", () => {
 
     expect(lastRequestOptions?.method).toBe("health");
   });
+  it("waits through a transient pre-hello close when the client later completes hello", async () => {
+    setLocalLoopbackGatewayConfig();
+    vi.useFakeTimers();
+    let healthRequests = 0;
+
+    class ReconnectingStubGatewayClient {
+      constructor(
+        private readonly opts: {
+          onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
+          onClose?: (code: number, reason: string) => void;
+        },
+      ) {}
+
+      async request(method: string) {
+        if (method === "health") {
+          healthRequests += 1;
+          return { ok: true };
+        }
+        return undefined;
+      }
+
+      start() {
+        setTimeout(() => this.opts.onClose?.(1000, ""), 0);
+        setTimeout(() => void this.opts.onHelloOk?.({ features: { methods: ["health"] } }), 1);
+      }
+
+      stop() {}
+    }
+
+    __testing.setCreateGatewayClientForTests(
+      (opts) => new ReconnectingStubGatewayClient(opts as never) as never,
+    );
+
+    const promise = callGateway({ method: "health" });
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(healthRequests).toBe(1);
+  });
+
 
   it("includes connection details on timeout", async () => {
     startMode = "silent";

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -932,6 +932,17 @@ describe("callGateway error details", () => {
     );
   });
 
+  it("rejects pre-hello 1000 closes when the reason is whitespace-only", async () => {
+    startMode = "close";
+    closeCode = 1000;
+    closeReason = " ";
+    setLocalLoopbackGatewayConfig();
+
+    await expect(callGateway({ method: "health" })).rejects.toThrow(
+      "gateway closed (1000 normal closure): no close reason",
+    );
+  });
+
   it("rejects empty 1000 closes after hello starts request execution", async () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -618,6 +618,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   } = params;
   return await new Promise<T>((resolve, reject) => {
     let settled = false;
+    let helloOkSeen = false;
     let ignoreClose = false;
     const startAbort = new AbortController();
     const stop = (err?: Error, value?: T) => {
@@ -657,6 +658,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {
+        helloOkSeen = true;
         try {
           ensureGatewaySupportsRequiredMethods({
             requiredMethods: opts.requiredMethods,
@@ -676,6 +678,12 @@ async function executeGatewayRequestWithScopes<T>(params: {
       },
       onClose: (code, reason) => {
         if (settled || ignoreClose) {
+          return;
+        }
+        // Some gateway / ws stacks can emit a transient 1000 close during the initial
+        // pre-hello handshake while the client reconnects immediately. Don't fail one-shot
+        // CLI calls on that specific transient close.
+        if (!helloOkSeen && code === 1000 && reason.trim().length === 0) {
           return;
         }
         ignoreClose = true;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -683,7 +683,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
         // Some gateway / ws stacks can emit a transient 1000 close during the initial
         // pre-hello handshake while the client reconnects immediately. Don't fail one-shot
         // CLI calls on that specific transient close.
-        if (!helloOkSeen && code === 1000 && reason.trim().length === 0) {
+        if (!helloOkSeen && code === 1000 && reason.length === 0) {
           return;
         }
         ignoreClose = true;

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -997,6 +997,34 @@ describe("GatewayClient connect auth payload", () => {
     }
   });
 
+  it("reports pre-hello 1000 closes when the reason is whitespace-only", async () => {
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onConnectError,
+    });
+
+    try {
+      const { ws } = startClientAndConnect({ client });
+      ws.emitClose(1000, " ");
+
+      await vi.waitFor(() =>
+        expect(onConnectError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            closeCode: 1000,
+            closeReason: " ",
+            message: "gateway closed (1000):  ",
+          }),
+        ),
+      );
+      expect(logErrorMock).toHaveBeenCalledWith(
+        expect.stringContaining("gateway connect failed: GatewayClientCloseError"),
+      );
+    } finally {
+      client.stop();
+    }
+  });
+
   it("continues to notify onClose for post-hello empty 1000 closes", () => {
     const onClose = vi.fn();
     const onConnectError = vi.fn();

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -937,6 +937,40 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
+  it("suppresses transient pre-hello 1000 closes while reconnect succeeds", async () => {
+    vi.useFakeTimers();
+    const onConnectError = vi.fn();
+    const onHelloOk = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onConnectError,
+      onHelloOk,
+    });
+
+    try {
+      const { ws: ws1 } = startClientAndConnect({ client });
+      ws1.emitClose(1000, "");
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.waitFor(() => expect(wsInstances.length).toBe(2));
+
+      const ws2 = getLatestWs();
+      ws2.emitOpen();
+      emitConnectChallenge(ws2, "nonce-2");
+      const secondConnect = connectRequestFrom(ws2);
+      emitHelloOk(ws2, secondConnect.id);
+
+      await vi.waitFor(() => expect(onHelloOk).toHaveBeenCalled());
+      expect(onConnectError).not.toHaveBeenCalled();
+      expect(logErrorMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("gateway connect failed: Error: gateway closed (1000):"),
+      );
+    } finally {
+      client.stop();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not auto-reconnect on AUTH_TOKEN_MISSING connect failures", async () => {
     const onReconnectPaused = vi.fn();
     const client = new GatewayClient({

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -971,6 +971,50 @@ describe("GatewayClient connect auth payload", () => {
     }
   });
 
+  it("reports pre-hello 1000 closes when the reason is non-empty", async () => {
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onConnectError,
+    });
+
+    try {
+      const { ws } = startClientAndConnect({ client });
+      ws.emitClose(1000, "restart requested");
+
+      await vi.waitFor(() =>
+        expect(onConnectError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "gateway closed (1000): restart requested",
+          }),
+        ),
+      );
+      expect(logErrorMock).toHaveBeenCalledWith(
+        expect.stringContaining("gateway connect failed: GatewayClientCloseError"),
+      );
+    } finally {
+      client.stop();
+    }
+  });
+
+  it("continues to notify onClose for post-hello empty 1000 closes", () => {
+    const onClose = vi.fn();
+    const onConnectError = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      onClose,
+      onConnectError,
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitHelloOk(ws, connect.id);
+    ws.emitClose(1000, "");
+
+    expect(onClose).toHaveBeenCalledWith(1000, "");
+    expect(onConnectError).not.toHaveBeenCalled();
+    client.stop();
+  });
+
   it("does not auto-reconnect on AUTH_TOKEN_MISSING connect failures", async () => {
     const onReconnectPaused = vi.fn();
     const client = new GatewayClient({

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -634,6 +634,13 @@ export class GatewayClient {
           this.deviceTokenRetryBudgetUsed = true;
           this.backoffMs = Math.min(this.backoffMs, 250);
         }
+        const isTransientPreHelloClose =
+          this.pendingConnectErrorDetailCode == null &&
+          err instanceof Error &&
+          /^gateway closed \(1000\):\s*$/.test(err.message);
+        if (isTransientPreHelloClose) {
+          return;
+        }
         const startupRetryAfterMs = resolveGatewayStartupRetryAfterMs(err);
         if (startupRetryAfterMs !== null) {
           this.pendingStartupReconnectDelayMs = startupRetryAfterMs;

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -650,7 +650,7 @@ export class GatewayClient {
           this.pendingConnectErrorDetailCode == null &&
           err instanceof GatewayClientCloseError &&
           err.closeCode === 1000 &&
-          err.closeReason.trim().length === 0;
+          err.closeReason.length === 0;
         if (isTransientPreHelloClose) {
           return;
         }

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -122,6 +122,18 @@ export class GatewayClientRequestError extends Error {
   }
 }
 
+class GatewayClientCloseError extends Error {
+  readonly closeCode: number;
+  readonly closeReason: string;
+
+  constructor(code: number, reason: string) {
+    super(`gateway closed (${code}): ${reason}`);
+    this.name = "GatewayClientCloseError";
+    this.closeCode = code;
+    this.closeReason = reason;
+  }
+}
+
 export type GatewayClientOptions = {
   url?: string; // ws://127.0.0.1:18789
   connectChallengeTimeoutMs?: number;
@@ -377,7 +389,7 @@ export class GatewayClient {
           );
         }
       }
-      this.flushPendingErrors(new Error(`gateway closed (${code}): ${reasonText}`));
+      this.flushPendingErrors(new GatewayClientCloseError(code, reasonText));
       if (this.shouldPauseReconnectAfterAuthFailure(connectErrorDetailCode)) {
         this.opts.onReconnectPaused?.({
           code,
@@ -636,8 +648,9 @@ export class GatewayClient {
         }
         const isTransientPreHelloClose =
           this.pendingConnectErrorDetailCode == null &&
-          err instanceof Error &&
-          /^gateway closed \(1000\):\s*$/.test(err.message);
+          err instanceof GatewayClientCloseError &&
+          err.closeCode === 1000 &&
+          err.closeReason.trim().length === 0;
         if (isTransientPreHelloClose) {
           return;
         }


### PR DESCRIPTION
## Summary

- Problem: One-shot gateway calls from the CLI (for example `openclaw cron status` / `openclaw cron list --json`) can fail with `gateway closed (1000):` when the first WebSocket connection closes with code `1000` and an empty reason *before* `hello-ok`, even though the client would immediately reconnect and complete the handshake successfully.
- Why it matters: This surfaces as a flaky but user-visible failure path for CLI commands while the gateway itself is healthy, which breaks automation and undermines trust in the CLI.
- What changed: `executeGatewayRequestWithScopes(...)` now tracks whether `hello-ok` has been seen and ignores only a **pre-hello** close with code `1000` and an empty reason; `GatewayClient.connect` treats that same transient connect error as non-fatal so the existing reconnect logic can complete; added focused tests covering both the one-shot call path and the client reconnect behavior.
- What did NOT change (scope boundary): No changes to auth/secret handling, no changes to other close codes or non-empty close reasons, no changes to broader reconnect policy, and no config or CLI surface changes.

*(AI-assisted: drafted and iterated with an OpenClaw workspace agent; changes and tests were reviewed and verified by a human.)*

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A (fixing a locally diagnosed CLI gateway handshake failure that did not yet have a public issue)
- Related: internal debugging of transient pre-hello `1000` closes on CLI gateway calls
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The one-shot gateway request wrapper (`executeGatewayRequestWithScopes`) treated any `onClose` event as terminal, even if it happened *before* `hello-ok`. In some environments, the underlying WebSocket stack can emit a transient `1000` close with an empty reason during the initial handshake, while `GatewayClient` reconnects and later completes `hello` successfully.
- Missing detection / guardrail: There was no distinction between a transient pre-hello close that can be recovered by reconnect vs. a final close after a completed hello. The wrapper did not track whether `hello-ok` had been seen and did not special-case this transient `1000` path.
- Prior context: This shows up as flaky failures on CLI commands like `openclaw cron status`/`list` with `gateway closed (1000):` even though the gateway is reachable and the Control UI can talk to it.
- Why this regressed now: This is a behavior interaction between the CLI wrapper and gateway/WebSocket behavior that surfaced more often in certain deployments; it is not tied to a single recent refactor, but to the lack of pre-hello vs post-hello distinction in the close handling.
- If unknown, what was ruled out: Verified that the gateway itself was healthy (Control UI worked, direct WebSocket loopback was fine) and that the failure was in the CLI handshake path, not gateway liveness.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/call.test.ts`: new test ensuring `callGateway({ method: "health" })` waits through a transient pre-hello `1000` close and resolves successfully once `hello-ok` arrives.
  - `src/gateway/client.test.ts`: new test ensuring `GatewayClient` suppresses the spurious `gateway connect failed: ... (1000)` log + `onConnectError` callback when a pre-hello `1000` close is followed by a successful reconnect and `hello-ok`.
- Scenario the test should lock in:
  - A CLI one-shot gateway call that sees a transient pre-hello `1000` + empty-reason close should not fail early; it should wait for the reconnect and complete normally.
  - The same transient close should not be logged as a connect-failed error or reported to `onConnectError` when the reconnect ultimately succeeds.
- Why this is the smallest reliable guardrail:
  - The bug is localized to the gateway call wrapper and `GatewayClient` connect path. Unit-level tests against these two entry points are sufficient to prevent future regressions in this exact transient-close path without requiring heavier end-to-end scenarios.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A (tests added).

## User-visible / Behavior Changes

- CLI calls that go through `callGateway`/`executeGatewayRequestWithScopes` are more robust against a specific transient handshake pattern: a pre-hello WebSocket close with code `1000` and an empty reason.
- Commands like `openclaw cron status` and `openclaw cron list --json` should no longer fail sporadically with `gateway closed (1000):` on otherwise healthy gateways.
- No change to error behavior for other close codes, non-empty close reasons, auth failures, or timeouts.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) **No**
- Secrets/tokens handling changed? (`Yes/No`) **No**
- New/changed network calls? (`Yes/No`) **No**
- Command/tool execution surface changed? (`Yes/No`) **No**
- Data access scope changed? (`Yes/No`) **No**

If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (container/VM environment)
- Runtime/container: Node 22, pnpm-managed workspace
- Model/provider: N/A (gateway + CLI path only)
- Integration/channel (if any): CLI (`openclaw cron`)
- Relevant config (redacted): Gateway reachable on local loopback, CLI configured to talk to the local gateway.

### Steps

1. Start a local gateway and configure the CLI against it.
2. On a build without this fix, run `openclaw cron status` or `openclaw cron list --json` repeatedly in an environment where the WebSocket stack occasionally emits a transient pre-hello `1000` + empty-reason close.
3. Observe intermittent failures with `gateway closed (1000):` even though the Control UI and direct WebSocket loopback remain healthy.
4. Apply this change and re-run the same CLI commands.

### Expected

- CLI commands should tolerate the transient pre-hello `1000` + empty-reason close, wait for the reconnect, and succeed normally when the gateway is healthy.

### Actual

- Before: CLI calls can fail immediately with `gateway closed (1000):` on the first handshake, despite the gateway being healthy and reconnects succeeding under the hood.
- After: The same commands complete successfully; the transient close is no longer reported as a fatal error, and the new unit tests cover this behavior.

## Evidence

- [x] Failing test/log before + passing after (simulated via new unit tests that reproduce the pre-hello `1000` close pattern and confirm the corrected behavior)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `corepack pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/call.test.ts src/gateway/client.test.ts` on the patched branch.
  - Manual verification on a local install that previously exhibited this bug: `openclaw cron status` and `openclaw cron list --json` no longer fail with `gateway closed (1000):` when the gateway is healthy.
- Edge cases checked:
  - Only the specific `pre-hello + code 1000 + empty reason` path is suppressed; other close codes or non-empty reasons still fail the call as before.
  - Timeouts still behave as before; this change does not alter timeout behavior.
- What you did **not** verify:
  - Full `pnpm build && pnpm check && pnpm test` for the entire monorepo; this PR focuses on gateway client + call behavior and is covered by targeted gateway tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment. *(No prior bot conversations for this PR; marked proactively.)*

## Compatibility / Migration

- Backward compatible? (`Yes/No`) **Yes**
- Config/env changes? (`Yes/No`) **No**
- Migration needed? (`Yes/No`) **No**

If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `fbe47e1874` (or the PR merge commit) to restore the prior `executeGatewayRequestWithScopes` and `GatewayClient.connect` behavior.
- Files/config to restore:
  - `src/gateway/call.ts`
  - `src/gateway/client.ts`
  - `src/gateway/call.test.ts`
  - `src/gateway/client.test.ts`
- Known bad symptoms reviewers should watch for:
  - If a real, unrecoverable pre-hello `1000` close starts occurring in the wild, CLI callers might now see a timeout instead of an immediate `gateway closed (1000):` error for that specific pattern.

## Risks and Mitigations

- Risk:
  - Misclassifying a non-recoverable pre-hello `1000` + empty-reason close as transient, causing the CLI to wait for a reconnect that never meaningfully succeeds and eventually hit a timeout instead of failing immediately.
  - Mitigation: The suppression is narrowly scoped to `pre-hello + code 1000 + empty reason`. Any close with a reason, any non-`1000` code, or any close after `hello-ok` still fails the call as before. Timeouts are unchanged, so a genuinely broken gateway still propagates as a failure rather than silently succeeding.
- Risk:
  - Future changes to error message formatting could break the `GatewayClient.connect` string match for the transient `gateway closed (1000):` error.
  - Mitigation: The new unit tests in `src/gateway/client.test.ts` exercise this behavior explicitly; if the error message shape changes in the future, the tests should fail and force an update to the matching logic or a move to more structured error signaling.
