### PR TITLE
fix(telegram): restore optional buttons schema in message tool

### DIFF
--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -111,7 +111,7 @@ function describeTelegramMessageTool({
   if (discovery.buttonsEnabled) {
     schema.push({
       properties: {
-        buttons: createMessageToolButtonsSchema(),
+        buttons: Type.Optional(createMessageToolButtonsSchema()),
       },
     });
   }


### PR DESCRIPTION
## Summary
- restore `Type.Optional(createMessageToolButtonsSchema())` in `extensions/telegram/src/channel-actions.ts`
- fix regression where Telegram injected `buttons` as a required property for plain `message` tool calls
- prevent validation failures like `buttons: must have required property 'buttons'` for non-button sends

## Root cause
PR #52589 fixed this originally, but a later commit (`a0cb443aa3`, part of #52461) restored `channel-actions.ts` to the older version during rebase conflict resolution, reintroducing the bug.

## Verification
- `npm run build`
- local runtime test: plain Telegram `message` send succeeded after restart
