### PR TITLE
fix(discord): honor guild entries in native command allowFrom

### DIFF
--- a/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
+++ b/extensions/discord/src/monitor/native-command.commands-allowfrom.test.ts
@@ -167,6 +167,36 @@ describe("Discord native slash commands with commands.allowFrom", () => {
     expectUnauthorizedReply(interaction);
   });
 
+  it("authorizes guild slash commands when commands.allowFrom.discord contains a matching guild: entry", async () => {
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          allowFrom: {
+            discord: ["guild:345678901234567890"],
+          },
+        };
+      },
+    });
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expectNotUnauthorizedReply(interaction);
+  });
+
+  it("rejects guild slash commands when commands.allowFrom.discord has a guild: entry that does not match", async () => {
+    const { dispatchSpy, interaction } = await runGuildSlashCommand({
+      userId: "999999999999999999",
+      mutateConfig: (cfg) => {
+        cfg.commands = {
+          allowFrom: {
+            discord: ["guild:000000000000000000"],
+          },
+        };
+      },
+    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expectUnauthorizedReply(interaction);
+  });
+
   it("uses the root discord maxLinesPerMessage when runtime discordConfig omits it", async () => {
     const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
     const { interaction } = await runGuildSlashCommand({

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -109,6 +109,7 @@ function resolveDiscordNativeCommandAllowlistAccess(params: {
   sender: { id: string; name?: string; tag?: string };
   chatType: "direct" | "group" | "thread" | "channel";
   conversationId?: string;
+  guildId?: string | null;
 }) {
   const commandsAllowFrom = params.cfg.commands?.allowFrom;
   if (!commandsAllowFrom || typeof commandsAllowFrom !== "object") {
@@ -119,6 +120,16 @@ function resolveDiscordNativeCommandAllowlistAccess(params: {
     : commandsAllowFrom["*"];
   if (!Array.isArray(rawAllowList)) {
     return { configured: false, allowed: false } as const;
+  }
+  // Check guild-level entries (e.g. "guild:123456") before user matching.
+  const guildId = params.guildId?.trim();
+  if (guildId) {
+    for (const entry of rawAllowList) {
+      const text = String(entry).trim();
+      if (text.startsWith("guild:") && text.slice("guild:".length) === guildId) {
+        return { configured: true, allowed: true } as const;
+      }
+    }
   }
   const allowList = normalizeDiscordAllowList(rawAllowList.map(String), [
     "discord:",
@@ -290,6 +301,7 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
           ? "channel"
           : "group",
     conversationId: rawChannelId || undefined,
+    guildId: interaction.guild?.id,
   });
   const guildInfo = resolveDiscordGuildEntry({
     guild: interaction.guild ?? undefined,
@@ -671,6 +683,7 @@ async function dispatchDiscordCommandInteraction(params: {
           ? "channel"
           : "group",
     conversationId: rawChannelId || undefined,
+    guildId: interaction.guild?.id,
   });
   const guildInfo = resolveDiscordGuildEntry({
     guild: interaction.guild ?? undefined,


### PR DESCRIPTION
## Summary
- honor `guild:<id>` entries in `commands.allowFrom.discord` for Discord native slash commands
- apply the same guild-level check in autocomplete authorization and command dispatch
- add regression tests for matching and non-matching guild entries

## Scope
This PR fixes Discord native command authorization only.
It does not change elevated exec approvals or gateway exec allowlist behavior.

## Test plan
- add tests for matching and non-matching `guild:<id>` entries
- run Discord native command allowFrom tests locally
