### PR TITLE
fix(discord): publish string-only snowflake arrays in config schema

### DIFF
--- a/extensions/discord/src/config-schema.test.ts
+++ b/extensions/discord/src/config-schema.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { DiscordChannelConfigSchema } from "./config-schema.js";
+
+type JsonSchemaNode = Record<string, unknown>;
+
+function getSchemaNode(path: readonly string[]) {
+  let current: unknown = DiscordChannelConfigSchema.schema;
+  for (const key of path) {
+    current = current && typeof current === "object" ? (current as JsonSchemaNode)[key] : undefined;
+  }
+  return current as JsonSchemaNode | undefined;
+}
+
+describe("DiscordChannelConfigSchema", () => {
+  it("publishes Discord snowflake ID lists as string arrays", () => {
+    const idListPaths = [
+      ["properties", "allowFrom"],
+      ["properties", "dm", "properties", "allowFrom"],
+      ["properties", "dm", "properties", "groupChannels"],
+      ["properties", "execApprovals", "properties", "approvers"],
+      ["properties", "guilds", "additionalProperties", "properties", "users"],
+      ["properties", "guilds", "additionalProperties", "properties", "roles"],
+      [
+        "properties",
+        "guilds",
+        "additionalProperties",
+        "properties",
+        "channels",
+        "additionalProperties",
+        "properties",
+        "users",
+      ],
+      [
+        "properties",
+        "guilds",
+        "additionalProperties",
+        "properties",
+        "channels",
+        "additionalProperties",
+        "properties",
+        "roles",
+      ],
+      ["properties", "accounts", "additionalProperties", "properties", "allowFrom"],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "dm",
+        "properties",
+        "allowFrom",
+      ],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "dm",
+        "properties",
+        "groupChannels",
+      ],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "execApprovals",
+        "properties",
+        "approvers",
+      ],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "guilds",
+        "additionalProperties",
+        "properties",
+        "users",
+      ],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "guilds",
+        "additionalProperties",
+        "properties",
+        "roles",
+      ],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "guilds",
+        "additionalProperties",
+        "properties",
+        "channels",
+        "additionalProperties",
+        "properties",
+        "users",
+      ],
+      [
+        "properties",
+        "accounts",
+        "additionalProperties",
+        "properties",
+        "guilds",
+        "additionalProperties",
+        "properties",
+        "channels",
+        "additionalProperties",
+        "properties",
+        "roles",
+      ],
+    ] as const;
+
+    for (const path of idListPaths) {
+      const node = getSchemaNode(path);
+      expect(node).toMatchObject({
+        type: "array",
+        items: { type: "string" },
+      });
+      expect(getSchemaNode([...path, "items", "anyOf"])).toBeUndefined();
+    }
+  });
+});

--- a/extensions/discord/src/config-schema.ts
+++ b/extensions/discord/src/config-schema.ts
@@ -1,3 +1,63 @@
 import { buildChannelConfigSchema, DiscordConfigSchema } from "./runtime-api.js";
 
-export const DiscordChannelConfigSchema = buildChannelConfigSchema(DiscordConfigSchema);
+type JsonSchemaNode = Record<string, unknown>;
+
+function asSchemaNode(value: unknown): JsonSchemaNode | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonSchemaNode)
+    : undefined;
+}
+
+function getSchemaNode(root: unknown, path: readonly string[]): JsonSchemaNode | undefined {
+  let current = asSchemaNode(root);
+  for (const key of path) {
+    current = asSchemaNode(current?.[key]);
+    if (!current) {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function forceStringArrayItems(schema: JsonSchemaNode | undefined) {
+  if (!schema) {
+    return;
+  }
+  schema.type = "array";
+  schema.items = { type: "string" };
+}
+
+function normalizeDiscordGuildSchema(schema: JsonSchemaNode | undefined) {
+  forceStringArrayItems(getSchemaNode(schema, ["properties", "users"]));
+  forceStringArrayItems(getSchemaNode(schema, ["properties", "roles"]));
+  const channelsSchema = getSchemaNode(schema, ["properties", "channels", "additionalProperties"]);
+  forceStringArrayItems(getSchemaNode(channelsSchema, ["properties", "users"]));
+  forceStringArrayItems(getSchemaNode(channelsSchema, ["properties", "roles"]));
+}
+
+function normalizeDiscordAccountSchema(schema: JsonSchemaNode | undefined) {
+  forceStringArrayItems(getSchemaNode(schema, ["properties", "allowFrom"]));
+  forceStringArrayItems(getSchemaNode(schema, ["properties", "dm", "properties", "allowFrom"]));
+  forceStringArrayItems(getSchemaNode(schema, ["properties", "dm", "properties", "groupChannels"]));
+  forceStringArrayItems(
+    getSchemaNode(schema, ["properties", "execApprovals", "properties", "approvers"]),
+  );
+  normalizeDiscordGuildSchema(
+    getSchemaNode(schema, ["properties", "guilds", "additionalProperties"]),
+  );
+}
+
+function normalizeDiscordChannelConfigSchema(schema: JsonSchemaNode) {
+  normalizeDiscordAccountSchema(schema);
+  normalizeDiscordAccountSchema(
+    getSchemaNode(schema, ["properties", "accounts", "additionalProperties"]),
+  );
+  return schema;
+}
+
+const baseSchema = buildChannelConfigSchema(DiscordConfigSchema);
+
+export const DiscordChannelConfigSchema = {
+  ...baseSchema,
+  schema: normalizeDiscordChannelConfigSchema(baseSchema.schema),
+};

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -9,10 +9,9 @@ import {
   resolveDiscordAccount,
   type ResolvedDiscordAccount,
 } from "./accounts.js";
+import { DiscordChannelConfigSchema } from "./config-schema.js";
 import {
   createScopedChannelConfigAdapter,
-  buildChannelConfigSchema,
-  DiscordConfigSchema,
   getChatChannelMeta,
   type ChannelPlugin,
 } from "./runtime-api.js";
@@ -70,7 +69,7 @@ export function createDiscordPluginBase(params: {
       blockStreamingCoalesceDefaults: { minChars: 1500, idleMs: 1000 },
     },
     reload: { configPrefixes: ["channels.discord"] },
-    configSchema: buildChannelConfigSchema(DiscordConfigSchema),
+    configSchema: DiscordChannelConfigSchema,
     config: {
       ...discordConfigAdapter,
       isConfigured: (account) => Boolean(account.token?.trim()),


### PR DESCRIPTION
## Summary
- normalize the exported Discord channel config schema so Snowflake ID lists are always exposed as string arrays
- keep runtime validation unchanged and only narrow the UI-facing JSON schema that the web config editor consumes
- reuse the normalized schema in the Discord plugin runtime and add regression coverage for top-level and account-level ID list paths

Closes #27775.

## Testing
- CI=1 pnpm exec vitest run extensions/discord/src/config-schema.test.ts src/channels/plugins/config-schema.test.ts src/config/load-channel-config-surface.test.ts