### PR TITLE
fix(errors): surface provider-specific rate-limit message instead of generic fallback

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -121,6 +121,33 @@ describe("formatAssistantErrorText", () => {
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
   });
 
+  it("surfaces provider-specific rate-limit message instead of generic fallback", () => {
+    const msg = makeAssistantError(
+      "You have hit your ChatGPT usage limit (go plan). Try again in ~4381 min.",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("usage limit");
+    expect(result).toContain("4381 min");
+    expect(result).not.toBe("⚠️ API rate limit reached. Please try again later.");
+  });
+
+  it("extracts provider message from JSON rate-limit error payloads", () => {
+    const msg = makeAssistantError(
+      '{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited. Retry after 30s."}}',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Rate limited. Retry after 30s.");
+  });
+
+  it("falls back to generic rate-limit message for Cloudflare HTML error pages", () => {
+    const msg = makeAssistantError(
+      "521 <!DOCTYPE html><html><head><title>Error</title></head><body>rate limit</body></html>",
+    );
+    const result = formatAssistantErrorText(msg);
+    // Cloudflare pages are handled by the HTML error path, not the rate limit path
+    expect(result).toBeDefined();
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -144,8 +144,7 @@ describe("formatAssistantErrorText", () => {
       "521 <!DOCTYPE html><html><head><title>Error</title></head><body>rate limit</body></html>",
     );
     const result = formatAssistantErrorText(msg);
-    // Cloudflare pages are handled by the HTML error path, not the rate limit path
-    expect(result).toBeDefined();
+    expect(result).toBe("⚠️ API rate limit reached. Please try again later.");
   });
 
   it("returns a friendly message for empty stream chunk errors", () => {

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -82,9 +82,9 @@ describe("sanitizeUserFacingText", () => {
     );
   });
 
-  it("returns a friendly message for rate limit errors in Error: prefixed payloads", () => {
+  it("surfaces provider-specific rate limit message from Error: prefixed payloads", () => {
     expect(sanitizeUserFacingText("Error: 429 Rate limit exceeded", { errorContext: true })).toBe(
-      "⚠️ API rate limit reached. Please try again later.",
+      "⚠️ Rate limit exceeded",
     );
   });
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -5,6 +5,7 @@ import {
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
   isCloudflareOrHtmlErrorPage,
+  parseApiErrorInfo,
   parseApiErrorPayload,
 } from "../../shared/assistant-error-format.js";
 export {
@@ -55,9 +56,46 @@ const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 
+/**
+ * Extract a human-readable provider-specific message from a raw rate-limit error.
+ * Handles JSON error payloads, HTTP-status-prefixed strings, and plain text.
+ * Returns `undefined` when the raw text is an HTML error page or too short to be useful,
+ * so callers can fall back to a generic message.
+ */
+function extractProviderRateLimitMessage(raw: string): string | undefined {
+  // Try to extract a specific message from JSON error payloads
+  const info = parseApiErrorInfo(raw);
+  if (info?.message?.trim()) {
+    return info.message.trim();
+  }
+
+  // Strip common error prefixes (e.g. "Error: ", "OpenAI API error: ")
+  const withoutPrefix = raw.replace(ERROR_PREFIX_RE, "").trim();
+  const candidate = withoutPrefix || raw;
+
+  // Skip HTML/Cloudflare error pages — fall back to generic message
+  if (isCloudflareOrHtmlErrorPage(raw)) {
+    return undefined;
+  }
+
+  // Strip leading HTTP status code (e.g. "429 Rate limit exceeded" → "Rate limit exceeded")
+  const status = extractLeadingHttpStatus(candidate);
+  const messageText = status?.rest?.trim() || candidate;
+
+  if (!messageText || messageText.length < 5) {
+    return undefined;
+  }
+
+  return messageText;
+}
+
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
-    return RATE_LIMIT_ERROR_USER_MESSAGE;
+    // Surface the provider-specific rate-limit message when available so users
+    // see actionable details (wait time, which limit was hit, etc.) instead of
+    // a generic fallback.
+    const providerMessage = extractProviderRateLimitMessage(raw);
+    return providerMessage ? `⚠️ ${providerMessage}` : RATE_LIMIT_ERROR_USER_MESSAGE;
   }
   if (isOverloadedErrorMessage(raw)) {
     return OVERLOADED_ERROR_USER_MESSAGE;

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -74,7 +74,7 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
   const candidate = withoutPrefix || raw;
 
   // Skip HTML/Cloudflare error pages — fall back to generic message
-  if (isCloudflareOrHtmlErrorPage(raw)) {
+  if (isCloudflareOrHtmlErrorPage(candidate)) {
     return undefined;
   }
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -438,6 +438,6 @@ describe("subscribeEmbeddedPiSession", () => {
     const lifecycleError = findLifecycleErrorAgentEvent(onAgentEvent.mock.calls);
 
     expect(lifecycleError).toBeDefined();
-    expect(lifecycleError?.data?.error).toContain("API rate limit reached");
+    expect(lifecycleError?.data?.error).toContain("Rate limit exceeded");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #54433.

When a provider returns a specific rate-limit error (e.g. `"You have hit your ChatGPT usage limit (go plan). Try again in ~4381 min."`), OpenClaw was discarding it and showing a generic fallback message instead.

## Root Cause

`formatRateLimitOrOverloadedErrorCopy()` in `src/agents/pi-embedded-helpers/errors.ts` always returned the generic `"⚠️ API rate limit reached. Please try again later."` message, ignoring the provider-specific `rawError`.

## Fix

Added an `extractProviderRateLimitMessage()` helper that:
1. Tries to extract the inner `message` from JSON error payloads (e.g. `{"error":{"message":"..."}}`)
2. Strips common error prefixes (`Error:`, `OpenAI API error:`, HTTP status codes) to give a clean message
3. Returns `undefined` for non-human-readable payloads (e.g. HTML error pages) so the generic fallback is used

`formatRateLimitOrOverloadedErrorCopy()` now uses the provider message when available, falling back to the generic message only when no useful text can be extracted.

## Testing

- 3 new test cases for provider-specific message extraction
- Updated 2 existing test expectations to match corrected output