### PR TITLE
fix(subagent): set announce inputProvenance.sourceChannel from delivery origin

### DIFF
--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -201,4 +201,61 @@ describe("subagent announce seam flow", () => {
       timeoutMs: 10_000,
     });
   });
+
+  it("sets inputProvenance.sourceChannel from requesterOrigin.channel for non-subagent requesters", async () => {
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test-channel",
+      childRunId: "run-channel-test",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "telegram", to: "telegram:-1003633911025", threadId: "284" },
+      task: "test channel propagation",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "channel test result",
+    });
+
+    const agentCall = agentSpy.mock.calls.find((call) => call[0]?.params?.inputProvenance != null);
+    expect(agentCall).toBeDefined();
+    const provenance = agentCall![0].params!.inputProvenance as Record<string, unknown>;
+    expect(provenance).toMatchObject({
+      kind: "inter_session",
+      sourceChannel: "telegram",
+    });
+  });
+
+  it("falls back sourceChannel to INTERNAL_MESSAGE_CHANNEL when requesterOrigin has no channel", async () => {
+    ({ runSubagentAnnounceFlow } = await import("./subagent-announce.js"));
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test-fallback",
+      childRunId: "run-fallback-test",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: undefined,
+      task: "test fallback channel",
+      timeoutMs: 10,
+      cleanup: "delete",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "fallback test result",
+    });
+
+    const agentCall = agentSpy.mock.calls.find((call) => call[0]?.params?.inputProvenance != null);
+    // When no origin channel, should fall back to internal message channel (webchat)
+    if (agentCall) {
+      const provenance = agentCall[0].params!.inputProvenance as Record<string, unknown>;
+      expect(provenance).toMatchObject({
+        kind: "inter_session",
+      });
+      // sourceChannel should NOT be "telegram" when no origin was provided
+      expect(provenance.sourceChannel).not.toBe("telegram");
+    }
+  });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -828,7 +828,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: item.sourceSessionKey,
-        sourceChannel: item.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+        sourceChannel: (!requesterIsSubagent ? origin?.channel : undefined) ?? item.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
         sourceTool: item.sourceTool ?? "subagent_announce",
       },
       idempotencyKey,
@@ -1024,7 +1024,7 @@ async function sendSubagentAnnounceDirectly(params: {
             inputProvenance: {
               kind: "inter_session",
               sourceSessionKey: params.sourceSessionKey,
-              sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+              sourceChannel: (shouldDeliverExternally ? directChannel : undefined) ?? params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
               sourceTool: params.sourceTool ?? "subagent_announce",
             },
             idempotencyKey: params.directIdempotencyKey,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -828,7 +828,10 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: item.sourceSessionKey,
-        sourceChannel: (!requesterIsSubagent ? origin?.channel : undefined) ?? item.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+        sourceChannel:
+          (!requesterIsSubagent ? origin?.channel : undefined) ||
+          item.sourceChannel ||
+          INTERNAL_MESSAGE_CHANNEL,
         sourceTool: item.sourceTool ?? "subagent_announce",
       },
       idempotencyKey,
@@ -1024,7 +1027,10 @@ async function sendSubagentAnnounceDirectly(params: {
             inputProvenance: {
               kind: "inter_session",
               sourceSessionKey: params.sourceSessionKey,
-              sourceChannel: (shouldDeliverExternally ? directChannel : undefined) ?? params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+              sourceChannel:
+                (shouldDeliverExternally ? directChannel : undefined) ||
+                params.sourceChannel ||
+                INTERNAL_MESSAGE_CHANNEL,
               sourceTool: params.sourceTool ?? "subagent_announce",
             },
             idempotencyKey: params.directIdempotencyKey,


### PR DESCRIPTION
## Problem

Subagent announce delivery fails silently for Telegram, Discord, and other channels because `inputProvenance.sourceChannel` is hardcoded to `INTERNAL_MESSAGE_CHANNEL` instead of the actual delivery channel.

**Root Cause:** When a subagent completes and injects its result into the parent session via announce, the parent session's reply to that announcement is routed back through webchat (internal-only) instead of the original channel. This happens because the gateway routes responses based on `inputProvenance.sourceChannel`, which was always set to the internal channel.

**Affected Issues:** #38055, #26803, #21968

## Solution

Set `sourceChannel` from the actual delivery origin instead of defaulting to internal:

1. **sendAnnounce()** (line 831): Use `origin?.channel` when the requester is not a subagent
2. **sendSubagentAnnounceDirectly()** (line 1027): Use `directChannel` when delivering externally

## Testing

✅ **Verified fix works** by patching the compiled JS in dist/ and restarting the gateway
- Spawned test subagent from Telegram forum topic
- Subagent completed and announce fired
- Parent session's reply now delivered correctly to Telegram topic (previously went to webchat)
- No regressions: internal channel handling still falls back correctly to INTERNAL_MESSAGE_CHANNEL

## Changes

- **src/agents/subagent-announce.ts**: 2 lines
  - Line 831: `sourceChannel: (!requesterIsSubagent ? origin?.channel : undefined) ?? item.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL`
  - Line 1027: `sourceChannel: (shouldDeliverExternally ? directChannel : undefined) ?? params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL`

Fixes #38055
Fixes #26803
Fixes #21968