### PR TITLE
fix: resolve xAI web search API key from correct config path (#54555)

### DIFF
--- a/extensions/xai/src/grok-web-search-provider.ts
+++ b/extensions/xai/src/grok-web-search-provider.ts
@@ -33,7 +33,7 @@ import {
 
 function resolveGrokApiKey(grok?: Record<string, unknown>): string | undefined {
   return (
-    readConfiguredSecretString(grok?.apiKey, "tools.web.search.grok.apiKey") ??
+    readConfiguredSecretString(grok?.apiKey, "plugins.entries.xai.config.webSearch.apiKey") ??
     readProviderEnvValue(["XAI_API_KEY"])
   );
 }
@@ -76,7 +76,7 @@ function createGrokToolDefinition(
         return {
           error: "missing_xai_api_key",
           message:
-            "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure tools.web.search.grok.apiKey.",
+            "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
           docs: "https://docs.openclaw.ai/tools/web",
         };
       }

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -24,7 +24,7 @@ describe("xai web search config resolution", () => {
     expect(
       resolveWebSearchProviderCredential({
         credentialValue: getScopedCredentialValue(searchConfig, "grok"),
-        path: "tools.web.search.grok.apiKey",
+        path: "plugins.entries.xai.config.webSearch.apiKey",
         envVars: ["XAI_API_KEY"],
       }),
     ).toBe("xai-test-key");
@@ -35,7 +35,7 @@ describe("xai web search config resolution", () => {
       expect(
         resolveWebSearchProviderCredential({
           credentialValue: getScopedCredentialValue({}, "grok"),
-          path: "tools.web.search.grok.apiKey",
+          path: "plugins.entries.xai.config.webSearch.apiKey",
           envVars: ["XAI_API_KEY"],
         }),
       ).toBeUndefined();

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -100,7 +100,7 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
       execute: async (args: Record<string, unknown>) => {
         const apiKey = resolveWebSearchProviderCredential({
           credentialValue: getScopedCredentialValue(ctx.searchConfig, "grok"),
-          path: "tools.web.search.grok.apiKey",
+          path: "plugins.entries.xai.config.webSearch.apiKey",
           envVars: ["XAI_API_KEY"],
         });
 


### PR DESCRIPTION
## Summary
- Fixes #54555
- xAI web search credential resolver was reading from the wrong config path
- Fixed to check `plugins.entries.xai.config.webSearch.apiKey` as documented

## Test plan
- Configure xAI web search API key via `plugins.entries.xai.config.webSearch.apiKey`
- Verify web search works without `missing_xai_api_key` error