### PR TITLE
fix: enable systemd linger before service install on headless servers

### DIFF
--- a/src/commands/onboard-non-interactive/local/daemon-install.ts
+++ b/src/commands/onboard-non-interactive/local/daemon-install.ts
@@ -69,6 +69,11 @@ export async function installGatewayDaemonNonInteractive(params: {
     warn: (message) => runtime.log(message),
     config: params.nextConfig,
   });
+  // Ensure linger is enabled before installing the service so the systemd user
+  // instance is running on headless servers (no desktop session). Without linger,
+  // `systemctl --user enable` fails with "Unit file does not exist" because the
+  // user systemd manager is not reachable.
+  await ensureSystemdUserLingerNonInteractive({ runtime });
   try {
     await service.install({
       env: process.env,
@@ -82,6 +87,5 @@ export async function installGatewayDaemonNonInteractive(params: {
     runtime.log(gatewayInstallErrorHint());
     return { installed: false };
   }
-  await ensureSystemdUserLingerNonInteractive({ runtime });
   return { installed: true };
 }


### PR DESCRIPTION
## Summary

- Problem: On a fresh headless Ubuntu Server (no desktop session), `loginctl` linger is disabled by default. Without linger the systemd user instance is not running when the install runs.
- Why it matters: `systemctl --user enable` silently fails with `Failed to enable unit: Unit file openclaw-gateway.service does not exist` because the user systemd manager is not reachable - not because the file is missing.
- What changed: Moved `ensureSystemdUserLingerNonInteractive` to run **before** `service.install()` in `installGatewayDaemonNonInteractive` so the user systemd session is up before `enable` is called.
- What did NOT change: The linger logic itself is unchanged. Non-Linux paths are unaffected. The fix is a single reordering of two existing calls.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54517
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `ensureSystemdUserLingerNonInteractive` was placed after `service.install()`. On a headless server with no prior linger state, the user systemd manager is not accessible at install time, so `systemctl --user enable` fails.
- Missing detection / guardrail: No pre-install check for linger status before attempting `systemctl --user enable`.
- Prior context: The linger helper exists and works correctly; it was just called in the wrong order.
- Why this regressed now: Likely always present on fresh headless installs; not caught because desktop installs have a running user session already.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/onboard-non-interactive/local/daemon-install.ts`
- Scenario the test should lock in: linger is called before service install when systemd is available on Linux
- Why this is the smallest reliable guardrail: the ordering is the entire fix
- Existing test that already covers this (if any): none for this ordering
- If no new test is added, why not: the call ordering is trivially visible in the source; adding a mock-heavy ordering test would be fragile and add more complexity than the fix itself

## User-visible / Behavior Changes

On headless Ubuntu Server, `openclaw setup --install-daemon` no longer fails with `Gateway service install failed: systemctl enable failed: Failed to enable unit: Unit file openclaw-gateway.service does not exist.`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu Server 24.04 LTS (headless, no desktop session)
- Runtime/container: systemd 255, npm global install
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: default, no prior linger state

### Steps

1. Fresh Ubuntu Server 24.04 with no prior openclaw install
2. `npm install -g openclaw`
3. `openclaw setup --install-daemon`
4. Observe `Gateway service install failed: systemctl enable failed: Failed to enable unit: Unit file openclaw-gateway.service does not exist.`

### Expected

- Linger is enabled first, user systemd instance becomes reachable
- Service installs and enables successfully

### Actual (before fix)

- Install fails because linger runs after enable, not before

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets (error in issue #54517)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced the full call stack from `installGatewayDaemonNonInteractive` through `service.install` -> `installSystemdService` -> `activateSystemdService` -> `execSystemctlUser(["enable", ...])` to confirm linger is the blocker
- Edge cases checked: desktop sessions (linger already enabled or user session running) are unaffected since `ensureSystemdUserLingerNonInteractive` no-ops when linger is already on
- What you did not verify: live headless server test (code change is a single call reorder)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/commands/onboard-non-interactive/local/daemon-install.ts`
- Known bad symptoms: if linger enable itself fails for some reason, the install will still proceed and hit the same error as before (no regression)

## Risks and Mitigations

- Risk: on systems where linger enable requires sudo and non-interactive sudo fails, the linger step logs a hint and continues; install may still fail as before - no worse than current behavior.
  - Mitigation: `ensureSystemdUserLingerNonInteractive` already handles this gracefully with a log message.