### PR TITLE
fix(slack): ignore own bot_message replies

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -398,6 +398,92 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(botsInfo).toHaveBeenCalledTimes(1);
   });
 
+  it("retries bot identity lookup after a transient bots.info failure", async () => {
+    const botsInfo = vi
+      .fn()
+      .mockRejectedValueOnce({ code: "slack_webapi_request_error", statusCode: 429 })
+      .mockResolvedValueOnce({
+        bot: {
+          app_id: "A1",
+          user_id: "B1",
+        },
+      });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, allowBots: true },
+        },
+      } as OpenClawConfig,
+      appClient: { bots: { info: botsInfo } } as unknown as App["client"],
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+    const account = createSlackAccount({ allowBots: true });
+
+    const firstPrepared = await prepareMessageWith(
+      slackCtx,
+      account,
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: undefined,
+        bot_id: "B0SELF",
+        subtype: "bot_message",
+        text: "assistant reply",
+        ts: "1.100",
+      }),
+    );
+    const secondPrepared = await prepareMessageWith(
+      slackCtx,
+      account,
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: undefined,
+        bot_id: "B0SELF",
+        subtype: "bot_message",
+        text: "assistant reply again",
+        ts: "1.101",
+      }),
+    );
+
+    expect(firstPrepared).toBeTruthy();
+    expect(secondPrepared).toBeNull();
+    expect(botsInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not look up bot identity when allowBots is false", async () => {
+    const botsInfo = vi.fn();
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, allowBots: false },
+        },
+      } as OpenClawConfig,
+      appClient: { bots: { info: botsInfo } } as unknown as App["client"],
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ allowBots: false }),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: undefined,
+        bot_id: "B0SELF",
+        subtype: "bot_message",
+        text: "assistant reply",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+    expect(botsInfo).not.toHaveBeenCalled();
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -297,6 +297,107 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
   });
 
