### PR TITLE
fix(discord): prevent gateway crash during health-monitor restart

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -128,6 +128,12 @@ export async function runDiscordGatewayLifecycle(params: {
     if (!gateway) {
       return;
     }
+    // Transition the supervisor to teardown phase *before* disconnecting so
+    // that the synchronous "Max reconnect attempts (0)" error emitted by
+    // @buape/carbon during disconnect is suppressed instead of being routed
+    // to the lifecycle handler and eventually surfacing as an uncaught
+    // exception that crashes the entire gateway process.  See #54931.
+    params.gatewaySupervisor.detachLifecycle();
     gateway.options.reconnect = { maxAttempts: 0 };
     gateway.disconnect();
   };
@@ -402,7 +408,16 @@ export async function runDiscordGatewayLifecycle(params: {
       },
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    // During an intentional abort (health-monitor restart, manual stop, etc.)
+    // the onAbort handler sets maxAttempts to 0 and disconnects, which causes
+    // @buape/carbon to emit a "Max reconnect attempts" error.  If the
+    // supervisor has already transitioned to teardown the error is suppressed
+    // there, but as an additional safety net we also swallow it here when the
+    // lifecycle is already stopping — re-throwing would crash the gateway.
+    // See #54931.
+    if (lifecycleStopping) {
+      // Intentional shutdown — swallow the error.
+    } else if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
       throw err;
     }
   } finally {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -415,9 +415,8 @@ export async function runDiscordGatewayLifecycle(params: {
     // there, but as an additional safety net we also swallow it here when the
     // lifecycle is already stopping — re-throwing would crash the gateway.
     // See #54931.
-    if (lifecycleStopping) {
-      // Intentional shutdown — swallow the error.
-    } else if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    // Intentional shutdown — swallow the error (see #54931).
+    if (!lifecycleStopping && !sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
       throw err;
     }
   } finally {


### PR DESCRIPTION
## Summary

— Discord `health-monitor` triggers uncaught exception crash loop, bringing down the entire gateway every ~35 minutes after upgrading from v2026.3.11 to v2026.3.24.

— `Discord WebSocket reconnect failure crashes entire gateway`

## Root Cause

An uncaught exception occurred due to a timing issue during the channel teardown sequence:

1. In the `onAbort` handler, setting `gateway.options.reconnect = { maxAttempts: 0 }` and calling `gateway.disconnect()` synchronously triggered a `Max reconnect attempts (0) reached` error from `@buape/carbon`.
2. Because `gatewaySupervisor.detachLifecycle()` was previously only called in the `finally` block, the supervisor was still in the `active` phase when this synchronous error was emitted.
3. The error was routed to the lifecycle handler, treated as a fatal `reconnect-exhausted` event, and eventually rejected the wait promise.
4. The `catch` block in `runDiscordGatewayLifecycle` only swallowed `disallowed-intents` errors, so this reconnect error was re-thrown, causing an uncaught exception that crashed the entire gateway process.

## Changes

**`extensions/discord/src/monitor/provider.lifecycle.ts`**
- Transitioned the supervisor to the `teardown` phase by calling `params.gatewaySupervisor.detachLifecycle()` *before* disconnecting the gateway in the `onAbort` handler. This ensures the synchronous reconnect error is safely suppressed by the supervisor's existing `logLateTeardownEvent` mechanism.
- Added a safety net in the `catch` block to swallow all errors when `lifecycleStopping` is true, preventing any residual reconnect errors from propagating as uncaught exceptions during an intentional shutdown.

## Test Results

All existing Discord lifecycle and supervisor tests pass. The idempotency of `detachLifecycle()` ensures the repeated call in the `finally` block remains safe.
