### PR TITLE
fix: Web UI context percentage shows 0% or >100% when using LCM

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1143,7 +1143,7 @@ export function buildGatewaySessionRow(params: {
         })
       : null;
   const totalTokens =
-    resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
+    resolvePositiveNumber(entry?.totalTokens) ??
     resolvePositiveNumber(transcriptUsage?.totalTokens);
   const totalTokensFresh =
     typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0


### PR DESCRIPTION
## Summary

Fixes #55217

When using LCM (Lossless Context Management), the Web UI occasionally displays incorrect context percentages (0% or >100%), while the `/status` command shows the correct value.

## Root Cause

The Web UI and `/status` command use different logic to calculate `totalTokens`:

**Web UI (before fix):**
```typescript
const totalTokens =
  resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
  resolvePositiveNumber(transcriptUsage?.totalTokens);
```

When `totalTokensFresh === false`, `resolveFreshSessionTotalTokens()` returns `undefined`, then falls back to `transcriptUsage?.totalTokens` (cumulative historical usage), which can result in:
- 0% (no data in transcript)
- >100% (cumulative historical usage exceeds current context window)

**`/status` command:**
```typescript
let totalTokens = entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
```

Directly uses `entry?.totalTokens` without checking `totalTokensFresh`.

## Fix

Align Web UI logic with `/status` command by using `entry?.totalTokens` directly:

```typescript
const totalTokens =
  resolvePositiveNumber(entry?.totalTokens) ??
  resolvePositiveNumber(transcriptUsage?.totalTokens);
```

## Test Plan

- [ ] Verify Web UI context percentage matches `/status` command
- [ ] Test with LCM enabled (compaction scenarios)
- [ ] All existing tests pass