### PR TITLE
fix: flush draft stream before reading messageId to prevent double Slack messages

### DIFF
--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -340,6 +340,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
       const reply = resolveSendableOutboundReplyParts(payload);
       const slackBlocks = readSlackReplyBlocks(payload);
+      // Flush pending draft so messageId is available — prevents double messages
+      // when the LLM finishes before the throttle fires (#54857)
+      if (hasStreamedMessage && draftStream && !draftStream.messageId()) await draftStream.flush();
       const draftMessageId = draftStream?.messageId();
       const draftChannelId = draftStream?.channelId();
       const finalText = reply.text;


### PR DESCRIPTION
Fixes #54857

## Problem
Fast LLM responses complete before the Slack stream throttle (1000ms) fires. `deliver()` reads `draftMessageId` as `undefined`, falls through to `deliverNormally()`, and posts a duplicate message.

## Fix
Flush the pending draft synchronously before reading `draftMessageId`:
```js
if (hasStreamedMessage && draftStream && !draftStream.messageId()) await draftStream.flush();
const draftMessageId = draftStream?.messageId();
```

## Impact
Eliminates double messages in Slack for fast/short responses. No change for longer responses where throttle already fires before delivery.