### PR TITLE
fix(discord): detach supervisor before disconnect in onAbort to prevent uncaught exception

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -123,6 +123,10 @@ export async function runDiscordGatewayLifecycle(params: {
   const onAbort = () => {
     lifecycleStopping = true;
     reconnectStallWatchdog.disarm();
+    // Transition supervisor to teardown phase before disconnecting so that
+    // any asynchronous WebSocket close events emitted after disconnect() are
+    // suppressed instead of propagating as uncaught exceptions.
+    params.gatewaySupervisor.detachLifecycle();
     const at = Date.now();
     pushStatus({ connected: false, lastEventAt: at });
     if (!gateway) {


### PR DESCRIPTION
## Summary

Fixes #54782

When the health-monitor detects a stale socket and aborts the Discord provider, `onAbort` sets `maxAttempts=0` and calls `gateway.disconnect()`. The asynchronous WebSocket close event then triggers `handleReconnectionAttempt`, which emits an error because `0 >= 0`. Since the supervisor is still in the `"active"` phase at that point, this error propagates through the lifecycle handler as an uncaught exception and crashes the gateway process.

## Fix

Call `params.gatewaySupervisor.detachLifecycle()` in `onAbort` before disconnecting. This transitions the supervisor to the `"teardown"` phase, so any late gateway errors (including the `reconnect-exhausted` error from the async close) are logged and suppressed via `logLateTeardownEvent` rather than propagated to the lifecycle handler.

`detachLifecycle()` is idempotent — the existing call in the `finally` block remains safe.

## Test plan

- [x] Existing `gateway-supervisor.test.ts` already verifies that errors emitted after `detachLifecycle()` are suppressed with a log (line 64-70)
- [x] `pnpm test:extension discord` — 92 test files, 801 tests all passing
- [ ] Verify health-monitor stale-socket restart no longer crashes the gateway in production