### PR TITLE
fix(telegram): preserve forum topic for exec approvals

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -686,6 +686,12 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   threading: {
     topLevelReplyToMode: "telegram",
+    buildToolContext: ({ context, hasRepliedRef }) => ({
+      currentChannelId: context.To?.trim() || undefined,
+      currentThreadTs:
+        context.MessageThreadId != null ? String(context.MessageThreadId) : undefined,
+      hasRepliedRef,
+    }),
     resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
       replyToId ? undefined : resolveTelegramAutoThreadId({ to, toolContext }),
   },

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { telegramPlugin } from "../../extensions/telegram/index.js";
 import { clearConfigCache } from "../config/config.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { buildSystemRunPreparePayload } from "../test-utils/system-run-prepare-payload.js";
 
 vi.mock("./tools/gateway.js", () => ({
@@ -590,6 +593,61 @@ describe("exec approvals", () => {
     expect(result.details.status).toBe("approval-pending");
     expect(calls[0]).toBe("exec.approval.request");
     expect(calls).toContain("exec.approval.waitDecision");
+  });
+
+  it("includes telegram topic ids in exec approval registrations", async () => {
+    let approvalRequestParams: Record<string, unknown> | undefined;
+
+    await writeOpenClawConfig({
+      channels: {
+        telegram: {
+          enabled: true,
+          execApprovals: { enabled: true, approvers: ["8460800771"], target: "channel" },
+        },
+      },
+    });
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", plugin: telegramPlugin, source: "test" }]),
+    );
+
+    try {
+      vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+        if (method === "exec.approval.request") {
+          approvalRequestParams = params as Record<string, unknown>;
+          return { status: "accepted", id: "approval-id" };
+        }
+        if (method === "exec.approval.waitDecision") {
+          return { decision: null };
+        }
+        return { ok: true };
+      });
+
+      const tool = createExecTool({
+        host: "gateway",
+        ask: "always",
+        approvalRunningNoticeMs: 0,
+        messageProvider: "telegram",
+        accountId: "default",
+        currentChannelId: "-1003841603622",
+        currentThreadTs: "928",
+      });
+
+      const result = await tool.execute("call-telegram-topic", {
+        command: "npm view diver name version description",
+      });
+
+      expect(result.details.status).toBe("approval-pending");
+      expect(approvalRequestParams).toEqual(
+        expect.objectContaining({
+          turnSourceChannel: "telegram",
+          turnSourceTo: "-1003841603622",
+          turnSourceAccountId: "default",
+          turnSourceThreadId: "928",
+        }),
+      );
+    } finally {
+      setActivePluginRegistry(createTestRegistry([]));
+    }
   });
 
   it("fails fast when approval registration fails", async () => {

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setDefaultChannelPluginRegistryForTests } from "../../commands/channel-test-helpers.js";
 import type { FollowupRun } from "./queue.js";
 
 const hoisted = vi.hoisted(() => {
@@ -46,6 +47,7 @@ function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"
 describe("agent-runner-utils", () => {
   beforeEach(() => {
     hoisted.resolveRunModelFallbacksOverrideMock.mockClear();
+    setDefaultChannelPluginRegistryForTests();
   });
 
   it("resolves model fallback options from run context", () => {
@@ -175,7 +177,7 @@ describe("agent-runner-utils", () => {
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
   });
 
-  it("uses OriginatingTo for telegram native command tool context without implicit thread state", () => {
+  it("preserves telegram topic thread state for native command tool context", () => {
     const context = buildThreadingToolContext({
       sessionCtx: {
         Provider: "telegram",
@@ -193,7 +195,7 @@ describe("agent-runner-utils", () => {
       currentChannelId: "telegram:-1003841603622",
       currentMessageId: "2284",
     });
-    expect(context.currentThreadTs).toBeUndefined();
+    expect(context.currentThreadTs).toBe("928");
   });
 
   it("uses OriginatingTo for threading tool context on discord native commands", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram forum-topic exec approvals dropped the originating topic/thread before approval registration, so inline approval prompts could land in the main topic instead of the source topic.
- Why it matters: forum-topic conversations lose approval context and main topics get spammed with approval UI.
- What changed: added Telegram `threading.buildToolContext` so inbound `MessageThreadId` is preserved as `currentThreadTs`, and added regression coverage for both the threading helper and exec approval registration.
- What did NOT change (scope boundary): the Telegram exec approval handler send path was not changed, and non-Telegram channel threading behavior was not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54505
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Telegram inbound context already carried `MessageThreadId`, but the Telegram plugin did not implement `threading.buildToolContext`, so `buildThreadingToolContext()` fell back to a generic context without `currentThreadTs`. Exec approval registration uses `currentThreadTs` as `turnSourceThreadId`, so the topic id was dropped before the Telegram approval handler ever ran.
- Missing detection / guardrail: no regression test asserted that Telegram native command tool context preserves topic ids into exec approval registration.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the Telegram exec approval handler already supports `turnSourceThreadId` and had topic-aware coverage; the break was in the earlier threading-context plumbing.
- Why this regressed now: Unknown.
- If unknown, what was ruled out: the downstream Telegram approval handler send path was ruled out and remains covered by its existing tests.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner-utils.test.ts`, `src/agents/bash-tools.exec.approval-id.test.ts`
- Scenario the test should lock in: Telegram forum-topic ids survive native command threading context and are forwarded as `turnSourceThreadId` during exec approval registration.
- Why this is the smallest reliable guardrail: it locks the exact seam where the topic id was dropped and verifies the downstream approval-registration contract without needing a live Telegram bot.
- Existing test that already covers this (if any): `extensions/telegram/src/exec-approvals-handler.test.ts` already covers topic-aware delivery once `turnSourceThreadId` is present.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- Telegram exec approval prompts now stay in the originating forum topic instead of falling back to the main topic when the request starts from a Telegram topic.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS local dev environment
- Runtime/container: Node 22, `pnpm test`
- Model/provider: N/A
- Integration/channel (if any): Telegram forum topics (test coverage only; no live bot)
- Relevant config (redacted): `channels.telegram.execApprovals.enabled=true`, `target=channel`, Telegram topic id present on inbound context

### Steps

1. Build native-command threading context from a Telegram session that includes `MessageThreadId`.
2. Trigger exec approval registration from Telegram tool defaults carrying `currentThreadTs`.
3. Run the Telegram exec approval handler coverage that routes a request containing `turnSourceThreadId`.

### Expected

- Telegram topic/thread ids remain attached to native command tool context and approval registration.
- Telegram approval prompts target the originating topic when channel approvals are used.

### Actual

- Before this fix, the generic fallback context omitted `currentThreadTs`, so exec approval registrations lost the originating Telegram topic id before the handler sent the approval UI.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test -- src/agents/bash-tools.exec.approval-id.test.ts`, `pnpm test -- src/auto-reply/reply/agent-runner-utils.test.ts -t "preserves telegram topic thread state"`, and `pnpm test -- extensions/telegram/src/exec-approvals-handler.test.ts`.
- Edge cases checked: existing handler behavior still routes topic-aware approval UI when `turnSourceThreadId` is already present.
- What you did **not** verify: a live end-to-end Telegram forum-topic approval flow against the Bot API.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `16ecc47435f28db6f46ec8f6330d0c7465dd0e69`, or temporarily route Telegram exec approvals away from channel topics by changing `channels.telegram.execApprovals.target`.
- Files/config to restore: `extensions/telegram/src/channel.ts`
- Known bad symptoms reviewers should watch for: Telegram exec approvals regressing to the main topic or losing topic-thread context again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Telegram topic ids could still be lost in a future refactor if threading context falls back to generic handling again.
  - Mitigation: regression tests now cover both threading-context construction and exec approval registration.
