### PR TITLE
fix(ui): tolerate malformed cron payloads in chat nav

### DIFF
--- a/ui/src/ui/app-render.test.ts
+++ b/ui/src/ui/app-render.test.ts
@@ -1,0 +1,31 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import { renderApp } from "./app-render.ts";
+import type { AppViewState } from "./app-view-state.ts";
+import { OpenClawApp } from "./app.ts";
+import type { CronJob } from "./types.ts";
+
+describe("renderApp", () => {
+  it("ignores cron jobs with malformed payloads when building model suggestions", () => {
+    const app = new OpenClawApp();
+    app.connected = true;
+    app.cronJobs = [
+      {
+        id: "job-bad-payload",
+        name: "Broken cron job",
+        sessionKey: "agent:main:main",
+        enabled: true,
+        createdAtMs: 0,
+        updatedAtMs: 0,
+        schedule: { kind: "cron", expr: "* * * * *" },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: undefined as unknown as CronJob["payload"],
+        delivery: { mode: "announce" },
+      } as unknown as CronJob,
+    ];
+
+    expect(() => renderApp(app as unknown as AppViewState)).not.toThrow();
+  });
+});

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -345,10 +345,11 @@ export function renderApp(state: AppViewState) {
         ...resolveConfiguredCronModelSuggestions(configValue),
         ...state.cronJobs
           .map((job) => {
-            if (job.payload.kind !== "agentTurn" || typeof job.payload.model !== "string") {
+            const payload = job.payload;
+            if (payload?.kind !== "agentTurn" || typeof payload.model !== "string") {
               return "";
             }
-            return job.payload.model.trim();
+            return payload.model.trim();
           })
           .filter(Boolean),
       ].filter(Boolean),


### PR DESCRIPTION
## Summary
- guard cron model suggestion generation against jobs with missing payloads
- ignore malformed cron entries instead of crashing the Control UI render path
- add a jsdom regression test that locks in the no-throw behavior

## Verification
- `pnpm --dir ui test -- --project unit src/ui/app-render.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/app-render.ts ui/src/ui/app-render.test.ts`

Closes #54439
