### PR TITLE
fix: apply host-env blocklist to auth-profile env refs in daemon install

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -315,6 +315,80 @@ describe("buildGatewayInstallPlan", () => {
     expect(plan.environment.ANTHROPIC_TOKEN).toBe("ant-test-token");
   });
 
+  it("blocks dangerous auth-profile env refs from the service environment", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
+      version: 1,
+      profiles: {
+        "node:default": {
+          type: "token",
+          provider: "node",
+          tokenRef: { source: "env", provider: "default", id: "NODE_OPTIONS" },
+        },
+        "git:default": {
+          type: "token",
+          provider: "git",
+          tokenRef: { source: "env", provider: "default", id: "GIT_ASKPASS" },
+        },
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+        },
+      },
+    });
+
+    const warn = vi.fn();
+    const plan = await buildGatewayInstallPlan({
+      env: {
+        NODE_OPTIONS: "--require ./pwn.js",
+        GIT_ASKPASS: "/tmp/askpass.sh",
+        OPENAI_API_KEY: "sk-openai-test", // pragma: allowlist secret
+      },
+      port: 3000,
+      runtime: "node",
+      warn,
+    });
+
+    expect(plan.environment.NODE_OPTIONS).toBeUndefined();
+    expect(plan.environment.GIT_ASKPASS).toBeUndefined();
+    expect(plan.environment.OPENAI_API_KEY).toBe("sk-openai-test");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("NODE_OPTIONS"), "Auth profile");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("GIT_ASKPASS"), "Auth profile");
+  });
+
+  it("skips non-portable auth-profile env ref keys", async () => {
+    mockNodeGatewayPlanFixture({
+      serviceEnvironment: {
+        OPENCLAW_PORT: "3000",
+      },
+    });
+    mocks.loadAuthProfileStoreForSecretsRuntime.mockReturnValue({
+      version: 1,
+      profiles: {
+        "broken:default": {
+          type: "token",
+          provider: "broken",
+          tokenRef: { source: "env", provider: "default", id: "BAD KEY" },
+        },
+      },
+    });
+
+    const plan = await buildGatewayInstallPlan({
+      env: {
+        "BAD KEY": "should-not-pass",
+      },
+      port: 3000,
+      runtime: "node",
+    });
+
+    expect(plan.environment["BAD KEY"]).toBeUndefined();
+  });
+
   it("skips unresolved auth-profile env refs", async () => {
     mockNodeGatewayPlanFixture({
       serviceEnvironment: {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -9,6 +9,11 @@ import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { buildServiceEnvironment } from "../daemon/service-env.js";
 import {
+  isDangerousHostEnvOverrideVarName,
+  isDangerousHostEnvVarName,
+  normalizeEnvVarKey,
+} from "../infra/host-env-security.js";
+import {
   emitDaemonInstallRuntimeWarning,
   resolveDaemonInstallRuntimeInputs,
   resolveDaemonNodeBinDir,
@@ -27,6 +32,7 @@ export type GatewayInstallPlan = {
 function collectAuthProfileServiceEnvVars(params: {
   env: Record<string, string | undefined>;
   authStore?: AuthProfileStore;
+  warn?: DaemonInstallWarnFn;
 }): Record<string, string> {
   const authStore = params.authStore ?? loadAuthProfileStoreForSecretsRuntime();
   const entries: Record<string, string> = {};
@@ -41,11 +47,22 @@ function collectAuthProfileServiceEnvVars(params: {
     if (!ref || ref.source !== "env") {
       continue;
     }
-    const value = params.env[ref.id]?.trim();
+    const key = normalizeEnvVarKey(ref.id, { portable: true });
+    if (!key) {
+      continue;
+    }
+    if (isDangerousHostEnvVarName(key) || isDangerousHostEnvOverrideVarName(key)) {
+      params.warn?.(
+        `Auth profile env ref "${key}" blocked by host-env security policy`,
+        "Auth profile",
+      );
+      continue;
+    }
+    const value = params.env[key]?.trim();
     if (!value) {
       continue;
     }
-    entries[ref.id] = value;
+    entries[key] = value;
   }
 
   return entries;
@@ -55,6 +72,7 @@ function buildGatewayInstallEnvironment(params: {
   env: Record<string, string | undefined>;
   config?: OpenClawConfig;
   authStore?: AuthProfileStore;
+  warn?: DaemonInstallWarnFn;
   serviceEnvironment: Record<string, string | undefined>;
 }): Record<string, string | undefined> {
   const environment: Record<string, string | undefined> = {
@@ -65,6 +83,7 @@ function buildGatewayInstallEnvironment(params: {
     ...collectAuthProfileServiceEnvVars({
       env: params.env,
       authStore: params.authStore,
+      warn: params.warn,
     }),
   };
   Object.assign(environment, params.serviceEnvironment);
@@ -125,6 +144,7 @@ export async function buildGatewayInstallPlan(params: {
       env: params.env,
       config: params.config,
       authStore: params.authStore,
+      warn: params.warn,
       serviceEnvironment,
     }),
   };

--- a/src/gateway/server.send-telegram-target-writeback-scope.test.ts
+++ b/src/gateway/server.send-telegram-target-writeback-scope.test.ts
@@ -105,38 +105,36 @@ async function withTelegramGatewayWritebackFixture(
             label: "Telegram",
             outbound: {
               deliveryMode: "direct",
-              sendText: async ({ cfg, to, text, accountId, gatewayClientScopes }) =>
-                ({
-                  channel: "telegram",
-                  ...(await sendMessageTelegram(to, text, {
-                    cfg,
-                    accountId: accountId ?? undefined,
-                    gatewayClientScopes,
-                    token: "123:abc",
-                    api: {
-                      getChat,
-                      sendMessage,
-                    },
-                  })),
-                }),
-              sendPoll: async ({ cfg, to, poll, accountId, gatewayClientScopes, threadId }) =>
-                ({
-                  channel: "telegram",
-                  ...(await sendPollTelegram(to, poll, {
-                    cfg,
-                    accountId: accountId ?? undefined,
-                    gatewayClientScopes,
-                    messageThreadId:
-                      typeof threadId === "number" && Number.isFinite(threadId)
-                        ? Math.trunc(threadId)
-                        : undefined,
-                    token: "123:abc",
-                    api: {
-                      getChat,
-                      sendPoll,
-                    },
-                  })),
-                }),
+              sendText: async ({ cfg, to, text, accountId, gatewayClientScopes }) => ({
+                channel: "telegram",
+                ...(await sendMessageTelegram(to, text, {
+                  cfg,
+                  accountId: accountId ?? undefined,
+                  gatewayClientScopes,
+                  token: "123:abc",
+                  api: {
+                    getChat,
+                    sendMessage,
+                  },
+                })),
+              }),
+              sendPoll: async ({ cfg, to, poll, accountId, gatewayClientScopes, threadId }) => ({
+                channel: "telegram",
+                ...(await sendPollTelegram(to, poll, {
+                  cfg,
+                  accountId: accountId ?? undefined,
+                  gatewayClientScopes,
+                  messageThreadId:
+                    typeof threadId === "number" && Number.isFinite(threadId)
+                      ? Math.trunc(threadId)
+                      : undefined,
+                  token: "123:abc",
+                  api: {
+                    getChat,
+                    sendPoll,
+                  },
+                })),
+              }),
             },
           }),
         },


### PR DESCRIPTION
## Summary
- Auth-profile env refs in `collectAuthProfileServiceEnvVars` were forwarded into the daemon service environment without passing through the host-env security blocklist, allowing dangerous vars like `NODE_OPTIONS` or `GIT_ASKPASS` to be injected via a crafted auth profile.
- Now validates refs through `normalizeEnvVarKey` (portable check), `isDangerousHostEnvVarName`, and `isDangerousHostEnvOverrideVarName` before accepting them — matching the existing guard pattern used elsewhere in `host-env-security.ts`.
- Emits a warning via the existing `warn` callback when a dangerous key is blocked, so operators get visibility into skipped refs.

## Test plan
- [x] New test: dangerous keys (`NODE_OPTIONS`, `GIT_ASKPASS`) are blocked while legitimate API keys pass through
- [x] New test: non-portable env ref keys (e.g. `"BAD KEY"`) are silently dropped
- [x] New test: `warn` callback is invoked with blocked key names
- [x] Existing tests continue to pass (`pnpm test -- src/commands/daemon-install-helpers.test.ts` — 18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)