### PR TITLE
fix(discord): force fresh gateway reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - CLI/message send: write manual `openclaw message send` deliveries into the resolved agent session transcript again by always threading the default CLI agent through outbound mirroring. (#54187) Thanks @KevInTheCloud5617.
 - CLI/onboarding: show the Kimi Code API key option again in the Moonshot setup menu so the interactive picker includes all Kimi setup paths together. Fixes #54412 Thanks @sparkyrider
 - WhatsApp: fix infinite echo loop in self-chat DM mode where the bot's own outbound replies were re-processed as new inbound user messages. (#54570) Thanks @joelnishanth
+- Discord/reconnect: drain stale gateway sockets, clear cached resume state before forced fresh reconnects, and fail closed when old sockets refuse to die so Discord recovery stops looping on poisoned resume state. (#54697) Thanks @ngutman.
 - BlueBubbles/groups: optionally enrich unnamed participant lists with local macOS Contacts names after group gating passes, so group member context can show names instead of only raw phone numbers.
 
 ## 2026.3.24

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -69,7 +69,7 @@ describe("runDiscordGatewayLifecycle", () => {
       };
       sequence?: number | null;
       emitter?: EventEmitter;
-      ws?: EventEmitter;
+      ws?: EventEmitter & { terminate?: () => void };
     };
   }) => {
     const start = vi.fn(params?.start ?? (async () => undefined));
@@ -153,7 +153,7 @@ describe("runDiscordGatewayLifecycle", () => {
       sequence?: number | null;
     };
     sequence?: number | null;
-    ws?: EventEmitter;
+    ws?: EventEmitter & { terminate?: () => void };
   }) {
     const emitter = new EventEmitter();
     const gateway = {
@@ -362,31 +362,30 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("fails closed when the old socket does not drain before a forced reconnect", async () => {
+  it("force-terminates stale sockets and continues reconnecting after drain timeout", async () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-      const socket = new EventEmitter();
+      const socket = Object.assign(new EventEmitter(), { terminate: vi.fn() });
       const { emitter, gateway } = createGatewayHarness({ ws: socket });
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
-      const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } =
-        createLifecycleHarness({ gateway });
-
-      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
-      lifecyclePromise.catch(() => {});
-      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_000);
-      await expect(lifecyclePromise).rejects.toThrow(
-        "discord gateway socket did not close within 5000ms before reconnect",
-      );
-
-      expect(gateway.connect).not.toHaveBeenCalled();
-      expectLifecycleCleanup({
-        start,
-        stop,
-        threadStop,
-        waitCalls: 0,
-        gatewaySupervisor,
+      gateway.connect.mockImplementation((_resume?: boolean) => {
+        setTimeout(() => {
+          gateway.isConnected = true;
+        }, 1_000);
       });
+
+      const { lifecycleParams, runtimeError } = createLifecycleHarness({ gateway });
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_000);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(socket.terminate).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledWith(false);
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("attempting forced terminate and reconnect"),
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -69,6 +69,7 @@ describe("runDiscordGatewayLifecycle", () => {
       };
       sequence?: number | null;
       emitter?: EventEmitter;
+      ws?: EventEmitter;
     };
   }) => {
     const start = vi.fn(params?.start ?? (async () => undefined));
@@ -152,6 +153,7 @@ describe("runDiscordGatewayLifecycle", () => {
       sequence?: number | null;
     };
     sequence?: number | null;
+    ws?: EventEmitter;
   }) {
     const emitter = new EventEmitter();
     const gateway = {
@@ -161,6 +163,7 @@ describe("runDiscordGatewayLifecycle", () => {
       connect: vi.fn(),
       ...(params?.state ? { state: params.state } : {}),
       ...(params?.sequence !== undefined ? { sequence: params.sequence } : {}),
+      ...(params?.ws ? { ws: params.ws } : {}),
       emitter,
     };
     return { emitter, gateway };
@@ -284,6 +287,76 @@ describe("runDiscordGatewayLifecycle", () => {
       expect(gateway.disconnect).toHaveBeenCalledTimes(1);
       expect(gateway.connect).toHaveBeenCalledTimes(1);
       expect(gateway.connect).toHaveBeenCalledWith(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears resume state and suppresses socket-driven auto-resume during forced startup reconnects", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({
+        state: {
+          sessionId: "stale-session",
+          resumeGatewayUrl: "wss://gateway.discord.gg",
+          sequence: 123,
+        },
+        sequence: 123,
+        ws: socket,
+      });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      socket.on("error", (err) => {
+        pendingGatewayEvents.push({
+          type: "other",
+          err,
+          message: String(err),
+          shouldStopLifecycle: false,
+        });
+      });
+      socket.on("close", () => {
+        gateway.connect(true);
+      });
+      gateway.disconnect.mockImplementation(() => {
+        setTimeout(() => {
+          socket.emit(
+            "error",
+            new Error("WebSocket was closed before the connection was established"),
+          );
+          socket.emit("close", 1006, "");
+        }, 1);
+      });
+      gateway.connect.mockImplementation((resume?: boolean) => {
+        if (resume === false) {
+          setTimeout(() => {
+            gateway.isConnected = true;
+          }, 1_000);
+        }
+      });
+
+      const { lifecycleParams, runtimeError } = createLifecycleHarness({
+        gateway,
+        pendingGatewayEvents,
+      });
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(17_000);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(gateway.connect).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).toHaveBeenCalledWith(false);
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("WebSocket was closed before the connection was established"),
+      );
+      if (!gateway.state) {
+        throw new Error("gateway state was not initialized");
+      }
+      expect(gateway.state.sessionId).toBeNull();
+      expect(gateway.state.resumeGatewayUrl).toBeNull();
+      expect(gateway.state.sequence).toBeNull();
+      expect(gateway.sequence).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -362,6 +362,65 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("fails closed when the old socket does not drain before a forced reconnect", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      const { lifecycleParams, start, stop, threadStop, gatewaySupervisor } =
+        createLifecycleHarness({ gateway });
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      lifecyclePromise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_000);
+      await expect(lifecyclePromise).rejects.toThrow(
+        "discord gateway socket did not close within 5000ms before reconnect",
+      );
+
+      expect(gateway.connect).not.toHaveBeenCalled();
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 0,
+        gatewaySupervisor,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not reconnect after lifecycle shutdown begins during socket drain", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      gateway.disconnect.mockImplementation(() => {
+        setTimeout(() => {
+          socket.emit("close", 1000, "");
+        }, 1_000);
+      });
+
+      const abortController = new AbortController();
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      lifecycleParams.abortSignal = abortController.signal;
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_100);
+      abortController.abort();
+      await vi.advanceTimersByTimeAsync(2_000);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(gateway.connect).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fails fast when startup never reaches READY after a forced reconnect", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -362,11 +362,21 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("force-terminates stale sockets and continues reconnecting after drain timeout", async () => {
+  it("waits for forced terminate to close the old socket before reconnecting", async () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-      const socket = Object.assign(new EventEmitter(), { terminate: vi.fn() });
+      const socket = Object.assign(new EventEmitter(), {
+        terminate: vi.fn(() => {
+          setTimeout(() => {
+            socket.emit(
+              "error",
+              new Error("WebSocket was closed before the connection was established"),
+            );
+            socket.emit("close", 1006, "");
+          }, 1);
+        }),
+      });
       const { emitter, gateway } = createGatewayHarness({ ws: socket });
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
       gateway.connect.mockImplementation((_resume?: boolean) => {
@@ -377,15 +387,64 @@ describe("runDiscordGatewayLifecycle", () => {
 
       const { lifecycleParams, runtimeError } = createLifecycleHarness({ gateway });
       const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
-      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_000);
+      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_500);
       await expect(lifecyclePromise).resolves.toBeUndefined();
 
       expect(socket.terminate).toHaveBeenCalledTimes(1);
       expect(gateway.connect).toHaveBeenCalledTimes(1);
       expect(gateway.connect).toHaveBeenCalledWith(false);
       expect(runtimeError).toHaveBeenCalledWith(
-        expect.stringContaining("attempting forced terminate and reconnect"),
+        expect.stringContaining("attempting forced terminate before giving up"),
       );
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("WebSocket was closed before the connection was established"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails closed when forced terminate still does not close the old socket", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = Object.assign(new EventEmitter(), {
+        terminate: vi.fn(() => {
+          setTimeout(() => {
+            socket.emit(
+              "error",
+              new Error("WebSocket was closed before the connection was established"),
+            );
+          }, 1);
+        }),
+      });
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+        createLifecycleHarness({ gateway });
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      lifecyclePromise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(15_000 + 5_000 + 1_500);
+      await expect(lifecyclePromise).rejects.toThrow(
+        "discord gateway socket did not close within 5000ms before reconnect",
+      );
+
+      expect(socket.terminate).toHaveBeenCalledTimes(1);
+      expect(gateway.connect).not.toHaveBeenCalled();
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("force-stopping instead of opening a parallel socket"),
+      );
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("WebSocket was closed before the connection was established"),
+      );
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 0,
+        gatewaySupervisor,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -479,6 +479,41 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("treats drain timeout as a graceful stop after lifecycle abort", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const socket = new EventEmitter();
+      const { emitter, gateway } = createGatewayHarness({ ws: socket });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      const abortController = new AbortController();
+      const { lifecycleParams, start, stop, threadStop, runtimeError, gatewaySupervisor } =
+        createLifecycleHarness({ gateway });
+      lifecycleParams.abortSignal = abortController.signal;
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      await vi.advanceTimersByTimeAsync(15_100);
+      abortController.abort();
+      await vi.advanceTimersByTimeAsync(5_500);
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+
+      expect(gateway.connect).not.toHaveBeenCalled();
+      expect(runtimeError).not.toHaveBeenCalledWith(
+        expect.stringContaining("gateway socket did not close within 5000ms before reconnect"),
+      );
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 0,
+        gatewaySupervisor,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fails fast when startup never reaches READY after a forced reconnect", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -219,7 +219,8 @@ export async function runDiscordGatewayLifecycle(params: {
       let drainTimeout: ReturnType<typeof setTimeout> | undefined;
       let terminateCloseTimeout: ReturnType<typeof setTimeout> | undefined;
       const ignoreSocketError = () => {};
-      const cleanup = () => {
+      const shouldStopWaiting = () => lifecycleStopping || params.abortSignal?.aborted;
+      const clearPendingTimers = () => {
         if (drainTimeout) {
           clearTimeout(drainTimeout);
           drainTimeout = undefined;
@@ -228,6 +229,9 @@ export async function runDiscordGatewayLifecycle(params: {
           clearTimeout(terminateCloseTimeout);
           terminateCloseTimeout = undefined;
         }
+      };
+      const cleanup = () => {
+        clearPendingTimers();
         socket.removeListener("close", onClose);
         socket.removeListener("error", ignoreSocketError);
       };
@@ -239,19 +243,28 @@ export async function runDiscordGatewayLifecycle(params: {
         settled = true;
         resolve();
       };
-      const rejectClose = (error: Error) => {
+      const resolveStoppedWait = () => {
         if (settled) {
           return;
         }
         settled = true;
-        if (drainTimeout) {
-          clearTimeout(drainTimeout);
-          drainTimeout = undefined;
+        clearPendingTimers();
+
+        // Keep suppressing late ws errors until the socket actually closes.
+        // The original Carbon listeners were removed above, and `terminate()`
+        // can still asynchronously emit "error" before "close".
+        resolve();
+      };
+      const rejectClose = (error: Error) => {
+        if (shouldStopWaiting()) {
+          resolveStoppedWait();
+          return;
         }
-        if (terminateCloseTimeout) {
-          clearTimeout(terminateCloseTimeout);
-          terminateCloseTimeout = undefined;
+        if (settled) {
+          return;
         }
+        settled = true;
+        clearPendingTimers();
 
         // Keep suppressing late ws errors until the socket actually closes.
         // The original Carbon listeners were removed above, and `terminate()`
@@ -261,6 +274,10 @@ export async function runDiscordGatewayLifecycle(params: {
 
       drainTimeout = setTimeout(() => {
         if (settled) {
+          return;
+        }
+        if (shouldStopWaiting()) {
+          resolveStoppedWait();
           return;
         }
         params.runtime.error?.(
@@ -296,6 +313,10 @@ export async function runDiscordGatewayLifecycle(params: {
 
         terminateCloseTimeout = setTimeout(() => {
           if (settled) {
+            return;
+          }
+          if (shouldStopWaiting()) {
+            resolveStoppedWait();
             return;
           }
           params.runtime.error?.(

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -18,6 +18,26 @@ type ExecApprovalsHandler = {
 
 const DISCORD_GATEWAY_READY_TIMEOUT_MS = 15_000;
 const DISCORD_GATEWAY_READY_POLL_MS = 250;
+const DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000;
+
+type GatewaySocketListener = (...args: unknown[]) => void;
+
+type DiscordGatewaySocket = {
+  once: (event: "close", listener: GatewaySocketListener) => unknown;
+  on: (event: "error", listener: GatewaySocketListener) => unknown;
+  listeners: (event: "close" | "error") => GatewaySocketListener[];
+  removeListener: (event: "close" | "error", listener: GatewaySocketListener) => unknown;
+};
+
+type MutableGateway = GatewayPlugin & {
+  state?: {
+    sessionId?: string | null;
+    resumeGatewayUrl?: string | null;
+    sequence?: number | null;
+  };
+  sequence?: number | null;
+  ws?: DiscordGatewaySocket | null;
+};
 
 type GatewayReadyWaitResult = "ready" | "timeout" | "stopped";
 
@@ -163,16 +183,7 @@ export async function runDiscordGatewayLifecycle(params: {
     return Number.isFinite(code) ? code : undefined;
   };
   const clearResumeState = () => {
-    const mutableGateway = gateway as
-      | (GatewayPlugin & {
-          state?: {
-            sessionId?: string | null;
-            resumeGatewayUrl?: string | null;
-            sequence?: number | null;
-          };
-          sequence?: number | null;
-        })
-      | undefined;
+    const mutableGateway = gateway as MutableGateway | undefined;
     if (!mutableGateway?.state) {
       return;
     }
@@ -180,6 +191,57 @@ export async function runDiscordGatewayLifecycle(params: {
     mutableGateway.state.resumeGatewayUrl = null;
     mutableGateway.state.sequence = null;
     mutableGateway.sequence = null;
+  };
+  const disconnectGatewaySocketWithoutAutoReconnect = async () => {
+    if (!gateway) {
+      return;
+    }
+    const mutableGateway = gateway as MutableGateway;
+    const socket = mutableGateway.ws;
+    if (!socket) {
+      gateway.disconnect();
+      return;
+    }
+
+    // Carbon reconnects from the socket close handler even for intentional
+    // disconnects. Drop the current socket's close/error listeners so a forced
+    // reconnect does not race the old socket's automatic resume path.
+    for (const listener of socket.listeners("close")) {
+      socket.removeListener("close", listener);
+    }
+    for (const listener of socket.listeners("error")) {
+      socket.removeListener("error", listener);
+    }
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve();
+      };
+      const timeout = setTimeout(finish, DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS);
+      timeout.unref?.();
+      socket.on("error", () => {});
+      socket.once("close", () => {
+        clearTimeout(timeout);
+        finish();
+      });
+      gateway.disconnect();
+    });
+  };
+  const reconnectGateway = async (resume: boolean) => {
+    await disconnectGatewaySocketWithoutAutoReconnect();
+    gateway?.connect(resume);
+  };
+  const reconnectGatewayFresh = async () => {
+    // Carbon still sends RESUME on HELLO when session state is populated, even
+    // after connect(false). Clear cached session data first so this path truly
+    // forces a fresh IDENTIFY.
+    clearResumeState();
+    await reconnectGateway(false);
   };
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
@@ -234,40 +296,55 @@ export async function runDiscordGatewayLifecycle(params: {
     }, HELLO_CONNECTED_POLL_MS);
 
     helloTimeoutId = setTimeout(() => {
-      if (helloConnectedPollId) {
-        clearInterval(helloConnectedPollId);
-        helloConnectedPollId = undefined;
-      }
-      if (sawConnected || gateway?.isConnected) {
-        resetHelloStallCounter();
-      } else {
-        consecutiveHelloStalls += 1;
-        const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
-        const stalledAt = Date.now();
-        reconnectStallWatchdog.arm(stalledAt);
-        pushStatus({
-          connected: false,
-          lastEventAt: stalledAt,
-          lastDisconnect: {
-            at: stalledAt,
-            error: "hello-timeout",
-          },
-        });
-        params.runtime.log?.(
-          danger(
-            forceFreshIdentify
-              ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
-              : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
-          ),
-        );
-        if (forceFreshIdentify) {
-          clearResumeState();
-          resetHelloStallCounter();
-        }
-        gateway?.disconnect();
-        gateway?.connect(!forceFreshIdentify);
-      }
       helloTimeoutId = undefined;
+      void (async () => {
+        try {
+          if (helloConnectedPollId) {
+            clearInterval(helloConnectedPollId);
+            helloConnectedPollId = undefined;
+          }
+          if (sawConnected || gateway?.isConnected) {
+            resetHelloStallCounter();
+            return;
+          }
+
+          consecutiveHelloStalls += 1;
+          const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
+          const stalledAt = Date.now();
+          reconnectStallWatchdog.arm(stalledAt);
+          pushStatus({
+            connected: false,
+            lastEventAt: stalledAt,
+            lastDisconnect: {
+              at: stalledAt,
+              error: "hello-timeout",
+            },
+          });
+          params.runtime.log?.(
+            danger(
+              forceFreshIdentify
+                ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
+                : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
+            ),
+          );
+          if (forceFreshIdentify) {
+            resetHelloStallCounter();
+          }
+          if (lifecycleStopping || params.abortSignal?.aborted) {
+            return;
+          }
+          if (forceFreshIdentify) {
+            await reconnectGatewayFresh();
+            return;
+          }
+          await reconnectGateway(true);
+        } catch (err) {
+          params.runtime.error?.(
+            danger(`discord: failed to restart stalled gateway socket: ${String(err)}`),
+          );
+          triggerForceStop(err);
+        }
+      })();
     }, HELLO_TIMEOUT_MS);
   };
   gatewayEmitter?.on("debug", onGatewayDebug);
@@ -336,8 +413,7 @@ export async function runDiscordGatewayLifecycle(params: {
             error: "startup-not-ready",
           },
         });
-        gateway?.disconnect();
-        gateway?.connect(false);
+        await reconnectGatewayFresh();
         const reconnected = await waitForDiscordGatewayReady({
           gateway,
           abortSignal: params.abortSignal,

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -23,10 +23,10 @@ const DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000;
 type GatewaySocketListener = (...args: unknown[]) => void;
 
 type DiscordGatewaySocket = {
-  once: (event: "close", listener: GatewaySocketListener) => unknown;
-  on: (event: "error", listener: GatewaySocketListener) => unknown;
+  on: (event: "close" | "error", listener: GatewaySocketListener) => unknown;
   listeners: (event: "close" | "error") => GatewaySocketListener[];
   removeListener: (event: "close" | "error", listener: GatewaySocketListener) => unknown;
+  terminate?: () => void;
 };
 
 type MutableGateway = GatewayPlugin & {
@@ -213,35 +213,84 @@ export async function runDiscordGatewayLifecycle(params: {
       socket.removeListener("error", listener);
     }
 
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       let settled = false;
-      const finish = () => {
+      const ignoreSocketError = () => {};
+      const cleanup = () => {
+        socket.removeListener("close", onClose);
+        socket.removeListener("error", ignoreSocketError);
+      };
+      const resolveClose = () => {
+        if (settled) {
+          cleanup();
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        cleanup();
+        resolve();
+      };
+      const onClose = () => {
+        resolveClose();
+      };
+      const timeout = setTimeout(() => {
         if (settled) {
           return;
         }
         settled = true;
-        resolve();
-      };
-      const timeout = setTimeout(finish, DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS);
+        params.runtime.error?.(
+          danger(
+            `discord: gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect; force-stopping instead of opening a parallel socket`,
+          ),
+        );
+        try {
+          socket.terminate?.();
+        } catch {
+          // Best-effort only: lifecycle callers treat this as fatal and stop
+          // instead of opening another socket on top of an unknown old one.
+        }
+        reject(
+          new Error(
+            `discord gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect`,
+          ),
+        );
+      }, DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS);
       timeout.unref?.();
-      socket.on("error", () => {});
-      socket.once("close", () => {
-        clearTimeout(timeout);
-        finish();
-      });
+      socket.on("error", ignoreSocketError);
+      socket.on("close", onClose);
       gateway.disconnect();
     });
   };
-  const reconnectGateway = async (resume: boolean) => {
-    await disconnectGatewaySocketWithoutAutoReconnect();
-    gateway?.connect(resume);
+  let reconnectInFlight: Promise<void> | undefined;
+  const reconnectGateway = async (reconnectParams: {
+    resume: boolean;
+    forceFreshIdentify?: boolean;
+  }) => {
+    if (reconnectInFlight) {
+      return await reconnectInFlight;
+    }
+    reconnectInFlight = (async () => {
+      if (reconnectParams.forceFreshIdentify) {
+        // Carbon still sends RESUME on HELLO when session state is populated,
+        // even after connect(false). Clear cached session data first so this
+        // path truly forces a fresh IDENTIFY.
+        clearResumeState();
+      }
+      if (lifecycleStopping || params.abortSignal?.aborted) {
+        return;
+      }
+      await disconnectGatewaySocketWithoutAutoReconnect();
+      if (lifecycleStopping || params.abortSignal?.aborted) {
+        return;
+      }
+      gateway?.connect(reconnectParams.resume);
+    })().finally(() => {
+      reconnectInFlight = undefined;
+    });
+    return await reconnectInFlight;
   };
   const reconnectGatewayFresh = async () => {
-    // Carbon still sends RESUME on HELLO when session state is populated, even
-    // after connect(false). Clear cached session data first so this path truly
-    // forces a fresh IDENTIFY.
-    clearResumeState();
-    await reconnectGateway(false);
+    await reconnectGateway({ resume: false, forceFreshIdentify: true });
   };
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
@@ -337,7 +386,7 @@ export async function runDiscordGatewayLifecycle(params: {
             await reconnectGatewayFresh();
             return;
           }
-          await reconnectGateway(true);
+          await reconnectGateway({ resume: true });
         } catch (err) {
           params.runtime.error?.(
             danger(`discord: failed to restart stalled gateway socket: ${String(err)}`),

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -19,6 +19,7 @@ type ExecApprovalsHandler = {
 const DISCORD_GATEWAY_READY_TIMEOUT_MS = 15_000;
 const DISCORD_GATEWAY_READY_POLL_MS = 250;
 const DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000;
+const DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS = 1_000;
 
 type GatewaySocketListener = (...args: unknown[]) => void;
 
@@ -213,44 +214,104 @@ export async function runDiscordGatewayLifecycle(params: {
       socket.removeListener("error", listener);
     }
 
-    await new Promise<void>((resolve) => {
+    await new Promise<void>((resolve, reject) => {
       let settled = false;
+      let drainTimeout: ReturnType<typeof setTimeout> | undefined;
+      let terminateCloseTimeout: ReturnType<typeof setTimeout> | undefined;
       const ignoreSocketError = () => {};
       const cleanup = () => {
+        if (drainTimeout) {
+          clearTimeout(drainTimeout);
+          drainTimeout = undefined;
+        }
+        if (terminateCloseTimeout) {
+          clearTimeout(terminateCloseTimeout);
+          terminateCloseTimeout = undefined;
+        }
         socket.removeListener("close", onClose);
         socket.removeListener("error", ignoreSocketError);
       };
-      const resolveClose = () => {
+      const onClose = () => {
+        cleanup();
         if (settled) {
-          cleanup();
           return;
         }
         settled = true;
-        clearTimeout(timeout);
-        cleanup();
         resolve();
       };
-      const onClose = () => {
-        resolveClose();
+      const rejectClose = (error: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (drainTimeout) {
+          clearTimeout(drainTimeout);
+          drainTimeout = undefined;
+        }
+        if (terminateCloseTimeout) {
+          clearTimeout(terminateCloseTimeout);
+          terminateCloseTimeout = undefined;
+        }
+
+        // Keep suppressing late ws errors until the socket actually closes.
+        // The original Carbon listeners were removed above, and `terminate()`
+        // can still asynchronously emit "error" before "close".
+        reject(error);
       };
-      const timeout = setTimeout(() => {
+
+      drainTimeout = setTimeout(() => {
         if (settled) {
           return;
         }
         params.runtime.error?.(
           danger(
-            `discord: gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect; attempting forced terminate and reconnect`,
+            `discord: gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect; attempting forced terminate before giving up`,
           ),
         );
+
+        let terminateStarted = false;
         try {
-          socket.terminate?.();
+          if (typeof socket.terminate === "function") {
+            socket.terminate();
+            terminateStarted = true;
+          }
         } catch {
-          // Best-effort only: if terminate is unavailable or fails, continue
-          // with the reconnect attempt rather than hard-stopping the monitor.
+          // Best-effort only. If terminate fails, fail closed instead of
+          // opening another socket on top of an unknown old one.
         }
-        resolveClose();
+
+        if (!terminateStarted) {
+          params.runtime.error?.(
+            danger(
+              `discord: gateway socket did not expose a working terminate() after ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms; force-stopping instead of opening a parallel socket`,
+            ),
+          );
+          rejectClose(
+            new Error(
+              `discord gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect`,
+            ),
+          );
+          return;
+        }
+
+        terminateCloseTimeout = setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          params.runtime.error?.(
+            danger(
+              `discord: gateway socket did not close ${DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS}ms after forced terminate; force-stopping instead of opening a parallel socket`,
+            ),
+          );
+          rejectClose(
+            new Error(
+              `discord gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect`,
+            ),
+          );
+        }, DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS);
+        terminateCloseTimeout.unref?.();
       }, DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS);
-      timeout.unref?.();
+      drainTimeout.unref?.();
       socket.on("error", ignoreSocketError);
       socket.on("close", onClose);
       gateway.disconnect();

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -213,7 +213,7 @@ export async function runDiscordGatewayLifecycle(params: {
       socket.removeListener("error", listener);
     }
 
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve) => {
       let settled = false;
       const ignoreSocketError = () => {};
       const cleanup = () => {
@@ -237,23 +237,18 @@ export async function runDiscordGatewayLifecycle(params: {
         if (settled) {
           return;
         }
-        settled = true;
         params.runtime.error?.(
           danger(
-            `discord: gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect; force-stopping instead of opening a parallel socket`,
+            `discord: gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect; attempting forced terminate and reconnect`,
           ),
         );
         try {
           socket.terminate?.();
         } catch {
-          // Best-effort only: lifecycle callers treat this as fatal and stop
-          // instead of opening another socket on top of an unknown old one.
+          // Best-effort only: if terminate is unavailable or fails, continue
+          // with the reconnect attempt rather than hard-stopping the monitor.
         }
-        reject(
-          new Error(
-            `discord gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect`,
-          ),
-        );
+        resolveClose();
       }, DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS);
       timeout.unref?.();
       socket.on("error", ignoreSocketError);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord stale-socket recovery could race Carbon's socket-close auto-reconnect path, so a forced reconnect was not reliably fresh.
- Why it matters: once the gateway got into a bad resume state, the health monitor could keep restarting the provider while the socket never reached READY again.
- What changed: forced reconnect paths now drain the old socket without letting its close/error listeners auto-resume, and fresh reconnects explicitly clear cached resume state before reconnecting.
- What did NOT change (scope boundary): this does not change model failover behavior or add a separate top-level health-monitor circuit breaker.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: OpenClaw's Discord lifecycle called `disconnect()` + `connect(false)` for forced reconnects, but Carbon still lets the old socket's `close` handler trigger its own reconnect path and will still send RESUME on HELLO when resume state is cached.
- Missing detection / guardrail: the lifecycle assumed an intentional disconnect prevented lower-level reconnect behavior and that `connect(false)` alone guaranteed a fresh IDENTIFY.
- Prior context (`git blame`, prior PR, issue, or refactor if known): existing lifecycle guards already handled HELLO stalls and startup-not-ready timeouts, but they still relied on Carbon's socket lifecycle underneath.
- Why this regressed now: a stale or invalid Discord session can leave the provider repeatedly attempting to recover with poisoned socket/session state.
- If unknown, what was ruled out: this PR does not attribute the bug to model-side `FailoverError` handling; the reproduced failure mechanism was in Discord gateway reconnect sequencing.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/provider.lifecycle.test.ts`
- Scenario the test should lock in: a forced startup reconnect must clear cached resume state, suppress close-driven auto-resume from the stale socket, and reconnect with a fresh IDENTIFY.
- Why this is the smallest reliable guardrail: the bug is in lifecycle coordination around the Carbon gateway socket, so a focused lifecycle test is enough to reproduce and lock the behavior without needing live Discord traffic.
- Existing test that already covers this (if any): existing lifecycle tests already covered HELLO stall retries and startup-not-ready failures.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Discord forced reconnect recovery is more reliable after stale sockets or startup-not-ready conditions.
- When a reconnect must be fresh, the provider now clears cached resume state before reconnecting.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord gateway lifecycle
- Relevant config (redacted): default test harness config

### Steps

1. Start the Discord provider with cached resume state and a stale socket.
2. Force the startup readiness timeout or HELLO-stall reconnect path.
3. Observe whether the old socket's close handler can auto-resume before the forced fresh reconnect completes.

### Expected

- Forced fresh reconnect clears cached resume state and reconnects with a fresh IDENTIFY.
- The stale socket cannot race in with a close-driven auto-resume.

### Actual

- Before this change, the old socket could still trigger reconnect behavior and the forced reconnect was not guaranteed to be fresh.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the focused lifecycle test file after the fix and confirmed the new regression case plus existing lifecycle cases pass; also ran `pnpm build` and `pnpm check`.
- Edge cases checked: intentional reconnect after startup-not-ready; HELLO stall recovery; stale socket attempting to emit a close/error during forced reconnect.
- What you did **not** verify: live Discord gateway behavior against a real bot token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the prior reconnect helpers in `extensions/discord/src/monitor/provider.lifecycle.ts`.
- Files/config to restore: `extensions/discord/src/monitor/provider.lifecycle.ts`, `extensions/discord/src/monitor/provider.lifecycle.test.ts`
- Known bad symptoms reviewers should watch for: reconnect attempts hanging unexpectedly during intentional disconnects.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: removing socket listeners during a forced reconnect could miss an unexpected close/error signal from the stale socket.
  - Mitigation: the suppression is limited to intentional reconnect teardown, the lifecycle still tracks the new socket normally, and the regression test covers the specific stale-socket race.
