### PR TITLE
fix: restore redacted SecretRef id during config.set round-trip

### DIFF
--- a/src/config/redact-snapshot.secret-ref.ts
+++ b/src/config/redact-snapshot.secret-ref.ts
@@ -4,6 +4,18 @@ export function isSecretRefShape(
   return typeof value.source === "string" && typeof value.id === "string";
 }
 
+export function restoreSecretRefId(params: {
+  value: Record<string, unknown> & { source: string; id: string };
+  original: Record<string, unknown> & { source: string; id: string };
+  redactedSentinel: string;
+}): Record<string, unknown> {
+  const { value, original, redactedSentinel } = params;
+  if (value.id !== redactedSentinel) {
+    return value;
+  }
+  return { ...value, id: original.id };
+}
+
 export function redactSecretRefId(params: {
   value: Record<string, unknown> & { source: string; id: string };
   values: string[];

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -5,7 +5,7 @@ import {
   replaceSensitiveValuesInRaw,
   shouldFallbackToStructuredRawRedaction,
 } from "./redact-snapshot.raw.js";
-import { isSecretRefShape, redactSecretRefId } from "./redact-snapshot.secret-ref.js";
+import { isSecretRefShape, redactSecretRefId, restoreSecretRefId } from "./redact-snapshot.secret-ref.js";
 import { isSensitiveConfigPath, type ConfigUiHints } from "./schema.hints.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
@@ -659,7 +659,23 @@ function restoreRedactedValuesWithLookup(
         ) {
           result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
         } else if (typeof value === "object" && value !== null) {
-          result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+          const objectValue = value as Record<string, unknown>;
+          const origValue = orig[key];
+          if (
+            isSecretRefShape(objectValue) &&
+            objectValue.id === REDACTED_SENTINEL &&
+            origValue &&
+            typeof origValue === "object" &&
+            isSecretRefShape(origValue as Record<string, unknown>)
+          ) {
+            result[key] = restoreSecretRefId({
+              value: objectValue,
+              original: origValue as Record<string, unknown> & { source: string; id: string },
+              redactedSentinel: REDACTED_SENTINEL,
+            });
+          } else {
+            result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+          }
         }
         break;
       }
@@ -673,7 +689,23 @@ function restoreRedactedValuesWithLookup(
       ) {
         result[key] = restoreOriginalValueOrThrow({ key, path, original: orig });
       } else if (typeof value === "object" && value !== null) {
-        result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+        const objectValue = value as Record<string, unknown>;
+        const origValue = orig[key];
+        if (
+          isSecretRefShape(objectValue) &&
+          objectValue.id === REDACTED_SENTINEL &&
+          origValue &&
+          typeof origValue === "object" &&
+          isSecretRefShape(origValue as Record<string, unknown>)
+        ) {
+          result[key] = restoreSecretRefId({
+            value: objectValue,
+            original: origValue as Record<string, unknown> & { source: string; id: string },
+            redactedSentinel: REDACTED_SENTINEL,
+          });
+        } else {
+          result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+        }
       }
     }
   }
@@ -715,7 +747,23 @@ function restoreRedactedValuesGuessing(
     ) {
       result[key] = restoreOriginalValueOrThrow({ key, path, original: orig });
     } else if (typeof value === "object" && value !== null) {
-      result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+      const objectValue = value as Record<string, unknown>;
+      const origValue = orig[key];
+      if (
+        isSecretRefShape(objectValue) &&
+        objectValue.id === REDACTED_SENTINEL &&
+        origValue &&
+        typeof origValue === "object" &&
+        isSecretRefShape(origValue as Record<string, unknown>)
+      ) {
+        result[key] = restoreSecretRefId({
+          value: objectValue,
+          original: origValue as Record<string, unknown> & { source: string; id: string },
+          redactedSentinel: REDACTED_SENTINEL,
+        });
+      } else {
+        result[key] = restoreRedactedValuesGuessing(value, orig[key], path, hints);
+      }
     } else {
       result[key] = value;
     }

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -5,7 +5,11 @@ import {
   replaceSensitiveValuesInRaw,
   shouldFallbackToStructuredRawRedaction,
 } from "./redact-snapshot.raw.js";
-import { isSecretRefShape, redactSecretRefId, restoreSecretRefId } from "./redact-snapshot.secret-ref.js";
+import {
+  isSecretRefShape,
+  redactSecretRefId,
+  restoreSecretRefId,
+} from "./redact-snapshot.secret-ref.js";
 import { isSensitiveConfigPath, type ConfigUiHints } from "./schema.hints.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
 
@@ -674,7 +678,13 @@ function restoreRedactedValuesWithLookup(
               redactedSentinel: REDACTED_SENTINEL,
             });
           } else {
-            result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+            result[key] = restoreRedactedValuesWithLookup(
+              value,
+              orig[key],
+              lookup,
+              candidate,
+              hints,
+            );
           }
         }
         break;


### PR DESCRIPTION
## Summary

Fix asymmetric redaction/restore for SecretRef objects in `config.set`.

- `redactSecretRefId` preserves the SecretRef structure and only redacts the `id` field, but `restoreRedactedValues` has no corresponding logic to restore it.
- This causes `config.set` to fail with `"File secret reference id must be an absolute JSON pointer"` when the config contains file-based SecretRef objects (e.g. `models.providers.*.headers.*` or `gateway.auth.token`).

## Changes

- Add `restoreSecretRefId` in `redact-snapshot.secret-ref.ts` (symmetric to `redactSecretRefId`)
- Detect SecretRef with redacted `id` in both `restoreRedactedValuesWithLookup` and `restoreRedactedValuesGuessing` before recursing into objects

## Reproduction

1. Configure a model provider with file-based SecretRef for headers or apiKey:
   ```json
   "headers": {
     "x-api-key": {
       "source": "file",
       "provider": "my-secret-provider",
       "id": "/my_secret_key"
     }
   }
   ```
2. Call `config.get` → returns `{ source: "file", provider: "my-secret-provider", id: "__OPENCLAW_REDACTED__" }`
3. Pass the result back to `config.set` → fails validation:
   ```
   File secret reference id must be an absolute JSON pointer (example: "/providers/openai/apiKey"), or "value" for singleValue mode.
   ```

## Root Cause

During redaction, `redactSecretRefId` does SecretRef-aware redaction — only replaces `id`, preserving `source` and `provider`. But during restoration, the code recurses into the object and encounters `id: "__OPENCLAW_REDACTED__"` at a path like `models.providers.*.headers.x-api-key.id`, which doesn't match `isSensitivePath()` patterns, so the sentinel value is left as-is and fails schema validation.

## Test plan

- [ ] Existing tests pass
- [ ] `config.get` → `config.set` round-trip with file SecretRef no longer fails validation
- [ ] Plain string secrets still restore correctly
- [ ] SecretRef with non-redacted `id` (e.g. env var placeholder) passes through unchanged

🤖 AI-assisted PR — code reviewed and tested manually.