### PR TITLE
Fix ACP session model reporting in sessions list

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -611,6 +611,30 @@ describe("resolveSessionModelIdentityRef", () => {
       model: "anthropic/claude-sonnet-4-6",
     });
   });
+
+  test("uses ACP runtimeOptions.model before generic defaults", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "xai/grok-4.20-0309-non-reasoning",
+    });
+
+    const resolved = resolveSessionModelIdentityRef(cfg, {
+      sessionId: "acp-session",
+      updatedAt: Date.now(),
+      acp: {
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: "runtime:1",
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+        runtimeOptions: {
+          model: "openai/gpt-5.4",
+        },
+      },
+    } as SessionEntry);
+
+    expect(resolved).toEqual({ provider: "openai", model: "gpt-5.4" });
+  });
 });
 
 describe("deriveSessionTitle", () => {
@@ -1986,5 +2010,68 @@ describe("loadCombinedSessionStoreForGateway includes disk-only agents (#32804)"
       expect(store["agent:main:main"]).toBeDefined();
       expect(store["agent:codex:acp-task"]).toBeDefined();
     });
+  });
+});
+
+describe("listSessionsFromStore ACP model reporting", () => {
+  const cfg = createModelDefaultsConfig({
+    primary: "xai/grok-4.20-0309-non-reasoning",
+  });
+
+  test("reports ACP runtime model from session metadata", () => {
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:codex:acp:task-1": {
+          sessionId: "sess-acp-1",
+          updatedAt: Date.now(),
+          acp: {
+            backend: "acpx",
+            agent: "codex",
+            runtimeSessionName: "runtime:1",
+            mode: "persistent",
+            state: "idle",
+            lastActivityAt: Date.now(),
+            runtimeOptions: {
+              model: "openai/gpt-5.4",
+            },
+          },
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]).toMatchObject({
+      key: "agent:codex:acp:task-1",
+      modelProvider: "openai",
+      model: "gpt-5.4",
+    });
+  });
+
+  test("does not fall back to configured default model for ACP sessions with no runtime model", () => {
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:claude:acp:task-2": {
+          sessionId: "sess-acp-2",
+          updatedAt: Date.now(),
+          acp: {
+            backend: "acpx",
+            agent: "claude",
+            runtimeSessionName: "runtime:2",
+            mode: "persistent",
+            state: "idle",
+            lastActivityAt: Date.now(),
+          },
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.key).toBe("agent:claude:acp:task-2");
+    expect(result.sessions[0]?.modelProvider).toBeUndefined();
+    expect(result.sessions[0]?.model).toBeUndefined();
   });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -37,7 +37,7 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import { isAcpSessionKey, isCronRunSessionKey } from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
   isAvatarDataUrl,
@@ -1018,51 +1018,116 @@ export function resolveSessionModelRef(
   return { provider, model };
 }
 
