### PR TITLE
feat: context provenance metadata for injected bootstrap segments

### DIFF
--- a/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
+++ b/src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts
@@ -32,6 +32,11 @@ describe("buildBootstrapContextFiles", () => {
       {
         path: "/tmp/AGENTS.md",
         content: "[MISSING] Expected at: /tmp/AGENTS.md",
+        provenance: {
+          source: DEFAULT_AGENTS_FILENAME,
+          injectedAt: "session_start",
+          volatile: true,
+        },
       },
     ]);
   });
@@ -115,6 +120,22 @@ describe("buildBootstrapContextFiles", () => {
     expect(result).toHaveLength(1);
     expect(result[0]?.content.length).toBeLessThanOrEqual(20);
     expect(result[0]?.content.startsWith("[MISSING]")).toBe(true);
+  });
+
+  it("attaches provenance metadata to each bootstrap context file", () => {
+    const files = [
+      makeFile({ name: "SOUL.md", path: "/tmp/SOUL.md", content: "hello" }),
+      makeFile({ name: "TOOLS.md", path: "/tmp/TOOLS.md", content: "world" }),
+    ];
+    const result = buildBootstrapContextFiles(files);
+    expect(result).toHaveLength(2);
+    for (const entry of result) {
+      expect(entry.provenance).toBeDefined();
+      expect(entry.provenance?.injectedAt).toBe("session_start");
+      expect(entry.provenance?.volatile).toBe(true);
+    }
+    expect(result[0]?.provenance?.source).toBe("SOUL.md");
+    expect(result[1]?.provenance?.source).toBe("TOOLS.md");
   });
 
   it("skips files with missing or invalid paths and emits warnings", () => {

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -227,6 +227,11 @@ export function buildBootstrapContextFiles(
       result.push({
         path: pathValue,
         content: cappedMissingText,
+        provenance: {
+          source: file.name,
+          injectedAt: "session_start",
+          volatile: true,
+        },
       });
       continue;
     }
@@ -251,6 +256,11 @@ export function buildBootstrapContextFiles(
     result.push({
       path: pathValue,
       content: contentWithinBudget,
+      provenance: {
+        source: file.name,
+        injectedAt: "session_start",
+        volatile: true,
+      },
     });
   }
   return result;

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -1,4 +1,21 @@
-export type EmbeddedContextFile = { path: string; content: string };
+export type EmbeddedContextFile = {
+  path: string;
+  content: string;
+  /**
+   * Context provenance metadata.
+   * When present, a `<!-- ctx:provenance ... -->` comment is prepended to the
+   * content during system-prompt assembly so the agent can distinguish stale
+   * injected context from freshly-read content.
+   */
+  provenance?: {
+    /** Human-readable origin, e.g. "SOUL.md", "memory_search". */
+    source: string;
+    /** When this segment was injected: "session_start" or a turn identifier. */
+    injectedAt: string;
+    /** Whether the underlying source may change during the session. */
+    volatile: boolean;
+  };
+};
 
 export type FailoverReason =
   | "auth"

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -570,13 +570,39 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("Use grep");
   });
 
-  it("includes context provenance guidance section", () => {
+  it("includes context provenance guidance section only when provenance is present", () => {
+    const withProvenance = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        {
+          path: "AGENTS.md",
+          content: "Hello",
+          provenance: { source: "AGENTS.md", injectedAt: "session_start", volatile: true },
+        },
+      ],
+    });
+    expect(withProvenance).toContain("## Context Provenance");
+
+    const withoutProvenance = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [{ path: "AGENTS.md", content: "Hello" }],
+    });
+    expect(withoutProvenance).not.toContain("## Context Provenance");
+  });
+
+  it("escapes special characters in provenance attributes", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        {
+          path: "test.md",
+          content: "data",
+          provenance: { source: 'file"name-->.md', injectedAt: "session_start", volatile: false },
+        },
+      ],
     });
