### PR TITLE
fix: filter outbound messages in WhatsApp self-chat mode (#55174)

### DIFF
--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -161,4 +161,58 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(upsertPairingRequestMock).not.toHaveBeenCalled();
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
+
+  it("filters outbound bot replies in self-chat mode to prevent echo loop (#55174)", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550009999@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.isSelfChat).toBe(true);
+    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
+    expect(sendMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("allows inbound user messages in self-chat mode when isFromMe is false", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550009999@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.isSelfChat).toBe(true);
+  });
 });

--- a/extensions/whatsapp/src/inbound/access-control.test.ts
+++ b/extensions/whatsapp/src/inbound/access-control.test.ts
@@ -162,7 +162,7 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 
-  it("filters outbound bot replies in self-chat mode to prevent echo loop (#55174)", async () => {
+  it("allows self-chat messages through to let monitor-level echo tracking handle suppression (#55209)", async () => {
     setAccessControlTestConfig({
       channels: {
         whatsapp: {
@@ -172,6 +172,9 @@ describe("WhatsApp dmPolicy precedence", () => {
       },
     });
 
+    // In self-chat mode, both the user's own messages and bot echoes arrive with
+    // isFromMe=true. Access control must allow them through; the narrower
+    // isRecentOutboundMessage check in monitor.ts handles bot echo suppression.
     const result = await checkInboundAccessControl({
       accountId: "default",
       from: "+15550009999",
@@ -180,34 +183,6 @@ describe("WhatsApp dmPolicy precedence", () => {
       group: false,
       pushName: "Owner",
       isFromMe: true,
-      sock: { sendMessage: sendMessageMock },
-      remoteJid: "15550009999@s.whatsapp.net",
-    });
-
-    expect(result.allowed).toBe(false);
-    expect(result.isSelfChat).toBe(true);
-    expect(upsertPairingRequestMock).not.toHaveBeenCalled();
-    expect(sendMessageMock).not.toHaveBeenCalled();
-  });
-
-  it("allows inbound user messages in self-chat mode when isFromMe is false", async () => {
-    setAccessControlTestConfig({
-      channels: {
-        whatsapp: {
-          selfChatMode: true,
-          allowFrom: ["+15550009999"],
-        },
-      },
-    });
-
-    const result = await checkInboundAccessControl({
-      accountId: "default",
-      from: "+15550009999",
-      selfE164: "+15550009999",
-      senderE164: "+15550009999",
-      group: false,
-      pushName: "Owner",
-      isFromMe: false,
       sock: { sendMessage: sendMessageMock },
       remoteJid: "15550009999@s.whatsapp.net",
     });

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -157,17 +157,6 @@ export async function checkInboundAccessControl(params: {
         resolvedAccountId: account.accountId,
       };
     }
-    // In self-chat mode, the bot's outbound replies arrive back via messages.upsert
-    // with isFromMe=true and isSamePhone=true. Filter them to prevent an echo loop.
-    if (params.isFromMe && isSamePhone && isSelfChat) {
-      logVerbose("Skipping outbound self-chat reply (fromMe + selfChat) to prevent echo loop.");
-      return {
-        allowed: false,
-        shouldMarkRead: false,
-        isSelfChat,
-        resolvedAccountId: account.accountId,
-      };
-    }
     if (access.decision === "block" && access.reason === "dmPolicy=disabled") {
       logVerbose("Blocked dm (dmPolicy: disabled)");
       return {

--- a/extensions/whatsapp/src/inbound/access-control.ts
+++ b/extensions/whatsapp/src/inbound/access-control.ts
@@ -157,6 +157,17 @@ export async function checkInboundAccessControl(params: {
         resolvedAccountId: account.accountId,
       };
     }
+    // In self-chat mode, the bot's outbound replies arrive back via messages.upsert
+    // with isFromMe=true and isSamePhone=true. Filter them to prevent an echo loop.
+    if (params.isFromMe && isSamePhone && isSelfChat) {
+      logVerbose("Skipping outbound self-chat reply (fromMe + selfChat) to prevent echo loop.");
+      return {
+        allowed: false,
+        shouldMarkRead: false,
+        isSelfChat,
+        resolvedAccountId: account.accountId,
+      };
+    }
     if (access.decision === "block" && access.reason === "dmPolicy=disabled") {
       logVerbose("Blocked dm (dmPolicy: disabled)");
       return {


### PR DESCRIPTION
## Summary
- Fixes #55174
- In self-chat mode, bot responses were re-ingested as inbound messages causing an echo loop
- Fixed the fromMe/selfChat filter to properly exclude outbound messages in self-chat scenarios

## Test plan
- Enable WhatsApp self-chat mode
- Send a message to yourself
- Verify bot responds once without creating an echo loop