### PR TITLE
fix(ui): avoid rerendering chat thread on draft changes

### DIFF
--- a/ui/src/ui/chat/deleted-messages.ts
+++ b/ui/src/ui/chat/deleted-messages.ts
@@ -5,6 +5,7 @@ const PREFIX = "openclaw:deleted:";
 export class DeletedMessages {
   private key: string;
   private _keys = new Set<string>();
+  private _version = 0;
 
   constructor(sessionKey: string) {
     this.key = PREFIX + sessionKey;
@@ -13,6 +14,10 @@ export class DeletedMessages {
 
   has(key: string): boolean {
     return this._keys.has(key);
+  }
+
+  get version(): number {
+    return this._version;
   }
 
   delete(key: string): void {
@@ -43,6 +48,7 @@ export class DeletedMessages {
     } catch {
       // ignore
     }
+    this.bumpVersion();
   }
 
   private save(): void {
@@ -51,5 +57,10 @@ export class DeletedMessages {
     } catch {
       // ignore
     }
+    this.bumpVersion();
+  }
+
+  private bumpVersion(): void {
+    this._version += 1;
   }
 }

--- a/ui/src/ui/views/chat.thread-cache.test.ts
+++ b/ui/src/ui/views/chat.thread-cache.test.ts
@@ -1,0 +1,114 @@
+/* @vitest-environment jsdom */
+
+import { html, render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionsListResult } from "../types.ts";
+
+const { renderMessageGroupMock } = vi.hoisted(() => ({
+  renderMessageGroupMock: vi.fn(() => html`<div class="mock-message-group"></div>`),
+}));
+
+vi.mock("../chat/grouped-render.ts", () => ({
+  renderMessageGroup: renderMessageGroupMock,
+  renderReadingIndicatorGroup: () => html`<div class="mock-reading-indicator"></div>`,
+  renderStreamingGroup: () => html`<div class="mock-streaming-group"></div>`,
+}));
+
+import { cleanupChatModuleState, renderChat, type ChatProps } from "./chat.ts";
+
+function createSessions(): SessionsListResult {
+  return {
+    ts: 0,
+    path: "",
+    count: 0,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions: [],
+  };
+}
+
+function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
+  return {
+    sessionKey: "main",
+    onSessionKeyChange: () => undefined,
+    thinkingLevel: null,
+    showThinking: false,
+    showToolCalls: true,
+    loading: false,
+    sending: false,
+    canAbort: false,
+    compactionStatus: null,
+    fallbackStatus: null,
+    messages: [],
+    toolMessages: [],
+    streamSegments: [],
+    stream: null,
+    streamStartedAt: null,
+    assistantAvatarUrl: null,
+    draft: "",
+    queue: [],
+    connected: true,
+    canSend: true,
+    disabledReason: null,
+    error: null,
+    sessions: createSessions(),
+    focusMode: false,
+    assistantName: "OpenClaw",
+    assistantAvatar: null,
+    onRefresh: () => undefined,
+    onToggleFocusMode: () => undefined,
+    onDraftChange: () => undefined,
+    onSend: () => undefined,
+    onQueueRemove: () => undefined,
+    onNewSession: () => undefined,
+    agentsList: null,
+    currentAgentId: "",
+    onAgentChange: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("chat thread caching", () => {
+  afterEach(() => {
+    cleanupChatModuleState();
+    renderMessageGroupMock.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("does not rebuild the message thread when only the draft changes", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const baseProps = createProps({
+      messages: [{ id: "m1", role: "assistant", content: "Hello", timestamp: 1 }],
+    });
+
+    render(renderChat(baseProps), container);
+    expect(renderMessageGroupMock).toHaveBeenCalledTimes(1);
+
+    render(renderChat({ ...baseProps, draft: "H" }), container);
+    expect(renderMessageGroupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds the message thread when the message list changes", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const baseProps = createProps({
+      messages: [{ id: "m1", role: "assistant", content: "Hello", timestamp: 1 }],
+    });
+
+    render(renderChat(baseProps), container);
+    const initialCallCount = renderMessageGroupMock.mock.calls.length;
+
+    render(
+      renderChat({
+        ...baseProps,
+        messages: [
+          ...baseProps.messages,
+          { id: "m2", role: "user", content: "Hi", timestamp: 2 },
+        ],
+      }),
+      container,
+    );
+
+    expect(renderMessageGroupMock.mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+});

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import { guard } from "lit/directives/guard.js";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
 import {
@@ -892,108 +893,131 @@ export function renderChat(props: ChatProps) {
     );
   };
 
-  const chatItems = buildChatItems(props);
-  const isEmpty = chatItems.length === 0 && !props.loading;
+  const thread = guard(
+    [
+      props.loading,
+      props.messages,
+      props.toolMessages,
+      props.streamSegments,
+      props.stream,
+      props.streamStartedAt,
+      props.showToolCalls,
+      showReasoning,
+      props.sessionKey,
+      props.assistantName,
+      assistantIdentity.avatar,
+      props.basePath,
+      activeSession?.contextTokens ?? null,
+      props.sessions?.defaults?.contextTokens ?? null,
+      vs.searchOpen,
+      vs.searchQuery,
+      deleted.version,
+    ],
+    () => {
+      const chatItems = buildChatItems(props);
+      const isEmpty = chatItems.length === 0 && !props.loading;
 
-  const thread = html`
-    <div
-      class="chat-thread"
-      role="log"
-      aria-live="polite"
-      @scroll=${props.onChatScroll}
-      @click=${handleCodeBlockCopy}
-    >
-      <div class="chat-thread-inner">
-      ${
-        props.loading
-          ? html`
-              <div class="chat-loading-skeleton" aria-label="Loading chat">
-                <div class="chat-line assistant">
-                  <div class="chat-msg">
-                    <div class="chat-bubble">
-                      <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
-                      <div class="skeleton skeleton-line skeleton-line--medium" style="margin-bottom: 8px"></div>
-                      <div class="skeleton skeleton-line skeleton-line--short"></div>
+      return html`
+        <div
+          class="chat-thread"
+          role="log"
+          aria-live="polite"
+          @scroll=${props.onChatScroll}
+          @click=${handleCodeBlockCopy}
+        >
+          <div class="chat-thread-inner">
+            ${
+              props.loading
+                ? html`
+                    <div class="chat-loading-skeleton" aria-label="Loading chat">
+                      <div class="chat-line assistant">
+                        <div class="chat-msg">
+                          <div class="chat-bubble">
+                            <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
+                            <div class="skeleton skeleton-line skeleton-line--medium" style="margin-bottom: 8px"></div>
+                            <div class="skeleton skeleton-line skeleton-line--short"></div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="chat-line user" style="margin-top: 12px">
+                        <div class="chat-msg">
+                          <div class="chat-bubble">
+                            <div class="skeleton skeleton-line skeleton-line--medium"></div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="chat-line assistant" style="margin-top: 12px">
+                        <div class="chat-msg">
+                          <div class="chat-bubble">
+                            <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
+                            <div class="skeleton skeleton-line skeleton-line--short"></div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                </div>
-                <div class="chat-line user" style="margin-top: 12px">
-                  <div class="chat-msg">
-                    <div class="chat-bubble">
-                      <div class="skeleton skeleton-line skeleton-line--medium"></div>
-                    </div>
-                  </div>
-                </div>
-                <div class="chat-line assistant" style="margin-top: 12px">
-                  <div class="chat-msg">
-                    <div class="chat-bubble">
-                      <div class="skeleton skeleton-line skeleton-line--long" style="margin-bottom: 8px"></div>
-                      <div class="skeleton skeleton-line skeleton-line--short"></div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            `
-          : nothing
-      }
-      ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
-      ${
-        isEmpty && vs.searchOpen
-          ? html`
-              <div class="agent-chat__empty">No matching messages</div>
-            `
-          : nothing
-      }
-      ${repeat(
-        chatItems,
-        (item) => item.key,
-        (item) => {
-          if (item.kind === "divider") {
-            return html`
-              <div class="chat-divider" role="separator" data-ts=${String(item.timestamp)}>
-                <span class="chat-divider__line"></span>
-                <span class="chat-divider__label">${item.label}</span>
-                <span class="chat-divider__line"></span>
-              </div>
-            `;
-          }
-          if (item.kind === "reading-indicator") {
-            return renderReadingIndicatorGroup(assistantIdentity, props.basePath);
-          }
-          if (item.kind === "stream") {
-            return renderStreamingGroup(
-              item.text,
-              item.startedAt,
-              props.onOpenSidebar,
-              assistantIdentity,
-              props.basePath,
-            );
-          }
-          if (item.kind === "group") {
-            if (deleted.has(item.key)) {
-              return nothing;
+                  `
+                : nothing
             }
-            return renderMessageGroup(item, {
-              onOpenSidebar: props.onOpenSidebar,
-              showReasoning,
-              showToolCalls: props.showToolCalls,
-              assistantName: props.assistantName,
-              assistantAvatar: assistantIdentity.avatar,
-              basePath: props.basePath,
-              contextWindow:
-                activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null,
-              onDelete: () => {
-                deleted.delete(item.key);
-                requestUpdate();
+            ${isEmpty && !vs.searchOpen ? renderWelcomeState(props) : nothing}
+            ${
+              isEmpty && vs.searchOpen
+                ? html`
+                    <div class="agent-chat__empty">No matching messages</div>
+                  `
+                : nothing
+            }
+            ${repeat(
+              chatItems,
+              (item) => item.key,
+              (item) => {
+                if (item.kind === "divider") {
+                  return html`
+                    <div class="chat-divider" role="separator" data-ts=${String(item.timestamp)}>
+                      <span class="chat-divider__line"></span>
+                      <span class="chat-divider__label">${item.label}</span>
+                      <span class="chat-divider__line"></span>
+                    </div>
+                  `;
+                }
+                if (item.kind === "reading-indicator") {
+                  return renderReadingIndicatorGroup(assistantIdentity, props.basePath);
+                }
+                if (item.kind === "stream") {
+                  return renderStreamingGroup(
+                    item.text,
+                    item.startedAt,
+                    props.onOpenSidebar,
+                    assistantIdentity,
+                    props.basePath,
+                  );
+                }
+                if (item.kind === "group") {
+                  if (deleted.has(item.key)) {
+                    return nothing;
+                  }
+                  return renderMessageGroup(item, {
+                    onOpenSidebar: props.onOpenSidebar,
+                    showReasoning,
+                    showToolCalls: props.showToolCalls,
+                    assistantName: props.assistantName,
+                    assistantAvatar: assistantIdentity.avatar,
+                    basePath: props.basePath,
+                    contextWindow:
+                      activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null,
+                    onDelete: () => {
+                      deleted.delete(item.key);
+                      requestUpdate();
+                    },
+                  });
+                }
+                return nothing;
               },
-            });
-          }
-          return nothing;
-        },
-      )}
-      </div>
-    </div>
-  `;
+            )}
+          </div>
+        </div>
+      `;
+    },
+  );
 
   const handleKeyDown = (e: KeyboardEvent) => {
     // Slash menu navigation — arg mode


### PR DESCRIPTION
Closes #54874

## Summary
- keep the chat thread behind a Lit `guard()` so draft-only updates do not rebuild the full message tree
- track deleted-message mutations with a lightweight version counter so thread cache invalidates when messages are hidden
- add a regression test that verifies changing the draft does not re-render message groups

## Testing
- pnpm --dir ui exec vitest run src/ui/views/chat.thread-cache.test.ts src/ui/views/chat.test.ts
- pnpm --dir ui exec vitest run src/ui/views/chat.browser.test.ts
- pnpm exec oxlint ui/src/ui/views/chat.ts ui/src/ui/views/chat.thread-cache.test.ts ui/src/ui/chat/deleted-messages.ts