-
-    expect(prompt).toContain("## Context Provenance");
-    expect(prompt).toContain("ctx:provenance");
+    expect(prompt).toContain("file&quot;name--&gt;.md");
+    expect(prompt).not.toContain('file"name-->');
   });
 
   it("omits project context when no context files are injected", () => {

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -546,6 +546,39 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("renders provenance tags when context files have provenance metadata", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      contextFiles: [
+        {
+          path: "SOUL.md",
+          content: "Be kind",
+          provenance: { source: "SOUL.md", injectedAt: "session_start", volatile: true },
+        },
+        { path: "TOOLS.md", content: "Use grep" },
+      ],
+    });
+
+    expect(prompt).toContain(
+      '<!-- ctx:provenance source="SOUL.md" injected_at="session_start" volatile="true" -->',
+    );
+    expect(prompt).toContain("## SOUL.md");
+    expect(prompt).toContain("Be kind");
+    // File without provenance should not have a tag
+    expect(prompt).not.toContain('source="TOOLS.md"');
+    expect(prompt).toContain("## TOOLS.md");
+    expect(prompt).toContain("Use grep");
+  });
+
+  it("includes context provenance guidance section", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("## Context Provenance");
+    expect(prompt).toContain("ctx:provenance");
+  });
+
   it("omits project context when no context files are injected", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -18,6 +18,11 @@ import { sanitizeForPromptLiteral } from "./sanitize-for-prompt.js";
 export type PromptMode = "full" | "minimal" | "none";
 type OwnerIdDisplay = "raw" | "hash";
 
+/** Escape a string for safe use inside an HTML comment attribute value. */
+function escapeProvenanceAttr(value: string): string {
+  return value.replace(/"/g, "&quot;").replace(/-->/g, "--&gt;");
+}
+
 function buildSkillsSection(params: { skillsPrompt?: string; readToolName: string }) {
   const trimmed = params.skillsPrompt?.trim();
   if (!trimmed) {
@@ -553,15 +558,6 @@ export function buildAgentSystemPrompt(params: {
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",
     "",
-    "## Context Provenance",
-    "Each injected context segment is tagged with provenance metadata in an HTML comment:",
-    '`<!-- ctx:provenance source="..." injected_at="..." volatile="..." -->`',
-    "- `source`: Origin file or system (e.g. SOUL.md, AGENTS.md, memory_search).",
-    '- `injected_at`: When it was injected ("session_start" or a turn identifier).',
-    "- `volatile`: Whether the underlying source may have changed since injection.",
-    'When relying on content marked `volatile="true"` and `injected_at="session_start"`,',
-    "prefer re-reading the source file to confirm it is still current before acting on it.",
-    "",
     ...buildReplyTagsSection(isMinimal),
     ...buildMessagingSection({
       isMinimal,
@@ -629,12 +625,26 @@ export function buildAgentSystemPrompt(params: {
     }
     for (const file of validContextFiles) {
       const provenanceTag = file.provenance
-        ? `<!-- ctx:provenance source="${file.provenance.source}" injected_at="${file.provenance.injectedAt}" volatile="${file.provenance.volatile}" -->`
+        ? `<!-- ctx:provenance source="${escapeProvenanceAttr(file.provenance.source)}" injected_at="${escapeProvenanceAttr(file.provenance.injectedAt)}" volatile="${file.provenance.volatile}" -->`
         : "";
       if (provenanceTag) {
         lines.push(provenanceTag);
       }
       lines.push(`## ${file.path}`, "", file.content, "");
+    }
+    const hasAnyProvenance = validContextFiles.some((f) => f.provenance);
+    if (hasAnyProvenance) {
+      lines.push(
+        "## Context Provenance",
+        "Each injected context segment above is tagged with provenance metadata in an HTML comment:",
+        '`<!-- ctx:provenance source="..." injected_at="..." volatile="..." -->`',
+        "- `source`: Origin file or system (e.g. SOUL.md, AGENTS.md, memory_search).",
+        '- `injected_at`: When it was injected ("session_start" or a turn identifier).',
+        "- `volatile`: Whether the underlying source may have changed since injection.",
+        'When relying on content marked `volatile="true"` and `injected_at="session_start"`,',
+        "prefer re-reading the source file to confirm it is still current before acting on it.",
+        "",
+      );
     }
   }
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -553,6 +553,15 @@ export function buildAgentSystemPrompt(params: {
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",
     "",
+    "## Context Provenance",
+    "Each injected context segment is tagged with provenance metadata in an HTML comment:",
+    '`<!-- ctx:provenance source="..." injected_at="..." volatile="..." -->`',
+    "- `source`: Origin file or system (e.g. SOUL.md, AGENTS.md, memory_search).",
+    '- `injected_at`: When it was injected ("session_start" or a turn identifier).',
+    "- `volatile`: Whether the underlying source may have changed since injection.",
+    'When relying on content marked `volatile="true"` and `injected_at="session_start"`,',
+    "prefer re-reading the source file to confirm it is still current before acting on it.",
+    "",
     ...buildReplyTagsSection(isMinimal),
     ...buildMessagingSection({
       isMinimal,
@@ -619,6 +628,12 @@ export function buildAgentSystemPrompt(params: {
       lines.push("");
     }
     for (const file of validContextFiles) {
+      const provenanceTag = file.provenance
+        ? `<!-- ctx:provenance source="${file.provenance.source}" injected_at="${file.provenance.injectedAt}" volatile="${file.provenance.volatile}" -->`
+        : "";
+      if (provenanceTag) {
+        lines.push(provenanceTag);
+      }
       lines.push(`## ${file.path}`, "", file.content, "");
     }
   }


### PR DESCRIPTION
## Summary

- Add optional `provenance` metadata (`source`, `injectedAt`, `volatile`) to `EmbeddedContextFile` type
- Bootstrap context files (SOUL.md, AGENTS.md, TOOLS.md, etc.) are now tagged with provenance when assembled by `buildBootstrapContextFiles()`
- System prompt injects `<!-- ctx:provenance ... -->` HTML comment before each tagged context segment
- New "Context Provenance" section in system prompt instructs the agent to re-read volatile content before relying on it
- Backward-compatible: `provenance` is optional, existing code works unchanged

Closes #54373 (Phase 1 of the RFC)

## Changed files

- `src/agents/pi-embedded-helpers/types.ts` — extended `EmbeddedContextFile` with optional `provenance`
- `src/agents/pi-embedded-helpers/bootstrap.ts` — attach provenance to each bootstrap file
- `src/agents/system-prompt.ts` — render provenance tags + add guidance section
- `src/agents/system-prompt.test.ts` — tests for provenance tag rendering
- `src/agents/pi-embedded-helpers.buildbootstrapcontextfiles.test.ts` — tests for provenance attachment

## Test plan

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests verify provenance tags are rendered in system prompt
- [ ] New tests verify provenance metadata attached to bootstrap context files
- [ ] Manual verification: start OpenClaw, inspect system prompt for `<!-- ctx:provenance ... -->` tags
- [ ] Token overhead < 1% of bootstrap budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)