### PR TITLE
fix(delivery-queue): skip stale first-attempt entries during startup recovery

### DIFF
--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -12,6 +12,7 @@ export type RecoverySummary = {
   recovered: number;
   failed: number;
   skippedMaxRetries: number;
+  skippedStale: number;
   deferredBackoff: number;
 };
 
@@ -30,6 +31,16 @@ export interface RecoveryLogger {
 }
 
 const MAX_RETRIES = 5;
+
+/**
+ * Maximum age for a pending delivery entry before it is considered stale.
+ * Applies only to first-attempt entries (retryCount === 0, no lastAttemptAt).
+ * Entries that have already been attempted at least once are legitimate retries
+ * and are not subject to this limit.
+ *
+ * Default: 10 minutes. Set maxEntryAgeMs to 0 in opts to disable.
+ */
+const DEFAULT_MAX_ENTRY_AGE_MS = 10 * 60 * 1_000;
 
 /** Backoff delays in milliseconds indexed by retry count (1-based). */
 const BACKOFF_MS: readonly number[] = [
@@ -58,6 +69,7 @@ function createEmptyRecoverySummary(): RecoverySummary {
     recovered: 0,
     failed: 0,
     skippedMaxRetries: 0,
+    skippedStale: 0,
     deferredBackoff: 0,
   };
 }
