### PR TITLE
fix(msteams): patch Teams HttpPlugin /api* route pattern in dist

### DIFF
--- a/scripts/patch-msteams-httpplugin-route.mjs
+++ b/scripts/patch-msteams-httpplugin-route.mjs
@@ -27,7 +27,8 @@ function listJsFilesRecursively(rootDir) {
 }
 
 export function patchMSTeamsHttpPluginApiRoute(params = {}) {
-  const distDir = params.distDir ?? path.join(process.cwd(), "dist");
+  const repoRoot = params.cwd ?? params.repoRoot ?? process.cwd();
+  const distDir = params.distDir ?? path.join(repoRoot, "dist");
   if (!fs.existsSync(distDir)) {
     return { changedFiles: [], distDir, skipped: "missing-dist" };
   }

--- a/scripts/patch-msteams-httpplugin-route.mjs
+++ b/scripts/patch-msteams-httpplugin-route.mjs
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const NEEDLE = 'this.express.use("/api*", express_1.default.json());';
+const REPLACEMENT = 'this.express.use("/api", express_1.default.json());';
+
+function listJsFilesRecursively(rootDir) {
+  const out = [];
+  const stack = [rootDir];
+
+  while (stack.length) {
+    const dir = stack.pop();
+    for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        stack.push(fullPath);
+        continue;
+      }
+      if (!dirent.isFile()) continue;
+      if (!dirent.name.endsWith(".js")) continue;
+      out.push(fullPath);
+    }
+  }
+
+  return out;
+}
+
+export function patchMSTeamsHttpPluginApiRoute(params = {}) {
+  const distDir = params.distDir ?? path.join(process.cwd(), "dist");
+  if (!fs.existsSync(distDir)) {
+    return { changedFiles: [], distDir, skipped: "missing-dist" };
+  }
+
+  const warnOnNoMatches = params.warnOnNoMatches ?? true;
+
+  const jsFiles = listJsFilesRecursively(distDir);
+  const changedFiles = [];
+  let matchedFiles = 0;
+  let sawReplacement = false;
+
+  for (const filePath of jsFiles) {
+    const src = fs.readFileSync(filePath, "utf8");
+    if (src.includes(REPLACEMENT)) sawReplacement = true;
+    if (!src.includes(NEEDLE)) continue;
+
+    matchedFiles++;
+
+    const next = src.split(NEEDLE).join(REPLACEMENT);
+    if (next !== src) {
+      fs.writeFileSync(filePath, next);
+      changedFiles.push(filePath);
+    }
+  }
+
+  if (warnOnNoMatches && jsFiles.length && matchedFiles === 0 && !sawReplacement) {
+    process.stderr.write(
+      "patch-msteams-httpplugin-route: warning: dist/ exists but no matches were found for the expected HttpPlugin route needle. " +
+        "This likely means the patch is stale or the bundle layout changed.\n",
+    );
+  }
+
+  return {
+    changedFiles,
+    distDir,
+    scannedFiles: jsFiles.length,
+    matchedFiles,
+    skipped: null,
+  };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const result = patchMSTeamsHttpPluginApiRoute();
+  if (result.skipped) {
+    process.stdout.write(`patch-msteams-httpplugin-route: skipped (${result.skipped})\n`);
+    process.exit(0);
+  }
+  process.stdout.write(
+    `patch-msteams-httpplugin-route: patched ${result.changedFiles.length} file(s)\n` +
+      result.changedFiles.map((f) => `- ${path.relative(process.cwd(), f)}`).join("\n") +
+      (result.changedFiles.length ? "\n" : ""),
+  );
+}

--- a/scripts/patch-msteams-httpplugin-route.mjs
+++ b/scripts/patch-msteams-httpplugin-route.mjs
@@ -17,8 +17,12 @@ function listJsFilesRecursively(rootDir) {
         stack.push(fullPath);
         continue;
       }
-      if (!dirent.isFile()) continue;
-      if (!dirent.name.endsWith(".js")) continue;
+      if (!dirent.isFile()) {
+        continue;
+      }
+      if (!dirent.name.endsWith(".js")) {
+        continue;
+      }
       out.push(fullPath);
     }
   }
