### PR TITLE
fix(channels): use pinned channel registry for outbound adapter resolution

### DIFF
--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { getActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -13,7 +13,7 @@ export function createChannelRegistryLoader<TValue>(
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
+    const registry = getActivePluginChannelRegistry();
     if (registry !== lastRegistry) {
       cache.clear();
       lastRegistry = registry;

--- a/src/plugins/runtime.channel-pin.test.ts
+++ b/src/plugins/runtime.channel-pin.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { loadChannelOutboundAdapter } from "../channels/plugins/outbound/load.js";
 import { getChannelPlugin } from "../channels/plugins/registry.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import {
@@ -172,5 +173,27 @@ describe("channel registry pinning", () => {
       startupRegistry: startup,
       freshRegistry: fresh,
     });
+  });
+
+  it("loadChannelOutboundAdapter resolves from pinned registry after active registry replacement", async () => {
+    const outboundAdapter = { send: async () => ({ messageId: "1" }) };
+    const startup = createEmptyPluginRegistry();
+    startup.channels = [
+      {
+        pluginId: "telegram",
+        plugin: { id: "telegram", meta: {}, outbound: outboundAdapter },
+        source: "test",
+      },
+    ] as never;
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    // Simulate a post-boot registry replacement (e.g. config-schema load, plugin status query).
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(replacement);
+
+    // The outbound loader must still find the telegram adapter from the pinned registry.
+    const adapter = await loadChannelOutboundAdapter("telegram");
+    expect(adapter).toBe(outboundAdapter);
   });
 });


### PR DESCRIPTION
## Summary

`loadChannelOutboundAdapter` (via `createChannelRegistryLoader` in `src/channels/plugins/registry-loader.ts`) was reading from `getActivePluginRegistry()` — the **unpinned** active registry that gets replaced whenever `loadOpenClawPlugins()` runs.

Multiple code paths replace the active registry after boot:
- Config schema reads (`runtime-schema.ts`)
- Plugin status queries (`plugins/status.ts`)
- Tool listings (`plugins/tools.ts`)
- Provider resolution (`providers.runtime.ts`)
- TTS/image-gen/media provider lookups

After replacement, the active registry may omit channel entries or carry them in setup mode without outbound adapters, causing:

```
Outbound not configured for channel: telegram
```

The channel **inbound** path already uses the pinned registry (`getActivePluginChannelRegistry()` via `requireActivePluginChannelRegistry` in `channels/plugins/registry.ts`), which is frozen at gateway startup and survives all subsequent `setActivePluginRegistry` calls. The **outbound** path was the only consumer still reading from the unpinned surface.

## Fix

Two-line change in `registry-loader.ts`: switch from `getActivePluginRegistry()` to `getActivePluginChannelRegistry()`. This aligns outbound adapter resolution with the same pinned channel registry that inbound already uses.

## Registry divergence diagram

```
Boot:  loadPlugins → setActivePluginRegistry(R1) → pinChannelRegistry(R1)
                     ┌─────────────────────────┐
                     │ Active registry: R1      │ ← both surfaces point here
                     │ Pinned channel reg: R1   │
                     └─────────────────────────┘

Post-boot:  config-schema read → loadPlugins → setActivePluginRegistry(R2)
                     ┌─────────────────────────┐
                     │ Active registry: R2      │ ← no channel entries
                     │ Pinned channel reg: R1   │ ← still has telegram
                     └─────────────────────────┘

Inbound:  getChannelPlugin("telegram")        → reads R1 (pinned) ✓
Outbound: loadChannelOutboundAdapter("telegram") → was reading R2 (active) ✗
                                                 → now reads R1 (pinned) ✓
```

## Test plan

- [x] Added regression test: pins registry with telegram outbound adapter, replaces active registry with empty one, asserts `loadChannelOutboundAdapter` still resolves the adapter
- [x] Existing channel pin tests pass (9/9)
- [x] Heartbeat runner tests pass (64/64)
- [x] Outbound delivery tests pass (95/95)
- [x] Channel outbound tests pass (18/18)
- [x] `pnpm tsgo` — zero type errors
- [x] `pnpm lint` (oxlint) — zero warnings/errors

Fixes #54745
Fixes #54013
Related: #50721