### PR TITLE
fix(gateway): preserve thread routing in delivery context for Slack/Telegram/Mattermost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeats/sessions: remove stale accumulated isolated heartbeat session keys when the next tick converges them back to the canonical sibling, so repaired sessions stop showing orphaned `:heartbeat:heartbeat` variants in session listings. (#59606) Thanks @rogerdigital.
 - Control UI/dreaming: keep the Dreaming trace area contained and scrollable so overlays no longer cover tabs or blow out the page layout.
 - Cron/Telegram: collapse isolated announce delivery to the final assistant-visible text only for Telegram targets, while preserving existing multi-message direct delivery semantics for other channels. (#63228) Thanks @welfo-beo.
+- Gateway/thread routing: preserve Slack, Telegram, and Mattermost thread-child delivery targets so bound subagent completion messages land in the originating thread instead of top-level channels. (#54840) Thanks @yzzymt.
 
 ## 2026.4.9
 
@@ -1060,7 +1061,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/forum topics: keep native `/new` and `/reset` routed to the active topic by preserving the topic target on forum-thread command context. (#35963)
 - Status/port diagnostics: treat single-process dual-stack loopback gateway listeners as healthy in `openclaw status --all`, suppressing false "port already in use" conflict warnings. (#53398) Thanks @DanWebb1949.
 - CLI/Docker: treat loopback private-host CLI gateway connects as local for silent pairing auto-approval, while keeping remote backend and public-host CLI connects behind pairing. (#55113) Thanks @sar618.
-- Gateway/thread routing: preserve Slack, Telegram, and Mattermost thread-child delivery targets so bound subagent completion messages land in the originating thread instead of top-level channels. (#54840) Thanks @yzzymt.
 
 ## 2026.3.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1060,6 +1060,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/forum topics: keep native `/new` and `/reset` routed to the active topic by preserving the topic target on forum-thread command context. (#35963)
 - Status/port diagnostics: treat single-process dual-stack loopback gateway listeners as healthy in `openclaw status --all`, suppressing false "port already in use" conflict warnings. (#53398) Thanks @DanWebb1949.
 - CLI/Docker: treat loopback private-host CLI gateway connects as local for silent pairing auto-approval, while keeping remote backend and public-host CLI connects behind pairing. (#55113) Thanks @sar618.
+- Gateway/thread routing: preserve Slack, Telegram, and Mattermost thread-child delivery targets so bound subagent completion messages land in the originating thread instead of top-level channels. (#54840) Thanks @yzzymt.
 
 ## 2026.3.24
 

--- a/extensions/telegram/src/outbound-params.test.ts
+++ b/extensions/telegram/src/outbound-params.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
+
+describe("parseTelegramThreadId", () => {
+  it("parses numeric and scoped thread ids", () => {
+    expect(parseTelegramThreadId("42")).toBe(42);
+    expect(parseTelegramThreadId("-10099")).toBe(-10099);
+    expect(parseTelegramThreadId("-10099:42")).toBe(42);
+    expect(parseTelegramThreadId("-1001234567890:topic:42")).toBe(42);
+    expect(parseTelegramThreadId(42)).toBe(42);
+  });
+
+  it("returns undefined for invalid thread ids", () => {
+    expect(parseTelegramThreadId("abc")).toBeUndefined();
+    expect(parseTelegramThreadId("")).toBeUndefined();
+    expect(parseTelegramThreadId(null)).toBeUndefined();
+    expect(parseTelegramThreadId(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseTelegramReplyToMessageId", () => {
+  it("parses reply-to message ids", () => {
+    expect(parseTelegramReplyToMessageId("123")).toBe(123);
+  });
+
+  it("returns undefined for missing reply-to ids", () => {
+    expect(parseTelegramReplyToMessageId(null)).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/outbound-params.ts
+++ b/extensions/telegram/src/outbound-params.ts
@@ -32,6 +32,10 @@ export function parseTelegramThreadId(threadId?: string | number | null): number
   if (!trimmed) {
     return undefined;
   }
+  const topicMatch = /^-?\d+:topic:(\d+)$/.exec(trimmed);
+  if (topicMatch) {
+    return parseIntegerId(topicMatch[1]);
+  }
   // DM topic session keys may scope thread ids as "<chatId>:<threadId>".
   const scopedMatch = /^-?\d+:(-?\d+)$/.exec(trimmed);
   const rawThreadId = scopedMatch ? scopedMatch[1] : trimmed;

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1249,6 +1249,69 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.threadId).toBeUndefined();
   });
 
+  it("preserves Slack thread routing for bound completion delivery", async () => {
+    sendSpy.mockClear();
+    agentSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-slack-thread-bound",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-slack-thread-bound",
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+    });
+    registerSessionBindingAdapter({
+      channel: "slack",
+      accountId: "acct-1",
+      listBySession: (targetSessionKey: string) =>
+        targetSessionKey === "agent:main:subagent:test"
+          ? [
+              {
+                bindingId: "slack:acct-1:C123:thread",
+                targetSessionKey,
+                targetKind: "subagent",
+                conversation: {
+                  channel: "slack",
+                  accountId: "acct-1",
+                  conversationId: "1710000000.000100",
+                  parentConversationId: "C123",
+                },
+                status: "active",
+                boundAt: Date.now(),
+              },
+            ]
+          : [],
+      resolveByConversation: () => null,
+    });
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-slack-thread-bound",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: {
+        channel: "slack",
+        to: "channel:C123",
+        accountId: "acct-1",
+        threadId: "1710000000.000100",
+      },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      spawnMode: "session",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.channel).toBe("slack");
+    expect(call?.params?.to).toBe("channel:C123");
+    expect(call?.params?.threadId).toBe("1710000000.000100");
+  });
+
   it("routes manual completion announce agent delivery for telegram forum topics", async () => {
     sendSpy.mockClear();
     agentSpy.mockClear();

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -149,6 +149,38 @@ describe("delivery context helpers", () => {
     });
   });
 
+  it.each([
+    {
+      channel: "slack",
+      conversationId: "1710000000.000100",
+      parentConversationId: "C123",
+      expected: { to: "channel:C123", threadId: "1710000000.000100" },
+    },
+    {
+      channel: "telegram",
+      conversationId: "42",
+      parentConversationId: "-10099",
+      expected: { to: "channel:-10099", threadId: "42" },
+    },
+    {
+      channel: "mattermost",
+      conversationId: "msg-child-id",
+      parentConversationId: "channel-parent-id",
+      expected: { to: "channel:channel-parent-id", threadId: "msg-child-id" },
+    },
+  ])(
+    "resolves parent-scoped thread delivery targets for $channel",
+    ({ channel, conversationId, parentConversationId, expected }) => {
+      expect(
+        resolveConversationDeliveryTarget({
+          channel,
+          conversationId,
+          parentConversationId,
+        }),
+      ).toEqual(expected);
+    },
+  );
+
   it("derives delivery context from a session entry", () => {
     expect(
       deliveryContextFromSession({

--- a/src/utils/delivery-context.ts
+++ b/src/utils/delivery-context.ts
@@ -128,6 +128,24 @@ export function resolveConversationDeliveryTarget(params: {
       ...(pluginTarget.threadId?.trim() ? { threadId: pluginTarget.threadId.trim() } : {}),
     };
   }
+  const isThreadChild =
+    conversationId && parentConversationId && parentConversationId !== conversationId;
+  if (channel && isThreadChild) {
+    if (
+      channel === "matrix" ||
+      channel === "slack" ||
+      channel === "mattermost" ||
+      channel === "telegram"
+    ) {
+      return {
+        to: formatConversationTarget({
+          channel,
+          conversationId: parentConversationId,
+        }),
+        threadId: conversationId,
+      };
+    }
+  }
   const to = formatConversationTarget(params);
   return { to };
 }


### PR DESCRIPTION
## Summary

- Problem: resolveConversationDeliveryTarget only extracted threadId for Matrix; Slack, Telegram, and Mattermost thread-child messages fell through to the plain { to } path, losing the thread identifier.
- Why it matters: Subagent completion announcements (and any thread-bound delivery) landed at the channel top-level instead of the originating thread — breaking conversational context for users.
- What changed: Generalized the thread-child detection in delivery-context.ts to handle Slack, Telegram, and Mattermost alongside Matrix; added unit tests for Slack/Telegram and an e2e test for Slack thread-bound subagent completion.
- What did NOT change (scope boundary): No changes to message send paths, plugin adapters, session binding logic, or any other delivery infrastructure. Matrix behavior is preserved as-is.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54780 
- Related #1241 #4911 
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)
- Root cause: The original Matrix thread support in resolveConversationDeliveryTarget was gated by channel === "matrix". When Slack/Telegram/Mattermost sessions had valid conversationId ≠ parentConversationId (thread-child), the function ignored it and returned only { to }.
- Missing detection / guardrail: No unit test asserting thread extraction for non-Matrix channels.
- Prior context (`git blame`, prior PR, issue, or refactor if known): 94693f7ff0 (Matrix plugin migration) introduced the Matrix-only gate; 02ca148583 and 310eed825e fixed Telegram/subagent thread routing at other layers but didn't generalize this function.
- Why this regressed now: It didn't regress — it was never implemented for these channels in this code path. The gap became visible when subagent completion relied on resolveConversationDeliveryTarget for final delivery routing.
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/utils/delivery-context.test.ts + src/agents/subagent-announce.format.e2e.test.ts
- Scenario the test should lock in: When channel=slack|telegram and conversationId ≠ parentConversationId, the function must return { to: channel:<parent>, threadId: <child> }.
- Why this is the smallest reliable guardrail: Unit test on the utility function directly covers the branching logic; e2e test validates the full announce flow end-to-end.
- Existing test that already covers this (if any): Matrix case was covered; Slack/Telegram were not.
- If no new test is added, why not: New tests ARE added (2 unit + 1 e2e).

## User-visible / Behavior Changes

Subagent completion messages now correctly appear in the originating Slack/Telegram/Mattermost thread instead of at channel top-level.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (Linux 6.8.0-106-generic x64)
- Runtime/container: Node.js v22.22.0
- Model/provider: Any (delivery is model-agnostic)
- Integration/channel (if any): Slack
- Relevant config (redacted): Standard OpenClaw config with Slack channel plugin

### Steps

1. In a Slack thread, trigger a subagent spawn (e.g. Codex execution)
2. Wait for subagent completion
3. Observe where the completion announcement is delivered

### Expected

- Completion message appears in the originating thread

### Actual

- Completion message appears at channel top-level

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Observed behavior (before fix):

When a subagent completes on a Slack thread-bound session, resolveConversationDeliveryTarget() is called with the bound conversation params. On main, only matrix channels enter the thread-aware branch — Slack/Telegram/Mattermost fall through to the default path:

// Input (Slack thread-bound subagent completion):
resolveConversationDeliveryTarget({
  channel: "slack",
  conversationId: "1710000000.000100",      // thread_ts
  parentConversationId: "C0ACK8C3DUG"       // actual Slack channel ID
})

// main branch execution:
// 1. to = formatConversationTarget(params)
//      → uses conversationId (thread_ts) as the target
//      → to = "channel:1710000000.000100"   ← WRONG: this is the thread_ts, not the channel
// 2. Only matrix enters the thread branch → Slack skips it
//      → threadId = undefined
//
// Output: { to: "channel:1710000000.000100" }
//
// Downstream: unrecognized target → falls back to session-level
// deliveryContext → message delivered to channel top-level instead of the original thread.
Real-world symptom: subagent completion announcements consistently land at the #magi channel top-level instead of the originating thread, requiring a manual workaround (message send with explicit threadId + NO_REPLY to suppress default delivery).

After fix:

// Same input:
resolveConversationDeliveryTarget({
  channel: "slack",
  conversationId: "1710000000.000100",
  parentConversationId: "C0ACK8C3DUG"
})

// Fixed execution:
// 1. isThreadChild: conversationId && parentConversationId
//    && parentConversationId !== conversationId → true
// 2. channel in ["matrix", "slack", "mattermost", "telegram"] → true
// 3. to = formatConversationTarget({ channel, conversationId: parentConversationId })
//      → to = "channel:C0ACK8C3DUG"        ← CORRECT: actual channel
// 4. threadId = conversationId = "1710000000.000100"  ← CORRECT
//
// Output: { to: "channel:C0ACK8C3DUG", threadId: "1710000000.000100" }
//
// Downstream: delivery correctly routes to the original Slack thread.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Real-world Slack subagent completion delivery was previously observed landing at channel top-level; the code change directly addresses the identified root cause path.
- Edge cases checked: Matrix path preserved (existing test still passes); non-thread messages (conversationId == parentConversationId) still return plain { to }.
- What you did **not** verify: Telegram forum topics (covered by existing separate test).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: git revert <commit> — single commit, clean revert.
- Files/config to restore: src/utils/delivery-context.ts — revert to prior Matrix-only gate.
- Known bad symptoms reviewers should watch for: Messages delivered to wrong thread or missing threadId on any channel.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Mattermost thread semantics may differ from Slack/Telegram in edge cases (e.g. permalink threads).
  - Mitigation: The guard only fires when conversationId ≠ parentConversationId, which is the universal thread-child signal. Mattermost uses the same parent/child model. Worst case: revert is a one-liner.
