### PR TITLE
fix: show file alias paths in tool display

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -38,17 +38,17 @@
     "read": {
       "emoji": "📖",
       "title": "Read",
-      "detailKeys": ["path"]
+      "detailKeys": ["path", "file", "filePath", "file_path"]
     },
     "write": {
       "emoji": "✍️",
       "title": "Write",
-      "detailKeys": ["path"]
+      "detailKeys": ["path", "file", "filePath", "file_path"]
     },
     "edit": {
       "emoji": "📝",
       "title": "Edit",
-      "detailKeys": ["path"]
+      "detailKeys": ["path", "file", "filePath", "file_path"]
     },
     "attach": {
       "emoji": "📎",

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -76,6 +76,36 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("does not warn when read tool uses filePath alias", async () => {
+    const { ctx, warn } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-1b",
+      args: { filePath: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when read tool uses file alias", async () => {
+    const { ctx, warn } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-1c",
+      args: { file: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("warns when read tool has neither path nor file_path", async () => {
     const { ctx, warn } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -12,6 +12,7 @@ import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
+import { resolvePathArg } from "./tool-display-common.js";
 import {
   extractToolResultMediaArtifact,
   extractMessagingToolSend,
@@ -346,14 +347,7 @@ export async function handleToolExecutionStart(
   toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });
 
   if (toolName === "read") {
-    const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-    const filePathValue =
-      typeof record.path === "string"
-        ? record.path
-        : typeof record.file_path === "string"
-          ? record.file_path
-          : "";
-    const filePath = filePathValue.trim();
+    const filePath = resolvePathArg(args) ?? "";
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
       ctx.log.warn(

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -175,7 +175,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
     if (typeof candidate !== "string") {
       continue;
     }

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -56,19 +56,19 @@ describe("tool display details", () => {
     const readDetail = formatToolDetail(
       resolveToolDisplay({
         name: "read",
-        args: { file_path: "/tmp/a.txt", offset: 2, limit: 2 },
+        args: { file: "/tmp/a.txt", offset: 2, limit: 2 },
       }),
     );
     const writeDetail = formatToolDetail(
       resolveToolDisplay({
         name: "write",
-        args: { file_path: "/tmp/a.txt", content: "abc" },
+        args: { filePath: "/tmp/a.txt", content: "abc" },
       }),
     );
     const editDetail = formatToolDetail(
       resolveToolDisplay({
         name: "edit",
-        args: { path: "/tmp/a.txt", newText: "abcd" },
+        args: { file_path: "/tmp/a.txt", newText: "abcd" },
       }),
     );
 


### PR DESCRIPTION
## Summary
- teach tool display path resolution to honor the `file` alias in addition to `path`, `file_path`, and `filePath`
- reuse the shared path resolver for read-tool start validation so warnings stay aligned with display behavior
- cover the alias handling in tool display and embedded subscribe tests

Closes #54882

## Testing
- pnpm exec vitest run src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/agents/tool-display.test.ts