### PR TITLE
fix(whatsapp): clarify allowFrom policy error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/outbound errors: preserve actionable 403 membership/block/kick details and treat `bot not a member` as a permanent delivery failure so Telegram sends stop retrying doomed chats. (#53635) Thanks @w-sss.
 - Telegram/photos: preflight Telegram photo dimension and aspect-ratio rules, and fall back to document sends when image metadata is invalid or unavailable so photo uploads stop failing with `PHOTO_INVALID_DIMENSIONS`. (#52545) Thanks @hnshah.
 - Slack/runtime defaults: trim Slack DM reply overhead, restore Codex auto transport, and tighten Slack/web-search runtime defaults around DM preview threading, cache scoping, warning dedupe, and explicit web-search opt-in. (#53957) Thanks @vincentkoc.
+- WhatsApp/allowFrom: show a specific allowFrom policy error for valid blocked targets instead of the misleading `<E.164|group JID>` format hint. Thanks @mcaxtr.
 
 ## 2026.3.24-beta.2
 

--- a/extensions/whatsapp/src/resolve-outbound-target.test.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.test.ts
@@ -21,6 +21,15 @@ function expectResolutionError(params: ResolveParams) {
   expect(result.error.message).toContain("WhatsApp");
 }
 
+function expectResolutionErrorMessage(params: ResolveParams, expectedMessage: string) {
+  const result = resolveWhatsAppOutboundTarget(params);
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("expected resolution to fail");
+  }
+  expect(result.error.message).toBe(expectedMessage);
+}
+
 function expectResolutionOk(params: ResolveParams, expectedTarget: string) {
   const result = resolveWhatsAppOutboundTarget(params);
   expect(result).toEqual({ ok: true, to: expectedTarget });
@@ -139,7 +148,30 @@ describe("resolveWhatsAppOutboundTarget", () => {
 
     it("denies message when target is not in allowList", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
+      expectResolutionErrorMessage(
+        {
+          to: PRIMARY_TARGET,
+          allowFrom: [SECONDARY_TARGET],
+          mode: "implicit",
+        },
+        `Target "${SECONDARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
+      );
+    });
+
+    it("uses the normalized target in the allowFrom error message", () => {
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(SECONDARY_TARGET)
+        .mockReturnValueOnce(PRIMARY_TARGET);
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+
+      expectResolutionErrorMessage(
+        {
+          to: "(123) 456-7890",
+          allowFrom: [SECONDARY_TARGET],
+          mode: "implicit",
+        },
+        `Target "${PRIMARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
+      );
     });
 
     it("handles mixed numeric and string allowList entries", () => {

--- a/extensions/whatsapp/src/resolve-outbound-target.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.ts
@@ -5,6 +5,10 @@ export type WhatsAppOutboundTargetResolution =
   | { ok: true; to: string }
   | { ok: false; error: Error };
 
+function whatsappAllowFromPolicyError(target: string): Error {
+  return new Error(`Target "${target}" is not listed in the configured WhatsApp allowFrom policy.`);
+}
+
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
@@ -39,7 +43,7 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: whatsappAllowFromPolicyError(normalizedTo),
     };
   }
 

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -166,6 +166,12 @@ describe("whatsappOutbound.resolveTarget", () => {
     });
 
     expectWhatsAppTargetResolutionError(result);
+    if (!result || result.ok) {
+      throw new Error("expected WhatsApp target resolution to fail");
+    }
+    expect(result.error.message).toBe(
+      'Target "+15550000000" is not listed in the configured WhatsApp allowFrom policy.',
+    );
   });
 
   it("keeps group JID targets even when allowFrom does not contain them", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: valid WhatsApp direct-message targets blocked by `channels.whatsapp.allowFrom` return the generic `Delivering to WhatsApp requires target <E.164|group JID>` error instead of a policy rejection.
- Why it matters: the current message sends operators toward reformatting a valid target instead of updating `channels.whatsapp.allowFrom`.
- What changed: `extensions/whatsapp/src/resolve-outbound-target.ts` now returns a dedicated allowFrom policy error for valid blocked targets, and the exact message is covered in unit and plugin-channel seam tests.
- What did NOT change (scope boundary): target normalization, allowFrom semantics, group JID handling, and outbound routing behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #35580
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the allowFrom rejection branch in `extensions/whatsapp/src/resolve-outbound-target.ts` reused `missingTargetError("WhatsApp", "<E.164|group JID>")`, which is the missing/invalid-target message, even when the target had already normalized successfully.
- Missing detection / guardrail: the existing tests only asserted that resolution failed, not that the failure message identified an allowFrom policy rejection.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the same bug was the subject of the earlier duplicate PR cluster (#35640, #35662, #35828, #35841). The stale fixes predated the move into `extensions/whatsapp`, but the misleading error remained on current `main`.
- Why this regressed now: this is not a new regression. The bug survived the refactor because the tests did not lock in the user-visible error text on the allowFrom-denied path.
- If unknown, what was ruled out: target normalization and allowFrom matching were ruled out; only the user-facing error path was wrong.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/resolve-outbound-target.test.ts` and `src/channels/plugins/plugins-channel.test.ts`
- Scenario the test should lock in: a valid WhatsApp target that is not listed in `channels.whatsapp.allowFrom` returns an allowFrom-specific error instead of the generic target-format hint, and the message uses the normalized target.
- Why this is the smallest reliable guardrail: the bug lives in the WhatsApp target resolver, but the plugin-channel seam test ensures the same message survives the outbound channel boundary.
- Existing test that already covers this (if any): existing tests covered the reject path, but they did not assert the error message.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Valid WhatsApp direct-message targets blocked by `channels.whatsapp.allowFrom` now return `Target "<normalized target>" is not listed in the configured WhatsApp allowFrom policy.` instead of `Delivering to WhatsApp requires target <E.164|group JID>`.
- Example: with `channels.whatsapp.allowFrom=["+15555550000"]`, sending to `+15555551234` now reports the policy rejection instead of a format error.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: global npm install from branch `fix/whatsapp-allowfrom-policy-error` (`OpenClaw 2026.3.24 (196df69)`)
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): `channels.whatsapp.allowFrom=["+15555550000"]`

### Steps

1. Configure `channels.whatsapp.allowFrom` to `+[15555550000]` equivalent JSON: `openclaw config set channels.whatsapp.allowFrom '["+15555550000"]' --strict-json`
2. Send to another valid direct-message target such as `+15555551234`.
3. Compare the error message on current `main` vs this branch.

### Expected

- A valid blocked target should fail with an allowFrom policy error that names the normalized target.

### Actual

- Before this change, the same valid blocked target failed with `Delivering to WhatsApp requires target <E.164|group JID>`.
- On this branch, the same scenario now returns `Target "+15555551234" is not listed in the configured WhatsApp allowFrom policy.`

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: manually reproduced the misleading error on current `main`, installed this branch locally, and re-ran the same WhatsApp allowFrom-denied send to confirm the new allowFrom-specific error; also ran the targeted tests plus `pnpm build` and `pnpm check` while preparing the branch.
- Edge cases checked: normalized-target messaging, allowed direct-message targets, and group JID targets that should bypass allowFrom matching.
- What you did **not** verify: full end-to-end WhatsApp delivery beyond the target-resolution error path, or behavior for other channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `196df69c2c` or reinstall the previous OpenClaw package version.
- Files/config to restore: `extensions/whatsapp/src/resolve-outbound-target.ts`; no config rollback required.
- Known bad symptoms reviewers should watch for: unexpected changes to WhatsApp target acceptance behavior instead of only the error text on valid allowFrom-denied direct-message targets.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: downstream tests or scripts might assert the old generic WhatsApp error string.
  - Mitigation: the change is limited to the valid allowFrom-denied path, and the new unit plus seam tests pin the intended replacement message.
