### PR TITLE
fix: invalidate skills snapshot on gateway restart

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -905,8 +905,12 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      (skillsSnapshotVersion > 0 &&
+        (sessionEntry.skillsSnapshot.version ?? 0) < skillsSnapshotVersion);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
+import { bumpSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { loadConfig } from "../config/config.js";
 import {
   resolveGatewayLaunchAgentLabel,
@@ -118,6 +119,7 @@ export function emitGatewayRestart(): boolean {
   const cycleToken = ++restartCycleToken;
   emittedRestartToken = cycleToken;
   authorizeGatewaySigusr1Restart();
+  bumpSkillsSnapshotVersion({ reason: "manual" });
   try {
     if (process.listenerCount("SIGUSR1") > 0) {
       process.emit("SIGUSR1");


### PR DESCRIPTION
Fixes #54938

Skills snapshot cached in sessions was never refreshed on `/restart` or gateway restart. Now: (1) bump the global skills snapshot version before SIGUSR1, and (2) compare snapshot version in agent-command.ts so stale snapshots get rebuilt.