### PR TITLE
fix: add actionable remediation hints for memory search embedding errors

### DIFF
--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -52,7 +52,12 @@ export function createMemorySearchTool(options: {
         agentId,
       });
       if (!manager) {
-        return jsonResult({ results: [], disabled: true, error });
+        return jsonResult({
+          results: [],
+          disabled: true,
+          error,
+          hint: resolveMemoryErrorHint(error),
+        });
       }
       try {
         const citationsMode = resolveMemoryCitationsMode(cfg);
@@ -215,4 +220,25 @@ function deriveChatTypeFromSessionKey(sessionKey?: string): "direct" | "group" |
     return "group";
   }
   return "direct";
+}
+
+/**
+ * Return a short, actionable hint for common memory search errors.
+ * Surfaced in the tool result so agents can inform the user.
+ */
+function resolveMemoryErrorHint(error?: string | null): string | undefined {
+  if (!error) {
+    return undefined;
+  }
+  const lower = error.toLowerCase();
+  if (lower.includes("leaked") || lower.includes("reported as leaked")) {
+    return "The embedding API key was flagged as leaked. Generate a new key, update it via `openclaw configure`, and restart the gateway.";
+  }
+  if (lower.includes("quota") || lower.includes("rate limit")) {
+    return "Embedding provider quota exhausted. Try again later or switch provider via `openclaw configure`.";
+  }
+  if (lower.includes("401") || lower.includes("unauthorized")) {
+    return "Embedding API key is invalid or expired. Update it via `openclaw configure`.";
+  }
+  return undefined;
 }

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -231,7 +231,7 @@ function resolveMemoryErrorHint(error?: string | null): string | undefined {
     return undefined;
   }
   const lower = error.toLowerCase();
-  if (lower.includes("leaked") || lower.includes("reported as leaked")) {
+  if (lower.includes("leaked")) {
     return "The embedding API key was flagged as leaked. Generate a new key, update it via `openclaw configure`, and restart the gateway.";
   }
   if (lower.includes("quota") || lower.includes("rate limit")) {

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -38,7 +38,7 @@ function resolveEmbeddingErrorRemediation(
 ): string | null {
   const lower = error.toLowerCase();
 
-  if (lower.includes("leaked") || lower.includes("reported as leaked")) {
+  if (lower.includes("leaked")) {
     const keyEnvHint =
       provider === "gemini" || provider === "google"
         ? "GEMINI_API_KEY"
@@ -60,7 +60,7 @@ function resolveEmbeddingErrorRemediation(
     return "Embedding provider quota exhausted. Wait and retry, or switch provider via: openclaw configure";
   }
 
-  if (lower.includes("401") || lower.includes("unauthorized") || lower.includes("invalid.*key")) {
+  if (lower.includes("401") || lower.includes("unauthorized") || lower.includes("invalid key") || lower.includes("invalid_key")) {
     return "API key is invalid or expired. Update it via: openclaw configure";
   }
 

--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -28,6 +28,45 @@ type MemoryCommandOptions = {
 
 type MemoryManager = NonNullable<MemorySearchManagerResult["manager"]>;
 
+/**
+ * Return an actionable remediation hint for common embedding errors.
+ * Helps users fix broken memory search without reading source code.
+ */
+function resolveEmbeddingErrorRemediation(
+  error: string,
+  provider?: string,
+): string | null {
+  const lower = error.toLowerCase();
+
+  if (lower.includes("leaked") || lower.includes("reported as leaked")) {
+    const keyEnvHint =
+      provider === "gemini" || provider === "google"
+        ? "GEMINI_API_KEY"
+        : provider === "openai"
+          ? "OPENAI_API_KEY"
+          : provider === "voyage"
+            ? "VOYAGE_API_KEY"
+            : null;
+    const lines = [
+      "Your API key was flagged as leaked by the provider.",
+      "1. Generate a new API key from your provider's console.",
+      `2. Update it: openclaw configure (or set ${keyEnvHint ?? "the API key env var"} and restart the gateway).`,
+      "3. Restart the gateway: openclaw gateway restart",
+    ];
+    return lines.join(" ");
+  }
+
+  if (lower.includes("quota") || lower.includes("rate limit") || lower.includes("429")) {
+    return "Embedding provider quota exhausted. Wait and retry, or switch provider via: openclaw configure";
+  }
+
+  if (lower.includes("401") || lower.includes("unauthorized") || lower.includes("invalid.*key")) {
+    return "API key is invalid or expired. Update it via: openclaw configure";
+  }
+
+  return null;
+}
+
 type MemorySourceName = "memory" | "sessions";
 
 type SourceScan = {
@@ -383,6 +422,10 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       lines.push(`${label("Embeddings")} ${colorize(rich, stateColor, state)}`);
       if (embeddingProbe.error) {
         lines.push(`${label("Embeddings error")} ${warn(embeddingProbe.error)}`);
+        const remediation = resolveEmbeddingErrorRemediation(embeddingProbe.error, status.provider);
+        if (remediation) {
+          lines.push(`${label("Fix")} ${info(remediation)}`);
+        }
       }
     }
     if (status.sourceCounts?.length) {


### PR DESCRIPTION
## Summary

When `memory_search` fails due to a leaked, invalid, or quota-exhausted API key, users currently get a raw error message with no guidance on how to fix it. This PR adds actionable remediation hints in two places.

## Changes

### 1. CLI: `openclaw memory status --deep` (`src/cli/memory-cli.ts`)

Adds a `Fix` line below the error with step-by-step recovery instructions:

```
Embeddings: unavailable
Embeddings error: gemini embeddings failed: 403 ... "reported as leaked"
Fix: Your API key was flagged as leaked by the provider. 1. Generate a new API key... 2. Update it: openclaw configure... 3. Restart the gateway: openclaw gateway restart
```

### 2. Tool result: `memory_search` (`src/agents/tools/memory-tool.ts`)

Adds a `hint` field to the JSON result when memory search is disabled, so agents can surface actionable guidance to users:

```json
{
  "results": [],
  "disabled": true,
  "error": "gemini embeddings failed: 403 ...",
  "hint": "The embedding API key was flagged as leaked. Generate a new key, update it via `openclaw configure`, and restart the gateway."
}
```

### Covered error patterns

| Pattern | Hint |
|---------|------|
| `leaked` / `reported as leaked` | Generate new key + `openclaw configure` + restart gateway |
| `quota` / `rate limit` / `429` | Wait and retry, or switch provider |
| `401` / `unauthorized` | Key invalid/expired, update via `openclaw configure` |

## Motivation

We run OpenClaw 24/7 for quantitative research. Our Gemini API key was flagged as leaked by Google's automated scanner, which silently broke `memory_search` for weeks. The fix required reading OpenClaw source code to find the stale key in `auth-profiles.json` — this PR ensures future users get clear, actionable guidance instead.

Closes #54912