@@ -153,6 +165,20 @@ export async function recoverPendingDeliveries(opts: {
   stateDir?: string;
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
   maxRecoveryMs?: number;
+  /**
+   * Maximum age in ms for a first-attempt entry (retryCount === 0, no lastAttemptAt)
+   * before it is considered stale and moved to failed/ rather than replayed.
+   *
+   * This prevents messages enqueued in a prior session from being delivered after a
+   * gateway restart — a confusing user experience when out-of-context messages appear
+   * long after the conversation that generated them.
+   *
+   * Entries with retryCount > 0 are unaffected; they are legitimate retry candidates
+   * for messages that genuinely failed to send (e.g., transient network error).
+   *
+   * Set to 0 to disable staleness checks entirely. Default: 10 minutes.
+   */
+  maxEntryAgeMs?: number;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
@@ -179,6 +205,24 @@ export async function recoverPendingDeliveries(opts: {
       );
       await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
       summary.skippedMaxRetries += 1;
+      continue;
+    }
+
+    // Skip first-attempt entries that are too old. These are typically messages
+    // enqueued during a prior session that were never sent before the gateway
+    // restarted. Replaying them would deliver stale, out-of-context content.
+    // Entries with retryCount > 0 have already been attempted and are legitimate
+    // retry candidates regardless of age.
+    const maxEntryAgeMs =
+      opts.maxEntryAgeMs !== undefined ? opts.maxEntryAgeMs : DEFAULT_MAX_ENTRY_AGE_MS;
+    const isFirstAttempt = entry.retryCount === 0 && entry.lastAttemptAt === undefined;
+    if (maxEntryAgeMs > 0 && isFirstAttempt && now - entry.enqueuedAt > maxEntryAgeMs) {
+      const ageSeconds = Math.round((now - entry.enqueuedAt) / 1_000);
+      opts.log.warn(
+        `Delivery ${entry.id} is stale (${ageSeconds}s old, limit ${maxEntryAgeMs / 1_000}s) — moving to failed/`,
+      );
+      await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
+      summary.skippedStale += 1;
       continue;
     }
 
@@ -215,7 +259,7 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.skippedStale} skipped (stale), ${summary.deferredBackoff} deferred (backoff)`,
   );
   return summary;
 }

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -33,10 +33,12 @@ describe("delivery-queue recovery", () => {
     deliver,
     log = createRecoveryLog(),
     maxRecoveryMs,
+    maxEntryAgeMs,
   }: {
     deliver: ReturnType<typeof vi.fn>;
     log?: ReturnType<typeof createRecoveryLog>;
     maxRecoveryMs?: number;
+    maxEntryAgeMs?: number;
   }) => {
     const result = await recoverPendingDeliveries({
       deliver: asDeliverFn(deliver),
@@ -44,6 +46,7 @@ describe("delivery-queue recovery", () => {
       cfg: baseCfg,
       stateDir: tmpDir(),
       ...(maxRecoveryMs === undefined ? {} : { maxRecoveryMs }),
+      ...(maxEntryAgeMs === undefined ? {} : { maxEntryAgeMs }),
     });
     return { result, log };
   };
@@ -58,6 +61,7 @@ describe("delivery-queue recovery", () => {
       recovered: 2,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 0,
     });
 
@@ -205,6 +209,7 @@ describe("delivery-queue recovery", () => {
       recovered: 0,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 0,
     });
 
@@ -232,6 +237,7 @@ describe("delivery-queue recovery", () => {
       recovered: 0,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 1,
     });
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(1);
@@ -263,6 +269,7 @@ describe("delivery-queue recovery", () => {
       recovered: 1,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 1,
     });
     expect(deliver).toHaveBeenCalledTimes(1);
@@ -292,6 +299,7 @@ describe("delivery-queue recovery", () => {
       recovered: 0,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 1,
     });
     expect(firstDeliver).not.toHaveBeenCalled();
@@ -303,12 +311,76 @@ describe("delivery-queue recovery", () => {
       recovered: 1,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 0,
     });
     expect(secondDeliver).toHaveBeenCalledTimes(1);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
 
     vi.useRealTimers();
+  });
+
+  it("skips first-attempt entries older than maxEntryAgeMs and moves them to failed/", async () => {
+    const staleId = await enqueueDelivery(
+      { channel: "telegram", to: "123", payloads: [{ text: "stale" }] },
+      tmpDir(),
+    );
+    // Backdate the entry to simulate it being enqueued 11 minutes ago
+    setQueuedEntryState(tmpDir(), staleId, {
+      retryCount: 0,
+      enqueuedAt: Date.now() - 11 * 60 * 1_000,
+    });
+
+    const freshId = await enqueueDelivery(
+      { channel: "telegram", to: "123", payloads: [{ text: "fresh" }] },
+      tmpDir(),
+    );
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const { result, log } = await runRecovery({
+      deliver,
+      maxEntryAgeMs: 10 * 60 * 1_000,
+    });
+
+    expect(result).toEqual({
+      recovered: 1,
+      failed: 0,
+      skippedMaxRetries: 0,
+      skippedStale: 1,
+      deferredBackoff: 0,
+    });
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("is stale"));
+
+    // Stale entry should be in failed/, fresh entry should be acked
+    const remaining = await loadPendingDeliveries(tmpDir());
+    expect(remaining).toHaveLength(0);
+    expect(remaining.find((e) => e.id === staleId)).toBeUndefined();
+    expect(remaining.find((e) => e.id === freshId)).toBeUndefined();
+  });
+
+  it("does not skip retried entries even if old (retryCount > 0 bypasses staleness check)", async () => {
+    const id = await enqueueDelivery(
+      { channel: "telegram", to: "123", payloads: [{ text: "retry" }] },
+      tmpDir(),
+    );
+    // Mark as already attempted once, backdate to simulate age
+    setQueuedEntryState(tmpDir(), id, {
+      retryCount: 1,
+      lastAttemptAt: Date.now() - 20 * 60 * 1_000,
+      enqueuedAt: Date.now() - 20 * 60 * 1_000,
+    });
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const { result } = await runRecovery({
+      deliver,
+      maxEntryAgeMs: 10 * 60 * 1_000,
+    });
+
+    // Should recover (not skip as stale) because retryCount > 0
+    expect(result.skippedStale).toBe(0);
+    expect(result.recovered).toBe(1);
+    expect(deliver).toHaveBeenCalledTimes(1);
   });
 
   it("returns zeros when queue is empty", async () => {
@@ -319,6 +391,7 @@ describe("delivery-queue recovery", () => {
       recovered: 0,
       failed: 0,
       skippedMaxRetries: 0,
+      skippedStale: 0,
       deferredBackoff: 0,
     });
     expect(deliver).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

When the gateway restarts, the delivery queue replays pending entries from previous runs. This is the correct behavior for messages that genuinely failed to send (network errors, provider downtime, etc.).

However, messages that were *enqueued but not yet sent* when the gateway stopped — due to an intentional restart or graceful shutdown — are also replayed. These entries have `retryCount === 0` and no `lastAttemptAt`, making them indistinguishable from crash survivors. The result: stale, out-of-context messages delivered to users long after the conversation that generated them.

**Example:** A user session generates 5 outbound messages. The gateway restarts before they're sent. On startup, recovery replays all 5 — delivering content from the previous session into the current one.

## Solution

Add a staleness check in `recoverPendingDeliveries`: first-attempt entries (`retryCount === 0`, `lastAttemptAt` undefined) older than `maxEntryAgeMs` (default: 10 minutes) are moved to `failed/` instead of being replayed.

Entries with `retryCount > 0` are unaffected — they are legitimate retry candidates regardless of age (a message that failed to send should keep retrying).

The check can be disabled by passing `maxEntryAgeMs: 0` to `recoverPendingDeliveries`.

## Changes

- `delivery-queue-recovery.ts`: add `DEFAULT_MAX_ENTRY_AGE_MS`, `skippedStale` field to `RecoverySummary`, `maxEntryAgeMs` opt to `recoverPendingDeliveries`, staleness check in recovery loop
- `delivery-queue.recovery.test.ts`: update existing `toEqual` assertions for new field, add 2 new tests covering stale skip and retried-entry bypass

## Tests

All 13 tests pass (`pnpm exec vitest run src/infra/outbound/delivery-queue.recovery.test.ts`).