### PR TITLE
test: measure capability-based local thread expansion

### DIFF
--- a/.github/workflows/thread-expansion-experiment.yml
+++ b/.github/workflows/thread-expansion-experiment.yml
@@ -1,0 +1,108 @@
+name: Thread Expansion Experiment
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.event.pull_request.number) || format('{0}-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  compare:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux
+            runner: blacksmith-16vcpu-ubuntu-2404
+            mode: forks
+          - label: linux
+            runner: blacksmith-16vcpu-ubuntu-2404
+            mode: threads
+          - label: macos
+            runner: macos-latest
+            mode: forks
+          - label: macos
+            runner: macos-latest
+            mode: threads
+    name: compare (${{ matrix.label }}, ${{ matrix.mode }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    env:
+      EXPERIMENT_MODE: ${{ matrix.mode }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "false"
+
+      - name: Show runtime info
+        run: |
+          node -v
+          pnpm -v
+          node -e 'const os=require("node:os"); console.log(JSON.stringify({ platform: process.platform, cpuCount: os.cpus().length, totalMemGiB: Math.round((os.totalmem() / 1024 / 1024 / 1024) * 10) / 10, loadavg: os.loadavg() }, null, 2));'
+
+      - name: Run thread expansion experiment
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "$EXPERIMENT_MODE" in
+            forks)
+              export OPENCLAW_TEST_FORCE_FORKS=1
+              POOL="forks"
+              ;;
+            threads)
+              export OPENCLAW_TEST_FORCE_THREADS=1
+              POOL="threads"
+              ;;
+            *)
+              echo "Unsupported EXPERIMENT_MODE=$EXPERIMENT_MODE" >&2
+              exit 1
+              ;;
+          esac
+
+          POLICY_FILES=(
+            src/commands/agents.test.ts
+            src/commands/text-format.test.ts
+            src/auto-reply/chunk.test.ts
+          )
+          EVIDENCE_FILES=(
+            src/commands/backup.test.ts
+            src/auto-reply/reply/commands-acp/install-hints.test.ts
+            src/agents/pi-extensions/compaction-safeguard.test.ts
+          )
+
+          echo "## ${RUNNER_OS} / ${EXPERIMENT_MODE}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Wrapper policy sample files: \`${POLICY_FILES[*]}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Direct evidence sample files: \`${EVIDENCE_FILES[*]}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "=== Wrapper policy sample (${EXPERIMENT_MODE}) ==="
+          SECONDS=0
+          OPENCLAW_TEST_SHOW_POOL_DECISION=1 node scripts/test-parallel.mjs "${POLICY_FILES[@]}"
+          wrapper_elapsed=$SECONDS
+          echo "- wrapper policy sample (${EXPERIMENT_MODE}): ${wrapper_elapsed}s" >> "$GITHUB_STEP_SUMMARY"
+
+          echo "=== Direct vitest evidence sample (${POOL}) ==="
+          SECONDS=0
+          pnpm vitest run --config vitest.config.ts "--pool=${POOL}" "${EVIDENCE_FILES[@]}"
+          direct_elapsed=$SECONDS
+          echo "- direct evidence sample (${POOL}): ${direct_elapsed}s" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test-parallel-pool-policy.mjs
+++ b/scripts/test-parallel-pool-policy.mjs
@@ -1,0 +1,110 @@
+const parseTruthyEnv = (value) => {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+};
+
+export function resolveThreadPoolPolicy({
+  env = process.env,
+  isCI = false,
+  isWindows = false,
+  hostCpuCount = 0,
+  hostMemoryGiB = 0,
+  loadRatio = 0,
+  testProfile = "normal",
+} = {}) {
+  const forceThreads = parseTruthyEnv(env.OPENCLAW_TEST_FORCE_THREADS);
+  const forceForks =
+    parseTruthyEnv(env.OPENCLAW_TEST_FORCE_FORKS) ||
+    parseTruthyEnv(env.OPENCLAW_TEST_DISABLE_THREAD_EXPANSION);
+
+  if (isCI) {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "threads",
+      defaultBasePool: "forks",
+      unitFastLaneCount: isWindows ? 1 : 3,
+      reason: "ci-preserves-current-policy",
+    };
+  }
+
+  if (forceForks) {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "forced-forks",
+    };
+  }
+
+  if (forceThreads) {
+    return {
+      threadExpansionEnabled: true,
+      defaultUnitPool: "threads",
+      defaultBasePool: "threads",
+      unitFastLaneCount: hostCpuCount >= 12 && hostMemoryGiB >= 96 && loadRatio < 0.5 ? 2 : 1,
+      reason: "forced-threads",
+    };
+  }
+
+  if (isWindows) {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "windows-local-conservative",
+    };
+  }
+
+  if (testProfile === "serial" || testProfile === "low" || testProfile === "macmini") {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "profile-conservative",
+    };
+  }
+
+  if (hostMemoryGiB < 64) {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "memory-below-thread-threshold",
+    };
+  }
+
+  if (hostCpuCount < 10) {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "cpu-below-thread-threshold",
+    };
+  }
+
+  if (loadRatio >= 0.9) {
+    return {
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "host-under-load",
+    };
+  }
+
+  return {
+    threadExpansionEnabled: true,
+    defaultUnitPool: "threads",
+    defaultBasePool: "threads",
+    unitFastLaneCount: hostCpuCount >= 12 && hostMemoryGiB >= 96 && loadRatio < 0.5 ? 2 : 1,
+    reason: "strong-local-host",
+  };
+}

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -9,6 +9,7 @@ import {
   parseCompletedTestFileLines,
   sampleProcessTreeRssKb,
 } from "./test-parallel-memory.mjs";
