### PR TITLE
Agents: cache bundle MCP runtime per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Security/LINE: make webhook signature validation run the timing-safe compare even when the supplied signature length is wrong, closing a small timing side-channel. (#55663) Thanks @gavyngong.
 - LINE/status: stop `openclaw status` from warning about missing credentials when sanitized LINE snapshots are already configured, while still surfacing whether the missing field is the token or secret. (#45701) Thanks @tamaosamu.
 - Gateway/health: carry webhook-vs-polling account mode from channel descriptors into runtime snapshots so passive channels like LINE and BlueBubbles skip false stale-socket health failures. (#47488) Thanks @karesansui-u.
+- Agents/MCP: reuse bundled MCP runtimes across turns in the same session, while recreating them when MCP config changes and disposing stale runtimes cleanly on session rollover. (#55090) Thanks @allan0509.
 - Memory/QMD: honor `memory.qmd.update.embedInterval` even when regular QMD update cadence is disabled or slower by arming a dedicated embed-cadence maintenance timer, while avoiding redundant timers when regular updates are already frequent enough. (#37326) Thanks @barronlroth.
 - Agents/memory flush: keep daily memory flush files append-only during embedded attempts so compaction writes do not overwrite earlier notes. (#53725) Thanks @HPluseven.
 - Web UI/markdown: stop bare auto-links from swallowing adjacent CJK text while preserving valid mixed-script path and query characters in rendered links. (#48410) Thanks @jnuyao.

--- a/src/agents/pi-bundle-mcp-tools.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.test.ts
@@ -3,13 +3,19 @@ import http from "node:http";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { writeBundleProbeMcpServer, writeClaudeBundle } from "./bundle-mcp.test-harness.js";
-import { createBundleMcpToolRuntime } from "./pi-bundle-mcp-tools.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  createBundleMcpToolRuntime,
+  disposeSessionMcpRuntime,
+  getOrCreateSessionMcpRuntime,
+  materializeBundleMcpToolsForRun,
+} from "./pi-bundle-mcp-tools.js";
 
 const require = createRequire(import.meta.url);
 const SDK_SERVER_MCP_PATH = require.resolve("@modelcontextprotocol/sdk/server/mcp.js");
 const SDK_SERVER_SSE_PATH = require.resolve("@modelcontextprotocol/sdk/server/sse.js");
+const SDK_SERVER_STDIO_PATH = require.resolve("@modelcontextprotocol/sdk/server/stdio.js");
 
 const tempDirs: string[] = [];
 
@@ -19,35 +25,134 @@ async function makeTempDir(prefix: string): Promise<string> {
   return dir;
 }
 
+async function writeExecutable(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, { encoding: "utf-8", mode: 0o755 });
+}
+
+async function writeBundleProbeMcpServer(
+  filePath: string,
+  params: {
+    startupCounterPath?: string;
+    startupDelayMs?: number;
+    pidPath?: string;
+    exitMarkerPath?: string;
+  } = {},
+): Promise<void> {
+  await writeExecutable(
+    filePath,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
+import { McpServer } from ${JSON.stringify(SDK_SERVER_MCP_PATH)};
+import { StdioServerTransport } from ${JSON.stringify(SDK_SERVER_STDIO_PATH)};
+
+const startupCounterPath = ${JSON.stringify(params.startupCounterPath ?? "")};
+if (startupCounterPath) {
+  let current = 0;
+  try {
+    current = Number.parseInt((await fsp.readFile(startupCounterPath, "utf8")).trim(), 10) || 0;
+  } catch {}
+  await fsp.writeFile(startupCounterPath, String(current + 1), "utf8");
+}
+const pidPath = ${JSON.stringify(params.pidPath ?? "")};
+if (pidPath) {
+  await fsp.writeFile(pidPath, String(process.pid), "utf8");
+}
+const exitMarkerPath = ${JSON.stringify(params.exitMarkerPath ?? "")};
+if (exitMarkerPath) {
+  process.once("exit", () => {
+    try {
+      fs.writeFileSync(exitMarkerPath, "exited", "utf8");
+    } catch {}
+  });
+}
+const startupDelayMs = ${JSON.stringify(params.startupDelayMs ?? 0)};
+if (startupDelayMs > 0) {
+  await delay(startupDelayMs);
+}
+
+const server = new McpServer({ name: "bundle-probe", version: "1.0.0" });
+server.tool("bundle_probe", "Bundle MCP probe", async () => {
+  return {
+    content: [{ type: "text", text: process.env.BUNDLE_PROBE_TEXT ?? "missing-probe-text" }],
+  };
+});
+
+await server.connect(new StdioServerTransport());
+`,
+  );
+}
+
+async function waitForFileText(filePath: string, timeoutMs = 5_000): Promise<string> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const content = await fs.readFile(filePath, "utf8").catch(() => undefined);
+    if (content != null) {
+      return content;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+async function writeClaudeBundle(params: {
+  pluginRoot: string;
+  serverScriptPath: string;
+}): Promise<void> {
+  await fs.mkdir(path.join(params.pluginRoot, ".claude-plugin"), { recursive: true });
+  await fs.writeFile(
+    path.join(params.pluginRoot, ".claude-plugin", "plugin.json"),
+    `${JSON.stringify({ name: "bundle-probe" }, null, 2)}\n`,
+    "utf-8",
+  );
+  await fs.writeFile(
+    path.join(params.pluginRoot, ".mcp.json"),
+    `${JSON.stringify(
+      {
+        mcpServers: {
+          bundleProbe: {
+            command: "node",
+            args: [path.relative(params.pluginRoot, params.serverScriptPath)],
+            env: {
+              BUNDLE_PROBE_TEXT: "FROM-BUNDLE",
+            },
+          },
+        },
+      },
+      null,
+      2,
+    )}\n`,
+    "utf-8",
+  );
+}
+
 afterEach(async () => {
+  await __testing.resetSessionMcpRuntimeManager();
   await Promise.all(
     tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
   );
 });
 
-async function createBundledRuntime(options?: { reservedToolNames?: string[] }) {
-  const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
-  const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
-  const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
-  await writeBundleProbeMcpServer(serverScriptPath);
-  await writeClaudeBundle({ pluginRoot, serverScriptPath });
-
-  return createBundleMcpToolRuntime({
-    workspaceDir,
-    cfg: {
-      plugins: {
-        entries: {
-          "bundle-probe": { enabled: true },
-        },
-      },
-    },
-    reservedToolNames: options?.reservedToolNames,
-  });
-}
-
 describe("createBundleMcpToolRuntime", () => {
   it("loads bundle MCP tools and executes them", async () => {
-    const runtime = await createBundledRuntime();
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
+    const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath);
+    await writeClaudeBundle({ pluginRoot, serverScriptPath });
+
+    const runtime = await createBundleMcpToolRuntime({
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+    });
 
     try {
       expect(runtime.tools.map((tool) => tool.name)).toEqual(["bundle_probe"]);
@@ -66,7 +171,23 @@ describe("createBundleMcpToolRuntime", () => {
   });
 
   it("skips bundle MCP tools that collide with existing tool names", async () => {
-    const runtime = await createBundledRuntime({ reservedToolNames: ["bundle_probe"] });
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
+    const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath);
+    await writeClaudeBundle({ pluginRoot, serverScriptPath });
+
+    const runtime = await createBundleMcpToolRuntime({
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+      reservedToolNames: ["bundle_probe"],
+    });
 
     try {
       expect(runtime.tools).toEqual([]);
@@ -119,7 +240,6 @@ describe("createBundleMcpToolRuntime", () => {
   });
 
   it("loads configured SSE MCP tools via url", async () => {
-    // Dynamically import the SSE server transport from the SDK.
     const { McpServer } = await import(SDK_SERVER_MCP_PATH);
     const { SSEServerTransport } = await import(SDK_SERVER_SSE_PATH);
 
@@ -130,7 +250,6 @@ describe("createBundleMcpToolRuntime", () => {
       };
     });
 
-    // Start an HTTP server that hosts the SSE MCP transport.
     let sseTransport:
       | {
           handlePostMessage: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
@@ -191,5 +310,199 @@ describe("createBundleMcpToolRuntime", () => {
         httpServer.close((err) => (err ? reject(err) : resolve())),
       );
     }
+  });
+
+  it("reuses the same session runtime across repeated materialization", async () => {
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const startupCounterPath = path.join(workspaceDir, "bundle-starts.txt");
+    const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
+    const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath, { startupCounterPath });
+    await writeClaudeBundle({ pluginRoot, serverScriptPath });
+
+    const runtimeA = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-a",
+      sessionKey: "agent:test:session-a",
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+    });
+    const runtimeB = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-a",
+      sessionKey: "agent:test:session-a",
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const materializedA = await materializeBundleMcpToolsForRun({ runtime: runtimeA });
+    const materializedB = await materializeBundleMcpToolsForRun({
+      runtime: runtimeB,
+      reservedToolNames: ["builtin_tool"],
+    });
+
+    expect(runtimeA).toBe(runtimeB);
+    expect(materializedA.tools.map((tool) => tool.name)).toEqual(["bundle_probe"]);
+    expect(materializedB.tools.map((tool) => tool.name)).toEqual(["bundle_probe"]);
+    expect(await fs.readFile(startupCounterPath, "utf8")).toBe("1");
+    expect(__testing.getCachedSessionIds()).toEqual(["session-a"]);
+  });
+
+  it("recreates the session runtime after explicit disposal", async () => {
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const startupCounterPath = path.join(workspaceDir, "bundle-starts.txt");
+    const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
+    const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath, { startupCounterPath });
+    await writeClaudeBundle({ pluginRoot, serverScriptPath });
+
+    const cfg = {
+      plugins: {
+        entries: {
+          "bundle-probe": { enabled: true },
+        },
+      },
+    };
+
+    const runtimeA = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-b",
+      sessionKey: "agent:test:session-b",
+      workspaceDir,
+      cfg,
+    });
+    await materializeBundleMcpToolsForRun({ runtime: runtimeA });
+    await disposeSessionMcpRuntime("session-b");
+
+    const runtimeB = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-b",
+      sessionKey: "agent:test:session-b",
+      workspaceDir,
+      cfg,
+    });
+    await materializeBundleMcpToolsForRun({ runtime: runtimeB });
+
+    expect(runtimeA).not.toBe(runtimeB);
+    expect(await fs.readFile(startupCounterPath, "utf8")).toBe("2");
+  });
+
+  it("recreates the session runtime when MCP config changes", async () => {
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const startupCounterPath = path.join(workspaceDir, "bundle-starts.txt");
+    const serverScriptPath = path.join(workspaceDir, "servers", "configured-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath, { startupCounterPath });
+
+    const runtimeA = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-c",
+      sessionKey: "agent:test:session-c",
+      workspaceDir,
+      cfg: {
+        mcp: {
+          servers: {
+            configuredProbe: {
+              command: "node",
+              args: [serverScriptPath],
+              env: {
+                BUNDLE_PROBE_TEXT: "FROM-CONFIG-A",
+              },
+            },
+          },
+        },
+      },
+    });
+    const toolsA = await materializeBundleMcpToolsForRun({ runtime: runtimeA });
+    const resultA = await toolsA.tools[0].execute(
+      "call-configured-probe-a",
+      {},
+      undefined,
+      undefined,
+    );
+
+    const runtimeB = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-c",
+      sessionKey: "agent:test:session-c",
+      workspaceDir,
+      cfg: {
+        mcp: {
+          servers: {
+            configuredProbe: {
+              command: "node",
+              args: [serverScriptPath],
+              env: {
+                BUNDLE_PROBE_TEXT: "FROM-CONFIG-B",
+              },
+            },
+          },
+        },
+      },
+    });
+    const toolsB = await materializeBundleMcpToolsForRun({ runtime: runtimeB });
+    const resultB = await toolsB.tools[0].execute(
+      "call-configured-probe-b",
+      {},
+      undefined,
+      undefined,
+    );
+
+    expect(runtimeA).not.toBe(runtimeB);
+    expect(resultA.content[0]).toMatchObject({ type: "text", text: "FROM-CONFIG-A" });
+    expect(resultB.content[0]).toMatchObject({ type: "text", text: "FROM-CONFIG-B" });
+    expect(await fs.readFile(startupCounterPath, "utf8")).toBe("2");
+  });
+
+  it("disposes startup-in-flight runtimes without leaking MCP processes", async () => {
+    vi.useRealTimers();
+    const workspaceDir = await makeTempDir("openclaw-bundle-mcp-tools-");
+    const startupCounterPath = path.join(workspaceDir, "bundle-starts.txt");
+    const pidPath = path.join(workspaceDir, "bundle.pid");
+    const exitMarkerPath = path.join(workspaceDir, "bundle.exit");
+    const pluginRoot = path.join(workspaceDir, ".openclaw", "extensions", "bundle-probe");
+    const serverScriptPath = path.join(pluginRoot, "servers", "bundle-probe.mjs");
+    await writeBundleProbeMcpServer(serverScriptPath, {
+      startupCounterPath,
+      startupDelayMs: 1_000,
+      pidPath,
+      exitMarkerPath,
+    });
+    await writeClaudeBundle({ pluginRoot, serverScriptPath });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-d",
+      sessionKey: "agent:test:session-d",
+      workspaceDir,
+      cfg: {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      },
+    });
+
+    const materializeResult = materializeBundleMcpToolsForRun({ runtime }).then(
+      () => ({ status: "resolved" as const }),
+      (error: unknown) => ({ status: "rejected" as const, error }),
+    );
+    await waitForFileText(pidPath);
+    await disposeSessionMcpRuntime("session-d");
+
+    const result = await materializeResult;
+    if (result.status !== "rejected") {
+      throw new Error("Expected bundle MCP materialization to reject after disposal");
+    }
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result.error as Error).message).toMatch(/disposed/);
+    expect(await waitForFileText(exitMarkerPath)).toBe("exited");
+    expect(await fs.readFile(startupCounterPath, "utf8")).toBe("1");
+    expect(__testing.getCachedSessionIds()).not.toContain("session-d");
   });
 });

--- a/src/agents/pi-bundle-mcp-tools.ts
+++ b/src/agents/pi-bundle-mcp-tools.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
@@ -6,6 +7,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { logDebug, logWarn } from "../logger.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { loadEmbeddedPiMcpConfig } from "./embedded-pi-mcp.js";
 import { describeSseMcpServerLaunchConfig, resolveSseMcpServerLaunchConfig } from "./mcp-sse.js";
 import {
@@ -26,12 +28,66 @@ type BundleMcpSession = {
   detachStderr?: () => void;
 };
 
+type LoadedMcpConfig = ReturnType<typeof loadEmbeddedPiMcpConfig>;
+type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
+
+export type McpServerCatalog = {
+  serverName: string;
+  launchSummary: string;
+  toolCount: number;
+};
+
+export type McpCatalogTool = {
+  serverName: string;
+  toolName: string;
+  title?: string;
+  description?: string;
+  inputSchema: unknown;
+  fallbackDescription: string;
+};
+
+export type McpToolCatalog = {
+  version: number;
+  generatedAt: number;
+  servers: Record<string, McpServerCatalog>;
+  tools: McpCatalogTool[];
+};
+
+export type SessionMcpRuntime = {
+  sessionId: string;
+  sessionKey?: string;
+  workspaceDir: string;
+  configFingerprint: string;
+  createdAt: number;
+  lastUsedAt: number;
+  getCatalog: () => Promise<McpToolCatalog>;
+  markUsed: () => void;
+  callTool: (serverName: string, toolName: string, input: unknown) => Promise<CallToolResult>;
+  dispose: () => Promise<void>;
+};
+
+export type SessionMcpRuntimeManager = {
+  getOrCreate: (params: {
+    sessionId: string;
+    sessionKey?: string;
+    workspaceDir: string;
+    cfg?: OpenClawConfig;
+  }) => Promise<SessionMcpRuntime>;
+  bindSessionKey: (sessionKey: string, sessionId: string) => void;
+  resolveSessionId: (sessionKey: string) => string | undefined;
+  disposeSession: (sessionId: string) => Promise<void>;
+  disposeAll: () => Promise<void>;
+  listSessionIds: () => string[];
+};
+
+const SESSION_MCP_RUNTIME_MANAGER_KEY = Symbol.for("openclaw.sessionMcpRuntimeManager");
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 async function listAllTools(client: Client) {
-  const tools: Awaited<ReturnType<Client["listTools"]>>["tools"] = [];
+  const tools: ListedTool[] = [];
   let cursor: string | undefined;
   do {
     const page = await client.listTools(cursor ? { cursor } : undefined);
@@ -122,7 +178,6 @@ async function disposeSession(session: BundleMcpSession) {
   await session.transport.close().catch(() => {});
 }
 
-/** Try to create a stdio or SSE transport for the given raw server config. */
 function resolveTransport(
   serverName: string,
   rawServer: unknown,
@@ -131,7 +186,6 @@ function resolveTransport(
   description: string;
   detachStderr?: () => void;
 } | null {
-  // Try stdio first (command-based servers).
   const stdioLaunch = resolveStdioMcpServerLaunchConfig(rawServer);
   if (stdioLaunch.ok) {
     const transport = new StdioClientTransport({
@@ -148,7 +202,6 @@ function resolveTransport(
     };
   }
 
-  // Try SSE (url-based servers).
   const sseLaunch = resolveSseMcpServerLaunchConfig(rawServer, {
     onDroppedHeader: (key) => {
       logWarn(
@@ -162,25 +215,18 @@ function resolveTransport(
     },
   });
   if (sseLaunch.ok) {
-    const headers: Record<string, string> = {
-      ...sseLaunch.config.headers,
-    };
+    const headers: Record<string, string> = { ...sseLaunch.config.headers };
     const hasHeaders = Object.keys(headers).length > 0;
     const transport = new SSEClientTransport(new URL(sseLaunch.config.url), {
-      // Apply headers to POST requests (tool calls, listTools, etc.).
       requestInit: hasHeaders ? { headers } : undefined,
-      // Apply headers to the initial SSE GET handshake (required for auth).
-      // Apply headers to the initial SSE GET handshake (required for auth).
-      // Note: init?.headers may be a Headers instance; convert to plain object
-      // so SDK defaults are preserved and user-configured headers take precedence.
       eventSourceInit: hasHeaders
         ? {
             fetch: (url, init) => {
               const sdkHeaders: Record<string, string> = {};
               if (init?.headers) {
                 if (init.headers instanceof Headers) {
-                  init.headers.forEach((v, k) => {
-                    sdkHeaders[k] = v;
+                  init.headers.forEach((value, key) => {
+                    sdkHeaders[key] = value;
                   });
                 } else {
                   Object.assign(sdkHeaders, init.headers);
@@ -206,102 +252,424 @@ function resolveTransport(
   return null;
 }
 
+function normalizeReservedToolNames(names?: Iterable<string>): Set<string> {
+  return new Set(Array.from(names ?? [], (name) => name.trim().toLowerCase()).filter(Boolean));
+}
+
+function createCatalogFingerprint(servers: Record<string, unknown>): string {
+  return crypto.createHash("sha1").update(JSON.stringify(servers)).digest("hex");
+}
+
+function loadSessionMcpConfig(params: {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  logDiagnostics?: boolean;
+}): {
+  loaded: LoadedMcpConfig;
+  fingerprint: string;
+} {
+  const loaded = loadEmbeddedPiMcpConfig({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+  });
+  if (params.logDiagnostics !== false) {
+    for (const diagnostic of loaded.diagnostics) {
+      logWarn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
+    }
+  }
+  return {
+    loaded,
+    fingerprint: createCatalogFingerprint(loaded.mcpServers),
+  };
+}
+
+function createDisposedError(sessionId: string): Error {
+  return new Error(`bundle-mcp runtime disposed for session ${sessionId}`);
+}
+
+export function createSessionMcpRuntime(params: {
+  sessionId: string;
+  sessionKey?: string;
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+}): SessionMcpRuntime {
+  const { loaded, fingerprint: configFingerprint } = loadSessionMcpConfig({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+    logDiagnostics: true,
+  });
+  const createdAt = Date.now();
+  let lastUsedAt = createdAt;
+  let disposed = false;
+  let catalog: McpToolCatalog | null = null;
+  let catalogInFlight: Promise<McpToolCatalog> | undefined;
+  const sessions = new Map<string, BundleMcpSession>();
+  const failIfDisposed = () => {
+    if (disposed) {
+      throw createDisposedError(params.sessionId);
+    }
+  };
+
+  const getCatalog = async (): Promise<McpToolCatalog> => {
+    failIfDisposed();
+    if (catalog) {
+      return catalog;
+    }
+    if (catalogInFlight) {
+      return catalogInFlight;
+    }
+    catalogInFlight = (async () => {
+      if (Object.keys(loaded.mcpServers).length === 0) {
+        return {
+          version: 1,
+          generatedAt: Date.now(),
+          servers: {},
+          tools: [],
+        };
+      }
+
+      const servers: Record<string, McpServerCatalog> = {};
+      const tools: McpCatalogTool[] = [];
+
+      try {
+        for (const [serverName, rawServer] of Object.entries(loaded.mcpServers)) {
+          failIfDisposed();
+          const resolved = resolveTransport(serverName, rawServer);
+          if (!resolved) {
+            continue;
+          }
+
+          const client = new Client(
+            {
+              name: "openclaw-bundle-mcp",
+              version: "0.0.0",
+            },
+            {},
+          );
+          const session: BundleMcpSession = {
+            serverName,
+            client,
+            transport: resolved.transport,
+            detachStderr: resolved.detachStderr,
+          };
+          sessions.set(serverName, session);
+
+          try {
+            failIfDisposed();
+            await client.connect(resolved.transport);
+            failIfDisposed();
+            const listedTools = await listAllTools(client);
+            failIfDisposed();
+            servers[serverName] = {
+              serverName,
+              launchSummary: resolved.description,
+              toolCount: listedTools.length,
+            };
+            for (const tool of listedTools) {
+              const toolName = tool.name.trim();
+              if (!toolName) {
+                continue;
+              }
+              tools.push({
+                serverName,
+                toolName,
+                title: tool.title,
+                description: tool.description?.trim() || undefined,
+                inputSchema: tool.inputSchema,
+                fallbackDescription: `Provided by bundle MCP server "${serverName}" (${resolved.description}).`,
+              });
+            }
+          } catch (error) {
+            if (!disposed) {
+              logWarn(
+                `bundle-mcp: failed to start server "${serverName}" (${resolved.description}): ${String(error)}`,
+              );
+            }
+            await disposeSession(session);
+            sessions.delete(serverName);
+            failIfDisposed();
+          }
+        }
+
+        failIfDisposed();
+        return {
+          version: 1,
+          generatedAt: Date.now(),
+          servers,
+          tools,
+        };
+      } catch (error) {
+        await Promise.allSettled(
+          Array.from(sessions.values(), (session) => disposeSession(session)),
+        );
+        sessions.clear();
+        throw error;
+      }
+    })();
+
+    try {
+      const nextCatalog = await catalogInFlight;
+      failIfDisposed();
+      catalog = nextCatalog;
+      return nextCatalog;
+    } finally {
+      catalogInFlight = undefined;
+    }
+  };
+
+  return {
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    workspaceDir: params.workspaceDir,
+    configFingerprint,
+    createdAt,
+    get lastUsedAt() {
+      return lastUsedAt;
+    },
+    getCatalog,
+    markUsed() {
+      lastUsedAt = Date.now();
+    },
+    async callTool(serverName, toolName, input) {
+      failIfDisposed();
+      await getCatalog();
+      const session = sessions.get(serverName);
+      if (!session) {
+        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
+      }
+      return (await session.client.callTool({
+        name: toolName,
+        arguments: isRecord(input) ? input : {},
+      })) as CallToolResult;
+    },
+    async dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      catalog = null;
+      catalogInFlight = undefined;
+      const sessionsToClose = Array.from(sessions.values());
+      sessions.clear();
+      await Promise.allSettled(sessionsToClose.map((session) => disposeSession(session)));
+    },
+  };
+}
+
+export async function materializeBundleMcpToolsForRun(params: {
+  runtime: SessionMcpRuntime;
+  reservedToolNames?: Iterable<string>;
+}): Promise<BundleMcpToolRuntime> {
+  params.runtime.markUsed();
+  const catalog = await params.runtime.getCatalog();
+  const reservedNames = normalizeReservedToolNames(params.reservedToolNames);
+  const tools: AnyAgentTool[] = [];
+
+  for (const tool of catalog.tools) {
+    const normalizedName = tool.toolName.trim().toLowerCase();
+    if (!normalizedName) {
+      continue;
+    }
+    if (reservedNames.has(normalizedName)) {
+      logWarn(
+        `bundle-mcp: skipped tool "${tool.toolName}" from server "${tool.serverName}" because the name already exists.`,
+      );
+      continue;
+    }
+    reservedNames.add(normalizedName);
+    tools.push({
+      name: tool.toolName,
+      label: tool.title ?? tool.toolName,
+      description: tool.description || tool.fallbackDescription,
+      parameters: tool.inputSchema,
+      execute: async (_toolCallId, input) => {
+        const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
+        return toAgentToolResult({
+          serverName: tool.serverName,
+          toolName: tool.toolName,
+          result,
+        });
+      },
+    });
+  }
+
+  return {
+    tools,
+    dispose: async () => {},
+  };
+}
+
+function createSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
+  const runtimesBySessionId = new Map<string, SessionMcpRuntime>();
+  const sessionIdBySessionKey = new Map<string, string>();
+  const createInFlight = new Map<
+    string,
+    {
+      promise: Promise<SessionMcpRuntime>;
+      workspaceDir: string;
+      configFingerprint: string;
+    }
+  >();
+
+  return {
+    async getOrCreate(params) {
+      if (params.sessionKey) {
+        sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
+      }
+      const { fingerprint: nextFingerprint } = loadSessionMcpConfig({
+        workspaceDir: params.workspaceDir,
+        cfg: params.cfg,
+        logDiagnostics: false,
+      });
+      const existing = runtimesBySessionId.get(params.sessionId);
+      if (existing) {
+        if (
+          existing.workspaceDir !== params.workspaceDir ||
+          existing.configFingerprint !== nextFingerprint
+        ) {
+          runtimesBySessionId.delete(params.sessionId);
+          await existing.dispose();
+        } else {
+          existing.markUsed();
+          return existing;
+        }
+      }
+      const inFlight = createInFlight.get(params.sessionId);
+      if (inFlight) {
+        if (
+          inFlight.workspaceDir === params.workspaceDir &&
+          inFlight.configFingerprint === nextFingerprint
+        ) {
+          return inFlight.promise;
+        }
+        createInFlight.delete(params.sessionId);
+        const staleRuntime = await inFlight.promise.catch(() => undefined);
+        runtimesBySessionId.delete(params.sessionId);
+        await staleRuntime?.dispose();
+      }
+      const created = Promise.resolve(
+        createSessionMcpRuntime({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
+          workspaceDir: params.workspaceDir,
+          cfg: params.cfg,
+        }),
+      ).then((runtime) => {
+        runtime.markUsed();
+        runtimesBySessionId.set(params.sessionId, runtime);
+        return runtime;
+      });
+      createInFlight.set(params.sessionId, {
+        promise: created,
+        workspaceDir: params.workspaceDir,
+        configFingerprint: nextFingerprint,
+      });
+      try {
+        return await created;
+      } finally {
+        createInFlight.delete(params.sessionId);
+      }
+    },
+    bindSessionKey(sessionKey, sessionId) {
+      sessionIdBySessionKey.set(sessionKey, sessionId);
+    },
+    resolveSessionId(sessionKey) {
+      return sessionIdBySessionKey.get(sessionKey);
+    },
+    async disposeSession(sessionId) {
+      const inFlight = createInFlight.get(sessionId);
+      createInFlight.delete(sessionId);
+      let runtime = runtimesBySessionId.get(sessionId);
+      if (!runtime && inFlight) {
+        runtime = await inFlight.promise.catch(() => undefined);
+      }
+      runtimesBySessionId.delete(sessionId);
+      if (!runtime) {
+        for (const [sessionKey, mappedSessionId] of sessionIdBySessionKey.entries()) {
+          if (mappedSessionId === sessionId) {
+            sessionIdBySessionKey.delete(sessionKey);
+          }
+        }
+        return;
+      }
+      for (const [sessionKey, mappedSessionId] of sessionIdBySessionKey.entries()) {
+        if (mappedSessionId === sessionId) {
+          sessionIdBySessionKey.delete(sessionKey);
+        }
+      }
+      await runtime.dispose();
+    },
+    async disposeAll() {
+      const inFlightRuntimes = Array.from(createInFlight.values());
+      createInFlight.clear();
+      const runtimes = Array.from(runtimesBySessionId.values());
+      runtimesBySessionId.clear();
+      sessionIdBySessionKey.clear();
+      const lateRuntimes = await Promise.all(
+        inFlightRuntimes.map(async ({ promise }) => await promise.catch(() => undefined)),
+      );
+      const allRuntimes = new Set<SessionMcpRuntime>(runtimes);
+      for (const runtime of lateRuntimes) {
+        if (runtime) {
+          allRuntimes.add(runtime);
+        }
+      }
+      await Promise.allSettled(Array.from(allRuntimes, (runtime) => runtime.dispose()));
+    },
+    listSessionIds() {
+      return Array.from(runtimesBySessionId.keys());
+    },
+  };
+}
+
+export function getSessionMcpRuntimeManager(): SessionMcpRuntimeManager {
+  return resolveGlobalSingleton(SESSION_MCP_RUNTIME_MANAGER_KEY, createSessionMcpRuntimeManager);
+}
+
+export async function getOrCreateSessionMcpRuntime(params: {
+  sessionId: string;
+  sessionKey?: string;
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+}): Promise<SessionMcpRuntime> {
+  return await getSessionMcpRuntimeManager().getOrCreate(params);
+}
+
+export async function disposeSessionMcpRuntime(sessionId: string): Promise<void> {
+  await getSessionMcpRuntimeManager().disposeSession(sessionId);
+}
+
+export async function disposeAllSessionMcpRuntimes(): Promise<void> {
+  await getSessionMcpRuntimeManager().disposeAll();
+}
+
 export async function createBundleMcpToolRuntime(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
   reservedToolNames?: Iterable<string>;
 }): Promise<BundleMcpToolRuntime> {
-  const loaded = loadEmbeddedPiMcpConfig({
+  const runtime = createSessionMcpRuntime({
+    sessionId: `bundle-mcp:${crypto.randomUUID()}`,
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
   });
-  for (const diagnostic of loaded.diagnostics) {
-    logWarn(`bundle-mcp: ${diagnostic.pluginId}: ${diagnostic.message}`);
-  }
-  // Skip spawning when no MCP servers are configured.
-  if (Object.keys(loaded.mcpServers).length === 0) {
-    return { tools: [], dispose: async () => {} };
-  }
-
-  const reservedNames = new Set(
-    Array.from(params.reservedToolNames ?? [], (name) => name.trim().toLowerCase()).filter(Boolean),
-  );
-  const sessions: BundleMcpSession[] = [];
-  const tools: AnyAgentTool[] = [];
-
-  try {
-    for (const [serverName, rawServer] of Object.entries(loaded.mcpServers)) {
-      const resolved = resolveTransport(serverName, rawServer);
-      if (!resolved) {
-        continue;
-      }
-
-      const client = new Client(
-        {
-          name: "openclaw-bundle-mcp",
-          version: "0.0.0",
-        },
-        {},
-      );
-      const session: BundleMcpSession = {
-        serverName,
-        client,
-        transport: resolved.transport,
-        detachStderr: resolved.detachStderr,
-      };
-
-      try {
-        await client.connect(resolved.transport);
-        const listedTools = await listAllTools(client);
-        sessions.push(session);
-        for (const tool of listedTools) {
-          const normalizedName = tool.name.trim().toLowerCase();
-          if (!normalizedName) {
-            continue;
-          }
-          if (reservedNames.has(normalizedName)) {
-            logWarn(
-              `bundle-mcp: skipped tool "${tool.name}" from server "${serverName}" because the name already exists.`,
-            );
-            continue;
-          }
-          reservedNames.add(normalizedName);
-          tools.push({
-            name: tool.name,
-            label: tool.title ?? tool.name,
-            description:
-              tool.description?.trim() ||
-              `Provided by bundle MCP server "${serverName}" (${resolved.description}).`,
-            parameters: tool.inputSchema,
-            execute: async (_toolCallId, input) => {
-              const result = (await client.callTool({
-                name: tool.name,
-                arguments: isRecord(input) ? input : {},
-              })) as CallToolResult;
-              return toAgentToolResult({
-                serverName,
-                toolName: tool.name,
-                result,
-              });
-            },
-          });
-        }
-      } catch (error) {
-        logWarn(
-          `bundle-mcp: failed to start server "${serverName}" (${resolved.description}): ${String(error)}`,
-        );
-        await disposeSession(session);
-      }
-    }
-
-    return {
-      tools,
-      dispose: async () => {
-        await Promise.allSettled(sessions.map((session) => disposeSession(session)));
-      },
-    };
-  } catch (error) {
-    await Promise.allSettled(sessions.map((session) => disposeSession(session)));
-    throw error;
-  }
+  const materialized = await materializeBundleMcpToolsForRun({
+    runtime,
+    reservedToolNames: params.reservedToolNames,
+  });
+  return {
+    tools: materialized.tools,
+    dispose: async () => {
+      await runtime.dispose();
+    },
+  };
 }
+
+export const __testing = {
+  async resetSessionMcpRuntimeManager() {
+    await disposeAllSessionMcpRuntimes();
+  },
+  getCachedSessionIds() {
+    return getSessionMcpRuntimeManager().listSessionIds();
+  },
+};

--- a/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
@@ -33,7 +33,26 @@ let streamCallCount = 0;
 let observedContexts: Array<Array<{ role?: string; content?: unknown }>> = [];
 
 vi.mock("./pi-bundle-mcp-tools.js", () => ({
-  createBundleMcpToolRuntime: async () => ({
+  getOrCreateSessionMcpRuntime: async () => ({
+    sessionId: "bundle-mcp-runtime",
+    sessionKey: "agent:test:bundle-mcp-e2e",
+    workspaceDir: "/tmp",
+    configFingerprint: "test",
+    createdAt: Date.now(),
+    lastUsedAt: Date.now(),
+    markUsed: () => {},
+    getCatalog: async () => ({
+      version: 1,
+      generatedAt: Date.now(),
+      servers: {},
+      tools: [],
+    }),
+    callTool: async () => ({
+      content: [{ type: "text", text: "FROM-BUNDLE" }],
+    }),
+    dispose: async () => {},
+  }),
+  materializeBundleMcpToolsForRun: async () => ({
     tools: [
       {
         name: "bundle_probe",

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -61,7 +61,10 @@ import { supportsModelTools } from "../../model-tool-support.js";
 import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws-stream.js";
 import { resolveOwnerDisplaySetting } from "../../owner-display.js";
 import { createBundleLspToolRuntime } from "../../pi-bundle-lsp-runtime.js";
-import { createBundleMcpToolRuntime } from "../../pi-bundle-mcp-tools.js";
+import {
+  getOrCreateSessionMcpRuntime,
+  materializeBundleMcpToolsForRun,
+} from "../../pi-bundle-mcp-tools.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   isCloudCodeAssistFormatError,
@@ -481,10 +484,17 @@ export async function runEmbeddedAttempt(
       provider: params.provider,
     });
     const clientTools = toolsEnabled ? params.clientTools : undefined;
-    const bundleMcpRuntime = toolsEnabled
-      ? await createBundleMcpToolRuntime({
+    const bundleMcpSessionRuntime = toolsEnabled
+      ? await getOrCreateSessionMcpRuntime({
+          sessionId: params.sessionId,
+          sessionKey: params.sessionKey,
           workspaceDir: effectiveWorkspace,
           cfg: params.config,
+        })
+      : undefined;
+    const bundleMcpRuntime = bundleMcpSessionRuntime
+      ? await materializeBundleMcpToolsForRun({
+          runtime: bundleMcpSessionRuntime,
           reservedToolNames: [
             ...tools.map((tool) => tool.name),
             ...(clientTools?.map((tool) => tool.function.name) ?? []),
@@ -1862,7 +1872,6 @@ export async function runEmbeddedAttempt(
       });
       session?.dispose();
       releaseWsSession(params.sessionId);
-      await bundleMcpRuntime?.dispose();
       await bundleLspRuntime?.dispose();
       await sessionLock.release();
     }

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
+import {
+  __testing as sessionMcpTesting,
+  getOrCreateSessionMcpRuntime,
+} from "../../agents/pi-bundle-mcp-tools.js";
 import { setDefaultChannelPluginRegistryForTests } from "../../commands/channel-test-helpers.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -66,7 +70,9 @@ async function writeSessionStoreFast(
 beforeEach(() => {
   sessionBindingTesting.resetSessionBindingAdaptersForTests();
 });
-
+afterEach(async () => {
+  await sessionMcpTesting.resetSessionMcpRuntimeManager();
+});
 describe("initSessionState thread forking", () => {
   it("forks a new session from the parent session file", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -1671,6 +1677,52 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("disposes the previous bundle MCP runtime on session rollover", async () => {
+    const storePath = await createStorePath("openclaw-stale-runtime-dispose-");
+    const sessionKey = "agent:main:telegram:dm:runtime-stale-user";
+    const existingSessionId = "stale-runtime-session";
+    const cfg = {
+      session: {
+        store: storePath,
+        reset: { mode: "idle", idleMinutes: 1 },
+      },
+    } as OpenClawConfig;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now() - 5 * 60_000,
+      },
+    });
+
+    await getOrCreateSessionMcpRuntime({
+      sessionId: existingSessionId,
+      sessionKey,
+      workspaceDir: path.dirname(storePath),
+      cfg,
+    });
+
+    expect(sessionMcpTesting.getCachedSessionIds()).toContain(existingSessionId);
+
+    await initSessionState({
+      ctx: {
+        Body: "hello",
+        RawBody: "hello",
+        CommandBody: "hello",
+        From: "user-stale-runtime",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(sessionMcpTesting.getCachedSessionIds()).not.toContain(existingSessionId);
   });
 
   it("idle-based new session does NOT preserve overrides (no entry to read)", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -7,6 +7,7 @@ import { disposeSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
+import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
 import { deriveSessionMetaPatch } from "../../config/sessions/metadata.js";
 import { resolveSessionTranscriptPath, resolveStorePath } from "../../config/sessions/paths.js";
 import {
@@ -25,7 +26,6 @@ import {
   type SessionEntry,
   type SessionScope,
 } from "../../config/sessions/types.js";
-import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { normalizeConversationText } from "../../acp/conversation-id.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { clearBootstrapSnapshotOnSessionRollover } from "../../agents/bootstrap-cache.js";
+import { disposeSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -639,6 +640,14 @@ export async function initSessionState(params: {
       sessionFile: previousSessionEntry.sessionFile,
       agentId,
       reason: "reset",
+    });
+    await disposeSessionMcpRuntime(previousSessionEntry.sessionId).catch((error) => {
+      log.warn(
+        `failed to dispose bundle MCP runtime for session ${previousSessionEntry.sessionId}`,
+        {
+          error: String(error),
+        },
+      );
     });
   }
 


### PR DESCRIPTION
## Summary
- cache bundle MCP connections and tool catalogs per session instead of rebuilding them every turn
- materialize per-run MCP tools from the cached session runtime inside embedded attempts
- dispose cached session runtimes when session rollover creates a new session id

## Testing
- pnpm test -- src/agents/pi-bundle-mcp-tools.test.ts
- pnpm test -- src/auto-reply/reply/session.test.ts -t "disposes the previous bundle MCP runtime on session rollover"
- pnpm test -- src/agents/pi-embedded-runner.bundle-mcp.e2e.test.ts
- pnpm build