### PR TITLE
test(auth): align device auth store scopes

### DIFF
--- a/src/shared/device-auth-store.test.ts
+++ b/src/shared/device-auth-store.test.ts
@@ -169,7 +169,7 @@ describe("device-auth-store", () => {
         operator: {
           token: "old-token",
           role: "operator",
-          scopes: ["operator.read"],
+          scopes: ["operator.audit"],
           updatedAtMs: 10,
         },
       },


### PR DESCRIPTION
## Summary
- align `device-auth-store` expectations with the already-landed implied-scope normalization
- keep the fix scoped to the stale test surface only

## Why
Current `main` expands `operator.write` to include `operator.read` in `src/shared/device-auth.ts`, and `src/shared/device-auth.test.ts` already covers that behavior. `src/shared/device-auth-store.test.ts` still expected only `operator.write`, which made the test fail on fresh `main` / merged-base CI.

This surfaced while triaging the unstable merged jobs around #53073, but the failure is independent of that PR diff.

## Validation
- `pnpm exec oxfmt --check src/shared/device-auth-store.test.ts`
- `pnpm exec oxlint --type-aware src/shared/device-auth-store.test.ts src/shared/device-auth.test.ts`
- `pnpm exec vitest --run src/shared/device-auth.test.ts src/shared/device-auth-store.test.ts`
- repeated the same focused validation a second time
- commit hook also ran the repo check pipeline cleanly on this branch

> ⚠️ This reopens #53153 which was accidentally closed due to fork deletion.