### PR TITLE
fix(configure): preserve OpenRouter default model choice after auth

### DIFF
--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -701,6 +701,7 @@ describe("promptAuthConfig", () => {
 
   it("keeps the user selected OpenRouter default model after auth", async () => {
     mocks.promptAuthChoiceGrouped.mockResolvedValue("openrouter-api-key");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("openrouter");
     mocks.applyAuthChoice.mockResolvedValue({
       config: {
         agents: {
@@ -714,5 +715,12 @@ describe("promptAuthConfig", () => {
 
     const result = await promptAuthConfig({}, makeRuntime(), noopPrompter);
     expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe("openrouter/free");
+    expect(mocks.promptDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeProviderPluginSetups: true,
+        loadCatalog: true,
+        preferredProvider: "openrouter",
+      }),
+    );
   });
 });

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { NormalizedModelCatalogRow } from "../model-catalog/index.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -199,7 +200,13 @@ vi.mock("./models/list.manifest-catalog.js", () => ({
 import { promptAuthConfig } from "./configure.gateway-auth.js";
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([]);
+  mocks.promptDefaultModel.mockResolvedValue({});
+  mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+  mocks.resolvePluginProviders.mockReturnValue([]);
+  mocks.resolveProviderPluginChoice.mockReturnValue(null);
+  mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue(undefined);
 });
 
 function makeRuntime(): RuntimeEnv {
@@ -690,5 +697,22 @@ describe("promptAuthConfig", () => {
     expect(mocks.promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
     expect(mocks.applyAuthChoice).toHaveBeenCalledTimes(2);
     expect(mocks.promptModelAllowlist).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the user selected OpenRouter default model after auth", async () => {
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("openrouter-api-key");
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/auto" },
+          },
+        },
+      },
+    });
+    mocks.promptDefaultModel.mockResolvedValue({ model: "openrouter/free" });
+
+    const result = await promptAuthConfig({}, makeRuntime(), noopPrompter);
+    expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe("openrouter/free");
   });
 });

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { NormalizedModelCatalogRow } from "../model-catalog/index.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -199,7 +200,13 @@ vi.mock("./models/list.manifest-catalog.js", () => ({
 import { promptAuthConfig } from "./configure.gateway-auth.js";
 
 beforeEach(() => {
+  vi.clearAllMocks();
   mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([]);
+  mocks.promptDefaultModel.mockResolvedValue({});
+  mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+  mocks.resolvePluginProviders.mockReturnValue([]);
+  mocks.resolveProviderPluginChoice.mockReturnValue(null);
+  mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue(undefined);
 });
 
 function makeRuntime(): RuntimeEnv {
@@ -650,5 +657,22 @@ describe("promptAuthConfig", () => {
     expect(mocks.promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
     expect(mocks.applyAuthChoice).toHaveBeenCalledTimes(2);
     expect(mocks.promptModelAllowlist).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the user selected OpenRouter default model after auth", async () => {
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("openrouter-api-key");
+    mocks.applyAuthChoice.mockResolvedValue({
+      config: {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/auto" },
+          },
+        },
+      },
+    });
+    mocks.promptDefaultModel.mockResolvedValue({ model: "openrouter/free" });
+
+    const result = await promptAuthConfig({}, makeRuntime(), noopPrompter);
+    expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe("openrouter/free");
   });
 });

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -661,6 +661,7 @@ describe("promptAuthConfig", () => {
 
   it("keeps the user selected OpenRouter default model after auth", async () => {
     mocks.promptAuthChoiceGrouped.mockResolvedValue("openrouter-api-key");
+    mocks.resolvePreferredProviderForAuthChoice.mockResolvedValue("openrouter");
     mocks.applyAuthChoice.mockResolvedValue({
       config: {
         agents: {
@@ -674,5 +675,12 @@ describe("promptAuthConfig", () => {
 
     const result = await promptAuthConfig({}, makeRuntime(), noopPrompter);
     expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe("openrouter/free");
+    expect(mocks.promptDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeProviderPluginSetups: true,
+        loadCatalog: true,
+        preferredProvider: "openrouter",
+      }),
+    );
   });
 });

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -185,6 +185,32 @@ export async function promptAuthConfig(
   let next = cfg;
   let authChoice: string = "skip";
   let preferredProvider: string | undefined;
+  const promptPrimaryModel = async (params: {
+    includeProviderPluginSetups: boolean;
+    loadCatalog: boolean;
+    browseCatalogOnDemand?: boolean;
+  }): Promise<void> => {
+    const modelSelection = await promptDefaultModel({
+      config: next,
+      prompter,
+      allowKeep: true,
+      ignoreAllowlist: true,
+      includeProviderPluginSetups: params.includeProviderPluginSetups,
+      loadCatalog: params.loadCatalog,
+      browseCatalogOnDemand: params.browseCatalogOnDemand,
+      preferredProvider,
+      workspaceDir: resolveDefaultAgentWorkspaceDir(),
+      runtime,
+    });
+    if (modelSelection.config) {
+      next = modelSelection.config;
+    }
+    if (modelSelection.model) {
+      next = applyPrimaryModel(next, modelSelection.model);
+      preferredProvider = resolveProviderFromModelRef(modelSelection.model) ?? preferredProvider;
+    }
+  };
+
   while (true) {
     authChoice = await promptAuthChoiceGrouped({
       prompter,
@@ -210,25 +236,11 @@ export async function promptAuthConfig(
     }
 
     if (authChoice === "skip") {
-      const modelSelection = await promptDefaultModel({
-        config: next,
-        prompter,
-        allowKeep: true,
-        ignoreAllowlist: true,
+      await promptPrimaryModel({
         includeProviderPluginSetups: false,
         loadCatalog: true,
         browseCatalogOnDemand: true,
-        preferredProvider,
-        workspaceDir: resolveDefaultAgentWorkspaceDir(),
-        runtime,
       });
-      if (modelSelection.config) {
-        next = modelSelection.config;
-      }
-      if (modelSelection.model) {
-        next = applyPrimaryModel(next, modelSelection.model);
-        preferredProvider = resolveProviderFromModelRef(modelSelection.model) ?? preferredProvider;
-      }
       break;
     }
 
@@ -250,6 +262,10 @@ export async function promptAuthConfig(
     if (applied.retrySelection) {
       continue;
     }
+    await promptPrimaryModel({
+      includeProviderPluginSetups: true,
+      loadCatalog: true,
+    });
     break;
   }
 

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -176,6 +176,26 @@ export async function promptAuthConfig(
   let next = cfg;
   let authChoice: string = "skip";
   let preferredProvider: string | undefined;
+  const promptPrimaryModel = async (includeProviderPluginSetups: boolean): Promise<void> => {
+    const modelSelection = await promptDefaultModel({
+      config: next,
+      prompter,
+      allowKeep: true,
+      ignoreAllowlist: true,
+      includeProviderPluginSetups,
+      loadCatalog: false,
+      preferredProvider,
+      workspaceDir: resolveDefaultAgentWorkspaceDir(),
+      runtime,
+    });
+    if (modelSelection.config) {
+      next = modelSelection.config;
+    }
+    if (modelSelection.model) {
+      next = applyPrimaryModel(next, modelSelection.model);
+    }
+  };
+
   while (true) {
     authChoice = await promptAuthChoiceGrouped({
       prompter,
@@ -201,23 +221,7 @@ export async function promptAuthConfig(
     }
 
     if (authChoice === "skip") {
-      const modelSelection = await promptDefaultModel({
-        config: next,
-        prompter,
-        allowKeep: true,
-        ignoreAllowlist: true,
-        includeProviderPluginSetups: false,
-        loadCatalog: false,
-        preferredProvider,
-        workspaceDir: resolveDefaultAgentWorkspaceDir(),
-        runtime,
-      });
-      if (modelSelection.config) {
-        next = modelSelection.config;
-      }
-      if (modelSelection.model) {
-        next = applyPrimaryModel(next, modelSelection.model);
-      }
+      await promptPrimaryModel(false);
       break;
     }
 
@@ -239,6 +243,7 @@ export async function promptAuthConfig(
     if (applied.retrySelection) {
       continue;
     }
+    await promptPrimaryModel(true);
     break;
   }
 

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -183,7 +183,7 @@ export async function promptAuthConfig(
       allowKeep: true,
       ignoreAllowlist: true,
       includeProviderPluginSetups,
-      loadCatalog: false,
+      loadCatalog: includeProviderPluginSetups,
       preferredProvider,
       workspaceDir: resolveDefaultAgentWorkspaceDir(),
       runtime,


### PR DESCRIPTION
## Summary
- preserve the user-selected OpenRouter default model during configure auth
- load the provider catalog for provider-backed auth choices so OpenRouter model defaults can be resolved after auth
- keep the current skip-path catalog browsing behavior while sharing the same primary-model prompt helper
- add regression coverage for the `openrouter/free` path

## Testing
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs src/commands/configure.gateway-auth.prompt-auth-config.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof
- **Behavior or issue addressed**: Configure auth keeps the OpenRouter default model selection (`openrouter/free`) instead of overwriting it after auth completes.
- **Real environment tested**: Local OpenClaw source checkout on Linux at head `a843e3e59d`, Node `v22.22.0`.
- **Exact steps or command run after this patch**:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs src/commands/configure.gateway-auth.prompt-auth-config.test.ts
git diff --check origin/main...HEAD
```

- **Evidence after fix**:

```text
RUN  v4.1.5 /media/vdc/0668001470/workSpace/claw-campaign/openclaw/.worktrees/issue-54581-openrouter-free

Test Files  1 passed (1)
Tests  14 passed (14)
Duration  6.16s

[test] passed 1 Vitest shard in 21.37s

git diff --check origin/main...HEAD
exit status: 0
```

- **Observed result after fix**: The configure auth regression test exercises the OpenRouter auth choice, calls `promptDefaultModel` with provider catalog context after auth, and preserves `openrouter/free` in the resulting config. The branch was also rebased onto current `main` and the configure-auth conflict was resolved without expanding the touched file set.
- **What was not tested**: I did not perform a live OpenRouter login in this local proof because no live OpenRouter credentials are available in this environment.

Fixes #54581
