### PR TITLE
fix: preflight local dashboard reachability before auto-open

### DIFF
--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -8,6 +8,9 @@ const openUrlMock = vi.hoisted(() => vi.fn());
 const formatControlUiSshHintMock = vi.hoisted(() => vi.fn());
 const copyToClipboardMock = vi.hoisted(() => vi.fn());
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
+const probeGatewayMock = vi.hoisted(() => vi.fn());
+const resolveGatewayProbeAuthResolutionMock = vi.hoisted(() => vi.fn());
+const getDaemonStatusSummaryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -25,8 +28,20 @@ vi.mock("../infra/clipboard.js", () => ({
   copyToClipboard: copyToClipboardMock,
 }));
 
+vi.mock("../gateway/probe.js", () => ({
+  probeGateway: (opts: unknown) => probeGatewayMock(opts),
+}));
+
 vi.mock("../secrets/resolve.js", () => ({
   resolveSecretRefValues: resolveSecretRefValuesMock,
+}));
+
+vi.mock("./status.gateway-probe.js", () => ({
+  resolveGatewayProbeAuthResolution: (cfg: unknown) => resolveGatewayProbeAuthResolutionMock(cfg),
+}));
+
+vi.mock("./status.daemon.js", () => ({
+  getDaemonStatusSummary: () => getDaemonStatusSummaryMock(),
 }));
 
 let dashboardCommand: typeof import("./dashboard.js").dashboardCommand;
@@ -43,14 +58,14 @@ function resetRuntime() {
   runtime.exit.mockClear();
 }
 
-function mockSnapshot(token: unknown = "abc") {
+function mockSnapshot(token: unknown = "abc", gateway: Record<string, unknown> = {}) {
   readConfigFileSnapshotMock.mockResolvedValue({
     path: "/tmp/openclaw.json",
     exists: true,
     raw: "{}",
     parsed: {},
     valid: true,
-    config: { gateway: { auth: { token } } },
+    config: { gateway: { auth: { token }, ...gateway } },
     issues: [],
     legacyIssues: [],
   });
@@ -60,6 +75,21 @@ function mockSnapshot(token: unknown = "abc") {
     wsUrl: "ws://127.0.0.1:18789",
   });
   resolveSecretRefValuesMock.mockReset();
+  resolveGatewayProbeAuthResolutionMock.mockResolvedValue({ auth: { token: "abc" } });
+  probeGatewayMock.mockResolvedValue({
+    ok: true,
+    close: null,
+    error: null,
+  });
+  getDaemonStatusSummaryMock.mockResolvedValue({
+    label: "LaunchAgent",
+    installed: true,
+    loaded: true,
+    managedByOpenClaw: true,
+    externallyManaged: false,
+    loadedText: "loaded",
+    runtimeShort: "running",
+  });
 }
 
 describe("dashboardCommand", () => {
@@ -76,6 +106,9 @@ describe("dashboardCommand", () => {
     openUrlMock.mockClear();
     formatControlUiSshHintMock.mockClear();
     copyToClipboardMock.mockClear();
+    probeGatewayMock.mockClear();
+    resolveGatewayProbeAuthResolutionMock.mockClear();
+    getDaemonStatusSummaryMock.mockClear();
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.CUSTOM_GATEWAY_TOKEN;
   });
@@ -196,5 +229,38 @@ describe("dashboardCommand", () => {
     expect(runtime.log).not.toHaveBeenCalledWith(
       expect.stringContaining("Token auto-auth is disabled for SecretRef-managed"),
     );
+  });
+
+  it("does not copy or open the dashboard when the local gateway is unreachable", async () => {
+    mockSnapshot("abc123");
+    probeGatewayMock.mockResolvedValue({
+      ok: false,
+      close: null,
+      error: "connect failed: ECONNREFUSED 127.0.0.1:18789",
+    });
+    getDaemonStatusSummaryMock.mockResolvedValue({
+      label: "LaunchAgent",
+      installed: false,
+      loaded: false,
+      managedByOpenClaw: false,
+      externallyManaged: false,
+      loadedText: "not loaded",
+      runtimeShort: null,
+    });
+
+    await dashboardCommand(runtime);
+
+    expect(copyToClipboardMock).not.toHaveBeenCalled();
+    expect(openUrlMock).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Gateway is not reachable at ws://127.0.0.1:18789 (connect failed: ECONNREFUSED 127.0.0.1:18789).",
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Gateway mode is unset; local gateway start is blocked. Run openclaw config set gateway.mode local.",
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Gateway service is not installed. Run openclaw daemon install.",
+    );
+    expect(runtime.log).toHaveBeenCalledWith("Fix reachability first: openclaw gateway probe");
   });
 });