@@ -42,8 +46,12 @@ export function patchMSTeamsHttpPluginApiRoute(params = {}) {
 
   for (const filePath of jsFiles) {
     const src = fs.readFileSync(filePath, "utf8");
-    if (src.includes(REPLACEMENT)) sawReplacement = true;
-    if (!src.includes(NEEDLE)) continue;
+    if (src.includes(REPLACEMENT)) {
+      sawReplacement = true;
+    }
+    if (!src.includes(NEEDLE)) {
+      continue;
+    }
 
     matchedFiles++;
 

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -4,6 +4,7 @@ import { copyPluginSdkRootAlias } from "./copy-plugin-sdk-root-alias.mjs";
 import { stageBundledPluginRuntimeDeps } from "./stage-bundled-plugin-runtime-deps.mjs";
 import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
 import { writeOfficialChannelCatalog } from "./write-official-channel-catalog.mjs";
+import { patchMSTeamsHttpPluginApiRoute } from "./patch-msteams-httpplugin-route.mjs";
 
 export function runRuntimePostBuild(params = {}) {
   copyPluginSdkRootAlias(params);
@@ -11,6 +12,13 @@ export function runRuntimePostBuild(params = {}) {
   writeOfficialChannelCatalog(params);
   stageBundledPluginRuntimeDeps(params);
   stageBundledPluginRuntime(params);
+
+  // The Teams SDK's HttpPlugin registers an Express route pattern of "/api*".
+  // That pattern is rejected by newer path-to-regexp versions (Express v5),
+  // causing the Teams channel to crash at startup.
+  //
+  // Patch the emitted runtime bundle to use the stable Express prefix mount.
+  patchMSTeamsHttpPluginApiRoute(params);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -1,10 +1,10 @@
 import { pathToFileURL } from "node:url";
 import { copyBundledPluginMetadata } from "./copy-bundled-plugin-metadata.mjs";
 import { copyPluginSdkRootAlias } from "./copy-plugin-sdk-root-alias.mjs";
-import { stageBundledPluginRuntimeDeps } from "./stage-bundled-plugin-runtime-deps.mjs";
-import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
-import { writeOfficialChannelCatalog } from "./write-official-channel-catalog.mjs";
 import { patchMSTeamsHttpPluginApiRoute } from "./patch-msteams-httpplugin-route.mjs";
+import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
+import { stageBundledPluginRuntimeDeps } from "./stage-bundled-plugin-runtime-deps.mjs";
+import { writeOfficialChannelCatalog } from "./write-official-channel-catalog.mjs";
 
 export function runRuntimePostBuild(params = {}) {
   copyPluginSdkRootAlias(params);

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -2,8 +2,8 @@ import { pathToFileURL } from "node:url";
 import { copyBundledPluginMetadata } from "./copy-bundled-plugin-metadata.mjs";
 import { copyPluginSdkRootAlias } from "./copy-plugin-sdk-root-alias.mjs";
 import { patchMSTeamsHttpPluginApiRoute } from "./patch-msteams-httpplugin-route.mjs";
-import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
 import { stageBundledPluginRuntimeDeps } from "./stage-bundled-plugin-runtime-deps.mjs";
+import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
 import { writeOfficialChannelCatalog } from "./write-official-channel-catalog.mjs";
 
 export function runRuntimePostBuild(params = {}) {


### PR DESCRIPTION
## Summary

- Problem: Teams channel crashes on startup after 2026.3.24 with `Missing parameter name at index 5: /api*`.
- Why it matters: This is a high-severity regression; Teams channels fail to start and cannot receive messages.
- What changed: Added a runtime-postbuild patch that rewrites the Teams SDK `HttpPlugin` Express mount from `"/api*"` to `"/api"` in the emitted `dist/` bundle.
- What did NOT change (scope boundary): No Teams runtime behavior changes beyond the route pattern; no config changes; no dependency upgrades.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54703
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The Teams SDK `HttpPlugin` registers `this.express.use("/api*", express.json())`, which is rejected by newer `path-to-regexp` behavior (commonly encountered via Express v5) with `Missing parameter name at index 5: /api*`.
- Missing detection / guardrail: No build-time check to catch invalid Express route patterns emitted from bundled dependencies.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Reported in #54703; appears related to the Teams SDK migration (see issue comments).
- Why this regressed now: 2026.3.24 update changed the runtime dependency graph such that the invalid pattern now triggers at startup.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A (build artifact patch)
- Scenario the test should lock in: After `scripts/runtime-postbuild.mjs`, no emitted `dist/*.js` should contain `this.express.use("/api*", express_1.default.json());`.
- Why this is the smallest reliable guardrail: This regression is in the emitted bundle codepath; a postbuild assertion/patch is the minimal containment.
- Existing test that already covers this (if any): None
- If no new test is added, why not: This PR is intentionally minimal and avoids adding a new test harness around build outputs; the patch is deterministic and idempotent.

## User-visible / Behavior Changes

- Teams channels no longer crash on startup due to the invalid `/api*` Express route pattern.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22
- Integration/channel (if any): Microsoft Teams

### Steps

1. Build the project (emits `dist/`).
2. Run `node scripts/runtime-postbuild.mjs`.
3. Confirm emitted bundle no longer contains the `"/api*"` route pattern for the Teams SDK `HttpPlugin`.

### Expected

- Teams channel startup should not throw `Missing parameter name at index 5: /api*`.

### Actual

- Before: startup crash when the emitted bundle registers `"/api*"`.
- After: postbuild rewrites `"/api*"` -> `"/api"`.

## Evidence

- [x] Trace/log snippets

Issue report + workaround confirmation: #54703

## Human Verification (required)

- Verified scenarios:
  - Ran a small node snippet to ensure `scripts/patch-msteams-httpplugin-route.mjs` rewrites the emitted code as intended.
- Edge cases checked:
  - Idempotency (no change when already patched).
  - Skips cleanly when `dist/` is missing.
- What you did **not** verify:
  - Full `pnpm build` / Teams E2E runtime startup in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `09f4445060`.
- Files/config to restore: `scripts/runtime-postbuild.mjs`, `scripts/patch-msteams-httpplugin-route.mjs`.
- Known bad symptoms reviewers should watch for: build postprocess step unexpectedly rewriting unrelated `dist` files (should be limited to exact needle match).

## Risks and Mitigations

- Risk: Postbuild patch misses future upstream changes if the emitted code string changes.
  - Mitigation: The patch is narrowly targeted; if the needle changes, Teams would regress again and the fix can be adjusted to match the new emitted form.

