### PR TITLE
fix(matrix): only use 2-member DM fallback when dm refresh fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat/runner: guarantee the interval timer is re-armed after heartbeat runs and unexpected runner errors so scheduled heartbeats do not silently stop after an interrupted cycle. (#52270) Thanks @MiloStack.
 - Config/Doctor: rewrite stale bundled plugin load paths from legacy `extensions/*` locations to the packaged bundled path, including directory-name mismatches and slash-suffixed config entries. (#55054) Thanks @SnowSky1.
 - WhatsApp/mentions: stop treating mentions embedded in quoted messages as direct mentions so replying to a message that @mentioned the bot no longer falsely triggers mention gating. (#52711) Thanks @lurebat.
+- Matrix: keep separate 2-person rooms out of DM routing after `m.direct` seeds successfully, while still honoring explicit `is_direct` state and startup fallback recovery. (#54890) thanks @private-peter
 - Agents/ollama fallback: surface non-2xx Ollama HTTP errors with a leading status code so HTTP 503 responses trigger model fallback again. (#55214) Thanks @bugkill3r.
 - Feishu/tools: stop synthetic agent ids like `agent-spawner` from being treated as Feishu account ids during tool execution, so tools fall back to the configured/default Feishu account unless the contextual id is a real enabled Feishu account. (#55627) Thanks @MonkeyLeeT.
 - Google/tools: strip empty `required: []` arrays from Gemini tool schemas so optional-only tool parameters no longer trigger Google validator 400s. (#52106) Thanks @oliviareid-svg.

--- a/extensions/matrix/src/matrix/direct-room.ts
+++ b/extensions/matrix/src/matrix/direct-room.ts
@@ -45,6 +45,23 @@ export async function readJoinedMatrixMembers(
   }
 }
 
+export async function hasDirectMatrixMemberFlag(
+  client: MatrixClient,
+  roomId: string,
+  userId?: string | null,
+): Promise<boolean> {
+  const normalizedUserId = trimMaybeString(userId);
+  if (!normalizedUserId) {
+    return false;
+  }
+  try {
+    const state = await client.getRoomStateEvent(roomId, "m.room.member", normalizedUserId);
+    return state?.is_direct === true;
+  } catch {
+    return false;
+  }
+}
+
 export async function isStrictDirectRoom(params: {
   client: MatrixClient;
   roomId: string;

--- a/extensions/matrix/src/matrix/monitor/direct.test.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.test.ts
@@ -30,73 +30,6 @@ describe("createDirectRoomTracker", () => {
   });
 
   it("treats m.direct rooms as DMs", async () => {
-    const tracker = createDirectRoomTracker(createMockClient({ isDm: true }));
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(true);
-  });
-
-  it("does not trust stale m.direct classifications for shared rooms", async () => {
-    const tracker = createDirectRoomTracker(
-      createMockClient({
-        isDm: true,
-        members: ["@alice:example.org", "@bot:example.org", "@extra:example.org"],
-      }),
-    );
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(false);
-  });
-
-  it("classifies 2-member rooms as DMs when direct metadata is missing", async () => {
-    const client = createMockClient({ isDm: false });
-    const tracker = createDirectRoomTracker(client);
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(true);
-    expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
-  });
-
-  it("does not classify rooms with extra members as DMs", async () => {
-    const tracker = createDirectRoomTracker(
-      createMockClient({
-        isDm: false,
-        members: ["@alice:example.org", "@bot:example.org", "@observer:example.org"],
-      }),
-    );
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(false);
-  });
-
-  it("does not classify 2-member rooms whose sender is not a joined member as DMs", async () => {
-    const tracker = createDirectRoomTracker(
-      createMockClient({
-        isDm: false,
-        members: ["@mallory:example.org", "@bot:example.org"],
-      }),
-    );
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(false);
-  });
-
-  it("re-checks room membership after invalidation when a DM gains extra members", async () => {
     const client = createMockClient({ isDm: true });
     const tracker = createDirectRoomTracker(client);
 
@@ -107,8 +40,100 @@ describe("createDirectRoomTracker", () => {
       }),
     ).resolves.toBe(true);
 
-    client.__setMembers(["@alice:example.org", "@bot:example.org", "@mallory:example.org"]);
+    expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
+  });
 
+  it("does not trust stale m.direct classifications for shared rooms", async () => {
+    const client = createMockClient({
+      isDm: true,
+      members: ["@alice:example.org", "@bot:example.org", "@extra:example.org"],
+    });
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
+  });
+
+  it("does not classify 2-member rooms as DMs when the dm cache refresh succeeds", async () => {
+    const client = createMockClient({ isDm: false });
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
+  });
+
+  it("falls back to strict 2-member membership when dm cache refresh fails", async () => {
+    const client = createMockClient({ isDm: false });
+    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+
+    expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
+  });
+
+  it("does not classify rooms with extra members as DMs when falling back", async () => {
+    const client = createMockClient({
+      isDm: false,
+      members: ["@alice:example.org", "@bot:example.org", "@observer:example.org"],
+    });
+    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("does not classify 2-member rooms whose sender is not a joined member when falling back", async () => {
+    const client = createMockClient({
+      isDm: false,
+      members: ["@mallory:example.org", "@bot:example.org"],
+    });
+    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("re-checks room membership after invalidation when fallback membership changes", async () => {
+    const client = createMockClient({ isDm: false });
+    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+
+    client.__setMembers(["@alice:example.org", "@bot:example.org", "@mallory:example.org"]);
     tracker.invalidateRoom("!room:example.org");
 
     await expect(
@@ -119,32 +144,9 @@ describe("createDirectRoomTracker", () => {
     ).resolves.toBe(false);
   });
 
-  it("still recognizes exact 2-member rooms when member state also claims is_direct", async () => {
-    const tracker = createDirectRoomTracker(createMockClient({}));
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(true);
-  });
-
-  it("ignores member-state is_direct when the room is not a strict DM", async () => {
-    const tracker = createDirectRoomTracker(
-      createMockClient({
-        members: ["@alice:example.org", "@bot:example.org", "@observer:example.org"],
-      }),
-    );
-    await expect(
-      tracker.isDirectMessage({
-        roomId: "!room:example.org",
-        senderId: "@alice:example.org",
-      }),
-    ).resolves.toBe(false);
-  });
-
   it("bounds joined-room membership cache size", async () => {
     const client = createMockClient({ isDm: false });
+    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
     const tracker = createDirectRoomTracker(client);
 
     for (let i = 0; i <= 1024; i += 1) {

--- a/extensions/matrix/src/matrix/monitor/direct.test.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.test.ts
@@ -2,15 +2,33 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MatrixClient } from "../sdk.js";
 import { createDirectRoomTracker } from "./direct.js";
 
-function createMockClient(params: { isDm?: boolean; members?: string[] }) {
+type MockStateEvents = Record<string, Record<string, unknown>>;
+
+function createMockClient(params: {
+  isDm?: boolean;
+  members?: string[];
+  stateEvents?: MockStateEvents;
+  dmCacheAvailable?: boolean;
+}) {
   let members = params.members ?? ["@alice:example.org", "@bot:example.org"];
+  const stateEvents = params.stateEvents ?? {};
   return {
     dms: {
-      update: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(params.dmCacheAvailable !== false),
       isDm: vi.fn().mockReturnValue(params.isDm === true),
     },
     getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
     getJoinedRoomMembers: vi.fn().mockImplementation(async () => members),
+    getRoomStateEvent: vi
+      .fn()
+      .mockImplementation(async (roomId: string, eventType: string, stateKey = "") => {
+        const key = `${roomId}|${eventType}|${stateKey}`;
+        const state = stateEvents[key];
+        if (state === undefined) {
+          throw new Error(`State event not found: ${key}`);
+        }
+        return state;
+      }),
     __setMembers(next: string[]) {
       members = next;
     },
@@ -20,6 +38,7 @@ function createMockClient(params: { isDm?: boolean; members?: string[] }) {
       isDm: ReturnType<typeof vi.fn>;
     };
     getJoinedRoomMembers: ReturnType<typeof vi.fn>;
+    getRoomStateEvent: ReturnType<typeof vi.fn>;
     __setMembers: (members: string[]) => void;
   };
 }
@@ -61,7 +80,7 @@ describe("createDirectRoomTracker", () => {
   });
 
   it("does not classify 2-member rooms as DMs when the dm cache refresh succeeds", async () => {
-    const client = createMockClient({ isDm: false });
+    const client = createMockClient({ isDm: false, dmCacheAvailable: true });
     const tracker = createDirectRoomTracker(client);
 
     await expect(
@@ -74,9 +93,8 @@ describe("createDirectRoomTracker", () => {
     expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
   });
 
-  it("falls back to strict 2-member membership when dm cache refresh fails", async () => {
-    const client = createMockClient({ isDm: false });
-    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+  it("falls back to strict 2-member membership before m.direct account data is available", async () => {
+    const client = createMockClient({ isDm: false, dmCacheAvailable: false });
     const tracker = createDirectRoomTracker(client);
 
     await expect(
@@ -89,12 +107,84 @@ describe("createDirectRoomTracker", () => {
     expect(client.getJoinedRoomMembers).toHaveBeenCalledWith("!room:example.org");
   });
 
+  it("keeps using the strict 2-member fallback until the dm cache seeds successfully", async () => {
+    const client = createMockClient({ isDm: false, dmCacheAvailable: false });
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+
+    expect(client.dms.update).toHaveBeenCalledTimes(1);
+  });
+
   it("does not classify rooms with extra members as DMs when falling back", async () => {
     const client = createMockClient({
       isDm: false,
       members: ["@alice:example.org", "@bot:example.org", "@observer:example.org"],
+      dmCacheAvailable: false,
     });
-    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    expect(client.getRoomStateEvent).not.toHaveBeenCalled();
+  });
+
+  it("treats sender is_direct member state as a DM signal", async () => {
+    const client = createMockClient({
+      isDm: false,
+      stateEvents: {
+        "!room:example.org|m.room.member|@alice:example.org": { is_direct: true },
+      },
+    });
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("treats self is_direct member state as a DM signal", async () => {
+    const client = createMockClient({
+      isDm: false,
+      stateEvents: {
+        "!room:example.org|m.room.member|@bot:example.org": { is_direct: true },
+      },
+    });
+    const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("does not classify 2-member rooms whose sender is not a joined member when falling back", async () => {
+    const client = createMockClient({
+      isDm: false,
+      members: ["@mallory:example.org", "@bot:example.org"],
+      dmCacheAvailable: false,
+    });
     const tracker = createDirectRoomTracker(client);
 
     await expect(
@@ -105,13 +195,19 @@ describe("createDirectRoomTracker", () => {
     ).resolves.toBe(false);
   });
 
-  it("does not classify 2-member rooms whose sender is not a joined member when falling back", async () => {
-    const client = createMockClient({
-      isDm: false,
-      members: ["@mallory:example.org", "@bot:example.org"],
-    });
-    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+  it("does not re-enable the strict 2-member fallback after the dm cache has seeded", async () => {
+    const client = createMockClient({ isDm: false, dmCacheAvailable: true });
     const tracker = createDirectRoomTracker(client);
+
+    await expect(
+      tracker.isDirectMessage({
+        roomId: "!room:example.org",
+        senderId: "@alice:example.org",
+      }),
+    ).resolves.toBe(false);
+
+    client.dms.update.mockResolvedValue(false);
+    tracker.invalidateRoom("!room:example.org");
 
     await expect(
       tracker.isDirectMessage({
@@ -122,8 +218,7 @@ describe("createDirectRoomTracker", () => {
   });
 
   it("re-checks room membership after invalidation when fallback membership changes", async () => {
-    const client = createMockClient({ isDm: false });
-    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const client = createMockClient({ isDm: false, dmCacheAvailable: false });
     const tracker = createDirectRoomTracker(client);
 
     await expect(
@@ -145,8 +240,7 @@ describe("createDirectRoomTracker", () => {
   });
 
   it("bounds joined-room membership cache size", async () => {
-    const client = createMockClient({ isDm: false });
-    client.dms.update.mockRejectedValue(new Error("dm cache unavailable"));
+    const client = createMockClient({ isDm: false, dmCacheAvailable: false });
     const tracker = createDirectRoomTracker(client);
 
     for (let i = 0; i <= 1024; i += 1) {
@@ -191,5 +285,38 @@ describe("createDirectRoomTracker", () => {
 
     expect(client.dms.update).toHaveBeenCalledTimes(2);
     expect(client.getJoinedRoomMembers).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches member-state direct flag lookups until the ttl expires", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-12T10:00:00Z"));
+    const client = createMockClient({
+      isDm: false,
+      dmCacheAvailable: true,
+      stateEvents: {
+        "!room:example.org|m.room.member|@alice:example.org": { is_direct: true },
+      },
+    });
+    const tracker = createDirectRoomTracker(client);
+
+    await tracker.isDirectMessage({
+      roomId: "!room:example.org",
+      senderId: "@alice:example.org",
+    });
+    await tracker.isDirectMessage({
+      roomId: "!room:example.org",
+      senderId: "@alice:example.org",
+    });
+
+    expect(client.getRoomStateEvent).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-03-12T10:00:31Z"));
+
+    await tracker.isDirectMessage({
+      roomId: "!room:example.org",
+      senderId: "@alice:example.org",
+    });
+
+    expect(client.getRoomStateEvent).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -48,11 +48,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       return;
     }
     lastDmUpdateMs = now;
-    try {
-      await client.dms.update();
-    } catch (err) {
-      log(`matrix: dm cache refresh failed (${String(err)})`);
-    }
+    await client.dms.update();
   };
 
   const resolveJoinedMembers = async (roomId: string): Promise<string[] | null> => {
@@ -82,34 +78,34 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     },
     isDirectMessage: async (params: DirectMessageCheck): Promise<boolean> => {
       const { roomId, senderId } = params;
-      await refreshDmCache();
       const selfUserId = params.selfUserId ?? (await ensureSelfUserId());
       const joinedMembers = await resolveJoinedMembers(roomId);
+      const strictDirectMembership = isStrictDirectMembership({
+        selfUserId,
+        remoteUserId: senderId,
+        joinedMembers,
+      });
+      let refreshFailed = false;
 
-      if (client.dms.isDm(roomId)) {
-        const directViaAccountData = Boolean(
-          isStrictDirectMembership({
-            selfUserId,
-            remoteUserId: senderId,
-            joinedMembers,
-          }),
-        );
-        if (directViaAccountData) {
+      try {
+        await refreshDmCache();
+      } catch (err) {
+        log(`matrix: dm cache refresh failed (${String(err)})`);
+        refreshFailed = true;
+      }
+
+      if (refreshFailed) {
+        if (strictDirectMembership) {
+          log(`matrix: dm detected via exact 2-member room room=${roomId}`);
+          return true;
+        }
+      } else if (client.dms.isDm(roomId)) {
+        if (strictDirectMembership) {
           log(`matrix: dm detected via m.direct room=${roomId}`);
           return true;
         }
         log(`matrix: ignoring stale m.direct classification room=${roomId}`);
-      }
-
-      if (
-        isStrictDirectMembership({
-          selfUserId,
-          remoteUserId: senderId,
-          joinedMembers,
-        })
-      ) {
-        log(`matrix: dm detected via exact 2-member room room=${roomId}`);
-        return true;
+        return false;
       }
 
       log(

--- a/extensions/matrix/src/matrix/monitor/direct.ts
+++ b/extensions/matrix/src/matrix/monitor/direct.ts
@@ -1,4 +1,8 @@
-import { isStrictDirectMembership, readJoinedMatrixMembers } from "../direct-room.js";
+import {
+  hasDirectMatrixMemberFlag,
+  isStrictDirectMembership,
+  readJoinedMatrixMembers,
+} from "../direct-room.js";
 import type { MatrixClient } from "../sdk.js";
 
 type DirectMessageCheck = {
@@ -13,6 +17,7 @@ type DirectRoomTrackerOptions = {
 
 const DM_CACHE_TTL_MS = 30_000;
 const MAX_TRACKED_DM_ROOMS = 1024;
+const MAX_TRACKED_DM_MEMBER_FLAGS = 2048;
 
 function rememberBounded<T>(map: Map<string, T>, key: string, value: T): void {
   map.set(key, value);
@@ -27,8 +32,12 @@ function rememberBounded<T>(map: Map<string, T>, key: string, value: T): void {
 export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTrackerOptions = {}) {
   const log = opts.log ?? (() => {});
   let lastDmUpdateMs = 0;
+  // Once m.direct has seeded successfully, prefer the explicit cache over
+  // re-enabling the broad 2-person fallback after a later transient failure.
+  let hasSeededDmCache = false;
   let cachedSelfUserId: string | null = null;
   const joinedMembersCache = new Map<string, { members: string[]; ts: number }>();
+  const directMemberFlagCache = new Map<string, { isDirect: boolean; ts: number }>();
 
   const ensureSelfUserId = async (): Promise<string | null> => {
     if (cachedSelfUserId) {
@@ -48,7 +57,7 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
       return;
     }
     lastDmUpdateMs = now;
-    await client.dms.update();
+    hasSeededDmCache = (await client.dms.update()) || hasSeededDmCache;
   };
 
   const resolveJoinedMembers = async (roomId: string): Promise<string[] | null> => {
@@ -70,9 +79,33 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
     }
   };
 
+  const resolveDirectMemberFlag = async (
+    roomId: string,
+    userId?: string | null,
+  ): Promise<boolean> => {
+    const normalizedUserId = userId?.trim();
+    if (!normalizedUserId) {
+      return false;
+    }
+    const cacheKey = `${roomId}\n${normalizedUserId}`;
+    const cached = directMemberFlagCache.get(cacheKey);
+    const now = Date.now();
+    if (cached && now - cached.ts < DM_CACHE_TTL_MS) {
+      return cached.isDirect;
+    }
+    const isDirect = await hasDirectMatrixMemberFlag(client, roomId, normalizedUserId);
+    rememberBounded(directMemberFlagCache, cacheKey, { isDirect, ts: now });
+    return isDirect;
+  };
+
   return {
     invalidateRoom: (roomId: string): void => {
       joinedMembersCache.delete(roomId);
+      for (const key of directMemberFlagCache.keys()) {
+        if (key.startsWith(`${roomId}\n`)) {
+          directMemberFlagCache.delete(key);
+        }
+      }
       lastDmUpdateMs = 0;
       log(`matrix: invalidated dm cache room=${roomId}`);
     },
@@ -85,27 +118,36 @@ export function createDirectRoomTracker(client: MatrixClient, opts: DirectRoomTr
         remoteUserId: senderId,
         joinedMembers,
       });
-      let refreshFailed = false;
 
       try {
         await refreshDmCache();
       } catch (err) {
         log(`matrix: dm cache refresh failed (${String(err)})`);
-        refreshFailed = true;
       }
 
-      if (refreshFailed) {
-        if (strictDirectMembership) {
-          log(`matrix: dm detected via exact 2-member room room=${roomId}`);
-          return true;
-        }
-      } else if (client.dms.isDm(roomId)) {
+      if (client.dms.isDm(roomId)) {
         if (strictDirectMembership) {
           log(`matrix: dm detected via m.direct room=${roomId}`);
           return true;
         }
         log(`matrix: ignoring stale m.direct classification room=${roomId}`);
-        return false;
+      }
+
+      if (strictDirectMembership) {
+        const directViaState =
+          (await resolveDirectMemberFlag(roomId, senderId)) ||
+          (await resolveDirectMemberFlag(roomId, selfUserId));
+        if (directViaState) {
+          log(`matrix: dm detected via member state room=${roomId}`);
+          return true;
+        }
+
+        if (!hasSeededDmCache) {
+          log(
+            `matrix: dm detected via exact 2-member fallback before dm cache seed room=${roomId}`,
+          );
+          return true;
+        }
       }
 
       log(

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -195,8 +195,8 @@ export class MatrixClient {
   private stopPersistPromise: Promise<void> | null = null;
 
   readonly dms = {
-    update: async (): Promise<void> => {
-      await this.refreshDmCache();
+    update: async (): Promise<boolean> => {
+      return await this.refreshDmCache();
     },
     isDm: (roomId: string): boolean => this.dmRoomIds.has(roomId),
   };
@@ -1510,11 +1510,11 @@ export class MatrixClient {
     }
   }
 
-  private async refreshDmCache(): Promise<void> {
+  private async refreshDmCache(): Promise<boolean> {
     const direct = await this.getAccountData("m.direct");
     this.dmRoomIds.clear();
     if (!direct || typeof direct !== "object") {
-      return;
+      return false;
     }
     for (const value of Object.values(direct)) {
       if (!Array.isArray(value)) {
@@ -1526,5 +1526,6 @@ export class MatrixClient {
         }
       }
     }
+    return true;
   }
 }


### PR DESCRIPTION
Issue #54772 reports that two separate 2-person Matrix rooms with the same participants can both get routed as DMs. The regression comes from treating strict 2-member membership as a general fallback even when the DM cache is available and says the room is not a DM.

Move the catch from refreshDmCache() into isDirectMessage(). When the refresh succeeds, keep the existing client.dms.isDm(roomId) && isStrictDirectMembership(...) gate so non-DM 2-person rooms stay grouped. Only when the refresh fails do we fall back to the exact 2-member heuristic and keep the warning log.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54772
- Related #54787
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: https://github.com/openclaw/openclaw/commit/94693f7ff0362cdd2096ba44c9380e7fda67f20e#r180612893 added back blind checks for `members.length == 2` so it assumes that any room with only 2 members is a DM. All DMs get collapsed into a single session. Openclaw can't keep context separate or figure out which room to reply to.
- Missing detection / guardrail:
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue was originally fixed here https://github.com/openclaw/openclaw/pull/31023/files#r2991791467
- Why this regressed now: https://github.com/openclaw/openclaw/commit/94693f7ff0362cdd2096ba44c9380e7fda67f20e#r180612893
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Users with multiple matrix rooms will no longer have their conversations duplicated or mis-routed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps to reproduce

1. Create two Matrix rooms each with exactly 2 members (bot + same user)
2. Mark only one as a DM in your Matrix client
3. Send a message in the non-DM room → OpenClaw routes as if it were a DM

### Expected behavior

A 2-person room should only be treated as a DM if it is explicitly marked as one (via m.direct or is_direct member state). Otherwise it should be handled as a regular group room.



### Actual behavior

This causes replies to be routed to both rooms simultaneously, producing duplicate or out-of-context messages.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Verified that with this change that rooms (not DM) get their own session)
- Edge cases checked:
- What you did **not** verify: State where you have no 1:1 / DM matrix channels

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
