### PR TITLE
fix(ui): hint to use #token after query-token auth failures

### DIFF
--- a/ui/src/ui/connect-error.test.ts
+++ b/ui/src/ui/connect-error.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
+import { formatConnectError } from "./connect-error.ts";
+
+function setTestWindowUrl(url: string) {
+  window.history.replaceState({}, "", url);
+}
+
+describe("formatConnectError", () => {
+  beforeEach(() => {
+    setTestWindowUrl("/ui/overview");
+  });
+
+  afterEach(() => {
+    setTestWindowUrl("/ui/overview");
+  });
+
+  it("suggests #token fragment syntax when device identity errors happen with a query token", () => {
+    setTestWindowUrl("/ui/overview?token=query-token");
+
+    const message = formatConnectError({
+      message: "device identity required",
+      details: { code: ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED },
+    });
+
+    expect(message).toContain("device identity required");
+    expect(message).toContain("?token=...");
+    expect(message).toContain("/#token=<token>");
+  });
+
+  it("keeps the standard insecure-auth guidance when the URL already uses a hash token", () => {
+    setTestWindowUrl("/ui/overview#token=hash-token");
+
+    const message = formatConnectError({
+      message: "device identity required",
+      details: { code: ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED },
+    });
+
+    expect(message).toBe(
+      "device identity required (use HTTPS/localhost or allow insecure auth explicitly)",
+    );
+  });
+});

--- a/ui/src/ui/connect-error.ts
+++ b/ui/src/ui/connect-error.ts
@@ -16,9 +16,44 @@ function normalizeErrorMessage(message: unknown): string {
   return "unknown error";
 }
 
+function isDeviceIdentityDetailCode(detailCode: string | null): boolean {
+  return (
+    detailCode === ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED ||
+    detailCode === ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED
+  );
+}
+
+function hasLegacyQueryTokenInUrl(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const url = new URL(window.location.href);
+    const params = new URLSearchParams(url.search);
+    const hashParams = new URLSearchParams(
+      url.hash.startsWith("#") ? url.hash.slice(1) : url.hash,
+    );
+    return params.has("token") && !hashParams.has("token");
+  } catch {
+    return false;
+  }
+}
+
+function formatLegacyQueryTokenHint(detailCode: string | null): string | null {
+  if (!isDeviceIdentityDetailCode(detailCode) || !hasLegacyQueryTokenInUrl()) {
+    return null;
+  }
+  return "device identity required (if your URL uses ?token=..., move it to /#token=<token>)";
+}
+
 function formatErrorFromMessageAndDetails(error: ErrorWithMessageAndDetails): string {
   const message = normalizeErrorMessage(error.message);
   const detailCode = resolveGatewayErrorDetailCode(error);
+  const legacyQueryTokenHint = formatLegacyQueryTokenHint(detailCode);
+
+  if (legacyQueryTokenHint) {
+    return legacyQueryTokenHint;
+  }
 
   switch (detailCode) {
     case ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH:
@@ -31,6 +66,8 @@ function formatErrorFromMessageAndDetails(error: ErrorWithMessageAndDetails): st
       return "gateway pairing required";
     case ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED:
       return "device identity required (use HTTPS/localhost or allow insecure auth explicitly)";
+    case ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED:
+      return "device identity required";
     case ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED:
       return "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)";
     case ConnectErrorDetailCodes.AUTH_TOKEN_MISSING:


### PR DESCRIPTION
Fixes #54842

## Summary
- detect device-identity auth errors when the current dashboard URL still uses `?token=`
- return an explicit `/#token=<token>` hint instead of the generic error text
- add UI tests covering the query-token hint and the existing hash-token path

## Testing
- pnpm --dir ui exec vitest run src/ui/connect-error.test.ts --config vitest.config.ts
- pnpm --dir ui exec vitest run src/ui/controllers/chat.test.ts --config vitest.config.ts --testNamePattern="structured non-auth connect failures for chat abort"