### PR TITLE
telegram: improve polling stall diagnostics

### DIFF
--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -186,11 +186,49 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    bot.api.config.use((prev, method, payload, signal) => {
-      if (method === "getUpdates") {
-        lastGetUpdatesAt = Date.now();
+    let lastGetUpdatesStartedAt: number | null = null;
+    let lastGetUpdatesFinishedAt: number | null = null;
+    let lastGetUpdatesDurationMs: number | null = null;
+    let lastGetUpdatesOutcome = "not-started";
+    let lastGetUpdatesError: string | null = null;
+    let lastGetUpdatesOffset: number | null = null;
+    let inFlightGetUpdates = 0;
+    let stopSequenceLogged = false;
+    let stallDiagLoggedAt = 0;
+
+    bot.api.config.use(async (prev, method, payload, signal) => {
+      if (method !== "getUpdates") {
+        return prev(method, payload, signal);
       }
-      return prev(method, payload, signal);
+
+      const startedAt = Date.now();
+      lastGetUpdatesAt = startedAt;
+      lastGetUpdatesStartedAt = startedAt;
+      lastGetUpdatesOffset =
+        payload && typeof payload === "object" && "offset" in payload
+          ? ((payload as { offset?: number }).offset ?? null)
+          : null;
+      inFlightGetUpdates += 1;
+      lastGetUpdatesOutcome = "started";
+      lastGetUpdatesError = null;
+
+      try {
+        const result = await prev(method, payload, signal);
+        const finishedAt = Date.now();
+        lastGetUpdatesFinishedAt = finishedAt;
+        lastGetUpdatesDurationMs = finishedAt - startedAt;
+        lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
+        return result;
+      } catch (err) {
+        const finishedAt = Date.now();
+        lastGetUpdatesFinishedAt = finishedAt;
+        lastGetUpdatesDurationMs = finishedAt - startedAt;
+        lastGetUpdatesOutcome = "error";
+        lastGetUpdatesError = formatErrorMessage(err);
+        throw err;
+      } finally {
+        inFlightGetUpdates = Math.max(0, inFlightGetUpdates - 1);
+      }
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -210,20 +248,33 @@ export class TelegramPollingSession {
     const forceCyclePromise = new Promise<void>((resolve) => {
       forceCycleResolve = resolve;
     });
+
+    const logDiagStop = (label: string) => {
+      if (stopSequenceLogged) {
+        return;
+      }
+      stopSequenceLogged = true;
+      this.opts.log(
+        `[telegram][diag] ${label} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
+      );
+    };
+
     const stopRunner = () => {
+      logDiagStop("stop sequence initiated");
       fetchAbortController?.abort();
       stopPromise ??= Promise.resolve(runner.stop())
         .then(() => undefined)
-        .catch(() => {
-          // Runner may already be stopped by abort/retry paths.
+        .catch((err) => {
+          this.opts.log(`[telegram][diag] runner.stop failed: ${formatErrorMessage(err)}`);
         });
       return stopPromise;
     };
     const stopBot = () => {
+      logDiagStop("stop sequence initiated");
       return Promise.resolve(bot.stop())
         .then(() => undefined)
-        .catch(() => {
-          // Bot may already be stopped by runner stop/abort paths.
+        .catch((err) => {
+          this.opts.log(`[telegram][diag] bot.stop failed: ${formatErrorMessage(err)}`);
         });
     };
     const stopOnAbort = () => {
@@ -236,11 +287,25 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
-      const elapsed = Date.now() - lastGetUpdatesAt;
+
+      const now = Date.now();
+      const activeElapsed =
+        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null ? now - lastGetUpdatesStartedAt : 0;
+      const idleElapsed = inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
+      const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
+
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+        if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {
+          return;
+        }
+        stallDiagLoggedAt = now;
         stalledRestart = true;
+        const elapsedLabel =
+          inFlightGetUpdates > 0
+            ? `active getUpdates stuck for ${formatDurationPrecise(elapsed)}`
+            : `no completed getUpdates for ${formatDurationPrecise(elapsed)}`;
         this.opts.log(
-          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
+          `[telegram] Polling stall detected (${elapsedLabel}); forcing restart. [diag inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
         );
         void stopRunner();
         void stopBot();
@@ -270,6 +335,9 @@ export class TelegramPollingSession {
           ? "unhandled network error"
           : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
+      this.opts.log(
+        `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
+      );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
       );
@@ -289,6 +357,9 @@ export class TelegramPollingSession {
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
       const errMsg = formatErrorMessage(err);
+      this.opts.log(
+        `[telegram][diag] polling cycle error reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"} err=${errMsg}${lastGetUpdatesError ? ` lastGetUpdatesError=${lastGetUpdatesError}` : ""}`,
+      );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
       );


### PR DESCRIPTION
## Summary

This improves Telegram long-polling diagnostics and makes polling stall detection more state-aware.

While investigating repeated Telegram polling stalls in a real deployment, I found that the existing watchdog only tracked the timestamp of the most recent `getUpdates` _start_, which made it hard to distinguish between:

- an actively stuck `getUpdates` request
- a healthy idle period with no completed polls yet
- repeated stop/restart noise during recovery

This patch keeps the existing recovery behavior, but improves visibility and slightly reduces diagnostic noise.

## What changed

### 1. Track richer `getUpdates` state
The polling session now records:

- `lastGetUpdatesStartedAt`
- `lastGetUpdatesFinishedAt`
- `lastGetUpdatesDurationMs`
- `lastGetUpdatesOutcome`
- `lastGetUpdatesError`
- `lastGetUpdatesOffset`
- `inFlightGetUpdates`

### 2. Make stall detection state-aware
Instead of only checking `Date.now() - lastGetUpdatesAt`, the watchdog now distinguishes between:

- **active request stalls**  
  `active getUpdates stuck for ...`

and

- **idle/no-completion stalls**  
  `no completed getUpdates for ...`

This gives more accurate context for why a restart is happening.

### 3. Reduce repeated stop diagnostics
When a stall triggers recovery, both `stopRunner()` and `stopBot()` may be invoked as part of the same stop sequence. This patch collapses that into a single diagnostic line:

- `[telegram][diag] stop sequence initiated ...`

instead of emitting multiple near-identical lines.

### 4. Throttle repeated stall diagnostics within the same cycle
Adds a small guard so the same stall does not repeatedly emit near-duplicate diagnostic lines in rapid succession.

## Why

In the affected deployment, Telegram health probes remained healthy, but OpenClaw repeatedly logged:

- `Polling stall detected ...`
- `Polling runner stop timed out after 15s ...`
- occasional `Network request for 'getUpdates' failed!`

The new diagnostics made it clear that the real failure mode was not just watchdog aggressiveness: an in-flight `getUpdates` request could remain stuck for far longer than expected before eventually failing, even though a request timeout was configured elsewhere.

Example diagnostic output from the patched build:

```text
[telegram] Polling stall detected (active getUpdates stuck for 222.22s); forcing restart. [diag inFlight=1 outcome=started ...]
[telegram][diag] stop sequence initiated inFlight=1 outcome=started ...
[telegram][diag] polling cycle finished reason=polling stall detected inFlight=0 outcome=error ... error=Network request for 'getUpdates' failed!
```

This patch does **not** attempt to fully solve the underlying stuck-request behavior yet. It focuses on making the failure mode observable and on reducing duplicate recovery logs.

## Behavior impact

- No intended change to the core restart policy
- No intended change to message routing or update handling
- Primarily diagnostic and watchdog-state clarification
- Slight reduction in duplicate stop-related log noise

## Follow-up ideas

Potential follow-up work (not included here):

- investigate why `getUpdates` can remain in-flight much longer than the configured request timeout
- consider rebuilding the bot/transport more aggressively after certain stuck-request failures
- consider whether `bot.stop()` confirmation behavior should be isolated from stall recovery paths
