### PR TITLE
fix(feishu): reject webhook requests on the wrong path

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -81,6 +81,26 @@ function respondText(res: http.ServerResponse, statusCode: number, body: string)
   res.end(body);
 }
 
+function normalizeWebhookPath(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "/";
+  }
+  const withSlash = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  if (withSlash.length > 1 && withSlash.endsWith("/")) {
+    return withSlash.slice(0, -1);
+  }
+  return withSlash;
+}
+
+function resolveRequestPath(req: http.IncomingMessage): string | null {
+  try {
+    return normalizeWebhookPath(new URL(req.url ?? "/", "http://localhost").pathname || "/");
+  } catch {
+    return null;
+  }
+}
+
 export async function monitorWebSocket({
   account,
   accountId,
@@ -148,7 +168,7 @@ export async function monitorWebhook({
   const error = runtime?.error ?? console.error;
 
   const port = account.config.webhookPort ?? 3000;
-  const path = account.config.webhookPath ?? "/feishu/events";
+  const path = normalizeWebhookPath(account.config.webhookPath ?? "/feishu/events");
   const host = account.config.webhookHost ?? "127.0.0.1";
 
   log(`feishu[${accountId}]: starting Webhook server on ${host}:${port}, path ${path}...`);
@@ -159,6 +179,12 @@ export async function monitorWebhook({
     res.on("finish", () => {
       recordWebhookStatus(runtime, accountId, path, res.statusCode);
     });
+
+    const requestPath = resolveRequestPath(req);
+    if (requestPath !== path) {
+      respondText(res, 404, "Not Found");
+      return;
+    }
 
     const rateLimitKey = `${accountId}:${path}:${req.socket.remoteAddress ?? "unknown"}`;
     if (

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -133,6 +133,31 @@ describe("Feishu webhook security hardening", () => {
     );
   });
 
+  it("rejects requests sent to the wrong webhook path before content-type or signature checks", async () => {
+    probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
+    await withRunningWebhookMonitor(
+      {
+        accountId: "wrong-path",
+        path: "/expected-feishu-hook",
+        verificationToken: "verify_token",
+        encryptKey: "encrypt_key",
+      },
+      monitorFeishuProvider,
+      async (url) => {
+        const wrongUrl = new URL(url);
+        wrongUrl.pathname = "/wrong-path";
+        const response = await fetch(wrongUrl, {
+          method: "POST",
+          headers: { "content-type": "text/plain" },
+          body: "{}",
+        });
+
+        expect(response.status).toBe(404);
+        expect(await response.text()).toBe("Not Found");
+      },
+    );
+  });
+
   it("rejects oversized unsigned webhook bodies with 413 before signature verification", async () => {
     probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "bot_open_id" });
     await withRunningWebhookMonitor(


### PR DESCRIPTION
Fixes #54841

## Summary
- normalize the configured Feishu webhook path before serving requests
- reject requests whose incoming pathname does not match the configured webhook path
- add a regression test proving wrong-path requests return 404 before content-type or signature checks

## Testing
- pnpm exec vitest run extensions/feishu/src/monitor.webhook-security.test.ts