### PR TITLE
Image tool: restore generic provider fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/pairing: ignore self-authored DM `message` updates so bot-pinned status cards and similar service updates do not trigger bogus pairing requests or re-enter inbound dispatch. (#54530) thanks @huntharo
 - iMessage: stop leaking inline `[[reply_to:...]]` tags into delivered text by sending `reply_to` as RPC metadata and stripping stray directive tags from outbound messages. (#39512) Thanks @mvanhorn.
 - Agents/embedded replies: surface mid-turn 429 and overload failures when embedded runs end without a user-visible reply, while preserving successful media-only replies that still use legacy `mediaUrl`. (#50930) Thanks @infichen.
+- Agents/image tool: restore the generic image-runtime fallback when no provider-specific media-understanding provider is registered, so image analysis works again for providers like `openrouter` and `minimax-portal`. (#54858) Thanks @MonkeyLeeT.
 - Agents/compaction: trigger timeout recovery compaction before retrying high-context LLM timeouts so embedded runs stop repeating oversized requests. (#46417) thanks @joeykrug.
 - Microsoft Teams/config: accept the existing `welcomeCard`, `groupWelcomeCard`, `promptStarters`, and feedback/reflection keys in strict config validation so already-supported Teams runtime settings stop failing schema checks. (#54679) Thanks @gumclaw.
 - Agents/status: use provider-aware context window lookup for fresh Anthropic 4.6 model overrides so `/status` shows the correct 1.0m window instead of an underreported shared-cache minimum. (#54796) Thanks @neeravmakwana.

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -705,6 +705,76 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("falls back to the generic image runtime when openrouter has no media provider registration", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const fetch = stubOpenAiCompletionsOkFetch("ok openrouter");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/google/gemini-2.5-flash-lite" },
+            imageModel: { primary: "openrouter/google/gemini-2.5-flash-lite" },
+          },
+        },
+        models: {
+          providers: {
+            openrouter: {
+              api: "openai-completions",
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter-test",
+              models: [makeModelDefinition("google/gemini-2.5-flash-lite", ["text", "image"])],
+            },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      const result = await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(result.content).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "text", text: "ok openrouter" })]),
+      );
+    });
+  });
+
+  it("falls back to the generic image runtime when minimax-portal has no media provider registration", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      await writeAuthProfiles(agentDir, {
+        version: 1,
+        profiles: {
+          "minimax-portal:default": {
+            type: "oauth",
+            provider: "minimax-portal",
+            access: "oauth-test",
+            refresh: "refresh-test",
+            expires: Date.now() + 60_000,
+          },
+        },
+      });
+      const fetch = stubMinimaxOkFetch();
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "minimax-portal/MiniMax-M2.7" },
+            imageModel: { primary: "minimax-portal/MiniMax-VL-01" },
+          },
+        },
+        plugins: {
+          entries: {
+            minimax: { enabled: true },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await expectImageToolExecOk(tool, `data:image/png;base64,${ONE_PIXEL_PNG_B64}`);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("exposes an Anthropic-safe image schema without union keywords", async () => {
     await withMinimaxImageToolFromTempAgentDir(async (tool) => {
       const violations = findSchemaUnionKeywords(tool.parameters, "image.parameters");

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -780,6 +780,7 @@ describe("image tool implicit imageModel config", () => {
 
   it("falls back to the generic image runtime when minimax-portal has no media provider registration", async () => {
     await withTempAgentDir(async (agentDir) => {
+      installImageUnderstandingProviderStubs();
       await writeAuthProfiles(agentDir, {
         version: 1,
         profiles: {
@@ -798,11 +799,6 @@ describe("image tool implicit imageModel config", () => {
           defaults: {
             model: { primary: "minimax-portal/MiniMax-M2.7" },
             imageModel: { primary: "minimax-portal/MiniMax-VL-01" },
-          },
-        },
-        plugins: {
-          entries: {
-            minimax: { enabled: true },
           },
         },
       };

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -740,6 +740,44 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("falls back to the generic multi-image runtime when openrouter has no media provider registration", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const fetch = stubOpenAiCompletionsOkFetch("ok multi");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openrouter/google/gemini-2.5-flash-lite" },
+            imageModel: { primary: "openrouter/google/gemini-2.5-flash-lite" },
+          },
+        },
+        models: {
+          providers: {
+            openrouter: {
+              api: "openai-completions",
+              baseUrl: "https://openrouter.ai/api/v1",
+              apiKey: "openrouter-test",
+              models: [makeModelDefinition("google/gemini-2.5-flash-lite", ["text", "image"])],
+            },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      const result = await tool.execute("t1", {
+        prompt: "Describe the images.",
+        images: [
+          `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+          `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+        ],
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(result.content).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "text", text: "ok multi" })]),
+      );
+    });
+  });
+
   it("falls back to the generic image runtime when minimax-portal has no media provider registration", async () => {
     await withTempAgentDir(async (agentDir) => {
       await writeAuthProfiles(agentDir, {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -222,45 +222,46 @@ function stubMinimaxFetch(baseResp: { status_code: number; status_msg: string },
 }
 
 function stubOpenAiCompletionsOkFetch(text = "ok") {
-  const fetch = vi.fn().mockResolvedValue(
-    new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          const encoder = new TextEncoder();
-          const chunks = [
-            `data: ${JSON.stringify({
-              id: "chatcmpl-moonshot-test",
-              object: "chat.completion.chunk",
-              created: Math.floor(Date.now() / 1000),
-              model: "kimi-k2.5",
-              choices: [
-                {
-                  index: 0,
-                  delta: { role: "assistant", content: text },
-                  finish_reason: null,
-                },
-              ],
-            })}\n\n`,
-            `data: ${JSON.stringify({
-              id: "chatcmpl-moonshot-test",
-              object: "chat.completion.chunk",
-              created: Math.floor(Date.now() / 1000),
-              model: "kimi-k2.5",
-              choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-            })}\n\n`,
-            "data: [DONE]\n\n",
-          ];
-          for (const chunk of chunks) {
-            controller.enqueue(encoder.encode(chunk));
-          }
-          controller.close();
+  const fetch = vi.fn().mockImplementation(
+    async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            const encoder = new TextEncoder();
+            const chunks = [
+              `data: ${JSON.stringify({
+                id: "chatcmpl-moonshot-test",
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: "kimi-k2.5",
+                choices: [
+                  {
+                    index: 0,
+                    delta: { role: "assistant", content: text },
+                    finish_reason: null,
+                  },
+                ],
+              })}\n\n`,
+              `data: ${JSON.stringify({
+                id: "chatcmpl-moonshot-test",
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: "kimi-k2.5",
+                choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+              })}\n\n`,
+              "data: [DONE]\n\n",
+            ];
+            for (const chunk of chunks) {
+              controller.enqueue(encoder.encode(chunk));
+            }
+            controller.close();
+          },
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
         },
-      }),
-      {
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-      },
-    ),
+      ),
   );
   global.fetch = withFetchPreconnect(fetch);
   return fetch;

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -3,7 +3,11 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
 import { buildProviderRegistry } from "../../media-understanding/runner.js";
 import { loadWebMedia } from "../../media/web-media.js";
-import type { MediaUnderstandingProvider } from "../../plugin-sdk/media-understanding.js";
+import {
+  describeImageWithModel,
+  describeImagesWithModel,
+  type MediaUnderstandingProvider,
+} from "../../plugin-sdk/media-understanding.js";
 import { resolveUserPath } from "../../utils.js";
 import { isMinimaxVlmProvider } from "../minimax-vlm.js";
 import {
@@ -164,11 +168,12 @@ async function runImagePrompt(params: {
         provider,
         providerRegistry as Map<string, MediaUnderstandingProvider>,
       );
-      if (!imageProvider) {
-        throw new Error(`No media-understanding provider registered for ${provider}`);
-      }
-      if (params.images.length > 1 && imageProvider.describeImages) {
-        const described = await imageProvider.describeImages({
+      if (
+        params.images.length > 1 &&
+        (imageProvider?.describeImages || !imageProvider?.describeImage)
+      ) {
+        const describeImages = imageProvider?.describeImages ?? describeImagesWithModel;
+        const described = await describeImages({
           images: params.images.map((image, index) => ({
             buffer: image.buffer,
             fileName: `image-${index + 1}`,
@@ -184,12 +189,10 @@ async function runImagePrompt(params: {
         });
         return { text: described.text, provider, model: described.model ?? modelId };
       }
-      if (!imageProvider.describeImage) {
-        throw new Error(`Provider does not support image analysis: ${provider}`);
-      }
+      const describeImage = imageProvider?.describeImage ?? describeImageWithModel;
       if (params.images.length === 1) {
         const image = params.images[0];
-        const described = await imageProvider.describeImage({
+        const described = await describeImage({
           buffer: image.buffer,
           fileName: "image-1",
           mime: image.mimeType,
@@ -206,7 +209,7 @@ async function runImagePrompt(params: {
 
       const parts: string[] = [];
       for (const [index, image] of params.images.entries()) {
-        const described = await imageProvider.describeImage({
+        const described = await describeImage({
           buffer: image.buffer,
           fileName: `image-${index + 1}`,
           mime: image.mimeType,


### PR DESCRIPTION
## Summary

- Problem: the image tool started requiring a registry-backed media-understanding provider for every provider/model pair, which broke image analysis for providers like `openrouter` and `minimax-portal` with `No media-understanding provider registered ...`.
- Why it matters: `#53093` reports a real regression on `2026.3.22+`, and the stricter image-tool path diverged from the broader media-understanding runtime.
- What changed: restored the generic `describeImageWithModel` / `describeImagesWithModel` fallback in `src/agents/tools/image-tool.ts` when no provider-specific image provider is registered, while still preferring provider-specific handlers when present.
- What did NOT change (scope boundary): no provider/plugin manifests were changed; this does not add new provider-specific media registrations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #53093
- Related #53093
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the image tool regression came from the March 16, 2026 `feat(media): route image tool through media providers` change, which made the image tool throw when no provider-specific media provider was registered.
- Missing detection / guardrail: there was no regression test covering providers that rely on the generic image runtime instead of a dedicated media provider registration.
- Prior context (`git blame`, prior PR, issue, or refactor if known): `50c3321d2e` (`feat(media): route image tool through media providers`).
- Why this regressed now: that refactor removed the generic fallback path from the image tool even though the broader media-understanding runtime still retained it.
- If unknown, what was ruled out: ruled out auth/model selection as the primary cause for the reproduced cases by verifying the failure happens before model execution with the missing-provider error.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tools/image-tool.test.ts`
- Scenario the test should lock in: image analysis still works for `openrouter` and `minimax-portal` even when there is no provider-specific media-understanding registration, by falling back to the generic image runtime.
- Why this is the smallest reliable guardrail: the regression is in the image-tool dispatch logic itself, so a focused image-tool test catches it without needing a full end-to-end setup.
- Existing test that already covers this (if any): none for the missing-provider fallback path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Image tool calls no longer fail with `No media-understanding provider registered for <provider>` when the provider/model can be handled by the generic image runtime.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, repo test/build environment
- Model/provider: `openrouter/google/gemini-2.5-flash-lite`, `minimax-portal/MiniMax-VL-01`
- Integration/channel (if any): image tool
- Relevant config (redacted): image tool configured with `agents.defaults.imageModel.primary` for the reproduced providers

### Steps

1. Configure an image-capable provider/model such as `openrouter/google/gemini-2.5-flash-lite` or `minimax-portal/MiniMax-VL-01`.
2. Call the image tool on `2026.3.22+` without a provider-specific media registration present.
3. Observe the pre-fix failure: `No media-understanding provider registered for <provider>`.

### Expected

- The image tool falls back to the generic image runtime and returns a model response.

### Actual

- Before the fix, the image tool threw before model execution.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: new targeted regression tests for `openrouter` and `minimax-portal`; full `src/agents/tools/image-tool.test.ts`; `pnpm build`.
- Edge cases checked: single-image and provider-missing fallback path; provider-specific handlers still remain preferred when present.
- What you did **not** verify: live network calls against real provider services outside the test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit.
- Files/config to restore: `src/agents/tools/image-tool.ts`, `src/agents/tools/image-tool.test.ts`.
- Known bad symptoms reviewers should watch for: image tool dispatch choosing the wrong fallback path for providers that do have custom multi-image handlers.

## Risks and Mitigations

- Risk: generic fallback could bypass a provider-specific multi-image implementation if the dispatch condition is wrong.
  - Mitigation: provider-specific `describeImages` and `describeImage` handlers are still preferred when present, and the full image-tool test file passed.
