### PR TITLE
fix: include channel in Control UI exec approval resolve for multi-channel setups

### DIFF
--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -139,6 +139,7 @@ export const ExecApprovalResolveParamsSchema = Type.Object(
   {
     id: NonEmptyString,
     decision: NonEmptyString,
+    channel: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -286,7 +286,7 @@ export function createExecApprovalHandlers(
         );
         return;
       }
-      const p = params as { id: string; decision: string };
+      const p = params as { id: string; decision: string; channel?: string };
       const decision = p.decision as ExecApprovalDecision;
       if (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny") {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "invalid decision"));
@@ -326,9 +326,17 @@ export function createExecApprovalHandlers(
         );
         return;
       }
+      const resolvedChannel = typeof p.channel === "string" ? p.channel.trim() || null : null;
       context.broadcast(
         "exec.approval.resolved",
-        { id: approvalId, decision, resolvedBy, ts: Date.now(), request: snapshot?.request },
+        {
+          id: approvalId,
+          decision,
+          resolvedBy,
+          resolvedChannel,
+          ts: Date.now(),
+          request: snapshot?.request,
+        },
         { dropIfSlow: true },
       );
       void opts?.forwarder

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -693,6 +693,7 @@ export class OpenClawApp extends LitElement {
       await this.client.request("exec.approval.resolve", {
         id: active.id,
         decision,
+        channel: "control",
       });
       this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
     } catch (err) {


### PR DESCRIPTION
Fixes #54855

## Problem
Control UI sends `exec.approval.resolve` with only `{id, decision}` — no `channel` field. In multi-channel setups, the gateway rejects this with 'Channel is required'.

## Fix
1. Added optional `channel` field to `ExecApprovalResolveParamsSchema`
2. Control UI now sends `channel: 'control'` in approval resolve requests
3. Gateway passes `resolvedChannel` in the broadcast

## Impact
Exec approvals from Control UI now work correctly in multi-channel setups.