### PR TITLE
fix(telegram): add buildToolContext to support forum topic thread IDs

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -72,6 +72,7 @@ import {
 } from "./shared.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
 import { parseTelegramTarget } from "./targets.js";
+import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
 
 type TelegramSendFn = ReturnType<
   typeof getTelegramRuntime
@@ -686,6 +687,7 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   threading: {
     topLevelReplyToMode: "telegram",
+    buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
       replyToId ? undefined : resolveTelegramAutoThreadId({ to, toolContext }),
   },

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -1,0 +1,146 @@
+import type { ChannelThreadingContext } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, it, expect } from "vitest";
+import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
+
+function createMockContext(
+  overrides: Partial<ChannelThreadingContext> = {},
+): ChannelThreadingContext {
+  return {
+    To: "group:-1001234567890",
+    ChatType: "group",
+    MessageThreadId: 42,
+    ...overrides,
+  };
+}
+
+const mockCfg: OpenClawConfig = {
+  channels: {
+    telegram: {
+      enabled: true,
+      accounts: {
+        default: {
+          enabled: true,
+        },
+      },
+    },
+  },
+};
+
+describe("buildTelegramThreadingToolContext", () => {
+  it("returns toolContext with currentThreadTs when MessageThreadId is present", () => {
+    const context = createMockContext({
+      MessageThreadId: 42,
+      To: "group:-1001234567890",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    expect(result).toBeDefined();
+    // parseTelegramTarget preserves the "group:" prefix in chatId
+    expect(result?.currentChannelId).toBe("group:-1001234567890");
+    expect(result?.currentThreadTs).toBe("42");
+    expect(result?.hasRepliedRef).toBeUndefined();
+  });
+
+  it("returns undefined when MessageThreadId is undefined", () => {
+    const context = createMockContext({
+      MessageThreadId: undefined,
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("extracts chat ID correctly from group To field", () => {
+    const context = createMockContext({
+      MessageThreadId: 100,
+      To: "group:-1009876543210",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    // parseTelegramTarget preserves the "group:" prefix in chatId
+    expect(result?.currentChannelId).toBe("group:-1009876543210");
+    expect(result?.currentThreadTs).toBe("100");
+  });
+
+  it("extracts chat ID correctly from DM To field", () => {
+    const context = createMockContext({
+      MessageThreadId: 200,
+      To: "123456",
+      ChatType: "direct",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    expect(result?.currentChannelId).toBe("123456");
+    expect(result?.currentThreadTs).toBe("200");
+  });
+
+  it("passes hasRepliedRef through when provided", () => {
+    const context = createMockContext({
+      MessageThreadId: 42,
+    });
+    const repliedRef = { value: false };
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+      hasRepliedRef: repliedRef,
+    });
+
+    expect(result?.hasRepliedRef).toBe(repliedRef);
+  });
+
+  it("handles forum topic with large thread ID", () => {
+    const context = createMockContext({
+      MessageThreadId: 999999,
+      To: "group:-1001111222333",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    // parseTelegramTarget preserves the "group:" prefix in chatId
+    expect(result?.currentChannelId).toBe("group:-1001111222333");
+    expect(result?.currentThreadTs).toBe("999999");
+  });
+
+  it("does not use ReplyToIdFull as fallback", () => {
+    const context = createMockContext({
+      MessageThreadId: undefined,
+      ReplyToIdFull: "999",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    // ReplyToIdFull should not be used as fallback
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/threading-tool-context.ts
+++ b/extensions/telegram/src/threading-tool-context.ts
@@ -1,0 +1,33 @@
+import type {
+  ChannelThreadingContext,
+  ChannelThreadingToolContext,
+} from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { parseTelegramTarget } from "./targets.js";
+
+export function buildTelegramThreadingToolContext(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  context: ChannelThreadingContext;
+  hasRepliedRef?: { value: boolean };
+}): ChannelThreadingToolContext | undefined {
+  // Extract thread ID from MessageThreadId (forum topics)
+  const threadId = params.context.MessageThreadId;
+
+  // For forum topics, To is "group:-100..." — extract the bare chat ID.
+  // For DMs, use the raw chat ID directly.
+  const toValue = params.context.To ?? "";
+  const parsedTo = parseTelegramTarget(toValue);
+  const currentChannelId = parsedTo.chatId;
+
+  // Only return toolContext if we have a valid thread ID
+  if (threadId == null) {
+    return undefined;
+  }
+
+  return {
+    currentChannelId,
+    currentThreadTs: String(threadId),
+    hasRepliedRef: params.hasRepliedRef,
+  };
+}


### PR DESCRIPTION
Fixes #54505

## Problem
When using Telegram groups with forum topics, exec approval prompts with inline buttons are delivered to the group's main topic (topic id 1) rather than the topic where the exec was triggered.

## Root Cause
The Telegram plugin did not implement the `buildToolContext` method in its threading adapter. This meant that `toolContext.currentThreadTs` was not set from the inbound message's `MessageThreadId`, so the approval handler didn't know which forum topic to send the approval buttons to.

## Solution
- Implement `buildTelegramThreadingToolContext` function to extract `MessageThreadId` from the inbound context
- Add `buildToolContext` to the threading adapter in channel.ts
- This ensures `toolContext.currentThreadTs` is set correctly for forum topics
- The exec approval handler can then use this value to send approval buttons to the correct topic

## Testing
- Approval buttons should now appear in the same forum topic where the command was executed
- No regression for regular groups or DMs (threadId will be undefined, behavior unchanged)

## Files Changed
- extensions/telegram/src/threading-tool-context.ts (new)
- extensions/telegram/src/channel.ts