### PR TITLE
fix(kimi): preserve valid Anthropic-compatible toolCall arguments in malformed-args repair path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/config: accept runtime channel plugin ids in `hooks.mappings[].channel` (for example `feishu`) instead of rejecting non-core channels during config validation. (#56226) Thanks @AiKrai001.
 - TUI/chat: keep optimistic outbound user messages visible during active runs by deferring local-run binding until the first gateway chat event reveals the real run id, preventing premature history reloads from wiping pending local sends. (#54722) Thanks @seanturner001.
 - TUI/model picker: keep searchable `/model` and `/models` input mode from hijacking `j`/`k` as navigation keys, and harden width bounds under `m`-filtered model lists so search no longer crashes on long rows. (#30156) Thanks @briannicholls.
+- Agents/Kimi: preserve already-valid Anthropic-compatible tool call argument objects while still clearing cached repairs when later trailing junk exceeds the repair allowance. (#54491) Thanks @yuanaichi.
 
 ## 2026.3.28
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1591,7 +1591,6 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(finalToolCall.arguments).toEqual({ path: "/tmp/report.txt" });
     expect(result).toBe(finalMessage);
   });
-
   it("preserves anthropic-compatible tool arguments when the streamed JSON is already valid", async () => {
     const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
     const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
@@ -1672,6 +1671,7 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(partialToolCall.arguments).toEqual({});
     expect(streamedToolCall.arguments).toEqual({});
   });
+
   it("keeps incomplete partial JSON unchanged until a complete object exists", async () => {
     const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
     const partialMessage = { role: "assistant", content: [partialToolCall] };
@@ -1753,6 +1753,45 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
             type: "toolcall_delta",
             contentIndex: 0,
             delta: "yzq",
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+          },
+        ],
+        resultMessage: { role: "assistant", content: [partialToolCall] },
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+
+    expect(partialToolCall.arguments).toEqual({});
+    expect(streamedToolCall.arguments).toEqual({});
+  });
+
+  it("clears a cached repair when a later delta adds a single oversized trailing suffix", async () => {
+    const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"path":"/tmp/report.txt"}',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: "oops",
             partial: partialMessage,
           },
           {

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1592,6 +1592,54 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(result).toBe(finalMessage);
   });
 
