### PR TITLE
fix(ui): Stop button shows Send during tool execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -431,6 +431,7 @@ Docs: https://docs.openclaw.ai
 - OpenShell and ACP file boundaries: skip symlinks and preserve trusted host-only directories during OpenShell mirror sync, and route ACP attachment reads through the shared attachment cache so local files outside allowed roots are no longer forwarded. (#57693, #57690)
 - Channel/webhook authorization: skip Discord audio preflight transcription for unauthorized guild senders, add a shared pre-auth in-flight guard to Synology Chat webhooks, and validate Microsoft Teams bearer auth before JSON body parsing. (#57695, #57722, #57686)
 - Infra/randomness: replace `Math.random()` in affected identifier and delay-jitter paths with shared secure-random helpers, including UI UUID generation. (#57744)
+- Control UI/chat: keep the Stop button visible during tool-only execution so abortable runs do not fall back to Send while tools are still running. (#54528) thanks @chziyue.
 
 ## 2026.3.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Docs: https://docs.openclaw.ai
 - Discord/ack reactions: keep automatic ACK reaction auth on the active hydrated Discord account so SecretRef-backed and non-default-account reactions stop falling back to stale default config resolution. (#60081) Thanks @FunJim.
 - Telegram/model switching: render non-default `/model` callback confirmations with HTML formatting so Telegram shows the selected model in bold instead of raw `**...**` markers. (#60042) Thanks @GitZhangChi.
 - Plugins/update: allow `openclaw plugins update` to use `--dangerously-force-unsafe-install` for built-in dangerous-code false positives during plugin updates. (#60066) Thanks @huntharo.
+- Control UI/chat: keep the Stop button visible during tool-only execution so abortable runs do not fall back to Send while tools are still running. (#54528) thanks @chziyue.
 
 ## 2026.4.2
 
@@ -431,7 +432,6 @@ Docs: https://docs.openclaw.ai
 - OpenShell and ACP file boundaries: skip symlinks and preserve trusted host-only directories during OpenShell mirror sync, and route ACP attachment reads through the shared attachment cache so local files outside allowed roots are no longer forwarded. (#57693, #57690)
 - Channel/webhook authorization: skip Discord audio preflight transcription for unauthorized guild senders, add a shared pre-auth in-flight guard to Synology Chat webhooks, and validate Microsoft Teams bearer auth before JSON body parsing. (#57695, #57722, #57686)
 - Infra/randomness: replace `Math.random()` in affected identifier and delay-jitter paths with shared secure-random helpers, including UI UUID generation. (#57744)
-- Control UI/chat: keep the Stop button visible during tool-only execution so abortable runs do not fall back to Send while tools are still running. (#54528) thanks @chziyue.
 
 ## 2026.3.28
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -689,6 +689,27 @@ describe("chat view", () => {
     expect(container.textContent).not.toContain("New session");
   });
 
+  it("shows a stop button when aborting is available without an active stream", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          canAbort: true,
+          sending: false,
+          stream: null,
+          onAbort: vi.fn(),
+        }),
+      ),
+      container,
+    );
+
+    const stopButton = container.querySelector<HTMLButtonElement>('button[title="Stop"]');
+    const sendButton = container.querySelector<HTMLButtonElement>('button[title="Send"]');
+    expect(stopButton).not.toBeNull();
+    expect(sendButton).toBeNull();
+    expect(container.textContent).not.toContain("New session");
+  });
+
   it("shows a new session button when aborting is unavailable", () => {
     const container = document.createElement("div");
     const onNewSession = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -893,7 +893,7 @@ function renderSlashMenu(
 
 export function renderChat(props: ChatProps) {
   const canCompose = props.connected;
-  const isBusy = props.sending || props.stream !== null;
+  const isBusy = props.sending || props.stream !== null || props.canAbort;
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const reasoningLevel = activeSession?.reasoningLevel ?? "off";


### PR DESCRIPTION
## Problem

In the Control UI, the Stop button incorrectly shows "Send" during tool execution (when `canAbort` is true but no text stream is active).

**Issue:**
- Stop button only showed "Stop" when AI was outputting text (`props.stream !== null`)
- During tool execution without text output, `isBusy` was false, causing "Send" to display
- Users couldn't visually tell if a task was running during tool calls

## Fix

Added `props.canAbort` to the `isBusy` condition in `ui/src/ui/views/chat.ts`:

```diff
- const isBusy = props.sending || props.stream !== null;
+ const isBusy = props.sending || props.stream !== null || props.canAbort;

Testing
✅ Stop button correctly displays during tool execution
✅ Stop button can interrupt running tasks
✅ Button returns to "Send" after task completion