### PR TITLE
fix(plugins): skip auto-enable for plugins already in plugins.allow (#55163)

### DIFF
--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -457,6 +457,13 @@ export function applyPluginAutoEnable(params: {
       continue;
     }
     const allow = next.plugins?.allow;
+    // Skip auto-enable for non-built-in plugins already listed in plugins.allow.
+    // plugins.allow is the user's explicit opt-in; writing to plugins.entries
+    // would trigger a config-change → gateway reload → doctor re-run loop.
+    // See: https://github.com/openclaw/openclaw/issues/55163
+    if (builtInChannelId == null && Array.isArray(allow) && allow.includes(entry.pluginId)) {
+      continue;
+    }
     const allowMissing =
       builtInChannelId == null && Array.isArray(allow) && !allow.includes(entry.pluginId);
     const alreadyEnabled =


### PR DESCRIPTION
## Summary

Fixes #55163

When a local extension is listed in `plugins.allow`, `openclaw doctor`'s `applyPluginAutoEnable()` still writes `plugins.entries.<id>: {enabled: true}` because the `alreadyEnabled` check only looks at `plugins.entries`, not `plugins.allow`.

This config write triggers a gateway reload → doctor re-runs → writes again → **infinite loop** that prevents the gateway from ever reaching the listening state under launchd or systemd.

## Root Cause

In `applyPluginAutoEnable`, for non-built-in plugins (i.e., `builtInChannelId == null`):

- `allowMissing` = false (plugin is in `plugins.allow`)
- `alreadyEnabled` = false (plugin is NOT in `plugins.entries`)
- Result: neither guard fires → `registerPluginEntry` writes to `entries` → config change → reload

## Fix

Add an early `continue` for plugins that are already in `plugins.allow`:

```ts
if (builtInChannelId == null && Array.isArray(allow) && allow.includes(entry.pluginId)) {
  continue;
}
```

The user's explicit opt-in via `plugins.allow` is sufficient to load the plugin; writing to `plugins.entries` is redundant and breaks idempotency.

Built-in channel plugins (`builtInChannelId != null`) are unaffected — they use the `channels.<id>.enabled` path and do not suffer from this loop.

## Testing

898 tests pass across 113 test files in `src/config/` with no regressions.