+  it("drops own bot messages when bot_profile app_id matches the current Slack app", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, allowBots: true },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ allowBots: true }),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: undefined,
+        bot_id: "B0SELF",
+        bot_profile: { app_id: "A1" },
+        subtype: "bot_message",
+        text: "assistant reply",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+  });
+
+  it("drops own bot messages when bots.info resolves the current bot identity", async () => {
+    const botsInfo = vi.fn().mockResolvedValue({
+      bot: {
+        app_id: "A1",
+        user_id: "B1",
+      },
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, allowBots: true },
+        },
+      } as OpenClawConfig,
+      appClient: { bots: { info: botsInfo } } as unknown as App["client"],
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ allowBots: true }),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: undefined,
+        bot_id: "B0SELF",
+        subtype: "bot_message",
+        text: "assistant reply",
+      }),
+    );
+
+    expect(prepared).toBeNull();
+    expect(botsInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps third-party bot messages allowed when allowBots is true", async () => {
+    const botsInfo = vi.fn().mockResolvedValue({
+      bot: {
+        app_id: "A_OTHER",
+        user_id: "U_OTHER",
+      },
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true, allowBots: true },
+        },
+      } as OpenClawConfig,
+      appClient: { bots: { info: botsInfo } } as unknown as App["client"],
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Bot" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ allowBots: true }),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        user: undefined,
+        bot_id: "B0THIRD",
+        subtype: "bot_message",
+        text: "third-party bot relay",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(botsInfo).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -20,6 +20,7 @@ import {
   resolveConversationLabel,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/infra-runtime";
 import {
   buildPendingHistoryContextFromMap,
   recordPendingHistoryEntryIfEnabled,
@@ -53,6 +54,7 @@ import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import type { PreparedSlackMessage } from "./types.js";
 
 const mentionRegexCache = new WeakMap<SlackMonitorContext, Map<string, RegExp[]>>();
+const SLACK_BOT_IDENTITY_CACHE_MAX = 512;
 const slackBotIdentityCache = new WeakMap<
   SlackMonitorContext,
   Map<string, { appId?: string; userId?: string } | null>
@@ -94,6 +96,32 @@ function getSlackBotIdentityCache(ctx: SlackMonitorContext) {
   return cache;
 }
 
+function setSlackBotIdentityCacheEntry(
+  cache: Map<string, { appId?: string; userId?: string } | null>,
+  botId: string,
+  value: { appId?: string; userId?: string } | null,
+) {
+  cache.delete(botId);
+  cache.set(botId, value);
+  pruneMapToMaxSize(cache, SLACK_BOT_IDENTITY_CACHE_MAX);
+}
+
+function formatSlackBotIdentityLookupError(err: unknown): string {
+  if (!err || typeof err !== "object") {
+    return "unknown_error";
+  }
+  const details = err as {
+    code?: unknown;
+    statusCode?: unknown;
+    data?: { error?: unknown };
+  };
+  const code = normalizeOptionalSlackId(details.code);
+  const slackError = normalizeOptionalSlackId(details.data?.error);
+  const statusCode =
+    typeof details.statusCode === "number" ? `status=${details.statusCode}` : undefined;
+  return [code, slackError, statusCode].filter(Boolean).join(" ") || "unknown_error";
+}
+
 async function resolveSlackBotIdentity(params: {
   ctx: SlackMonitorContext;
   botId: string;
@@ -113,7 +141,7 @@ async function resolveSlackBotIdentity(params: {
     };
   };
   if (typeof client.bots?.info !== "function") {
-    cache.set(botId, null);
+    setSlackBotIdentityCacheEntry(cache, botId, null);
     return null;
   }
 
@@ -124,11 +152,12 @@ async function resolveSlackBotIdentity(params: {
       userId: normalizeOptionalSlackId(info.bot?.user_id),
     };
     const normalized = identity.appId || identity.userId ? identity : null;
-    cache.set(botId, normalized);
+    setSlackBotIdentityCacheEntry(cache, botId, normalized);
     return normalized;
   } catch (err) {
-    logVerbose(`slack: failed to resolve bot identity for ${botId}: ${String(err)}`);
-    cache.set(botId, null);
+    logVerbose(
+      `slack: failed to resolve bot identity for ${botId}: ${formatSlackBotIdentityLookupError(err)}`,
+    );
     return null;
   }
 }
@@ -148,6 +177,9 @@ async function isOwnSlackBotMessage(params: {
   const inlineBotAppId = normalizeOptionalSlackId(message.bot_profile?.app_id);
   if (inlineBotAppId && ctx.apiAppId && inlineBotAppId === ctx.apiAppId) {
     return true;
+  }
+  if (!ctx.apiAppId && !ctx.botUserId) {
+    return false;
   }
 
   const botIdentity = await resolveSlackBotIdentity({ ctx, botId: message.bot_id });
@@ -265,12 +297,12 @@ async function authorizeSlackInboundMessage(params: {
     conversation;
 
   if (isBotMessage) {
-    if (await isOwnSlackBotMessage({ ctx, message })) {
-      logVerbose(`slack: drop own bot message ${message.bot_id ?? "unknown"}`);
-      return null;
-    }
     if (!allowBots) {
       logVerbose(`slack: drop bot message ${message.bot_id ?? "unknown"} (allowBots=false)`);
+      return null;
+    }
+    if (await isOwnSlackBotMessage({ ctx, message })) {
+      logVerbose(`slack: drop own bot message ${message.bot_id ?? "unknown"}`);
       return null;
     }
   }

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -53,6 +53,10 @@ import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import type { PreparedSlackMessage } from "./types.js";
 
 const mentionRegexCache = new WeakMap<SlackMonitorContext, Map<string, RegExp[]>>();
+const slackBotIdentityCache = new WeakMap<
+  SlackMonitorContext,
+  Map<string, { appId?: string; userId?: string } | null>
+>();
 
 function resolveCachedMentionRegexes(
   ctx: SlackMonitorContext,
@@ -71,6 +75,89 @@ function resolveCachedMentionRegexes(
   const built = buildMentionRegexes(ctx.cfg, agentId);
   byAgent.set(key, built);
   return built;
+}
+
+function normalizeOptionalSlackId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function getSlackBotIdentityCache(ctx: SlackMonitorContext) {
+  let cache = slackBotIdentityCache.get(ctx);
+  if (!cache) {
+    cache = new Map<string, { appId?: string; userId?: string } | null>();
+    slackBotIdentityCache.set(ctx, cache);
+  }
+  return cache;
+}
+
+async function resolveSlackBotIdentity(params: {
+  ctx: SlackMonitorContext;
+  botId: string;
+}): Promise<{ appId?: string; userId?: string } | null> {
+  const { ctx, botId } = params;
+  const cache = getSlackBotIdentityCache(ctx);
+  const cached = cache.get(botId);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const client = ctx.app.client as unknown as {
+    bots?: {
+      info?: (args: { bot: string; token?: string }) => Promise<{
+        bot?: { app_id?: unknown; user_id?: unknown };
+      }>;
+    };
+  };
+  if (typeof client.bots?.info !== "function") {
+    cache.set(botId, null);
+    return null;
+  }
+
+  try {
+    const info = await client.bots.info({ bot: botId, token: ctx.botToken });
+    const identity = {
+      appId: normalizeOptionalSlackId(info.bot?.app_id),
+      userId: normalizeOptionalSlackId(info.bot?.user_id),
+    };
+    const normalized = identity.appId || identity.userId ? identity : null;
+    cache.set(botId, normalized);
+    return normalized;
+  } catch (err) {
+    logVerbose(`slack: failed to resolve bot identity for ${botId}: ${String(err)}`);
+    cache.set(botId, null);
+    return null;
+  }
+}
+
+async function isOwnSlackBotMessage(params: {
+  ctx: SlackMonitorContext;
+  message: SlackMessageEvent;
+}): Promise<boolean> {
+  const { ctx, message } = params;
+  if (!message.bot_id) {
+    return false;
+  }
+  if (message.user && ctx.botUserId && message.user === ctx.botUserId) {
+    return true;
+  }
+
+  const inlineBotAppId = normalizeOptionalSlackId(message.bot_profile?.app_id);
+  if (inlineBotAppId && ctx.apiAppId && inlineBotAppId === ctx.apiAppId) {
+    return true;
+  }
+
+  const botIdentity = await resolveSlackBotIdentity({ ctx, botId: message.bot_id });
+  if (botIdentity?.appId && ctx.apiAppId && botIdentity.appId === ctx.apiAppId) {
+    return true;
+  }
+  if (botIdentity?.userId && ctx.botUserId && botIdentity.userId === ctx.botUserId) {
+    return true;
+  }
+  return false;
 }
 
 type SlackConversationContext = {
@@ -178,7 +265,8 @@ async function authorizeSlackInboundMessage(params: {
     conversation;
 
   if (isBotMessage) {
-    if (message.user && ctx.botUserId && message.user === ctx.botUserId) {
+    if (await isOwnSlackBotMessage({ ctx, message })) {
+      logVerbose(`slack: drop own bot message ${message.bot_id ?? "unknown"}`);
       return null;
     }
     if (!allowBots) {

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -28,10 +28,16 @@ export type SlackAttachment = {
   message_blocks?: unknown[];
 };
 
+export type SlackBotProfile = {
+  app_id?: string;
+  user_id?: string;
+};
+
 export type SlackMessageEvent = {
   type: "message";
   user?: string;
   bot_id?: string;
+  bot_profile?: SlackBotProfile;
   subtype?: string;
   username?: string;
   text?: string;
@@ -49,6 +55,7 @@ export type SlackAppMentionEvent = {
   type: "app_mention";
   user?: string;
   bot_id?: string;
+  bot_profile?: SlackBotProfile;
   username?: string;
   text?: string;
   ts?: string;


### PR DESCRIPTION
## Summary

- Problem: Slack can ingest the app's own threaded `bot_message` replies as fresh inbound turns when `allowBots=true`, which can produce duplicate agent replies.
- Why it matters: users see duplicate Slack responses and pay for an unnecessary extra agent run.
- What changed: own-bot detection now drops self-authored Slack `bot_message` events using `bot_profile.app_id` first and a cached `bots.info` fallback when needed, while preserving third-party bot relays.
- What did NOT change (scope boundary): the existing `message` vs `app_mention` race handling and non-Slack channel behavior.

AI-assisted: yes. Testing level: fully tested for this scoped fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55128
- Related #55128
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Slack `bot_message` events were allowed through the inbound path when `allowBots=true`, and the self-message guard only checked `message.user === ctx.botUserId`.
- Missing detection / guardrail: documented Slack `bot_message` payloads commonly identify the sender through `bot_id`/`bot_profile`, so our own threaded bot replies could bypass the self-message guard and re-enter inbound processing.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the Slack monitor intentionally supports third-party bot relays via `allowBots`, and issue #55128 provided the real-world duplicate reply symptom.
- Why this regressed now: once the bot has already replied in a thread, thread participation makes follow-up thread messages implicitly mentionable, so a self-authored threaded `bot_message` can trigger another run.
- If unknown, what was ruled out: current `main` already has dedicated `message`/`app_mention` race coverage, and those focused tests stayed green during this fix.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/slack/src/monitor/message-handler/prepare.test.ts`
- Scenario the test should lock in: drop self-authored `bot_message` events identified by inline `bot_profile.app_id` or by `bots.info`, while continuing to allow third-party bot relays when `allowBots=true`.
- Why this is the smallest reliable guardrail: the bug lives in Slack inbound authorization before dispatch, so a prepare-path test isolates the decision point without requiring a live Slack workspace.
- Existing test that already covers this (if any): the existing `allowBots` attachment-text test still covers allowed bot relays.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Slack no longer reprocesses the app's own threaded `bot_message` replies as new inbound turns when `allowBots=true`.
- Third-party Slack bot relays remain allowed when `allowBots=true`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No new required calls; the existing optional `bots.info` path is now used only as a fallback for bot identity resolution.
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: the fallback reuses the existing Slack client and token, is cached per bot id, and only runs when inline payload fields do not already prove bot ownership.

## Repro + Verification

### Environment

- OS: macOS 15.3 / darwin 25.3.0
- Runtime/container: Node 22 via repo scripts
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): `channels.slack.allowBots=true`, room `requireMention=true`, threaded replies enabled (`replyToMode=first`), native streaming enabled in the issue repro

### Steps

1. Configure Slack with `allowBots=true` for a channel and have the bot reply in-thread to an `@mention`.
2. Let Slack emit the bot's own threaded `message` event with subtype `bot_message`.
3. Observe that the inbound Slack path sees that event after thread participation has already been recorded.

### Expected

- The bot's own reply should be ignored by inbound processing.
- The original mention should produce only one agent reply.

### Actual

- The bot's own threaded `bot_message` could be treated as a new inbound turn and produce a duplicate reply.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the failure path with temporary targeted tests during development; added permanent regression tests for inline self-bot identity, cached `bots.info` fallback, and third-party bot relay preservation; ran `pnpm test -- extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler.app-mention-race.test.ts extensions/slack/src/monitor/message-handler.test.ts`, `pnpm test:extension slack`, `pnpm check`, `pnpm build`, and `pnpm test`.
- Edge cases checked: inline `bot_profile.app_id`, missing inline bot metadata with `bots.info` fallback, and third-party bot messages under `allowBots=true`.
- What you did **not** verify: a live Slack workspace round-trip.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `705fbdd81`, or temporarily disable `allowBots` for the affected Slack channel/account if self-bot echoes reappear.
- Files/config to restore: `extensions/slack/src/monitor/message-handler/prepare.ts`, `extensions/slack/src/types.ts`, and `extensions/slack/src/monitor/message-handler/prepare.test.ts`.
- Known bad symptoms reviewers should watch for: legitimate third-party Slack bot relays being dropped when `allowBots=true`.

## Risks and Mitigations

- Risk: Slack bot identity fallback could overmatch and suppress non-self bot traffic.
  - Mitigation: self-detection prefers exact inline `bot_profile.app_id`, falls back to exact `app_id`/`user_id` matches from `bots.info`, and regression tests keep third-party bot relays allowed.

Made with [Cursor](https://cursor.com)