### PR TITLE
fix: use normalizeUsage for DashScope usage metrics

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -50,6 +50,7 @@ import {
   buildUsageWithNoCost,
   buildStreamErrorAssistantMessage,
 } from "./stream-message-shared.js";
+import { normalizeUsage } from "./usage.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-session state
@@ -584,11 +585,16 @@ export function buildAssistantMessageFromResponse(
     model: modelInfo,
     content,
     stopReason,
-    usage: buildUsageWithNoCost({
-      input: response.usage?.input_tokens ?? 0,
-      output: response.usage?.output_tokens ?? 0,
-      totalTokens: response.usage?.total_tokens ?? 0,
-    }),
+    usage: (() => {
+      const normalized = normalizeUsage(response.usage);
+      return buildUsageWithNoCost({
+        input: normalized?.input ?? 0,
+        output: normalized?.output ?? 0,
+        cacheRead: normalized?.cacheRead,
+        cacheWrite: normalized?.cacheWrite,
+        totalTokens: normalized?.total ?? 0,
+      });
+    })(),
   });
 
   return assistantPhase


### PR DESCRIPTION
## Summary

- `buildAssistantMessageFromResponse` directly accessed `input_tokens`/`output_tokens` from the API response, but DashScope returns `prompt_tokens`/`completion_tokens` instead
- Replaced direct field access with `normalizeUsage()` which already handles all provider naming variants
- This fixes zero usage reporting for DashScope and any other provider using OpenAI-compat naming

Fixes #54859

## Test plan

- [x] Existing `buildAssistantMessageFromResponse` tests pass (49 tests)
- [x] Usage normalization tests pass (26 tests)
- [x] All lint/format/type checks pass
- [ ] Manual verification with DashScope provider showing non-zero usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)