### PR TITLE
fix(msteams): preserve channel reply threading in proactive fallback

### DIFF
--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -404,6 +404,100 @@ describe("msteams messenger", () => {
       expect(ids).toEqual(["id:one", "id:two", "id:three"]);
     });
 
+    it("reconstructs threaded conversation ID for channel revoke fallback", async () => {
+      const proactiveSent: string[] = [];
+      let capturedReference: unknown;
+
+      const channelRef: StoredConversationReference = {
+        activityId: "activity456",
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        conversation: {
+          id: "19:abc@thread.tacv2;messageid=deadbeef",
+          conversationType: "channel",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+      };
+
+      const ctx = createRevokedThreadContext();
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference;
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: channelRef,
+        context: ctx,
+        messages: [{ text: "hello" }],
+      });
+
+      expect(proactiveSent).toEqual(["hello"]);
+      const ref = capturedReference as { conversation?: { id?: string }; activityId?: string };
+      // Conversation ID should include the thread suffix for channel messages
+      expect(ref.conversation?.id).toBe("19:abc@thread.tacv2;messageid=activity456");
+      expect(ref.activityId).toBeUndefined();
+    });
+
+    it("does not add thread suffix for group chat revoke fallback", async () => {
+      const proactiveSent: string[] = [];
+      let capturedReference: unknown;
+
+      const groupRef: StoredConversationReference = {
+        activityId: "activity789",
+        user: { id: "user123", name: "User" },
+        agent: { id: "bot123", name: "Bot" },
+        conversation: {
+          id: "19:group123@thread.v2",
+          conversationType: "groupChat",
+        },
+        channelId: "msteams",
+        serviceUrl: "https://service.example.com",
+      };
+
+      const ctx = createRevokedThreadContext();
+      const adapter: MSTeamsAdapter = {
+        continueConversation: async (_appId, reference, logic) => {
+          capturedReference = reference;
+          await logic({
+            sendActivity: createRecordedSendActivity(proactiveSent),
+            updateActivity: noopUpdateActivity,
+            deleteActivity: noopDeleteActivity,
+          });
+        },
+        process: async () => {},
+        updateActivity: noopUpdateActivity,
+        deleteActivity: noopDeleteActivity,
+      };
+
+      await sendMSTeamsMessages({
+        replyStyle: "thread",
+        adapter,
+        appId: "app123",
+        conversationRef: groupRef,
+        context: ctx,
+        messages: [{ text: "hello" }],
+      });
+
+      expect(proactiveSent).toEqual(["hello"]);
+      const ref = capturedReference as { conversation?: { id?: string }; activityId?: string };
+      // Group chat should NOT have thread suffix — flat conversation
+      expect(ref.conversation?.id).toBe("19:group123@thread.v2");
+      expect(ref.activityId).toBeUndefined();
+    });
+
     it("retries top-level sends on transient (5xx)", async () => {
       const attempts: string[] = [];
 

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -538,9 +538,7 @@ export async function sendMSTeamsMessages(params: {
           const remaining = messages.slice(idx);
           return {
             ids:
-              remaining.length > 0
-                ? await sendProactively(remaining, idx, threadActivityId)
-                : [],
+              remaining.length > 0 ? await sendProactively(remaining, idx, threadActivityId) : [],
             fellBack: true,
           };
         },

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -523,7 +523,7 @@ export async function sendMSTeamsMessages(params: {
     if (!ctx) {
       throw new Error("Missing context for replyStyle=thread");
     }
-    const threadActivityId = params.conversationRef.activityId ?? undefined;
+    const threadActivityId = params.conversationRef.activityId;
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
       const result = await withRevokedProxyFallback({

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -494,11 +494,21 @@ export async function sendMSTeamsMessages(params: {
   const sendProactively = async (
     batch: MSTeamsRenderedMessage[],
     startIndex: number,
+    threadActivityId?: string,
   ): Promise<string[]> => {
     const baseRef = buildConversationReference(params.conversationRef);
+    const isChannel = params.conversationRef.conversation?.conversationType === "channel";
+    // For Teams channels, reconstruct the threaded conversation ID so the
+    // proactive message lands in the correct thread instead of creating a
+    // new top-level post in the channel.
+    const conversationId =
+      isChannel && threadActivityId
+        ? `${baseRef.conversation.id};messageid=${threadActivityId}`
+        : baseRef.conversation.id;
     const proactiveRef: MSTeamsConversationReference = {
       ...baseRef,
       activityId: undefined,
+      conversation: { ...baseRef.conversation, id: conversationId },
     };
 
     const messageIds: string[] = [];
@@ -513,6 +523,7 @@ export async function sendMSTeamsMessages(params: {
     if (!ctx) {
       throw new Error("Missing context for replyStyle=thread");
     }
+    const threadActivityId = params.conversationRef.activityId ?? undefined;
     const messageIds: string[] = [];
     for (const [idx, message] of messages.entries()) {
       const result = await withRevokedProxyFallback({
@@ -521,9 +532,15 @@ export async function sendMSTeamsMessages(params: {
           fellBack: false,
         }),
         onRevoked: async () => {
+          // When the live turn context is revoked (e.g. debounced messages),
+          // reconstruct the threaded conversation ID so the proactive
+          // fallback delivers the reply into the correct channel thread.
           const remaining = messages.slice(idx);
           return {
-            ids: remaining.length > 0 ? await sendProactively(remaining, idx) : [],
+            ids:
+              remaining.length > 0
+                ? await sendProactively(remaining, idx, threadActivityId)
+                : [],
             fellBack: true,
           };
         },


### PR DESCRIPTION
## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: When the Bot Framework turn context is revoked (e.g. due to inbound message debouncing), proactive messaging fallback posts replies as new top-level messages in Teams channels instead of threading
  them under the original message.
  - Why it matters: Users see bot replies as disconnected new messages instead of threaded replies, breaking conversation flow in Teams channels.
  - What changed: `sendProactively` in `messenger.ts` now reconstructs the threaded conversation ID (`{channelId};messageid={activityId}`) for channel messages when the reply style is `"thread"`, so the proactive
  fallback delivers replies into the correct thread. Two new unit tests added.
  - What did NOT change (scope boundary): Non-channel conversations (DMs, group chats) are unaffected. The `buildActivity`, `sendMessageInContext`, and `sendMessageBatchInContext` functions are unchanged. No
  config or schema changes.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Related #27189
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History (if applicable)

  - Root cause: `normalizeConversationId` strips the `;messageid=...` thread suffix from the conversation ID when storing the conversation reference. When `sendProactively` builds the proactive reference, it uses
  this normalized ID, so `continueConversation` sends the message to the channel root instead of the original thread.
  - Missing detection / guardrail: No test covered the proactive fallback path with channel-specific threading. The existing revoke fallback test used a conversation reference without `conversationType:
  "channel"`.
  - Prior context: PR #27224 added `withRevokedProxyFallback` to fix the revoked proxy error (#27189), which solved the delivery failure but introduced this threading regression — replies were delivered but as new
   top-level messages.
  - Why this regressed now: The proactive fallback path was added to handle revoked contexts, but the conversation ID reconstruction for channel threading was not considered at that time.
  - If unknown, what was ruled out: N/A — root cause confirmed.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [ ] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file: `extensions/msteams/src/messenger.test.ts`
  - Scenario the test should lock in: When context is revoked for a channel message (`conversationType: "channel"`), the proactive reference's conversation ID must include `;messageid={activityId}`. For group chat
   (`conversationType: "groupChat"`), it must NOT add the suffix.
  - Why this is the smallest reliable guardrail: Unit test on `sendMSTeamsMessages` directly verifies the conversation reference passed to `continueConversation`, covering the exact bug surface.
  - Existing test that already covers this (if any): None — existing revoke fallback test did not assert on conversation ID.
  - If no new test is added, why not: Two new tests added.

  ## User-visible / Behavior Changes

  When the bot's turn context is revoked and the proactive fallback is used in a Teams channel, replies now appear as threaded replies under the original message instead of new top-level posts.

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - OS: Ubuntu 24.04 LTS
  - Runtime/container: Node.js v22.22.0
  - Model/provider: Amazon Bedrock / Claude Sonnet 4.6
  - Integration/channel: Microsoft Teams (channel)
  - Relevant config: `channels.msteams.enabled: true`, `messages.inbound.debounceMs: 100` (for testing)

  ### Steps

  1. Configure MS Teams channel with the bot
  2. Force a turn context revoke (either via debouncing or simulated 20s delay + TypeError throw in the `run` callback)
  3. Send a message to the bot in a Teams channel via @mention

  ### Expected

  - Bot reply appears as a threaded reply under the original message

  ### Actual (before fix)

  - Bot reply appears as a new top-level message in the channel

  ## Evidence

  - [x] Failing test/log before + passing after
  - [x] Trace/log snippets

  **Before fix (revoke, no fix):**
  sendProactively: baseRef.activityId=1774527433372 proactiveRef.activityId=undefined conversationId=19:f28cbacc30214c03bad8262bdacf8fe2@thread.tacv2
  sendMessageInContext: activity.replyToId=undefined activity.type=message
  → New top-level message posted

  **After fix (revoke, with fix):**
  sendProactively: baseRef.activityId=1774527601946 replyToId=1774527601946 isChannel=true conversationId=19:f28cbacc30214c03bad8262bdacf8fe2@thread.tacv2;messageid=1774527601946
  sendMessageInContext: activity.replyToId=1774527601946 activity.type=message
  → Reply correctly threaded under original message

  ## Human Verification (required)

  - Verified scenarios: Forced revoke on live Teams channel (with and without fix), normal non-revoked path, DM path
  - Edge cases checked: Group chat (no thread suffix added), channel (thread suffix reconstructed), missing activityId (no suffix added)
  - What you did **not** verify: Natural revoke via actual debouncing (current CloudAdapter version does not revoke proxy; tested with simulated revoke instead)

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert the single commit; only `messenger.ts` changed
  - Files/config to restore: `extensions/msteams/src/messenger.ts`
  - Known bad symptoms reviewers should watch for: Replies landing in wrong thread or failing to send in Teams channels

  ## Risks and Mitigations

  - Risk: The reconstructed conversation ID format (`{channelId};messageid={activityId}`) depends on the Teams Bot Framework convention for thread addressing.
    - Mitigation: This is the documented Teams threading format, and was verified to work on a live Teams channel. The reconstruction only activates for `conversationType: "channel"` with a valid `activityId`,
  falling back to the original behavior otherwise.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>