### PR TITLE
feat(feishu): add cardHeader config to hide card title header

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -15534,6 +15534,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.feishu.accounts.*.cardHeader",
+      "kind": "channel",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.feishu.accounts.*.chunkMode",
       "kind": "channel",
       "type": "string",
@@ -16482,6 +16492,16 @@
       "path": "channels.feishu.capabilities.*",
       "kind": "channel",
       "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.feishu.cardHeader",
+      "kind": "channel",
+      "type": "boolean",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5645}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5647}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1379,6 +1379,7 @@
 {"recordType":"path","path":"channels.feishu.accounts.*.blockStreamingCoalesce.minDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.capabilities","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.accounts.*.capabilities.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.accounts.*.cardHeader","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.configWrites","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.accounts.*.connectionMode","kind":"channel","type":"string","required":false,"enumValues":["websocket","webhook"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -1465,6 +1466,7 @@
 {"recordType":"path","path":"channels.feishu.blockStreamingCoalesce.minDelayMs","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.capabilities","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.feishu.capabilities.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.feishu.cardHeader","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.chunkMode","kind":"channel","type":"string","required":false,"enumValues":["length","newline"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.configWrites","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.feishu.connectionMode","kind":"channel","type":"string","required":true,"enumValues":["websocket","webhook"],"defaultValue":"websocket","deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -175,6 +175,7 @@ const FeishuSharedConfigShape = {
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,
+  cardHeader: z.boolean().optional(), // When false, hides the card header to improve message list preview readability (default: true)
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   actions: ChannelActionsSchema,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -120,14 +120,15 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
       if (useCard) {
         const cardHeaderEnabled = account.config?.cardHeader !== false;
-        const header = (identity && cardHeaderEnabled)
-          ? {
-              title: identity.emoji
-                ? `${identity.emoji} ${identity.name ?? ""}`.trim()
-                : (identity.name ?? ""),
-              template: "blue" as const,
-            }
-          : undefined;
+        const header =
+          identity && cardHeaderEnabled
+            ? {
+                title: identity.emoji
+                  ? `${identity.emoji} ${identity.name ?? ""}`.trim()
+                  : (identity.name ?? ""),
+                template: "blue" as const,
+              }
+            : undefined;
         return await sendStructuredCardFeishu({
           cfg,
           to,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -119,7 +119,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       const renderMode = account.config?.renderMode ?? "auto";
       const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
       if (useCard) {
-        const header = identity
+        const cardHeaderEnabled = account.config?.cardHeader !== false;
+        const header = (identity && cardHeaderEnabled)
           ? {
               title: identity.emoji
                 ? `${identity.emoji} ${identity.name ?? ""}`.trim()

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -416,7 +416,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
           if (useCard) {
             const cardHeaderEnabled2 = account.config?.cardHeader !== false;
-            const cardHeader = cardHeaderEnabled2 ? resolveCardHeader(agentId, identity) : undefined;
+            const cardHeader = cardHeaderEnabled2
+              ? resolveCardHeader(agentId, identity)
+              : undefined;
             const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
             await sendChunkedTextReply({
               text,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -270,7 +270,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.log?.(`feishu[${account.accountId}] ${message}`),
       );
       try {
-        const cardHeader = resolveCardHeader(agentId, identity);
+        const cardHeaderEnabled = account.config?.cardHeader !== false;
+        const cardHeader = cardHeaderEnabled ? resolveCardHeader(agentId, identity) : undefined;
         const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId,
@@ -414,7 +415,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
 
           if (useCard) {
-            const cardHeader = resolveCardHeader(agentId, identity);
+            const cardHeaderEnabled2 = account.config?.cardHeader !== false;
+            const cardHeader = cardHeaderEnabled2 ? resolveCardHeader(agentId, identity) : undefined;
             const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
             await sendChunkedTextReply({
               text,


### PR DESCRIPTION
## Problem

In the Feishu message list, each message preview only shows the card title (e.g. `🤖 Friday`), hiding the actual reply content. This makes it hard to scan conversations without opening each message.

Introduced by #29938.

## Solution

Add a `cardHeader` boolean config option under `channels.feishu`. When set to `false`, the card header is omitted, allowing the message list preview to show actual message content.

## Usage

```json5
{
  channels: {
    feishu: {
      cardHeader: false  // hide card title header to improve message list preview
    }
  }
}
```

## Changes

- `extensions/feishu/src/config-schema.ts`: add `cardHeader: z.boolean().optional()` to `FeishuSharedConfigShape`
- `extensions/feishu/src/outbound.ts`: respect `cardHeader` config when building the card header object

Closes #54237