### PR TITLE
podman: harden setup shell handling and quadlet startup flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,7 +140,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       DEBIAN_FRONTEND=noninteractive apt-get upgrade -y --no-install-recommends; \
     fi && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      procps hostname curl git lsof openssl
+      procps hostname curl git lsof openssl zsh
 
 RUN chown node:node /app
 
@@ -236,6 +236,29 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
  && chmod 755 /app/openclaw.mjs
 
 ENV NODE_ENV=production
+
+# Configure zsh for interactive container shells and preload OpenClaw completion.
+RUN install -d -m 0755 /home/node && \
+    cat > /home/node/.zshrc <<'ZSHRC' && \
+    chown node:node /home/node/.zshrc && \
+    chmod 0644 /home/node/.zshrc
+export LANG=${LANG:-C.UTF-8}
+export TERM=${TERM:-xterm-256color}
+
+autoload -U compinit
+compinit -i
+
+setopt auto_cd
+setopt interactive_comments
+setopt hist_ignore_dups
+setopt share_history
+
+if command -v openclaw >/dev/null 2>&1; then
+  source <(openclaw completion --shell zsh)
+fi
+
+PROMPT='%F{cyan}%n@%m%f %F{yellow}%~%f %# '
+ZSHRC
 
 # Security hardening: Run as non-root user
 # The node:24-bookworm image includes a 'node' user (uid 1000)

--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -17,7 +17,7 @@ Environment=HOME=/home/node
 Environment=TERM=xterm-256color
 Environment=NPM_CONFIG_CACHE=/home/node/.openclaw/.npm
 Environment=NPM_CONFIG_PREFIX=/home/node/.openclaw/.npm-global
-Environment=PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
+Environment=PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=OPENCLAW_NO_RESPAWN=1
 PublishPort=18789:18789
 PublishPort=18790:18790

--- a/scripts/podman/openclaw.container.in
+++ b/scripts/podman/openclaw.container.in
@@ -15,6 +15,10 @@ Volume={{OPENCLAW_HOME}}/.openclaw:/home/node/.openclaw:Z
 EnvironmentFile={{OPENCLAW_HOME}}/.openclaw/.env
 Environment=HOME=/home/node
 Environment=TERM=xterm-256color
+Environment=NPM_CONFIG_CACHE=/home/node/.openclaw/.npm
+Environment=NPM_CONFIG_PREFIX=/home/node/.openclaw/.npm-global
+Environment=PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
+Environment=OPENCLAW_NO_RESPAWN=1
 PublishPort=18789:18789
 PublishPort=18790:18790
 Pull=never

--- a/scripts/podman/setup.sh
+++ b/scripts/podman/setup.sh
@@ -269,9 +269,10 @@ podman build -t openclaw:local -f "$REPO_PATH/Dockerfile" "${BUILD_ARGS[@]}" "$R
 echo "Saving image to $IMAGE_TAR ..."
 podman save -o "$IMAGE_TAR" openclaw:local
 
-# The image is loaded as the openclaw user, so grant read/traverse access.
-chmod 755 "$IMAGE_TAR_DIR"
-chmod 644 "$IMAGE_TAR"
+# The image is loaded as the openclaw user; grant group-only read/traverse access.
+chown "root:$OPENCLAW_UID" "$IMAGE_TAR_DIR" "$IMAGE_TAR"
+chmod 750 "$IMAGE_TAR_DIR"
+chmod 640 "$IMAGE_TAR"
 
 echo "Loading image into $OPENCLAW_USER Podman store..."
 run_as_openclaw podman load -i "$IMAGE_TAR"

--- a/scripts/podman/setup.sh
+++ b/scripts/podman/setup.sh
@@ -269,6 +269,10 @@ podman build -t openclaw:local -f "$REPO_PATH/Dockerfile" "${BUILD_ARGS[@]}" "$R
 echo "Saving image to $IMAGE_TAR ..."
 podman save -o "$IMAGE_TAR" openclaw:local
 
