### PR TITLE
fix(gateway): clear plugin loader cache on in-process restart

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -29,6 +29,7 @@ const abortEmbeddedPiRun = vi.fn(
 );
 const getActiveEmbeddedRunCount = vi.fn(() => 0);
 const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
+const clearPluginLoaderCache = vi.fn();
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
 const gatewayLog = {
   info: vi.fn(),
@@ -64,6 +65,10 @@ vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
     abortEmbeddedPiRun(sessionId, opts),
   getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
   waitForActiveEmbeddedRuns: (timeoutMs: number) => waitForActiveEmbeddedRuns(timeoutMs),
+}));
+
+vi.mock("../../plugins/loader.js", () => ({
+  clearPluginLoaderCache: () => clearPluginLoaderCache(),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -280,6 +285,7 @@ describe("runGatewayLoop", () => {
       });
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
+      expect(clearPluginLoaderCache).toHaveBeenCalledTimes(1);
 
       sigusr1();
 
@@ -292,6 +298,7 @@ describe("runGatewayLoop", () => {
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
       expect(markGatewayDraining).toHaveBeenCalledTimes(2);
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
+      expect(clearPluginLoaderCache).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
 
       sigterm();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -13,6 +13,7 @@ import {
   scheduleGatewaySigusr1Restart,
 } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { clearPluginLoaderCache } from "../../plugins/loader.js";
 import {
   getActiveTaskCount,
   markGatewayDraining,
@@ -221,6 +222,11 @@ export async function runGatewayLoop(params: {
       // coordinator level — rather than inside individual subsystem init
       // functions, to avoid surprising cross-cutting side effects.
       resetAllLanes();
+      // Release cached plugin registries from the previous lifecycle so stale
+      // entries don't accumulate across in-process restarts. Each cached entry
+      // holds a full PluginRegistry with loaded runtimes; without this, the
+      // 128-entry LRU cap lets old registries persist indefinitely.
+      clearPluginLoaderCache();
     });
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).


### PR DESCRIPTION
## Summary

The plugin registry cache (`registryCache` Map in `src/plugins/loader.ts`, LRU-capped at 128 entries) was never cleared during in-process restarts (SIGUSR1). Old cache entries from the previous lifecycle survived, accumulating stale `PluginRegistry` objects with loaded runtimes. Over multiple restarts, this caused RSS to grow steadily (~200MB over 15 minutes in production).

**Fix:** Add `clearPluginLoaderCache()` to the restart iteration hook in `src/cli/gateway-cli/run-loop.ts`, alongside the existing `resetAllLanes()` call. This ensures stale plugin registry entries are released before each new lifecycle starts.

## Changes

- `src/cli/gateway-cli/run-loop.ts` — import and call `clearPluginLoaderCache()` in the restart iteration hook
- `src/cli/gateway-cli/run-loop.test.ts` — add mock and assertions verifying cache is cleared on each restart iteration

## What was considered but not changed

- **Cache cap (128→16)**: Not reduced. `config.schema` calls `loadOpenClawPlugins` with `cache: true, activate: true`, so a smaller cap would increase cache misses triggering full plugin reloads with side effects.
- **`cachedChannelRuntime` resets**: Not needed. Channel resolution already invalidates based on registry version.
- **Model pricing cache clear**: Not needed. Trivial memory footprint; timer already stopped on close.

## Test plan

- [x] `pnpm test -- src/cli/gateway-cli/run-loop.test.ts` — all 9 tests pass
- [x] `pnpm check` — all lint/format/type checks pass
- [ ] Monitor gateway RSS in production after deploy to verify stabilization