### PR TITLE
fix(model-fallback): add HTTP 410 to failover reason classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Docs: https://docs.openclaw.ai
 - Brave/web search: normalize unsupported Brave `country` filters to `ALL` before request and cache-key generation so locale-derived values like `VN` stop failing with upstream 422 validation errors. (#55695) Thanks @chen-zhang-cs-code.
 - Discord/replies: preserve leading indentation when stripping inline reply tags so reply-tagged plain text and fenced code blocks keep their formatting. (#55960) Thanks @Nanako0129.
 - Daemon/status: surface immediate gateway close reasons from lightweight probes and prefer those concrete auth or pairing failures over generic timeouts in `openclaw daemon status`. (#56282) Thanks @mbelinky.
+- Agents/failover: classify HTTP 410 errors as retryable timeouts by default while still preserving explicit session-expired, billing, and auth signals from the payload. (#55201) thanks @nikus-pan.
 
 ## 2026.3.24
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -102,6 +102,27 @@ describe("failover-error", () => {
     ).toBe("session_expired");
   });
 
+  it("preserves explicit auth and billing signals on HTTP 410", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 410,
+        message: "invalid_api_key",
+      }),
+    ).toBe("auth_permanent");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 410,
+        message: "authentication failed",
+      }),
+    ).toBe("auth");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 410,
+        message: "insufficient credits",
+      }),
+    ).toBe("billing");
+  });
+
   it("classifies documented provider error shapes at the error boundary", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -67,6 +67,7 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 410 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
     expect(resolveFailoverReasonFromError({ status: 422 })).toBe("format");
@@ -80,6 +81,25 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 523 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 524 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
+  });
+
+  it("treats session-specific HTTP 410s differently from generic 410s", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 410,
+        message: "session not found",
+      }),
+    ).toBe("session_expired");
+    expect(
+      resolveFailoverReasonFromError({
+        message: "HTTP 410: No body",
+      }),
+    ).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
+        message: "HTTP 410: conversation expired",
+      }),
+    ).toBe("session_expired");
   });
 
   it("classifies documented provider error shapes at the error boundary", () => {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -228,6 +228,10 @@ describe("formatRawAssistantErrorForUi", () => {
     );
   });
 
+  it("formats colon-delimited HTTP status lines", () => {
+    expect(formatRawAssistantErrorForUi("HTTP 410: No body")).toBe("HTTP 410: No body");
+  });
+
   it("sanitizes HTML error pages into a clean unavailable message", () => {
     const htmlError = `521 <!DOCTYPE html>
 <html lang="en-US">

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -558,6 +558,21 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
       ),
     ).toBe("overloaded");
   });
+
+  it("treats HTTP 410 Gone as session_expired to trigger fallback", () => {
+    expect(classifyFailoverReasonFromHttpStatus(410)).toBe("session_expired");
+    expect(classifyFailoverReasonFromHttpStatus(410, "")).toBe("session_expired");
+    expect(classifyFailoverReasonFromHttpStatus(410, "No body response")).toBe("session_expired");
+  });
+
+  it("classifies 410 error messages as session_expired", () => {
+    expect(classifyFailoverReason("410")).toBe("session_expired");
+    expect(classifyFailoverReason("HTTP 410")).toBe("session_expired");
+    expect(classifyFailoverReason("410 Gone")).toBe("session_expired");
+    expect(classifyFailoverReason("410: No body")).toBe("session_expired");
+    expect(classifyFailoverReason("HTTP 410 Gone")).toBe("session_expired");
+    expect(classifyFailoverReason("No body (410)")).toBe("session_expired");
+  });
 });
 
 describe("isFailoverErrorMessage", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -571,6 +571,12 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
       "session_expired",
     );
   });
+
+  it("preserves explicit billing and auth signals on HTTP 410", () => {
+    expect(classifyFailoverReasonFromHttpStatus(410, "invalid_api_key")).toBe("auth_permanent");
+    expect(classifyFailoverReasonFromHttpStatus(410, "authentication failed")).toBe("auth");
+    expect(classifyFailoverReasonFromHttpStatus(410, "insufficient credits")).toBe("billing");
+  });
 });
 
 describe("classifyFailoverReason", () => {
@@ -586,6 +592,12 @@ describe("classifyFailoverReason", () => {
   it("keeps session-specific 410 text mapped to session_expired", () => {
     expect(classifyFailoverReason("HTTP 410: session not found")).toBe("session_expired");
     expect(classifyFailoverReason("410 conversation expired")).toBe("session_expired");
+  });
+
+  it("keeps explicit billing and auth signals on 410 text", () => {
+    expect(classifyFailoverReason("HTTP 410: invalid_api_key")).toBe("auth_permanent");
+    expect(classifyFailoverReason("HTTP 410: authentication failed")).toBe("auth");
+    expect(classifyFailoverReason("HTTP 410: insufficient credits")).toBe("billing");
   });
 });
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -559,19 +559,33 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     ).toBe("overloaded");
   });
 
-  it("treats HTTP 410 Gone as session_expired to trigger fallback", () => {
-    expect(classifyFailoverReasonFromHttpStatus(410)).toBe("session_expired");
-    expect(classifyFailoverReasonFromHttpStatus(410, "")).toBe("session_expired");
-    expect(classifyFailoverReasonFromHttpStatus(410, "No body response")).toBe("session_expired");
+  it("treats generic HTTP 410 responses as retryable timeouts", () => {
+    expect(classifyFailoverReasonFromHttpStatus(410)).toBe("timeout");
+    expect(classifyFailoverReasonFromHttpStatus(410, "")).toBe("timeout");
+    expect(classifyFailoverReasonFromHttpStatus(410, "No body response")).toBe("timeout");
   });
 
-  it("classifies 410 error messages as session_expired", () => {
-    expect(classifyFailoverReason("410")).toBe("session_expired");
-    expect(classifyFailoverReason("HTTP 410")).toBe("session_expired");
-    expect(classifyFailoverReason("410 Gone")).toBe("session_expired");
-    expect(classifyFailoverReason("410: No body")).toBe("session_expired");
-    expect(classifyFailoverReason("HTTP 410 Gone")).toBe("session_expired");
-    expect(classifyFailoverReason("No body (410)")).toBe("session_expired");
+  it("treats session-specific HTTP 410 responses as session_expired", () => {
+    expect(classifyFailoverReasonFromHttpStatus(410, "session not found")).toBe("session_expired");
+    expect(classifyFailoverReasonFromHttpStatus(410, "conversation expired")).toBe(
+      "session_expired",
+    );
+  });
+});
+
+describe("classifyFailoverReason", () => {
+  it("treats generic 410 text as retryable timeout", () => {
+    expect(classifyFailoverReason("410")).toBe("timeout");
+    expect(classifyFailoverReason("HTTP 410")).toBe("timeout");
+    expect(classifyFailoverReason("410 Gone")).toBe("timeout");
+    expect(classifyFailoverReason("410: No body")).toBe("timeout");
+    expect(classifyFailoverReason("HTTP 410: No body")).toBe("timeout");
+    expect(classifyFailoverReason("HTTP 410 Gone")).toBe("timeout");
+  });
+
+  it("keeps session-specific 410 text mapped to session_expired", () => {
+    expect(classifyFailoverReason("HTTP 410: session not found")).toBe("session_expired");
+    expect(classifyFailoverReason("410 conversation expired")).toBe("session_expired");
   });
 });
 

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -492,6 +492,15 @@ export function classifyFailoverReasonFromHttpStatus(
     if (message && isCliSessionExpiredErrorMessage(message)) {
       return "session_expired";
     }
+    if (message && isBillingErrorMessage(message)) {
+      return "billing";
+    }
+    if (message && isAuthPermanentErrorMessage(message)) {
+      return "auth_permanent";
+    }
+    if (message && isAuthErrorMessage(message)) {
+      return "auth";
+    }
     return "timeout";
   }
   if (status === 503) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -502,6 +502,9 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 529) {
     return "overloaded";
   }
+  if (status === 410) {
+    return "session_expired";
+  }
   if (status === 400 || status === 422) {
     // Some providers return quota/balance errors under HTTP 400, so do not
     // let the generic format fallback mask an explicit billing signal.
@@ -972,6 +975,14 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isModelNotFoundErrorMessage(raw)) {
     return "model_not_found";
+  }
+  const trimmed = raw.trim();
+  const status = extractLeadingHttpStatus(trimmed);
+  if (status?.code === 410) {
+    return "session_expired";
+  }
+  if (/^410[\s:]/i.test(trimmed) || /\(410[\s)]/.test(trimmed)) {
+    return "session_expired";
   }
   const reasonFrom402Text = classifyFailoverReasonFrom402Text(raw);
   if (reasonFrom402Text) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -484,6 +484,16 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 408) {
     return "timeout";
   }
+  if (status === 410) {
+    // HTTP 410 is only a true session-expiry signal when the payload says the
+    // remote session/conversation is gone. Generic 410/no-body responses from
+    // OpenAI-compatible proxies are better treated as retryable transport-path
+    // failures so we do not clear session state or poison auth-profile health.
+    if (message && isCliSessionExpiredErrorMessage(message)) {
+      return "session_expired";
+    }
+    return "timeout";
+  }
   if (status === 503) {
     if (message && isOverloadedErrorMessage(message)) {
       return "overloaded";
@@ -501,9 +511,6 @@ export function classifyFailoverReasonFromHttpStatus(
   }
   if (status === 529) {
     return "overloaded";
-  }
-  if (status === 410) {
-    return "session_expired";
   }
   if (status === 400 || status === 422) {
     // Some providers return quota/balance errors under HTTP 400, so do not
@@ -977,12 +984,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "model_not_found";
   }
   const trimmed = raw.trim();
-  const status = extractLeadingHttpStatus(trimmed);
-  if (status?.code === 410) {
-    return "session_expired";
-  }
-  if (/^410[\s:]/i.test(trimmed) || /\(410[\s)]/.test(trimmed)) {
-    return "session_expired";
+  const leadingStatus = extractLeadingHttpStatus(trimmed);
+  if (leadingStatus?.code === 410) {
+    return classifyFailoverReasonFromHttpStatus(leadingStatus.code, leadingStatus.rest);
   }
   const reasonFrom402Text = classifyFailoverReasonFrom402Text(raw);
   if (reasonFrom402Text) {
@@ -999,7 +1003,7 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isTransientHttpError(raw)) {
     // 529 is always overloaded, even without explicit overload keywords in the body.
-    const status = extractLeadingHttpStatus(raw.trim());
+    const status = extractLeadingHttpStatus(trimmed);
     if (status?.code === 529) {
       return "overloaded";
     }

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -1,7 +1,14 @@
 const ERROR_PAYLOAD_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|apierror|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error)(?:\s+\d{3})?[:\s-]+/i;
-const HTTP_STATUS_PREFIX_RE = /^(?:http\s*)?(\d{3})\s+(.+)$/i;
-const HTTP_STATUS_CODE_PREFIX_RE = /^(?:http\s*)?(\d{3})(?:\s+([\s\S]+))?$/i;
+const HTTP_STATUS_DELIMITER_RE = /(?:\s*:\s*|\s+)/;
+const HTTP_STATUS_PREFIX_RE = new RegExp(
+  `^(?:http\\s*)?(\\d{3})${HTTP_STATUS_DELIMITER_RE.source}(.+)$`,
+  "i",
+);
+const HTTP_STATUS_CODE_PREFIX_RE = new RegExp(
+  `^(?:http\\s*)?(\\d{3})(?:${HTTP_STATUS_DELIMITER_RE.source}([\\s\\S]+))?$`,
+  "i",
+);
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
 


### PR DESCRIPTION
## Summary

Add HTTP 410 Gone status code handling to `classifyFailoverReasonFromHttpStatus()`,
mapping it to `session_expired` which triggers the model fallback chain.

## Problem

Previously, HTTP 410 responses were not classified as a failover reason in
`classifyFailoverReasonFromHttpStatus()`. This caused model fallback to not
trigger when providers returned 410 errors, leaving users with raw error
messages instead of automatic failover to configured fallback models.

## Root Cause

The `classifyFailoverReasonFromHttpStatus()` function in
`src/agents/pi-embedded-helpers/errors.ts` handles many HTTP status codes
(400, 401, 402, 403, 408, 429, 499, 502, 503, 504, 529) but was missing
the 410 status code.

Notably, the reverse mapping (`session_expired` → 410) already exists in
`resolveFailoverStatus()` in `src/agents/failover-error.ts`, making this fix
a simple addition to complete the bidirectional mapping.

## Fix

Added handling for HTTP 410 in `classifyFailoverReasonFromHttpStatus()`:

```typescript
if (status === 410) {
  return "session_expired";
}
```

This maps 410 Gone responses to the `session_expired` failover reason,
which correctly triggers the model fallback chain.

## Related Issues

Fixes openclaw/openclaw#54612
See also openclaw/openclaw#26355