### PR TITLE
fix: include --fix-missing in doctor cleanup preview suggestion

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -172,7 +172,9 @@ describe("doctor state integrity oauth dir checks", () => {
     const text = await runStateIntegrityText(cfg);
     expect(text).toContain("recent sessions are missing transcripts");
     expect(text).toMatch(/openclaw sessions --store ".*sessions\.json"/);
-    expect(text).toMatch(/openclaw sessions cleanup --store ".*sessions\.json" --dry-run/);
+    expect(text).toMatch(
+      /openclaw sessions cleanup --store ".*sessions\.json" --dry-run --fix-missing/,
+    );
     expect(text).toMatch(
       /openclaw sessions cleanup --store ".*sessions\.json" --enforce --fix-missing/,
     );

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -731,7 +731,7 @@ export async function noteStateIntegrity(
         [
           `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
           `  Verify sessions in store: ${formatCliCommand(`openclaw sessions --store "${absoluteStorePath}"`)}`,
-          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --dry-run`)}`,
+          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --dry-run --fix-missing`)}`,
           `  Prune missing entries: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --enforce --fix-missing`)}`,
         ].join("\n"),
       );


### PR DESCRIPTION
Fixes #54877

## Problem
`openclaw doctor` suggests a preview command without `--fix-missing`, so `sessions cleanup --dry-run` reports 0 missing transcripts even when they exist.

## Fix
Added `--fix-missing` to the doctor's suggested preview command so the dry-run actually counts missing transcripts.

## Impact
Doctor preview command now correctly shows missing transcript count, matching the doctor's own warning.