### PR TITLE
fix(agents): classify "Failed to extract accountId from token" as auth error for failover (#27055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sandbox: make blocked-tool guidance glob-aware again, redact/sanitize session-specific explain hints for safer copy-paste, and avoid leaking control-character session keys in those hints. (#54684) Thanks @ngutman.
 - Agents/compaction: trigger timeout recovery compaction before retrying high-context LLM timeouts so embedded runs stop repeating oversized requests. (#46417) thanks @joeykrug.
 - Agents/compaction: reconcile `sessions.json.compactionCount` after a late embedded auto-compaction success so persisted session counts catch up once the handler reports completion. (#45493) Thanks @jackal092927.
+- Agents/failover: classify Codex accountId token extraction failures as auth errors so model fallback continues to the next configured candidate. (#55206) Thanks @cosmicnet.
 
 ## 2026.3.24
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -104,6 +104,7 @@ describe("isAuthErrorMessage", () => {
     "No API key found for profile openai.",
     "OAuth token refresh failed for anthropic: Failed to refresh OAuth token for anthropic. Please try again or re-authenticate.",
     "Please re-authenticate to continue.",
+    "Failed to extract accountId from token",
   ])("matches auth errors for %j", (sample) => {
     expect(isAuthErrorMessage(sample)).toBe(true);
   });

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -91,7 +91,7 @@ const ERROR_PATTERNS = {
     /\b403\b/,
     "no credentials found",
     "no api key found",
-    /\bfailed to (?:extract|parse|validate|decode)\b.*\btoken\b/i,
+    /\bfailed to (?:extract|parse|validate|decode)\b.*\btoken\b/,
   ],
   format: [
     "string should match pattern",

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -91,6 +91,7 @@ const ERROR_PATTERNS = {
     /\b403\b/,
     "no credentials found",
     "no api key found",
+    /\bfailed to (?:extract|parse|validate|decode)\b.*\btoken\b/i,
   ],
   format: [
     "string should match pattern",


### PR DESCRIPTION
## Summary

- **Problem:** "Failed to extract accountId from token" error from the `openai-codex-responses` stream provider is not classified by `failover-matches.ts`, so model fallback never triggers and subsequent models in the chain are skipped.
- **Why it matters:** Users with multi-model failover chains (e.g. Codex → GPT → Gemini) see the raw error instead of automatic fallback to the next candidate.
- **What changed:** Added a regex auth pattern in `failover-matches.ts` and a corresponding test case.
- **What did NOT change (scope boundary):** No changes to OAuth flows, token refresh, provider logic, or the failover engine itself. Only error classification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #27055
- Related #27091 (includes same classification fix as part of a larger OAuth overhaul, currently stale/blocked)
- Related #36604 (fixed a different aspect — token refresh fallback — not error classification)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `classifyFailoverReason()` checks error messages against patterns in `failover-matches.ts`. The existing `auth` patterns (`"invalid token"`, `"no api key found"`, etc.) don't match `"Failed to extract accountId from token"`, so `isFailoverAssistantError()` returns `false` and the runner treats it as a non-retriable stop.
- Missing detection / guardrail: No auth pattern covered token extraction/parsing failures from the Codex provider's `extractAccountId()`.
- Prior context: `extractAccountId()` in `openai-codex-responses.ts` throws this when the JWT lacks the `chatgpt_account_id` claim — a scenario that became common with ChatGPT Pro OAuth tokens and GPT-5+ models.
- Why this regressed now: Not a regression per se — this error path was never classified since `extractAccountId` was introduced.
- If unknown, what was ruled out: N/A — root cause is clear.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- Scenario the test should lock in: `"Failed to extract accountId from token"` is classified as an auth error by `isAuthErrorMessage()`.
- Why this is the smallest reliable guardrail: The pattern matching is pure string/regex — a unit test on the classification function is sufficient.
- Existing test that already covers this (if any): None previously.
- If no new test is added, why not: A new test IS added.

## User-visible / Behavior Changes

When `extractAccountId` fails, the model candidate is now skipped and fallback continues to the next candidate in the chain, instead of displaying the raw error as the assistant's response.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 22.04 (WSL2)
- Runtime/container: Node.js via pnpm, OpenClaw v2026.3.14
- Model/provider: openai-codex (ChatGPT Pro OAuth)
- Integration/channel (if any): Any
- Relevant config (redacted): Failover chain with openai-codex as non-terminal candidate

### Steps

1. Configure a model failover chain where an `openai-codex` profile is followed by another provider (e.g. Gemini).
2. Trigger a message where the Codex provider's JWT lacks `chatgpt_account_id`.
3. Observe the error message instead of fallback.

### Expected

- Error is classified as `auth`, failover triggers, next model candidate is tried.

### Actual

- Error `"Failed to extract accountId from token"` is returned as displayable text. No fallback.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` — 72/72 pass (including new test case).
`pnpm vitest run src/agents/model-fallback.test.ts` — 59/60 pass (1 pre-existing ANSI sanitization failure on `main`, unrelated).

## Human Verification (required)

- Verified scenarios: Unit tests for auth error classification pass; model fallback tests unaffected; `pnpm build` and `pnpm check` pass clean.
- Edge cases checked: Confirmed regex does not match normal model output — patterns only execute against `errorMessage` when `stopReason === "error"`, never against assistant text.
- What you did **not** verify: End-to-end with a live ChatGPT Pro OAuth token (no access to one with the broken JWT).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit.
- Files/config to restore: `src/agents/pi-embedded-helpers/failover-matches.ts`
- Known bad symptoms reviewers should watch for: False-positive auth classification on a non-auth error containing "token" — extremely unlikely given the regex requires "failed to extract/parse/validate/decode" prefix with word boundaries, and patterns only match `errorMessage` on `stopReason === "error"`.

## Risks and Mitigations

- Risk: Regex could match a future non-auth error containing similar wording.
  - Mitigation: Pattern requires `\bfailed to (extract|parse|validate|decode)\b.*\btoken\b` with word boundaries. Only evaluated against `errorMessage` when `stopReason === "error"`, never against model output.

AI-assisted: Yes — investigated and implemented with AI tooling. Fully tested. Contributor understands the code and the fix.