### PR TITLE
Stabilize runtime facade builds and mark dirty local versions

### DIFF
--- a/scripts/write-build-info.ts
+++ b/scripts/write-build-info.ts
@@ -1,13 +1,13 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const distDir = path.join(rootDir, "dist");
-const pkgPath = path.join(rootDir, "package.json");
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-const readPackageVersion = () => {
+type ExecSyncLike = typeof execSync;
+
+export function readPackageVersion(pkgPath: string) {
   try {
     const raw = fs.readFileSync(pkgPath, "utf8");
     const parsed = JSON.parse(raw) as { version?: string };
@@ -15,33 +15,117 @@ const readPackageVersion = () => {
   } catch {
     return null;
   }
-};
+}
 
-const resolveCommit = () => {
-  const envCommit = process.env.GIT_COMMIT?.trim() || process.env.GIT_SHA?.trim();
-  if (envCommit) {
-    return envCommit;
-  }
+function readGitText(
+  command: string,
+  options: {
+    rootDir: string;
+    execSyncImpl?: ExecSyncLike;
+  },
+): string | null {
+  const execSyncImpl = options.execSyncImpl ?? execSync;
   try {
-    return execSync("git rev-parse HEAD", {
-      cwd: rootDir,
+    const raw = execSyncImpl(command, {
+      cwd: options.rootDir,
       stdio: ["ignore", "pipe", "ignore"],
-    })
-      .toString()
-      .trim();
+    });
+    return raw.toString().trim();
   } catch {
     return null;
   }
-};
+}
 
-const version = readPackageVersion();
-const commit = resolveCommit();
+export function resolveCommit(
+  options: {
+    rootDir?: string;
+    env?: NodeJS.ProcessEnv;
+    execSyncImpl?: ExecSyncLike;
+  } = {},
+) {
+  const env = options.env ?? process.env;
+  const rootDir = options.rootDir ?? repoRoot;
+  const envCommit = env.GIT_COMMIT?.trim() || env.GIT_SHA?.trim();
+  if (envCommit) {
+    return envCommit;
+  }
+  return readGitText("git rev-parse HEAD", {
+    rootDir,
+    execSyncImpl: options.execSyncImpl,
+  });
+}
 
-const buildInfo = {
-  version,
-  commit,
-  builtAt: new Date().toISOString(),
-};
+export function resolveDisplayVersionMarker(
+  options: {
+    rootDir?: string;
+    env?: NodeJS.ProcessEnv;
+    execSyncImpl?: ExecSyncLike;
+  } = {},
+) {
+  const env = options.env ?? process.env;
+  const rootDir = options.rootDir ?? repoRoot;
+  const explicitMarker = env.OPENCLAW_DISPLAY_VERSION_MARKER?.trim();
+  if (explicitMarker) {
+    return explicitMarker;
+  }
+  const gitStatus = readGitText("git status --porcelain --untracked-files=normal", {
+    rootDir,
+    execSyncImpl: options.execSyncImpl,
+  });
+  return gitStatus ? "dirty" : null;
+}
 
-fs.mkdirSync(distDir, { recursive: true });
-fs.writeFileSync(path.join(distDir, "build-info.json"), `${JSON.stringify(buildInfo, null, 2)}\n`);
+export function createBuildInfo(
+  options: {
+    rootDir?: string;
+    env?: NodeJS.ProcessEnv;
+    now?: Date;
+    execSyncImpl?: ExecSyncLike;
+  } = {},
+) {
+  const rootDir = options.rootDir ?? repoRoot;
+  const pkgPath = path.join(rootDir, "package.json");
+  return {
+    version: readPackageVersion(pkgPath),
+    displayVersionMarker: resolveDisplayVersionMarker({
+      rootDir,
+      env: options.env,
+      execSyncImpl: options.execSyncImpl,
+    }),
+    commit: resolveCommit({
+      rootDir,
+      env: options.env,
+      execSyncImpl: options.execSyncImpl,
+    }),
+    builtAt: (options.now ?? new Date()).toISOString(),
+  };
+}
+
+export function writeBuildInfo(
+  options: {
+    rootDir?: string;
+    distDir?: string;
+    env?: NodeJS.ProcessEnv;
+    now?: Date;
+    execSyncImpl?: ExecSyncLike;
+  } = {},
+) {
+  const rootDir = options.rootDir ?? repoRoot;
+  const distDir = options.distDir ?? path.join(rootDir, "dist");
+  const buildInfo = createBuildInfo({
+    rootDir,
+    env: options.env,
+    now: options.now,
+    execSyncImpl: options.execSyncImpl,
+  });
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(distDir, "build-info.json"),
+    `${JSON.stringify(buildInfo, null, 2)}\n`,
+  );
+  return buildInfo;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  writeBuildInfo();
+}

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import tsdownConfig from "../../tsdown.config.ts";
 
@@ -15,6 +17,30 @@ function entryKeys(config: TsdownConfigEntry): string[] {
     return [];
   }
   return Object.keys(config.entry);
+}
+
+function listRuntimeFacadeEntryKeys(): string[] {
+  const srcRoot = path.resolve(process.cwd(), "src");
+  const entries: string[] = [];
+
+  function walk(dir: string) {
+    for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (!dirent.isFile() || !dirent.name.endsWith(".runtime.ts")) {
+        continue;
+      }
+      entries.push(
+        path.relative(srcRoot, fullPath).slice(0, -".ts".length).split(path.sep).join("/"),
+      );
+    }
+  }
+
+  walk(srcRoot);
+  return entries.toSorted();
 }
 
 describe("tsdown config", () => {
@@ -63,5 +89,13 @@ describe("tsdown config", () => {
           : false,
       ),
     ).toBe(false);
+  });
+
+  it("emits runtime facades as stable dist entries", () => {
+    const configs = asConfigArray(tsdownConfig);
+    const distGraph = configs.find((config) => entryKeys(config).includes("index"));
+
+    expect(distGraph).toBeDefined();
+    expect(entryKeys(distGraph!)).toEqual(expect.arrayContaining(listRuntimeFacadeEntryKeys()));
   });
 });

