### PR TITLE
fix(matrix): encrypt thumbnails in E2EE rooms using thumbnail_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify HTTP 410 errors as retryable timeouts by default while still preserving explicit session-expired, billing, and auth signals from the payload. (#55201) thanks @nikus-pan.
 - Agents/subagents: restore completion announce delivery for extension channels like BlueBubbles. (#56348)
 - Plugins/Matrix: load bundled `@matrix-org/matrix-sdk-crypto-nodejs` through `createRequire(...)` so E2EE media send and receive keep the package-local native binding lookup working in packaged ESM builds. (#54566) thanks @joelnishanth.
+- Plugins/Matrix: encrypt E2EE image thumbnails with `thumbnail_file` while keeping unencrypted-room previews on `thumbnail_url`, so encrypted Matrix image events keep thumbnail metadata without leaking plaintext previews. (#54711) thanks @frischeDaten.
 
 ## 2026.3.24
 

--- a/extensions/matrix/src/matrix/sdk/types.ts
+++ b/extensions/matrix/src/matrix/sdk/types.ts
@@ -52,6 +52,7 @@ export type FileWithThumbnailInfo = {
   size?: number;
   mimetype?: string;
   thumbnail_url?: string;
+  thumbnail_file?: EncryptedFile;
   thumbnail_info?: {
     w?: number;
     h?: number;

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -174,6 +174,7 @@ describe("sendMessageMatrix media", () => {
 
   it("encrypts thumbnail via thumbnail_file when room is encrypted", async () => {
     const { client, sendMessage, uploadContent } = makeClient();
+    const isRoomEncrypted = vi.fn().mockResolvedValue(true);
     const encryptMedia = vi.fn().mockResolvedValue({
       buffer: Buffer.from("encrypted-thumb"),
       file: {
@@ -184,7 +185,7 @@ describe("sendMessageMatrix media", () => {
       },
     });
     (client as { crypto?: object }).crypto = {
-      isRoomEncrypted: vi.fn().mockResolvedValue(true),
+      isRoomEncrypted,
       encryptMedia,
     };
     // Return image metadata so thumbnail generation is triggered (image > 800px)
@@ -203,6 +204,7 @@ describe("sendMessageMatrix media", () => {
     });
 
     // encryptMedia called twice: once for main media, once for thumbnail
+    expect(isRoomEncrypted).toHaveBeenCalledTimes(1);
     expect(encryptMedia).toHaveBeenCalledTimes(2);
 
     const content = sendMessage.mock.calls[0]?.[1] as {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -172,19 +172,50 @@ describe("sendMessageMatrix media", () => {
     expect(content.file?.url).toBe("mxc://example/file");
   });
 
-  it("does not upload plaintext thumbnails for encrypted image sends", async () => {
-    const { client, uploadContent } = makeEncryptedMediaClient();
+  it("encrypts thumbnail via thumbnail_file when room is encrypted", async () => {
+    const { client, sendMessage, uploadContent } = makeClient();
+    const encryptMedia = vi.fn().mockResolvedValue({
+      buffer: Buffer.from("encrypted-thumb"),
+      file: {
+        key: { kty: "oct", key_ops: ["encrypt", "decrypt"], alg: "A256CTR", k: "tkey", ext: true },
+        iv: "tiv",
+        hashes: { sha256: "thash" },
+        v: "v2",
+      },
+    });
+    (client as { crypto?: object }).crypto = {
+      isRoomEncrypted: vi.fn().mockResolvedValue(true),
+      encryptMedia,
+    };
+    // Return image metadata so thumbnail generation is triggered (image > 800px)
     getImageMetadataMock
-      .mockResolvedValueOnce({ width: 1600, height: 1200 })
-      .mockResolvedValueOnce({ width: 800, height: 600 });
-    resizeToJpegMock.mockResolvedValueOnce(Buffer.from("thumb"));
+      .mockResolvedValueOnce({ width: 1920, height: 1080 }) // original image
+      .mockResolvedValueOnce({ width: 800, height: 450 }); // thumbnail
+    resizeToJpegMock.mockResolvedValueOnce(Buffer.from("thumb-bytes"));
+    // Two uploadContent calls: one for the main encrypted image, one for the encrypted thumbnail
+    uploadContent
+      .mockResolvedValueOnce("mxc://example/main")
+      .mockResolvedValueOnce("mxc://example/thumb");
 
     await sendMessageMatrix("room:!room:example", "caption", {
       client,
       mediaUrl: "file:///tmp/photo.png",
     });
 
-    expect(uploadContent).toHaveBeenCalledTimes(1);
+    // encryptMedia called twice: once for main media, once for thumbnail
+    expect(encryptMedia).toHaveBeenCalledTimes(2);
+
+    const content = sendMessage.mock.calls[0]?.[1] as {
+      url?: string;
+      file?: { url?: string };
+      info?: { thumbnail_url?: string; thumbnail_file?: { url?: string } };
+    };
+    // Main media encrypted correctly
+    expect(content.url).toBeUndefined();
+    expect(content.file?.url).toBe("mxc://example/main");
+    // Thumbnail must use thumbnail_file (encrypted), NOT thumbnail_url (unencrypted)
+    expect(content.info?.thumbnail_url).toBeUndefined();
+    expect(content.info?.thumbnail_file?.url).toBe("mxc://example/thumb");
   });
 
   it("keeps reply context on voice transcript follow-ups outside threads", async () => {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -277,7 +277,7 @@ describe("sendMessageMatrix media", () => {
     expect(mediaContent["org.matrix.msc3245.voice"]).toBeUndefined();
   });
 
-  it("uploads thumbnail metadata for unencrypted large images", async () => {
+  it("keeps thumbnail_url metadata for unencrypted large images", async () => {
     const { client, sendMessage, uploadContent } = makeClient();
     getImageMetadataMock
       .mockResolvedValueOnce({ width: 1600, height: 1200 })
@@ -293,6 +293,7 @@ describe("sendMessageMatrix media", () => {
     const content = sendMessage.mock.calls[0]?.[1] as {
       info?: {
         thumbnail_url?: string;
+        thumbnail_file?: { url?: string };
         thumbnail_info?: {
           w?: number;
           h?: number;
@@ -302,6 +303,7 @@ describe("sendMessageMatrix media", () => {
       };
     };
     expect(content.info?.thumbnail_url).toBe("mxc://example/file");
+    expect(content.info?.thumbnail_file).toBeUndefined();
     expect(content.info?.thumbnail_info).toMatchObject({
       w: 800,
       h: 600,

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -135,7 +135,7 @@ export async function sendMessageMatrix(
           ? await prepareImageInfo({
               buffer: media.buffer,
               client,
-              roomId,
+              encrypted: Boolean(uploaded.file),
             })
           : undefined;
         const [firstChunk, ...rest] = chunks;

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -135,7 +135,7 @@ export async function sendMessageMatrix(
           ? await prepareImageInfo({
               buffer: media.buffer,
               client,
-              encrypted: Boolean(uploaded.file),
+              roomId,
             })
           : undefined;
         const [firstChunk, ...rest] = chunks;

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -113,7 +113,7 @@ const THUMBNAIL_QUALITY = 80;
 export async function prepareImageInfo(params: {
   buffer: Buffer;
   client: MatrixClient;
-  roomId?: string;
+  encrypted?: boolean;
 }): Promise<DimensionalFileInfo | undefined> {
   const meta = await getCore()
     .media.getImageMetadata(params.buffer)
@@ -134,23 +134,15 @@ export async function prepareImageInfo(params: {
       const thumbMeta = await getCore()
         .media.getImageMetadata(thumbBuffer)
         .catch(() => null);
-      if (params.roomId) {
-        const result = await uploadMediaMaybeEncrypted(params.client, params.roomId, thumbBuffer, {
-          contentType: "image/jpeg",
-          filename: "thumbnail.jpg",
-        });
-        if (result.file) {
-          imageInfo.thumbnail_file = result.file;
-        } else {
-          imageInfo.thumbnail_url = result.url;
-        }
+      const result = await uploadMediaWithEncryption(params.client, thumbBuffer, {
+        contentType: "image/jpeg",
+        filename: "thumbnail.jpg",
+        encrypted: params.encrypted === true,
+      });
+      if (result.file) {
+        imageInfo.thumbnail_file = result.file;
       } else {
-        const thumbUri = await params.client.uploadContent(
-          thumbBuffer,
-          "image/jpeg",
-          "thumbnail.jpg",
-        );
-        imageInfo.thumbnail_url = thumbUri;
+        imageInfo.thumbnail_url = result.url;
       }
       if (thumbMeta) {
         imageInfo.thumbnail_info = {
@@ -210,6 +202,29 @@ async function uploadFile(
   return await client.uploadContent(file, params.contentType, params.filename);
 }
 
+async function uploadMediaWithEncryption(
+  client: MatrixClient,
+  buffer: Buffer,
+  params: {
+    contentType?: string;
+    filename?: string;
+    encrypted: boolean;
+  },
+): Promise<{ url: string; file?: EncryptedFile }> {
+  if (params.encrypted && client.crypto) {
+    const encrypted = await client.crypto.encryptMedia(buffer);
+    const mxc = await client.uploadContent(encrypted.buffer, params.contentType, params.filename);
+    const file: EncryptedFile = { url: mxc, ...encrypted.file };
+    return {
+      url: mxc,
+      file,
+    };
+  }
+
+  const mxc = await uploadFile(client, buffer, params);
+  return { url: mxc };
+}
+
 /**
  * Upload media with optional encryption for E2EE rooms.
  */
@@ -223,20 +238,9 @@ export async function uploadMediaMaybeEncrypted(
   },
 ): Promise<{ url: string; file?: EncryptedFile }> {
   // Check if room is encrypted and crypto is available
-  const isEncrypted = client.crypto && (await client.crypto.isRoomEncrypted(roomId));
-
-  if (isEncrypted && client.crypto) {
-    // Encrypt the media before uploading
-    const encrypted = await client.crypto.encryptMedia(buffer);
-    const mxc = await client.uploadContent(encrypted.buffer, params.contentType, params.filename);
-    const file: EncryptedFile = { url: mxc, ...encrypted.file };
-    return {
-      url: mxc,
-      file,
-    };
-  }
-
-  // Upload unencrypted
-  const mxc = await uploadFile(client, buffer, params);
-  return { url: mxc };
+  const isEncrypted = Boolean(client.crypto && (await client.crypto.isRoomEncrypted(roomId)));
+  return await uploadMediaWithEncryption(client, buffer, {
+    ...params,
+    encrypted: isEncrypted,
+  });
 }

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -113,7 +113,7 @@ const THUMBNAIL_QUALITY = 80;
 export async function prepareImageInfo(params: {
   buffer: Buffer;
   client: MatrixClient;
-  encrypted?: boolean;
+  roomId?: string;
 }): Promise<DimensionalFileInfo | undefined> {
   const meta = await getCore()
     .media.getImageMetadata(params.buffer)
@@ -122,10 +122,6 @@ export async function prepareImageInfo(params: {
     return undefined;
   }
   const imageInfo: DimensionalFileInfo = { w: meta.width, h: meta.height };
-  if (params.encrypted) {
-    // For E2EE media, avoid uploading plaintext thumbnails.
-    return imageInfo;
-  }
   const maxDim = Math.max(meta.width, meta.height);
   if (maxDim > THUMBNAIL_MAX_SIDE) {
     try {
@@ -138,12 +134,24 @@ export async function prepareImageInfo(params: {
       const thumbMeta = await getCore()
         .media.getImageMetadata(thumbBuffer)
         .catch(() => null);
-      const thumbUri = await params.client.uploadContent(
-        thumbBuffer,
-        "image/jpeg",
-        "thumbnail.jpg",
-      );
-      imageInfo.thumbnail_url = thumbUri;
+      if (params.roomId) {
+        const result = await uploadMediaMaybeEncrypted(params.client, params.roomId, thumbBuffer, {
+          contentType: "image/jpeg",
+          filename: "thumbnail.jpg",
+        });
+        if (result.file) {
+          imageInfo.thumbnail_file = result.file;
+        } else {
+          imageInfo.thumbnail_url = result.url;
+        }
+      } else {
+        const thumbUri = await params.client.uploadContent(
+          thumbBuffer,
+          "image/jpeg",
+          "thumbnail.jpg",
+        );
+        imageInfo.thumbnail_url = thumbUri;
+      }
       if (thumbMeta) {
         imageInfo.thumbnail_info = {
           w: thumbMeta.width,


### PR DESCRIPTION
## Summary

- In encrypted Matrix rooms, image thumbnails were uploaded unencrypted via `thumbnail_url`, violating the [Matrix E2EE spec](https://spec.matrix.org/v1.9/client-server-api/#extensions-to-mroommessage-msgtypes) which requires `thumbnail_file` (an `EncryptedFile` object) for thumbnails in encrypted events
- Pass `roomId` to `prepareImageInfo` so it can check whether the room is encrypted
- When encrypted: use `crypto.encryptMedia()` + `thumbnail_file` instead of uploading plaintext + `thumbnail_url`
- Unencrypted rooms are unchanged

## Test plan

- [x] Existing 5 tests still pass
- [x] New test: `encrypts thumbnail via thumbnail_file when room is encrypted` — verifies `encryptMedia` is called for both the main media and the thumbnail, `thumbnail_file` is set, and `thumbnail_url` is absent

🤖 Generated with [Claude Code](https://claude.ai/claude-code)