### PR TITLE
fix(telegram): add 'callback_data:' prefix to inline button callbacks

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1567,7 +1567,7 @@ export const registerTelegramHandlers = ({
       const syntheticMessage = buildSyntheticTextMessage({
         base: withResolvedTelegramForumFlag(callbackMessage, isForum),
         from: callback.from,
-        text: data,
+        text: `callback_data: ${data}`,
       });
       await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
         forceWasMentioned: true,


### PR DESCRIPTION
# Fix Telegram inline button callback routing

Fixes #54909

## Problem

Telegram inline button callbacks were not triggering agent tool calls as documented.

**Expected behavior:**
1. User presses inline button with `callback_data: "accept_BK-TEST-006"`
2. Agent receives message: `"callback_data: accept_BK-TEST-006"`
3. SKILL.md instruction: "When you receive callback containing 'accept_', use http tool..."
4. Agent calls http tool → webhook receives POST

**Actual behavior:**
1. User presses button
2. Agent receives message: `"accept_BK-TEST-006"` (missing prefix!)
3. SKILL.md pattern doesn't match (no "callback" keyword)
4. Agent hallucinates confirmation instead of calling tool
5. No API call made (silent failure)

## Root Cause

The callback fallback handler (line 1560) forwarded raw callback data to the agent:

```typescript
const syntheticMessage = buildSyntheticTextMessage({
  text: data,  // ❌ Raw: "accept_BK-TEST-006"
});
```

But documentation and SKILL.md examples expect the prefixed format:

```
callback_data: accept_BK-TEST-006
```

## Solution

Add `callback_data:` prefix when forwarding callbacks to agent:

```typescript
const syntheticMessage = buildSyntheticTextMessage({
  text: `callback_data: ${data}`,  // ✅ Prefixed format
});
```

## Testing

Tested with reproduction case from issue #54909:

**Setup:**
- Agent: `tuition`
- Model: `ollama_pro/nemotron-3-super:cloud`
- Tools: `["http"]`
- Capabilities: `inlineButtons: "all"`
- SKILL.md: "When you receive callback containing 'accept_', use http tool to POST http://127.0.0.1:5010/api/accept"

**Test:**
1. Send message with inline button (callback_data: "accept_BK-TEST-006")
2. User presses ✅ Accept button
3. Agent receives: "callback_data: accept_BK-TEST-006"
4. Agent recognizes pattern from SKILL.md
5. Agent calls http tool with POST to webhook
6. Webhook receives request ✅

## Impact

- ✅ Unblocks Telegram inline button workflows
- ✅ Matches documented behavior
- ✅ No breaking changes (only adds prefix to already-broken functionality)
- ✅ Affects only generic callbacks (not exec approvals, plugin handlers, or model selection)

## Related

- Issue #54909 (6 failed attempts reproduced)
- Documentation already describes this format correctly
- Implementation just needed to match docs
