### PR TITLE
fix(chunk): prevent markdown code fence chunks from exceeding size limit

### DIFF
--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -374,7 +374,10 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
         }
 
         if (!pickedNewline) {
-          if (minProgressIdx > maxIdxIfAlreadyNewline) {
+          if (minProgressIdx > maxIdxIfNeedNewline) {
+            // Cannot fit closing fence + newline within the limit while
+            // still making minimum forward progress.  Give up on fence
+            // splitting for this chunk to avoid exceeding the size limit.
             fenceToSplit = undefined;
             breakIdx = windowEnd;
           } else {
@@ -383,9 +386,11 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
         }
       }
 
-      const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
-      fenceToSplit =
-        fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
+      if (fenceToSplit) {
+        const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
+        fenceToSplit =
+          fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
+      }
     }
 
     const rawContent = text.slice(start, breakIdx);


### PR DESCRIPTION
## Summary

`chunkMarkdownText()` can produce chunks that exceed the configured size limit when splitting inside code fences. The closing fence marker and its newline are appended **after** the content limit is applied, causing an overshoot of 1+ characters.

## Root Cause

Two issues in `src/auto-reply/chunk.ts`:

1. **Threshold too lenient** (line 377): The give-up condition used `maxIdxIfAlreadyNewline` (accounts for close fence only) instead of `maxIdxIfNeedNewline` (accounts for close fence + newline). When `minProgressIdx` falls between these two thresholds, the code proceeds with fence splitting but the closing `\n``` ` pushes the chunk past the limit.

2. **Give-up overridden** (line 389): After explicitly setting `fenceToSplit = undefined` to give up on fence splitting, the unconditional re-evaluation at line 389 (`findFenceSpanAt(spans, breakIdx)`) would detect the break was still inside a fence and re-enable splitting, negating the give-up.

**Mathematical proof** (limit=8, fence=` ``` `):
- `contentLimit = 8`, `closeLine = "` ``` `"` (3 chars)
- `maxIdxIfNeedNewline = start + (8-4) = start+4`
- `minProgressIdx = start+5` (fence open + 2 chars minimum)
- `breakIdx = max(start+5, start+4) = start+5` → content is 5 chars
- Final chunk: 5 + `\n` + ```` ``` ```` = **9 > 8** — exceeds limit

**Runtime verification:**
```
text = "```\n" + "a".repeat(100) + "\n```", limit = 8
Before fix: 26/27 chunks exceed limit (lengths 9-12)
After fix:  0/26 chunks exceed limit (all ≤ 8)
```

## Fix

1. Tighten the give-up threshold from `maxIdxIfAlreadyNewline` to `maxIdxIfNeedNewline` — give up on fence splitting when minimum progress would exceed the fence-aware safe limit.
2. Guard the `fenceAtBreak` re-evaluation with `if (fenceToSplit)` so explicit give-up decisions aren't overridden.

## Test Plan

- [x] Runtime verification: `npx tsx` confirms all chunks ≤ limit after fix
- [x] Content preservation: all 100 `a` characters present across chunks
- [x] Existing test case (limit=120, ` ```txt `) still produces 5 correctly-sized chunks
- [x] `pnpm tsgo` — no type errors in changed file
- [ ] Pre-existing test runner failure (`@mariozechner/pi-ai/oauth` missing) blocks `pnpm test` — not caused by this change