### PR TITLE
Feishu: reject empty message cards

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -375,6 +375,44 @@ describe("feishuPlugin actions", () => {
     expect(result?.details).toMatchObject({ ok: true, messageId: "om_card", chatId: "oc_group_1" });
   });
 
+  it("rejects empty card-only sends with a clear error", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: { to: "chat:oc_group_1", card: {} },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+      } as never),
+    ).rejects.toThrow("Feishu send card payload cannot be empty.");
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to text when an empty card accompanies message text", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", message: "hello", card: {} },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: "hello",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+    expect(result?.details).toMatchObject({ ok: true, messageId: "om_sent", chatId: "oc_group_1" });
+  });
+
   it("allows structured card button payloads", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
     const card = {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -61,6 +61,7 @@ import { listFeishuDirectoryPeers, listFeishuDirectoryGroups } from "./directory
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { collectFeishuSecurityAuditFindings } from "./security-audit.js";
+import { hasFeishuCardPayload } from "./send.js";
 import {
   resolveFeishuParentConversationCandidates,
   resolveFeishuSessionConversation,
@@ -664,16 +665,18 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
-            const card =
-              ctx.params.card && typeof ctx.params.card === "object"
-                ? (ctx.params.card as Record<string, unknown>)
-                : undefined;
+            const rawCard = ctx.params.card;
+            const cardProvided = rawCard != null && typeof rawCard === "object";
+            const card = hasFeishuCardPayload(rawCard) ? rawCard : undefined;
             const text = readFirstString(ctx.params, ["text", "message"]);
             const mediaUrl = readFeishuMediaParam(ctx.params);
             if (card && mediaUrl) {
               throw new Error(`Feishu ${ctx.action} does not support card with media.`);
             }
             if (!card && !text && !mediaUrl) {
+              if (cardProvided) {
+                throw new Error(`Feishu ${ctx.action} card payload cannot be empty.`);
+              }
               throw new Error(`Feishu ${ctx.action} requires text/message, media, or card.`);
             }
             const runtime = await loadFeishuChannelRuntime();

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -266,4 +266,17 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
 
     expect(createMock).not.toHaveBeenCalled();
   });
+
+  it("rejects empty card payloads before calling Feishu APIs", async () => {
+    await expect(
+      sendCardFeishu({
+        cfg: {} as never,
+        to: "user:ou_target",
+        card: {},
+      }),
+    ).rejects.toThrow("Feishu card payload cannot be empty.");
+
+    expect(replyMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -57,6 +57,7 @@ let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
+let sendCardFeishu: typeof import("./send.js").sendCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
 
 describe("getMessageFeishu", () => {
@@ -67,6 +68,7 @@ describe("getMessageFeishu", () => {
       getMessageFeishu,
       listFeishuThreadMessages,
       resolveFeishuCardTemplate,
+      sendCardFeishu,
       sendMessageFeishu,
     } = await import("./send.js"));
   });
@@ -393,6 +395,40 @@ describe("editMessageFeishu", () => {
       },
     });
     expect(result).toEqual({ messageId: "om_card", contentType: "interactive" });
+  });
+
+  it("rejects empty card edits before patching", async () => {
+    await expect(
+      editMessageFeishu({
+        cfg: {} as ClawdbotConfig,
+        messageId: "om_card",
+        card: {},
+      }),
+    ).rejects.toThrow("Feishu edit card payload cannot be empty.");
+
+    expect(mockClientPatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendCardFeishu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveFeishuAccount.mockReturnValue({
+      accountId: "default",
+      configured: true,
+    });
+  });
+
+  it("rejects empty cards before resolving the Feishu target", async () => {
+    await expect(
+      sendCardFeishu({
+        cfg: {} as ClawdbotConfig,
+        to: "chat:oc_group_1",
+        card: {},
+      }),
+    ).rejects.toThrow("Feishu card payload cannot be empty.");
+
+    expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -28,6 +28,15 @@ const FEISHU_CARD_TEMPLATES = new Set([
   "lime",
 ]);
 
+export function hasFeishuCardPayload(card: unknown): card is Record<string, unknown> {
+  return (
+    typeof card === "object" &&
+    card !== null &&
+    !Array.isArray(card) &&
+    Object.keys(card).length > 0
+  );
+}
+
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
     return true;
@@ -485,6 +494,9 @@ export type SendFeishuCardParams = {
 
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
   const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
+  if (!hasFeishuCardPayload(card)) {
+    throw new Error("Feishu card payload cannot be empty.");
+  }
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
@@ -514,7 +526,11 @@ export async function editMessageFeishu(params: {
   }
 
   const hasText = typeof text === "string" && text.trim().length > 0;
-  const hasCard = Boolean(card);
+  const cardProvided = card !== undefined;
+  const hasCard = hasFeishuCardPayload(card);
+  if (cardProvided && !hasCard) {
+    throw new Error("Feishu edit card payload cannot be empty.");
+  }
   if (hasText === hasCard) {
     throw new Error("Feishu edit requires exactly one of text or card.");
   }


### PR DESCRIPTION
## Summary

- Problem: Feishu message actions treated `card: {}` as a valid card-only payload, then forwarded it to Feishu and triggered a 400 API error.
- Why it matters: proactive Feishu sends can fail when the model emits an empty card object, especially in cron/reporting flows.
- What changed: reject empty Feishu card payloads at the channel action/runtime send layers, and fall back to plain-text sends when `message` is present alongside an empty card.
- What did NOT change (scope boundary): card-only sends remain supported for non-empty card payloads, and other channels/plugins were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54430
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Feishu `send`/`thread-reply` handling only checked `typeof card === "object"` / `Boolean(card)`, so an empty object passed validation as a card payload.
- Missing detection / guardrail: tests covered non-empty card sends but did not lock in behavior for `card: {}` or direct `sendCardFeishu({ card: {} })`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the message action path tolerated structurally empty card objects instead of validating that the payload contained card content.
- If unknown, what was ruled out: ruled out Feishu API-side formatting issues by tracing the failure to local validation and dispatch before the API request.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/channel.test.ts`, `extensions/feishu/src/send.reply-fallback.test.ts`, `extensions/feishu/src/send.test.ts`
- Scenario the test should lock in: empty card-only sends are rejected, empty card + text falls back to text, and direct Feishu send/edit helpers also reject empty cards.
- Why this is the smallest reliable guardrail: the regression is pure input validation/dispatch logic and does not require a live Feishu API call to verify.
- Existing test that already covers this (if any): existing Feishu tests only covered non-empty card sends.
- If no new test is added, why not:

## User-visible / Behavior Changes

- Feishu `message` tool calls with `card: {}` now fail fast with a clear local error instead of sending a bad request to Feishu.
- When text is present alongside an empty card, OpenClaw sends the text message instead of attempting a broken card send.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): Feishu channel enabled

### Steps

1. Invoke the Feishu message tool with `action=send`, `channel=feishu`, and `card={}`.
2. Observe the local validation / dispatch behavior.
3. Repeat with both `message` text and `card={}`.

### Expected

- Empty card-only payloads should be rejected locally.
- Empty card + text should still send the text payload.

### Actual

- Before this change, `{}` was treated as a valid card and produced a Feishu 400 error.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test -- extensions/feishu/src/channel.test.ts extensions/feishu/src/send.reply-fallback.test.ts extensions/feishu/src/send.test.ts`; all passed with the new empty-card cases.
- Edge cases checked: empty card-only payload, empty card plus text fallback, direct `sendCardFeishu`, and `editMessageFeishu`.
- What you did **not** verify: live Feishu API behavior beyond the mocked unit tests.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `extensions/feishu/src/channel.ts`, `extensions/feishu/src/send.ts`
- Known bad symptoms reviewers should watch for: legitimate non-empty Feishu cards being rejected, or text fallback not triggering when both `message` and empty `card` are present.

## Risks and Mitigations

- Risk: the new guard could reject malformed-but-previously-tolerated payloads that some custom caller relied on.
  - Mitigation: the change is limited to truly empty objects/arrays/null-ish cards; non-empty card-only sends are still covered by existing tests plus the new guardrail cases.
