### PR TITLE
fix: invalidate stale skillsSnapshot on gateway restart

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -905,8 +905,10 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot ||
+      (sessionEntry?.skillsSnapshot?.snapshotVersion !== undefined &&
+       sessionEntry.skillsSnapshot.snapshotVersion < skillsSnapshotVersion);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {


### PR DESCRIPTION
## Summary

The `skillsSnapshot` cached in `sessions.json` was never invalidated on gateway restart because the staleness check only looked at whether a snapshot existed, not whether it was outdated.

## Changes

- Moved `skillsSnapshotVersion` computation before the `needsSkillsSnapshot` check
- Compare the cached `snapshotVersion` against the current `getSkillsSnapshotVersion()` to detect stale snapshots and rebuild them

## Testing

- Adding a new skill and restarting now correctly picks up the new skill in existing sessions.

Fixes openclaw/openclaw#54938