### PR TITLE
Normalize OpenAI-compatible websocket usage fields

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -285,6 +285,7 @@ function makeResponseObject(
   outputText?: string,
   toolCallName?: string,
   phase?: "commentary" | "final_answer",
+  usage?: ResponseObject["usage"],
 ): ResponseObject {
   const output: ResponseObject["output"] = [];
   if (outputText) {
@@ -312,7 +313,7 @@ function makeResponseObject(
     status: "completed",
     model: "gpt-5.2",
     output,
-    usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    usage: usage ?? { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
   };
 }
 
@@ -648,6 +649,18 @@ describe("buildAssistantMessageFromResponse", () => {
     const msg = buildAssistantMessageFromResponse(response, modelInfo);
     expect(msg.usage.input).toBe(100);
     expect(msg.usage.output).toBe(50);
+    expect(msg.usage.totalTokens).toBe(150);
+  });
+
+  it("normalizes OpenAI-compatible prompt_tokens/completion_tokens usage", () => {
+    const response = makeResponseObject("resp_5b", "Hello", undefined, undefined, {
+      prompt_tokens: 120,
+      completion_tokens: 30,
+      total_tokens: 150,
+    });
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    expect(msg.usage.input).toBe(120);
+    expect(msg.usage.output).toBe(30);
     expect(msg.usage.totalTokens).toBe(150);
   });
 

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -50,6 +50,7 @@ import {
   buildUsageWithNoCost,
   buildStreamErrorAssistantMessage,
 } from "./stream-message-shared.js";
+import { normalizeUsage } from "./usage.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-session state
@@ -579,15 +580,18 @@ export function buildAssistantMessageFromResponse(
 
   const hasToolCalls = content.some((c) => c.type === "toolCall");
   const stopReason: StopReason = hasToolCalls ? "toolUse" : "stop";
+  const normalizedUsage = normalizeUsage(response.usage);
 
   const message = buildAssistantMessage({
     model: modelInfo,
     content,
     stopReason,
     usage: buildUsageWithNoCost({
-      input: response.usage?.input_tokens ?? 0,
-      output: response.usage?.output_tokens ?? 0,
-      totalTokens: response.usage?.total_tokens ?? 0,
+      input: normalizedUsage?.input ?? 0,
+      output: normalizedUsage?.output ?? 0,
+      cacheRead: normalizedUsage?.cacheRead ?? 0,
+      cacheWrite: normalizedUsage?.cacheWrite ?? 0,
+      totalTokens: normalizedUsage?.total ?? response.usage?.total_tokens ?? 0,
     }),
   });
 


### PR DESCRIPTION
## Summary
- normalize websocket response usage through the existing `normalizeUsage` helper
- preserve cache usage fields when present instead of dropping them on the floor
- add regression coverage for providers that return `prompt_tokens` / `completion_tokens`

## Testing
- pnpm exec vitest run --config vitest.config.ts src/agents/openai-ws-stream.test.ts
- pnpm exec vitest run --config vitest.config.ts src/agents/usage.test.ts src/agents/usage.normalization.test.ts

Closes #54859