### PR TITLE
fix: pin 15 unpinned action(s)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -85,10 +85,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Builder
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -155,7 +155,7 @@ jobs:
       - name: Build and push amd64 image
         id: build
         # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64
@@ -169,7 +169,7 @@ jobs:
       - name: Build and push amd64 slim image
         id: build-slim
         # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/amd64
@@ -202,10 +202,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Builder
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -272,7 +272,7 @@ jobs:
       - name: Build and push arm64 image
         id: build
         # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/arm64
@@ -286,7 +286,7 @@ jobs:
       - name: Build and push arm64 slim image
         id: build-slim
         # WARNING: KEEP THE OFFICIAL DOCKER ACTION HERE; DO NOT SWITCH THIS BACK TO BLACKSMITH BLINDLY.
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           platforms: linux/arm64
@@ -316,7 +316,7 @@ jobs:
           fetch-depth: 0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -90,12 +90,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Builder
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       # Blacksmith can fall back to the local docker driver, which rejects gha
       # cache export/import. Keep smoke builds driver-agnostic.
       - name: Build root Dockerfile smoke image
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
           file: ./Dockerfile
@@ -114,7 +114,7 @@ jobs:
       # runtime deps declared by the plugin and that matrix discovery stays
       # healthy in the final runtime image.
       - name: Build extension Dockerfile smoke image
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: .
           file: ./Dockerfile
@@ -172,7 +172,7 @@ jobs:
           '
 
       - name: Build installer smoke image
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: ./scripts/docker
           file: ./scripts/docker/install-sh-smoke/Dockerfile
@@ -183,7 +183,7 @@ jobs:
 
       - name: Build installer non-root image
         if: github.event_name != 'pull_request'
-        uses: useblacksmith/build-push-action@v2
+        uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
         with:
           context: ./scripts/docker
           file: ./scripts/docker/install-sh-nonroot/Dockerfile

--- a/.github/workflows/sandbox-common-smoke.yml
+++ b/.github/workflows/sandbox-common-smoke.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: false
 
       - name: Set up Docker Builder
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Build minimal sandbox base (USER sandbox)
         shell: bash


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/docker-release.yml` | Pinned 9 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/install-smoke.yml` | Pinned 5 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/sandbox-common-smoke.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/auto-response.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/auto-response.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/auto-response.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-003 | high | `.github/workflows/docker-release.yml` | Filename Injection via Git Diff or File Listing |
| RGS-003 | high | `.github/workflows/docker-release.yml` | Filename Injection via Git Diff or File Listing |
| RGS-018 | high | `.github/workflows/workflow-sanity.yml` | Suspicious Payload Execution Pattern |
| RGS-005 | medium | `.github/workflows/auto-response.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/labeler.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/labeler.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/labeler.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.