### PR TITLE
fix: align codex simple completions with responses API

### DIFF
--- a/src/auto-reply/reply/auto-topic-label.test.ts
+++ b/src/auto-reply/reply/auto-topic-label.test.ts
@@ -171,4 +171,56 @@ describe("generateTopicLabel", () => {
       cfg: {},
     });
   });
+
+  it("passes prompt as systemPrompt and omits temperature for codex simple completion", async () => {
+    resolveDefaultModelForAgent.mockReturnValue({ provider: "openai-codex", model: "gpt-5.4" });
+    resolveModelAsync.mockResolvedValue({
+      model: { provider: "openai-codex", api: "openai-codex-responses" },
+      authStorage: {},
+      modelRegistry: {},
+    });
+    prepareModelForSimpleCompletion.mockImplementation(({ model }) => model);
+
+    await generateTopicLabel({
+      userMessage: "Tell me a joke",
+      prompt: "Generate a very short topic label.",
+      cfg: {},
+      agentId: "main",
+    });
+
+    expect(completeSimple).toHaveBeenCalledWith(
+      { provider: "openai-codex", api: "openai-codex-responses" },
+      {
+        systemPrompt: "Generate a very short topic label.",
+        messages: [
+          {
+            role: "user",
+            content: "Tell me a joke",
+            timestamp: expect.any(Number),
+          },
+        ],
+      },
+      {
+        apiKey: "resolved-key",
+        maxTokens: 100,
+        signal: expect.any(AbortSignal),
+      },
+    );
+  });
+
+  it("returns null when simple completion reports an error", async () => {
+    completeSimple.mockResolvedValue({
+      content: [],
+      stopReason: "error",
+      errorMessage: "boom",
+    });
+
+    await expect(
+      generateTopicLabel({
+        userMessage: "Need help",
+        prompt: "Generate a label",
+        cfg: {},
+      }),
+    ).resolves.toBeNull();
+  });
 });