--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -8,9 +8,10 @@ const openUrlMock = vi.hoisted(() => vi.fn());
 const formatControlUiSshHintMock = vi.hoisted(() => vi.fn());
 const copyToClipboardMock = vi.hoisted(() => vi.fn());
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
-const probeGatewayMock = vi.hoisted(() => vi.fn());
-const resolveGatewayProbeAuthResolutionMock = vi.hoisted(() => vi.fn());
 const getDaemonStatusSummaryMock = vi.hoisted(() => vi.fn());
+const fetchMock = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal("fetch", fetchMock);
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -28,16 +29,8 @@ vi.mock("../infra/clipboard.js", () => ({
   copyToClipboard: copyToClipboardMock,
 }));
 
-vi.mock("../gateway/probe.js", () => ({
-  probeGateway: (opts: unknown) => probeGatewayMock(opts),
-}));
-
 vi.mock("../secrets/resolve.js", () => ({
   resolveSecretRefValues: resolveSecretRefValuesMock,
-}));
-
-vi.mock("./status.gateway-probe.js", () => ({
-  resolveGatewayProbeAuthResolution: (cfg: unknown) => resolveGatewayProbeAuthResolutionMock(cfg),
 }));
 
 vi.mock("./status.daemon.js", () => ({
@@ -77,12 +70,7 @@ function mockSnapshot(token: unknown = "abc", gateway: Record<string, unknown> =
     }),
   );
   resolveSecretRefValuesMock.mockReset();
-  resolveGatewayProbeAuthResolutionMock.mockResolvedValue({ auth: { token: "abc" } });
-  probeGatewayMock.mockResolvedValue({
-    ok: true,
-    close: null,
-    error: null,
-  });
+  fetchMock.mockResolvedValue({ ok: true, status: 200 });
   getDaemonStatusSummaryMock.mockResolvedValue({
     label: "LaunchAgent",
     installed: true,
@@ -101,6 +89,7 @@ describe("dashboardCommand", () => {
 
   beforeEach(() => {
     resetRuntime();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
     readConfigFileSnapshotMock.mockClear();
     resolveGatewayPortMock.mockClear();
     resolveControlUiLinksMock.mockClear();
@@ -108,9 +97,8 @@ describe("dashboardCommand", () => {
     openUrlMock.mockClear();
     formatControlUiSshHintMock.mockClear();
     copyToClipboardMock.mockClear();
-    probeGatewayMock.mockClear();
-    resolveGatewayProbeAuthResolutionMock.mockClear();
     getDaemonStatusSummaryMock.mockClear();
+    fetchMock.mockClear();
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.CUSTOM_GATEWAY_TOKEN;
   });
@@ -157,7 +145,7 @@ describe("dashboardCommand", () => {
 
     await dashboardCommand(runtime, { noOpen: true });
 
-    expect(probeGatewayMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(detectBrowserOpenSupportMock).not.toHaveBeenCalled();
     expect(openUrlMock).not.toHaveBeenCalled();
     expect(runtime.log).toHaveBeenCalledWith(
@@ -165,7 +153,7 @@ describe("dashboardCommand", () => {
     );
   });
 
-  it("uses loopback for local preflight even when the dashboard URL keeps custom bind", async () => {
+  it("uses the resolved dashboard host for the preflight health probe", async () => {
     mockSnapshot("abc123", { bind: "custom", customBindHost: "10.0.0.5" });
     copyToClipboardMock.mockResolvedValue(true);
     detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
@@ -179,13 +167,10 @@ describe("dashboardCommand", () => {
       customBindHost: "10.0.0.5",
       basePath: undefined,
     });
-    expect(resolveControlUiLinksMock).toHaveBeenNthCalledWith(2, {
-      port: 18789,
-      bind: "loopback",
-      basePath: undefined,
-    });
-    expect(probeGatewayMock).toHaveBeenCalledWith(
-      expect.objectContaining({ url: "ws://127.0.0.1:18789" }),
+    expect(resolveControlUiLinksMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://10.0.0.5:18789/healthz",
+      expect.objectContaining({ method: "HEAD", redirect: "manual" }),
     );
     expect(openUrlMock).toHaveBeenCalledWith("http://10.0.0.5:18789/#token=abc123");
   });
@@ -261,11 +246,7 @@ describe("dashboardCommand", () => {
 
   it("does not copy or open the dashboard when the local gateway is unreachable", async () => {
     mockSnapshot("abc123");
-    probeGatewayMock.mockResolvedValue({
-      ok: false,
-      close: null,
-      error: "connect failed: ECONNREFUSED 127.0.0.1:18789",
-    });
+    fetchMock.mockRejectedValue(new Error("connect failed: ECONNREFUSED 127.0.0.1:18789"));
     getDaemonStatusSummaryMock.mockResolvedValue({
       label: "LaunchAgent",
       installed: false,
@@ -278,34 +259,20 @@ describe("dashboardCommand", () => {
 
     await dashboardCommand(runtime);
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:18789/healthz",
+      expect.objectContaining({ method: "HEAD", redirect: "manual" }),
+    );
     expect(copyToClipboardMock).not.toHaveBeenCalled();
     expect(openUrlMock).not.toHaveBeenCalled();
     expect(runtime.error).toHaveBeenCalledWith(
-      "Gateway is not reachable at ws://127.0.0.1:18789 (connect failed: ECONNREFUSED 127.0.0.1:18789).",
+      "Gateway is not reachable at http://127.0.0.1:18789/healthz (connect failed: ECONNREFUSED 127.0.0.1:18789).",
     );
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Gateway mode is unset"));
     expect(runtime.log).toHaveBeenCalledWith(
       expect.stringContaining("Gateway service is not installed"),
     );
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Fix reachability first"));
-  });
-
-  it("treats device-identity close as reachable during local preflight", async () => {
-    mockSnapshot("abc123");
-    copyToClipboardMock.mockResolvedValue(true);
-    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
-    openUrlMock.mockResolvedValue(true);
-    probeGatewayMock.mockResolvedValue({
-      ok: false,
-      close: { code: 1008, reason: "device identity required" },
-      error: "device identity required",
-    });
-
-    await dashboardCommand(runtime);
-
-    expect(copyToClipboardMock).toHaveBeenCalledWith("http://127.0.0.1:18789/#token=abc123");
-    expect(openUrlMock).toHaveBeenCalledWith("http://127.0.0.1:18789/#token=abc123");
-    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("avoids the mode-unset hint when the config file is missing", async () => {
@@ -326,12 +293,7 @@ describe("dashboardCommand", () => {
         wsUrl: bind === "loopback" ? "ws://127.0.0.1:18789" : "ws://10.0.0.5:18789",
       }),
     );
-    resolveGatewayProbeAuthResolutionMock.mockResolvedValue({ auth: {} });
-    probeGatewayMock.mockResolvedValue({
-      ok: false,
-      close: null,
-      error: "connect failed: ECONNREFUSED 127.0.0.1:18789",
-    });
+    fetchMock.mockRejectedValue(new Error("connect failed: ECONNREFUSED 127.0.0.1:18789"));
     getDaemonStatusSummaryMock.mockResolvedValue({
       label: "LaunchAgent",
       installed: false,
@@ -344,6 +306,10 @@ describe("dashboardCommand", () => {
 
     await dashboardCommand(runtime);
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1:18789/healthz",
+      expect.objectContaining({ method: "HEAD", redirect: "manual" }),
+    );
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Missing config"));
     expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Gateway mode is unset"));
   });

--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -70,10 +70,12 @@ function mockSnapshot(token: unknown = "abc", gateway: Record<string, unknown> =
     legacyIssues: [],
   });
   resolveGatewayPortMock.mockReturnValue(18789);
-  resolveControlUiLinksMock.mockReturnValue({
-    httpUrl: "http://127.0.0.1:18789/",
-    wsUrl: "ws://127.0.0.1:18789",
-  });
+  resolveControlUiLinksMock.mockImplementation(
+    ({ bind }: { bind?: string; port: number; customBindHost?: string; basePath?: string }) => ({
+      httpUrl: bind === "custom" ? "http://10.0.0.5:18789/" : "http://127.0.0.1:18789/",
+      wsUrl: bind === "custom" ? "ws://10.0.0.5:18789" : "ws://127.0.0.1:18789",
+    }),
+  );
   resolveSecretRefValuesMock.mockReset();
   resolveGatewayProbeAuthResolutionMock.mockResolvedValue({ auth: { token: "abc" } });
   probeGatewayMock.mockResolvedValue({
@@ -155,11 +157,37 @@ describe("dashboardCommand", () => {
 
     await dashboardCommand(runtime, { noOpen: true });
 
+    expect(probeGatewayMock).not.toHaveBeenCalled();
     expect(detectBrowserOpenSupportMock).not.toHaveBeenCalled();
     expect(openUrlMock).not.toHaveBeenCalled();
     expect(runtime.log).toHaveBeenCalledWith(
       "Browser launch disabled (--no-open). Use the URL above.",
     );
+  });
+
+  it("uses loopback for local preflight even when the dashboard URL keeps custom bind", async () => {
+    mockSnapshot("abc123", { bind: "custom", customBindHost: "10.0.0.5" });
+    copyToClipboardMock.mockResolvedValue(true);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(true);
+
+    await dashboardCommand(runtime);
+
+    expect(resolveControlUiLinksMock).toHaveBeenNthCalledWith(1, {
+      port: 18789,
+      bind: "custom",
+      customBindHost: "10.0.0.5",
+      basePath: undefined,
+    });
+    expect(resolveControlUiLinksMock).toHaveBeenNthCalledWith(2, {
+      port: 18789,
+      bind: "loopback",
+      basePath: undefined,
+    });
+    expect(probeGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "ws://127.0.0.1:18789" }),
+    );
+    expect(openUrlMock).toHaveBeenCalledWith("http://10.0.0.5:18789/#token=abc123");
   });
 
   it("prints non-tokenized URL with guidance when token SecretRef is unresolved", async () => {
@@ -255,12 +283,68 @@ describe("dashboardCommand", () => {
     expect(runtime.error).toHaveBeenCalledWith(
       "Gateway is not reachable at ws://127.0.0.1:18789 (connect failed: ECONNREFUSED 127.0.0.1:18789).",
     );
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Gateway mode is unset"));
     expect(runtime.log).toHaveBeenCalledWith(
-      "Gateway mode is unset; local gateway start is blocked. Run openclaw config set gateway.mode local.",
+      expect.stringContaining("Gateway service is not installed"),
     );
-    expect(runtime.log).toHaveBeenCalledWith(
-      "Gateway service is not installed. Run openclaw daemon install.",
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Fix reachability first"));
+  });
+
+  it("treats device-identity close as reachable during local preflight", async () => {
+    mockSnapshot("abc123");
+    copyToClipboardMock.mockResolvedValue(true);
+    detectBrowserOpenSupportMock.mockResolvedValue({ ok: true });
+    openUrlMock.mockResolvedValue(true);
+    probeGatewayMock.mockResolvedValue({
+      ok: false,
+      close: { code: 1008, reason: "device identity required" },
+      error: "device identity required",
+    });
+
+    await dashboardCommand(runtime);
+
+    expect(copyToClipboardMock).toHaveBeenCalledWith("http://127.0.0.1:18789/#token=abc123");
+    expect(openUrlMock).toHaveBeenCalledWith("http://127.0.0.1:18789/#token=abc123");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("avoids the mode-unset hint when the config file is missing", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      exists: false,
+      raw: "",
+      parsed: null,
+      valid: false,
+      config: {},
+      issues: [],
+      legacyIssues: [],
+    });
+    resolveGatewayPortMock.mockReturnValue(18789);
+    resolveControlUiLinksMock.mockImplementation(
+      ({ bind }: { bind?: string; port: number; customBindHost?: string; basePath?: string }) => ({
+        httpUrl: "http://127.0.0.1:18789/",
+        wsUrl: bind === "loopback" ? "ws://127.0.0.1:18789" : "ws://10.0.0.5:18789",
+      }),
     );
-    expect(runtime.log).toHaveBeenCalledWith("Fix reachability first: openclaw gateway probe");
+    resolveGatewayProbeAuthResolutionMock.mockResolvedValue({ auth: {} });
+    probeGatewayMock.mockResolvedValue({
+      ok: false,
+      close: null,
+      error: "connect failed: ECONNREFUSED 127.0.0.1:18789",
+    });
+    getDaemonStatusSummaryMock.mockResolvedValue({
+      label: "LaunchAgent",
+      installed: false,
+      loaded: false,
+      managedByOpenClaw: false,
+      externallyManaged: false,
+      loadedText: "not loaded",
+      runtimeShort: null,
+    });
+
+    await dashboardCommand(runtime);
+
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Missing config"));
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Gateway mode is unset"));
   });
 });

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -1,6 +1,8 @@
+import { formatCliCommand } from "../cli/command-format.js";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { readGatewayTokenEnv } from "../gateway/credentials.js";
+import { probeGateway } from "../gateway/probe.js";
 import { resolveConfiguredSecretInputWithFallback } from "../gateway/resolve-configured-secret-input-string.js";
 import { copyToClipboard } from "../infra/clipboard.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -11,10 +13,82 @@ import {
   openUrl,
   resolveControlUiLinks,
 } from "./onboard-helpers.js";
+import { getDaemonStatusSummary } from "./status.daemon.js";
+import { resolveGatewayProbeAuthResolution } from "./status.gateway-probe.js";
 
 type DashboardOptions = {
   noOpen?: boolean;
 };
+
+function looksLikeGatewayAuthClose(code: number | undefined, reason: string | undefined): boolean {
+  if (code !== 1008) {
+    return false;
+  }
+  const normalized = (reason ?? "").toLowerCase();
+  return (
+    normalized.includes("auth") ||
+    normalized.includes("token") ||
+    normalized.includes("password") ||
+    normalized.includes("scope") ||
+    normalized.includes("role")
+  );
+}
+
+async function shouldBlockOnUnreachableGateway(params: {
+  cfg: OpenClawConfig;
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
+  wsUrl: string;
+  runtime: RuntimeEnv;
+}): Promise<boolean> {
+  if (params.cfg.gateway?.mode === "remote") {
+    return false;
+  }
+
+  const authResolution = await resolveGatewayProbeAuthResolution(params.cfg);
+  const probe = await probeGateway({
+    url: params.wsUrl,
+    auth: authResolution.auth,
+    timeoutMs: 1_500,
+    includeDetails: false,
+  }).catch(() => null);
+
+  if (!probe) {
+    return false;
+  }
+  if (probe.ok || looksLikeGatewayAuthClose(probe.close?.code, probe.close?.reason)) {
+    return false;
+  }
+
+  const detail = probe.error ? ` (${probe.error})` : "";
+  params.runtime.error(`Gateway is not reachable at ${params.wsUrl}${detail}.`);
+
+  if (!params.snapshot.exists) {
+    params.runtime.log(`Missing config: run ${formatCliCommand("openclaw setup")}.`);
+  }
+  if (!params.cfg.gateway?.mode) {
+    params.runtime.log(
+      `Gateway mode is unset; local gateway start is blocked. Run ${formatCliCommand("openclaw config set gateway.mode local")}.`,
+    );
+  }
+
+  const daemon = await getDaemonStatusSummary().catch(() => null);
+  if (daemon?.installed === false) {
+    params.runtime.log(
+      `Gateway service is not installed. Run ${formatCliCommand("openclaw daemon install")}.`,
+    );
+  } else if (daemon?.installed && !daemon.loaded) {
+    params.runtime.log(
+      `Gateway service is installed but not loaded. Run ${formatCliCommand("openclaw daemon start")}.`,
+    );
+  } else if (daemon?.installed) {
+    params.runtime.log(
+      `Gateway service appears installed. Try ${formatCliCommand("openclaw daemon restart")} if the dashboard still stays down.`,
+    );
+  }
+
+  params.runtime.log(`Fix reachability first: ${formatCliCommand("openclaw gateway probe")}`);
+  return true;
+}
 
 async function resolveDashboardToken(
   cfg: OpenClawConfig,
@@ -86,6 +160,17 @@ export async function dashboardCommand(
     runtime.log(
       "Set OPENCLAW_GATEWAY_TOKEN in this shell or resolve your secret provider, then rerun `openclaw dashboard`.",
     );
+  }
+
+  if (
+    await shouldBlockOnUnreachableGateway({
+      cfg,
+      snapshot,
+      wsUrl: links.wsUrl,
+      runtime,
+    })
+  ) {
+    return;
   }
 
   const copied = await copyToClipboard(dashboardUrl).catch(() => false);

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -2,7 +2,6 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { readConfigFileSnapshot, resolveGatewayPort } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { readGatewayTokenEnv } from "../gateway/credentials.js";
-import { probeGateway } from "../gateway/probe.js";
 import { resolveConfiguredSecretInputWithFallback } from "../gateway/resolve-configured-secret-input-string.js";
 import { copyToClipboard } from "../infra/clipboard.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -14,57 +13,52 @@ import {
   resolveControlUiLinks,
 } from "./onboard-helpers.js";
 import { getDaemonStatusSummary } from "./status.daemon.js";
-import { resolveGatewayProbeAuthResolution } from "./status.gateway-probe.js";
 
 type DashboardOptions = {
   noOpen?: boolean;
 };
 
-function looksLikeGatewayReachableClose(
-  code: number | undefined,
-  reason: string | undefined,
-): boolean {
-  if (code !== 1008) {
-    return false;
+async function probeDashboardHttpReachability(
+  url: string,
+  timeoutMs: number,
+): Promise<{ reachable: boolean; error?: string }> {
+  if (typeof fetch !== "function") {
+    return { reachable: false, error: "fetch unavailable" };
   }
-  const normalized = (reason ?? "").toLowerCase();
-  return (
-    normalized.includes("auth") ||
-    normalized.includes("token") ||
-    normalized.includes("password") ||
-    normalized.includes("scope") ||
-    normalized.includes("role") ||
-    normalized.includes("device identity")
-  );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await fetch(url, {
+      method: "HEAD",
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    return { reachable: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { reachable: false, error: message };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function shouldBlockOnUnreachableGateway(params: {
   cfg: OpenClawConfig;
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
-  probeWsUrl: string;
+  probeHttpUrl: string;
   runtime: RuntimeEnv;
 }): Promise<boolean> {
   if (params.cfg.gateway?.mode === "remote") {
     return false;
   }
 
-  const authResolution = await resolveGatewayProbeAuthResolution(params.cfg);
-  const probe = await probeGateway({
-    url: params.probeWsUrl,
-    auth: authResolution.auth,
-    timeoutMs: 1_500,
-    includeDetails: false,
-  }).catch(() => null);
-
-  if (!probe) {
-    return false;
-  }
-  if (probe.ok || looksLikeGatewayReachableClose(probe.close?.code, probe.close?.reason)) {
+  const probe = await probeDashboardHttpReachability(params.probeHttpUrl, 1_500);
+  if (probe.reachable) {
     return false;
   }
 
   const detail = probe.error ? ` (${probe.error})` : "";
-  params.runtime.error(`Gateway is not reachable at ${params.probeWsUrl}${detail}.`);
+  params.runtime.error(`Gateway is not reachable at ${params.probeHttpUrl}${detail}.`);
 
   if (!params.snapshot.exists) {
     params.runtime.log(`Missing config: run ${formatCliCommand("openclaw setup")}.`);
@@ -166,16 +160,12 @@ export async function dashboardCommand(
   }
 
   if (!options.noOpen) {
-    const localProbeWsUrl = resolveControlUiLinks({
-      port,
-      bind: "loopback",
-      basePath,
-    }).wsUrl;
+    const probeHttpUrl = new URL("/healthz", links.httpUrl).toString();
     if (
       await shouldBlockOnUnreachableGateway({
         cfg,
         snapshot,
-        probeWsUrl: localProbeWsUrl,
+        probeHttpUrl,
         runtime,
       })
     ) {

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -20,7 +20,10 @@ type DashboardOptions = {
   noOpen?: boolean;
 };
 
-function looksLikeGatewayAuthClose(code: number | undefined, reason: string | undefined): boolean {
+function looksLikeGatewayReachableClose(
+  code: number | undefined,
+  reason: string | undefined,
+): boolean {
   if (code !== 1008) {
     return false;
   }
@@ -30,14 +33,15 @@ function looksLikeGatewayAuthClose(code: number | undefined, reason: string | un
     normalized.includes("token") ||
     normalized.includes("password") ||
     normalized.includes("scope") ||
-    normalized.includes("role")
+    normalized.includes("role") ||
+    normalized.includes("device identity")
   );
 }
 
 async function shouldBlockOnUnreachableGateway(params: {
   cfg: OpenClawConfig;
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>;
-  wsUrl: string;
+  probeWsUrl: string;
   runtime: RuntimeEnv;
 }): Promise<boolean> {
   if (params.cfg.gateway?.mode === "remote") {
@@ -46,7 +50,7 @@ async function shouldBlockOnUnreachableGateway(params: {
 
   const authResolution = await resolveGatewayProbeAuthResolution(params.cfg);
   const probe = await probeGateway({
-    url: params.wsUrl,
+    url: params.probeWsUrl,
     auth: authResolution.auth,
     timeoutMs: 1_500,
     includeDetails: false,
@@ -55,17 +59,16 @@ async function shouldBlockOnUnreachableGateway(params: {
   if (!probe) {
     return false;
   }
-  if (probe.ok || looksLikeGatewayAuthClose(probe.close?.code, probe.close?.reason)) {
+  if (probe.ok || looksLikeGatewayReachableClose(probe.close?.code, probe.close?.reason)) {
     return false;
   }
 
   const detail = probe.error ? ` (${probe.error})` : "";
-  params.runtime.error(`Gateway is not reachable at ${params.wsUrl}${detail}.`);
+  params.runtime.error(`Gateway is not reachable at ${params.probeWsUrl}${detail}.`);
 
   if (!params.snapshot.exists) {
     params.runtime.log(`Missing config: run ${formatCliCommand("openclaw setup")}.`);
-  }
-  if (!params.cfg.gateway?.mode) {
+  } else if (!params.cfg.gateway?.mode) {
     params.runtime.log(
       `Gateway mode is unset; local gateway start is blocked. Run ${formatCliCommand("openclaw config set gateway.mode local")}.`,
     );
@@ -162,15 +165,22 @@ export async function dashboardCommand(
     );
   }
 
-  if (
-    await shouldBlockOnUnreachableGateway({
-      cfg,
-      snapshot,
-      wsUrl: links.wsUrl,
-      runtime,
-    })
-  ) {
-    return;
+  if (!options.noOpen) {
+    const localProbeWsUrl = resolveControlUiLinks({
+      port,
+      bind: "loopback",
+      basePath,
+    }).wsUrl;
+    if (
+      await shouldBlockOnUnreachableGateway({
+        cfg,
+        snapshot,
+        probeWsUrl: localProbeWsUrl,
+        runtime,
+      })
+    ) {
+      return;
+    }
   }
 
   const copied = await copyToClipboard(dashboardUrl).catch(() => false);

--- a/src/commands/status.daemon.ts
+++ b/src/commands/status.daemon.ts
@@ -6,6 +6,7 @@ import { readServiceStatusSummary } from "./status.service-summary.js";
 type DaemonStatusSummary = {
   label: string;
   installed: boolean | null;
+  loaded: boolean;
   managedByOpenClaw: boolean;
   externallyManaged: boolean;
   loadedText: string;
@@ -21,6 +22,7 @@ async function buildDaemonStatusSummary(
   return {
     label: summary.label,
     installed: summary.installed,
+    loaded: summary.loaded,
     managedByOpenClaw: summary.managedByOpenClaw,
     externallyManaged: summary.externallyManaged,
     loadedText: summary.loadedText,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw dashboard` always copied and opened the local dashboard URL without first checking whether the local gateway was reachable.
- Why it matters: on fresh installs this produced a dead `127.0.0.1:18789` tab and pushed users toward browser/firewall debugging instead of the real daemon/config fixes.
- What changed: add a local-mode dashboard preflight probe, treat auth-close responses as reachable, skip clipboard/browser side effects when the gateway is down, and print direct remediation commands for missing config/mode/service state.
- What did NOT change (scope boundary): remote-mode dashboard flows, tokenized dashboard URL generation, and the existing happy-path browser open behavior when the gateway is reachable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55003
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `dashboardCommand` built the local URL, copied it, and opened the browser without probing the local gateway or consulting local service/config state first.
- Missing detection / guardrail: there was no preflight reachability gate before side effects, even though the CLI already had probe helpers and daemon/config diagnostics.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the command originated in `bb7397c636` (`feat: add dashboard command`), and later auth/token refactors preserved URL generation but still did not add a reachability check.
- Why this regressed now: this path is an existing missing guardrail, not a newly identified behavioral regression; the beta install flow made it obvious because `gateway.mode` unset now blocks startup more explicitly.
- If unknown, what was ruled out: ruled out browser/firewall as the primary cause on the reproduced install because no process was listening on `127.0.0.1:18789`, `openclaw status` reported `ECONNREFUSED`, and `openclaw daemon status` pointed at `gateway.mode=local` being unset.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/dashboard.links.test.ts`
- Scenario the test should lock in: when the local gateway probe returns a connect failure, `openclaw dashboard` must print remediation and skip clipboard/browser side effects.
- Why this is the smallest reliable guardrail: the bug is entirely in the CLI decision branch before any browser or service integration boundary; mocked probe + daemon state is sufficient and deterministic.
- Existing test that already covers this (if any): the file already covered the reachable happy path, `--no-open`, and SecretRef token handling; `src/cli/daemon-cli/restart-health.test.ts` already covered auth-close reachability semantics.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `openclaw dashboard` no longer copies or opens a dead local dashboard URL when the local gateway is unreachable.
- In the local unreachable case, the CLI now prints direct fixes such as `openclaw config set gateway.mode local`, `openclaw daemon install`, `openclaw daemon start`/`restart`, and `openclaw gateway probe`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 14.7.5 (arm64)
- Runtime/container: Node 25.1.0, npm global install via official beta installer
- Model/provider: openai-codex/gpt-5.4 via `openai-codex`
- Integration/channel (if any): none
- Relevant config (redacted): local dashboard config with `gateway.mode` initially unset; later local token auth enabled by `openclaw daemon install`

### Steps

1. Install OpenClaw beta locally and leave the local gateway unbootstrapped (`gateway.mode` unset and no LaunchAgent installed yet).
2. Run `openclaw dashboard`.
3. Observe the current CLI behavior opens `http://127.0.0.1:18789/` even though `openclaw status` reports the local gateway unreachable.

### Expected

- The command should stop before copy/open side effects and print actionable remediation.

### Actual

- The command printed a dashboard URL, copied it, and opened a dead localhost tab.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the broken local bootstrap path on a fresh beta macOS install; verified `openclaw status` / `openclaw daemon status` showed the real root cause; ran `npx pnpm vitest run src/commands/dashboard.links.test.ts src/cli/daemon-cli/restart-health.test.ts`; ran the repo pre-commit check chain successfully during commit.
- Edge cases checked: existing happy-path dashboard tests still pass; SecretRef/unresolved token tests still pass; auth-close reachability semantics still pass via `src/cli/daemon-cli/restart-health.test.ts`.
- What you did **not** verify: remote-mode dashboard behavior, end-to-end browser rendering against a freshly built CLI binary, and non-macOS service wording.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `2abe342da8` or remove the local preflight gate from `src/commands/dashboard.ts`
- Files/config to restore: `src/commands/dashboard.ts`, `src/commands/dashboard.links.test.ts`, `src/commands/status.daemon.ts`
- Known bad symptoms reviewers should watch for: false negatives where `openclaw dashboard` refuses to auto-open a healthy local gateway

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a transient local probe failure could suppress browser auto-open even though the gateway would have become reachable moments later.
  - Mitigation: auth-close cases are explicitly treated as reachable, the probe timeout stays short and local-only, and the CLI now prints direct remediation instead of a misleading success message.
