### PR TITLE
fix(moonshot): pass search_id back to Kimi on round-2 tool result

### DIFF
--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -34,4 +34,58 @@ describe("kimi web search provider", () => {
       }),
     ).toEqual(["https://a.test", "https://b.test", "https://c.test"]);
   });
+
+  it("builds tool result content by echoing search_id from tool call arguments", () => {
+    // The Kimi $web_search builtin returns a search_id in the tool call arguments.
+    // buildKimiToolResultContent must pass it back unchanged so Kimi can resolve
+    // the cached search results on the next round.
+    const searchId = "abc123";
+    const result = __testing.buildKimiToolResultContent({
+      choices: [
+        {
+          finish_reason: "tool_calls",
+          message: {
+            tool_calls: [
+              {
+                id: "t-web_search-1",
+                function: {
+                  name: "$web_search",
+                  arguments: JSON.stringify({ search_result: { search_id: searchId } }),
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(JSON.parse(result)).toEqual({ search_result: { search_id: searchId } });
+  });
+
+  it("falls back to search_results array when no search_id is present in tool call arguments", () => {
+    const result = __testing.buildKimiToolResultContent({
+      search_results: [
+        { title: "Page A", url: "https://a.test", content: "content A" },
+        { title: "Page B", url: "https://b.test", content: "content B" },
+      ],
+    });
+    expect(JSON.parse(result)).toEqual({
+      search_results: [
+        { title: "Page A", url: "https://a.test", content: "content A" },
+        { title: "Page B", url: "https://b.test", content: "content B" },
+      ],
+    });
+  });
+
+  it("falls back gracefully when tool call arguments are malformed JSON", () => {
+    const result = __testing.buildKimiToolResultContent({
+      choices: [
+        {
+          message: {
+            tool_calls: [{ function: { arguments: "not-valid-json" } }],
+          },
+        },
+      ],
+    });
+    expect(JSON.parse(result)).toEqual({ search_results: [] });
+  });
 });

--- a/extensions/moonshot/src/kimi-web-search-provider.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.ts
@@ -47,6 +47,12 @@ type KimiToolCall = {
   };
 };
 
+type KimiWebSearchArguments = {
+  search_result?: {
+    search_id?: string;
+  };
+};
+
 type KimiMessage = {
   role?: string;
   content?: string;
@@ -129,6 +135,27 @@ function extractKimiCitations(data: KimiSearchResponse): string[] {
 }
 
 function buildKimiToolResultContent(data: KimiSearchResponse): string {
+  // The Kimi $web_search builtin function embeds a search_id in the tool call
+  // arguments rather than populating `search_results` in the response body.
+  // We must echo the search_id back as-is so Kimi can resolve the cached
+  // search results on the next round.
+  for (const toolCall of data.choices?.[0]?.message?.tool_calls ?? []) {
+    const rawArguments = toolCall.function?.arguments;
+    if (!rawArguments) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(rawArguments) as KimiWebSearchArguments;
+      const searchId = parsed.search_result?.search_id;
+      if (searchId) {
+        return JSON.stringify({ search_result: { search_id: searchId } });
+      }
+    } catch {
+      // ignore malformed tool arguments
+    }
+  }
+  // Fallback: original behaviour for any future Kimi API variant that returns
+  // search_results directly in the response body.
   return JSON.stringify({
     search_results: (data.search_results ?? []).map((entry) => ({
       title: entry.title ?? "",
@@ -350,4 +377,5 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  buildKimiToolResultContent,
 } as const;


### PR DESCRIPTION
## What and why

Kimi's `$web_search` builtin uses a two-round protocol:

- **Round 1** — Kimi responds with `finish_reason: "tool_calls"` and embeds a `search_id` inside the tool call arguments:
  ```json
  { "search_result": { "search_id": "abc123" } }
  ```
- **Round 2** — the client must echo that exact payload back as the tool result so Kimi can resolve the cached search.

`buildKimiToolResultContent` was reading `data.search_results`, which is **never present** in Kimi's `/v1/chat/completions` response. It always returned `{ search_results: [] }`. Kimi received an empty result and fabricated "I could not find any information" responses regardless of query.

## Changes

**`extensions/moonshot/src/kimi-web-search-provider.ts`**

- Added `KimiWebSearchArguments` type (mirrors the `search_result.search_id` shape from Kimi's tool call arguments).
- Rewrote `buildKimiToolResultContent` to inspect the first tool call's arguments. If a `search_id` is found, it is echoed back verbatim. The original `search_results`-array path is kept as a fallback for any future Kimi API variant that may populate it.

**`extensions/moonshot/src/kimi-web-search-provider.test.ts`**

Three new test cases:

| Test | Covers |
|------|--------|
| `builds tool result content by echoing search_id from tool call arguments` | happy-path: search_id is present → returned as-is |
| `falls back to search_results array when no search_id is present in tool call arguments` | fallback path works correctly |
| `falls back gracefully when tool call arguments are malformed JSON` | JSON.parse error is swallowed, returns `{ search_results: [] }` |

## Validation

Tested end-to-end on a self-hosted OpenClaw instance (v2026.3.24) with a real Moonshot API key (`api.moonshot.cn/v1`). Before the fix every search query returned a hallucinated "no results" answer. After the fix, multi-turn search completes correctly and returns cited web content.

```
pnpm test:extension moonshot

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Duration  7.77s
```