### PR TITLE
fix(telegram): always return currentChannelId to prevent DM regression

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -72,6 +72,7 @@ import {
 } from "./shared.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
 import { parseTelegramTarget } from "./targets.js";
+import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
 
 type TelegramSendFn = ReturnType<
   typeof getTelegramRuntime
@@ -686,6 +687,7 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   threading: {
     topLevelReplyToMode: "telegram",
+    buildToolContext: (params) => buildTelegramThreadingToolContext(params),
     resolveAutoThreadId: ({ to, toolContext, replyToId }) =>
       replyToId ? undefined : resolveTelegramAutoThreadId({ to, toolContext }),
   },

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -1,0 +1,174 @@
+import type { ChannelThreadingContext } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, it, expect } from "vitest";
+import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
+
+function createMockContext(
+  overrides: Partial<ChannelThreadingContext> = {},
+): ChannelThreadingContext {
+  return {
+    To: "group:-1001234567890",
+    ChatType: "group",
+    MessageThreadId: 42,
+    ...overrides,
+  };
+}
+
+const mockCfg: OpenClawConfig = {
+  channels: {
+    telegram: {
+      enabled: true,
+      accounts: {
+        default: {
+          enabled: true,
+        },
+      },
+    },
+  },
+};
+
+describe("buildTelegramThreadingToolContext", () => {
+  it("returns toolContext with currentThreadTs when MessageThreadId is present (forum topic)", () => {
+    const context = createMockContext({
+      MessageThreadId: 42,
+      To: "group:-1001234567890",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    expect(result).toBeDefined();
+    // parseTelegramTarget preserves the "group:" prefix in chatId
+    expect(result?.currentChannelId).toBe("group:-1001234567890");
+    expect(result?.currentThreadTs).toBe("42");
+    expect(result?.hasRepliedRef).toBeUndefined();
+  });
+
+  it("returns toolContext WITHOUT currentThreadTs for DMs (no MessageThreadId) - FIXES REGRESSION", () => {
+    const context = createMockContext({
+      MessageThreadId: undefined,
+      To: "123456",
+      ChatType: "direct",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    // Should NOT return undefined for DMs!
+    expect(result).toBeDefined();
+    expect(result?.currentChannelId).toBe("123456");
+    expect(result?.currentThreadTs).toBeUndefined();
+    expect(result?.hasRepliedRef).toBeUndefined();
+  });
+
+  it("returns toolContext WITHOUT currentThreadTs for regular groups (no MessageThreadId)", () => {
+    const context = createMockContext({
+      MessageThreadId: undefined,
+      To: "group:-1009876543210",
+      ChatType: "group",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    // Should NOT return undefined for regular groups!
+    expect(result).toBeDefined();
+    expect(result?.currentChannelId).toBe("group:-1009876543210");
+    expect(result?.currentThreadTs).toBeUndefined();
+  });
+
+  it("extracts chat ID correctly from group To field", () => {
+    const context = createMockContext({
+      MessageThreadId: 100,
+      To: "group:-1009876543210",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    // parseTelegramTarget preserves the "group:" prefix in chatId
+    expect(result?.currentChannelId).toBe("group:-1009876543210");
+    expect(result?.currentThreadTs).toBe("100");
+  });
+
+  it("extracts chat ID correctly from DM To field", () => {
+    const context = createMockContext({
+      MessageThreadId: 200,
+      To: "123456",
+      ChatType: "direct",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    expect(result?.currentChannelId).toBe("123456");
+    expect(result?.currentThreadTs).toBe("200");
+  });
+
+  it("passes hasRepliedRef through when provided", () => {
+    const context = createMockContext({
+      MessageThreadId: 42,
+    });
+    const repliedRef = { value: false };
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+      hasRepliedRef: repliedRef,
+    });
+
+    expect(result?.hasRepliedRef).toBe(repliedRef);
+  });
+
+  it("passes hasRepliedRef through for DMs (no MessageThreadId)", () => {
+    const context = createMockContext({
+      MessageThreadId: undefined,
+      To: "123456",
+      ChatType: "direct",
+    });
+    const repliedRef = { value: true };
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+      hasRepliedRef: repliedRef,
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.hasRepliedRef).toBe(repliedRef);
+    expect(result?.currentThreadTs).toBeUndefined();
+  });
+
+  it("handles forum topic with large thread ID", () => {
+    const context = createMockContext({
+      MessageThreadId: 999999,
+      To: "group:-1001111222333",
+    });
+
+    const result = buildTelegramThreadingToolContext({
+      cfg: mockCfg,
+      accountId: "default",
+      context,
+    });
+
+    expect(result?.currentChannelId).toBe("group:-1001111222333");
+    expect(result?.currentThreadTs).toBe("999999");
+  });
+});

--- a/extensions/telegram/src/threading-tool-context.ts
+++ b/extensions/telegram/src/threading-tool-context.ts
@@ -10,7 +10,7 @@ export function buildTelegramThreadingToolContext(params: {
   accountId?: string | null;
   context: ChannelThreadingContext;
   hasRepliedRef?: { value: boolean };
-}): ChannelThreadingToolContext | undefined {
+}): ChannelThreadingToolContext {
   // Extract thread ID from MessageThreadId (forum topics only)
   const threadId = params.context.MessageThreadId;
 
@@ -18,7 +18,7 @@ export function buildTelegramThreadingToolContext(params: {
   // For DMs, use the raw chat ID directly.
   const toValue = params.context.To ?? "";
   const parsedTo = parseTelegramTarget(toValue);
-  const currentChannelId = parsedTo.chatId;
+  const currentChannelId = parsedTo.chatId || undefined;
 
   // Always return toolContext with currentChannelId and hasRepliedRef
   // Only include currentThreadTs for forum topics (when MessageThreadId exists)

--- a/extensions/telegram/src/threading-tool-context.ts
+++ b/extensions/telegram/src/threading-tool-context.ts
@@ -1,0 +1,30 @@
+import type {
+  ChannelThreadingContext,
+  ChannelThreadingToolContext,
+} from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { parseTelegramTarget } from "./targets.js";
+
+export function buildTelegramThreadingToolContext(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  context: ChannelThreadingContext;
+  hasRepliedRef?: { value: boolean };
+}): ChannelThreadingToolContext | undefined {
+  // Extract thread ID from MessageThreadId (forum topics only)
+  const threadId = params.context.MessageThreadId;
+
+  // For forum topics, To is "group:-100..." — extract the bare chat ID.
+  // For DMs, use the raw chat ID directly.
+  const toValue = params.context.To ?? "";
+  const parsedTo = parseTelegramTarget(toValue);
+  const currentChannelId = parsedTo.chatId;
+
+  // Always return toolContext with currentChannelId and hasRepliedRef
+  // Only include currentThreadTs for forum topics (when MessageThreadId exists)
+  return {
+    currentChannelId,
+    currentThreadTs: threadId != null ? String(threadId) : undefined,
+    hasRepliedRef: params.hasRepliedRef,
+  };
+}


### PR DESCRIPTION
## 🐛 Problem

When `buildTelegramThreadingToolContext` returns `undefined` for non-forum chats (DMs, regular groups), it causes regression:
- `currentChannelId` and `hasRepliedRef` are lost entirely
- Message actions relying on implicit target inference fail with target-required errors
- Affects Telegram DMs and non-forum group chats

## ✅ Solution

Always return `toolContext` with `currentChannelId` and `hasRepliedRef`:
- Only set `currentThreadTs` for forum topics (when `MessageThreadId` exists)
- For DMs/regular groups: return `currentChannelId` + `hasRepliedRef` without `currentThreadTs`
- Preserves backward compatibility while adding forum topic support

## 📝 Changes

- `extensions/telegram/src/threading-tool-context.ts`: Modified to always return toolContext
- `extensions/telegram/src/channel.ts`: Added `buildToolContext` integration
- `extensions/telegram/src/threading-tool-context.test.ts`: Added comprehensive tests (8 tests)
  - ✅ Forum topics with MessageThreadId
  - ✅ DMs without MessageThreadId (regression fix)
  - ✅ Regular groups without MessageThreadId
  - ✅ hasRepliedRef passthrough for all cases

## 🧪 Test Results

```
✓ extensions/telegram/src/threading-tool-context.test.ts (8 tests) 5ms
Test Files 1 passed (1)
Tests 8 passed (8)
```

## 🔗 Related

- Fixes regression introduced by forum topic support
- Ensures DMs and regular groups continue to work correctly