### PR TITLE
fix: use configured default when subagent runTimeoutSeconds is omitted

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -834,7 +834,7 @@ function resolveSubagentWaitTimeoutMs(
   cfg: ReturnType<typeof loadConfig>,
   runTimeoutSeconds?: number,
 ) {
-  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds ?? 0 });
+  return resolveAgentTimeoutMs({ cfg, overrideSeconds: runTimeoutSeconds });
 }
 
 function startSweeper() {
@@ -1344,7 +1344,7 @@ export function replaceSubagentRunAfterSteer(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const preserveFrozenResultFallback = params.preserveFrozenResultFallback === true;
   const sessionStartedAt = resolveSubagentSessionStartedAt(source) ?? now;
@@ -1421,7 +1421,7 @@ export function registerSubagentRun(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   subagentRuns.set(params.runId, {


### PR DESCRIPTION
## Summary

When spawning a subagent without an explicit `runTimeoutSeconds`, the fallback chain resolved to `0`, which the timeout resolver interprets as "disable timeout" (infinite). The configured default at `agents.defaults.subagents.runTimeoutSeconds` was never applied.

## Changes

- Remove `?? 0` fallback in `resolveSubagentWaitTimeoutMs()` so `undefined` flows through to `resolveAgentTimeoutMs()`, which correctly falls back to the configured default.
- Also remove `?? 0` in the two call sites that pass `runTimeoutSeconds` to this function, ensuring `undefined` propagates correctly.

## Testing

- Existing test suite passes
- The resolver now correctly uses `agents.defaults.subagents.runTimeoutSeconds` when no explicit timeout is provided

Fixes openclaw/openclaw#54936