+  it("preserves anthropic-compatible tool arguments when the streamed JSON is already valid", async () => {
+    const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const endMessageToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const finalToolCall = { type: "toolCall", name: "read", arguments: {} };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const endMessage = { role: "assistant", content: [endMessageToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"path":"/tmp/report.txt"',
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: "}",
+            partial: partialMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+            message: endMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect(partialToolCall.arguments).toEqual({ path: "/tmp/report.txt" });
+    expect(streamedToolCall.arguments).toEqual({ path: "/tmp/report.txt" });
+    expect(endMessageToolCall.arguments).toEqual({ path: "/tmp/report.txt" });
+    expect(finalToolCall.arguments).toEqual({ path: "/tmp/report.txt" });
+    expect(result).toBe(finalMessage);
+  });
+
   it("does not repair tool arguments when leading text is not tool-call metadata", async () => {
     const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
     const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };
@@ -1624,7 +1672,6 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(partialToolCall.arguments).toEqual({});
     expect(streamedToolCall.arguments).toEqual({});
   });
-
   it("keeps incomplete partial JSON unchanged until a complete object exists", async () => {
     const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
     const partialMessage = { role: "assistant", content: [partialToolCall] };

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-argument-repair.ts
@@ -103,8 +103,10 @@ function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair
     return undefined;
   }
   try {
-    JSON.parse(raw);
-    return undefined;
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? { args: parsed as Record<string, unknown>, trailingSuffix: "" }
+      : undefined;
   } catch {
     const extracted = extractBalancedJsonPrefix(raw);
     if (!extracted) {
@@ -255,7 +257,10 @@ function wrapStreamRepairMalformedToolCallArguments(
                   repairedArgsByIndex.set(event.contentIndex, repair.args);
                   repairToolCallArgumentsInMessage(event.partial, event.contentIndex, repair.args);
                   repairToolCallArgumentsInMessage(event.message, event.contentIndex, repair.args);
-                  if (!loggedRepairIndices.has(event.contentIndex)) {
+                  if (
+                    !loggedRepairIndices.has(event.contentIndex) &&
+                    repair.trailingSuffix.length > 0
+                  ) {
                     loggedRepairIndices.add(event.contentIndex);
                     log.warn(
                       `repairing Kimi tool call arguments with ${repair.leadingPrefix.length} leading chars and ${repair.trailingSuffix.length} trailing chars`,

--- a/src/agents/pi-embedded-runner/run/attempt.tool-call-argument-repair.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.tool-call-argument-repair.ts
@@ -81,6 +81,7 @@ function shouldAttemptMalformedToolCallRepair(partialJson: string, delta: string
 
 type ToolCallArgumentRepair = {
   args: Record<string, unknown>;
+  kind: "preserved" | "repaired";
   leadingPrefix: string;
   trailingSuffix: string;
 };
@@ -98,14 +99,19 @@ function isAllowedToolCallRepairLeadingPrefix(prefix: string): boolean {
   return /^[.:'"`-]/.test(prefix) || /^(?:functions?|tools?)[._:/-]?/i.test(prefix);
 }
 
-function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
+function tryExtractUsableToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
   if (!raw.trim()) {
     return undefined;
   }
   try {
     const parsed = JSON.parse(raw) as unknown;
     return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? { args: parsed as Record<string, unknown>, trailingSuffix: "" }
+      ? {
+          args: parsed as Record<string, unknown>,
+          kind: "preserved",
+          leadingPrefix: "",
+          trailingSuffix: "",
+        }
       : undefined;
   } catch {
     const extracted = extractBalancedJsonPrefix(raw);
@@ -131,6 +137,7 @@ function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair
       return parsed && typeof parsed === "object" && !Array.isArray(parsed)
         ? {
             args: parsed as Record<string, unknown>,
+            kind: "repaired",
             leadingPrefix,
             trailingSuffix: suffix,
           }
@@ -251,16 +258,16 @@ function wrapStreamRepairMalformedToolCallArguments(
                 return result;
               }
               partialJsonByIndex.set(event.contentIndex, nextPartialJson);
-              if (shouldAttemptMalformedToolCallRepair(nextPartialJson, event.delta)) {
-                const repair = tryParseMalformedToolCallArguments(nextPartialJson);
+              const shouldReevaluateRepair =
+                shouldAttemptMalformedToolCallRepair(nextPartialJson, event.delta) ||
+                repairedArgsByIndex.has(event.contentIndex);
+              if (shouldReevaluateRepair) {
+                const repair = tryExtractUsableToolCallArguments(nextPartialJson);
                 if (repair) {
                   repairedArgsByIndex.set(event.contentIndex, repair.args);
                   repairToolCallArgumentsInMessage(event.partial, event.contentIndex, repair.args);
                   repairToolCallArgumentsInMessage(event.message, event.contentIndex, repair.args);
-                  if (
-                    !loggedRepairIndices.has(event.contentIndex) &&
-                    repair.trailingSuffix.length > 0
-                  ) {
+                  if (!loggedRepairIndices.has(event.contentIndex) && repair.kind === "repaired") {
                     loggedRepairIndices.add(event.contentIndex);
                     log.warn(
                       `repairing Kimi tool call arguments with ${repair.leadingPrefix.length} leading chars and ${repair.trailingSuffix.length} trailing chars`,


### PR DESCRIPTION
## Summary

- Problem: When using Kimi in Anthropic-compatible (`anthropic-messages`) mode, the malformed toolCall-arguments repair logic could fail to preserve otherwise-valid JSON arguments (resulting in missing/empty tool arguments).
- Why it matters: Tool execution depends on correct `toolCall.arguments`; losing valid arguments can cause wrong tool behavior, failures, or unexpected “empty args” executions.
- What changed: Adjusted the Kimi/Anthropic toolCall-argument repair path to keep valid, complete JSON arguments intact and only apply “balanced-prefix + short trailing junk” repair when the arguments are actually malformed.
- What did NOT change (scope boundary): No changes to tool dispatch logic, tool allowlists, transcript storage, or non-Kimi providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: https://github.com/openclaw/openclaw/issues/53813
- Closes: https://github.com/openclaw/openclaw/issues/54688
- Closes: https://github.com/openclaw/openclaw/issues/54733
- Closes: https://github.com/openclaw/openclaw/issues/55005
- Closes: https://github.com/openclaw/openclaw/issues/54975
- Closes: https://github.com/openclaw/openclaw/issues/54920
- Closes: https://github.com/openclaw/openclaw/issues/55039
- Closes: https://github.com/openclaw/openclaw/issues/55930
- Closes: https://github.com/openclaw/openclaw/issues/55889
- Closes: https://github.com/openclaw/openclaw/issues/58250
- Related: https://github.com/openclaw/openclaw/issues/54978

- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The malformed-args repair wrapper for Kimi/Anthropic streams treated some valid toolCall argument payloads as candidates for repair, and under certain stream delta patterns it could clear/override arguments instead of preserving the complete JSON object.
- Missing detection / guardrail: Unit coverage focused on “valid JSON + short trailing junk” but didn’t adequately lock in “valid JSON must remain unchanged” across all relevant stream delta/event sequences.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Likely triggered by Kimi’s Anthropic-compatible streaming behavior (toolcall deltas containing `}` early / nested JSON / event chunking), which increased the chance the heuristic attempted repair at the wrong time.
- If unknown, what was ruled out: Not an auth/key issue and not a tool registry/dispatch mismatch; reproduces at the stream parsing/repair layer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.test.ts` (malformed toolCall args repair tests)
- Scenario the test should lock in: When toolCall arguments are already valid JSON (including nested objects), the repair path must not alter or clear them; when valid JSON is followed by 1–3 trailing junk characters, it should repair to the valid object.
- Why this is the smallest reliable guardrail: This bug is purely in the stream repair/parsing layer; unit tests can deterministically simulate deltas/events without requiring a live model.
- Existing test that already covers this (if any): The suite includes a test for “trailing junk follows valid JSON”; this PR strengthens/extends coverage to ensure valid JSON remains intact.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None (except improved reliability of tool execution for Kimi Anthropic-compatible runs).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js (local)
- Model/provider: kimi-coding/k2p5
- Integration/channel (if any): N/A
- Relevant config (redacted): Provider set to `kimi`, model API `anthropic-messages`

### Steps

1. Configure provider `kimi` with Anthropic-compatible API (`anthropic-messages`).
2. Trigger a tool call where arguments are a valid nested JSON object (e.g. `{"path":{"a":"/tmp/report.txt"}}`) and/or where streaming deltas include early `}` tokens.
3. Observe tool call arguments during/after stream assembly.

### Expected

- Valid JSON arguments are preserved exactly and passed to tool execution unchanged.

### Actual

- Arguments could be cleared/overwritten in the repair path, resulting in incomplete or empty arguments passed to tools.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran the unit tests for the malformed toolCall-arguments repair and confirmed that the final assembled message preserves valid arguments; also confirmed that the “short trailing junk” repair still works. Before the fix, with Kimi in Anthropic-messages streaming mode, multiple consecutive tool_call invocations could carry empty arguments; after the fix, empty-argument tool calls no longer occur.
- Edge cases checked: -
- What you did **not** verify: -

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; alternatively disable the Kimi/Anthropic malformed-args repair wrapper if maintainers prefer.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for: Tool calls executed with `{}`/missing required parameters; intermittent tool failures only on Kimi Anthropic-compatible runs.

## Risks and Mitigations

- Risk: Repair logic might still be triggered too aggressively for some unusual streaming chunk patterns.
  - Mitigation: Keep repair gated to Kimi + `anthropic-messages`, retain strict trailing-suffix limits, and add/extend unit coverage for representative delta sequences.