### PR TITLE
Discord: suppress reconnects during shutdown

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -22,6 +22,10 @@ type DiscordGatewayFetch = (
 
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
 
+type ShutdownAwareGatewayPlugin = GatewayPlugin & {
+  prepareForShutdown?: () => void;
+};
+
 export function resolveDiscordGatewayIntents(
   intentsConfig?: import("openclaw/plugin-sdk/config-runtime").DiscordIntentsConfig,
 ): number {
@@ -231,9 +235,14 @@ function createGatewayPlugin(params: {
 }): GatewayPlugin {
   class SafeGatewayPlugin extends GatewayPlugin {
     private gatewayInfoUsedFallback = false;
+    private shuttingDown = false;
 
     constructor() {
       super(params.options);
+    }
+
+    prepareForShutdown() {
+      this.shuttingDown = true;
     }
 
     override async registerClient(client: Parameters<GatewayPlugin["registerClient"]>[0]) {
@@ -254,6 +263,25 @@ function createGatewayPlugin(params: {
       return super.registerClient(client);
     }
 
+    override connect(resume = false) {
+      this.shuttingDown = false;
+      super.connect(resume);
+    }
+
+    override handleReconnectionAttempt(
+      options: Parameters<GatewayPlugin["handleReconnectionAttempt"]>[0],
+    ) {
+      if (this.shuttingDown) {
+        this.emitter.emit(
+          "debug",
+          `Suppressing reconnect during intentional shutdown${options.code ? ` after code ${options.code}` : ""}`,
+        );
+        this.monitor.destroy();
+        return;
+      }
+      super.handleReconnectionAttempt(options);
+    }
+
     override createWebSocket(url: string) {
       if (!params.wsAgent) {
         return super.createWebSocket(url);
@@ -263,6 +291,10 @@ function createGatewayPlugin(params: {
   }
 
   return new SafeGatewayPlugin();
+}
+
+export function prepareDiscordGatewayForShutdown(gateway?: GatewayPlugin): void {
+  (gateway as ShutdownAwareGatewayPlugin | undefined)?.prepareForShutdown?.();
 }
 
 export function createDiscordGatewayPlugin(params: {

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -62,6 +62,7 @@ describe("runDiscordGatewayLifecycle", () => {
       options?: Record<string, unknown>;
       disconnect?: () => void;
       connect?: (resume?: boolean) => void;
+      prepareForShutdown?: () => void;
       state?: {
         sessionId?: string | null;
         resumeGatewayUrl?: string | null;
@@ -159,6 +160,7 @@ describe("runDiscordGatewayLifecycle", () => {
       options: {},
       disconnect: vi.fn(),
       connect: vi.fn(),
+      prepareForShutdown: vi.fn(),
       ...(params?.state ? { state: params.state } : {}),
       ...(params?.sequence !== undefined ? { sequence: params.sequence } : {}),
       emitter,
@@ -579,6 +581,7 @@ describe("runDiscordGatewayLifecycle", () => {
       options: { reconnect: { maxAttempts: 3 } },
       disconnect: vi.fn(),
       connect: vi.fn(),
+      prepareForShutdown: vi.fn(),
       emitter,
     };
     getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
@@ -605,5 +608,6 @@ describe("runDiscordGatewayLifecycle", () => {
     // guarded by !lifecycleStopping to avoid contradicting the abort.
     const connectedTrue = statusUpdates.find((s) => s.connected === true);
     expect(connectedTrue).toBeUndefined();
+    expect(gateway.prepareForShutdown).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -130,10 +130,6 @@ export async function runDiscordGatewayLifecycle(params: {
       return;
     }
     prepareDiscordGatewayForShutdown(gateway);
-    gateway.options.reconnect = {
-      ...(gateway.options.reconnect ?? {}),
-      maxAttempts: 0,
-    };
     gateway.disconnect();
   };
 

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -7,6 +7,7 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import type { DiscordVoiceManager } from "../voice/manager.js";
+import { prepareDiscordGatewayForShutdown } from "./gateway-plugin.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import type { DiscordGatewayEvent, DiscordGatewaySupervisor } from "./gateway-supervisor.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
@@ -128,7 +129,11 @@ export async function runDiscordGatewayLifecycle(params: {
     if (!gateway) {
       return;
     }
-    gateway.options.reconnect = { maxAttempts: 0 };
+    prepareDiscordGatewayForShutdown(gateway);
+    gateway.options.reconnect = {
+      ...(gateway.options.reconnect ?? {}),
+      maxAttempts: 0,
+    };
     gateway.disconnect();
   };
 

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -1,12 +1,17 @@
+import { EventEmitter } from "node:events";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   GatewayIntents,
   baseRegisterClientSpy,
+  baseHandleReconnectionAttemptSpy,
+  connectSpy,
+  disconnectSpy,
   GatewayPlugin,
   globalFetchMock,
   HttpsProxyAgent,
   getLastAgent,
+  monitorDestroySpy,
   restProxyAgentSpy,
   undiciFetchMock,
   undiciProxyAgentSpy,
@@ -20,6 +25,10 @@ const {
   const undiciFetchMock = vi.fn();
   const globalFetchMock = vi.fn();
   const baseRegisterClientSpy = vi.fn();
+  const baseHandleReconnectionAttemptSpy = vi.fn();
+  const connectSpy = vi.fn();
+  const disconnectSpy = vi.fn();
+  const monitorDestroySpy = vi.fn();
   const webSocketSpy = vi.fn();
 
   const GatewayIntents = {
@@ -36,12 +45,36 @@ const {
   class GatewayPlugin {
     options: unknown;
     gatewayInfo: unknown;
+    emitter = new EventEmitter();
+    monitor = { destroy: monitorDestroySpy };
     constructor(options?: unknown, gatewayInfo?: unknown) {
       this.options = options;
       this.gatewayInfo = gatewayInfo;
     }
     async registerClient(client: unknown) {
       baseRegisterClientSpy(client);
+    }
+    connect(resume = false) {
+      connectSpy(resume);
+    }
+    disconnect() {
+      disconnectSpy();
+    }
+    handleReconnectionAttempt(options: unknown) {
+      baseHandleReconnectionAttemptSpy(options);
+      const reconnect = (this.options as { reconnect?: { maxAttempts?: number } } | undefined)
+        ?.reconnect;
+      const maxAttempts = reconnect?.maxAttempts ?? 5;
+      const code = (options as { code?: number } | undefined)?.code;
+      this.emitter.emit(
+        "error",
+        new Error(
+          `Max reconnect attempts (${maxAttempts}) reached${code ? ` after code ${code}` : ""}`,
+        ),
+      );
+    }
+    handleClose(code: number) {
+      this.handleReconnectionAttempt({ code });
     }
   }
 
@@ -60,11 +93,15 @@ const {
 
   return {
     baseRegisterClientSpy,
+    baseHandleReconnectionAttemptSpy,
+    connectSpy,
+    disconnectSpy,
     GatewayIntents,
     GatewayPlugin,
     globalFetchMock,
     HttpsProxyAgent,
     getLastAgent: () => HttpsProxyAgent.lastCreated,
+    monitorDestroySpy,
     restProxyAgentSpy,
     undiciFetchMock,
     undiciProxyAgentSpy,
@@ -182,7 +219,11 @@ describe("createDiscordGatewayPlugin", () => {
     vi.stubGlobal("fetch", globalFetchMock);
     vi.useRealTimers();
     baseRegisterClientSpy.mockClear();
+    baseHandleReconnectionAttemptSpy.mockClear();
+    connectSpy.mockClear();
+    disconnectSpy.mockClear();
     globalFetchMock.mockClear();
+    monitorDestroySpy.mockClear();
     restProxyAgentSpy.mockClear();
     undiciFetchMock.mockClear();
     undiciProxyAgentSpy.mockClear();
@@ -354,5 +395,53 @@ describe("createDiscordGatewayPlugin", () => {
       url: "wss://gateway.discord.gg/?v=10",
       shards: 8,
     });
+  });
+
+  it("suppresses reconnect-exhausted errors during intentional shutdown", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      emitter: EventEmitter;
+      handleClose: (code: number) => void;
+      prepareForShutdown?: () => void;
+    };
+    const errors: unknown[] = [];
+    plugin.emitter.on("error", (error) => {
+      errors.push(error);
+    });
+
+    plugin.prepareForShutdown?.();
+    plugin.handleClose(1005);
+
+    expect(baseHandleReconnectionAttemptSpy).not.toHaveBeenCalled();
+    expect(monitorDestroySpy).toHaveBeenCalledTimes(1);
+    expect(errors).toEqual([]);
+  });
+
+  it("resumes normal reconnect handling after a new connect", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    }) as unknown as {
+      emitter: EventEmitter;
+      connect: (resume?: boolean) => void;
+      handleClose: (code: number) => void;
+      prepareForShutdown?: () => void;
+    };
+    const errors: string[] = [];
+    plugin.emitter.on("error", (error) => {
+      errors.push(String(error));
+    });
+
+    plugin.prepareForShutdown?.();
+    plugin.connect(true);
+    plugin.handleClose(1006);
+
+    expect(connectSpy).toHaveBeenCalledWith(true);
+    expect(baseHandleReconnectionAttemptSpy).toHaveBeenCalledWith({ code: 1006 });
+    expect(errors).toEqual(["Error: Max reconnect attempts (50) reached after code 1006"]);
   });
 });

--- a/package.json
+++ b/package.json
@@ -881,6 +881,9 @@
           "strip-ansi": "^7.2.0"
         }
       }
+    },
+    "patchedDependencies": {
+      "@buape/carbon@0.0.0-beta-20260317045421": "patches/@buape__carbon@0.0.0-beta-20260317045421.patch"
     }
   }
 }

--- a/patches/@buape__carbon@0.0.0-beta-20260317045421.patch
+++ b/patches/@buape__carbon@0.0.0-beta-20260317045421.patch
@@ -1,0 +1,72 @@
+diff --git a/dist/src/plugins/gateway/GatewayPlugin.js b/dist/src/plugins/gateway/GatewayPlugin.js
+index ec63a49239e20d571fe998034434ae7e88b91df8..e8a2650b26eb160445d8f3b6671c8e8962313c11 100644
+--- a/dist/src/plugins/gateway/GatewayPlugin.js
++++ b/dist/src/plugins/gateway/GatewayPlugin.js
+@@ -9,6 +9,12 @@ import { startHeartbeat, stopHeartbeat } from "./utils/heartbeat.js";
+ import { ConnectionMonitor } from "./utils/monitor.js";
+ import { createIdentifyPayload, createRequestGuildMembersPayload, createResumePayload, createUpdatePresencePayload, createUpdateVoiceStatePayload, validatePayload } from "./utils/payload.js";
+ import { GatewayRateLimit } from "./utils/rateLimit.js";
++function markIntentionalSocketClose(ws) {
++    if (!ws) {
++        return;
++    }
++    ws.__carbonIntentionalClose = true;
++}
+ export class GatewayPlugin extends Plugin {
+     id = "gateway";
+     client;
+@@ -90,6 +96,7 @@ export class GatewayPlugin extends Plugin {
+             clearTimeout(this.reconnectTimeout);
+             this.reconnectTimeout = undefined;
+         }
++        markIntentionalSocketClose(this.ws);
+         this.ws?.close();
+         const baseUrl = resume && this.state.resumeGatewayUrl
+             ? this.state.resumeGatewayUrl
+@@ -105,6 +112,7 @@ export class GatewayPlugin extends Plugin {
+         stopHeartbeat(this);
+         this.lastHeartbeatAck = true;
+         this.monitor.resetUptime();
++        markIntentionalSocketClose(this.ws);
+         this.ws?.close();
+         this.ws = null;
+         if (this.reconnectTimeout) {
+@@ -124,15 +132,16 @@ export class GatewayPlugin extends Plugin {
+     setupWebSocket() {
+         if (!this.ws)
+             return;
++        const ws = this.ws;
+         let closed = false;
+-        this.ws.on("open", () => {
++        ws.on("open", () => {
+             this.isConnecting = false;
+             // Note: reconnectAttempts is reset on READY/RESUMED instead of here,
+             // so that exponential backoff keeps increasing when the socket opens
+             // but Discord closes it before completing the handshake.
+             this.emitter.emit("debug", "WebSocket connection opened");
+         });
+-        this.ws.on("message", (data) => {
++        ws.on("message", (data) => {
+             this.monitor.recordMessageReceived();
+             const payload = validatePayload(data.toString());
+             if (!payload) {
+@@ -284,16 +293,16 @@ export class GatewayPlugin extends Plugin {
+                     break;
+             }
+         });
+-        this.ws.on("close", (code, _reason) => {
++        ws.on("close", (code, _reason) => {
+             this.isConnecting = false;
+             this.emitter.emit("debug", `WebSocket connection closed with code ${code}`);
+             this.monitor.recordReconnect();
+-            if (closed)
++            if (closed || ws.__carbonIntentionalClose)
+                 return;
+             closed = true;
+             this.handleClose(code);
+         });
+-        this.ws.on("error", (error) => {
++        ws.on("error", (error) => {
+             this.isConnecting = false;
+             this.monitor.recordError();
+             this.emitter.emit("error", error);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=
 
+patchedDependencies:
+  '@buape/carbon@0.0.0-beta-20260317045421':
+    hash: 0688852f67329a988d3b0f6d071f5906170e130c29d3a32fbfbc066b1f15ecfb
+    path: patches/@buape__carbon@0.0.0-beta-20260317045421.patch
+
 importers:
 
   .:
@@ -325,7 +330,7 @@ importers:
     dependencies:
       '@buape/carbon':
         specifier: 0.0.0-beta-20260317045421
-        version: 0.0.0-beta-20260317045421(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260317045421(patch_hash=0688852f67329a988d3b0f6d071f5906170e130c29d3a32fbfbc066b1f15ecfb)(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)
       '@discordjs/voice':
         specifier: ^0.19.2
         version: 0.19.2(@discordjs/opus@0.10.0)(opusscript@0.1.1)
@@ -7559,7 +7564,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@buape/carbon@0.0.0-beta-20260317045421(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260317045421(patch_hash=0688852f67329a988d3b0f6d071f5906170e130c29d3a32fbfbc066b1f15ecfb)(@discordjs/opus@0.10.0)(hono@4.12.8)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.5.0
       discord-api-types: 0.38.37


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: I hit an uncaught `Max reconnect attempts (0) reached after code 1005` exception when shutting down Discord with `Ctrl-C`.
- Why it matters: intentional shutdown should disconnect Discord cleanly instead of surfacing a teardown exception from the gateway reconnect path.
- What changed: I patched Carbon so intentional websocket closes are marked as intentional before `disconnect()`/`connect()` tears sockets down, kept the Discord shutdown latch as a secondary guard, and removed the OpenClaw-side `maxAttempts=0` shutdown mutation that was amplifying the teardown failure.
- What did NOT change (scope boundary): I did not change normal Discord reconnect policy outside intentional shutdown, and I did not change other channel providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Carbon’s gateway close handler still routes an intentional disconnect through the reconnect path because `disconnect()` does not mark the socket close as intentional, so a shutdown-time `maxAttempts=0` setting turns that final close into an emitted reconnect-exhausted error instead of a clean teardown.
- Missing detection / guardrail: we did not have a shutdown-specific regression test around lifecycle abort, and we had not patched the underlying Carbon gateway close semantics for intentional disconnects.
- Prior context (`git blame`, prior PR, issue, or refactor if known): I traced this to the current Carbon gateway reconnect behavior rather than a repo-local reconnect refactor.
- Why this regressed now: once shutdown started forcing reconnect attempts to zero, Carbon’s existing intentional-close blind spot made the final close reliably trigger reconnect exhaustion on exit.
- If unknown, what was ruled out: I ruled out a separate missing-`await` bug in the OpenClaw shutdown path for this exception; the failure was emitted synchronously from the gateway reconnect logic during teardown.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/provider.proxy.test.ts` and `extensions/discord/src/monitor/provider.lifecycle.test.ts`
- Scenario the test should lock in: intentional shutdown must not feed the final close back into reconnect handling, while later fresh connects still use normal reconnect behavior.
- Why this is the smallest reliable guardrail: the bug lives at the gateway wrapper and lifecycle seam, and these focused tests exercise the shutdown latch without needing a live Discord connection.
- Existing test that already covers this (if any): the lifecycle suite already covered aborted startup/shutdown status behavior, and I extended that coverage to assert the shutdown preparation hook runs.
- If no new test is added, why not:

## User-visible / Behavior Changes

Discord shutdown on `Ctrl-C` now disconnects cleanly instead of logging an uncaught reconnect-exhausted exception during exit.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord channel enabled with gateway lifecycle active

### Steps

1. Start OpenClaw with Discord enabled.
2. Wait until the Discord gateway is connected.
3. Press `Ctrl-C` to trigger shutdown.

### Expected

- Discord marks shutdown as intentional, does not schedule reconnects, and exits without an uncaught gateway exception.

### Actual

- Before this change, shutdown could emit `Max reconnect attempts (0) reached after code 1005` as an uncaught exception during exit.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I verified the focused Discord shutdown/reconnect regressions pass, `pnpm build` passes, and `pnpm check` passes after the Carbon patch and lifecycle cleanup.
- Edge cases checked: I checked that intentional shutdown suppresses reconnect exhaustion, and that a later fresh connect resets the latch so real reconnect handling still works.
- What you did **not** verify: I did not run a live Discord bot session manually in this worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `e9fb395825` and `2219aa0570`
- Files/config to restore: `patches/@buape__carbon@0.0.0-beta-20260317045421.patch`, `package.json`, `pnpm-lock.yaml`, and `extensions/discord/src/monitor/provider.lifecycle.ts`
- Known bad symptoms reviewers should watch for: Discord failing to reconnect after a real transient disconnect, or shutdown hanging instead of disconnecting promptly

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the Carbon patch could suppress a close that should still reconnect if the socket is marked intentional too broadly.
  - Mitigation: the patch only marks closes triggered by `connect()` replacement or explicit `disconnect()`, and the existing Discord proxy tests still cover post-connect reconnect behavior.
