### PR TITLE
docs: explain owner-only tools setup

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -733,6 +733,7 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
       "*": ["user1"],
       discord: ["user:123"],
     },
+    ownerAllowFrom: ["discord:123456789012345678"],
     useAccessGroups: true,
   },
 }
@@ -749,6 +750,8 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
 - `channels.<provider>.configWrites` gates config mutations per channel (default: true).
 - For multi-account channels, `channels.<provider>.accounts.<id>.configWrites` also gates writes that target that account (for example `/allowlist --config --account <id>` or `/config set channels.<provider>.accounts.<id>...`).
 - `allowFrom` is per-provider. When set, it is the **only** authorization source (channel allowlists/pairing and `useAccessGroups` are ignored).
+- `ownerAllowFrom` explicitly marks senders as owners for owner-only tools and commands. Use channel-native IDs (optionally provider-prefixed like `whatsapp:+15551234567`); `["*"]` is ignored.
+- Owner-only built-in tools currently include `gateway`, `cron`, and `nodes`. If the current sender is not recognized as an owner, these tools are omitted from the agent's tool list.
 - `useAccessGroups: false` allows commands to bypass access-group policies when `allowFrom` is not set.
 
 </Accordion>

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -146,6 +146,30 @@ When validation fails:
 
   </Accordion>
 
+  <Accordion title="Enable owner-only tools and commands">
+    Some built-in tools are hidden unless the sender is recognized as an owner.
+    This affects `gateway`, `cron`, and `nodes`, plus owner-level command
+    surfaces.
+
+    Set `commands.ownerAllowFrom` to the sender IDs that should count as owners:
+
+    ```bash
+    openclaw config set commands.ownerAllowFrom '["YOUR_SENDER_ID"]' --strict-json
+    ```
+
+    Use the same **channel-native sender IDs** that your channel exposes
+    elsewhere in config, such as:
+
+    - WhatsApp phone numbers like `+15551234567`
+    - Discord user IDs like `123456789012345678`
+    - Provider-prefixed IDs like `whatsapp:+15551234567`
+
+    `["*"]` does not grant owner access here; use explicit sender IDs only.
+    See the [full reference](/gateway/configuration-reference#commands-chat-command-handling)
+    for the complete `commands` block.
+
+  </Accordion>
+
   <Accordion title="Set up group chat mention gating">
     Group messages default to **require mention**. Configure patterns per agent:
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -68,6 +68,30 @@ These tools ship with OpenClaw and are available without installing any plugins:
 
 For image work, use `image` for analysis and `image_generate` for generation or editing. If you target `openai/*`, `google/*`, `fal/*`, or another non-default image provider, configure that provider's auth/API key first.
 
+## Owner-only tools
+
+Some built-in tools are only exposed when the current sender is recognized as an
+owner. If ownership is not configured, these tools are hidden from the agent
+entirely.
+
+The current owner-only tools are:
+
+- `gateway`
+- `cron`
+- `nodes`
+
+To enable them, set `commands.ownerAllowFrom` to the sender IDs that should be
+treated as owners. Use **channel-native IDs** such as a phone number, Discord
+user ID, or provider-prefixed value like `whatsapp:+15551234567`.
+
+```bash
+openclaw config set commands.ownerAllowFrom '["YOUR_SENDER_ID"]' --strict-json
+```
+
+See [Configuration](/gateway/configuration#enable-owner-only-tools-and-commands)
+for setup guidance and [Configuration Reference](/gateway/configuration-reference#commands-chat-command-handling)
+for the full `commands` schema.
+
 ### Plugin-provided tools
 
 Plugins can register additional tools. Some examples:


### PR DESCRIPTION
## Summary
- document that `gateway`, `cron`, and `nodes` are owner-only tools
- show how to enable owner access with `commands.ownerAllowFrom`
- add the missing config reference details for channel-native owner IDs

## Testing
- git diff --check

Closes #53058