+# The image is loaded as the openclaw user, so grant read/traverse access.
+chmod 755 "$IMAGE_TAR_DIR"
+chmod 644 "$IMAGE_TAR"
+
 echo "Loading image into $OPENCLAW_USER Podman store..."
 run_as_openclaw podman load -i "$IMAGE_TAR"
 

--- a/scripts/podman/setup.sh
+++ b/scripts/podman/setup.sh
@@ -285,9 +285,38 @@ if [[ ! -f "$OPENCLAW_CONFIG/.env" ]]; then
   echo "Generated OPENCLAW_GATEWAY_TOKEN and wrote it to $OPENCLAW_CONFIG/.env"
 fi
 
+INSTALLER_SHELL="$(basename "${SHELL:-sh}")"
+if [[ ! "$INSTALLER_SHELL" =~ ^[A-Za-z0-9._+-]+$ ]]; then
+  INSTALLER_SHELL="sh"
+fi
+
+CONTAINER_SHELL="$INSTALLER_SHELL"
+if ! run_as_openclaw podman run --rm --pull=never openclaw:local sh -lc "command -v '$CONTAINER_SHELL' >/dev/null 2>&1"; then
+  for candidate in zsh bash sh; do
+    if run_as_openclaw podman run --rm --pull=never openclaw:local sh -lc "command -v '$candidate' >/dev/null 2>&1"; then
+      CONTAINER_SHELL="$candidate"
+      break
+    fi
+  done
+fi
+
+if run_as_openclaw sh -lc "grep -q '^OPENCLAW_CONTAINER_SHELL=' '$OPENCLAW_CONFIG/.env'"; then
+  run_as_openclaw sh -lc "sed -i 's/^OPENCLAW_CONTAINER_SHELL=.*/OPENCLAW_CONTAINER_SHELL=$CONTAINER_SHELL/' '$OPENCLAW_CONFIG/.env'"
+else
+  run_as_openclaw sh -lc "printf '%s\n' 'OPENCLAW_CONTAINER_SHELL=$CONTAINER_SHELL' >> '$OPENCLAW_CONFIG/.env'"
+fi
+echo "Set OPENCLAW_CONTAINER_SHELL=$CONTAINER_SHELL in $OPENCLAW_CONFIG/.env"
+
 if [[ ! -f "$OPENCLAW_CONFIG/openclaw.json" ]]; then
   run_as_openclaw sh -lc "umask 077 && cat > '$OPENCLAW_CONFIG/openclaw.json' <<'JSON'
-{ \"gateway\": { \"mode\": \"local\" } }
+{
+  \"gateway\": {
+    \"mode\": \"local\",
+    \"controlUi\": {
+      \"allowedOrigins\": [\"http://127.0.0.1:18789\", \"http://localhost:18789\"]
+    }
+  }
+}
 JSON"
   echo "Wrote minimal config to $OPENCLAW_CONFIG/openclaw.json"
 fi
@@ -302,9 +331,11 @@ if [[ "$INSTALL_QUADLET" == true ]]; then
     run_as_openclaw sh -lc "cat > '$QUADLET_DST'"
   run_as_openclaw chmod 0644 "$QUADLET_DST"
 
-  echo "Reloading and enabling user service..."
+  echo "Reloading and starting user service..."
   run_root systemctl --machine "${OPENCLAW_USER}@" --user daemon-reload
-  run_root systemctl --machine "${OPENCLAW_USER}@" --user enable --now openclaw.service
+  # Quadlet-generated units cannot be enabled (they are auto-activated by the generator).
+  # daemon-reload picks up the .container file; start brings it up immediately.
+  run_root systemctl --machine "${OPENCLAW_USER}@" --user start openclaw.service
   echo "Quadlet installed and service started."
 else
   echo "Container + launch script installed."

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -208,6 +208,9 @@ if [[ "$RUN_SETUP" == true ]]; then
     --init \
     "${USERNS_ARGS[@]}" "${RUN_USER_ARGS[@]}" \
     -e HOME=/home/node -e TERM=xterm-256color -e BROWSER=echo \
