### PR TITLE
fix(whatsapp): filter fromMe messages in self-chat mode to prevent echo loop

### DIFF
--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -148,7 +148,9 @@ export async function checkInboundAccessControl(params: {
 
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
   if (!params.group) {
-    if (params.isFromMe && !isSamePhone) {
+    // Filter outbound messages (fromMe) to prevent echo loop in self-chat mode.
+    // This applies to both same-phone (self-chat) and different-phone (paired) scenarios.
+    if (params.isFromMe) {
       logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
       return {
         allowed: false,


### PR DESCRIPTION
Fixes #54460

## Problem
In WhatsApp self-chat mode, outbound messages sent by the gateway are echoed back by WhatsApp and processed as new inbound user messages, causing the agent to see and respond to its own output.

## Root Cause
The fromMe filtering in access-control.ts had a condition `params.isFromMe && !isSamePhone` which only filtered fromMe messages when the phone numbers didn't match. In self-chat mode (same phone), this condition was false, allowing the bot's own messages to be processed.

## Solution
Remove the `!isSamePhone` condition - filter all fromMe messages regardless of whether it's self-chat mode or paired mode. This prevents the echo loop at the inbound access control layer.

## Testing
- Verified the fix prevents echo in self-chat mode
- No impact on normal DM or group message processing
- Existing access control logic preserved for all other cases

## Files Changed
- extensions/whatsapp/src/inbound/access-control.ts