--- a/src/scripts/write-build-info.test.ts
+++ b/src/scripts/write-build-info.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createBuildInfo,
+  resolveDisplayVersionMarker,
+  writeBuildInfo,
+} from "../../scripts/write-build-info.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempRepo() {
+  const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-write-build-info-"));
+  tempDirs.push(rootDir);
+  await fs.writeFile(
+    path.join(rootDir, "package.json"),
+    JSON.stringify({ name: "openclaw", version: "9.9.9-test" }),
+    "utf8",
+  );
+  return rootDir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("write-build-info", () => {
+  it("prefers an explicit display version marker over inferred dirty state", () => {
+    const execSyncImpl = vi.fn(() => Buffer.from(" M src/entry.ts\n"));
+
+    expect(
+      resolveDisplayVersionMarker({
+        rootDir: "/tmp/openclaw",
+        env: { OPENCLAW_DISPLAY_VERSION_MARKER: "harness-local" },
+        execSyncImpl,
+      }),
+    ).toBe("harness-local");
+    expect(execSyncImpl).not.toHaveBeenCalled();
+  });
+
+  it("marks dirty git builds when the worktree has local changes", () => {
+    expect(
+      resolveDisplayVersionMarker({
+        rootDir: "/tmp/openclaw",
+        env: {},
+        execSyncImpl: vi.fn(() => Buffer.from("?? src/agents/task-profile.ts\n")),
+      }),
+    ).toBe("dirty");
+  });
+
+  it("writes build-info.json with an inferred dirty marker", async () => {
+    const rootDir = await makeTempRepo();
+    const distDir = path.join(rootDir, "dist");
+    const execSyncImpl = vi.fn((command: string) => {
+      if (command === "git rev-parse HEAD") {
+        return Buffer.from("abcdef0123456789\n");
+      }
+      if (command === "git status --porcelain --untracked-files=normal") {
+        return Buffer.from(" M src/entry.ts\n");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    const buildInfo = writeBuildInfo({
+      rootDir,
+      distDir,
+      now: new Date("2026-03-26T00:00:00.000Z"),
+      env: {},
+      execSyncImpl,
+    });
+
+    expect(buildInfo).toEqual({
+      version: "9.9.9-test",
+      displayVersionMarker: "dirty",
+      commit: "abcdef0123456789",
+      builtAt: "2026-03-26T00:00:00.000Z",
+    });
+    await expect(fs.readFile(path.join(distDir, "build-info.json"), "utf8")).resolves.toContain(
+      '"displayVersionMarker": "dirty"',
+    );
+  });
+
+  it("builds clean metadata without a marker when git status is clean", async () => {
+    const rootDir = await makeTempRepo();
+    const buildInfo = createBuildInfo({
+      rootDir,
+      now: new Date("2026-03-26T00:00:00.000Z"),
+      env: {},
+      execSyncImpl: vi.fn((command: string) => {
+        if (command === "git rev-parse HEAD") {
+          return Buffer.from("abcdef0123456789\n");
+        }
+        if (command === "git status --porcelain --untracked-files=normal") {
+          return Buffer.from("");
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      }),
+    });
+
+    expect(buildInfo.displayVersionMarker).toBeNull();
+  });
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -109,6 +109,36 @@ function buildBundledHookEntries(): Record<string, string> {
 
 const bundledHookEntries = buildBundledHookEntries();
 
+function buildRuntimeFacadeEntries(): Record<string, string> {
+  const srcRoot = path.join(process.cwd(), "src");
+  const entries: Record<string, string> = {};
+
+  if (!fs.existsSync(srcRoot)) {
+    return entries;
+  }
+
+  function walk(dir: string) {
+    for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, dirent.name);
+      if (dirent.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+      if (!dirent.isFile() || !dirent.name.endsWith(".runtime.ts")) {
+        continue;
+      }
+      const relativePath = path.relative(srcRoot, fullPath);
+      const entryName = relativePath.slice(0, -".ts".length).split(path.sep).join("/");
+      entries[entryName] = fullPath;
+    }
+  }
+
+  walk(srcRoot);
+  return entries;
+}
+
+const runtimeFacadeEntries = buildRuntimeFacadeEntries();
+
 function buildCoreDistEntries(): Record<string, string> {
   return {
     index: "src/index.ts",
@@ -132,6 +162,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "plugins/build-smoke-entry": "src/plugins/build-smoke-entry.ts",
     "plugins/runtime/index": "src/plugins/runtime/index.ts",
     "llm-slug-generator": "src/hooks/llm-slug-generator.ts",
+    ...runtimeFacadeEntries,
   };
 }
 


### PR DESCRIPTION
## Summary
- emit `src/**/*.runtime.ts` files as stable dist entries so long-lived processes do not keep importing stale hashed runtime chunks after rebuilds
- add a tsdown config test that locks runtime facade entries into the main dist graph
- mark local dirty builds in `dist/build-info.json` so `openclaw --version` clearly shows when the running binary comes from a modified checkout
- add focused tests for build-info marker inference and version output expectations

## Testing
- pnpm exec vitest run src/infra/tsdown-config.test.ts
- pnpm exec vitest run src/scripts/write-build-info.test.ts src/version.test.ts src/entry.version-fast-path.test.ts
- pnpm build