+    -e NPM_CONFIG_CACHE=/home/node/.openclaw/.npm \
+    -e NPM_CONFIG_PREFIX=/home/node/.openclaw/.npm-global \
+    -e PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl \
     -e OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN" \
     -v "$CONFIG_DIR:/home/node/.openclaw:rw${SELINUX_MOUNT_OPTS}" \
     -v "$WORKSPACE_DIR:/home/node/.openclaw/workspace:rw${SELINUX_MOUNT_OPTS}" \
@@ -221,6 +224,9 @@ podman run --pull="$PODMAN_PULL" -d --replace \
   --init \
   "${USERNS_ARGS[@]}" "${RUN_USER_ARGS[@]}" \
   -e HOME=/home/node -e TERM=xterm-256color \
+  -e NPM_CONFIG_CACHE=/home/node/.openclaw/.npm \
+  -e NPM_CONFIG_PREFIX=/home/node/.openclaw/.npm-global \
+  -e PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl \
   -e OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN" \
   "${ENV_FILE_ARGS[@]}" \
   -v "$CONFIG_DIR:/home/node/.openclaw:rw${SELINUX_MOUNT_OPTS}" \

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -210,7 +210,7 @@ if [[ "$RUN_SETUP" == true ]]; then
     -e HOME=/home/node -e TERM=xterm-256color -e BROWSER=echo \
     -e NPM_CONFIG_CACHE=/home/node/.openclaw/.npm \
     -e NPM_CONFIG_PREFIX=/home/node/.openclaw/.npm-global \
-    -e PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl \
+    -e PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     -e OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN" \
     -v "$CONFIG_DIR:/home/node/.openclaw:rw${SELINUX_MOUNT_OPTS}" \
     -v "$WORKSPACE_DIR:/home/node/.openclaw/workspace:rw${SELINUX_MOUNT_OPTS}" \
@@ -226,7 +226,7 @@ podman run --pull="$PODMAN_PULL" -d --replace \
   -e HOME=/home/node -e TERM=xterm-256color \
   -e NPM_CONFIG_CACHE=/home/node/.openclaw/.npm \
   -e NPM_CONFIG_PREFIX=/home/node/.openclaw/.npm-global \
-  -e PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl \
+  -e PATH=/home/node/.openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
   -e OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN" \
   "${ENV_FILE_ARGS[@]}" \
   -v "$CONFIG_DIR:/home/node/.openclaw:rw${SELINUX_MOUNT_OPTS}" \


### PR DESCRIPTION
## Summary

AI-assisted PR (Codex). Testing degree: lightly tested in this environment.

- Problem: Podman setup/startup had a few rough edges for shell ergonomics, local control UI defaults, and quadlet activation behavior.
- Why it matters: setup can fail or behave unexpectedly on quadlet-generated units, and operator ergonomics/defaults were weaker than intended.
- What changed: persisted a validated `OPENCLAW_CONTAINER_SHELL`, added `gateway.controlUi.allowedOrigins` defaults, switched quadlet activation from `enable --now` to `start`, and aligned Podman env defaults in container/unit/run paths.
- What did NOT change (scope boundary): no protocol/API contract changes; no unrelated refactors; no new external integrations.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #53828
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: quadlet-generated units are generator-backed and should be started, not enabled; setup defaults also did not persist a validated shell selection for container usage.
- Missing detection / guardrail: no setup-path assertion for quadlet `enable --now` behavior and no explicit config guardrail for container shell/env defaults.
- Prior context (`git blame`, prior PR, issue, or refactor if known): supersedes #53828 after branch rebase/divergence and follow-up fixes.
- Why this regressed now: assumptions from regular unit management leaked into quadlet flow and default setup generation paths.
- If unknown, what was ruled out: ruled out image pull/runtime mismatch as primary cause for quadlet activation error path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Podman setup + quadlet install path (`scripts/podman/setup.sh`) and launcher env propagation (`scripts/run-openclaw-podman.sh`).
- Scenario the test should lock in: quadlet install path succeeds with `daemon-reload` + `start`, `.env` persists a valid `OPENCLAW_CONTAINER_SHELL`, and generated local config includes control UI localhost origins.
- Why this is the smallest reliable guardrail: behavior depends on systemd user manager + Podman interaction; pure unit tests would miss integration semantics.
- Existing test that already covers this (if any): none known for this exact quadlet activation edge.
- If no new test is added, why not: this PR is a focused fix; broader Podman+systemd integration harness is not present in this local environment.