+function resolveSessionModelIdentityLiteral(
+  cfg: OpenClawConfig,
+  modelRef?: string,
+): { provider?: string; model: string } | undefined {
+  const trimmed = modelRef?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg,
+    model: trimmed,
+  });
+  if (inferredProvider) {
+    return { provider: inferredProvider, model: trimmed };
+  }
+  if (trimmed.includes("/")) {
+    const parsed = parseModelRef(trimmed, DEFAULT_PROVIDER);
+    if (parsed) {
+      return { provider: parsed.provider, model: parsed.model };
+    }
+  }
+  return { model: trimmed };
+}
+
+function resolveSessionModelIdentityLiteralWithProvider(
+  cfg: OpenClawConfig,
+  modelRef: string | undefined,
+  providerRef: string | undefined,
+): { provider?: string; model: string } | undefined {
+  const trimmedModel = modelRef?.trim();
+  if (!trimmedModel) {
+    return undefined;
+  }
+  const trimmedProvider = providerRef?.trim();
+  if (!trimmedProvider) {
+    return resolveSessionModelIdentityLiteral(cfg, trimmedModel);
+  }
+  const parsed = parseModelRef(trimmedModel, trimmedProvider);
+  if (parsed) {
+    return { provider: parsed.provider, model: parsed.model };
+  }
+  return { provider: trimmedProvider, model: trimmedModel };
+}
+
+function resolveExplicitSessionModelIdentityRef(
+  cfg: OpenClawConfig,
+  entry?:
+    | SessionEntry
+    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride" | "acp">,
+  fallbackModelRef?: string,
+): { provider?: string; model: string } | undefined {
+  const runtimeIdentity = resolveSessionModelIdentityLiteralWithProvider(
+    cfg,
+    entry?.model,
+    entry?.modelProvider,
+  );
+  if (runtimeIdentity) {
+    return runtimeIdentity;
+  }
+
+  const acpRuntimeIdentity = resolveSessionModelIdentityLiteral(
+    cfg,
+    entry?.acp?.runtimeOptions?.model,
+  );
+  if (acpRuntimeIdentity) {
+    return acpRuntimeIdentity;
+  }
+
+  const fallbackIdentity = resolveSessionModelIdentityLiteral(cfg, fallbackModelRef);
+  if (fallbackIdentity) {
+    return fallbackIdentity;
+  }
+
+  return resolveSessionModelIdentityLiteralWithProvider(
+    cfg,
+    entry?.modelOverride,
+    entry?.providerOverride,
+  );
+}
+
 export function resolveSessionModelIdentityRef(
   cfg: OpenClawConfig,
   entry?:
     | SessionEntry
-    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">,
+    | Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride" | "acp">,
   agentId?: string,
   fallbackModelRef?: string,
 ): { provider?: string; model: string } {
-  const runtimeModel = entry?.model?.trim();
-  const runtimeProvider = entry?.modelProvider?.trim();
-  if (runtimeModel) {
-    if (runtimeProvider) {
-      return { provider: runtimeProvider, model: runtimeModel };
-    }
-    const inferredProvider = inferUniqueProviderFromConfiguredModels({
-      cfg,
-      model: runtimeModel,
-    });
-    if (inferredProvider) {
-      return { provider: inferredProvider, model: runtimeModel };
-    }
-    if (runtimeModel.includes("/")) {
-      const parsedRuntime = parseModelRef(runtimeModel, DEFAULT_PROVIDER);
-      if (parsedRuntime) {
-        return { provider: parsedRuntime.provider, model: parsedRuntime.model };
-      }
-      return { model: runtimeModel };
-    }
-    return { model: runtimeModel };
+  const runtimeIdentity = resolveSessionModelIdentityLiteralWithProvider(
+    cfg,
+    entry?.model,
+    entry?.modelProvider,
+  );
+  if (runtimeIdentity) {
+    return runtimeIdentity;
   }
-  const fallbackRef = fallbackModelRef?.trim();
-  if (fallbackRef) {
-    const parsedFallback = parseModelRef(fallbackRef, DEFAULT_PROVIDER);
-    if (parsedFallback) {
-      return { provider: parsedFallback.provider, model: parsedFallback.model };
-    }
-    const inferredProvider = inferUniqueProviderFromConfiguredModels({
-      cfg,
-      model: fallbackRef,
-    });
-    if (inferredProvider) {
-      return { provider: inferredProvider, model: fallbackRef };
-    }
-    return { model: fallbackRef };
+
+  const acpRuntimeIdentity = resolveSessionModelIdentityLiteral(
+    cfg,
+    entry?.acp?.runtimeOptions?.model,
+  );
+  if (acpRuntimeIdentity) {
+    return acpRuntimeIdentity;
   }
+
+  const fallbackIdentity = resolveSessionModelIdentityLiteral(cfg, fallbackModelRef);
+  if (fallbackIdentity) {
+    return fallbackIdentity;
+  }
+
   const resolved = resolveSessionModelRef(cfg, entry, agentId);
   return { provider: resolved.provider, model: resolved.model };
 }
@@ -1112,14 +1177,11 @@ export function buildGatewaySessionRow(params: {
   const subagentStartedAt = subagentRun ? getSubagentSessionStartedAt(subagentRun) : undefined;
   const subagentEndedAt = subagentRun ? subagentRun.endedAt : undefined;
   const subagentRuntimeMs = subagentRun ? resolveSessionRuntimeMs(subagentRun, now) : undefined;
-  const resolvedModel = resolveSessionModelIdentityRef(
-    cfg,
-    entry,
-    sessionAgentId,
-    subagentRun?.model,
-  );
-  const modelProvider = resolvedModel.provider;
-  const model = resolvedModel.model ?? DEFAULT_MODEL;
+  const resolvedModel = isAcpSessionKey(key)
+    ? resolveExplicitSessionModelIdentityRef(cfg, entry, subagentRun?.model)
+    : resolveSessionModelIdentityRef(cfg, entry, sessionAgentId, subagentRun?.model);
+  const modelProvider = resolvedModel?.provider;
+  const model = resolvedModel?.model ?? (isAcpSessionKey(key) ? undefined : DEFAULT_MODEL);
   const transcriptUsage =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined ||
     resolvePositiveNumber(entry?.contextTokens) === undefined ||


### PR DESCRIPTION
## Summary
- read the ACP runtime model from session entry ACP metadata when resolving session model identity
- avoid falling back to the configured default model for ACP session rows when no explicit ACP model is known
- add regression coverage for ACP session model reporting in sessions list

Closes #54640

## Testing
- pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/session-utils.test.ts -t ACP
- full src/gateway/session-utils.test.ts currently has one unrelated existing failure in uses persisted active subagent runs when the local worker only has terminal snapshots