### PR TITLE
fix: sanitize leaked directive tags before outbound delivery

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -1,5 +1,6 @@
 import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
+import { sanitizeLeakedDirectiveTags } from "../../utils/directive-tags.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
@@ -89,6 +90,11 @@ export function normalizeReplyPayload(
 
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
+    // Safety net: strip malformed/partial directive tags that survived the
+    // precise regex passes (e.g. corrupted `[[replyReturn_current` with no
+    // closing `]]`).  Runs after sanitizeUserFacingText so it catches any
+    // fragments that other passes left behind.  (#55019)
+    text = sanitizeLeakedDirectiveTags(text);
   }
   if (!hasContent(text)) {
     opts.onSkip?.("empty");

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  sanitizeLeakedDirectiveTags,
   stripInlineDirectiveTagsForDelivery,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
@@ -48,6 +49,56 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
     const result = stripInlineDirectiveTagsForDelivery(input);
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
+  });
+});
+
+describe("sanitizeLeakedDirectiveTags", () => {
+  test("strips malformed reply tag with no closing brackets", () => {
+    expect(sanitizeLeakedDirectiveTags("hello [[replyReturn_current world")).toBe("hello  world");
+  });
+
+  test("strips partial reply_to_current with no closing brackets", () => {
+    expect(sanitizeLeakedDirectiveTags("hello [[reply_to_current world")).toBe("hello  world");
+  });
+
+  test("strips partial reply_to: with no closing brackets", () => {
+    expect(sanitizeLeakedDirectiveTags("hello [[ reply_to : 123 world")).toBe("hello  world");
+  });
+
+  test("strips partial audio_as_voice with no closing brackets", () => {
+    expect(sanitizeLeakedDirectiveTags("hello [[audio_as_voice world")).toBe("hello  world");
+  });
+
+  test("strips malformed tag with only one closing bracket", () => {
+    expect(sanitizeLeakedDirectiveTags("hello [[reply_to_current] world")).toBe("hello  world");
+  });
+
+  test("still strips well-formed tags as a safety net", () => {
+    expect(sanitizeLeakedDirectiveTags("hello [[reply_to_current]] world")).toBe("hello  world");
+  });
+
+  test("does not strip normal double-bracket content", () => {
+    expect(sanitizeLeakedDirectiveTags("array [[1,2,3]] here")).toBe("array [[1,2,3]] here");
+  });
+
+  test("does not strip unrelated double-bracket text", () => {
+    expect(sanitizeLeakedDirectiveTags("see [[wikipedia]] for details")).toBe(
+      "see [[wikipedia]] for details",
+    );
+  });
+
+  test("returns empty string unchanged", () => {
+    expect(sanitizeLeakedDirectiveTags("")).toBe("");
+  });
+
+  test("handles text with no brackets at all", () => {
+    expect(sanitizeLeakedDirectiveTags("just normal text")).toBe("just normal text");
+  });
+
+  test("handles multiple malformed tags in one string", () => {
+    expect(sanitizeLeakedDirectiveTags("a [[replyReturn_current b [[audio_as_voice c")).toBe(
+      "a  b  c",
+    );
   });
 });
 

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -19,6 +19,25 @@ const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
 
+// Catches malformed/partial directive tags that bypass the precise regexes above.
+// Targets reply_to*, replyReturn*, audio_as_voice variants with missing or partial
+// closing brackets — a safety net so corrupted output never reaches the user.
+const LEAKED_DIRECTIVE_TAG_RE =
+  /\[\[\s*(?:reply[\w]*(?:\s*:\s*\S+)?|audio_as_voice)(?:\s*\]\]?)?/gi;
+
+/**
+ * Defensive sanitization for directive tag fragments that survive the precise
+ * strip passes (e.g. `[[replyReturn_current` with no closing `]]`).
+ * Safe for arbitrary text — only matches `[[` followed by known directive
+ * keywords, so normal bracket content like `[[1,2,3]]` passes through.
+ */
+export function sanitizeLeakedDirectiveTags(text: string): string {
+  if (!text || !text.includes("[[")) {
+    return text;
+  }
+  return text.replace(LEAKED_DIRECTIVE_TAG_RE, "");
+}
+
 function normalizeDirectiveWhitespace(text: string): string {
   return text
     .replace(/[ \t]+/g, " ")


### PR DESCRIPTION
## Summary
- Adds `sanitizeLeakedDirectiveTags()` in `src/utils/directive-tags.ts` — a defensive safety net that catches malformed/partial directive tags (e.g. `[[replyReturn_current` with no closing `]]`) that bypass the precise `REPLY_TAG_RE` regex
- Wires the sanitization into `normalizeReplyPayload()` in `src/auto-reply/reply/normalize-reply.ts`, right after `sanitizeUserFacingText()` — the central outbound path for all channels

Fixes #55019

## Test plan
- [x] 11 new tests in `src/utils/directive-tags.test.ts` covering:
  - Malformed tags with no closing brackets (`[[replyReturn_current`, `[[reply_to_current`, `[[ reply_to : 123`)
  - Partial audio tag (`[[audio_as_voice`)
  - Single closing bracket (`[[reply_to_current]`)
  - Well-formed tags still stripped as safety net
  - Normal `[[...]]` content NOT stripped (e.g. `[[1,2,3]]`, `[[wikipedia]]`)
  - Empty string, plain text, multiple malformed tags
- [x] All 20 directive-tags tests pass
- [x] `pnpm check` passes (lint, format, type-check, boundaries)