### PR TITLE
test: fix portable stderr capture and env leakage

### DIFF
--- a/scripts/committer
+++ b/scripts/committer
@@ -104,12 +104,18 @@ last_commit_error=''
 run_git_command() {
   local stderr_log
   stderr_log=$(mktemp)
-  if "$@" 2> >(tee "$stderr_log" >&2); then
+  if "$@" 2>"$stderr_log"; then
+    if [ -s "$stderr_log" ]; then
+      cat "$stderr_log" >&2
+    fi
     rm -f "$stderr_log"
     last_commit_error=''
     return 0
   fi
 
+  if [ -s "$stderr_log" ]; then
+    cat "$stderr_log" >&2
+  fi
   last_commit_error=$(cat "$stderr_log")
   rm -f "$stderr_log"
   return 1

--- a/test/scripts/test-parallel.test.ts
+++ b/test/scripts/test-parallel.test.ts
@@ -18,6 +18,10 @@ const clearPlannerShardEnv = (env) => {
   const nextEnv = { ...env };
   delete nextEnv.OPENCLAW_TEST_SHARDS;
   delete nextEnv.OPENCLAW_TEST_SHARD_INDEX;
+  delete nextEnv.OPENCLAW_TEST_FORCE_THREADS;
+  delete nextEnv.OPENCLAW_TEST_FORCE_FORKS;
+  delete nextEnv.OPENCLAW_TEST_DISABLE_THREAD_EXPANSION;
+  delete nextEnv.OPENCLAW_TEST_SHOW_POOL_DECISION;
   return nextEnv;
 };
 


### PR DESCRIPTION
## Summary
- make the committer helper capture stderr without bash process substitution
- stop forced thread benchmarking env vars from leaking into subprocess planner tests
- keep the change scoped to the durable portability and test-isolation fixes

## Testing
- pnpm vitest run test/scripts/committer.test.ts test/scripts/test-parallel.test.ts
