### PR TITLE
fix: add workspace templates to npm release check

### DIFF
--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -47,6 +47,7 @@ const MAX_CALVER_DISTANCE_DAYS = 2;
 const REQUIRED_PACKED_PATHS = [
   "dist/control-ui/index.html",
   "docs/reference/templates/AGENTS.md",
+  "docs/reference/templates/BOOT.md",
   "docs/reference/templates/SOUL.md",
   "docs/reference/templates/TOOLS.md",
   "docs/reference/templates/IDENTITY.md",
@@ -409,7 +410,7 @@ export function collectControlUiPackErrors(paths: Iterable<string>): string[] {
   for (const requiredPath of REQUIRED_PACKED_PATHS) {
     if (!packedPaths.has(requiredPath)) {
       errors.push(
-        `npm package is missing required path "${requiredPath}". Ensure UI assets are built and included before publish.`,
+        `npm package is missing required path "${requiredPath}". Ensure all required files (UI assets and workspace templates) are included before publish.`,
       );
     }
   }

--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -44,7 +44,16 @@ const CORRECTION_VERSION_REGEX =
   /^(?<year>\d{4})\.(?<month>[1-9]\d?)\.(?<day>[1-9]\d?)-(?<correction>[1-9]\d*)$/;
 const EXPECTED_REPOSITORY_URL = "https://github.com/openclaw/openclaw";
 const MAX_CALVER_DISTANCE_DAYS = 2;
-const REQUIRED_PACKED_PATHS = ["dist/control-ui/index.html"];
+const REQUIRED_PACKED_PATHS = [
+  "dist/control-ui/index.html",
+  "docs/reference/templates/AGENTS.md",
+  "docs/reference/templates/SOUL.md",
+  "docs/reference/templates/TOOLS.md",
+  "docs/reference/templates/IDENTITY.md",
+  "docs/reference/templates/USER.md",
+  "docs/reference/templates/HEARTBEAT.md",
+  "docs/reference/templates/BOOTSTRAP.md",
+];
 const CONTROL_UI_ASSET_PREFIX = "dist/control-ui/assets/";
 const NPM_PACK_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 


### PR DESCRIPTION
## Summary

- Add `docs/reference/templates/*.md` files to `REQUIRED_PACKED_PATHS` in `openclaw-npm-release-check.ts`
- Ensures workspace templates are included in npm tarball during release
- Prevents regression of AGENTS.md bootstrap failures

## Problem

Issue #54514 reported that `docs/reference/templates/` was missing from an npm installation of version 2026.3.13.

### Investigation findings

1. `npm pack openclaw@2026.3.13` **does include** the templates in the tarball
2. The user's machine had no templates installed → likely an installation issue (npm cache, Homebrew Node, partial install)
3. `docs/` has been in the `package.json` files array since Feb 3, 2026

### Why this PR is still useful

- Adds a **safeguard** to the release check script
- Verifies templates are in the tarball before publishing
- Complements PR #54597 which adds an explicit entry for `docs/reference/templates/`

## Files Added to Check

- `docs/reference/templates/AGENTS.md`
- `docs/reference/templates/SOUL.md`
- `docs/reference/templates/TOOLS.md`
- `docs/reference/templates/IDENTITY.md`
- `docs/reference/templates/USER.md`
- `docs/reference/templates/HEARTBEAT.md`
- `docs/reference/templates/BOOTSTRAP.md`

Fixes #54514