### PR TITLE
fix(plugins): skip auto-enable for plugins already in plugins.allow

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -225,6 +225,52 @@ describe("applyPluginAutoEnable", () => {
     expect(second.config).toEqual(first.config);
   });
 
+  it("skips writing plugins.entries for plugins already in plugins.allow (prevents reload loop)", () => {
+    // Regression test for https://github.com/openclaw/openclaw/issues/55163
+    // When a local extension is placed in plugins.allow but NOT in plugins.entries,
+    // applyPluginAutoEnable should treat it as already opted-in and NOT write a new
+    // plugins.entries record.  Writing that record triggers a config-change event which
+    // causes the gateway to reload, re-run the doctor, detect the same "missing" entry,
+    // write it again — an infinite loop under launchd / systemd supervision.
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "my-plugin");
+    writePluginManifestFixture({
+      rootDir: pluginDir,
+      id: "my-plugin",
+      channels: ["my-channel"],
+    });
+
+    const config = {
+      channels: { "my-channel": { enabled: true } },
+      plugins: {
+        allow: ["my-plugin"],
+        // Intentionally no plugins.entries for my-plugin
+      },
+    };
+
+    const result = applyPluginAutoEnable({
+      config,
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: "/nonexistent/bundled/plugins",
+      },
+      manifestRegistry: makeRegistry([{ id: "my-plugin", channels: ["my-channel"] }]),
+    });
+
+    // Should produce no config changes — plugin is already allow-listed
+    expect(result.changes).toEqual([]);
+    expect(result.config.plugins?.entries?.["my-plugin"]).toBeUndefined();
+    // Running again should also produce no changes (idempotency)
+    const second = applyPluginAutoEnable({
+      config: result.config,
+      env: {},
+      manifestRegistry: makeRegistry([{ id: "my-plugin", channels: ["my-channel"] }]),
+    });
+    expect(second.changes).toEqual([]);
+    expect(second.config).toEqual(result.config);
+  });
+
   it("respects explicit disable", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -457,6 +457,16 @@ export function applyPluginAutoEnable(params: {
       continue;
     }
     const allow = next.plugins?.allow;
+    // A plugin listed in plugins.allow is intentionally opted-in by the user.
+    // Treat it as already enabled so we don't write a redundant plugins.entries
+    // record, which would trigger a config-change event and cause an infinite
+    // reload loop when the gateway is managed by launchd or systemd.
+    // See: https://github.com/openclaw/openclaw/issues/55163
+    const alreadyInAllowlist =
+      builtInChannelId == null && Array.isArray(allow) && allow.includes(entry.pluginId);
+    if (alreadyInAllowlist) {
+      continue;
+    }
     const allowMissing =
       builtInChannelId == null && Array.isArray(allow) && !allow.includes(entry.pluginId);
     const alreadyEnabled =


### PR DESCRIPTION
## Problem

When a local extension is placed in `~/.openclaw/extensions/` and added to `plugins.allow`, the doctor's `applyPluginAutoEnable` function detects that the plugin is missing from `plugins.entries` and writes a new entry. This config write triggers a gateway reload, which re-runs the doctor, which detects the same "missing" entry, writes it again — **infinite config reload loop**.

This prevents the gateway from reaching the "listening" state when managed by launchd or systemd.

Fixes #55163.

## Root Cause

In `applyPluginAutoEnable`, the `alreadyEnabled` check for non-built-in plugins only looks at `plugins.entries[id].enabled === true`. It does not consider `plugins.allow`, so a plugin that is explicitly allow-listed (user intent already expressed) is treated as "needs enabling" → new `entries` record written → config change event fired.

## Fix

Before checking `alreadyEnabled`, short-circuit for any plugin already present in `plugins.allow`:

```ts
const alreadyInAllowlist =
  builtInChannelId == null && Array.isArray(allow) && allow.includes(entry.pluginId);
if (alreadyInAllowlist) {
  continue;
}
```

`plugins.allow` is the user's explicit opt-in signal. The doctor does not need to also write `plugins.entries` — doing so is what causes the reload loop.

## Testing

Added a regression test (`plugin-auto-enable.test.ts`) that verifies:
- No `plugins.entries` record is created for a plugin already in `plugins.allow`
- Running `applyPluginAutoEnable` twice produces no changes (idempotency)

All 28 tests pass.

## Impact

- Fixes launchd/systemd-managed gateway startup for local extensions
- Zero impact on normal (non-allow-listed) plugin auto-enable behavior
- No behavior change for built-in channel plugins