### PR TITLE
fix: preserve valid Kimi tool call arguments in malformed-args repair

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1572,6 +1572,57 @@ describe("wrapStreamFnRepairMalformedToolCallArguments", () => {
     expect(partialToolCall.arguments).toEqual({});
   });
 
+  it("preserves valid tool arguments when a closing delta completes valid JSON", async () => {
+    const parsedArgs = { path: "/tmp/report.txt" };
+    const partialToolCall = { type: "toolCall", name: "read", arguments: parsedArgs };
+    const streamedToolCall = { type: "toolCall", name: "read", arguments: parsedArgs };
+    const endMessageToolCall = { type: "toolCall", name: "read", arguments: parsedArgs };
+    const finalToolCall = { type: "toolCall", name: "read", arguments: parsedArgs };
+    const partialMessage = { role: "assistant", content: [partialToolCall] };
+    const endMessage = { role: "assistant", content: [endMessageToolCall] };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: '{"path":"/tmp/report.txt"',
+            partial: partialMessage,
+            message: finalMessage,
+          },
+          {
+            type: "toolcall_delta",
+            contentIndex: 0,
+            delta: "}",
+            partial: partialMessage,
+            message: finalMessage,
+          },
+          {
+            type: "toolcall_end",
+            contentIndex: 0,
+            toolCall: streamedToolCall,
+            partial: partialMessage,
+            message: endMessage,
+          },
+        ],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    for await (const _item of stream) {
+      // drain
+    }
+    const result = await stream.result();
+
+    expect(partialToolCall.arguments).toEqual(parsedArgs);
+    expect(streamedToolCall.arguments).toEqual(parsedArgs);
+    expect(endMessageToolCall.arguments).toEqual(parsedArgs);
+    expect(finalToolCall.arguments).toEqual(parsedArgs);
+    expect(result).toBe(finalMessage);
+  });
+
   it("does not repair tool arguments when trailing junk exceeds the Kimi-specific allowance", async () => {
     const partialToolCall = { type: "toolCall", name: "read", arguments: {} };
     const streamedToolCall = { type: "toolCall", name: "read", arguments: {} };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1145,6 +1145,15 @@ type ToolCallArgumentRepair = {
   trailingSuffix: string;
 };
 
+function isValidJsonObject(raw: string): boolean {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
 function tryParseMalformedToolCallArguments(raw: string): ToolCallArgumentRepair | undefined {
   if (!raw.trim()) {
     return undefined;
@@ -1298,7 +1307,8 @@ function wrapStreamRepairMalformedToolCallArguments(
                       `repairing Kimi tool call arguments after ${repair.trailingSuffix.length} trailing chars`,
                     );
                   }
-                } else {
+                } else if (!isValidJsonObject(nextPartialJson)) {
+                  // Leave already-parsed arguments intact when the accumulated JSON is valid.
                   repairedArgsByIndex.delete(event.contentIndex);
                   clearToolCallArgumentsInMessage(event.partial, event.contentIndex);
                   clearToolCallArgumentsInMessage(event.message, event.contentIndex);


### PR DESCRIPTION
## Summary

- Problem: the Kimi Anthropic-compatible malformed-args repair wrapper can clear already-valid tool-call arguments when a closing `}` delta completes a valid JSON object.
- Why it matters: valid Kimi tool calls can arrive downstream as `{}`, which breaks tool validation and execution.
- What changed: add a JSON-object validity guard before the destructive clear path and add a regression test for the split-delta completion case.
- What did NOT change (scope boundary): no provider matching changes, no repair-heuristic widening, and no behavior changes for non-Kimi providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54442
- Related #54448
- Related #54491

## User-visible / Behavior Changes

Kimi Anthropic-compatible tool calls no longer lose valid arguments on the wrapper's valid-JSON path.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js 22, local checkout
- Model/provider: `kimi` with `anthropic-messages` wrapper path
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A, unit reproduction in `attempt.test.ts`

### Steps

1. Stream a Kimi tool call where the JSON object is completed by a later `}` delta.
2. Let the malformed-args wrapper evaluate that closing delta.
3. Observe whether the wrapper preserves the parsed arguments or clears them.

### Expected

- Valid JSON arguments stay intact.

### Actual

- Before this change, the wrapper could clear arguments to `{}` because "valid JSON" and "unrepairable" both took the same branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- src/agents/pi-embedded-runner/run/attempt.test.ts` on the rebased branch (94 tests passed), and `pnpm build` on the same branch.
- Edge cases checked: existing malformed trailing-junk repair coverage in `attempt.test.ts` still passes alongside the new valid-JSON regression.
- What you did **not** verify: a live Kimi session against the provider.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/agents/pi-embedded-runner/run/attempt.ts`, `src/agents/pi-embedded-runner/run/attempt.test.ts`
- Known bad symptoms reviewers should watch for: valid Kimi tool calls regressing back to empty `{}` arguments.

## Risks and Mitigations

- Risk: malformed-but-unrepairable payloads could still be misunderstood if a future provider changes the wrapper contract.
  - Mitigation: this change only skips the clear path when the accumulated payload is already a valid JSON object; existing malformed-payload behavior is otherwise unchanged, and the regression test locks in the closing-delta case.
