### PR TITLE
fix(ui): handle willRetry in compaction event to show correct retry s…

### DIFF
--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -248,6 +248,7 @@ export type CompactionStatus = {
   active: boolean;
   startedAt: number | null;
   completedAt: number | null;
+  message?: string;
 };
 
 export type FallbackStatus = {
@@ -287,16 +288,28 @@ export function handleCompactionEvent(host: CompactionHost, payload: AgentEventP
       completedAt: null,
     };
   } else if (phase === "end") {
-    host.compactionStatus = {
-      active: false,
-      startedAt: host.compactionStatus?.startedAt ?? null,
-      completedAt: Date.now(),
-    };
-    // Auto-clear the toast after duration
-    host.compactionClearTimer = window.setTimeout(() => {
-      host.compactionStatus = null;
-      host.compactionClearTimer = null;
-    }, COMPACTION_TOAST_DURATION_MS);
+    const willRetry = data.willRetry === true;
+    if (willRetry) {
+      // Retry will happen: stay active and show retry message
+      host.compactionStatus = {
+        active: true,
+        startedAt: host.compactionStatus?.startedAt ?? null,
+        completedAt: null,
+        message: "Retrying compaction...",
+      };
+    } else {
+      // Final completion
+      host.compactionStatus = {
+        active: false,
+        startedAt: host.compactionStatus?.startedAt ?? null,
+        completedAt: Date.now(),
+      };
+      // Auto-clear the toast after duration
+      host.compactionClearTimer = window.setTimeout(() => {
+        host.compactionStatus = null;
+        host.compactionClearTimer = null;
+      }, COMPACTION_TOAST_DURATION_MS);
+    }
   }
 }
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -39,6 +39,7 @@ export type CompactionIndicatorStatus = {
   active: boolean;
   startedAt: number | null;
   completedAt: number | null;
+  message?: string;
 };
 
 export type FallbackIndicatorStatus = {
@@ -194,9 +195,10 @@ function renderCompactionIndicator(status: CompactionIndicatorStatus | null | un
     return nothing;
   }
   if (status.active) {
+    const message = status.message ?? "Compacting context...";
     return html`
       <div class="compaction-indicator compaction-indicator--active" role="status" aria-live="polite">
-        ${icons.loader} Compacting context...
+        ${icons.loader} ${message}
       </div>
     `;
   }


### PR DESCRIPTION
## Summary
- Problem: When compaction triggers a retry (willRetry=true), the UI incorrectly shows \"Context compacted\" completion status
- Why it matters: Users see misleading status messages during compaction retry scenarios
- What changed: Skip status update when willRetry=true, keeping UI in active state until final completion
- What did NOT change: No changes to backend compaction logic
## Change Type
- [x] Bug fix
## Scope
- [x] UI / DX
## Security Impact
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
## Compatibility
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

cc @BunsDev @jalehman