### PR TITLE
fix(discord): suppress reconnect-exhausted crash during health-monitor restart

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -402,7 +402,14 @@ export async function runDiscordGatewayLifecycle(params: {
       },
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    // When the lifecycle is stopping intentionally (abort signal), the
+    // "Max reconnect attempts" error from the Discord gateway is expected
+    // and should not propagate.  Rethrowing it causes an uncaught exception
+    // crash loop when the health-monitor restarts a stale channel.
+    // See: https://github.com/openclaw/openclaw/issues/54931
+    const isIntentionalShutdownError =
+      lifecycleStopping && String(err).includes("Max reconnect attempts");
+    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err) && !isIntentionalShutdownError) {
       throw err;
     }
   } finally {

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -1131,7 +1131,14 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     if (onEarlyGatewayDebug) {
       earlyGatewayEmitter?.removeListener("debug", onEarlyGatewayDebug);
     }
-    gatewaySupervisor?.dispose();
+    // Defer disposal so that any late "Max reconnect attempts" error emitted
+    // asynchronously by the Discord gateway after disconnect() is still caught
+    // by the supervisor's error listener (in "teardown" phase) instead of
+    // becoming an uncaught EventEmitter error that crashes the process.
+    // See: https://github.com/openclaw/openclaw/issues/54931
+    if (gatewaySupervisor) {
+      setTimeout(() => gatewaySupervisor.dispose(), 5_000);
+    }
     if (!lifecycleStarted) {
       threadBindings.stop();
     }


### PR DESCRIPTION
## Summary

Fixes #54931 — Discord health-monitor triggers uncaught exception crash loop.

## Root Cause

When the health-monitor detects a stale socket and restarts a Discord channel:
1. `stopChannel()` aborts the controller
2. `onAbort()` sets `gateway.options.reconnect = { maxAttempts: 0 }` and calls `disconnect()`
3. Carbon emits "Max reconnect attempts" error asynchronously

Two race conditions caused this to crash:

1. **Error rethrown during intentional shutdown**: `startDiscordLifecycle` catch block rethrew the reconnect-exhausted error even when `lifecycleStopping=true` (abort was intentional)
2. **Supervisor disposed too early**: `gatewaySupervisor.dispose()` removed the error listener immediately in the finally block. Late async errors from Carbon had no listener and became uncaught EventEmitter errors crashing the process.

## Fix

1. **`provider.lifecycle.ts`**: Suppress reconnect-exhausted errors in the catch block when `lifecycleStopping` is true (intentional shutdown)
2. **`provider.ts`**: Defer `gatewaySupervisor.dispose()` by 5 seconds so late errors are handled in the supervisor's teardown phase instead of crashing

## Testing

The crash occurs ~35 minutes after startup when the health-monitor fires. Both changes are defensive guards that only activate during intentional shutdown (abort signal), so they cannot affect normal reconnection behavior.