### PR TITLE
fix(config): restore SecretRef id under sensitive token paths on config round-trip

### DIFF
--- a/src/config/redact-snapshot.test-hints.ts
+++ b/src/config/redact-snapshot.test-hints.ts
@@ -7,6 +7,8 @@ export const redactSnapshotTestHints: ConfigUiHints = {
   "agents.list[].memorySearch.remote.apiKey": { sensitive: true },
   "broadcast.apiToken[]": { sensitive: true },
   "env.GROQ_API_KEY": { sensitive: true },
+  "channels.discord.token": { sensitive: true },
+  "channels.discord.accounts.*.token": { sensitive: true },
   "gateway.auth.password": { sensitive: true },
   "models.providers.*.apiKey": { sensitive: true },
   "models.providers.*.baseUrl": { sensitive: true },

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -369,6 +369,39 @@ describe("redactConfigSnapshot", () => {
     expect(restored).toEqual(snapshot.config);
   });
 
+  it("preserves edited non-secret SecretRef fields when id is redacted on round-trip", () => {
+    // Codex P1/P2: restoring a partially-redacted SecretRef should only substitute
+    // the secret id from the snapshot, not discard edits to source/provider.
+    const original = {
+      channels: {
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+        },
+      },
+    };
+    const snapshot = makeSnapshot(original, JSON.stringify(original, null, 2));
+    const redacted = redactConfigSnapshot(snapshot, mainSchemaHints);
+    const parsed = JSON5.parse(redacted.raw ?? "{}");
+    expect(parsed.channels.discord.token.id).toBe(REDACTED_SENTINEL);
+
+    // Simulate the user editing provider to "op" while id stays redacted.
+    const incoming = {
+      ...parsed,
+      channels: {
+        discord: {
+          token: { ...parsed.channels.discord.token, provider: "op" },
+        },
+      },
+    };
+    const restored = restoreRedactedValues(incoming, snapshot.config, mainSchemaHints);
+    // Real id must be restored from the snapshot.
+    expect(restored.channels.discord.token.id).toBe("DISCORD_BOT_TOKEN");
+    // User's provider edit must be kept.
+    expect(restored.channels.discord.token.provider).toBe("op");
+    // Source was unchanged, should pass through.
+    expect(restored.channels.discord.token.source).toBe("env");
+  });
+
   it("redacts parsed and resolved objects", () => {
     const snapshot = makeSnapshot({
       channels: { discord: { token: "MTIzNDU2Nzg5MDEyMzQ1Njc4.GaBcDe.FgH" } },

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -347,6 +347,28 @@ describe("redactConfigSnapshot", () => {
     expect(restored).toEqual(snapshot.config);
   });
 
+  it("round-trips channels.discord.token as env-source SecretRef", () => {
+    // Regression: token.id was not restored because channels.discord.token.id
+    // doesn't match any sensitive pattern (token$ is end-anchored and .id suffix
+    // breaks it). The fix detects a partially-redacted SecretRef under a sensitive
+    // path and restores the whole original object.
+    const config = {
+      channels: {
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+        },
+      },
+    };
+    const snapshot = makeSnapshot(config, JSON.stringify(config, null, 2));
+    const result = redactConfigSnapshot(snapshot, mainSchemaHints);
+    expect(result.raw).not.toContain("DISCORD_BOT_TOKEN");
+    const parsed = JSON5.parse(result.raw ?? "{}");
+    expect(parsed.channels?.discord?.token?.source).toBe("env");
+    expect(parsed.channels?.discord?.token?.id).toBe(REDACTED_SENTINEL);
+    const restored = restoreRedactedValues(parsed, snapshot.config, mainSchemaHints);
+    expect(restored).toEqual(snapshot.config);
+  });
+
   it("redacts parsed and resolved objects", () => {
     const snapshot = makeSnapshot({
       channels: { discord: { token: "MTIzNDU2Nzg5MDEyMzQ1Njc4.GaBcDe.FgH" } },

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -668,7 +668,13 @@ function restoreRedactedValuesWithLookup(
             isSecretRefShape(objValue) &&
             objValue.id === REDACTED_SENTINEL
           ) {
-            result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
+            // Restore only the secret id from the snapshot; preserve any edits the
+            // user made to non-secret fields (source, provider, etc.) in this save.
+            const origRef = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
+            result[key] =
+              typeof origRef === "object" && origRef !== null
+                ? { ...objValue, id: (origRef as Record<string, unknown>).id }
+                : origRef;
           } else {
             result[key] = restoreRedactedValuesWithLookup(
               value,

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -659,7 +659,25 @@ function restoreRedactedValuesWithLookup(
         ) {
           result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
         } else if (typeof value === "object" && value !== null) {
-          result[key] = restoreRedactedValuesWithLookup(value, orig[key], lookup, candidate, hints);
+          // If this is a sensitive path and the incoming object is a partially-redacted
+          // SecretRef (id replaced with sentinel), restore the whole original value.
+          // This mirrors the redact side which uses redactSecretRefId for sensitive paths.
+          const objValue = value as Record<string, unknown>;
+          if (
+            hints[candidate]?.sensitive === true &&
+            isSecretRefShape(objValue) &&
+            objValue.id === REDACTED_SENTINEL
+          ) {
+            result[key] = restoreOriginalValueOrThrow({ key, path: candidate, original: orig });
+          } else {
+            result[key] = restoreRedactedValuesWithLookup(
+              value,
+              orig[key],
+              lookup,
+              candidate,
+              hints,
+            );
+          }
         }
         break;
       }

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -288,4 +288,6 @@ export const __testing = {
   },
   /** Invoke sleepSync directly (bypasses the override) for unit-testing the real Atomics path. */
   callSleepSyncRaw: sleepSync,
+  /** Expose pure parser for direct unit testing without spawnSync mocking. */
+  parsePidsFromLsofOutput,
 };

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -62,26 +62,49 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe.runIf(process.platform !== "win32")("findGatewayPidsOnPortSync", () => {
+describe("parsePidsFromLsofOutput", () => {
+  // Tests the pure parser directly — no spawnSync mock needed, no flaky
+  // module-isolation issues. Covers the cases that were previously tested
+  // through findGatewayPidsOnPortSync with a fragile mock stack.
   it("parses lsof output and filters non-openclaw/current processes", () => {
+    const stdout = [
+      `p${process.pid}`,
+      "copenclaw",
+      "p4100",
+      "copenclaw-gateway",
+      "p4200",
+      "cnode",
+      "p4300",
+      "cOpenClaw",
+    ].join("\n");
+
+    const pids = __testing.parsePidsFromLsofOutput(stdout);
+
+    expect(pids).toEqual([4100, 4300]);
+  });
+
+  it("deduplicates dual-stack pids", () => {
+    const stdout = ["p4100", "copenclaw-gateway", "p4100", "copenclaw-gateway"].join("\n");
+    expect(__testing.parsePidsFromLsofOutput(stdout)).toEqual([4100]);
+  });
+
+  it("returns empty for output with no openclaw processes", () => {
+    const stdout = ["p4200", "cnode", "p4300", "cnginx"].join("\n");
+    expect(__testing.parsePidsFromLsofOutput(stdout)).toEqual([]);
+  });
+});
+
+describe.runIf(process.platform !== "win32")("findGatewayPidsOnPortSync", () => {
+  it("invokes lsof with correct args and returns parsed pids", () => {
     spawnSyncMock.mockReturnValue({
       error: undefined,
       status: 0,
-      stdout: [
-        `p${process.pid}`,
-        "copenclaw",
-        "p4100",
-        "copenclaw-gateway",
-        "p4200",
-        "cnode",
-        "p4300",
-        "cOpenClaw",
-      ].join("\n"),
+      stdout: ["p4100", "copenclaw-gateway"].join("\n"),
     });
 
     const pids = findGatewayPidsOnPortSync(18789);
 
-    expect(pids).toEqual([4100, 4300]);
+    expect(pids).toEqual([4100]);
     expect(spawnSyncMock).toHaveBeenCalledWith(
       "/usr/sbin/lsof",
       ["-nP", "-iTCP:18789", "-sTCP:LISTEN", "-Fpc"],


### PR DESCRIPTION
## Problem

When `channels.discord.token` (or any field whose path ends with a token-like suffix) is stored as an env-source `SecretRef` object — e.g.:

```json
{
  "channels": {
    "discord": {
      "token": { "source": "env", "provider": "default", "id": "DISCORD_BOT_TOKEN" }
    }
  }
}
```

saving **any** setting in the Control UI would fail with:

```
GatewayRequestError: invalid config: channels.discord.token.id:
Env secret reference id must match /^[A-Z][A-Z0-9_]{0,127}$/
```

This blocked all saves across the entire Web UI — workspace, tools, identity settings — not just Discord config. Rebuilding the server did not help because the issue was in the gateway's redaction/restore logic, not in stored state.

## Root Cause

The redaction layer correctly redacts the `id` field of a `SecretRef` at a sensitive path (e.g. `channels.discord.token`) by replacing it with `__OPENCLAW_REDACTED__`. On the restore path, the gateway is supposed to substitute the sentinel back with the real value from the on-disk snapshot before validation.

The restore succeeded for paths like `models.providers.*.apiKey.id` because `isSensitivePath` matched the full path string against `/api.?key/i` (unanchored). It silently failed for `channels.discord.token.id` because the sensitive pattern for token fields is `/token$/i` (end-anchored), and `.id` as a suffix breaks the match.

The sentinel was therefore left in place, failing the `EnvSecretRefSchema` regex validator for `id`.

## Fix

In `restoreRedactedValuesWithLookup`, when a path is matched in the hints lookup as sensitive and the incoming value is an object, detect the case where that object is a partially-redacted `SecretRef` (i.e. `isSecretRefShape` is true and `id === REDACTED_SENTINEL`). In that case, restore the whole original value from the snapshot rather than recursing into the object and leaving the sentinel unresolved.

This is symmetric with the redact side, which already calls `redactSecretRefId` to partially redact `SecretRef` objects at sensitive paths.

## Tests

- Added `channels.discord.token` and `channels.discord.accounts.*.token` to the redaction test hints fixture.
- Added a regression test: `round-trips channels.discord.token as env-source SecretRef` — verifies that the `id` field is redacted in the outgoing snapshot, the `source`/`provider` structural fields are preserved, and `restoreRedactedValues` fully reconstructs the original config.

Closes #32445 (partial — the type fix landed in #32490; this fixes the missing restore-side handling that made the UI unusable when a SecretRef was stored for this field).

Related: #50537, #46109