### PR TITLE
drop thinking blocks for stepfun models

### DIFF
--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -45,6 +45,9 @@ const CORE_PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> 
     providerFamily: "anthropic",
     dropThinkingBlockModelHints: ["claude"],
   },
+  "openrouter": {
+    dropThinkingBlockModelHints: ["step"],
+  },
 };
 
 const PLUGIN_CAPABILITIES_FALLBACKS: Record<string, Partial<ProviderCapabilities>> = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:  
  Inconsistent behavior between training and inference when using `provider=openrouter` with models whose `model_id` contains `"step"`.

- Why it matters:  
  The mismatch (presence of thinking blocks during inference but not in training) can lead to degraded performance and unstable outputs.

- What changed:  
  Added a configuration rule to automatically enable `dropthinkingblocks` when `provider=openrouter` and `model_id` contains `"step"`.

- What did NOT change (scope boundary):  
  No changes to model logic, training pipeline, or behavior for other providers/models.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:  
  `dropthinkingblocks` was not enabled for certain OpenRouter `"step"` models during inference, while training implicitly assumed this behavior.

- Missing detection / guardrail:  
  No provider/model-specific guard to enforce consistent configuration.

- Prior context (`git blame`, prior PR, issue, or refactor if known):  
  Behavior likely introduced during integration with OpenRouter without aligning config defaults.

- Why this regressed now:  
  Use of `"step"` models exposed the inconsistency between training and inference paths.

- If unknown, what was ruled out:  
  Not caused by model weights or prompt changes.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient

- Target test or file:  
  Integration test covering OpenRouter `"step"` model inference path

- Scenario the test should lock in:  
  Ensure `dropthinkingblocks` is applied when `provider=openrouter` and `model_id` contains `"step"`

- Why this is the smallest reliable guardrail:  
  The behavior depends on provider + model combination rather than isolated function logic

- Existing test that already covers this (if any):  
  None

- If no new test is added, why not:  
  Change is config-level and low risk; can be validated via manual verification

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Outputs from affected OpenRouter `"step"` models will no longer include thinking blocks  
- Behavior is now consistent with training

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: N/A
- Model/provider: OpenRouter
- Integration/channel (if any): N/A
- Relevant config (redacted): `provider=openrouter`, `model_id=*step*`

### Steps

1. Use OpenRouter with a `"step"` model  
2. Run inference before change  
3. Run inference after change  

### Expected

- No thinking blocks in history message in trace
- Behavior aligned with training

### Actual

- Before: thinking blocks present  
- After: thinking blocks removed

## Evidence

Attach at least one:

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:  
  - OpenRouter `"step"` model inference  
  - Non-step models unaffected  

- Edge cases checked:  
  - model_id not containing `"step"`  
  - other providers  

- What you did **not** verify:  
  - Full E2E pipeline with all downstream consumers  

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:  
  Revert this PR or remove the conditional config logic

- Files/config to restore:  
  Relevant config handling file

- Known bad symptoms reviewers should watch for:  
  Missing expected reasoning blocks in non-step models (unexpected scope bleed)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:  
  Over-matching model IDs containing `"step"` unintentionally  

  - Mitigation:  
    Matching is limited to OpenRouter provider and explicit substring condition  