### PR TITLE
fix(feishu): unbind stale cross-agent conversation bindings

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -26,6 +26,8 @@ const {
   mockEnsureConfiguredBindingRouteReady,
   mockResolveBoundConversation,
   mockTouchBinding,
+  mockUnbindBinding,
+  mockDispatchReplyFromConfigAcp,
 } = vi.hoisted(() => ({
   mockCreateFeishuReplyDispatcher: vi.fn(() => ({
     dispatcher: vi.fn(),
@@ -59,6 +61,11 @@ const {
   mockEnsureConfiguredBindingRouteReady: vi.fn(async (_params?: unknown) => ({ ok: true })),
   mockResolveBoundConversation: vi.fn(() => null),
   mockTouchBinding: vi.fn(),
+  mockUnbindBinding: vi.fn(async () => []),
+  mockDispatchReplyFromConfigAcp: vi.fn().mockResolvedValue({
+    queuedFinal: false,
+    counts: { final: 1 },
+  }),
 }));
 
 vi.mock("./reply-dispatcher.js", () => ({
@@ -89,6 +96,7 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
     getSessionBindingService: () => ({
       resolveByConversation: mockResolveBoundConversation,
       touch: mockTouchBinding,
+      unbind: mockUnbindBinding,
     }),
   };
 });
@@ -97,6 +105,7 @@ vi.mock("../../../src/infra/outbound/session-binding-service.js", () => ({
   getSessionBindingService: () => ({
     resolveByConversation: mockResolveBoundConversation,
     touch: mockTouchBinding,
+    unbind: mockUnbindBinding,
   }),
 }));
 
@@ -124,6 +133,11 @@ describe("handleFeishuMessage ACP routing", () => {
     mockEnsureConfiguredBindingRouteReady.mockReset().mockResolvedValue({ ok: true });
     mockResolveBoundConversation.mockReset().mockReturnValue(null);
     mockTouchBinding.mockReset();
+    mockUnbindBinding.mockReset().mockResolvedValue([]);
+    mockDispatchReplyFromConfigAcp.mockReset().mockResolvedValue({
+      queuedFinal: false,
+      counts: { final: 1 },
+    });
     mockResolveAgentRoute.mockReset().mockReturnValue({
       agentId: "main",
       channel: "feishu",
@@ -168,10 +182,8 @@ describe("handleFeishuMessage ACP routing", () => {
             formatAgentEnvelope: vi.fn((params: { body: string }) => params.body),
             finalizeInboundContext: ((ctx: unknown) =>
               ctx) as unknown as PluginRuntime["channel"]["reply"]["finalizeInboundContext"],
-            dispatchReplyFromConfig: vi.fn().mockResolvedValue({
-              queuedFinal: false,
-              counts: { final: 1 },
-            }),
+            dispatchReplyFromConfig:
+              mockDispatchReplyFromConfigAcp as unknown as PluginRuntime["channel"]["reply"]["dispatchReplyFromConfig"],
             withReplyDispatcher: vi.fn(
               async ({
                 run,
@@ -423,6 +435,70 @@ describe("handleFeishuMessage ACP routing", () => {
       }),
     );
     expect(mockTouchBinding).toHaveBeenCalledWith("default:oc_group_chat:topic:om_topic_root");
+  });
+
+  it("ignores stale bound conversation when route agent differs", async () => {
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "germany",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:germany:feishu:group:oc_group_chat",
+      mainSessionKey: "agent:germany:main",
+      matchedBy: "binding.peer",
+    });
+    mockResolveBoundConversation.mockReturnValue({
+      bindingId: "default:oc_group_chat:topic:om_topic_root",
+      targetSessionKey: "agent:main:feishu:group:oc_group_chat:topic:om_topic_root",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        parentConversationId: "oc_group_chat",
+      },
+      status: "active",
+      boundAt: 0,
+    } as any);
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: {
+          feishu: {
+            enabled: true,
+            allowFrom: ["ou_sender_1"],
+            groups: {
+              oc_group_chat: {
+                allow: true,
+                requireMention: false,
+                groupSessionScope: "group_topic",
+              },
+            },
+          },
+        },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-stale-bound",
+          chat_id: "oc_group_chat",
+          chat_type: "group",
+          message_type: "text",
+          root_id: "om_topic_root",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockTouchBinding).not.toHaveBeenCalled();
+    expect(mockUnbindBinding).toHaveBeenCalledWith({
+      bindingId: "default:oc_group_chat:topic:om_topic_root",
+      reason: "stale-bound-agent-mismatch",
+    });
+    const call = mockDispatchReplyFromConfigAcp.mock.calls[0]?.[0] as
+      | { ctx?: { SessionKey?: string } }
+      | undefined;
+    expect(call?.ctx?.SessionKey).toBe("agent:germany:feishu:group:oc_group_chat");
   });
 });
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -386,7 +386,7 @@ describe("handleFeishuMessage ACP routing", () => {
   it("routes Feishu topic messages through active bound conversations", async () => {
     mockResolveBoundConversation.mockReturnValue({
       bindingId: "default:oc_group_chat:topic:om_topic_root",
-      targetSessionKey: "agent:codex:acp:binding:feishu:default:feedface",
+      targetSessionKey: "agent:main:feishu:group:oc_group_chat:topic:om_topic_root",
       targetKind: "session",
       conversation: {
         channel: "feishu",

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -605,21 +605,38 @@ export async function handleFeishuMessage(params: {
       });
       const boundSessionKey = threadBinding?.targetSessionKey?.trim();
       if (threadBinding && boundSessionKey) {
-        route = {
-          ...route,
-          sessionKey: boundSessionKey,
-          agentId: resolveAgentIdFromSessionKey(boundSessionKey) || route.agentId,
-          lastRoutePolicy: deriveLastRoutePolicy({
+        const boundAgentId = resolveAgentIdFromSessionKey(boundSessionKey) || route.agentId;
+        if (normalizeAgentId(boundAgentId) === normalizeAgentId(route.agentId)) {
+          route = {
+            ...route,
             sessionKey: boundSessionKey,
-            mainSessionKey: route.mainSessionKey,
-          }),
-          matchedBy: "binding.channel",
-        };
-        configuredBinding = null;
-        getSessionBindingService().touch(threadBinding.bindingId);
-        log(
-          `feishu[${account.accountId}]: routed via bound conversation ${currentConversationId} -> ${boundSessionKey}`,
-        );
+            agentId: boundAgentId,
+            lastRoutePolicy: deriveLastRoutePolicy({
+              sessionKey: boundSessionKey,
+              mainSessionKey: route.mainSessionKey,
+            }),
+            matchedBy: "binding.channel",
+          };
+          configuredBinding = null;
+          getSessionBindingService().touch(threadBinding.bindingId);
+          log(
+            `feishu[${account.accountId}]: routed via bound conversation ${currentConversationId} -> ${boundSessionKey}`,
+          );
+        } else {
+          try {
+            await getSessionBindingService().unbind({
+              bindingId: threadBinding.bindingId,
+              reason: "stale-bound-agent-mismatch",
+            });
+          } catch (unbindErr) {
+            log(
+              `feishu[${account.accountId}]: failed to unbind stale conversation ${currentConversationId} -> ${boundSessionKey}: ${String(unbindErr)}`,
+            );
+          }
+          log(
+            `feishu[${account.accountId}]: ignore stale bound conversation ${currentConversationId} -> ${boundSessionKey} (routeAgent=${route.agentId}, boundAgent=${boundAgentId})`,
+          );
+        }
       }
     }
 

--- a/extensions/feishu/src/monitor.bot-menu.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.bot-menu.lifecycle.test.ts
@@ -95,7 +95,7 @@ describe("Feishu bot-menu lifecycle", () => {
 
     resolveBoundConversationMock.mockImplementation(() => ({
       bindingId: "binding-menu",
-      targetSessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+      targetSessionKey: "agent:main:feishu:direct:ou_user1",
     }));
 
     resolveAgentRouteMock.mockReturnValue({
@@ -182,7 +182,7 @@ describe("Feishu bot-menu lifecycle", () => {
     expect(finalizeInboundContextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         AccountId: "acct-menu",
-        SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+        SessionKey: "agent:main:feishu:direct:ou_user1",
         MessageSid: "bot-menu:quick-actions:1700000000001",
       }),
     );

--- a/extensions/feishu/src/monitor.card-action.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.card-action.lifecycle.test.ts
@@ -124,7 +124,7 @@ describe("Feishu card-action lifecycle", () => {
 
     resolveBoundConversationMock.mockImplementation(() => ({
       bindingId: "binding-card",
-      targetSessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+      targetSessionKey: "agent:main:feishu:direct:ou_user1",
     }));
 
     resolveAgentRouteMock.mockReturnValue({
@@ -186,7 +186,7 @@ describe("Feishu card-action lifecycle", () => {
     expect(finalizeInboundContextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         AccountId: "acct-card",
-        SessionKey: "agent:bound-agent:feishu:direct:ou_user1",
+        SessionKey: "agent:main:feishu:direct:ou_user1",
         MessageSid: "card-action-tok-card-once",
       }),
     );

--- a/extensions/feishu/src/monitor.reply-once.lifecycle.test.ts
+++ b/extensions/feishu/src/monitor.reply-once.lifecycle.test.ts
@@ -92,7 +92,7 @@ describe("Feishu reply-once lifecycle", () => {
 
     resolveBoundConversationMock.mockReturnValue({
       bindingId: "binding-1",
-      targetSessionKey: "agent:bound-agent:feishu:topic:om_root_topic_1:ou_sender_1",
+      targetSessionKey: "agent:main:feishu:topic:om_root_topic_1:ou_sender_1",
     });
 
     resolveAgentRouteMock.mockReturnValue({
@@ -157,7 +157,7 @@ describe("Feishu reply-once lifecycle", () => {
     expect(finalizeInboundContextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         AccountId: "acct-lifecycle",
-        SessionKey: "agent:bound-agent:feishu:topic:om_root_topic_1:ou_sender_1",
+        SessionKey: "agent:main:feishu:topic:om_root_topic_1:ou_sender_1",
         MessageSid: "om_lifecycle_once",
         MessageThreadId: "om_root_topic_1",
       }),


### PR DESCRIPTION
## Summary
- proactively unbind stale Feishu conversation bindings when bound session agent does not match resolved route agent
- keep existing safe fallback (ignore stale binding and continue with resolved route)
- add regression test for topic-scoped stale binding cleanup

## Why
When a group is re-bound from `main` to another agent (e.g. `germany`), old conversation bindings can linger and be reused later. This change turns that stale-binding detection into active cleanup, preventing cross-agent session reuse.

## Validation
- local recovery actions executed: cleaned stale `main` session key for group `oc_9ab00898e488f79c4b52c40e0fdd43a7`, restarted gateway, and performed end-to-end germany delivery smoke check
- targeted test:
  - `corepack pnpm vitest --run extensions/feishu/src/bot.test.ts -t "ignores stale bound conversation when route agent differs"`
