### PR TITLE
fix(plugins): skip auto-enable for allowlisted non-channel plugins

### DIFF
--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -459,6 +459,7 @@ export function applyPluginAutoEnable(params: {
     const allow = next.plugins?.allow;
     const allowMissing =
       builtInChannelId == null && Array.isArray(allow) && !allow.includes(entry.pluginId);
+    if (!allowMissing && builtInChannelId == null) continue;
     const alreadyEnabled =
       builtInChannelId != null
         ? (() => {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -459,7 +459,7 @@ export function applyPluginAutoEnable(params: {
     const allow = next.plugins?.allow;
     const allowMissing =
       builtInChannelId == null && Array.isArray(allow) && !allow.includes(entry.pluginId);
-    if (!allowMissing && builtInChannelId == null) continue;
+    if (builtInChannelId == null && Array.isArray(allow) && allow.includes(entry.pluginId)) continue;
     const alreadyEnabled =
       builtInChannelId != null
         ? (() => {


### PR DESCRIPTION
## Problem

When a local tool-registering plugin is placed in `~/.openclaw/extensions/` and added to `plugins.allow`, `applyPluginAutoEnable` still writes `plugins.entries.<id>.enabled = true` on every startup. This triggers the config file watcher → reload → auto-enable → write loop, preventing the gateway from ever reaching the listening state.

Affects any non-channel, non-provider plugin loaded from the extensions directory.

## Root Cause

In `applyPluginAutoEnable`, the skip condition for non-channel plugins only checks `plugins.entries[id].enabled === true`. If the plugin has no entry (because it's auto-discovered), the function proceeds to `registerPluginEntry` which writes the entry, triggering a reload.

## Fix

Add one line: skip `registerPluginEntry` for non-channel plugins (`builtInChannelId == null`) that are already allowlisted (`!allowMissing`). These plugins are already loaded via filesystem discovery and don't need an explicit entries record.

```typescript
if (!allowMissing && builtInChannelId == null) continue;
```

## Testing

- Tested with 4 local tool-registering plugins (clawpipe, clawwrap, clawagentskill, clawinterview)
- Before patch: infinite config reload loop, gateway never reaches listening state
- After patch: 0 duplicate warnings, all 4 tools register, gateway healthy via launchd
- Channel-based plugins (slack, whatsapp, telegram) unaffected — they have `builtInChannelId != null`

Fixes #50382, #55163
Related: #40537, #45805