--- a/src/auto-reply/reply/auto-topic-label.ts
+++ b/src/auto-reply/reply/auto-topic-label.ts
@@ -64,24 +64,32 @@ export async function generateTopicLabel(params: {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
   try {
+    const completionOptions = {
+      apiKey,
+      maxTokens: 100,
+      signal: controller.signal,
+      ...(completionModel.api === "openai-codex-responses" ? {} : { temperature: 0.3 }),
+    };
+
     const result = await completeSimple(
       completionModel,
       {
+        systemPrompt: prompt,
         messages: [
           {
             role: "user",
-            content: `${prompt}\n\n${userMessage}`,
+            content: userMessage,
             timestamp: Date.now(),
           },
         ],
       },
-      {
-        apiKey,
-        maxTokens: 100,
-        temperature: 0.3,
-        signal: controller.signal,
-      },
+      completionOptions,
     );
+
+    if (result.stopReason === "error") {
+      logVerbose(`auto-topic-label: completion error: ${result.errorMessage ?? "unknown error"}`);
+      return null;
+    }
 
     const text = result.content
       .filter(isTextContentBlock)

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -473,28 +473,34 @@ export async function summarizeText(params: {
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
+      const summaryPrompt =
+        `You are an assistant that summarizes texts concisely while keeping the most important information. ` +
+        `Summarize the text to approximately ${targetLength} characters. Maintain the original tone and style. ` +
+        `Reply only with the summary, without additional explanations.`;
+      const completionOptions = {
+        apiKey,
+        maxTokens: Math.ceil(targetLength / 2),
+        signal: controller.signal,
+        ...(completionModel.api === "openai-codex-responses" ? {} : { temperature: 0.3 }),
+      };
       const res = await completeSimple(
         completionModel,
         {
+          systemPrompt: summaryPrompt,
           messages: [
             {
               role: "user",
-              content:
-                `You are an assistant that summarizes texts concisely while keeping the most important information. ` +
-                `Summarize the text to approximately ${targetLength} characters. Maintain the original tone and style. ` +
-                `Reply only with the summary, without additional explanations.\n\n` +
-                `<text_to_summarize>\n${text}\n</text_to_summarize>`,
+              content: `<text_to_summarize>\n${text}\n</text_to_summarize>`,
               timestamp: Date.now(),
             },
           ],
         },
-        {
-          apiKey,
-          maxTokens: Math.ceil(targetLength / 2),
-          temperature: 0.3,
-          signal: controller.signal,
-        },
+        completionOptions,
       );
+
+      if (res.stopReason === "error") {
+        throw new Error(res.errorMessage ?? "No summary returned");
+      }
 
       const summary = res.content
         .filter(isTextContentBlock)

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -487,7 +487,11 @@ describe("tts", () => {
       });
 
       const callArgs = vi.mocked(completeSimpleForTest).mock.calls[0];
+      expect(callArgs?.[1]?.systemPrompt).toContain(
+        "You are an assistant that summarizes texts concisely while keeping the most important information.",
+      );
       expect(callArgs?.[1]?.messages?.[0]?.role).toBe("user");
+      expect(callArgs?.[1]?.messages?.[0]?.content).toContain("<text_to_summarize>");
       expect(callArgs?.[2]?.maxTokens).toBe(250);
       expect(callArgs?.[2]?.temperature).toBe(0.3);
       expect(getApiKeyForModelForTest).toHaveBeenCalledTimes(1);
@@ -534,6 +538,44 @@ describe("tts", () => {
       });
 
       expect(ensureCustomApiRegisteredForTest).toHaveBeenCalledWith("ollama", expect.any(Function));
+    });
+
+    it("passes summary instructions via systemPrompt and omits temperature", async () => {
+      const baseConfig = resolveTtsConfigForTest(baseCfg);
+      vi.mocked(resolveModelAsyncForTest).mockResolvedValue({
+        ...createResolvedModel("openai-codex", "gpt-5.4", "openai-codex-responses"),
+      } as never);
+
+      await summarizeTextForTest({
+        text: "Long text to summarize",
+        targetLength: 500,
+        cfg: baseCfg,
+        config: baseConfig,
+        timeoutMs: 30_000,
+      });
+
+      expect(completeSimpleForTest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "openai-codex",
+          api: "openai-codex-responses",
+        }),
+        {
+          systemPrompt:
+            "You are an assistant that summarizes texts concisely while keeping the most important information. Summarize the text to approximately 500 characters. Maintain the original tone and style. Reply only with the summary, without additional explanations.",
+          messages: [
+            {
+              role: "user",
+              content: "<text_to_summarize>\nLong text to summarize\n</text_to_summarize>",
+              timestamp: expect.any(Number),
+            },
+          ],
+        },
+        {
+          apiKey: "test-api-key",
+          maxTokens: 250,
+          signal: expect.any(AbortSignal),
+        },
+      );
     });
 
     it("validates targetLength bounds", async () => {


### PR DESCRIPTION
This PR was created with AI assistance.

## Summary
- pass simple-completion instructions via `systemPrompt` for auto topic labels and direct TTS summarization
- omit `temperature` only for `openai-codex-responses` while keeping existing behavior for other simple-completion backends
- surface simple-completion errors for auto topic label generation and add regression coverage

## Why
`openai-codex-responses` expects instructions in the request's `instructions` field, which the simple completion transport derives from `systemPrompt`.

These call sites were previously embedding the instruction text into the user message instead. That works for some simple-completion backends, but it causes Codex Responses requests to fail because no `instructions` value is sent. In practice, auto topic label generation would then fall back to an empty label, and direct summarization could also fail on the same path.

This change keeps the fix local to OpenClaw's simple-completion call sites instead of changing shared provider behavior.

## Testing
- `corepack pnpm exec vitest run src/tts/tts.test.ts -t "passes summary instructions via systemPrompt and omits temperature"`
