### PR TITLE
fix: use systemctl --user for user-level gateway service commands (#54517)

### DIFF
--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -185,8 +185,8 @@ sudo loginctl enable-linger <user>
 Use a system unit for multi-user/always-on hosts.
 
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now openclaw-gateway[-<profile>].service
+systemctl --user daemon-reload
+systemctl --user enable --now openclaw-gateway[-<profile>].service
 ```
 
   </Tab>


### PR DESCRIPTION
## Summary
- Fixes #54517
- Changed systemctl commands to use `--user` flag for the user-level gateway service
- The service is installed at `~/.config/systemd/user/` and requires user-level systemctl commands

## Test plan
- Install OpenClaw Gateway on Ubuntu Server
- Verify `systemctl --user enable openclaw-gateway.service` succeeds
- Verify the service starts correctly