### PR TITLE
sessions: fix durable restore after recovery

### DIFF
--- a/src/agents/subagent-registry.mocks.shared.ts
+++ b/src/agents/subagent-registry.mocks.shared.ts
@@ -13,3 +13,17 @@ vi.mock("../gateway/call.js", () => ({
 vi.mock("../infra/agent-events.js", () => ({
   onAgentEvent: vi.fn(() => noop),
 }));
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(async () => ({
+    access: "test-token",
+    expires: 0,
+    provider: "",
+    refresh: "",
+  })),
+  getOAuthProviders: vi.fn(() => []),
+}));
+
+vi.mock("./subagent-orphan-recovery.js", () => ({
+  scheduleOrphanRecovery: vi.fn(),
+}));

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -185,8 +185,14 @@ describe("subagent registry persistence", () => {
   afterEach(async () => {
     announceSpy.mockClear();
     resetSubagentRegistryForTests({ persist: false });
+    await flushQueuedRegistryWork();
     if (tempStateDir) {
-      await fs.rm(tempStateDir, { recursive: true, force: true });
+      await fs.rm(tempStateDir, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 20,
+      });
       tempStateDir = null;
     }
     envSnapshot.restore();

--- a/src/agents/subagent-registry.restore-retry.test.ts
+++ b/src/agents/subagent-registry.restore-retry.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const noop = () => {};
+const CHILD_SESSION_KEY = "agent:main:subagent:restore-retry";
+
+const mocks = vi.hoisted(() => ({
+  restoreSubagentRunsFromDisk: vi.fn(),
+  persistSubagentRunsToDisk: vi.fn(),
+  announceSpy: vi.fn(async () => true),
+  onAgentEvent: vi.fn(() => noop),
+  callGateway: vi.fn(async () => ({ status: "pending" })),
+  loadSessionStore: vi.fn(() => ({
+    [CHILD_SESSION_KEY]: {
+      sessionId: "sess-restore-retry",
+      updatedAt: Date.now(),
+    },
+  })),
+}));
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: vi.fn(async () => ({
+    access: "test-token",
+    expires: 0,
+    provider: "",
+    refresh: "",
+  })),
+  getOAuthProviders: vi.fn(() => []),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({
+      agents: { defaults: { subagents: { archiveAfterMinutes: 0 } } },
+      session: { store: {} },
+    })),
+  };
+});
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: mocks.loadSessionStore,
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions-main.json"),
+}));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+}));
+
+vi.mock("../infra/agent-events.js", () => ({
+  onAgentEvent: mocks.onAgentEvent,
+}));
+
+vi.mock("./subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: mocks.announceSpy,
+  captureSubagentCompletionReply: vi.fn(async () => undefined),
+}));
+
+vi.mock("./subagent-announce-queue.js", () => ({
+  resetAnnounceQueuesForTests: vi.fn(),
+}));
+
+vi.mock("./subagent-orphan-recovery.js", () => ({
+  scheduleOrphanRecovery: vi.fn(),
+}));
+
+vi.mock("./subagent-registry-state.js", () => ({
+  getSubagentRunsSnapshotForRead: vi.fn((runs: Map<string, unknown>) => new Map(runs)),
+  persistSubagentRunsToDisk: mocks.persistSubagentRunsToDisk,
+  restoreSubagentRunsFromDisk: mocks.restoreSubagentRunsFromDisk,
+}));
+
+vi.mock("./timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn(() => 1_000),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+describe("subagent registry restore retry", () => {
+  let mod: typeof import("./subagent-registry.js");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mod = await import("./subagent-registry.js");
+    mod.resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("retries restore on the next init after a transient restore failure", async () => {
+    mocks.restoreSubagentRunsFromDisk
+      .mockImplementationOnce(({ runs }: { runs: Map<string, unknown> }) => {
+        runs.set("run-partial-restore", {
+          runId: "run-partial-restore",
+          childSessionKey: "agent:main:subagent:partial",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "partial restore",
+          cleanup: "keep",
+          createdAt: Date.now() - 20,
+        });
+        throw new Error("transient restore failure");
+      })
+      .mockImplementationOnce(({ runs }: { runs: Map<string, unknown> }) => {
+        expect(runs.has("run-partial-restore")).toBe(false);
+        const now = Date.now();
+        runs.set("run-restore-retry", {
+          runId: "run-restore-retry",
+          childSessionKey: CHILD_SESSION_KEY,
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "restore retry",
+          cleanup: "keep",
+          createdAt: now - 10,
+          startedAt: now - 5,
+          endedAt: now - 1,
+          cleanupHandled: false,
+          expectsCompletionMessage: true,
+        });
+        return 1;
+      });
+
+    mod.initSubagentRegistry();
+    await Promise.resolve();
+    expect(mocks.announceSpy).not.toHaveBeenCalled();
+
+    mod.initSubagentRegistry();
+    expect(mocks.restoreSubagentRunsFromDisk).toHaveBeenCalledTimes(2);
+
+    const restoredRuns = mod.listSubagentRunsForRequester("agent:main:main");
+    expect(restoredRuns).toHaveLength(1);
+    expect(restoredRuns[0]).toMatchObject({
+      runId: "run-restore-retry",
+      childSessionKey: CHILD_SESSION_KEY,
+      requesterSessionKey: "agent:main:main",
+    });
+    expect(restoredRuns.some((entry) => entry.runId === "run-partial-restore")).toBe(false);
+
+    mod.initSubagentRegistry();
+    await Promise.resolve();
+    expect(mocks.restoreSubagentRunsFromDisk).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -777,6 +777,7 @@ function restoreSubagentRunsOnce() {
   if (restoreAttempted) {
     return;
   }
+  const restoreSnapshot = new Map(subagentRuns);
   restoreAttempted = true;
   try {
     const restoredCount = restoreSubagentRunsFromDisk({
@@ -814,7 +815,11 @@ function restoreSubagentRunsOnce() {
       },
     );
   } catch {
-    // ignore restore failures
+    subagentRuns.clear();
+    for (const [runId, entry] of restoreSnapshot.entries()) {
+      subagentRuns.set(runId, entry);
+    }
+    restoreAttempted = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- restore the registry from a snapshot so failed restore attempts do not poison later init cycles
- reset the restore latch after a transient restore failure so the next init retries cleanly
- harden the targeted registry tests by mocking orphan-recovery side effects and stabilizing temp-state cleanup

## Validation
- `pnpm exec vitest run src/agents/subagent-registry.restore-retry.test.ts src/agents/subagent-registry.persistence.test.ts --config vitest.config.ts`
- `pnpm exec oxfmt --check src/agents/subagent-registry.ts src/agents/subagent-registry.mocks.shared.ts src/agents/subagent-registry.restore-retry.test.ts src/agents/subagent-registry.persistence.test.ts`

## Rollback
- revert `23e36522ea`
