### PR TITLE
fix: use normalizeUsage in buildAssistantMessageFromResponse for DashScope compatibility

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -50,6 +50,7 @@ import {
   buildUsageWithNoCost,
   buildStreamErrorAssistantMessage,
 } from "./stream-message-shared.js";
+import { normalizeUsage } from "./usage.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-session state
@@ -580,14 +581,17 @@ export function buildAssistantMessageFromResponse(
   const hasToolCalls = content.some((c) => c.type === "toolCall");
   const stopReason: StopReason = hasToolCalls ? "toolUse" : "stop";
 
+  const normalized = normalizeUsage(response.usage);
   const message = buildAssistantMessage({
     model: modelInfo,
     content,
     stopReason,
     usage: buildUsageWithNoCost({
-      input: response.usage?.input_tokens ?? 0,
-      output: response.usage?.output_tokens ?? 0,
-      totalTokens: response.usage?.total_tokens ?? 0,
+      input: normalized?.input ?? 0,
+      output: normalized?.output ?? 0,
+      cacheRead: normalized?.cacheRead,
+      cacheWrite: normalized?.cacheWrite,
+      totalTokens: normalized?.total ?? 0,
     }),
   });
 


### PR DESCRIPTION
Fixes #54859

## Problem
DashScope provider (and other OpenAI-compatible APIs) returns `prompt_tokens` and `completion_tokens` in usage data, but `buildAssistantMessageFromResponse` directly accesses `input_tokens` and `output_tokens`, resulting in all usage metrics being recorded as zero.

## Fix
Use the existing `normalizeUsage` function which already handles all field name variations (`prompt_tokens`, `input_tokens`, `completion_tokens`, `output_tokens`, etc.) instead of directly accessing specific field names.

## Impact
- Fixes cost tracking for DashScope and other OpenAI-compatible providers
- No behavior change for providers that already use `input_tokens`/`output_tokens`