### PR TITLE
fix: let subagent runTimeoutSeconds fall through to configured default

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1344,7 +1344,7 @@ export function replaceSubagentRunAfterSteer(params: {
       : archiveAfterMs
         ? now + archiveAfterMs
         : undefined;
-  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? 0;
+  const runTimeoutSeconds = params.runTimeoutSeconds ?? source.runTimeoutSeconds ?? undefined;
   const waitTimeoutMs = resolveSubagentWaitTimeoutMs(cfg, runTimeoutSeconds);
   const preserveFrozenResultFallback = params.preserveFrozenResultFallback === true;
   const sessionStartedAt = resolveSubagentSessionStartedAt(source) ?? now;


### PR DESCRIPTION
Fixes #54936

When no explicit `runTimeoutSeconds` is passed, the fallback was `0` which the timeout resolver treats as "disable timeout". Changed to `undefined` so the resolver falls through to the configured `agents.defaults.subagents.runTimeoutSeconds`.