### PR TITLE
fix: surface provider-specific rate limit error message (#54433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: fix infinite echo loop in self-chat DM mode where the bot's own outbound replies were re-processed as new inbound user messages. (#54570) Thanks @joelnishanth
 - Discord/reconnect: drain stale gateway sockets, clear cached resume state before forced fresh reconnects, and fail closed when old sockets refuse to die so Discord recovery stops looping on poisoned resume state. (#54697) Thanks @ngutman.
 - BlueBubbles/groups: optionally enrich unnamed participant lists with local macOS Contacts names after group gating passes, so group member context can show names instead of only raw phone numbers.
+- Agents/errors: surface provider quota/reset details when available, but keep HTML/Cloudflare rate-limit pages on the generic fallback so raw error pages are not shown to users. (#54512) Thanks @bugkill3r.
 
 ## 2026.3.24
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -147,6 +147,14 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("strips leading HTTP status code prefix from non-JSON rate limit messages", () => {
+    const msg = makeAssistantError("429 Your quota has been exhausted, try again in 24 hours");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("try again in 24 hours");
+    expect(result).not.toMatch(/^⚠️ 429\b/);
+    expect(result).toBe("⚠️ Your quota has been exhausted, try again in 24 hours");
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -121,6 +121,32 @@ describe("formatAssistantErrorText", () => {
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
   });
 
+  it("surfaces provider-specific rate limit message with reset time (#54433)", () => {
+    const msg = makeAssistantError(
+      "You have hit your ChatGPT usage limit (go plan). Try again in ~4381 min.",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("4381 min");
+    expect(result).toContain("go plan");
+    expect(result).not.toBe("⚠️ API rate limit reached. Please try again later.");
+  });
+
+  it("surfaces provider-specific rate limit message from JSON payload (#54433)", () => {
+    const msg = makeAssistantError(
+      '429 {"type":"error","error":{"type":"rate_limit_error","message":"Rate limit reached. Try again in 30 seconds."}}',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("30 seconds");
+    expect(result).not.toBe("⚠️ API rate limit reached. Please try again later.");
+  });
+
+  it("returns generic rate limit message when no specific details are present", () => {
+    const msg = makeAssistantError("429 Too Many Requests");
+    expect(formatAssistantErrorText(msg)).toBe(
+      "⚠️ API rate limit reached. Please try again later.",
+    );
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -155,6 +155,24 @@ describe("formatAssistantErrorText", () => {
     expect(result).toBe("⚠️ Your quota has been exhausted, try again in 24 hours");
   });
 
+  it("falls back to generic copy for HTML quota pages", () => {
+    const msg = makeAssistantError(
+      "429 <!DOCTYPE html><html><body>Your quota is exhausted</body></html>",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "⚠️ API rate limit reached. Please try again later.",
+    );
+  });
+
+  it("falls back to generic copy for prefixed HTML rate-limit pages", () => {
+    const msg = makeAssistantError(
+      "Error: 521 <!DOCTYPE html><html><body>rate limit</body></html>",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "⚠️ API rate limit reached. Please try again later.",
+    );
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -68,7 +68,9 @@ const RATE_LIMIT_SPECIFIC_HINT_RE =
 function extractProviderRateLimitMessage(raw: string): string | undefined {
   // Try to pull a human-readable message out of a JSON error payload first.
   const info = parseApiErrorInfo(raw);
-  const candidate = info?.message ?? raw;
+  // When the raw string is not a JSON payload, strip any leading HTTP status
+  // code (e.g. "429 ") so the surfaced message stays clean.
+  const candidate = info?.message ?? (extractLeadingHttpStatus(raw.trim())?.rest || raw);
 
   if (!candidate || !RATE_LIMIT_SPECIFIC_HINT_RE.test(candidate)) {
     return undefined;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -66,19 +66,30 @@ const RATE_LIMIT_SPECIFIC_HINT_RE =
   /\bmin(ute)?s?\b|\bhours?\b|\bseconds?\b|\btry again in\b|\breset\b|\bplan\b|\bquota\b/i;
 
 function extractProviderRateLimitMessage(raw: string): string | undefined {
+  const withoutPrefix = raw.replace(ERROR_PREFIX_RE, "").trim();
   // Try to pull a human-readable message out of a JSON error payload first.
-  const info = parseApiErrorInfo(raw);
+  const info = parseApiErrorInfo(raw) ?? parseApiErrorInfo(withoutPrefix);
   // When the raw string is not a JSON payload, strip any leading HTTP status
   // code (e.g. "429 ") so the surfaced message stays clean.
-  const candidate = info?.message ?? (extractLeadingHttpStatus(raw.trim())?.rest || raw);
+  const candidate =
+    info?.message ?? (extractLeadingHttpStatus(withoutPrefix)?.rest || withoutPrefix);
 
   if (!candidate || !RATE_LIMIT_SPECIFIC_HINT_RE.test(candidate)) {
     return undefined;
   }
 
+  // Skip HTML/Cloudflare error pages even if the body mentions quota/plan text.
+  if (isCloudflareOrHtmlErrorPage(withoutPrefix)) {
+    return undefined;
+  }
+
   // Avoid surfacing very long or clearly non-human-readable blobs.
   const trimmed = candidate.trim();
-  if (trimmed.length > 300 || trimmed.startsWith("{")) {
+  if (
+    trimmed.length > 300 ||
+    trimmed.startsWith("{") ||
+    /^(?:<!doctype\s+html\b|<html\b)/i.test(trimmed)
+  ) {
     return undefined;
   }
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -5,6 +5,7 @@ import {
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
   isCloudflareOrHtmlErrorPage,
+  parseApiErrorInfo,
   parseApiErrorPayload,
 } from "../../shared/assistant-error-format.js";
 export {
@@ -55,9 +56,38 @@ const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 
+/**
+ * Check whether the raw rate-limit error contains provider-specific details
+ * worth surfacing (e.g. reset times, plan names, quota info).  Bare status
+ * codes like "429" or generic phrases like "rate limit exceeded" are not
+ * considered specific enough.
+ */
+const RATE_LIMIT_SPECIFIC_HINT_RE =
+  /\bmin(ute)?s?\b|\bhours?\b|\bseconds?\b|\btry again in\b|\breset\b|\bplan\b|\bquota\b/i;
+
+function extractProviderRateLimitMessage(raw: string): string | undefined {
+  // Try to pull a human-readable message out of a JSON error payload first.
+  const info = parseApiErrorInfo(raw);
+  const candidate = info?.message ?? raw;
+
+  if (!candidate || !RATE_LIMIT_SPECIFIC_HINT_RE.test(candidate)) {
+    return undefined;
+  }
+
+  // Avoid surfacing very long or clearly non-human-readable blobs.
+  const trimmed = candidate.trim();
+  if (trimmed.length > 300 || trimmed.startsWith("{")) {
+    return undefined;
+  }
+
+  return `⚠️ ${trimmed}`;
+}
+
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
-    return RATE_LIMIT_ERROR_USER_MESSAGE;
+    // Surface the provider's specific message when it contains actionable
+    // details (reset time, plan name, quota info) instead of the generic copy.
+    return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
   }
   if (isOverloadedErrorMessage(raw)) {
     return OVERLOADED_ERROR_USER_MESSAGE;


### PR DESCRIPTION
## Summary
- Fixes #54433
- When a provider returns a rate limit error with a specific message (e.g. quota details, reset time), surface that message to the user instead of the generic "API rate limit reached"
- The provider's rawError was already captured internally but never shown to the user

## Test plan
- Configure a provider that returns rate limit errors with specific messages
- Verify the specific message is shown to the user instead of the generic one