### PR TITLE
fix: include all file parameter aliases in tool display resolution

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -38,17 +38,17 @@
     "read": {
       "emoji": "📖",
       "title": "Read",
-      "detailKeys": ["path"]
+      "detailKeys": ["path", "file", "filePath", "file_path"]
     },
     "write": {
       "emoji": "✍️",
       "title": "Write",
-      "detailKeys": ["path"]
+      "detailKeys": ["path", "file", "filePath", "file_path"]
     },
     "edit": {
       "emoji": "📝",
       "title": "Edit",
-      "detailKeys": ["path"]
+      "detailKeys": ["path", "file", "filePath", "file_path"]
     },
     "attach": {
       "emoji": "📎",

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -352,7 +352,11 @@ export async function handleToolExecutionStart(
         ? record.path
         : typeof record.file_path === "string"
           ? record.file_path
-          : "";
+          : typeof record.filePath === "string"
+            ? record.filePath
+            : typeof record.file === "string"
+              ? record.file
+              : "";
     const filePath = filePathValue.trim();
     if (!filePath) {
       const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -175,7 +175,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
     if (typeof candidate !== "string") {
       continue;
     }


### PR DESCRIPTION
Fixes #54882

## Problem
When models use the `file` parameter alias (instead of `path`, `file_path`, or `filePath`) for Read/Write/Edit tools, the verbose tool display shows only the emoji + label without the file path.

## Fix
Three changes:
1. `resolvePathArg()` — added `record.file` to candidates
2. `handleToolExecutionStart()` — added `record.filePath` and `record.file` fallbacks
3. `tool-display.json` — added all aliases to `detailKeys` for read/write/edit

## Impact
All 4 parameter aliases now produce consistent verbose display with file path.