### PR TITLE
doctor: include --fix-missing in sessions cleanup preview (AI-assisted)

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -172,7 +172,9 @@ describe("doctor state integrity oauth dir checks", () => {
     const text = await runStateIntegrityText(cfg);
     expect(text).toContain("recent sessions are missing transcripts");
     expect(text).toMatch(/openclaw sessions --store ".*sessions\.json"/);
-    expect(text).toMatch(/openclaw sessions cleanup --store ".*sessions\.json" --dry-run/);
+    expect(text).toMatch(
+      /openclaw sessions cleanup --store ".*sessions\.json" --dry-run --fix-missing/,
+    );
     expect(text).toMatch(
       /openclaw sessions cleanup --store ".*sessions\.json" --enforce --fix-missing/,
     );

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -731,7 +731,7 @@ export async function noteStateIntegrity(
         [
           `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
           `  Verify sessions in store: ${formatCliCommand(`openclaw sessions --store "${absoluteStorePath}"`)}`,
-          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --dry-run`)}`,
+          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --dry-run --fix-missing`)}`,
           `  Prune missing entries: ${formatCliCommand(`openclaw sessions cleanup --store "${absoluteStorePath}" --enforce --fix-missing`)}`,
         ].join("\n"),
       );


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` warns that recent sessions are missing transcripts, but the suggested **preview** command (`openclaw sessions cleanup --dry-run`) does not include `--fix-missing`, so the preview output misleadingly shows `Would prune missing transcripts: 0`.
- Why it matters: Users get conflicting guidance (doctor warns about missing transcripts, preview shows none), which makes it harder to trust/operate cleanup safely.
- What changed: When doctor detects missing transcripts, it now suggests `openclaw sessions cleanup --dry-run --fix-missing` for the preview command.
- What did NOT change (scope boundary): No changes to cleanup behavior/logic; only doctor guidance text + a regression test.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The doctor "missing transcripts" warning printed a generic cleanup preview command that didn’t include the `--fix-missing` flag required for `sessions cleanup` to count/prune missing transcript entries.
- Missing detection / guardrail: No assertion that doctor’s preview command matches the recommended remediation flags for the detected condition.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: Unknown (likely an oversight when `--fix-missing` support was added).
- If unknown, what was ruled out: Cleanup logic itself is already correct; only doctor output was incomplete.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-state-integrity.test.ts`
- Scenario the test should lock in: When recent sessions are missing transcripts, doctor’s suggested preview command includes `--dry-run --fix-missing`.
- Why this is the smallest reliable guardrail: It directly asserts the exact guidance string that users copy/paste.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `openclaw doctor` now suggests `openclaw sessions cleanup --dry-run --fix-missing` when recent sessions are missing transcripts.

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js (repo dev env)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Create a sessions store entry whose `sessionId` transcript file does not exist.
2. Run `openclaw doctor`.
3. Copy/paste the suggested preview cleanup command.

### Expected

- The preview command includes `--fix-missing` and `sessions cleanup` reports the correct missing transcript count.

### Actual

- Before: doctor suggested `openclaw sessions cleanup --dry-run` (no `--fix-missing`), leading to `Would prune missing transcripts: 0` even when missing transcripts exist.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Updated doctor output via unit test assertion.
- Edge cases checked:
  - N/A (string-level guidance change only).
- What you did **not** verify:
  - Manual CLI run against a real user store (not required for this small guidance-only change).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: Doctor output still suggests preview command without `--fix-missing`.

## Risks and Mitigations

None.

---

AI-assisted: yes (OpenClaw subagent). Testing: `pnpm exec vitest run --config vitest.config.ts src/commands/doctor-state-integrity.test.ts`; `pnpm format:check`; pre-commit ran `pnpm check`.
