### PR TITLE
fix(sandbox): honor sandbox alsoAllow and explicit re-allows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
+
 ## 2026.3.24-beta.2
 
 ### Breaking

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -13,8 +13,8 @@ export {
   isCloudflareOrHtmlErrorPage,
   parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
-import { formatSandboxToolPolicyBlockedMessage } from "../sandbox/runtime-status.js";
 import { stableStringify } from "../stable-stringify.js";
+import { formatEffectiveSandboxToolPolicyBlockedMessage } from "../tool-policy-sandbox.js";
 import {
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
@@ -563,7 +563,7 @@ export function formatAssistantErrorText(
     raw.match(/unknown tool[:\s]+["']?([a-z0-9_-]+)["']?/i) ??
     raw.match(/tool\s+["']?([a-z0-9_-]+)["']?\s+(?:not found|is not available)/i);
   if (unknownTool?.[1]) {
-    const rewritten = formatSandboxToolPolicyBlockedMessage({
+    const rewritten = formatEffectiveSandboxToolPolicyBlockedMessage({
       cfg: opts?.cfg,
       sessionKey: opts?.sessionKey,
       toolName: unknownTool[1],

--- a/src/agents/pi-tools.sandbox-policy.test.ts
+++ b/src/agents/pi-tools.sandbox-policy.test.ts
@@ -1,19 +1,29 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { createOpenClawCodingTools } from "./pi-tools.js";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
 import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 import { createPiToolsSandboxContext } from "./test-helpers/pi-tools-sandbox-context.js";
 
-function listToolNames(cfg: OpenClawConfig): string[] {
+function listToolNames(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  sandboxAgentId?: string;
+}): string[] {
   const workspaceDir = "/tmp/openclaw-sandbox-policy";
+  const sessionKey = params.sessionKey ?? "agent:tavern:main";
+  const sandboxAgentId = params.sandboxAgentId ?? params.agentId ?? "tavern";
   const sandbox = createPiToolsSandboxContext({
     workspaceDir,
     fsBridge: createHostSandboxFsBridge(workspaceDir),
+    sessionKey,
+    tools: resolveSandboxConfigForAgent(params.cfg, sandboxAgentId).tools,
   });
   return createOpenClawCodingTools({
-    config: cfg,
-    agentId: "tavern",
-    sessionKey: "agent:tavern:main",
+    config: params.cfg,
+    agentId: params.agentId,
+    sessionKey,
     sandbox,
     workspaceDir,
   })
@@ -24,24 +34,26 @@ function listToolNames(cfg: OpenClawConfig): string[] {
 describe("pi-tools sandbox policy", () => {
   it("re-exposes omitted sandbox tools via sandbox alsoAllow", () => {
     const names = listToolNames({
-      agents: {
-        defaults: {
-          sandbox: { mode: "all", scope: "agent" },
-        },
-        list: [
-          {
-            id: "tavern",
-            tools: {
-              sandbox: {
-                tools: {
-                  alsoAllow: ["message", "tts"],
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent" },
+          },
+          list: [
+            {
+              id: "tavern",
+              tools: {
+                sandbox: {
+                  tools: {
+                    alsoAllow: ["message", "tts"],
+                  },
                 },
               },
             },
-          },
-        ],
-      },
-    } as OpenClawConfig);
+          ],
+        },
+      } as OpenClawConfig,
+    });
 
     expect(names).toContain("message");
     expect(names).toContain("tts");
@@ -49,41 +61,78 @@ describe("pi-tools sandbox policy", () => {
 
   it("re-enables default-denied sandbox tools when explicitly allowed", () => {
     const names = listToolNames({
-      agents: {
-        defaults: {
-          sandbox: { mode: "all", scope: "agent" },
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent" },
+          },
+          list: [{ id: "tavern" }],
         },
-        list: [{ id: "tavern" }],
-      },
-      tools: {
-        sandbox: {
-          tools: {
-            allow: ["browser"],
+        tools: {
+          sandbox: {
+            tools: {
+              allow: ["browser"],
+            },
           },
         },
-      },
-    } as OpenClawConfig);
+      } as OpenClawConfig,
+    });
 
     expect(names).toContain("browser");
   });
 
-  it("preserves allow-all semantics for allow: [] plus alsoAllow", () => {
-    const names = listToolNames({
+  it("prefers the resolved sandbox context policy for legacy main session aliases", () => {
+    const cfg = {
       agents: {
         defaults: {
           sandbox: { mode: "all", scope: "agent" },
         },
-        list: [{ id: "tavern" }],
+        list: [
+          {
+            id: "tavern",
+            default: true,
+            tools: {
+              sandbox: {
+                tools: {
+                  allow: ["browser"],
+                  alsoAllow: ["message"],
+                },
+              },
+            },
+          },
+        ],
       },
-      tools: {
-        sandbox: {
-          tools: {
-            allow: [],
-            alsoAllow: ["browser"],
+    } as OpenClawConfig;
+
+    const names = listToolNames({
+      cfg,
+      sessionKey: "main",
+      sandboxAgentId: "tavern",
+    });
+
+    expect(names).toContain("browser");
+    expect(names).toContain("message");
+  });
+
+  it("preserves allow-all semantics for allow: [] plus alsoAllow", () => {
+    const names = listToolNames({
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent" },
+          },
+          list: [{ id: "tavern" }],
+        },
+        tools: {
+          sandbox: {
+            tools: {
+              allow: [],
+              alsoAllow: ["browser"],
+            },
           },
         },
-      },
-    } as OpenClawConfig);
+      } as OpenClawConfig,
+    });
 
     expect(names).toContain("browser");
     expect(names).toContain("read");
@@ -91,21 +140,23 @@ describe("pi-tools sandbox policy", () => {
 
   it("keeps explicit sandbox deny precedence over explicit allow", () => {
     const names = listToolNames({
-      agents: {
-        defaults: {
-          sandbox: { mode: "all", scope: "agent" },
+      cfg: {
+        agents: {
+          defaults: {
+            sandbox: { mode: "all", scope: "agent" },
+          },
+          list: [{ id: "tavern" }],
         },
-        list: [{ id: "tavern" }],
-      },
-      tools: {
-        sandbox: {
-          tools: {
-            allow: ["browser", "message"],
-            deny: ["browser"],
+        tools: {
+          sandbox: {
+            tools: {
+              allow: ["browser", "message"],
+              deny: ["browser"],
+            },
           },
         },
-      },
-    } as OpenClawConfig);
+      } as OpenClawConfig,
+    });
 
     expect(names).not.toContain("browser");
     expect(names).toContain("message");

--- a/src/agents/pi-tools.sandbox-policy.test.ts
+++ b/src/agents/pi-tools.sandbox-policy.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createOpenClawCodingTools } from "./pi-tools.js";
+import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
+import { createPiToolsSandboxContext } from "./test-helpers/pi-tools-sandbox-context.js";
+
+function listToolNames(cfg: OpenClawConfig): string[] {
+  const workspaceDir = "/tmp/openclaw-sandbox-policy";
+  const sandbox = createPiToolsSandboxContext({
+    workspaceDir,
+    fsBridge: createHostSandboxFsBridge(workspaceDir),
+  });
+  return createOpenClawCodingTools({
+    config: cfg,
+    agentId: "tavern",
+    sessionKey: "agent:tavern:main",
+    sandbox,
+    workspaceDir,
+  })
+    .map((tool) => tool.name)
+    .toSorted();
+}
+
+describe("pi-tools sandbox policy", () => {
+  it("re-exposes omitted sandbox tools via sandbox alsoAllow", () => {
+    const names = listToolNames({
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [
+          {
+            id: "tavern",
+            tools: {
+              sandbox: {
+                tools: {
+                  alsoAllow: ["message", "tts"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig);
+
+    expect(names).toContain("message");
+    expect(names).toContain("tts");
+  });
+
+  it("re-enables default-denied sandbox tools when explicitly allowed", () => {
+    const names = listToolNames({
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [{ id: "tavern" }],
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: ["browser"],
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(names).toContain("browser");
+  });
+
+  it("preserves allow-all semantics for allow: [] plus alsoAllow", () => {
+    const names = listToolNames({
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [{ id: "tavern" }],
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: [],
+            alsoAllow: ["browser"],
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(names).toContain("browser");
+    expect(names).toContain("read");
+  });
+
+  it("keeps explicit sandbox deny precedence over explicit allow", () => {
+    const names = listToolNames({
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [{ id: "tavern" }],
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: ["browser", "message"],
+            deny: ["browser"],
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(names).not.toContain("browser");
+    expect(names).toContain("message");
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -51,6 +51,7 @@ import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
 } from "./tool-policy-pipeline.js";
+import { resolveEffectiveSandboxToolPolicyForAgent } from "./tool-policy-sandbox.js";
 import {
   applyOwnerOnlyToolPolicy,
   collectExplicitAllowlist,
@@ -300,6 +301,11 @@ export function createOpenClawCodingTools(options?: {
     modelProvider: options?.modelProvider,
     modelId: options?.modelId,
   });
+  const sandboxToolPolicy = sandbox
+    ? options?.config
+      ? resolveEffectiveSandboxToolPolicyForAgent(options.config, agentId)
+      : sandbox.tools
+    : undefined;
   const groupPolicy = resolveGroupToolPolicy({
     config: options?.config,
     sessionKey: options?.sessionKey,
@@ -338,7 +344,7 @@ export function createOpenClawCodingTools(options?: {
     agentPolicy,
     agentProviderPolicy,
     groupPolicy,
-    sandbox?.tools,
+    sandboxToolPolicy,
     subagentPolicy,
   ]);
   const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
@@ -526,7 +532,7 @@ export function createOpenClawCodingTools(options?: {
         agentPolicy,
         agentProviderPolicy,
         groupPolicy,
-        sandbox?.tools,
+        sandboxToolPolicy,
         subagentPolicy,
       ]),
       currentChannelId: options?.currentChannelId,
@@ -594,7 +600,7 @@ export function createOpenClawCodingTools(options?: {
         groupPolicy,
         agentId,
       }),
-      { policy: sandbox?.tools, label: "sandbox tools.allow" },
+      { policy: sandboxToolPolicy, label: "sandbox tools.allow" },
       { policy: subagentPolicy, label: "subagent tools.allow" },
     ],
   });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -51,7 +51,6 @@ import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
 } from "./tool-policy-pipeline.js";
-import { resolveEffectiveSandboxToolPolicyForAgent } from "./tool-policy-sandbox.js";
 import {
   applyOwnerOnlyToolPolicy,
   collectExplicitAllowlist,
@@ -301,11 +300,10 @@ export function createOpenClawCodingTools(options?: {
     modelProvider: options?.modelProvider,
     modelId: options?.modelId,
   });
-  const sandboxToolPolicy = sandbox
-    ? options?.config
-      ? resolveEffectiveSandboxToolPolicyForAgent(options.config, agentId)
-      : sandbox.tools
-    : undefined;
+  // Prefer the already-resolved sandbox context policy. Recomputing from
+  // sessionKey/config can lose the real sandbox agent when callers pass a
+  // legacy alias like `main` instead of an agent session key.
+  const sandboxToolPolicy = sandbox?.tools;
   const groupPolicy = resolveGroupToolPolicy({
     config: options?.config,
     sessionKey: options?.sessionKey,

--- a/src/agents/sandbox/tool-policy.ts
+++ b/src/agents/sandbox/tool-policy.ts
@@ -1,109 +1,17 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { resolveAgentConfig } from "../agent-scope.js";
-import { compileGlobPatterns, matchesAnyGlobPattern } from "../glob-pattern.js";
-import { expandToolGroups } from "../tool-policy.js";
-import { DEFAULT_TOOL_ALLOW, DEFAULT_TOOL_DENY } from "./constants.js";
-import type {
-  SandboxToolPolicy,
-  SandboxToolPolicyResolved,
-  SandboxToolPolicySource,
-} from "./types.js";
-
-function normalizeGlob(value: string) {
-  return value.trim().toLowerCase();
-}
+import {
+  isToolAllowedBySandboxToolPolicy,
+  resolveEffectiveSandboxToolPolicyForAgent,
+} from "../tool-policy-sandbox.js";
+import type { SandboxToolPolicy, SandboxToolPolicyResolved } from "./types.js";
 
 export function isToolAllowed(policy: SandboxToolPolicy, name: string) {
-  const normalized = normalizeGlob(name);
-  const deny = compileGlobPatterns({
-    raw: expandToolGroups(policy.deny ?? []),
-    normalize: normalizeGlob,
-  });
-  if (matchesAnyGlobPattern(normalized, deny)) {
-    return false;
-  }
-  const allow = compileGlobPatterns({
-    raw: expandToolGroups(policy.allow ?? []),
-    normalize: normalizeGlob,
-  });
-  if (allow.length === 0) {
-    return true;
-  }
-  return matchesAnyGlobPattern(normalized, allow);
+  return isToolAllowedBySandboxToolPolicy(name, policy);
 }
 
 export function resolveSandboxToolPolicyForAgent(
   cfg?: OpenClawConfig,
   agentId?: string,
 ): SandboxToolPolicyResolved {
-  const agentConfig = cfg && agentId ? resolveAgentConfig(cfg, agentId) : undefined;
-  const agentAllow = agentConfig?.tools?.sandbox?.tools?.allow;
-  const agentDeny = agentConfig?.tools?.sandbox?.tools?.deny;
-  const globalAllow = cfg?.tools?.sandbox?.tools?.allow;
-  const globalDeny = cfg?.tools?.sandbox?.tools?.deny;
-
-  const allowSource = Array.isArray(agentAllow)
-    ? ({
-        source: "agent",
-        key: "agents.list[].tools.sandbox.tools.allow",
-      } satisfies SandboxToolPolicySource)
-    : Array.isArray(globalAllow)
-      ? ({
-          source: "global",
-          key: "tools.sandbox.tools.allow",
-        } satisfies SandboxToolPolicySource)
-      : ({
-          source: "default",
-          key: "tools.sandbox.tools.allow",
-        } satisfies SandboxToolPolicySource);
-
-  const denySource = Array.isArray(agentDeny)
-    ? ({
-        source: "agent",
-        key: "agents.list[].tools.sandbox.tools.deny",
-      } satisfies SandboxToolPolicySource)
-    : Array.isArray(globalDeny)
-      ? ({
-          source: "global",
-          key: "tools.sandbox.tools.deny",
-        } satisfies SandboxToolPolicySource)
-      : ({
-          source: "default",
-          key: "tools.sandbox.tools.deny",
-        } satisfies SandboxToolPolicySource);
-
-  const deny = Array.isArray(agentDeny)
-    ? agentDeny
-    : Array.isArray(globalDeny)
-      ? globalDeny
-      : [...DEFAULT_TOOL_DENY];
-  const allow = Array.isArray(agentAllow)
-    ? agentAllow
-    : Array.isArray(globalAllow)
-      ? globalAllow
-      : [...DEFAULT_TOOL_ALLOW];
-
-  const expandedDeny = expandToolGroups(deny);
-  let expandedAllow = expandToolGroups(allow);
-
-  // `image` is essential for multimodal workflows; always include it in sandboxed
-  // sessions unless explicitly denied.
-  if (
-    // Empty allowlist means "allow all" for `isToolAllowed`, so don't inject a
-    // single tool that would accidentally turn it into an explicit allowlist.
-    expandedAllow.length > 0 &&
-    !expandedDeny.map((v) => v.toLowerCase()).includes("image") &&
-    !expandedAllow.map((v) => v.toLowerCase()).includes("image")
-  ) {
-    expandedAllow = [...expandedAllow, "image"];
-  }
-
-  return {
-    allow: expandedAllow,
-    deny: expandedDeny,
-    sources: {
-      allow: allowSource,
-      deny: denySource,
-    },
-  };
+  return resolveEffectiveSandboxToolPolicyForAgent(cfg, agentId);
 }

--- a/src/agents/tool-policy-sandbox.test.ts
+++ b/src/agents/tool-policy-sandbox.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
+import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import {
+  formatEffectiveSandboxToolPolicyBlockedMessage,
+  isToolAllowedBySandboxToolPolicy,
+  resolveEffectiveSandboxToolPolicyForAgent,
+} from "./tool-policy-sandbox.js";
+
+describe("tool-policy-sandbox", () => {
+  it("merges sandbox alsoAllow into the default sandbox allowlist", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [
+          {
+            id: "tavern",
+            tools: {
+              sandbox: {
+                tools: {
+                  alsoAllow: ["message", "tts"],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    const resolved = resolveEffectiveSandboxToolPolicyForAgent(cfg, "tavern");
+    expect(resolved.allow).toContain("message");
+    expect(resolved.allow).toContain("tts");
+    expect(resolved.sources.allow).toEqual({
+      source: "agent",
+      key: "agents.list[].tools.sandbox.tools.alsoAllow",
+    });
+  });
+
+  it("lets explicit sandbox allow remove entries from the default sandbox denylist", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: ["browser"],
+          },
+        },
+      },
+    };
+
+    const resolved = resolveEffectiveSandboxToolPolicyForAgent(cfg, "main");
+    expect(resolved.allow).toContain("browser");
+    expect(resolved.deny).not.toContain("browser");
+    expect(
+      isToolAllowedBySandboxToolPolicy("browser", {
+        allow: resolved.allow,
+        deny: resolved.deny,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves allow-all semantics for allow: [] plus alsoAllow", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: [],
+            alsoAllow: ["browser"],
+          },
+        },
+      },
+    };
+
+    const resolved = resolveEffectiveSandboxToolPolicyForAgent(cfg, "main");
+    expect(resolved.allow).toEqual([]);
+    expect(resolved.deny).not.toContain("browser");
+    expect(
+      isToolAllowedBySandboxToolPolicy("read", {
+        allow: resolved.allow,
+        deny: resolved.deny,
+      }),
+    ).toBe(true);
+    expect(
+      isToolAllowedBySandboxToolPolicy("browser", {
+        allow: resolved.allow,
+        deny: resolved.deny,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps canonical sandbox config and runtime status aligned with the effective resolver", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [
+          {
+            id: "tavern",
+            tools: {
+              sandbox: {
+                tools: {
+                  alsoAllow: ["message", "tts"],
+                },
+              },
+            },
+          },
+        ],
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: ["browser"],
+          },
+        },
+      },
+    };
+
+    const sandbox = resolveSandboxConfigForAgent(cfg, "tavern");
+    expect(sandbox.tools.allow).toEqual(expect.arrayContaining(["browser", "message", "tts"]));
+    expect(sandbox.tools.deny).not.toContain("browser");
+
+    const runtime = resolveSandboxRuntimeStatus({
+      cfg,
+      sessionKey: "agent:tavern:main",
+    });
+    expect(runtime.toolPolicy.allow).toEqual(expect.arrayContaining(["browser", "message", "tts"]));
+    expect(runtime.toolPolicy.deny).not.toContain("browser");
+  });
+
+  it("keeps explicit sandbox deny precedence over allow and alsoAllow", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: ["browser"],
+            alsoAllow: ["message"],
+            deny: ["browser", "message"],
+          },
+        },
+      },
+    };
+
+    const resolved = resolveEffectiveSandboxToolPolicyForAgent(cfg, "main");
+    expect(resolved.deny).toContain("browser");
+    expect(resolved.deny).toContain("message");
+    expect(
+      isToolAllowedBySandboxToolPolicy("browser", {
+        allow: resolved.allow,
+        deny: resolved.deny,
+      }),
+    ).toBe(false);
+    expect(
+      isToolAllowedBySandboxToolPolicy("message", {
+        allow: resolved.allow,
+        deny: resolved.deny,
+      }),
+    ).toBe(false);
+  });
+
+  it("uses the effective sandbox policy when formatting blocked-tool guidance", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent" },
+        },
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            alsoAllow: ["message"],
+          },
+        },
+      },
+    };
+
+    const browserMessage = formatEffectiveSandboxToolPolicyBlockedMessage({
+      cfg,
+      sessionKey: "agent:main:main",
+      toolName: "browser",
+    });
+    expect(browserMessage).toContain('Tool "browser" blocked by sandbox tool policy');
+    expect(browserMessage).toContain("tools.sandbox.tools.deny");
+
+    const messageToolMessage = formatEffectiveSandboxToolPolicyBlockedMessage({
+      cfg,
+      sessionKey: "agent:main:main",
+      toolName: "message",
+    });
+    expect(messageToolMessage).toBeUndefined();
+  });
+});

--- a/src/agents/tool-policy-sandbox.ts
+++ b/src/agents/tool-policy-sandbox.ts
@@ -1,0 +1,358 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentMainSessionKey,
+  resolveMainSessionKey,
+} from "../config/sessions/main-session.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "./agent-scope.js";
+import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
+import { DEFAULT_TOOL_ALLOW, DEFAULT_TOOL_DENY } from "./sandbox/constants.js";
+import type {
+  SandboxToolPolicy,
+  SandboxToolPolicyResolved,
+  SandboxToolPolicySource,
+} from "./sandbox/types.js";
+import { expandToolGroups, normalizeToolName } from "./tool-policy.js";
+
+type SandboxToolPolicyConfig = {
+  allow?: string[];
+  alsoAllow?: string[];
+  deny?: string[];
+};
+
+function buildSource(params: {
+  scope: "agent" | "global" | "default";
+  key: string;
+}): SandboxToolPolicySource {
+  return {
+    source: params.scope,
+    key: params.key,
+  } satisfies SandboxToolPolicySource;
+}
+
+function pickConfiguredList(params: { agent?: string[]; global?: string[] }): {
+  values?: string[];
+  source: SandboxToolPolicySource;
+} {
+  if (Array.isArray(params.agent)) {
+    return {
+      values: params.agent,
+      source: buildSource({ scope: "agent", key: "agents.list[].tools.sandbox.tools.allow" }),
+    };
+  }
+  if (Array.isArray(params.global)) {
+    return {
+      values: params.global,
+      source: buildSource({ scope: "global", key: "tools.sandbox.tools.allow" }),
+    };
+  }
+  return {
+    values: undefined,
+    source: buildSource({ scope: "default", key: "tools.sandbox.tools.allow" }),
+  };
+}
+
+function pickConfiguredDeny(params: { agent?: string[]; global?: string[] }): {
+  values?: string[];
+  source: SandboxToolPolicySource;
+} {
+  if (Array.isArray(params.agent)) {
+    return {
+      values: params.agent,
+      source: buildSource({ scope: "agent", key: "agents.list[].tools.sandbox.tools.deny" }),
+    };
+  }
+  if (Array.isArray(params.global)) {
+    return {
+      values: params.global,
+      source: buildSource({ scope: "global", key: "tools.sandbox.tools.deny" }),
+    };
+  }
+  return {
+    values: undefined,
+    source: buildSource({ scope: "default", key: "tools.sandbox.tools.deny" }),
+  };
+}
+
+function pickConfiguredAlsoAllow(params: { agent?: string[]; global?: string[] }): {
+  values?: string[];
+  source?: SandboxToolPolicySource;
+} {
+  if (Array.isArray(params.agent)) {
+    return {
+      values: params.agent,
+      source: buildSource({
+        scope: "agent",
+        key: "agents.list[].tools.sandbox.tools.alsoAllow",
+      }),
+    };
+  }
+  if (Array.isArray(params.global)) {
+    return {
+      values: params.global,
+      source: buildSource({ scope: "global", key: "tools.sandbox.tools.alsoAllow" }),
+    };
+  }
+  return { values: undefined, source: undefined };
+}
+
+function mergeAllowlist(base: string[] | undefined, extra: string[] | undefined): string[] {
+  if (Array.isArray(base)) {
+    // Preserve the existing sandbox meaning of `allow: []` => allow all.
+    if (base.length === 0) {
+      return [];
+    }
+    if (!Array.isArray(extra) || extra.length === 0) {
+      return [...base];
+    }
+    return Array.from(new Set([...base, ...extra]));
+  }
+  if (Array.isArray(extra) && extra.length > 0) {
+    return Array.from(new Set([...DEFAULT_TOOL_ALLOW, ...extra]));
+  }
+  return [...DEFAULT_TOOL_ALLOW];
+}
+
+function pickAllowSource(params: {
+  allow: SandboxToolPolicySource;
+  allowDefined: boolean;
+  alsoAllow?: SandboxToolPolicySource;
+}): SandboxToolPolicySource {
+  if (params.allowDefined && params.allow.source === "agent") {
+    return params.allow;
+  }
+  if (params.alsoAllow?.source === "agent") {
+    return params.alsoAllow;
+  }
+  if (params.allowDefined && params.allow.source === "global") {
+    return params.allow;
+  }
+  if (params.alsoAllow?.source === "global") {
+    return params.alsoAllow;
+  }
+  return params.allow;
+}
+
+function resolveExplicitSandboxReAllowPatterns(params: {
+  allow?: string[];
+  alsoAllow?: string[];
+}): string[] {
+  return Array.from(new Set([...(params.allow ?? []), ...(params.alsoAllow ?? [])]));
+}
+
+function filterDefaultDenyForExplicitAllows(params: {
+  deny: string[];
+  explicitAllowPatterns: string[];
+}): string[] {
+  if (params.explicitAllowPatterns.length === 0) {
+    return [...params.deny];
+  }
+  const allowPatterns = compileGlobPatterns({
+    raw: expandToolGroups(params.explicitAllowPatterns),
+    normalize: normalizeToolName,
+  });
+  if (allowPatterns.length === 0) {
+    return [...params.deny];
+  }
+  return params.deny.filter(
+    (toolName) => !matchesAnyGlobPattern(normalizeToolName(toolName), allowPatterns),
+  );
+}
+
+function expandResolvedPolicy(policy: SandboxToolPolicy): SandboxToolPolicy {
+  const expandedDeny = expandToolGroups(policy.deny ?? []);
+  let expandedAllow = expandToolGroups(policy.allow ?? []);
+
+  // `image` is essential for multimodal workflows; keep the existing sandbox
+  // behavior that auto-includes it for explicit allowlists unless it is denied.
+  if (
+    expandedAllow.length > 0 &&
+    !expandedDeny.map((value) => value.toLowerCase()).includes("image") &&
+    !expandedAllow.map((value) => value.toLowerCase()).includes("image")
+  ) {
+    expandedAllow = [...expandedAllow, "image"];
+  }
+
+  return {
+    allow: expandedAllow,
+    deny: expandedDeny,
+  };
+}
+
+export function resolveEffectiveSandboxToolPolicyForAgent(
+  cfg?: OpenClawConfig,
+  agentId?: string,
+): SandboxToolPolicyResolved {
+  const agentConfig = cfg && agentId ? resolveAgentConfig(cfg, agentId) : undefined;
+  const agentPolicy = agentConfig?.tools?.sandbox?.tools as SandboxToolPolicyConfig | undefined;
+  const globalPolicy = cfg?.tools?.sandbox?.tools as SandboxToolPolicyConfig | undefined;
+
+  const allowConfig = pickConfiguredList({
+    agent: agentPolicy?.allow,
+    global: globalPolicy?.allow,
+  });
+  const alsoAllowConfig = pickConfiguredAlsoAllow({
+    agent: agentPolicy?.alsoAllow,
+    global: globalPolicy?.alsoAllow,
+  });
+  const denyConfig = pickConfiguredDeny({
+    agent: agentPolicy?.deny,
+    global: globalPolicy?.deny,
+  });
+
+  const explicitAllowPatterns = resolveExplicitSandboxReAllowPatterns({
+    allow: allowConfig.values,
+    alsoAllow: alsoAllowConfig.values,
+  });
+
+  const resolvedAllow = mergeAllowlist(allowConfig.values, alsoAllowConfig.values);
+  const resolvedDeny = Array.isArray(denyConfig.values)
+    ? [...denyConfig.values]
+    : filterDefaultDenyForExplicitAllows({
+        deny: [...DEFAULT_TOOL_DENY],
+        explicitAllowPatterns,
+      });
+
+  const expanded = expandResolvedPolicy({
+    allow: resolvedAllow,
+    deny: resolvedDeny,
+  });
+
+  return {
+    allow: expanded.allow ?? [],
+    deny: expanded.deny ?? [],
+    sources: {
+      allow: pickAllowSource({
+        allow: allowConfig.source,
+        allowDefined: Array.isArray(allowConfig.values),
+        alsoAllow: alsoAllowConfig.source,
+      }),
+      deny: denyConfig.source,
+    },
+  };
+}
+
+function classifyToolAgainstSandboxToolPolicy(name: string, policy?: SandboxToolPolicy) {
+  if (!policy) {
+    return {
+      blockedByDeny: false,
+      blockedByAllow: false,
+    };
+  }
+
+  const normalized = normalizeToolName(name);
+  const deny = compileGlobPatterns({
+    raw: expandToolGroups(policy.deny ?? []),
+    normalize: normalizeToolName,
+  });
+  const blockedByDeny = matchesAnyGlobPattern(normalized, deny);
+  const allow = compileGlobPatterns({
+    raw: expandToolGroups(policy.allow ?? []),
+    normalize: normalizeToolName,
+  });
+  const blockedByAllow =
+    !blockedByDeny && allow.length > 0 && !matchesAnyGlobPattern(normalized, allow);
+  return {
+    blockedByDeny,
+    blockedByAllow,
+  };
+}
+
+export function isToolAllowedBySandboxToolPolicy(
+  name: string,
+  policy?: SandboxToolPolicy,
+): boolean {
+  const { blockedByDeny, blockedByAllow } = classifyToolAgainstSandboxToolPolicy(name, policy);
+  return !blockedByDeny && !blockedByAllow;
+}
+
+function resolveSandboxModeForAgent(
+  cfg?: OpenClawConfig,
+  agentId?: string,
+): "off" | "non-main" | "all" {
+  const defaults = cfg?.agents?.defaults?.sandbox;
+  const agentConfig = cfg && agentId ? resolveAgentConfig(cfg, agentId) : undefined;
+  return agentConfig?.sandbox?.mode ?? defaults?.mode ?? "off";
+}
+
+function shouldSandboxSession(
+  mode: "off" | "non-main" | "all",
+  sessionKey: string,
+  mainKey: string,
+) {
+  if (mode === "off") {
+    return false;
+  }
+  if (mode === "all") {
+    return true;
+  }
+  return sessionKey.trim() !== mainKey.trim();
+}
+
+export function formatEffectiveSandboxToolPolicyBlockedMessage(params: {
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+  toolName: string;
+}): string | undefined {
+  const tool = params.toolName.trim().toLowerCase();
+  if (!tool) {
+    return undefined;
+  }
+
+  const sessionKey = params.sessionKey?.trim() ?? "";
+  const agentId = resolveSessionAgentId({
+    sessionKey,
+    config: params.cfg,
+  });
+  const mainSessionKey =
+    params.cfg?.session?.scope === "global"
+      ? resolveMainSessionKey(params.cfg)
+      : resolveAgentMainSessionKey({
+          cfg: params.cfg,
+          agentId,
+        });
+  const comparableSessionKey = canonicalizeMainSessionAlias({
+    cfg: params.cfg,
+    agentId,
+    sessionKey,
+  });
+  const sandboxMode = resolveSandboxModeForAgent(params.cfg, agentId);
+  const sandboxed = sessionKey
+    ? shouldSandboxSession(sandboxMode, comparableSessionKey, mainSessionKey)
+    : false;
+  if (!sandboxed) {
+    return undefined;
+  }
+
+  const policy = resolveEffectiveSandboxToolPolicyForAgent(params.cfg, agentId);
+  const { blockedByDeny, blockedByAllow } = classifyToolAgainstSandboxToolPolicy(tool, policy);
+  if (!blockedByDeny && !blockedByAllow) {
+    return undefined;
+  }
+
+  const reasons: string[] = [];
+  const fixes: string[] = [];
+  if (blockedByDeny) {
+    reasons.push("deny list");
+    fixes.push(`Remove "${tool}" from ${policy.sources.deny.key}.`);
+  }
+  if (blockedByAllow) {
+    reasons.push("allow list");
+    fixes.push(`Add "${tool}" to ${policy.sources.allow.key} (or set it to [] to allow all).`);
+  }
+
+  const lines = [
+    `Tool "${tool}" blocked by sandbox tool policy (mode=${sandboxMode}).`,
+    `Session: ${sessionKey || "(unknown)"}`,
+    `Reason: ${reasons.join(" + ")}`,
+    "Fix:",
+    "- agents.defaults.sandbox.mode=off (disable sandbox)",
+    ...fixes.map((fix) => `- ${fix}`),
+  ];
+  if (sandboxMode === "non-main") {
+    lines.push(`- Use main session key (direct): ${mainSessionKey}`);
+  }
+  lines.push(`- See: ${formatCliCommand(`openclaw sandbox explain --session ${sessionKey}`)}`);
+  return lines.join("\n");
+}

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -43,6 +43,54 @@ describe("sandbox explain command", () => {
     expect(parsed).toHaveProperty("sandbox.tools.sources.allow.source");
     expect(Array.isArray(parsed.fixIt)).toBe(true);
     expect(parsed.fixIt).toContain("agents.defaults.sandbox.mode=off");
+    expect(parsed.fixIt).toContain("tools.sandbox.tools.alsoAllow");
     expect(parsed.fixIt).toContain("tools.sandbox.tools.deny");
+  });
+
+  it("shows effective sandbox alsoAllow grants and default-deny removals", async () => {
+    mockCfg = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "agent", workspaceAccess: "none" },
+        },
+        list: [
+          {
+            id: "tavern",
+            tools: {
+              sandbox: {
+                tools: {
+                  alsoAllow: ["message", "tts"],
+                },
+              },
+            },
+          },
+        ],
+      },
+      tools: {
+        sandbox: {
+          tools: {
+            allow: ["browser"],
+          },
+        },
+      },
+      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, agent: "tavern" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed.sandbox.tools.allow).toEqual(
+      expect.arrayContaining(["browser", "message", "tts"]),
+    );
+    expect(parsed.sandbox.tools.deny).not.toContain("browser");
+    expect(parsed.sandbox.tools.sources.allow).toEqual({
+      source: "agent",
+      key: "agents.list[].tools.sandbox.tools.alsoAllow",
+    });
   });
 });

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -1,8 +1,6 @@
 import { resolveAgentConfig } from "../agents/agent-scope.js";
-import {
-  resolveSandboxConfigForAgent,
-  resolveSandboxToolPolicyForAgent,
-} from "../agents/sandbox.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
+import { resolveEffectiveSandboxToolPolicyForAgent } from "../agents/tool-policy-sandbox.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -148,7 +146,7 @@ export async function sandboxExplainCommand(
   });
 
   const sandboxCfg = resolveSandboxConfigForAgent(cfg, resolvedAgentId);
-  const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, resolvedAgentId);
+  const toolPolicy = resolveEffectiveSandboxToolPolicyForAgent(cfg, resolvedAgentId);
   const mainSessionKey = resolveAgentMainSessionKey({
     cfg,
     agentId: resolvedAgentId,
@@ -221,8 +219,10 @@ export async function sandboxExplainCommand(
     fixIt.push("agents.list[].sandbox.mode=off");
   }
   fixIt.push("tools.sandbox.tools.allow");
+  fixIt.push("tools.sandbox.tools.alsoAllow");
   fixIt.push("tools.sandbox.tools.deny");
   fixIt.push("agents.list[].tools.sandbox.tools.allow");
+  fixIt.push("agents.list[].tools.sandbox.tools.alsoAllow");
   fixIt.push("agents.list[].tools.sandbox.tools.deny");
   fixIt.push("tools.elevated.enabled");
   if (channel) {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -312,6 +312,8 @@ export type AgentToolsConfig = {
   sandbox?: {
     tools?: {
       allow?: string[];
+      /** Additional allowlist entries merged into allow and/or the sandbox default allowlist. */
+      alsoAllow?: string[];
       deny?: string[];
     };
   };
@@ -604,6 +606,8 @@ export type ToolsConfig = {
   sandbox?: {
     tools?: {
       allow?: string[];
+      /** Additional allowlist entries merged into allow and/or the sandbox default allowlist. */
+      alsoAllow?: string[];
       deny?: string[];
     };
   };

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -9,9 +9,9 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
 import { SANDBOX_BROWSER_SECURITY_HASH_EPOCH } from "../agents/sandbox/constants.js";
 import { execDockerRaw, type ExecDockerRawResult } from "../agents/sandbox/docker.js";
-import { resolveSandboxToolPolicyForAgent } from "../agents/sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
+import { resolveEffectiveSandboxToolPolicyForAgent } from "../agents/tool-policy-sandbox.js";
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -151,7 +151,9 @@ function resolveToolPolicies(params: {
     pickSandboxToolPolicy(params.agentTools),
   ];
   if (params.sandboxMode === "all") {
-    policies.push(resolveSandboxToolPolicyForAgent(params.cfg, params.agentId ?? undefined));
+    policies.push(
+      resolveEffectiveSandboxToolPolicyForAgent(params.cfg, params.agentId ?? undefined),
+    );
   }
   return policies;
 }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -5,10 +5,10 @@ import { isDangerousNetworkMode, normalizeNetworkMode } from "../agents/sandbox/
  *
  * These functions analyze config-based security properties without I/O.
  */
-import { resolveSandboxToolPolicyForAgent } from "../agents/sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "../agents/sandbox/types.js";
 import { getBlockedBindReason } from "../agents/sandbox/validate-sandbox-security.js";
 import { isToolAllowedByPolicies } from "../agents/tool-policy-match.js";
+import { resolveEffectiveSandboxToolPolicyForAgent } from "../agents/tool-policy-sandbox.js";
 import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { resolveBrowserConfig } from "../browser/config.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -318,7 +318,10 @@ function resolveToolPolicies(params: {
   }
 
   if (params.sandboxMode === "all") {
-    const sandboxPolicy = resolveSandboxToolPolicyForAgent(params.cfg, params.agentId ?? undefined);
+    const sandboxPolicy = resolveEffectiveSandboxToolPolicyForAgent(
+      params.cfg,
+      params.agentId ?? undefined,
+    );
     policies.push(sandboxPolicy);
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: sandbox tool policy accepted `tools.sandbox.tools.alsoAllow`, but the canonical sandbox resolver ignored it, and explicit sandbox `allow` entries could not re-enable tools from the built-in sandbox default deny list.
- Why it matters: sandboxed agents could not access explicitly intended tools like `message`, `tts`, or `browser`, while `openclaw sandbox explain`, audits, and unknown-tool guidance could drift from actual effective policy.
- What changed: added a shared effective sandbox policy resolver, made the canonical sandbox resolver delegate to it, wired the same effective policy into tool exposure, explain output, audits, and blocked-tool messaging, and added regression coverage.
- What did NOT change (scope boundary): no sandbox mode/scope semantics changed, configured `deny` still wins, and `/new` / `/reset` behavior was not touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the sandbox config schema accepted `alsoAllow`, but `src/agents/sandbox/tool-policy.ts` only read `allow` and `deny`, so additive sandbox grants were ignored. The same resolver also left the built-in default deny list intact even when users explicitly re-allowed one of those tools.
- Missing detection / guardrail: there was no regression test covering sandbox `alsoAllow`, default-deny re-allows, or consistency between the canonical sandbox resolver and downstream consumers.
- Prior context (`git blame`, prior PR, issue, or refactor if known): sandbox policy behavior had drifted from schema/config support and from downstream effective-policy callers.
- Why this regressed now: runtime sandbox tool resolution never caught up with the additive config shape.
- If unknown, what was ruled out: verified this was not a missing core-tool registration issue; the bug was in sandbox policy resolution.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/tool-policy-sandbox.test.ts`
  - `src/agents/pi-tools.sandbox-policy.test.ts`
  - `src/commands/sandbox-explain.test.ts`
- Scenario the test should lock in: sandbox `alsoAllow` is additive, explicit sandbox `allow` can re-enable built-in default-denied tools, `allow: []` preserves allow-all semantics, and canonical sandbox config/runtime views stay aligned with effective resolution.
- Why this is the smallest reliable guardrail: the bug lived in policy resolution and then surfaced through tool exposure and explain output, so unit + seam coverage is the narrowest reliable mix.
- Existing test that already covers this (if any): prior sandbox policy tests covered allow/deny basics but not `alsoAllow` or default-deny re-allows.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `tools.sandbox.tools.alsoAllow` and `agents.list[].tools.sandbox.tools.alsoAllow` now work for sandboxed agents.
- Explicit sandbox `allow` / `alsoAllow` entries can re-enable tools from the built-in sandbox default deny list, unless an explicit configured `deny` still blocks them.
- `openclaw sandbox explain` now reports the same effective sandbox allow/deny behavior used at runtime.
- Unknown-tool error rewrites for sandboxed sessions now use the effective sandbox policy.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: sandboxed tool exposure now matches existing user config instead of under-enforcing `alsoAllow` / explicit re-allows. Mitigations: configured `deny` still wins, built-in deny removal only happens for explicitly re-allowed tool patterns, and regression tests cover the intended precedence and `allow: []` semantics.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm local dev environment
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): sandbox mode `all`, with `tools.sandbox.tools.alsoAllow` and/or `tools.sandbox.tools.allow`

### Steps

1. Configure a sandboxed agent with `agents.defaults.sandbox.mode=all`.
2. Set `agents.list[].tools.sandbox.tools.alsoAllow: ["message", "tts"]` or `tools.sandbox.tools.allow: ["browser"]`.
3. Inspect effective sandbox tools via `openclaw sandbox explain --json --agent <id>` or build the sandboxed tool list.

### Expected

- `alsoAllow` tools appear in the effective sandbox allowlist.
- Explicitly re-allowed default-denied tools are available unless also explicitly denied.

### Actual

- Before this change, sandbox `alsoAllow` was ignored and explicit re-allows did not remove built-in default-denied tools.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - sandbox `alsoAllow` re-exposes omitted tools
  - explicit sandbox `allow` re-enables `browser`
  - explicit `deny` still overrides allow/alsoAllow
  - `allow: []` + `alsoAllow` preserves allow-all semantics
  - canonical sandbox config/runtime and `sandbox explain` match the effective resolver
- Edge cases checked:
  - global-session main key handling for blocked-tool formatting
  - downstream audit and error-rewrite consumers use the same resolver
- What you did **not** verify:
  - no live channel/integration-specific manual run; verification stayed in repo tests and local CLI/runtime code paths

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit, or temporarily avoid `alsoAllow`/explicit re-allow reliance in sandbox config.
- Files/config to restore: `src/agents/sandbox/tool-policy.ts` and downstream callers listed in this PR.
- Known bad symptoms reviewers should watch for: sandboxed agents unexpectedly missing explicitly granted tools, or `sandbox explain`/audit views drifting from runtime behavior.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: sandbox precedence semantics could drift again across runtime, explain, audits, and error rewriting.
  - Mitigation: all of those call sites now use the same effective resolver, and tests cover canonical + downstream behavior.
- Risk: `allow: []` could accidentally turn into an explicit allowlist.
  - Mitigation: explicit regression coverage locks in allow-all semantics for `allow: []` plus `alsoAllow`.
