### PR TITLE
fix: show file alias in tool display summaries

### DIFF
--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -175,7 +175,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
     if (typeof candidate !== "string") {
       continue;
     }

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -77,6 +77,31 @@ describe("tool display details", () => {
     expect(editDetail).toBe("in /tmp/a.txt (4 chars)");
   });
 
+  it("formats read/write/edit when file alias is used", () => {
+    const readDetail = formatToolDetail(
+      resolveToolDisplay({
+        name: "read",
+        args: { file: "/tmp/b.txt", offset: 4, limit: 1 },
+      }),
+    );
+    const writeDetail = formatToolDetail(
+      resolveToolDisplay({
+        name: "write",
+        args: { file: "/tmp/b.txt", content: "abcd" },
+      }),
+    );
+    const editDetail = formatToolDetail(
+      resolveToolDisplay({
+        name: "edit",
+        args: { file: "/tmp/b.txt", newText: "abcde" },
+      }),
+    );
+
+    expect(readDetail).toBe("line 4-4 from /tmp/b.txt");
+    expect(writeDetail).toBe("to /tmp/b.txt (4 chars)");
+    expect(editDetail).toBe("in /tmp/b.txt (5 chars)");
+  });
+
   it("formats web_search query with quotes", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({


### PR DESCRIPTION
## Summary\n- include the supported `file` alias when resolving tool display path details\n- add a regression test covering read/write/edit summaries that use `file`\n\n## Testing\n- attempted: `pnpm test -- src/agents/tool-display.test.ts` *(blocked in this environment because the temp checkout had no `node_modules`, and `pnpm install` hit npm registry DNS `EAI_AGAIN` failures)*\n\nCloses #54882