### PR TITLE
fix(msteams): prefer freshest personal conversation for proactive DM sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/diffs: load bundled Pierre themes without JSON module imports so diff rendering keeps working on newer Node builds. (#45869) thanks @NickHood1984.
 - Plugins/uninstall: remove owned `channels.<id>` config when uninstalling channel plugins, and keep the uninstall preview aligned with explicit channel ownership so built-in channels and shared keys stay intact. (#35915) Thanks @wbxl2000.
 - Plugins/Matrix: prefer explicit DM signals when choosing outbound direct rooms and routing unmapped verification summaries, so strict 2-person fallback rooms do not outrank the real DM. (#56076) thanks @gumadeiras
+- Microsoft Teams/proactive DMs: prefer the freshest personal conversation reference for `user:<aadObjectId>` sends when multiple stored references exist, so replies stop targeting stale DM threads. (#54702) Thanks @gumclaw.
 
 ## 2026.3.24
 

--- a/extensions/msteams/src/conversation-store-fs.test.ts
+++ b/extensions/msteams/src/conversation-store-fs.test.ts
@@ -123,48 +123,6 @@ describe("msteams conversation store (fs)", () => {
     expect(retrieved).not.toBeNull();
     expect(retrieved!.timezone).toBe("Europe/London");
   });
-
-  it("prefers the freshest personal conversation when a user has multiple references", async () => {
-    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
-    const store = createMSTeamsConversationStoreFs({
-      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-      ttlMs: 60_000,
-    });
-
-    await store.upsert("a:old-personal", {
-      conversation: { id: "a:old-personal", conversationType: "personal" },
-      channelId: "msteams",
-      serviceUrl: "https://service.example.com",
-      user: { id: "old-user", aadObjectId: "shared-aad" },
-    });
-
-    await store.upsert("19:group-chat", {
-      conversation: { id: "19:group-chat", conversationType: "groupChat" },
-      channelId: "msteams",
-      serviceUrl: "https://service.example.com",
-      user: { id: "group-user", aadObjectId: "shared-aad" },
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    await store.upsert("a:new-personal", {
-      conversation: { id: "a:new-personal", conversationType: "personal" },
-      channelId: "msteams",
-      serviceUrl: "https://service.example.com",
-      user: { id: "new-user", aadObjectId: "shared-aad" },
-    });
-
-    await expect(store.findByUserId("shared-aad")).resolves.toEqual({
-      conversationId: "a:new-personal",
-      reference: expect.objectContaining({
-        conversation: expect.objectContaining({
-          id: "a:new-personal",
-          conversationType: "personal",
-        }),
-        user: expect.objectContaining({ id: "new-user", aadObjectId: "shared-aad" }),
-      }),
-    });
-  });
 });
 
 describe("msteams conversation store (memory)", () => {
@@ -196,6 +154,30 @@ describe("msteams conversation store (memory)", () => {
           user: { id: "user-a", aadObjectId: "aad-a", name: "Alice" },
         },
       },
+      {
+        conversationId: "dm-old",
+        reference: {
+          conversation: { id: "dm-old", conversationType: "personal" },
+          user: { id: "user-shared-old", aadObjectId: "aad-shared", name: "Old DM" },
+          lastSeenAt: "2026-03-25T20:00:00.000Z",
+        },
+      },
+      {
+        conversationId: "group-shared",
+        reference: {
+          conversation: { id: "group-shared", conversationType: "groupChat" },
+          user: { id: "user-shared-group", aadObjectId: "aad-shared", name: "Group" },
+          lastSeenAt: "2026-03-25T20:30:00.000Z",
+        },
+      },
+      {
+        conversationId: "dm-new",
+        reference: {
+          conversation: { id: "dm-new", conversationType: "personal" },
+          user: { id: "user-shared-new", aadObjectId: "aad-shared", name: "New DM" },
+          lastSeenAt: "2026-03-25T21:00:00.000Z",
+        },
+      },
     ]);
 
     await store.upsert("conv-b", {
@@ -214,6 +196,30 @@ describe("msteams conversation store (memory)", () => {
         reference: {
           conversation: { id: "conv-a" },
           user: { id: "user-a", aadObjectId: "aad-a", name: "Alice" },
+        },
+      },
+      {
+        conversationId: "dm-old",
+        reference: {
+          conversation: { id: "dm-old", conversationType: "personal" },
+          user: { id: "user-shared-old", aadObjectId: "aad-shared", name: "Old DM" },
+          lastSeenAt: "2026-03-25T20:00:00.000Z",
+        },
+      },
+      {
+        conversationId: "group-shared",
+        reference: {
+          conversation: { id: "group-shared", conversationType: "groupChat" },
+          user: { id: "user-shared-group", aadObjectId: "aad-shared", name: "Group" },
+          lastSeenAt: "2026-03-25T20:30:00.000Z",
+        },
+      },
+      {
+        conversationId: "dm-new",
+        reference: {
+          conversation: { id: "dm-new", conversationType: "personal" },
+          user: { id: "user-shared-new", aadObjectId: "aad-shared", name: "New DM" },
+          lastSeenAt: "2026-03-25T21:00:00.000Z",
         },
       },
       {
@@ -237,6 +243,14 @@ describe("msteams conversation store (memory)", () => {
       reference: {
         conversation: { id: "conv-a" },
         user: { id: "user-a", aadObjectId: "aad-a", name: "Alice" },
+      },
+    });
+    await expect(store.findByUserId("aad-shared")).resolves.toEqual({
+      conversationId: "dm-new",
+      reference: {
+        conversation: { id: "dm-new", conversationType: "personal" },
+        user: { id: "user-shared-new", aadObjectId: "aad-shared", name: "New DM" },
+        lastSeenAt: "2026-03-25T21:00:00.000Z",
       },
     });
     await expect(store.findByUserId("   ")).resolves.toBeNull();

--- a/extensions/msteams/src/conversation-store-fs.test.ts
+++ b/extensions/msteams/src/conversation-store-fs.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMSTeamsConversationStoreFs } from "./conversation-store-fs.js";
 import { createMSTeamsConversationStoreMemory } from "./conversation-store-memory.js";
 import type { StoredConversationReference } from "./conversation-store.js";
@@ -36,7 +36,7 @@ describe("msteams conversation store (fs)", () => {
     const raw = await fs.promises.readFile(filePath, "utf-8");
     const json = JSON.parse(raw) as {
       version: number;
-      conversations: Record<string, StoredConversationReference & { lastSeenAt?: string }>;
+      conversations: Record<string, StoredConversationReference>;
     };
 
     json.conversations["19:old@thread.tacv2"] = {
@@ -122,6 +122,55 @@ describe("msteams conversation store (fs)", () => {
     const retrieved = await store.get("19:tz-keep@thread.tacv2");
     expect(retrieved).not.toBeNull();
     expect(retrieved!.timezone).toBe("Europe/London");
+  });
+
+  it("prefers the freshest personal conversation when a user has multiple references", async () => {
+    vi.useFakeTimers();
+    try {
+      const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+      const store = createMSTeamsConversationStoreFs({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        ttlMs: 60_000,
+      });
+
+      vi.setSystemTime(new Date("2026-03-25T20:00:00.000Z"));
+      await store.upsert("a:old-personal", {
+        conversation: { id: "a:old-personal", conversationType: "personal" },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        user: { id: "old-user", aadObjectId: "shared-aad" },
+      });
+
+      vi.setSystemTime(new Date("2026-03-25T20:30:00.000Z"));
+      await store.upsert("19:group-chat", {
+        conversation: { id: "19:group-chat", conversationType: "groupChat" },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        user: { id: "group-user", aadObjectId: "shared-aad" },
+      });
+
+      vi.setSystemTime(new Date("2026-03-25T21:00:00.000Z"));
+      await store.upsert("a:new-personal", {
+        conversation: { id: "a:new-personal", conversationType: "personal" },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        user: { id: "new-user", aadObjectId: "shared-aad" },
+      });
+
+      await expect(store.findByUserId("shared-aad")).resolves.toEqual({
+        conversationId: "a:new-personal",
+        reference: expect.objectContaining({
+          conversation: expect.objectContaining({
+            id: "a:new-personal",
+            conversationType: "personal",
+          }),
+          user: expect.objectContaining({ id: "new-user", aadObjectId: "shared-aad" }),
+          lastSeenAt: "2026-03-25T21:00:00.000Z",
+        }),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -226,6 +275,7 @@ describe("msteams conversation store (memory)", () => {
         conversationId: "conv-b",
         reference: {
           conversation: { id: "conv-b" },
+          lastSeenAt: expect.any(String),
           user: { id: "user-b", aadObjectId: "aad-b", name: "Bob" },
         },
       },
@@ -235,6 +285,7 @@ describe("msteams conversation store (memory)", () => {
       conversationId: "conv-b",
       reference: {
         conversation: { id: "conv-b" },
+        lastSeenAt: expect.any(String),
         user: { id: "user-b", aadObjectId: "aad-b", name: "Bob" },
       },
     });
@@ -281,5 +332,49 @@ describe("msteams conversation store (memory)", () => {
     await expect(store.get("conv-tz")).resolves.toMatchObject({
       timezone: "Europe/London",
     });
+  });
+
+  it("prefers the freshest personal conversation for repeated upserts of the same user", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = createMSTeamsConversationStoreMemory();
+
+      vi.setSystemTime(new Date("2026-03-25T20:00:00.000Z"));
+      await store.upsert("dm-old", {
+        conversation: { id: "dm-old", conversationType: "personal" },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        user: { id: "user-shared-old", aadObjectId: "aad-shared", name: "Old DM" },
+      });
+
+      vi.setSystemTime(new Date("2026-03-25T20:30:00.000Z"));
+      await store.upsert("group-shared", {
+        conversation: { id: "group-shared", conversationType: "groupChat" },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        user: { id: "user-shared-group", aadObjectId: "aad-shared", name: "Group" },
+      });
+
+      vi.setSystemTime(new Date("2026-03-25T21:00:00.000Z"));
+      await store.upsert("dm-new", {
+        conversation: { id: "dm-new", conversationType: "personal" },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+        user: { id: "user-shared-new", aadObjectId: "aad-shared", name: "New DM" },
+      });
+
+      await expect(store.findByUserId("aad-shared")).resolves.toEqual({
+        conversationId: "dm-new",
+        reference: {
+          conversation: { id: "dm-new", conversationType: "personal" },
+          channelId: "msteams",
+          serviceUrl: "https://service.example.com",
+          user: { id: "user-shared-new", aadObjectId: "aad-shared", name: "New DM" },
+          lastSeenAt: "2026-03-25T21:00:00.000Z",
+        },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/msteams/src/conversation-store-fs.test.ts
+++ b/extensions/msteams/src/conversation-store-fs.test.ts
@@ -123,6 +123,48 @@ describe("msteams conversation store (fs)", () => {
     expect(retrieved).not.toBeNull();
     expect(retrieved!.timezone).toBe("Europe/London");
   });
+
+  it("prefers the freshest personal conversation when a user has multiple references", async () => {
+    const stateDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-store-"));
+    const store = createMSTeamsConversationStoreFs({
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      ttlMs: 60_000,
+    });
+
+    await store.upsert("a:old-personal", {
+      conversation: { id: "a:old-personal", conversationType: "personal" },
+      channelId: "msteams",
+      serviceUrl: "https://service.example.com",
+      user: { id: "old-user", aadObjectId: "shared-aad" },
+    });
+
+    await store.upsert("19:group-chat", {
+      conversation: { id: "19:group-chat", conversationType: "groupChat" },
+      channelId: "msteams",
+      serviceUrl: "https://service.example.com",
+      user: { id: "group-user", aadObjectId: "shared-aad" },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    await store.upsert("a:new-personal", {
+      conversation: { id: "a:new-personal", conversationType: "personal" },
+      channelId: "msteams",
+      serviceUrl: "https://service.example.com",
+      user: { id: "new-user", aadObjectId: "shared-aad" },
+    });
+
+    await expect(store.findByUserId("shared-aad")).resolves.toEqual({
+      conversationId: "a:new-personal",
+      reference: expect.objectContaining({
+        conversation: expect.objectContaining({
+          id: "a:new-personal",
+          conversationType: "personal",
+        }),
+        user: expect.objectContaining({ id: "new-user", aadObjectId: "shared-aad" }),
+      }),
+    });
+  });
 });
 
 describe("msteams conversation store (memory)", () => {

--- a/extensions/msteams/src/conversation-store-fs.ts
+++ b/extensions/msteams/src/conversation-store-fs.ts
@@ -8,7 +8,7 @@ import { readJsonFile, withFileLock, writeJsonFile } from "./store-fs.js";
 
 type ConversationStoreData = {
   version: 1;
-  conversations: Record<string, StoredConversationReference & { lastSeenAt?: string }>;
+  conversations: Record<string, StoredConversationReference>;
 };
 
 const STORE_FILENAME = "msteams-conversations.json";
@@ -26,9 +26,7 @@ function parseTimestamp(value: string | undefined): number | null {
   return parsed;
 }
 
-function pruneToLimit(
-  conversations: Record<string, StoredConversationReference & { lastSeenAt?: string }>,
-) {
+function pruneToLimit(conversations: Record<string, StoredConversationReference>) {
   const entries = Object.entries(conversations);
   if (entries.length <= MAX_CONVERSATIONS) {
     return conversations;
@@ -45,7 +43,7 @@ function pruneToLimit(
 }
 
 function pruneExpired(
-  conversations: Record<string, StoredConversationReference & { lastSeenAt?: string }>,
+  conversations: Record<string, StoredConversationReference>,
   nowMs: number,
   ttlMs: number,
 ) {

--- a/extensions/msteams/src/conversation-store-fs.ts
+++ b/extensions/msteams/src/conversation-store-fs.ts
@@ -1,3 +1,7 @@
+import {
+  findPreferredConversationByUserId,
+  parseStoredConversationTimestamp,
+} from "./conversation-store-selection.js";
 import type {
   MSTeamsConversationStore,
   MSTeamsConversationStoreEntry,
@@ -15,17 +19,6 @@ const STORE_FILENAME = "msteams-conversations.json";
 const MAX_CONVERSATIONS = 1000;
 const CONVERSATION_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
-function parseTimestamp(value: string | undefined): number | null {
-  if (!value) {
-    return null;
-  }
-  const parsed = Date.parse(value);
-  if (!Number.isFinite(parsed)) {
-    return null;
-  }
-  return parsed;
-}
-
 function pruneToLimit(conversations: Record<string, StoredConversationReference>) {
   const entries = Object.entries(conversations);
   if (entries.length <= MAX_CONVERSATIONS) {
@@ -33,8 +26,8 @@ function pruneToLimit(conversations: Record<string, StoredConversationReference>
   }
 
   entries.sort((a, b) => {
-    const aTs = parseTimestamp(a[1].lastSeenAt) ?? 0;
-    const bTs = parseTimestamp(b[1].lastSeenAt) ?? 0;
+    const aTs = parseStoredConversationTimestamp(a[1].lastSeenAt) ?? 0;
+    const bTs = parseStoredConversationTimestamp(b[1].lastSeenAt) ?? 0;
     return aTs - bTs;
   });
 
@@ -50,7 +43,7 @@ function pruneExpired(
   let removed = false;
   const kept: typeof conversations = {};
   for (const [conversationId, reference] of Object.entries(conversations)) {
-    const lastSeenAt = parseTimestamp(reference.lastSeenAt);
+    const lastSeenAt = parseStoredConversationTimestamp(reference.lastSeenAt);
     // Preserve legacy entries that have no lastSeenAt until they're seen again.
     if (lastSeenAt != null && nowMs - lastSeenAt > ttlMs) {
       removed = true;
@@ -112,38 +105,7 @@ export function createMSTeamsConversationStoreFs(params?: {
   };
 
   const findByUserId = async (id: string): Promise<MSTeamsConversationStoreEntry | null> => {
-    const target = id.trim();
-    if (!target) {
-      return null;
-    }
-
-    const matches: MSTeamsConversationStoreEntry[] = [];
-    for (const entry of await list()) {
-      const { conversationId, reference } = entry;
-      if (reference.user?.aadObjectId === target || reference.user?.id === target) {
-        matches.push({ conversationId, reference });
-      }
-    }
-
-    if (matches.length === 0) {
-      return null;
-    }
-
-    matches.sort((a, b) => {
-      const aType = a.reference.conversation?.conversationType?.toLowerCase() ?? "";
-      const bType = b.reference.conversation?.conversationType?.toLowerCase() ?? "";
-      const aPersonal = aType === "personal" ? 1 : 0;
-      const bPersonal = bType === "personal" ? 1 : 0;
-      if (aPersonal !== bPersonal) {
-        return bPersonal - aPersonal;
-      }
-      return (
-        (parseTimestamp(b.reference.lastSeenAt) ?? 0) -
-        (parseTimestamp(a.reference.lastSeenAt) ?? 0)
-      );
-    });
-
-    return matches[0] ?? null;
+    return findPreferredConversationByUserId(await list(), id);
   };
 
   const upsert = async (

--- a/extensions/msteams/src/conversation-store-fs.ts
+++ b/extensions/msteams/src/conversation-store-fs.ts
@@ -118,16 +118,34 @@ export function createMSTeamsConversationStoreFs(params?: {
     if (!target) {
       return null;
     }
+
+    const matches: MSTeamsConversationStoreEntry[] = [];
     for (const entry of await list()) {
       const { conversationId, reference } = entry;
-      if (reference.user?.aadObjectId === target) {
-        return { conversationId, reference };
-      }
-      if (reference.user?.id === target) {
-        return { conversationId, reference };
+      if (reference.user?.aadObjectId === target || reference.user?.id === target) {
+        matches.push({ conversationId, reference });
       }
     }
-    return null;
+
+    if (matches.length === 0) {
+      return null;
+    }
+
+    matches.sort((a, b) => {
+      const aType = a.reference.conversation?.conversationType?.toLowerCase() ?? "";
+      const bType = b.reference.conversation?.conversationType?.toLowerCase() ?? "";
+      const aPersonal = aType === "personal" ? 1 : 0;
+      const bPersonal = bType === "personal" ? 1 : 0;
+      if (aPersonal !== bPersonal) {
+        return bPersonal - aPersonal;
+      }
+      return (
+        (parseTimestamp(b.reference.lastSeenAt) ?? 0) -
+        (parseTimestamp(a.reference.lastSeenAt) ?? 0)
+      );
+    });
+
+    return matches[0] ?? null;
   };
 
   const upsert = async (

--- a/extensions/msteams/src/conversation-store-memory.ts
+++ b/extensions/msteams/src/conversation-store-memory.ts
@@ -39,15 +39,33 @@ export function createMSTeamsConversationStoreMemory(
       if (!target) {
         return null;
       }
+
+      const matches: MSTeamsConversationStoreEntry[] = [];
       for (const [conversationId, reference] of map.entries()) {
-        if (reference.user?.aadObjectId === target) {
-          return { conversationId, reference };
-        }
-        if (reference.user?.id === target) {
-          return { conversationId, reference };
+        if (reference.user?.aadObjectId === target || reference.user?.id === target) {
+          matches.push({ conversationId, reference });
         }
       }
-      return null;
+
+      if (matches.length === 0) {
+        return null;
+      }
+
+      matches.sort((a, b) => {
+        const aType = a.reference.conversation?.conversationType?.toLowerCase() ?? "";
+        const bType = b.reference.conversation?.conversationType?.toLowerCase() ?? "";
+        const aPersonal = aType === "personal" ? 1 : 0;
+        const bPersonal = bType === "personal" ? 1 : 0;
+        if (aPersonal !== bPersonal) {
+          return bPersonal - aPersonal;
+        }
+        return (
+          (Date.parse(b.reference.lastSeenAt ?? "") || 0) -
+          (Date.parse(a.reference.lastSeenAt ?? "") || 0)
+        );
+      });
+
+      return matches[0] ?? null;
     },
   };
 }

--- a/extensions/msteams/src/conversation-store-memory.ts
+++ b/extensions/msteams/src/conversation-store-memory.ts
@@ -1,3 +1,4 @@
+import { findPreferredConversationByUserId } from "./conversation-store-selection.js";
 import type {
   MSTeamsConversationStore,
   MSTeamsConversationStoreEntry,
@@ -20,6 +21,7 @@ export function createMSTeamsConversationStoreMemory(
       map.set(normalizedId, {
         ...(existing?.timezone && !reference.timezone ? { timezone: existing.timezone } : {}),
         ...reference,
+        lastSeenAt: new Date().toISOString(),
       });
     },
     get: async (conversationId) => {
@@ -35,37 +37,13 @@ export function createMSTeamsConversationStoreMemory(
       return map.delete(normalizeConversationId(conversationId));
     },
     findByUserId: async (id) => {
-      const target = id.trim();
-      if (!target) {
-        return null;
-      }
-
-      const matches: MSTeamsConversationStoreEntry[] = [];
-      for (const [conversationId, reference] of map.entries()) {
-        if (reference.user?.aadObjectId === target || reference.user?.id === target) {
-          matches.push({ conversationId, reference });
-        }
-      }
-
-      if (matches.length === 0) {
-        return null;
-      }
-
-      matches.sort((a, b) => {
-        const aType = a.reference.conversation?.conversationType?.toLowerCase() ?? "";
-        const bType = b.reference.conversation?.conversationType?.toLowerCase() ?? "";
-        const aPersonal = aType === "personal" ? 1 : 0;
-        const bPersonal = bType === "personal" ? 1 : 0;
-        if (aPersonal !== bPersonal) {
-          return bPersonal - aPersonal;
-        }
-        return (
-          (Date.parse(b.reference.lastSeenAt ?? "") || 0) -
-          (Date.parse(a.reference.lastSeenAt ?? "") || 0)
-        );
-      });
-
-      return matches[0] ?? null;
+      return findPreferredConversationByUserId(
+        Array.from(map.entries()).map(([conversationId, reference]) => ({
+          conversationId,
+          reference,
+        })),
+        id,
+      );
     },
   };
 }

--- a/extensions/msteams/src/conversation-store-selection.ts
+++ b/extensions/msteams/src/conversation-store-selection.ts
@@ -1,0 +1,49 @@
+import type { MSTeamsConversationStoreEntry } from "./conversation-store.js";
+
+export function parseStoredConversationTimestamp(value: string | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
+}
+
+export function findPreferredConversationByUserId(
+  entries: Iterable<MSTeamsConversationStoreEntry>,
+  id: string,
+): MSTeamsConversationStoreEntry | null {
+  const target = id.trim();
+  if (!target) {
+    return null;
+  }
+
+  const matches: MSTeamsConversationStoreEntry[] = [];
+  for (const entry of entries) {
+    if (entry.reference.user?.aadObjectId === target || entry.reference.user?.id === target) {
+      matches.push(entry);
+    }
+  }
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  matches.sort((a, b) => {
+    const aType = a.reference.conversation?.conversationType?.toLowerCase() ?? "";
+    const bType = b.reference.conversation?.conversationType?.toLowerCase() ?? "";
+    const aPersonal = aType === "personal" ? 1 : 0;
+    const bPersonal = bType === "personal" ? 1 : 0;
+    if (aPersonal !== bPersonal) {
+      return bPersonal - aPersonal;
+    }
+    return (
+      (parseStoredConversationTimestamp(b.reference.lastSeenAt) ?? 0) -
+      (parseStoredConversationTimestamp(a.reference.lastSeenAt) ?? 0)
+    );
+  });
+
+  return matches[0] ?? null;
+}

--- a/extensions/msteams/src/conversation-store.ts
+++ b/extensions/msteams/src/conversation-store.ts
@@ -7,6 +7,8 @@
 
 /** Minimal ConversationReference shape for proactive messaging */
 export type StoredConversationReference = {
+  /** Timestamp when this reference was last seen/updated. */
+  lastSeenAt?: string;
   /** Activity ID from the last message */
   activityId?: string;
   /** User who sent the message */


### PR DESCRIPTION
## Summary

- Problem: MS Teams proactive sends to `user:<aadObjectId>` could resolve to a stale personal DM conversation reference when the same user had multiple stored references.
- Why it matters: replies could be generated successfully but then fail outbound with HTTP 403 because the send path targeted an old Bot Framework conversation ID.
- What changed: `findByUserId` now considers all matching references, prefers `personal` conversations, and then selects the freshest `lastSeenAt`; added a regression test covering multiple references for one user.
- What did NOT change (scope boundary): no changes to Teams webhook ingestion, proactive send transport, or conversation reference storage format beyond typing `lastSeenAt` on the stored reference.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the MS Teams FS conversation store returned the first stored user match instead of selecting the newest valid DM reference.
- Missing detection / guardrail: there was no regression test for multiple conversation references sharing the same AAD object ID.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Teams rotated/recreated a personal DM conversation reference for the same user, leaving both old and new references in the store.
- If unknown, what was ruled out: ruled out inbound processing failure and ruled out a Teams-wide outage; the failing path was specifically proactive outbound resolution for the DM user target.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/conversation-store-fs.test.ts`
- Scenario the test should lock in: when a single AAD user has multiple stored references, the store should pick the freshest personal conversation instead of the first inserted one.
- Why this is the smallest reliable guardrail: the bug lives entirely in store-side lookup/selection logic.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- MS Teams proactive replies to DM users now prefer the latest personal conversation reference when multiple references exist for the same user.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin 25.3.0 (arm64)
- Runtime/container: local OpenClaw dev repo
- Model/provider: N/A
- Integration/channel (if any): MS Teams
- Relevant config (redacted): stored conversation references containing two personal DMs and one group/chat reference for the same AAD user

### Steps

1. Store an older personal conversation reference for a user.
2. Store another reference for the same AAD user, including a newer personal DM.
3. Resolve `findByUserId` for that user.

### Expected

- The newest personal conversation reference is returned.

### Actual

- Before this change, the first inserted matching reference was returned, which could be stale.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced a real MS Teams DM delivery failure caused by stale conversation resolution; hot-patched the installed runtime; confirmed replies started arriving; added repo-level regression test; confirmed targeted test passes and `pnpm build` passes.
- Edge cases checked: multiple references for the same AAD user across personal and group chat conversation types; newest personal reference wins.
- What you did **not** verify: full repo-wide `pnpm check` and `pnpm test` green, because `origin/main` currently has unrelated TUI type errors in `src/tui/components/*` for `getEditorKeybindings`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the previous `findByUserId` selection behavior.
- Files/config to restore: `extensions/msteams/src/conversation-store-fs.ts`, `extensions/msteams/src/conversation-store.ts`
- Known bad symptoms reviewers should watch for: proactive DM sends choosing an unexpected conversation reference for users with multiple stored references.

## Risks and Mitigations

- Risk: preferring `personal` and newest `lastSeenAt` could change resolution behavior for edge cases where a non-personal reference was intentionally preferred.
  - Mitigation: this only affects `user:<id>` lookup, which is used for person-targeted proactive sends; the new regression test locks the expected DM-preference behavior.
