### PR TITLE
fix: reject empty card objects in Feishu message tool (#54430)

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -206,6 +206,20 @@ describe("feishuPlugin actions", () => {
     expect(result?.details).toMatchObject({ ok: true, messageId: "om_card", chatId: "oc_group_1" });
   });
 
+  it("rejects empty card objects as if no content was provided", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: { to: "chat:oc_group_1", card: {} },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+      } as never),
+    ).rejects.toThrow("Feishu send requires text/message, media, or card.");
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("sends media through the outbound adapter", async () => {
     feishuOutboundSendMediaMock.mockResolvedValueOnce({
       channel: "feishu",

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -506,10 +506,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
-            const card =
+            const rawCard =
               ctx.params.card && typeof ctx.params.card === "object"
                 ? (ctx.params.card as Record<string, unknown>)
                 : undefined;
+            // Reject empty card objects — they pass the typeof check but cause 400 errors from the Feishu API.
+            const card = rawCard && Object.keys(rawCard).length > 0 ? rawCard : undefined;
             const text = readFirstString(ctx.params, ["text", "message"]);
             const mediaUrl = readFeishuMediaParam(ctx.params);
             if (card && mediaUrl) {
@@ -596,10 +598,11 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               throw new Error("Feishu edit requires messageId.");
             }
             const text = readFirstString(ctx.params, ["text", "message"]);
-            const card =
+            const rawCard =
               ctx.params.card && typeof ctx.params.card === "object"
                 ? (ctx.params.card as Record<string, unknown>)
                 : undefined;
+            const card = rawCard && Object.keys(rawCard).length > 0 ? rawCard : undefined;
             const { editMessageFeishu } = await loadFeishuChannelRuntime();
             const result = await editMessageFeishu({
               cfg: ctx.cfg,


### PR DESCRIPTION
## Summary
- Fixes #54430
- Empty card objects `{}` pass the existing `typeof card === "object"` check but cause 400 errors from the Feishu API
- Added validation to reject empty card objects before making the API call

## Test plan
- Send a Feishu message with `card: {}` and no text — should return a validation error
- Send a Feishu message with a valid card — should work as before