### PR TITLE
fix(docs/zh-CN): correct node pairing commands in zh-CN node doc

### DIFF
--- a/docs/zh-CN/cli/node.md
+++ b/docs/zh-CN/cli/node.md
@@ -95,13 +95,16 @@ openclaw node uninstall
 
 ## 配对
 
-首次连接会在 Gateway 网关上创建待处理的节点配对请求。
+首次连接会在 Gateway 网关上创建待处理的设备配对请求（`role: node`）。
 通过以下方式批准：
 
 ```bash
-openclaw nodes pending
-openclaw nodes approve <requestId>
+openclaw devices list
+openclaw devices approve <requestId>
 ```
+
+如果节点重试配对时认证信息发生变化（role/scopes/公钥），之前的待处理请求会被替换，并生成新的 `requestId`。
+批准前请重新运行 `openclaw devices list`。
 
 节点主机将其节点 id、token、显示名称和 Gateway 网关连接信息存储在
 `~/.openclaw/node.json` 中。


### PR DESCRIPTION
  Summary                                                                                                                                                           
                                                                                                                                                                    
  - Fix zh-CN translation error in docs/zh-CN/cli/node.md: node host pairing section incorrectly listed openclaw nodes pending/approve instead of openclaw devices
  list/approve.

  Change Type

  - Docs

  User-visible / Behavior Changes

  None.

  Security Impact

  All No.