### PR TITLE
fix(plugins): prevent schema load from re-activating plugin registry

### DIFF
--- a/src/config/runtime-schema.test.ts
+++ b/src/config/runtime-schema.test.ts
@@ -211,4 +211,21 @@ describe("loadGatewayRuntimeConfigSchema", () => {
     expect(channelProps?.telegram).toBeTruthy();
     expect(channelProps?.matrix).toBeTruthy();
   });
+
+  it('calls loadPluginManifestRegistry with cache:false on every invocation (regression guard for #54816)', async () => {
+    // Each MCP connection triggers a config.schema / config.get gateway request which calls
+    // loadGatewayRuntimeConfigSchema. The original bug caused a fresh full plugin registry to
+    // be activated on every call, re-running registerFull for all channel plugins including
+    // Feishu. Verify that repeated calls always pass cache:false so the manifest registry
+    // path is used and no activation state accumulates between calls.
+    const { loadGatewayRuntimeConfigSchema } = await import('./runtime-schema.js');
+    loadGatewayRuntimeConfigSchema();
+    loadGatewayRuntimeConfigSchema();
+    loadGatewayRuntimeConfigSchema();
+
+    expect(mockLoadPluginManifestRegistry).toHaveBeenCalledTimes(3);
+    for (const call of mockLoadPluginManifestRegistry.mock.calls) {
+      expect(call[0]).toMatchObject({ cache: false });
+    }
+  });
 });

--- a/src/config/runtime-schema.test.ts
+++ b/src/config/runtime-schema.test.ts
@@ -1,4 +1,12 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryKey,
+  getActivePluginRegistryVersion,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "./types.js";
 
 const mockLoadConfig = vi.hoisted(() => vi.fn<() => OpenClawConfig>());
@@ -144,6 +152,10 @@ beforeAll(async () => {
     await import("./runtime-schema.js"));
 });
 
+afterEach(() => {
+  resetPluginRuntimeStateForTest();
+});
+
 describe("readBestEffortRuntimeConfigSchema", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -212,13 +224,16 @@ describe("loadGatewayRuntimeConfigSchema", () => {
     expect(channelProps?.matrix).toBeTruthy();
   });
 
-  it('calls loadPluginManifestRegistry with cache:false on every invocation (regression guard for #54816)', async () => {
+  it("does not activate or replace the active plugin registry across repeated schema loads (regression guard for #54816)", () => {
     // Each MCP connection triggers a config.schema / config.get gateway request which calls
     // loadGatewayRuntimeConfigSchema. The original bug caused a fresh full plugin registry to
     // be activated on every call, re-running registerFull for all channel plugins including
-    // Feishu. Verify that repeated calls always pass cache:false so the manifest registry
-    // path is used and no activation state accumulates between calls.
-    const { loadGatewayRuntimeConfigSchema } = await import('./runtime-schema.js');
+    // Feishu. Verify that repeated calls keep using manifest metadata without replacing the
+    // already-active runtime registry or mutating its activation version.
+    const activeRegistry = createEmptyPluginRegistry();
+    setActivePluginRegistry(activeRegistry, "startup-registry");
+    const versionBefore = getActivePluginRegistryVersion();
+
     loadGatewayRuntimeConfigSchema();
     loadGatewayRuntimeConfigSchema();
     loadGatewayRuntimeConfigSchema();
@@ -227,5 +242,8 @@ describe("loadGatewayRuntimeConfigSchema", () => {
     for (const call of mockLoadPluginManifestRegistry.mock.calls) {
       expect(call[0]).toMatchObject({ cache: false });
     }
+    expect(getActivePluginRegistry()).toBe(activeRegistry);
+    expect(getActivePluginRegistryKey()).toBe("startup-registry");
+    expect(getActivePluginRegistryVersion()).toBe(versionBefore);
   });
 });


### PR DESCRIPTION
Fixes #54816

## Root Cause

`loadGatewayRuntimeConfigSchema` called `loadPluginSchemaRegistry` with `activate: true` (the default) and `cache: true`. This produced a cache key **different** from the gateway startup load because it omits the `onlyPluginIds` scope filter used by `loadGatewayPlugins`.

As a result, every `config.schema` / `config.get` gateway request (triggered on each browser MCP connection) caused a fresh full plugin registry to be created and activated — re-running `registerFull` for every channel plugin, including Feishu. This produced duplicate tool entries and log pollution proportional to the number of MCP connections.

## Fix

The upstream refactor replaced `loadPluginSchemaRegistry` with `loadPluginManifestRegistry` (which reads manifest JSON, never activates the plugin runtime) and always passes `cache: false`. This commit adds an explicit regression test to guard against the issue being silently re-introduced.

The test calls `loadGatewayRuntimeConfigSchema` three times — simulating three successive MCP connections — and asserts:
1. `loadPluginManifestRegistry` is invoked **on each call** (not served from a cached active registry)
2. Every call passes `cache: false` (no activation state accumulates between connections)

## Changed Files

- `src/config/runtime-schema.test.ts` — regression test for #54816