### PR TITLE
Telegram: ignore self-authored DM message updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: close WebSocket connections on monitor stop/abort so ghost connections no longer persist, preventing duplicate event processing and resource leaks across restart cycles. (#52844) Thanks @schumilin.
 - Feishu: use the original message `create_time` instead of `Date.now()` for inbound timestamps so offline-retried messages carry the correct authoring time, preventing mis-targeted agent actions on stale instructions. (#52809) Thanks @schumilin.
 - Plugins/SDK: thread `moduleUrl` through plugin-sdk alias resolution so user-installed plugins outside the openclaw directory (e.g. `~/.openclaw/extensions/`) correctly resolve `openclaw/plugin-sdk/*` subpath imports, and gate `plugin-sdk:check-exports` in `release:check`. (#54283) Thanks @xieyongliang.
+- Telegram/pairing: ignore self-authored DM `message` updates so bot-pinned status cards and similar service updates do not trigger bogus pairing requests or re-enter inbound dispatch. (#54530) thanks @huntharo
 
 ## 2026.3.24
 

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -193,6 +193,13 @@ export const registerTelegramHandlers = ({
         : async () => ({});
     return { message, me: ctx.me, getFile };
   };
+  const isSelfAuthoredTelegramMessage = (
+    ctx: Pick<TelegramContext, "me">,
+    message: Message,
+  ): boolean => {
+    const botId = ctx.me?.id;
+    return typeof botId === "number" && message.from?.id === botId;
+  };
   const inboundDebouncer = createInboundDebouncer<TelegramDebounceEntry>({
     debounceMs,
     resolveDebounceMs: (entry) =>
@@ -1726,6 +1733,9 @@ export const registerTelegramHandlers = ({
   bot.on("message", async (ctx) => {
     const msg = ctx.message;
     if (!msg) {
+      return;
+    }
+    if (isSelfAuthoredTelegramMessage(ctx, msg)) {
       return;
     }
     const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -507,6 +507,44 @@ describe("createTelegramBot", () => {
       }
     });
   });
+
+  it("ignores private self-authored message updates instead of issuing a pairing challenge", async () => {
+    await withIsolatedStateDirAsync(async () => {
+      loadConfig.mockReturnValue({
+        channels: { telegram: { dmPolicy: "pairing" } },
+      });
+      readChannelAllowFromStore.mockResolvedValue([]);
+      upsertChannelPairingRequest.mockClear();
+      sendMessageSpy.mockClear();
+      replySpy.mockClear();
+
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: 1234, type: "private", first_name: "Harold" },
+          message_id: 1884,
+          date: 1736380800,
+          from: { id: 7, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
+          pinned_message: {
+            message_id: 1883,
+            date: 1736380799,
+            chat: { id: 1234, type: "private", first_name: "Harold" },
+            from: { id: 7, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
+            text: "Binding: Review pull request 54118 (openclaw)",
+          },
+        },
+        me: { id: 7, is_bot: true, first_name: "OpenClaw", username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
+
+      expect(upsertChannelPairingRequest).not.toHaveBeenCalled();
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+      expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("blocks unauthorized DM media before download and sends pairing reply", async () => {
     await withIsolatedStateDirAsync(async () => {
       loadConfig.mockReturnValue({


### PR DESCRIPTION
## Summary

- Problem: Telegram private-chat service updates authored by the OpenClaw bot itself could flow through DM pairing enforcement and generate a pairing challenge for the bot's own Telegram id.
- Why it matters: binding and pinning a status card in a 1:1 Telegram DM could immediately produce a bogus "OpenClaw: access not configured" reply even though the human sender was already authorized.
- What changed: I added a regression test for a self-authored `pinned_message` DM update and I now ignore `message` updates whose sender id exactly matches `ctx.me.id`.
- What did NOT change (scope boundary): I did not broaden this to all Telegram bots; unknown third-party bot senders still follow the existing DM policy and pairing flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Telegram `message` handler accepted self-authored DM service updates, and DM pairing enforcement used the inbound sender id before message dispatch.
- Missing detection / guardrail: there was no guard that recognized "this message is from our own Telegram bot identity" and short-circuited the handler.
- Prior context (`git blame`, prior PR, issue, or refactor if known): not traced further for this PR.
- Why this regressed now: the pin/status flow started producing a Telegram `pinned_message` update in a private DM, which exposed the missing self-message guard.
- If unknown, what was ruled out: I ruled out a generic `is_bot` check because the fix only compares `msg.from.id` to `ctx.me.id`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot.create-telegram-bot.test.ts`
- Scenario the test should lock in: a private Telegram `message` update from the bot's own id with a `pinned_message` payload must not create a pairing request or send a pairing reply.
- Why this is the smallest reliable guardrail: it exercises the exact message-handler and DM-pairing path without needing a live Telegram session.
- Existing test that already covers this (if any): the existing pairing DM tests in the same file still cover unknown senders.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram DMs no longer send a bogus pairing challenge after OpenClaw pins its own status message in the same DM.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev worktree
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.dmPolicy=pairing`

### Steps

1. Start a Telegram bot with DM policy set to `pairing`.
2. Deliver a private-chat `message` update authored by the bot itself, such as a `pinned_message` service update after pinning a status card.
3. Observe whether DM pairing is triggered for the bot's own Telegram id.

### Expected

- Self-authored Telegram DM updates are ignored and no pairing request/reply is created.

### Actual

- Before this fix, OpenClaw created a pairing request for the bot's own Telegram id and replied with a pairing code.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: I ran the new self-authored DM regression test and the existing unknown-sender pairing test, then ran `pnpm check`.
- Edge cases checked: I verified the fix keys off `ctx.me.id`, not `is_bot`, so third-party bots are not implicitly allowlisted.
- What you did **not** verify: I did not run a live Telegram bot session in this worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit to restore the previous Telegram message handling behavior.
- Files/config to restore: `extensions/telegram/src/bot-handlers.runtime.ts`
- Known bad symptoms reviewers should watch for: legitimate self-authored Telegram bot messages would start being processed again and could recreate bogus DM pairing prompts.

## Risks and Mitigations

- Risk: a real inbound Telegram message could be skipped if it somehow arrives with the same sender id as `ctx.me.id`.
  - Mitigation: the guard is intentionally strict and only matches the current bot identity, not `is_bot` or username.
