### PR TITLE
fix(matrix): load crypto-nodejs via createRequire to fix __dirname in ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Docs: https://docs.openclaw.ai
 - Daemon/status: surface immediate gateway close reasons from lightweight probes and prefer those concrete auth or pairing failures over generic timeouts in `openclaw daemon status`. (#56282) Thanks @mbelinky.
 - Agents/failover: classify HTTP 410 errors as retryable timeouts by default while still preserving explicit session-expired, billing, and auth signals from the payload. (#55201) thanks @nikus-pan.
 - Agents/subagents: restore completion announce delivery for extension channels like BlueBubbles. (#56348)
+- Plugins/Matrix: load bundled `@matrix-org/matrix-sdk-crypto-nodejs` through `createRequire(...)` so E2EE media send and receive keep the package-local native binding lookup working in packaged ESM builds. (#54566) thanks @joelnishanth.
 
 ## 2026.3.24
 

--- a/extensions/matrix/src/matrix/sdk/crypto-node.runtime.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-node.runtime.test.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+const sdkDir = path.dirname(fileURLToPath(import.meta.url));
+const cryptoNodeRuntimePath = path.join(sdkDir, "crypto-node.runtime.ts");
+
+describe("crypto-node runtime bundling", () => {
+  it("keeps the native Matrix crypto package behind a runtime require boundary", async () => {
+    const result = await build({
+      entryPoints: [cryptoNodeRuntimePath],
+      bundle: true,
+      external: ["@matrix-org/matrix-sdk-crypto-nodejs"],
+      format: "esm",
+      platform: "node",
+      write: false,
+    });
+
+    const bundled = result.outputFiles.at(0)?.text ?? "";
+
+    expect(bundled).toContain('from "node:module"');
+    expect(bundled).toContain("createRequire(import.meta.url)");
+    expect(bundled).toMatch(/require\d*\("@matrix-org\/matrix-sdk-crypto-nodejs"\)/);
+    expect(bundled).not.toContain('from "@matrix-org/matrix-sdk-crypto-nodejs"');
+  });
+});

--- a/extensions/matrix/src/matrix/sdk/crypto-node.runtime.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-node.runtime.ts
@@ -1,3 +1,9 @@
-import { Attachment, EncryptedAttachment } from "@matrix-org/matrix-sdk-crypto-nodejs";
+import { createRequire } from "node:module";
+
+// Load via createRequire so the CJS package gets __dirname (its index.js
+// uses __dirname to locate platform-specific native .node bindings).
+const require = createRequire(import.meta.url);
+const { Attachment, EncryptedAttachment } =
+  require("@matrix-org/matrix-sdk-crypto-nodejs") as typeof import("@matrix-org/matrix-sdk-crypto-nodejs");
 
 export { Attachment, EncryptedAttachment };


### PR DESCRIPTION
## Summary

Fixes #54556.

- `@matrix-org/matrix-sdk-crypto-nodejs` is a CJS package that uses `__dirname` in its `index.js` to locate platform-specific native `.node` bindings
- The Matrix plugin has `"type": "module"`, so when `crypto-node.runtime.ts` used a bare ESM `import`, the CJS `__dirname` global was undefined at runtime
- This broke all media send/receive in E2EE rooms (text messages were unaffected because they use the separate WASM crypto path)

The fix switches to `createRequire(import.meta.url)` so the CJS package is loaded in its native module context where `__dirname` is defined. This follows the existing pattern already used in `extensions/matrix/src/matrix/deps.ts`.

## Test plan

- [x] All 79 Matrix extension test files pass (519 tests)
- [x] All pre-commit checks pass (format, lint, type-check, boundary checks)
- [ ] Manual verification: send/receive media in an E2EE Matrix room

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)