## User-visible / Behavior Changes

- Setup now writes/updates `OPENCLAW_CONTAINER_SHELL` in `.openclaw/.env`.
- Generated `openclaw.json` now includes local Control UI `allowedOrigins` defaults (`127.0.0.1` and `localhost` on port `18789`).
- Quadlet setup now starts the service without trying to enable generator-backed units.
- Podman run paths now set npm cache/prefix/path defaults under `.openclaw`.
- Image includes `zsh` and initializes a basic `/home/node/.zshrc` for interactive shells and completion.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: shell-selection logic could select an unexpected shell if unsafely sourced; mitigation is strict basename sanitization and in-image command existence checks with fallback order (`zsh`, `bash`, `sh`).

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local shell + git/gh; Podman/systemd integration not executed end-to-end in this sandbox
- Model/provider: GPT-5.3-Codex
- Integration/channel (if any): N/A
- Relevant config (redacted): default local `.openclaw` setup paths

### Steps

1. Run syntax checks on modified shell entrypoints.
2. Inspect patch and generated defaults for `.env`, `openclaw.json`, and quadlet start flow.
3. Verify PR contains only the targeted files and behavior changes.

### Expected

- Shell scripts parse successfully.
- Quadlet path uses `start` (not `enable --now`).
- Container env/setup defaults are consistent across setup/unit/run scripts.

### Actual

- `bash -n scripts/podman/setup.sh` and `bash -n scripts/run-openclaw-podman.sh` passed.
- Patch reflects expected behavior updates across the 4 touched files.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Trace/log snippets used:
- `bash syntax checks passed` for both modified shell scripts.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: shell syntax validity and patch-level behavior alignment for quadlet start flow, shell/env defaults, and generated config defaults.
- Edge cases checked: invalid installer shell names are sanitized; fallback selection probes `zsh`/`bash`/`sh`.
- What you did **not** verify: full Podman runtime execution, systemd user-unit lifecycle on a live host, and full `pnpm build && pnpm check && pnpm test` (toolchain unavailable in this environment).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `c8f58b9462` or roll back PR branch.
- Files/config to restore: `scripts/podman/setup.sh`, `scripts/podman/openclaw.container.in`, `scripts/run-openclaw-podman.sh`, `Dockerfile`; remove `OPENCLAW_CONTAINER_SHELL` line from `.openclaw/.env` if needed.
- Known bad symptoms reviewers should watch for: container starts with wrong shell expectation, Control UI origin mismatch for localhost, or quadlet service not starting after setup.

## Risks and Mitigations

- Risk: shell auto-detection may differ from user expectation on uncommon images.
  - Mitigation: deterministic fallback order and persisted explicit env value.
- Risk: PATH/npm env defaults may conflict with user-custom overrides.
  - Mitigation: values are scoped to container/unit launch paths and can be overridden by env file.
- Risk: quadlet behavior differences across distro/systemd versions.
  - Mitigation: uses standard generator-friendly `daemon-reload` + `start` flow.
