### PR TITLE
fix: auto-enable minimax plugin for API key auth route

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -386,6 +386,24 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.entries?.["minimax-portal-auth"]).toBeUndefined();
   });
 
+  it("auto-enables minimax when minimax API key auth is configured", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        auth: {
+          profiles: {
+            "minimax:global": {
+              provider: "minimax",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.plugins?.entries?.minimax?.enabled).toBe(true);
+  });
+
   it("auto-enables acpx plugin when ACP is configured", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -34,6 +34,7 @@ const PROVIDER_PLUGIN_IDS: Array<{ pluginId: string; providerId: string }> = [
   { pluginId: "google", providerId: "google-gemini-cli" },
   { pluginId: "qwen-portal-auth", providerId: "qwen-portal" },
   { pluginId: "copilot-proxy", providerId: "copilot-proxy" },
+  { pluginId: "minimax", providerId: "minimax" },
   { pluginId: "minimax", providerId: "minimax-portal" },
 ];
 const ENV_CATALOG_PATHS = ["OPENCLAW_PLUGIN_CATALOG_PATHS", "OPENCLAW_MPM_CATALOG_PATHS"];


### PR DESCRIPTION
Summary
  - Problem: The image_generate tool is not activated when a user authenticates with MiniMax via the API key route, but works correctly via the OAuth route.
  - Why it matters: Users who choose API key auth over OAuth get a degraded experience — no image generation capability despite having valid MiniMax credentials.
  - What changed: Added { pluginId: "minimax", providerId: "minimax" } to the PROVIDER_PLUGIN_IDS auto-enable mapping in src/config/plugin-auto-enable.ts, plus a corresponding test.
  - What did NOT change: The OAuth route, plugin loading order, image generation provider registration, or any auth storage logic.

Change Type
  - Bug fix

Scope
  - Auth / tokens
  - Skills / tool execution

Root Cause
  - Root cause: PROVIDER_PLUGIN_IDS mapped the minimax plugin only to provider ID "minimax-portal" (OAuth). The API key route stores auth under provider ID "minimax", which was never checked. At gateway startup, applyPluginAutoEnable therefore never auto-enables the minimax plugin or adds it to plugins.allow for API key users. When an allowlist exists, the plugin is blocked before BUNDLED_ENABLED_BY_DEFAULT is evaluated, so the plugin's register() never runs and no image generation providers are registered.

User-visible / Behavior Changes
  - Users authenticating with MiniMax via API key will now have the image_generate tool available, matching the behavior of the OAuth route.

Security Impact
  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification
  Environment
  - Model/provider: MiniMax (API key auth route)

  Steps
  1. Run onboarding and select MiniMax API key (Global or CN)
  2. Start a session
  3. Check whether the image_generate tool is available

  Expected
  image_generate tool is listed and functional.

  Actual (before fix)
  image_generate tool is absent.


  Human Verification
  - Verified scenarios: Ran the full plugin-auto-enable test suite; confirmed the new test fails without the mapping addition and passes with it.
  - Edge cases checked: Confirmed the existing OAuth test still passes; confirmed resolveConfiguredPlugins iterates all entries so duplicate pluginId values are handled correctly (both entries can fire, idempotently enabling the same plugin).
  - Live end-to-end onboarding with a real MiniMax API key: image_generate tool was present and functional

  Compatibility / Migration
  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Failure Recovery
  - Revert: Remove the added line from PROVIDER_PLUGIN_IDS.

  Risks and Mitigations
  None. The change adds one entry to a declarative mapping table; duplicate pluginId values are idempotent.