### PR TITLE
fix: reject path traversal and home-dir patterns in media parse layer

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -29,7 +29,7 @@ describe("splitMediaFromOutput", () => {
     }
   });
 
-  it("rejects traversal and home-dir paths", () => {
+  it("rejects traversal and home-dir paths and strips them from output", () => {
     const traversalCases = [
       "MEDIA:../../../etc/passwd",
       "MEDIA:../../.env",
@@ -39,7 +39,8 @@ describe("splitMediaFromOutput", () => {
     ];
     for (const input of traversalCases) {
       const result = splitMediaFromOutput(input);
-      expect(result.mediaUrls, `should reject: ${input}`).toBeUndefined();
+      expect(result.mediaUrls, `should reject media: ${input}`).toBeUndefined();
+      expect(result.text, `should strip from text: ${input}`).toBe("");
     }
   });
 

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -12,8 +12,6 @@ describe("splitMediaFromOutput", () => {
     const pathCases = [
       ["/Users/pete/My File.png", "MEDIA:/Users/pete/My File.png"],
       ["/Users/pete/My File.png", 'MEDIA:"/Users/pete/My File.png"'],
-      ["~/Pictures/My File.png", "MEDIA:~/Pictures/My File.png"],
-      ["../../etc/passwd", "MEDIA:../../etc/passwd"],
       ["./screenshots/image.png", "MEDIA:./screenshots/image.png"],
       ["media/inbound/image.png", "MEDIA:media/inbound/image.png"],
       ["./screenshot.png", "  MEDIA:./screenshot.png"],
@@ -28,6 +26,20 @@ describe("splitMediaFromOutput", () => {
       const result = splitMediaFromOutput(input);
       expect(result.mediaUrls).toEqual([expectedPath]);
       expect(result.text).toBe("");
+    }
+  });
+
+  it("rejects traversal and home-dir paths", () => {
+    const traversalCases = [
+      "MEDIA:../../../etc/passwd",
+      "MEDIA:../../.env",
+      "MEDIA:~/.ssh/id_rsa",
+      "MEDIA:~/Pictures/My File.png",
+      "MEDIA:./foo/../../../etc/shadow",
+    ];
+    for (const input of traversalCases) {
+      const result = splitMediaFromOutput(input);
+      expect(result.mediaUrls, `should reject: ${input}`).toBeUndefined();
     }
   });
 

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -30,8 +30,22 @@ function hasTraversalOrHomeDirPrefix(candidate: string): boolean {
   );
 }
 
-// Recognize local file path patterns, rejecting traversal and home-dir paths
-// up front so they never reach downstream load/send logic.
+// Broad structural check: does this look like a local file path? Used only for
+// stripping MEDIA: lines from output text — never for media approval.
+function looksLikeLocalFilePath(candidate: string): boolean {
+  return (
+    candidate.startsWith("/") ||
+    candidate.startsWith("./") ||
+    candidate.startsWith("../") ||
+    candidate.startsWith("~") ||
+    WINDOWS_DRIVE_RE.test(candidate) ||
+    candidate.startsWith("\\\\") ||
+    (!SCHEME_RE.test(candidate) && (candidate.includes("/") || candidate.includes("\\")))
+  );
+}
+
+// Recognize safe local file path patterns for media approval, rejecting
+// traversal and home-dir paths so they never reach downstream load/send logic.
 function isLikelyLocalPath(candidate: string): boolean {
   if (hasTraversalOrHomeDirPrefix(candidate)) {
     return false;
@@ -187,7 +201,7 @@ export function splitMediaFromOutput(raw: string): {
 
       const trimmedPayload = payloadValue.trim();
       const looksLikeLocalPath =
-        isLikelyLocalPath(trimmedPayload) || trimmedPayload.startsWith("file://");
+        looksLikeLocalFilePath(trimmedPayload) || trimmedPayload.startsWith("file://");
       if (
         !unwrapped &&
         validCount === 1 &&

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -18,15 +18,27 @@ const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT = /\.\w{1,10}$/;
 
-// Recognize local file path patterns. Security validation is deferred to the
-// load layer (loadWebMedia / resolveSandboxedMediaSource) which has the context
-// needed to enforce sandbox roots and allowed directories.
+// Matches ".." as a standalone path segment (start, middle, or end).
+const TRAVERSAL_SEGMENT_RE = /(?:^|[/\\])\.\.(?:[/\\]|$)/;
+
+function hasTraversalOrHomeDirPrefix(candidate: string): boolean {
+  return (
+    candidate.startsWith("../") ||
+    candidate === ".." ||
+    candidate.startsWith("~") ||
+    TRAVERSAL_SEGMENT_RE.test(candidate)
+  );
+}
+
+// Recognize local file path patterns, rejecting traversal and home-dir paths
+// up front so they never reach downstream load/send logic.
 function isLikelyLocalPath(candidate: string): boolean {
+  if (hasTraversalOrHomeDirPrefix(candidate)) {
+    return false;
+  }
   return (
     candidate.startsWith("/") ||
     candidate.startsWith("./") ||
-    candidate.startsWith("../") ||
-    candidate.startsWith("~") ||
     WINDOWS_DRIVE_RE.test(candidate) ||
     candidate.startsWith("\\\\") ||
     (!SCHEME_RE.test(candidate) && (candidate.includes("/") || candidate.includes("\\")))
@@ -52,6 +64,12 @@ function isValidMedia(
 
   if (isLikelyLocalPath(candidate)) {
     return true;
+  }
+
+  // Hard reject traversal/home-dir patterns before the bare-filename fallback
+  // to prevent path traversal bypasses (e.g. "../../.env" matching HAS_FILE_EXT).
+  if (hasTraversalOrHomeDirPrefix(candidate)) {
+    return false;
   }
 
   // Accept bare filenames (e.g. "image.png") only when the caller opts in.


### PR DESCRIPTION
## Summary

- Problem: `isLikelyLocalPath()` in `src/media/parse.ts` accepted traversal (`../`) and home-dir (`~`) paths as valid local media, and `isValidMedia()` had a secondary bypass via `allowBareFilename` where patterns like `../../.env` matched the file-extension regex.
- Why it matters: untrusted input through `splitMediaFromOutput()` could reference arbitrary files outside the application sandbox (e.g. `/etc/passwd`, `~/.ssh/id_rsa`, `.env`).
- What changed: a shared `hasTraversalOrHomeDirPrefix()` guard now rejects `../`, `..`, `~`, and embedded `..` segments in both `isLikelyLocalPath()` (primary gate) and `isValidMedia()` (before the `allowBareFilename` fallback).
- What did NOT change: downstream sandbox enforcement in `assertLocalMediaAllowed()` / `resolveSandboxedMediaSource()` is untouched. This fix adds defense-in-depth at the parse layer.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: `isLikelyLocalPath()` treated `../` and `~` as valid local path prefixes without considering that these are traversal/escape patterns.
- Secondary bypass: `isValidMedia()` accepted any candidate matching `HAS_FILE_EXT` (e.g. `../../.env`) when `allowBareFilename` was set, bypassing the primary classifier entirely.
- Regression: fixed in c67df653b6 (2026-01-30), reintroduced in 4baa43384a (2026-02-08).
- Why this is the right fix location: `splitMediaFromOutput()` is the shared entry point for all media token parsing. Rejecting traversal patterns here prevents them from reaching any downstream consumer.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target tests:
  - `src/media/parse.test.ts`
- Scenario locked in:
  - `../../../etc/passwd` is rejected
  - `../../.env` is rejected (covers `allowBareFilename` bypass)
  - `~/.ssh/id_rsa` is rejected
  - `~/Pictures/My File.png` is rejected
  - `./foo/../../../etc/shadow` is rejected (embedded traversal segment)
  - Legitimate paths (`/absolute`, `./relative`, `C:\windows`, bare `image.png`) still accepted

## User-visible / Behavior Changes

`MEDIA:` tokens containing path traversal (`../`) or home-dir (`~`) patterns are no longer extracted as media URLs. They are stripped as invalid media lines instead of being forwarded to downstream file-read logic.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes` — narrows accepted media paths)
- Risk + mitigation: this narrows the media parse layer to reject traversal and home-dir escape patterns at the earliest possible point, before any downstream file access.

## Repro + Verification

### Environment

- OS: Linux host
- Runtime/container: Docker validation container (node:22-bookworm)

### Steps

1. `docker run --rm -v "$(pwd)/worktrees/media-parse-path-traversal":/app -w /app node:22-bookworm bash -c "corepack enable && pnpm install --frozen-lockfile && pnpm test -- src/media/parse.test.ts"`
2. `docker run --rm -v "$(pwd)/worktrees/media-parse-path-traversal":/app -w /app node:22-bookworm bash -c "corepack enable && pnpm install --frozen-lockfile && pnpm test -- src/media/"`

### Actual

- 6/6 parse tests passed (including new traversal rejection cases)
- 166/166 total media tests passed across 20 test files — zero regressions

## Human Verification

- Verified scenarios: confirmed in Docker that traversal paths (`../../../etc/passwd`, `../../.env`), home-dir paths (`~/.ssh/id_rsa`), and embedded traversal (`./foo/../../../etc/shadow`) are all rejected by `splitMediaFromOutput()`, while legitimate absolute, relative, Windows, and bare-filename paths continue to work.
- What I did not verify: did not run a live end-to-end media send because the parse-layer unit tests directly cover the classification boundary this PR changes.

## Compatibility / Migration

- Backward compatible? (`Yes` — only rejects paths that should never have been accepted)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery

- How to disable/revert quickly: revert the `hasTraversalOrHomeDirPrefix()` guard and restore the old `isLikelyLocalPath()` accept list in `src/media/parse.ts`
- Known bad symptoms to watch for: a legitimate relative media path being misclassified as traversal (would show as missing media in outbound messages)

## Risks and Mitigations

- Risk: legitimate `./path/../sibling/file.png` style paths would now be rejected.
- Mitigation: this is intentional — embedded `..` segments are a traversal vector. Callers should use normalized paths.
- Risk: `~`-prefixed paths from internal tools (e.g. TTS output) could be affected.
- Mitigation: internal tools already produce absolute paths (`/tmp/...`). The `~` prefix is only relevant for user-supplied input, which is exactly what this fix targets.