### PR TITLE
fix: prevent duplicate Feishu plugin tool registration

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -46,6 +46,8 @@ export {
   type MentionTarget,
 } from "./src/mention.js";
 
+let fullRegistered = false;
+
 export default defineChannelPluginEntry({
   id: "feishu",
   name: "Feishu",
@@ -53,6 +55,8 @@ export default defineChannelPluginEntry({
   plugin: feishuPlugin,
   setRuntime: setFeishuRuntime,
   registerFull(api) {
+    if (fullRegistered) return;
+    fullRegistered = true;
     registerFeishuSubagentHooks(api);
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);


### PR DESCRIPTION
Fixes #54949

Feishu plugin tools were being registered twice on gateway startup in v2026.3.24.