### PR TITLE
feat(routing): support per-binding workspace override

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -44,6 +44,31 @@ function loadStageSandboxMediaRuntime() {
   return stageSandboxMediaRuntimePromise;
 }
 
+
+/**
+ * Resolve per-binding workspace override from route bindings.
+ *
+ * When a binding specifies a `workspace` field, the agent runs in that
+ * directory instead of its default workspace.  This enables a single generic
+ * agent to work in different workspaces (e.g., git worktrees) depending on
+ * which chat/peer it is responding to.
+ */
+function resolveBindingWorkspace(
+  cfg: OpenClawConfig,
+  agentId: string,
+  sessionKey?: string,
+): string | undefined {
+  if (!sessionKey) return undefined;
+  for (const binding of listRouteBindings(cfg)) {
+    if (!binding.workspace || binding.agentId !== agentId) continue;
+    const peer = binding.match?.peer;
+    if (peer?.id && sessionKey.includes(peer.id)) {
+      return binding.workspace;
+    }
+  }
+  return undefined;
+}
+
 function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): string[] | undefined {
   const normalize = (list?: string[]) => {
     if (!Array.isArray(list)) {
@@ -166,7 +191,8 @@ export async function getReplyFromConfig(
     }
   }
 
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+  const bindingWorkspace = resolveBindingWorkspace(cfg, agentId, opts.sessionKey);
+  const workspaceDirRaw = bindingWorkspace ?? resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -62,7 +62,7 @@ function resolveBindingWorkspace(
   for (const binding of listRouteBindings(cfg)) {
     if (!binding.workspace || binding.agentId !== agentId) continue;
     const peer = binding.match?.peer;
-    if (peer?.id && sessionKey.includes(peer.id)) {
+    if (peer?.id && sessionKey.endsWith(`:${peer.id.toLowerCase()}`)) {
       return binding.workspace;
     }
   }

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -40,6 +40,8 @@ export type AgentRouteBinding = {
   type?: "route";
   agentId: string;
   comment?: string;
+  /** Optional workspace override — lets the same agent use a different workspace for this binding. */
+  workspace?: string;
   match: AgentBindingMatch;
 };
 

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -39,6 +39,7 @@ const RouteBindingSchema = z
     type: z.literal("route").optional(),
     agentId: z.string(),
     comment: z.string().optional(),
+    workspace: z.string().optional(),
     match: BindingMatchSchema,
   })
   .strict();

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -46,6 +46,8 @@ export type ResolvedAgentRoute = {
   mainSessionKey: string;
   /** Which session should receive inbound last-route updates. */
   lastRoutePolicy: "main" | "session";
+  /** Per-binding workspace override — lets the same agent use a different workspace for this binding. */
+  workspace?: string;
   /** Match description for debugging/logging. */
   matchedBy:
     | "binding.peer"
@@ -658,7 +660,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
-  const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
+  const choose = (
+    agentId: string,
+    matchedBy: ResolvedAgentRoute["matchedBy"],
+    workspace?: string,
+  ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
@@ -672,7 +678,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       agentId: resolvedAgentId,
       mainKey: DEFAULT_MAIN_KEY,
     }).toLowerCase();
-    const route = {
+    const route: ResolvedAgentRoute = {
       agentId: resolvedAgentId,
       channel,
       accountId,
@@ -680,6 +686,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       mainSessionKey,
       lastRoutePolicy: deriveLastRoutePolicy({ sessionKey, mainSessionKey }),
       matchedBy,
+      ...(workspace ? { workspace } : {}),
     };
     if (routeCache && routeCacheKey) {
       routeCache.set(routeCacheKey, route);
@@ -796,7 +803,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       if (shouldLogDebug) {
         logDebug(`[routing] match: matchedBy=${tier.matchedBy} agentId=${matched.binding.agentId}`);
       }
-      return choose(matched.binding.agentId, tier.matchedBy);
+      return choose(matched.binding.agentId, tier.matchedBy, matched.binding.workspace);
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds an optional `workspace` field to route bindings so that the same agent can operate in different directories depending on which chat/peer it responds to.
- Threads the workspace through `ResolvedAgentRoute` so downstream consumers can use it.
- In `getReplyFromConfig`, binding workspace takes precedence over the agent-level default workspace.

### Motivation

In git-worktree workflows, each worktree lives in a separate directory but logically belongs to the same agent. Currently, the only way to point an agent at a different directory is to create a separate agent entry per workspace. With per-binding workspace, a single agent definition can serve multiple worktrees — each bound to a different chat/group via the existing binding mechanism.

**Example config:**
```json
{
  "bindings": [{
    "agentId": "coder",
    "workspace": "/path/to/feature-worktree-A",
    "match": { "channel": "slack", "peer": { "kind": "group", "id": "C_CHANNEL_A" } }
  }, {
    "agentId": "coder",
    "workspace": "/path/to/feature-worktree-B",
    "match": { "channel": "slack", "peer": { "kind": "group", "id": "C_CHANNEL_B" } }
  }]
}
```

### Changes

| File | Change |
|------|--------|
| `src/config/types.agents.ts` | Add `workspace?: string` to `AgentRouteBinding` |
| `src/config/zod-schema.agents.ts` | Add `workspace` to `RouteBindingSchema` |
| `src/routing/resolve-route.ts` | Thread `workspace` through `ResolvedAgentRoute` and `choose()` |
| `src/auto-reply/reply/get-reply.ts` | Add `resolveBindingWorkspace()` — binding workspace takes precedence |

## Test plan

- [ ] Verify existing routing tests pass (`pnpm test -- --grep routing`)
- [ ] Add a binding with `workspace` field and confirm the agent runs in that directory
- [ ] Confirm bindings without `workspace` behave identically to before (no regression)
- [ ] Verify `resolveBindingWorkspace` returns `undefined` when no binding matches


Made with [Cursor](https://cursor.com)