### PR TITLE
test: fix unrelated CI failures

### DIFF
--- a/src/gateway/server.send-telegram-target-writeback-scope.test.ts
+++ b/src/gateway/server.send-telegram-target-writeback-scope.test.ts
@@ -105,38 +105,36 @@ async function withTelegramGatewayWritebackFixture(
             label: "Telegram",
             outbound: {
               deliveryMode: "direct",
-              sendText: async ({ cfg, to, text, accountId, gatewayClientScopes }) =>
-                ({
-                  channel: "telegram",
-                  ...(await sendMessageTelegram(to, text, {
-                    cfg,
-                    accountId: accountId ?? undefined,
-                    gatewayClientScopes,
-                    token: "123:abc",
-                    api: {
-                      getChat,
-                      sendMessage,
-                    },
-                  })),
-                }),
-              sendPoll: async ({ cfg, to, poll, accountId, gatewayClientScopes, threadId }) =>
-                ({
-                  channel: "telegram",
-                  ...(await sendPollTelegram(to, poll, {
-                    cfg,
-                    accountId: accountId ?? undefined,
-                    gatewayClientScopes,
-                    messageThreadId:
-                      typeof threadId === "number" && Number.isFinite(threadId)
-                        ? Math.trunc(threadId)
-                        : undefined,
-                    token: "123:abc",
-                    api: {
-                      getChat,
-                      sendPoll,
-                    },
-                  })),
-                }),
+              sendText: async ({ cfg, to, text, accountId, gatewayClientScopes }) => ({
+                channel: "telegram",
+                ...(await sendMessageTelegram(to, text, {
+                  cfg,
+                  accountId: accountId ?? undefined,
+                  gatewayClientScopes,
+                  token: "123:abc",
+                  api: {
+                    getChat,
+                    sendMessage,
+                  },
+                })),
+              }),
+              sendPoll: async ({ cfg, to, poll, accountId, gatewayClientScopes, threadId }) => ({
+                channel: "telegram",
+                ...(await sendPollTelegram(to, poll, {
+                  cfg,
+                  accountId: accountId ?? undefined,
+                  gatewayClientScopes,
+                  messageThreadId:
+                    typeof threadId === "number" && Number.isFinite(threadId)
+                      ? Math.trunc(threadId)
+                      : undefined,
+                  token: "123:abc",
+                  api: {
+                    getChat,
+                    sendPoll,
+                  },
+                })),
+              }),
             },
           }),
         },

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -103,6 +103,21 @@ type DeliverOutboundArgs = Parameters<DeliverModule["deliverOutboundPayloads"]>[
 type DeliverOutboundPayload = DeliverOutboundArgs["payloads"][number];
 type DeliverSession = DeliverOutboundArgs["session"];
 
+function normalizeComparablePath(value: string): string {
+  return path
+    .normalize(value)
+    .replace(/\\/g, "/")
+    .replace(/^[A-Za-z]:/, "");
+}
+
+function expectMediaLocalRootsToContainPreferredTmpRoot(
+  roots: readonly string[] | undefined,
+): void {
+  const expected = normalizeComparablePath(resolvePreferredOpenClawTmpDir());
+  const normalizedRoots = (roots ?? []).map((root) => normalizeComparablePath(root));
+  expect(normalizedRoots).toContain(expected);
+}
+
 async function deliverWhatsAppPayload(params: {
   sendWhatsApp: NonNullable<
     NonNullable<Parameters<DeliverModule["deliverOutboundPayloads"]>[0]["deps"]>["sendWhatsApp"]
@@ -486,13 +501,9 @@ describe("deliverOutboundPayloads", () => {
       payload: { text: "hi", mediaUrl: "https://example.com/x.png" },
     });
 
-    expect(sendTelegram).toHaveBeenCalledWith(
-      "123",
-      "hi",
-      expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([resolvePreferredOpenClawTmpDir()]),
-      }),
-    );
+    const sendOpts = sendTelegram.mock.calls[0]?.[2] as { mediaLocalRoots?: string[] } | undefined;
+    expect(sendTelegram).toHaveBeenCalledWith("123", "hi", expect.any(Object));
+    expectMediaLocalRootsToContainPreferredTmpRoot(sendOpts?.mediaLocalRoots);
   });
 
   it("includes OpenClaw tmp root in signal mediaLocalRoots", async () => {
@@ -506,13 +517,9 @@ describe("deliverOutboundPayloads", () => {
       deps: { sendSignal },
     });
 
-    expect(sendSignal).toHaveBeenCalledWith(
-      "+1555",
-      "hi",
-      expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([resolvePreferredOpenClawTmpDir()]),
-      }),
-    );
+    const sendOpts = sendSignal.mock.calls[0]?.[2] as { mediaLocalRoots?: string[] } | undefined;
+    expect(sendSignal).toHaveBeenCalledWith("+1555", "hi", expect.any(Object));
+    expectMediaLocalRootsToContainPreferredTmpRoot(sendOpts?.mediaLocalRoots);
   });
 
   it("forwards audioAsVoice through generic plugin media delivery", async () => {
@@ -569,13 +576,9 @@ describe("deliverOutboundPayloads", () => {
       deps: { sendWhatsApp },
     });
 
-    expect(sendWhatsApp).toHaveBeenCalledWith(
-      "+1555",
-      "hi",
-      expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([resolvePreferredOpenClawTmpDir()]),
-      }),
-    );
+    const sendOpts = sendWhatsApp.mock.calls[0]?.[2] as { mediaLocalRoots?: string[] } | undefined;
+    expect(sendWhatsApp).toHaveBeenCalledWith("+1555", "hi", expect.any(Object));
+    expectMediaLocalRootsToContainPreferredTmpRoot(sendOpts?.mediaLocalRoots);
   });
 
   it("includes OpenClaw tmp root in imessage mediaLocalRoots", async () => {
@@ -589,13 +592,9 @@ describe("deliverOutboundPayloads", () => {
       deps: { sendIMessage },
     });
 
-    expect(sendIMessage).toHaveBeenCalledWith(
-      "imessage:+15551234567",
-      "hi",
-      expect.objectContaining({
-        mediaLocalRoots: expect.arrayContaining([resolvePreferredOpenClawTmpDir()]),
-      }),
-    );
+    const sendOpts = sendIMessage.mock.calls[0]?.[2] as { mediaLocalRoots?: string[] } | undefined;
+    expect(sendIMessage).toHaveBeenCalledWith("imessage:+15551234567", "hi", expect.any(Object));
+    expectMediaLocalRootsToContainPreferredTmpRoot(sendOpts?.mediaLocalRoots);
   });
 
   it("uses signal media maxBytes from config", async () => {


### PR DESCRIPTION
## Summary
- fix unrelated CI failures that showed up while validating #49834
- keep the cooldown/fallback work isolated from repo-level test/format cleanup

## Changes
- format `src/gateway/server.send-telegram-target-writeback-scope.test.ts` so `pnpm check` stops failing on oxfmt drift
- make `src/infra/outbound/deliver.test.ts` compare OpenClaw tmp roots using normalized paths so the Windows shard stops failing on `C:\\tmp\\openclaw` vs `/tmp/openclaw` path spelling

## Validation
- `pnpm test -- src/infra/outbound/deliver.test.ts -t "includes OpenClaw tmp root in telegram mediaLocalRoots|includes OpenClaw tmp root in signal mediaLocalRoots|includes OpenClaw tmp root in whatsapp mediaLocalRoots|includes OpenClaw tmp root in imessage mediaLocalRoots"`
- `pnpm test -- src/gateway/server.send-telegram-target-writeback-scope.test.ts`
- `pnpm exec oxfmt --check src/gateway/server.send-telegram-target-writeback-scope.test.ts src/infra/outbound/deliver.test.ts`

## Context
These failures were unrelated to #49834 and were split into a separate branch to keep that PR focused.
