### PR TITLE
fix: validate hooks.token requirement at config.patch time

### DIFF
--- a/src/config/config.hooks-module-paths.test.ts
+++ b/src/config/config.hooks-module-paths.test.ts
@@ -111,4 +111,22 @@ describe("config hooks module paths", () => {
       "hooks.mappings.0.channel",
     );
   });
+
+  it("rejects hooks.enabled=true without hooks.token", () => {
+    expectRejectedIssuePath(
+      {
+        agents: { list: [{ id: "openclaw" }] },
+        hooks: { enabled: true },
+      },
+      "hooks.token",
+    );
+  });
+
+  it("accepts hooks.enabled=true when hooks.token is present", () => {
+    const res = validateConfigObjectWithPlugins({
+      agents: { list: [{ id: "openclaw" }] },
+      hooks: { enabled: true, token: "secret" },
+    });
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -514,6 +514,19 @@ function validateConfigObjectWithPluginsBase(
     }
   }
 
+  // Cross-field: hooks.enabled requires hooks.token
+  if (config.hooks?.enabled === true) {
+    const token = config.hooks?.token?.trim();
+    if (!token) {
+      issues.push({
+        path: "hooks.token",
+        message:
+          "hooks.enabled is true but hooks.token is not set. " +
+          "Provide a token, e.g.: openclaw config.patch '{ hooks: { token: \"<your-secret>\" } }'",
+      });
+    }
+  }
+
   if (!hasExplicitPluginsConfig) {
     if (issues.length > 0) {
       return { ok: false, issues, warnings };

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1598,6 +1598,15 @@ function validateConfigObjectWithPluginsBase(
   validateWebSearchProvider();
   validateConfiguredModelRefs();
 
+  if (config.hooks?.enabled === true && !config.hooks?.token?.trim()) {
+    issues.push({
+      path: "hooks.token",
+      message:
+        "hooks.enabled is true but hooks.token is not set. " +
+        "Set hooks.token before enabling hooks (for example with `openclaw config set hooks.token <redacted>` or a redacted `openclaw gateway call config.patch --params ...`).",
+    });
+  }
+
   if (!hasExplicitPluginsConfig) {
     if (issues.length > 0) {
       return { ok: false, issues, warnings };

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -42,7 +42,10 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   }
   const token = cfg.hooks?.token?.trim();
   if (!token) {
-    throw new Error("hooks.enabled requires hooks.token");
+    throw new Error(
+      "hooks.enabled requires hooks.token to be set. " +
+        "Add a token via: openclaw config.patch '{ hooks: { token: \"<your-secret>\" } }'",
+    );
   }
   const rawPath = cfg.hooks?.path?.trim() || DEFAULT_HOOKS_PATH;
   const withSlash = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -52,7 +52,10 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
   }
   const token = normalizeOptionalString(cfg.hooks?.token);
   if (!token) {
-    throw new Error("hooks.enabled requires hooks.token");
+    throw new Error(
+      "hooks.enabled requires hooks.token. " +
+        "Set hooks.token before enabling hooks (for example with `openclaw config set hooks.token <redacted>` or a redacted `openclaw gateway call config.patch --params ...`).",
+    );
   }
   const rawPath = normalizeOptionalString(cfg.hooks?.path) || DEFAULT_HOOKS_PATH;
   const withSlash = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;


### PR DESCRIPTION
## Problem

When `hooks.enabled: true` is set via `config.patch` without `hooks.token`, the gateway fails on startup with an unclear error message (`hooks.enabled requires hooks.token`). Users have no guidance on how to fix it.

## Fix

1. **Config-time validation**: Added a cross-field validation check in `validateConfigObjectWithPluginsBase` that catches `hooks.enabled=true` without `hooks.token` and returns a clear error at `config.patch` time — before the gateway restarts.

2. **Improved startup error**: Updated the error message in `resolveHooksConfig` to suggest the exact `config.patch` command needed to set the token.

## Changes

- `src/config/validation.ts`: Added cross-field validation for `hooks.enabled` requiring `hooks.token`
- `src/gateway/hooks.ts`: Improved error message with actionable guidance

Fixes #54804