### PR TITLE
feat: thread sessionKey/sessionId into ProviderPrepareExtraParamsContext

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -124,6 +124,10 @@ export function resolvePreparedExtraParams(params: {
   thinkingLevel?: ThinkLevel;
   agentId?: string;
   resolvedExtraParams?: Record<string, unknown>;
+  /** Active session key — forwarded to provider hooks for spend attribution. */
+  sessionKey?: string;
+  /** Ephemeral session UUID — forwarded to provider hooks for per-conversation isolation. */
+  sessionId?: string;
 }): Record<string, unknown> {
   const resolvedExtraParams =
     params.resolvedExtraParams ??
@@ -155,6 +159,8 @@ export function resolvePreparedExtraParams(params: {
         modelId: params.modelId,
         extraParams: merged,
         thinkingLevel: params.thinkingLevel,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
       },
     }) ?? merged
   );
@@ -298,6 +304,8 @@ export function applyExtraParamsToAgent(
   thinkingLevel?: ThinkLevel,
   agentId?: string,
   workspaceDir?: string,
+  sessionKey?: string,
+  sessionId?: string,
 ): { effectiveExtraParams: Record<string, unknown> } {
   const resolvedExtraParams = resolveExtraParams({
     cfg,
@@ -319,6 +327,8 @@ export function applyExtraParamsToAgent(
     thinkingLevel,
     agentId,
     resolvedExtraParams,
+    sessionKey,
+    sessionId,
   });
 
   if (provider === "openai" || provider === "openai-codex") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2299,6 +2299,8 @@ export async function runEmbeddedAttempt(
         params.thinkLevel,
         sessionAgentId,
         effectiveWorkspace,
+        params.sessionKey,
+        params.sessionId,
       );
       const agentTransportOverride = resolveAgentTransportOverride({
         settingsManager,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -465,6 +465,17 @@ export type ProviderPrepareExtraParamsContext = {
   modelId: string;
   extraParams?: Record<string, unknown>;
   thinkingLevel?: ThinkLevel;
+  /**
+   * The active session key (e.g. `agent:main:telegram:direct:571820863`).
+   * Useful for spend attribution — providers can forward this as the `user`
+   * field so LiteLLM / downstream proxies can tag spend logs per session.
+   */
+  sessionKey?: string;
+  /**
+   * Ephemeral session UUID — regenerated on /new and /reset.
+   * Useful for per-conversation isolation in downstream proxies.
+   */
+  sessionId?: string;
 };
 
 /**


### PR DESCRIPTION
## Problem

OpenClaw never sets the `user` field in LiteLLM completion requests. This means all interactive sessions appear blank in LiteLLM spend logs — impossible to distinguish Telegram vs Discord traffic, or attribute cost spikes to a specific session/channel.

Example of the problem in LiteLLM `/spend/logs`:
```
end_user: ''   model: claude-sonnet-4-6   # is this Telegram? Discord? no way to know
end_user: ''   model: claude-sonnet-4-6
```

## Solution

Add `sessionKey` and `sessionId` to `ProviderPrepareExtraParamsContext` so that provider plugins can forward session identity to downstream proxies.

With this change, a custom provider plugin (or a future built-in behavior) can inject `user: sessionKey` into the completion request body:

```typescript
// In a custom provider plugin:
prepareExtraParams(ctx) {
  if (ctx.sessionKey) {
    return { ...ctx.extraParams, user: ctx.sessionKey };
  }
}
```

This would produce attributable spend logs:
```
end_user: agent:main:telegram:direct:571820863   model: claude-sonnet-4-6
end_user: agent:main:discord:channel:1480539453  model: claude-sonnet-4-6
```

## Changes

- **`src/plugins/types.ts`**: Add `sessionKey?: string` and `sessionId?: string` to `ProviderPrepareExtraParamsContext` with JSDoc
- **`src/agents/pi-embedded-runner/extra-params.ts`**: Thread `sessionKey`/`sessionId` through `resolvePreparedExtraParams` and `applyExtraParamsToAgent`  
- **`src/agents/pi-embedded-runner/run/attempt.ts`**: Pass `params.sessionKey` and `params.sessionId` at the `applyExtraParamsToAgent` call site

## Non-breaking

Both fields are optional. No existing behavior changes. Providers that don't use them are unaffected.