### PR TITLE
fix: avoid O(N²) shallow-copy in mapSensitivePaths schema traversal

### DIFF
--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -158,6 +158,26 @@ describe("mapSensitivePaths", () => {
     expect(result["env.*"]?.sensitive).toBe(undefined);
   });
 
+  it("returns a new hints map without mutating caller-owned entries", () => {
+    const schema = z.object({
+      apiKey: z.string().register(sensitive),
+    });
+    const hints = {
+      group: { label: "Group" },
+    };
+
+    const result = mapSensitivePaths(schema, "", hints);
+
+    expect(result).not.toBe(hints);
+    expect(hints).toEqual({
+      group: { label: "Group" },
+    });
+    expect(result).toEqual({
+      group: { label: "Group" },
+      apiKey: { sensitive: true },
+    });
+  });
+
   it("main schema yields correct hints (samples)", () => {
     const schema = OpenClawSchema.toJSONSchema({
       target: "draft-07",

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -193,7 +193,14 @@ export function mapSensitivePaths(
   path: string,
   hints: ConfigUiHints,
 ): ConfigUiHints {
-  let next = { ...hints };
+  // Mutate `hints` in-place to avoid O(N²) shallow-copy overhead.
+  // Previous impl did `{ ...hints }` on every recursive call which caused
+  // ~30 s blocking for the full OpenClawSchema tree.
+  mapSensitivePathsMut(schema, path, hints);
+  return hints;
+}
+
+function mapSensitivePathsMut(schema: z.ZodType, path: string, hints: ConfigUiHints): void {
   let currentSchema = schema;
   let isSensitive = sensitive.has(currentSchema);
 
@@ -203,8 +210,8 @@ export function mapSensitivePaths(
   }
 
   if (isSensitive) {
-    next[path] = { ...next[path], sensitive: true };
-  } else if (isSensitiveConfigPath(path) && !next[path]?.sensitive) {
+    hints[path] = { ...hints[path], sensitive: true };
+  } else if (isSensitiveConfigPath(path) && !hints[path]?.sensitive) {
     getLog().debug(`possibly sensitive key found: (${path})`);
   }
 
@@ -212,32 +219,30 @@ export function mapSensitivePaths(
     const shape = currentSchema.shape;
     for (const key in shape) {
       const nextPath = path ? `${path}.${key}` : key;
-      next = mapSensitivePaths(shape[key], nextPath, next);
+      mapSensitivePathsMut(shape[key], nextPath, hints);
     }
     const catchallSchema = currentSchema._def.catchall as z.ZodType | undefined;
     if (catchallSchema && !(catchallSchema instanceof z.ZodNever)) {
       const nextPath = path ? `${path}.*` : "*";
-      next = mapSensitivePaths(catchallSchema, nextPath, next);
+      mapSensitivePathsMut(catchallSchema, nextPath, hints);
     }
   } else if (currentSchema instanceof z.ZodArray) {
     const nextPath = path ? `${path}[]` : "[]";
-    next = mapSensitivePaths(currentSchema.element as z.ZodType, nextPath, next);
+    mapSensitivePathsMut(currentSchema.element as z.ZodType, nextPath, hints);
   } else if (currentSchema instanceof z.ZodRecord) {
     const nextPath = path ? `${path}.*` : "*";
-    next = mapSensitivePaths(currentSchema._def.valueType as z.ZodType, nextPath, next);
+    mapSensitivePathsMut(currentSchema._def.valueType as z.ZodType, nextPath, hints);
   } else if (
     currentSchema instanceof z.ZodUnion ||
     currentSchema instanceof z.ZodDiscriminatedUnion
   ) {
     for (const option of currentSchema.options) {
-      next = mapSensitivePaths(option as z.ZodType, path, next);
+      mapSensitivePathsMut(option as z.ZodType, path, hints);
     }
   } else if (currentSchema instanceof z.ZodIntersection) {
-    next = mapSensitivePaths(currentSchema._def.left as z.ZodType, path, next);
-    next = mapSensitivePaths(currentSchema._def.right as z.ZodType, path, next);
+    mapSensitivePathsMut(currentSchema._def.left as z.ZodType, path, hints);
+    mapSensitivePathsMut(currentSchema._def.right as z.ZodType, path, hints);
   }
-
-  return next;
 }
 
 /** @internal */

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -188,6 +188,12 @@ function isUnwrappable(object: unknown): object is ZodDummy {
   );
 }
 
+/**
+ * Traverses the Zod schema tree and marks every sensitive path in `hints`.
+ *
+ * Note: `hints` is mutated in-place for performance (avoids O(N²) copies).
+ * The same object is also returned for call-site convenience.
+ */
 export function mapSensitivePaths(
   schema: z.ZodType,
   path: string,

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -261,7 +261,10 @@ function isUnwrappable(object: unknown): object is ZodDummy {
   );
 }
 
-/** Walk a Zod schema and return copied hints with sensitive schema marker paths marked. */
+/**
+ * Traverses the Zod schema tree and returns a copy of `hints` with every
+ * sensitive path marked.
+ */
 export function mapSensitivePaths(
   schema: z.ZodType,
   path: string,

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -261,13 +261,18 @@ function isUnwrappable(object: unknown): object is ZodDummy {
   );
 }
 
-/** Walk a Zod schema and mark hints for fields registered with the sensitive schema marker. */
+/** Walk a Zod schema and return copied hints with sensitive schema marker paths marked. */
 export function mapSensitivePaths(
   schema: z.ZodType,
   path: string,
   hints: ConfigUiHints,
 ): ConfigUiHints {
-  let next = { ...hints };
+  const next = { ...hints };
+  mapSensitivePathsMut(schema, path, next);
+  return next;
+}
+
+function mapSensitivePathsMut(schema: z.ZodType, path: string, hints: ConfigUiHints): void {
   let currentSchema = schema;
   let isSensitive = sensitive.has(currentSchema);
 
@@ -277,8 +282,8 @@ export function mapSensitivePaths(
   }
 
   if (isSensitive) {
-    next[path] = { ...next[path], sensitive: true };
-  } else if (isSensitiveConfigPath(path) && !next[path]?.sensitive) {
+    hints[path] = { ...hints[path], sensitive: true };
+  } else if (isSensitiveConfigPath(path) && !hints[path]?.sensitive) {
     getLog().debug(`possibly sensitive key found: (${path})`);
   }
 
@@ -286,32 +291,30 @@ export function mapSensitivePaths(
     const shape = currentSchema.shape;
     for (const key in shape) {
       const nextPath = path ? `${path}.${key}` : key;
-      next = mapSensitivePaths(shape[key], nextPath, next);
+      mapSensitivePathsMut(shape[key], nextPath, hints);
     }
     const catchallSchema = currentSchema["_def"].catchall as z.ZodType | undefined;
     if (catchallSchema && !(catchallSchema instanceof z.ZodNever)) {
       const nextPath = path ? `${path}.*` : "*";
-      next = mapSensitivePaths(catchallSchema, nextPath, next);
+      mapSensitivePathsMut(catchallSchema, nextPath, hints);
     }
   } else if (currentSchema instanceof z.ZodArray) {
     const nextPath = path ? `${path}[]` : "[]";
-    next = mapSensitivePaths(currentSchema.element as z.ZodType, nextPath, next);
+    mapSensitivePathsMut(currentSchema.element as z.ZodType, nextPath, hints);
   } else if (currentSchema instanceof z.ZodRecord) {
     const nextPath = path ? `${path}.*` : "*";
-    next = mapSensitivePaths(currentSchema["_def"].valueType as z.ZodType, nextPath, next);
+    mapSensitivePathsMut(currentSchema["_def"].valueType as z.ZodType, nextPath, hints);
   } else if (
     currentSchema instanceof z.ZodUnion ||
     currentSchema instanceof z.ZodDiscriminatedUnion
   ) {
     for (const option of currentSchema.options) {
-      next = mapSensitivePaths(option as z.ZodType, path, next);
+      mapSensitivePathsMut(option as z.ZodType, path, hints);
     }
   } else if (currentSchema instanceof z.ZodIntersection) {
-    next = mapSensitivePaths(currentSchema["_def"].left as z.ZodType, path, next);
-    next = mapSensitivePaths(currentSchema["_def"].right as z.ZodType, path, next);
+    mapSensitivePathsMut(currentSchema["_def"].left as z.ZodType, path, hints);
+    mapSensitivePathsMut(currentSchema["_def"].right as z.ZodType, path, hints);
   }
-
-  return next;
 }
 
 /** @internal */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where config schema hint generation could spend excessive time copying a growing hints map while walking large Zod schema trees. As OpenClaw's config schema grows, the recursive `{ ...hints }` copy pattern turns traversal into repeated work and can block config/schema initialization paths.

## Why This Change Was Made

The traversal now copies the caller-provided hints map once at the public `mapSensitivePaths` boundary, then uses an internal accumulator for recursive schema walking. That keeps the existing copy-return contract for callers while removing the recursive O(N^2)-style shallow-copy cost.

## User Impact

Config schema and UI-hint generation stay behaviorally identical but avoid a large repeated-allocation slowdown on bigger schema trees. Sensitive config path marking remains unchanged.

## Evidence

- Autoreview branch vs `origin/main`: clean, no accepted/actionable findings, patch correctness 0.98.
- Crabbox Azure `cbx_fd11288428d7`, run `run_627efbec345c`: focused `src/config/schema.hints.test.ts` passed 11 tests.
- Crabbox Azure `cbx_fd11288428d7`, run `run_627efbec345c`: `corepack pnpm check:changed` passed.
- Touched-file `oxfmt --check` and `git diff --check` passed after the final rebase.
- Synthetic benchmark on 3000 schema sections / 6000 mapped paths: old recursive shallow-copy traversal about 8599 ms; new single-copy accumulator about 11.6 ms.

## Compatibility / Migration

No config, migration, or user action required. The public `mapSensitivePaths` function still returns a new hints map and does not mutate caller-owned entries.

Co-authored-by: Vincent Koc <25068+vincentkoc@users.noreply.github.com>