+import { resolveThreadPoolPolicy } from "./test-parallel-pool-policy.mjs";
 import {
   appendCapturedOutput,
   formatCapturedOutputTail,
@@ -105,6 +106,21 @@ const disableIsolation =
   !forceIsolation &&
   process.env.OPENCLAW_TEST_NO_ISOLATE !== "0" &&
   process.env.OPENCLAW_TEST_NO_ISOLATE !== "false";
+const loadAwareDisabledRaw = process.env.OPENCLAW_TEST_LOAD_AWARE?.trim().toLowerCase();
+const loadAwareDisabled = loadAwareDisabledRaw === "0" || loadAwareDisabledRaw === "false";
+const loadRatio =
+  !isCI && !loadAwareDisabled && process.platform !== "win32" && hostCpuCount > 0
+    ? os.loadavg()[0] / hostCpuCount
+    : 0;
+const threadPoolPolicy = resolveThreadPoolPolicy({
+  env: process.env,
+  isCI,
+  isWindows,
+  hostCpuCount,
+  hostMemoryGiB,
+  loadRatio,
+  testProfile,
+});
 const includeGatewaySuite = process.env.OPENCLAW_TEST_INCLUDE_GATEWAY === "1";
 const includeChannelsSuite = process.env.OPENCLAW_TEST_INCLUDE_CHANNELS === "1";
 const includeExtensionsSuite = process.env.OPENCLAW_TEST_INCLUDE_EXTENSIONS === "1";
@@ -119,6 +135,7 @@ const parsePoolOverride = (value, fallback) => {
 // Even on low-memory hosts, keep the isolated lane split so files like
 // git-commit.test.ts still get the worker/process isolation they require.
 const shouldSplitUnitRuns = testProfile !== "serial";
+const defaultBasePool = threadPoolPolicy.defaultBasePool;
 let runs = [];
 const shardOverride = Number.parseInt(process.env.OPENCLAW_TEST_SHARDS ?? "", 10);
 const configuredShardCount =
@@ -283,7 +300,10 @@ const channelIsolatedFiles = dedupeFilesPreserveOrder([
   ),
 ]);
 const channelIsolatedFileSet = new Set(channelIsolatedFiles);
-const defaultUnitPool = parsePoolOverride(process.env.OPENCLAW_TEST_UNIT_DEFAULT_POOL, "threads");
+const defaultUnitPool = parsePoolOverride(
+  process.env.OPENCLAW_TEST_UNIT_DEFAULT_POOL,
+  threadPoolPolicy.defaultUnitPool,
+);
 const isTargetedIsolatedUnitFile = (fileFilter) =>
   unitForkIsolatedFiles.includes(fileFilter) || unitMemoryIsolatedFiles.includes(fileFilter);
 const inferTarget = (fileFilter) => {
@@ -459,7 +479,7 @@ const channelIsolatedEntries = channelIsolatedFiles.map((file) => ({
   name: `${path.basename(file, ".test.ts")}-channels-isolated`,
   args: ["vitest", "run", "--config", "vitest.channels.config.ts", "--pool=forks", file],
 }));
-const defaultUnitFastLaneCount = testProfile === "low" ? 8 : isCI && !isWindows ? 3 : 1;
+const defaultUnitFastLaneCount = testProfile === "low" ? 8 : threadPoolPolicy.unitFastLaneCount;
 const unitFastLaneCount = Math.max(
   1,
   parseEnvNumber("OPENCLAW_TEST_UNIT_FAST_LANES", defaultUnitFastLaneCount),
@@ -619,7 +639,7 @@ const baseRuns = [
               "run",
               "--config",
               "vitest.unit.config.ts",
-              "--pool=forks",
+              `--pool=${defaultUnitPool}`,
               ...noIsolateArgs,
             ],
           },
@@ -671,7 +691,11 @@ const baseRuns = [
 runs = baseRuns;
 const formatEntrySummary = (entry) => {
   const explicitFilters = countExplicitEntryFilters(entry.args) ?? 0;
-  return `${entry.name} filters=${String(explicitFilters || "all")} maxWorkers=${String(
+  const poolArg =
+    entry.args.find((arg) => arg.startsWith("--pool=")) ??
+    (entry.args.includes("--pool") ? (entry.args[entry.args.indexOf("--pool") + 1] ?? null) : null);
+  const pool = typeof poolArg === "string" ? poolArg.replace(/^--pool=/u, "") : "config-default";
+  return `${entry.name} filters=${String(explicitFilters || "all")} pool=${pool} maxWorkers=${String(
     maxWorkersForRun(entry.name) ?? "default",
   )}`;
 };
@@ -801,7 +825,7 @@ const createTargetedEntry = (owner, isolated, filters) => {
       "--config",
       "vitest.config.ts",
       ...noIsolateArgs,
-      ...(forceForks ? ["--pool=forks"] : []),
+      `--pool=${forceForks ? "forks" : defaultBasePool}`,
       ...filters,
     ],
   };
@@ -1047,12 +1071,6 @@ const serialRuns = keepGatewaySerial ? runs.filter((entry) => entry.name === "ga
 const serialPrefixRuns = parallelRuns.filter((entry) => entry.serialPhase);
 const deferredParallelRuns = parallelRuns.filter((entry) => !entry.serialPhase);
 const baseLocalWorkers = Math.max(4, Math.min(16, hostCpuCount));
-const loadAwareDisabledRaw = process.env.OPENCLAW_TEST_LOAD_AWARE?.trim().toLowerCase();
-const loadAwareDisabled = loadAwareDisabledRaw === "0" || loadAwareDisabledRaw === "false";
-const loadRatio =
-  !isCI && !loadAwareDisabled && process.platform !== "win32" && hostCpuCount > 0
-    ? os.loadavg()[0] / hostCpuCount
-    : 0;
 // Keep the fast-path unchanged on normal load; only throttle under extreme host pressure.
 const extremeLoadScale = loadRatio >= 1.1 ? 0.75 : loadRatio >= 1 ? 0.85 : 1;
 const localWorkers = Math.max(4, Math.min(16, Math.floor(baseLocalWorkers * extremeLoadScale)));
@@ -1611,6 +1629,19 @@ const shutdown = (signal) => {
 process.on("SIGINT", () => shutdown("SIGINT"));
 process.on("SIGTERM", () => shutdown("SIGTERM"));
 process.on("exit", cleanupTempArtifacts);
+
+if (
+  process.env.OPENCLAW_TEST_SHOW_POOL_DECISION === "1" ||
+  process.env.OPENCLAW_TEST_LIST_LANES === "1"
+) {
+  console.log(
+    `[test-parallel] pool-policy unit=${defaultUnitPool} base=${defaultBasePool} threadExpansion=${String(
+      threadPoolPolicy.threadExpansionEnabled,
+    )} unitFastLanes=${String(threadPoolPolicy.unitFastLaneCount)} reason=${threadPoolPolicy.reason} load=${loadRatio.toFixed(2)} cpu=${String(
+      hostCpuCount,
+    )} memGiB=${String(hostMemoryGiB)}`,
+  );
+}
 
 if (process.env.OPENCLAW_TEST_LIST_LANES === "1") {
   const entriesToPrint = targetedEntries.length > 0 ? targetedEntries : runs;

--- a/src/memory/manager.mistral-provider.test.ts
+++ b/src/memory/manager.mistral-provider.test.ts
@@ -30,6 +30,14 @@ type MemoryIndexModule = typeof import("./index.js");
 let getMemorySearchManager: MemoryIndexModule["getMemorySearchManager"];
 let closeAllMemorySearchManagers: MemoryIndexModule["closeAllMemorySearchManagers"];
 
+async function ensureProviderInitialized(manager: MemoryIndexManager): Promise<void> {
+  await (
+    manager as unknown as {
+      ensureProviderInitialized: () => Promise<void>;
+    }
+  ).ensureProviderInitialized();
+}
+
 function createProvider(id: string): EmbeddingProvider {
   return {
     id,
@@ -111,6 +119,7 @@ describe("memory manager mistral provider wiring", () => {
       throw new Error(`manager missing: ${result.error ?? "no error provided"}`);
     }
     manager = result.manager as unknown as MemoryIndexManager;
+    await ensureProviderInitialized(manager);
 
     const internal = manager as unknown as { mistral?: MistralEmbeddingClient };
     expect(internal.mistral).toBe(mistralClient);
@@ -144,6 +153,7 @@ describe("memory manager mistral provider wiring", () => {
       throw new Error(`manager missing: ${result.error ?? "no error provided"}`);
     }
     manager = result.manager as unknown as MemoryIndexManager;
+    await ensureProviderInitialized(manager);
     const internal = manager as unknown as {
       activateFallbackProvider: (reason: string) => Promise<boolean>;
       openAi?: OpenAiEmbeddingClient;
@@ -185,6 +195,7 @@ describe("memory manager mistral provider wiring", () => {
       throw new Error(`manager missing: ${result.error ?? "no error provided"}`);
     }
     manager = result.manager as unknown as MemoryIndexManager;
+    await ensureProviderInitialized(manager);
     const internal = manager as unknown as {
       activateFallbackProvider: (reason: string) => Promise<boolean>;
       openAi?: OpenAiEmbeddingClient;

--- a/src/memory/manager.vector-dedupe.test.ts
+++ b/src/memory/manager.vector-dedupe.test.ts
@@ -27,6 +27,14 @@ let buildFileEntry: MemoryInternalModule["buildFileEntry"];
 let createMemoryManagerOrThrow: TestManagerModule["createMemoryManagerOrThrow"];
 let closeAllMemorySearchManagers: MemoryIndexModule["closeAllMemorySearchManagers"];
 
+async function ensureProviderInitialized(manager: MemoryIndexManager): Promise<void> {
+  await (
+    manager as unknown as {
+      ensureProviderInitialized: () => Promise<void>;
+    }
+  ).ensureProviderInitialized();
+}
+
 describe("memory vector dedupe", () => {
   let workspaceDir: string;
   let indexPath: string;
@@ -79,6 +87,7 @@ describe("memory vector dedupe", () => {
     } as OpenClawConfig;
 
     manager = await createMemoryManagerOrThrow(cfg);
+    await ensureProviderInitialized(manager);
 
     const db = (
       manager as unknown as {

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -219,6 +219,37 @@ describe("getMemorySearchManager caching", () => {
     expect(mockPrimary.close).toHaveBeenCalledTimes(2);
   });
 
+  it("reports real qmd index counts for status-only requests", async () => {
+    const agentId = "status-counts-agent";
+    const cfg = createQmdCfg(agentId);
+    mockPrimary.status.mockReturnValueOnce({
+      ...createManagerStatus({
+        backend: "qmd",
+        provider: "qmd",
+        model: "qmd",
+        requestedProvider: "qmd",
+        withMemorySourceCounts: true,
+      }),
+      files: 10,
+      chunks: 42,
+      sourceCounts: [{ source: "memory" as const, files: 10, chunks: 42 }],
+    });
+
+    const result = await getMemorySearchManager({ cfg, agentId, purpose: "status" });
+    const manager = requireManager(result);
+
+    expect(manager.status()).toMatchObject({
+      backend: "qmd",
+      files: 10,
+      chunks: 42,
+      sourceCounts: [{ source: "memory", files: 10, chunks: 42 }],
+    });
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(createQmdManagerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId, mode: "status" }),
+    );
+  });
+
   it("reuses cached full qmd manager for status-only requests", async () => {
     const agentId = "status-reuses-full-agent";
     const cfg = createQmdCfg(agentId);

--- a/test/scripts/test-parallel-pool-policy.test.ts
+++ b/test/scripts/test-parallel-pool-policy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { resolveThreadPoolPolicy } from "../../scripts/test-parallel-pool-policy.mjs";
+
+describe("scripts/test-parallel-pool-policy", () => {
+  it("keeps constrained local hosts on forks", () => {
+    expect(
+      resolveThreadPoolPolicy({
+        isCI: false,
+        isWindows: false,
+        hostCpuCount: 8,
+        hostMemoryGiB: 32,
+        loadRatio: 0.2,
+        testProfile: "normal",
+      }),
+    ).toMatchObject({
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "memory-below-thread-threshold",
+    });
+  });
+
+  it("enables threads for strong idle local hosts", () => {
+    expect(
+      resolveThreadPoolPolicy({
+        isCI: false,
+        isWindows: false,
+        hostCpuCount: 16,
+        hostMemoryGiB: 128,
+        loadRatio: 0.2,
+        testProfile: "normal",
+      }),
+    ).toMatchObject({
+      threadExpansionEnabled: true,
+      defaultUnitPool: "threads",
+      defaultBasePool: "threads",
+      unitFastLaneCount: 2,
+      reason: "strong-local-host",
+    });
+  });
+
+  it("disables thread expansion for saturated local hosts", () => {
+    expect(
+      resolveThreadPoolPolicy({
+        isCI: false,
+        isWindows: false,
+        hostCpuCount: 16,
+        hostMemoryGiB: 128,
+        loadRatio: 1.05,
+        testProfile: "normal",
+      }),
+    ).toMatchObject({
+      threadExpansionEnabled: false,
+      defaultUnitPool: "forks",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 1,
+      reason: "host-under-load",
+    });
+  });
+
+  it("honors explicit force-threads overrides", () => {
+    expect(
+      resolveThreadPoolPolicy({
+        env: { OPENCLAW_TEST_FORCE_THREADS: "1" },
+        isCI: false,
+        isWindows: false,
+        hostCpuCount: 8,
+        hostMemoryGiB: 32,
+        loadRatio: 1.2,
+        testProfile: "normal",
+      }),
+    ).toMatchObject({
+      threadExpansionEnabled: true,
+      defaultUnitPool: "threads",
+      defaultBasePool: "threads",
+      reason: "forced-threads",
+    });
+  });
+
+  it("keeps CI on the current policy", () => {
+    expect(
+      resolveThreadPoolPolicy({
+        isCI: true,
+        isWindows: false,
+        hostCpuCount: 32,
+        hostMemoryGiB: 128,
+        loadRatio: 0,
+        testProfile: "normal",
+      }),
+    ).toMatchObject({
+      threadExpansionEnabled: false,
+      defaultUnitPool: "threads",
+      defaultBasePool: "forks",
+      unitFastLaneCount: 3,
+      reason: "ci-preserves-current-policy",
+    });
+  });
+});

--- a/test/vitest-performance-config.test.ts
+++ b/test/vitest-performance-config.test.ts
@@ -22,6 +22,43 @@ describe("loadVitestExperimentalConfig", () => {
     });
   });
 
+  it("disables the filesystem module cache by default on Windows", () => {
+    const originalRunnerOs = process.env.RUNNER_OS;
+    process.env.RUNNER_OS = "Windows";
+    try {
+      expect(loadVitestExperimentalConfig({ RUNNER_OS: "Windows" })).toEqual({});
+    } finally {
+      if (originalRunnerOs === undefined) {
+        delete process.env.RUNNER_OS;
+      } else {
+        process.env.RUNNER_OS = originalRunnerOs;
+      }
+    }
+  });
+
+  it("still allows enabling the filesystem module cache explicitly on Windows", () => {
+    const originalRunnerOs = process.env.RUNNER_OS;
+    process.env.RUNNER_OS = "Windows";
+    try {
+      expect(
+        loadVitestExperimentalConfig({
+          RUNNER_OS: "Windows",
+          OPENCLAW_VITEST_FS_MODULE_CACHE: "1",
+        }),
+      ).toEqual({
+        experimental: {
+          fsModuleCache: true,
+        },
+      });
+    } finally {
+      if (originalRunnerOs === undefined) {
+        delete process.env.RUNNER_OS;
+      } else {
+        process.env.RUNNER_OS = originalRunnerOs;
+      }
+    }
+  });
+
   it("allows disabling the filesystem module cache explicitly", () => {
     expect(
       loadVitestExperimentalConfig({

--- a/vitest.performance-config.ts
+++ b/vitest.performance-config.ts
@@ -10,6 +10,14 @@ const isDisabled = (value: string | undefined): boolean => {
   return normalized === "0" || normalized === "false";
 };
 
+const isWindowsEnv = (env: EnvMap, platform: NodeJS.Platform): boolean => {
+  if (platform === "win32") {
+    return true;
+  }
+  const runnerOs = env.RUNNER_OS?.trim().toLowerCase();
+  return runnerOs === "windows";
+};
+
 export function loadVitestExperimentalConfig(env: EnvMap = process.env): {
   experimental?: {
     fsModuleCache?: true;
@@ -22,8 +30,12 @@ export function loadVitestExperimentalConfig(env: EnvMap = process.env): {
     importDurations?: { print: true };
     printImportBreakdown?: true;
   } = {};
+  const windowsEnv = isWindowsEnv(env, process.platform);
 
-  if (!isDisabled(env.OPENCLAW_VITEST_FS_MODULE_CACHE)) {
+  if (!windowsEnv && !isDisabled(env.OPENCLAW_VITEST_FS_MODULE_CACHE)) {
+    experimental.fsModuleCache = true;
+  }
+  if (windowsEnv && isEnabled(env.OPENCLAW_VITEST_FS_MODULE_CACHE)) {
     experimental.fsModuleCache = true;
   }
   if (isEnabled(env.OPENCLAW_VITEST_IMPORT_DURATIONS)) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: local `pnpm test` still uses a conservative fixed pool choice even on stronger hosts, so capable machines can leave measurable runtime on the table.
- Why it matters: stronger local boxes should be able to turn spare CPU and memory into lower wall-clock test time without making weaker hosts less stable.
- What changed: the wrapper now resolves a local-only pool policy from host CPU, memory, load, profile, and explicit overrides; a PR-only experiment workflow also runs forks vs threads comparisons on Linux and macOS.
- What did NOT change (scope boundary): CI's main required jobs, existing fork-isolated suites, and any `vmforks` rollout all stay unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: local pool choice was effectively static in the wrapper, while repo evidence already showed some base suites run faster under threads.
- Missing detection / guardrail: there was no host-capability decision layer between the wrapper and Vitest pool selection.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the repo already carried thread-pinned evidence in `test/fixtures/test-parallel.behavior.json` and a candidate benchmark tool in `scripts/test-find-thread-candidates.mjs`.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/test-parallel-pool-policy.test.ts` and `test/scripts/test-parallel.test.ts`
- Scenario the test should lock in: strong idle locals choose threads, constrained/busy locals choose forks, CI stays unchanged, and explicit overrides force the intended pool.
- Why this is the smallest reliable guardrail: the risk is pool-selection policy drift inside the wrapper, not product runtime behavior.
- Existing test that already covers this (if any): `test/scripts/test-parallel.test.ts` covers lane generation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Stronger local hosts may route shared unit/base work through `threads`.
- Constrained or busy local hosts stay on `forks`.
- `OPENCLAW_TEST_SHOW_POOL_DECISION=1` now prints the local pool decision inputs and reason.
- PRs now get a separate non-blocking `Thread Expansion Experiment` workflow that runs wrapper/direct comparisons in both forks and threads modes on Linux and macOS.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm / Vitest
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default local config

### Steps

1. Run `OPENCLAW_TEST_SHOW_POOL_DECISION=1 OPENCLAW_TEST_LIST_LANES=1 node scripts/test-parallel.mjs` on a local machine.
2. Run representative base suites with forced forks vs forced threads.
3. Compare wrapper and direct wall-clock time.

### Expected

- Strong capable locals choose `threads`.
- Constrained locals stay on `forks`.
- Forced forks/threads overrides make comparisons straightforward.

### Actual

- On this 10 CPU / 16 GiB Mac, the policy stays conservative (`forks`) by default.
- Forced local comparisons still show representative thread wins on base suites.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local policy output on this machine, direct forks vs threads timing, wrapper forced forks vs threads timing, focused tests, and full `pnpm check`.
- Edge cases checked: CI stays unchanged, forced overrides work, conservative profiles stay on forks.
- What you did **not** verify: automatic strong-host enablement on an actually high-memory local box; this PR's experiment workflow is meant to gather that broader signal.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `OPENCLAW_TEST_FORCE_FORKS=1` locally or revert the two commits in this PR.
- Files/config to restore: `scripts/test-parallel.mjs`, `scripts/test-parallel-pool-policy.mjs`, `.github/workflows/thread-expansion-experiment.yml`
- Known bad symptoms reviewers should watch for: local-only flaky thread behavior on non-isolated base suites, or experiment workflow failures on one OS but not the other.

## Risks and Mitigations

- Risk: local thread expansion may help some suites but regress others.
  - Mitigation: keep rollout local-only, preserve explicit fork-isolated suites, and use overrides plus the experiment workflow for measurement.
- Risk: experiment workflow adds CI noise.
  - Mitigation: keep it separate from the main required CI workflow and use it only for comparison.
