### PR TITLE
fix(minimax): mark MiniMax-M2.7 as image-capable

### DIFF
--- a/extensions/minimax/model-definitions.test.ts
+++ b/extensions/minimax/model-definitions.test.ts
@@ -35,6 +35,7 @@ describe("minimax model definitions", () => {
       id: "MiniMax-M2.7",
       name: "MiniMax M2.7",
       reasoning: true,
+      input: ["text", "image"],
     });
   });
 
@@ -43,6 +44,11 @@ describe("minimax model definitions", () => {
     expect(model.cost).toEqual(MINIMAX_API_COST);
     expect(model.contextWindow).toBe(DEFAULT_MINIMAX_CONTEXT_WINDOW);
     expect(model.maxTokens).toBe(DEFAULT_MINIMAX_MAX_TOKENS);
+  });
+
+  it("keeps MiniMax-M2.7-highspeed text-only until MiniMax documents image support for it", () => {
+    const model = buildMinimaxApiModelDefinition("MiniMax-M2.7-highspeed");
+    expect(model.input).toEqual(["text"]);
   });
 
   it("falls back to generated name for unknown model id", () => {

--- a/extensions/minimax/model-definitions.ts
+++ b/extensions/minimax/model-definitions.ts
@@ -1,6 +1,7 @@
 import {
   MINIMAX_DEFAULT_MODEL_ID,
   MINIMAX_TEXT_MODEL_CATALOG,
+  getMiniMaxModelInput,
   type ModelDefinitionConfig,
 } from "openclaw/plugin-sdk/provider-models";
 
@@ -46,7 +47,7 @@ export function buildMinimaxModelDefinition(params: {
     id: params.id,
     name: params.name ?? catalog?.name ?? `MiniMax ${params.id}`,
     reasoning: params.reasoning ?? catalog?.reasoning ?? false,
-    input: ["text"],
+    input: getMiniMaxModelInput(params.id),
     cost: params.cost,
     contextWindow: params.contextWindow,
     maxTokens: params.maxTokens,

--- a/extensions/minimax/provider-catalog.test.ts
+++ b/extensions/minimax/provider-catalog.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { buildMinimaxPortalProvider, buildMinimaxProvider } from "./provider-catalog.js";
+
+describe("minimax provider catalog", () => {
+  it("marks MiniMax-M2.7 as image-capable in both provider catalogs", () => {
+    for (const provider of [buildMinimaxProvider(), buildMinimaxPortalProvider()]) {
+      expect(provider.models.find((model) => model.id === "MiniMax-M2.7")?.input).toEqual([
+        "text",
+        "image",
+      ]);
+    }
+  });
+
+  it("keeps MiniMax-M2.7-highspeed text-only", () => {
+    for (const provider of [buildMinimaxProvider(), buildMinimaxPortalProvider()]) {
+      expect(provider.models.find((model) => model.id === "MiniMax-M2.7-highspeed")?.input).toEqual(
+        ["text"],
+      );
+    }
+  });
+});

--- a/extensions/minimax/provider-catalog.ts
+++ b/extensions/minimax/provider-catalog.ts
@@ -3,6 +3,7 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-models";
 import {
+  getMiniMaxModelInput,
   MINIMAX_DEFAULT_MODEL_ID,
   MINIMAX_TEXT_MODEL_CATALOG,
   MINIMAX_TEXT_MODEL_ORDER,
@@ -35,18 +36,18 @@ function buildMinimaxModel(params: {
   };
 }
 
-function buildMinimaxTextModel(params: {
+function buildMinimaxCatalogModel(params: {
   id: string;
   name: string;
   reasoning: boolean;
 }): ModelDefinitionConfig {
-  return buildMinimaxModel({ ...params, input: ["text"] });
+  return buildMinimaxModel({ ...params, input: getMiniMaxModelInput(params.id) });
 }
 
 function buildMinimaxCatalog(): ModelDefinitionConfig[] {
   return MINIMAX_TEXT_MODEL_ORDER.map((id) => {
     const model = MINIMAX_TEXT_MODEL_CATALOG[id];
-    return buildMinimaxTextModel({
+    return buildMinimaxCatalogModel({
       id,
       name: model.name,
       reasoning: model.reasoning,

--- a/src/plugin-sdk/provider-models.ts
+++ b/src/plugin-sdk/provider-models.ts
@@ -36,6 +36,7 @@ export {
   MINIMAX_TEXT_MODEL_CATALOG,
   MINIMAX_TEXT_MODEL_ORDER,
   MINIMAX_TEXT_MODEL_REFS,
+  getMiniMaxModelInput,
   isMiniMaxModernModelId,
 } from "../plugins/provider-model-minimax.js";
 

--- a/src/plugins/provider-model-definitions.ts
+++ b/src/plugins/provider-model-definitions.ts
@@ -6,7 +6,11 @@ import {
   KILOCODE_DEFAULT_MODEL_ID,
   KILOCODE_DEFAULT_MODEL_NAME,
 } from "./provider-model-kilocode.js";
-import { MINIMAX_DEFAULT_MODEL_ID, MINIMAX_TEXT_MODEL_CATALOG } from "./provider-model-minimax.js";
+import {
+  getMiniMaxModelInput,
+  MINIMAX_DEFAULT_MODEL_ID,
+  MINIMAX_TEXT_MODEL_CATALOG,
+} from "./provider-model-minimax.js";
 
 const KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/";
 const KIMI_CODING_MODEL_ID = "kimi-code";
@@ -140,7 +144,7 @@ function buildMinimaxModelDefinition(params: {
     id: params.id,
     name: params.name ?? catalog?.name ?? `MiniMax ${params.id}`,
     reasoning: params.reasoning ?? catalog?.reasoning ?? false,
-    input: ["text"],
+    input: getMiniMaxModelInput(params.id),
     cost: params.cost,
     contextWindow: params.contextWindow,
     maxTokens: params.maxTokens,

--- a/src/plugins/provider-model-minimax.ts
+++ b/src/plugins/provider-model-minimax.ts
@@ -4,6 +4,7 @@ export const MINIMAX_DEFAULT_MODEL_ID = "MiniMax-M2.7";
 export const MINIMAX_DEFAULT_MODEL_REF = `minimax/${MINIMAX_DEFAULT_MODEL_ID}`;
 
 export const MINIMAX_TEXT_MODEL_ORDER = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"] as const;
+export const MINIMAX_VISION_MODEL_IDS = ["MiniMax-M2.7"] as const;
 
 export const MINIMAX_TEXT_MODEL_CATALOG = {
   "MiniMax-M2.7": { name: "MiniMax M2.7", reasoning: true },
@@ -18,4 +19,10 @@ export const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
 
 export function isMiniMaxModernModelId(modelId: string): boolean {
   return matchesExactOrPrefix(modelId, MINIMAX_MODERN_MODEL_MATCHERS);
+}
+
+export function getMiniMaxModelInput(modelId: string): Array<"text" | "image"> {
+  return MINIMAX_VISION_MODEL_IDS.includes(modelId as (typeof MINIMAX_VISION_MODEL_IDS)[number])
+    ? ["text", "image"]
+    : ["text"];
 }


### PR DESCRIPTION
## Summary
- add a shared MiniMax input capability helper and mark `MiniMax-M2.7` as supporting image input
- use the shared helper in both the extension catalog and core provider model definition builder
- add regression tests for `MiniMax-M2.7` and keep `MiniMax-M2.7-highspeed` text-only until MiniMax documents image support

Fixes #54791.

## Testing
- `CI=1 pnpm exec vitest run --reporter=verbose extensions/minimax/model-definitions.test.ts extensions/minimax/provider-catalog.test.ts src/plugins/contracts/discovery.contract.test.ts -t "MiniMax"`