### PR TITLE
FIX (gateway): skip device pairing for authenticated CLI connections in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -619,6 +619,9 @@ Docs: https://docs.openclaw.ai
 - Plugins/Matrix: encrypt E2EE image thumbnails with `thumbnail_file` while keeping unencrypted-room previews on `thumbnail_url`, so encrypted Matrix image events keep thumbnail metadata without leaking plaintext previews. (#54711) thanks @frischeDaten.
 - Telegram/forum topics: keep native `/new` and `/reset` routed to the active topic by preserving the topic target on forum-thread command context. (#35963)
 - Status/port diagnostics: treat single-process dual-stack loopback gateway listeners as healthy in `openclaw status --all`, suppressing false "port already in use" conflict warnings. (#53398) Thanks @DanWebb1949.
+- CLI/Docker: treat loopback private-host CLI gateway connects as local for silent pairing auto-approval, while keeping remote backend and public-host CLI connects behind pairing. (#55113) Thanks @sar618.
+
+## 2026.3.24
 
 ### Breaking
 

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1373,6 +1373,44 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("auto-approves Docker-style CLI connects on loopback with a private host header", async () => {
+    const { getPairedDevice, listDevicePairing } = await import("../infra/device-pairing.js");
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    ws.close();
+    const wsDockerCli = await openWs(port, { host: "172.17.0.2:18789" });
+    try {
+      const { identity, identityPath } =
+        await createOperatorIdentityFixture("openclaw-cli-docker-");
+      const nonce = await readConnectChallengeNonce(wsDockerCli);
+      const dockerCli = await connectReq(wsDockerCli, {
+        token: "secret",
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CLI,
+          version: "1.0.0",
+          platform: "linux",
+          mode: GATEWAY_CLIENT_MODES.CLI,
+        },
+        device: await buildSignedDeviceForIdentity({
+          identityPath,
+          client: {
+            id: GATEWAY_CLIENT_NAMES.CLI,
+            mode: GATEWAY_CLIENT_MODES.CLI,
+          },
+          scopes: ["operator.admin"],
+          nonce,
+        }),
+      });
+      expect(dockerCli.ok).toBe(true);
+      const pending = await listDevicePairing();
+      expect(pending.pending).toHaveLength(0);
+      expect(await getPairedDevice(identity.deviceId)).toBeTruthy();
+    } finally {
+      wsDockerCli.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("requires pairing for gateway backend clients when connection is not local-direct", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     ws.close();
@@ -1384,6 +1422,47 @@ export function registerControlUiAndPairingSuite(): void {
       });
       expect(remoteLikeBackend.ok).toBe(false);
       expect(remoteLikeBackend.error?.message ?? "").toContain("pairing required");
+    } finally {
+      wsRemoteLike.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("requires pairing for gateway backend clients on loopback with a private host header", async () => {
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    ws.close();
+    const wsPrivateHost = await openWs(port, { host: "172.17.0.2:18789" });
+    try {
+      const remoteLikeBackend = await connectReq(wsPrivateHost, {
+        token: "secret",
+        client: BACKEND_GATEWAY_CLIENT,
+      });
+      expect(remoteLikeBackend.ok).toBe(false);
+      expect(remoteLikeBackend.error?.message ?? "").toContain("pairing required");
+    } finally {
+      wsPrivateHost.close();
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
+  test("requires pairing for CLI clients when the host header is not private-or-loopback", async () => {
+    const { server, ws, port, prevToken } = await startServerWithClient("secret");
+    ws.close();
+    const wsRemoteLike = await openWs(port, { host: "gateway.example" });
+    try {
+      const remoteCli = await connectReq(wsRemoteLike, {
+        token: "secret",
+        client: {
+          id: GATEWAY_CLIENT_NAMES.CLI,
+          version: "1.0.0",
+          platform: "linux",
+          mode: GATEWAY_CLIENT_MODES.CLI,
+        },
+      });
+      expect(remoteCli.ok).toBe(false);
+      expect(remoteCli.error?.message ?? "").toContain("pairing required");
     } finally {
       wsRemoteLike.close();
       await server.close();

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
+import type { ConnectParams } from "../../protocol/schema/types.js";
 import {
   BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP,
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
+  shouldSkipBackendSelfPairing,
+  shouldTreatCliContainerHostAsLocal,
 } from "./handshake-auth-helpers.js";
 
 function createRateLimiter(): AuthRateLimiter {
@@ -103,7 +107,6 @@ describe("handshake auth helpers", () => {
       }),
     ).toBe(false);
   });
-
   it("rejects silent role-upgrade for remote clients", () => {
     expect(
       shouldAllowSilentLocalPairing({
@@ -112,6 +115,169 @@ describe("handshake auth helpers", () => {
         isControlUi: false,
         isWebchat: false,
         reason: "role-upgrade",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats CLI loopback/private-host connects as local only with shared auth", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.CLI,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+      },
+    } as ConnectParams;
+    expect(
+      shouldTreatCliContainerHostAsLocal({
+        connectParams,
+        requestHost: "172.17.0.2:18789",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldTreatCliContainerHostAsLocal({
+        connectParams,
+        requestHost: "172.17.0.2:18789",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatCliContainerHostAsLocal({
+        connectParams,
+        requestHost: "gateway.example",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+    expect(
+      shouldTreatCliContainerHostAsLocal({
+        connectParams,
+        requestHost: "172.17.0.2:18789",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat non-CLI clients as Docker-local CLI bypass candidates", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+    expect(
+      shouldTreatCliContainerHostAsLocal({
+        connectParams,
+        requestHost: "172.17.0.2:18789",
+        remoteAddress: "127.0.0.1",
+        hasProxyHeaders: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+  });
+
+  it("skips backend self-pairing only for local backend clients", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "password",
+      }),
+    ).toBe(false);
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "device-token",
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: false,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: false,
+        authMethod: "device-token",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not skip backend self-pairing for CLI clients", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.CLI,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+      },
+    } as ConnectParams;
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: false,
+        sharedAuthOk: true,
+        authMethod: "token",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects pairing bypass when browser origin header is present", () => {
+    const connectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      },
+    } as ConnectParams;
+    expect(
+      shouldSkipBackendSelfPairing({
+        connectParams,
+        isLocalClient: true,
+        hasBrowserOriginHeader: true,
+        sharedAuthOk: true,
+        authMethod: "token",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -2,7 +2,7 @@ import { verifyDeviceSignature } from "../../../infra/device-identity.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult } from "../../auth.js";
 import { buildDeviceAuthPayload, buildDeviceAuthPayloadV3 } from "../../device-auth.js";
-import { isLoopbackAddress } from "../../net.js";
+import { isLoopbackAddress, isPrivateOrLoopbackHost, resolveHostName } from "../../net.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
@@ -69,34 +69,42 @@ export function shouldSkipBackendSelfPairing(params: {
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
 }): boolean {
-  const isLocalTrustedClient =
-    (params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
-      params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND) ||
-    (params.connectParams.client.id === GATEWAY_CLIENT_IDS.CLI &&
-      params.connectParams.client.mode === GATEWAY_CLIENT_MODES.CLI);
-  if (!isLocalTrustedClient) {
+  const isBackendClient =
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
+  if (!isBackendClient) {
     return false;
   }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   const usesDeviceTokenAuth = params.authMethod === "device-token";
-  // `authMethod === "device-token"` only reaches this helper after the caller
-  // has already accepted auth (`authOk === true`), so a separate
-  // `deviceTokenAuthOk` flag would be redundant here.
-  //
-  // For any trusted client identity (backend or CLI) with a valid shared
-  // secret (token/password) and no browser Origin header, skip pairing
-  // regardless of isLocalClient.  The shared secret is the trust anchor;
-  // isLocalDirectRequest() produces false negatives in Docker containers
-  // that share the gateway's network namespace via network_mode, even when
-  // remoteAddress is 127.0.0.1.
-  if (params.sharedAuthOk && usesSharedSecretAuth && !params.hasBrowserOriginHeader) {
-    return true;
-  }
-  // For device-token auth, retain the locality check as defense-in-depth.
   return (
     params.isLocalClient &&
     !params.hasBrowserOriginHeader &&
-    usesDeviceTokenAuth
+    ((params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth)
+  );
+}
+
+export function shouldTreatCliContainerHostAsLocal(params: {
+  connectParams: ConnectParams;
+  requestHost?: string;
+  remoteAddress?: string;
+  hasProxyHeaders: boolean;
+  hasBrowserOriginHeader: boolean;
+  sharedAuthOk: boolean;
+  authMethod: GatewayAuthResult["method"];
+}): boolean {
+  const isCliClient =
+    params.connectParams.client.id === GATEWAY_CLIENT_IDS.CLI &&
+    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.CLI;
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  return (
+    isCliClient &&
+    params.sharedAuthOk &&
+    usesSharedSecretAuth &&
+    !params.hasProxyHeaders &&
+    !params.hasBrowserOriginHeader &&
+    isLoopbackAddress(params.remoteAddress) &&
+    isPrivateOrLoopbackHost(resolveHostName(params.requestHost))
   );
 }
 

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -3,6 +3,7 @@ import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult } from "../../auth.js";
 import { buildDeviceAuthPayload, buildDeviceAuthPayloadV3 } from "../../device-auth.js";
 import { isLoopbackAddress } from "../../net.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
 
@@ -58,6 +59,44 @@ export function shouldAllowSilentLocalPairing(params: {
     (params.reason === "not-paired" ||
       params.reason === "scope-upgrade" ||
       params.reason === "role-upgrade")
+  );
+}
+
+export function shouldSkipBackendSelfPairing(params: {
+  connectParams: ConnectParams;
+  isLocalClient: boolean;
+  hasBrowserOriginHeader: boolean;
+  sharedAuthOk: boolean;
+  authMethod: GatewayAuthResult["method"];
+}): boolean {
+  const isLocalTrustedClient =
+    (params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
+      params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND) ||
+    (params.connectParams.client.id === GATEWAY_CLIENT_IDS.CLI &&
+      params.connectParams.client.mode === GATEWAY_CLIENT_MODES.CLI);
+  if (!isLocalTrustedClient) {
+    return false;
+  }
+  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
+  const usesDeviceTokenAuth = params.authMethod === "device-token";
+  // `authMethod === "device-token"` only reaches this helper after the caller
+  // has already accepted auth (`authOk === true`), so a separate
+  // `deviceTokenAuthOk` flag would be redundant here.
+  //
+  // For any trusted client identity (backend or CLI) with a valid shared
+  // secret (token/password) and no browser Origin header, skip pairing
+  // regardless of isLocalClient.  The shared secret is the trust anchor;
+  // isLocalDirectRequest() produces false negatives in Docker containers
+  // that share the gateway's network namespace via network_mode, even when
+  // remoteAddress is 127.0.0.1.
+  if (params.sharedAuthOk && usesSharedSecretAuth && !params.hasBrowserOriginHeader) {
+    return true;
+  }
+  // For device-token auth, retain the locality check as defense-in-depth.
+  return (
+    params.isLocalClient &&
+    !params.hasBrowserOriginHeader &&
+    usesDeviceTokenAuth
   );
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -109,6 +109,7 @@ import {
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
+  shouldSkipBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
@@ -247,6 +248,7 @@ export function attachGatewayWsMessageHandler(params: {
   const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
   const hostIsLocalish = isLocalishHost(requestHost);
   const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback);
+
   const reportedClientIp =
     isLocalClient || hasUntrustedProxyHeaders
       ? undefined
@@ -723,12 +725,20 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
-        const skipPairing = shouldSkipControlUiPairing(
-          controlUiAuthPolicy,
-          role,
-          trustedProxyAuthOk,
-          resolvedAuth.mode,
-        );
+        const skipPairing =
+          shouldSkipBackendSelfPairing({
+            connectParams,
+            isLocalClient,
+            hasBrowserOriginHeader,
+            sharedAuthOk,
+            authMethod,
+          }) ||
+          shouldSkipControlUiPairing(
+            controlUiAuthPolicy,
+            role,
+            trustedProxyAuthOk,
+            resolvedAuth.mode,
+          );
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -110,6 +110,7 @@ import {
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
   shouldSkipBackendSelfPairing,
+  shouldTreatCliContainerHostAsLocal,
 } from "./handshake-auth-helpers.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
@@ -725,6 +726,16 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
+        const allowCliContainerLocalPairing = shouldTreatCliContainerHostAsLocal({
+          connectParams,
+          requestHost,
+          remoteAddress: remoteAddr,
+          hasProxyHeaders,
+          hasBrowserOriginHeader,
+          sharedAuthOk,
+          authMethod,
+        });
+        const effectiveIsLocalClient = isLocalClient || allowCliContainerLocalPairing;
         const skipPairing =
           shouldSkipBackendSelfPairing({
             connectParams,
@@ -814,7 +825,7 @@ export function attachGatewayWsMessageHandler(params: {
               });
             };
             const allowSilentLocalPairing = shouldAllowSilentLocalPairing({
-              isLocalClient,
+              isLocalClient: effectiveIsLocalClient,
               hasBrowserOriginHeader,
               isControlUi,
               isWebchat,


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:
- Problem: Docker CLI commands fail with `pairing required` (1008) because `shouldSkipBackendSelfPairing` only matches `gateway-client/backend` mode. CLI connections use `cli/cli` mode and are excluded.
- Problem (secondary): `isLocalDirectRequest` returns `false` in Docker even when `remoteAddress` is `127.0.0.1`, so the locality check fails as a second blocker.
- Why it matters: Every Docker deployment using CLI commands hits this. At least 12 issues report the same root cause (#2284, #4531, #4941, #6959, #9028, #12210, #19352, #20707, #23471, #30740, #42931, #45232). Users are forced to abandon Docker or lose CLI access entirely.
- What changed: `handshake-auth-helpers.ts` — extend `shouldSkipBackendSelfPairing` to match `cli/cli` clients. For CLI connections with valid shared auth (token/password), skip the locality check since the token is the trust anchor.
- What did NOT change (scope boundary): Pairing behavior for external clients (Control UI, mobile apps, nodes); backend self-connection locality requirement; auth validation logic; TLS checks.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #55067
- Related #12210, #23471, #30740, #30801
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)
- Root cause: `shouldSkipBackendSelfPairing` gates on `GATEWAY_CLIENT_IDS.GATEWAY_CLIENT` + `GATEWAY_CLIENT_MODES.BACKEND`. CLI connections send `GATEWAY_CLIENT_IDS.CLI` + `GATEWAY_CLIENT_MODES.CLI` and are excluded from the bypass. Even if the client ID check is broadened, `isLocalDirectRequest()` returns `false` in Docker host networking despite `remoteAddress` being `127.0.0.1` — a secondary false-negative in the locality detection.
- Missing detection / guardrail: No test coverage for CLI-mode pairing bypass. No Docker-specific integration test for CLI→gateway WebSocket connectivity.
- Prior context: PR #30801 (merged March 2) added `isBackendSelfConnection` to broaden the bypass for TLS+subagent scenarios (#30740), but (a) the fix only covered `gateway-client/backend` mode, not `cli/cli`, and (b) the `isBackendSelfConnection` identifier is absent from built output on both v2026.3.23 and main at 2026.3.24-beta.1 — suggesting it was reverted or overwritten.
- Why this regressed now: This never worked — it's a design gap, not a regression. The pairing system was built for remote mobile/external clients and never accommodated co-located Docker containers.
- If unknown, what was ruled out: N/A — root cause is confirmed via debug instrumentation.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/ws-connection/handshake-auth-helpers.test.ts`
- Scenario the test should lock in: `shouldSkipBackendSelfPairing` returns `true` for `cli/cli` client with `isLocalClient: true`, `sharedAuthOk: true`, `authMethod: "token"`. Returns `false` when remote or when auth fails.
- Why this is the smallest reliable guardrail: Unit test directly exercises the bypass function with CLI-mode inputs — catches any future narrowing of the client ID/mode match.
- Existing test that already covers this (if any): Existing tests only cover `gateway-client/backend` mode.
- If no new test is added, why not: New test IS added — three cases for CLI mode (local+auth passes, remote fails, no-auth fails).

## User-visible / Behavior Changes
- `docker compose run --rm openclaw-cli <command>` now works in Docker deployments
- `docker exec openclaw-openclaw-cli-1 openclaw <command>` now works
- Internal `callGateway()` operations from CLI-mode clients no longer fail with pairing required

## Security Impact (required)
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: The CLI pairing bypass is gated on: (1) client ID is `cli`, (2) client mode is `cli`, (3) shared auth succeeded, (4) no browser origin header. A CLI connection with a valid token already has full operator access — skipping pairing does not expand the access surface. Backend self-connections retain the existing locality check as defense-in-depth.

## Repro + Verification
### Environment
- OS: Ubuntu (headless)
- Runtime/container: Docker Engine + Compose v2, host networking, `network_mode: "service:openclaw-gateway"` for CLI
- Model/provider: Not model-specific (moonshot/kimi-k2.5 in test)
- Integration/channel (if any): N/A
- Relevant config (redacted): `gateway.auth.mode: "token"`, `gateway.bind: "loopback"`, standard `docker-compose.yml` from repo

### Steps
1. Deploy with Docker Compose (gateway + CLI containers sharing network namespace)
2. Run: `docker compose run --rm --entrypoint /usr/local/bin/openclaw openclaw-cli cron list`
3. Observe result

### Expected
- Cron job list displayed

### Actual
- Before fix: `gateway closed (1008): pairing required`
- After fix: 14 cron jobs listed successfully

## Evidence
- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Before:
```
gateway connect failed: GatewayClientRequestError: pairing required
Error: gateway closed (1008): pairing required
Gateway target: ws://127.0.0.1:18789
Source: local loopback
```

Debug instrumentation showing `isLocalClient: false` despite `remoteAddress: "127.0.0.1"`:
```json
{"isLocalClient":false,"remoteAddress":"127.0.0.1","hostHeader":"127.0.0.1:18789","xForwardedFor":null,"xRealIp":null,"xForwardedHost":null}
```

Debug instrumentation showing bypass function receiving correct values but blocked by `isLocalClient`:
```json
{"clientId":"cli","clientMode":"cli","isLocalTrustedClient":true,"isLocalClient":false,"sharedAuthOk":true,"authMethod":"token"}
```

After fix: CLI returns full cron job listing (14 jobs).

## Human Verification (required)
- Verified scenarios: CLI `cron list` works in Docker deployment after fix. Gateway starts cleanly. Web UI still works. Telegram/Discord bots unaffected.
- Edge cases checked: Backend self-connections unaffected (retain locality check); failed auth does not skip pairing; browser-origin header blocks bypass.
- What you did **not** verify: Non-Docker native installs (no access to test environment), TLS configurations, mobile app pairing.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)
- How to disable/revert this change quickly: Revert the `isLocalTrustedClient` and `isCli` changes in `handshake-auth-helpers.ts`, restoring the original `isGatewayBackendClient` check.
- Files/config to restore: `src/gateway/server/ws-connection/handshake-auth-helpers.ts`
- Known bad symptoms reviewers should watch for: Unauthorized CLI connections bypassing pairing from non-localhost origins (would require a valid gateway token, so low risk).

## Risks and Mitigations
- Risk: A process on a remote host with a stolen gateway token could impersonate a CLI client and bypass pairing.
  - Mitigation: The token already grants full operator access. An attacker with the token can use the Web UI (which already bypasses pairing via `dangerouslyDisableDeviceAuth`). Skipping pairing for CLI does not expand the attack surface.
- Risk: `isLocalDirectRequest` false negative in Docker may indicate a deeper networking issue worth a separate fix.
  - Mitigation: Filed as a note in the issue. This PR works around it for CLI; a separate investigation into `isLocalDirectRequest` Docker behavior is recommended.