### PR TITLE
Fix local copied package installs honoring staged project .npmrc

### DIFF
--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -21,6 +21,11 @@ async function listMatchingDirs(root: string, prefix: string): Promise<string[]>
     .map((entry) => entry.name);
 }
 
+async function listMatchingEntries(root: string, prefix: string): Promise<string[]> {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  return entries.filter((entry) => entry.name.startsWith(prefix)).map((entry) => entry.name);
+}
+
 function normalizeDarwinTmpPath(filePath: string): string {
   return process.platform === "darwin" && filePath.startsWith("/private/var/")
     ? filePath.slice("/private".length)
@@ -316,5 +321,60 @@ describe("installPackageDir", () => {
         cwd: expect.stringContaining(".openclaw-install-stage-"),
       }),
     );
+  });
+
+  it("hides the staged project .npmrc while npm install runs and restores it afterward", async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-install-package-dir-"));
+    const sourceDir = path.join(fixtureRoot, "source");
+    const targetDir = path.join(fixtureRoot, "plugins", "demo");
+    const npmrcContent = "git=calc.exe\n";
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({
+        name: "demo-plugin",
+        version: "1.0.0",
+        dependencies: {
+          zod: "^4.0.0",
+        },
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(path.join(sourceDir, ".npmrc"), npmrcContent, "utf-8");
+
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (_argv, optionsOrTimeout) => {
+      const cwd = typeof optionsOrTimeout === "number" ? undefined : optionsOrTimeout.cwd;
+      expect(cwd).toBeTruthy();
+      await expect(fs.stat(path.join(cwd ?? "", ".npmrc"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(
+        listMatchingEntries(cwd ?? "", ".openclaw-install-hidden-npmrc-"),
+      ).resolves.toHaveLength(1);
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    const result = await installPackageDir({
+      sourceDir,
+      targetDir,
+      mode: "install",
+      timeoutMs: 1_000,
+      copyErrorPrefix: "failed to copy plugin",
+      hasDeps: true,
+      depsLogMessage: "Installing deps…",
+    });
+
+    expect(result).toEqual({ ok: true });
+    await expect(fs.readFile(path.join(targetDir, ".npmrc"), "utf8")).resolves.toBe(npmrcContent);
+    await expect(
+      listMatchingEntries(targetDir, ".openclaw-install-hidden-npmrc-"),
+    ).resolves.toHaveLength(0);
   });
 });

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -9,6 +9,14 @@ const INSTALL_BASE_CHANGED_ABORT_WARNING =
   "Install base directory changed during install; aborting staged publish.";
 const INSTALL_BASE_CHANGED_BACKUP_WARNING =
   "Install base directory changed before backup cleanup; leaving backup in place.";
+const STAGED_NPM_PROJECT_CONFIG_NAME = ".npmrc";
+const STAGED_NPM_PROJECT_CONFIG_PREFIX = ".openclaw-install-hidden-npmrc-";
+
+type HiddenProjectConfigFile = {
+  hiddenDir: string;
+  originalPath: string;
+  hiddenPath: string;
+} | null;
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -53,6 +61,35 @@ async function sanitizeManifestForNpmInstall(targetDir: string): Promise<void> {
     manifest.devDependencies = Object.fromEntries(filteredEntries);
   }
   await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+}
+
+async function hideProjectNpmConfigForInstall(targetDir: string): Promise<HiddenProjectConfigFile> {
+  const originalPath = path.join(targetDir, STAGED_NPM_PROJECT_CONFIG_NAME);
+  let hiddenDir = "";
+  try {
+    hiddenDir = await fs.mkdtemp(path.join(targetDir, STAGED_NPM_PROJECT_CONFIG_PREFIX));
+    const hiddenPath = path.join(hiddenDir, STAGED_NPM_PROJECT_CONFIG_NAME);
+    await fs.rename(originalPath, hiddenPath);
+    return { hiddenDir, originalPath, hiddenPath };
+  } catch (error) {
+    if (hiddenDir) {
+      await fs.rm(hiddenDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function restoreProjectNpmConfigAfterInstall(
+  hiddenConfig: HiddenProjectConfigFile,
+): Promise<void> {
+  if (!hiddenConfig) {
+    return;
+  }
+  await fs.rename(hiddenConfig.hiddenPath, hiddenConfig.originalPath);
+  await fs.rm(hiddenConfig.hiddenDir, { recursive: true, force: true });
 }
 
 async function assertInstallBoundaryPaths(params: {
@@ -186,19 +223,30 @@ export async function installPackageDir(params: {
   }
 
   if (params.hasDeps) {
-    await sanitizeManifestForNpmInstall(stageDir);
-    params.logger?.info?.(params.depsLogMessage);
-    const npmRes = await runCommandWithTimeout(
-      // Plugins install into isolated directories, so omitting peer deps can strip
-      // runtime requirements that npm would otherwise materialize for the package.
-      ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
-      {
-        timeoutMs: Math.max(params.timeoutMs, 300_000),
-        cwd: stageDir,
-      },
-    );
-    if (npmRes.code !== 0) {
-      return await fail(`npm install failed: ${npmRes.stderr.trim() || npmRes.stdout.trim()}`);
+    try {
+      await sanitizeManifestForNpmInstall(stageDir);
+      const hiddenProjectNpmConfig = await hideProjectNpmConfigForInstall(stageDir);
+      params.logger?.info?.(params.depsLogMessage);
+      const npmRes = await (async () => {
+        try {
+          return await runCommandWithTimeout(
+            // Plugins install into isolated directories, so omitting peer deps can strip
+            // runtime requirements that npm would otherwise materialize for the package.
+            ["npm", "install", "--omit=dev", "--silent", "--ignore-scripts"],
+            {
+              timeoutMs: Math.max(params.timeoutMs, 300_000),
+              cwd: stageDir,
+            },
+          );
+        } finally {
+          await restoreProjectNpmConfigAfterInstall(hiddenProjectNpmConfig);
+        }
+      })();
+      if (npmRes.code !== 0) {
+        return await fail(`npm install failed: ${npmRes.stderr.trim() || npmRes.stdout.trim()}`);
+      }
+    } catch (error) {
+      return await fail(`npm install failed: ${String(error)}`, error);
     }
   }
 


### PR DESCRIPTION
## Summary

- Problem: local copied package installs ran `npm install` from an attacker-controlled staged package root, so a staged `.npmrc` could steer npm’s execution behavior during install.
- Why it matters: a malicious local plugin or hook package could reach install-time command execution before the package was accepted as trusted runtime code.
- What changed: the shared install helper now hides the staged root `.npmrc` during `npm install` and restores it immediately afterward.
- What did NOT change: this PR does not refactor plugin or hook trust semantics, linked local installs, npm-sourced installs, or unrelated package-manager behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: `src/infra/install-package-dir.ts` stages a local package directory and then runs `npm install --omit=dev --silent --ignore-scripts` with `cwd` set to that staged package root.
- Missing guardrail: the staged root `.npmrc` remained in place, so npm still consumed attacker-controlled project config during install.
- Why `--ignore-scripts` was insufficient: npm config can still influence executable selection and dependency resolution paths that occur before any plugin or hook is later trusted as runtime code.
- Why this is the right fix location: local plugin and local hook copied installs share this helper, so fixing the helper closes the exploit path once instead of patching each CLI entry point separately.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test: `src/infra/install-package-dir.test.ts`
- Scenario locked in: the staged package root `.npmrc` is absent while the helper invokes `npm install`, and it is restored before the staged install is published.
- Why this is the smallest reliable guardrail: the vulnerability lives at the exact staging and install boundary, not in later plugin or hook runtime loading.

## User-visible / Behavior Changes

Normal copied local package installs should behave the same, except the staged package root `.npmrc` no longer influences the installer’s `npm install` step. The final installed package still keeps its original `.npmrc` contents.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- Risk + mitigation: the installer’s npm execution surface is intentionally narrowed so staged package project config does not steer install-time tool selection.

## Repro + Verification

### Environment

- OS: Linux host
- Runtime/container: Docker validation container
- Relevant config: none

### Steps

1. `docker build -f scratch/Dockerfile.test -t openclaw-test .`
2. `docker run --rm --entrypoint pnpm openclaw-test exec oxfmt --check src/infra/install-package-dir.ts src/infra/install-package-dir.test.ts`
3. `docker run --rm --entrypoint pnpm openclaw-test test -- src/infra/install-package-dir.test.ts`
4. `docker run --rm --entrypoint pnpm openclaw-test build`

### Actual

- Formatting passed
- Focused installer regression passed with `6/6` tests green
- Build passed

## Human Verification

- Verified scenarios: I verified in Docker that the shared staged package installer now hides the staged root `.npmrc` during the `npm install` call and restores it afterward, while the full touched test file and full build still pass.
- What I did not verify: I did not run a live malicious package PoC through the full plugin or hook CLI because the seam test already asserts the precise enforcement boundary that the exploit depends on.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery

- How to disable/revert quickly: revert the staged `.npmrc` hide/restore helper in `src/infra/install-package-dir.ts` and the companion regression in `src/infra/install-package-dir.test.ts`
- Known bad symptoms to watch for: copied local installs unexpectedly failing before publish because the staged `.npmrc` could not be moved aside or restored

## Risks and Mitigations

- Risk: some local package author expected their root `.npmrc` to affect dependency installation.
- Mitigation: the final installed package still preserves `.npmrc`; only the installer’s staged npm execution is isolated.
- Risk: the hide/restore flow could leave temp artifacts behind on failure.
- Mitigation: the helper uses a unique temp directory under the stage root and removes it during restore or cleanup.