### PR TITLE
feat(feishu): support im.message.recall_v1 event

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -618,7 +618,7 @@ function registerEventHandlers(
         error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
       }
     },
-    "im.message.recall_v1": async (data: unknown) => {
+    "im.message.recalled_v1": async (data: unknown) => {
       const event = data as { message_id: string };
       await deleteBotReplies({ cfg, recalledUserMessageId: event.message_id, accountId, log });
     },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -24,6 +24,7 @@ import { applyBotIdentityState, startBotIdentityRecovery } from "./monitor.bot-i
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
+import { deleteBotReplies } from "./recall-handler.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import { createFeishuThreadBindingManager } from "./thread-bindings.js";
@@ -616,6 +617,10 @@ function registerEventHandlers(
       } catch (err) {
         error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
       }
+    },
+    "im.message.recall_v1": async (data: unknown) => {
+      const event = data as { message_id: string };
+      await deleteBotReplies({ cfg, recalledUserMessageId: event.message_id, accountId, log });
     },
   });
 }

--- a/extensions/feishu/src/recall-handler.ts
+++ b/extensions/feishu/src/recall-handler.ts
@@ -1,7 +1,7 @@
 /**
  * Feishu message recall handler.
  *
- * Handles im.message.recall_v1 events by deleting the corresponding bot reply
+ * Handles im.message.recalled_v1 events by deleting the corresponding bot reply
  * messages that were sent in response to the recalled user message.
  *
  * Architecture:

--- a/extensions/feishu/src/recall-handler.ts
+++ b/extensions/feishu/src/recall-handler.ts
@@ -1,18 +1,18 @@
 /**
  * Feishu message recall handler.
- * 
+ *
  * Handles im.message.recall_v1 events by deleting the corresponding bot reply
  * messages that were sent in response to the recalled user message.
- * 
+ *
  * Architecture:
  * - user_message_id → bot_reply_message_id[] mapping is stored in memory
  * - On outbound send: registerMapping(userMsgId, botMsgId)
  * - On recall event: deleteBotReplies(userMsgId)
  */
 
-import { createFeishuClient } from "./client.js";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
 
 // In-memory mapping: user message ID → bot reply message IDs
 // One user message may trigger multiple bot replies
@@ -40,7 +40,7 @@ export async function deleteBotReplies(params: {
 }): Promise<void> {
   const { cfg, recalledUserMessageId, accountId, log = console.log } = params;
   const botMessageIds = userToBotMessageMap.get(recalledUserMessageId);
-  
+
   if (!botMessageIds || botMessageIds.length === 0) {
     log(`feishu[recall]: no bot replies found for recalled message ${recalledUserMessageId}`);
     return;
@@ -77,10 +77,18 @@ export async function deleteBotReplies(params: {
     }
   }
 
-  // Clean up mapping after processing
-  userToBotMessageMap.delete(recalledUserMessageId);
-
-  log(`feishu[recall]: recall processed for ${recalledUserMessageId} — deleted ${deletedCount}, failed ${failedCount}`);
+  // Only clean up mapping if all messages were deleted (or already gone)
+  // If some failed with transient errors, keep them for retry on next recall event
+  if (failedCount === 0) {
+    userToBotMessageMap.delete(recalledUserMessageId);
+    log(
+      `feishu[recall]: recall processed for ${recalledUserMessageId} — deleted ${deletedCount}, mapping cleared`,
+    );
+  } else {
+    log(
+      `feishu[recall]: recall processed for ${recalledUserMessageId} — deleted ${deletedCount}, failed ${failedCount}, mapping retained for retry`,
+    );
+  }
 }
 
 /**

--- a/extensions/feishu/src/recall-handler.ts
+++ b/extensions/feishu/src/recall-handler.ts
@@ -1,0 +1,109 @@
+/**
+ * Feishu message recall handler.
+ * 
+ * Handles im.message.recall_v1 events by deleting the corresponding bot reply
+ * messages that were sent in response to the recalled user message.
+ * 
+ * Architecture:
+ * - user_message_id → bot_reply_message_id[] mapping is stored in memory
+ * - On outbound send: registerMapping(userMsgId, botMsgId)
+ * - On recall event: deleteBotReplies(userMsgId)
+ */
+
+import { createFeishuClient } from "./client.js";
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { resolveFeishuRuntimeAccount } from "./accounts.js";
+
+// In-memory mapping: user message ID → bot reply message IDs
+// One user message may trigger multiple bot replies
+const userToBotMessageMap = new Map<string, string[]>();
+
+/**
+ * Register that bot sent a reply to a user message.
+ * Call this after sendMessageFeishu() succeeds.
+ */
+export function registerBotReply(userMessageId: string, botMessageId: string): void {
+  const existing = userToBotMessageMap.get(userMessageId) ?? [];
+  existing.push(botMessageId);
+  userToBotMessageMap.set(userMessageId, existing);
+}
+
+/**
+ * Delete all bot replies linked to a recalled user message.
+ * Idempotent: safe to call multiple times, deleting non-existent messages is not an error.
+ */
+export async function deleteBotReplies(params: {
+  cfg: ClawdbotConfig;
+  recalledUserMessageId: string;
+  accountId?: string;
+  log?: (msg: string) => void;
+}): Promise<void> {
+  const { cfg, recalledUserMessageId, accountId, log = console.log } = params;
+  const botMessageIds = userToBotMessageMap.get(recalledUserMessageId);
+  
+  if (!botMessageIds || botMessageIds.length === 0) {
+    log(`feishu[recall]: no bot replies found for recalled message ${recalledUserMessageId}`);
+    return;
+  }
+
+  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
+  if (!account.configured) {
+    log(`feishu[recall]: account "${account.accountId}" not configured, skipping`);
+    return;
+  }
+
+  const client = createFeishuClient(account);
+  let deletedCount = 0;
+  let failedCount = 0;
+
+  for (const botMessageId of botMessageIds) {
+    try {
+      await client.im.message.delete({
+        path: { message_id: botMessageId },
+      });
+      deletedCount++;
+      log(`feishu[recall]: deleted bot reply ${botMessageId}`);
+    } catch (err) {
+      // 230011 = message not found / already deleted, 231003 = withdrawn
+      const code = (err as { code?: number }).code;
+      if (code === 230011 || code === 231003) {
+        // Already gone, treat as success
+        deletedCount++;
+        log(`feishu[recall]: bot reply ${botMessageId} already deleted (code ${code})`);
+      } else {
+        failedCount++;
+        log(`feishu[recall]: failed to delete ${botMessageId}: ${String(err)}`);
+      }
+    }
+  }
+
+  // Clean up mapping after processing
+  userToBotMessageMap.delete(recalledUserMessageId);
+
+  log(`feishu[recall]: recall processed for ${recalledUserMessageId} — deleted ${deletedCount}, failed ${failedCount}`);
+}
+
+/**
+ * Check if a user message has been recalled by querying the message.
+ * Returns true if the message no longer exists or returns a recall error.
+ */
+export async function isMessageRecalled(params: {
+  cfg: ClawdbotConfig;
+  userMessageId: string;
+  accountId?: string;
+}): Promise<boolean> {
+  const { cfg, userMessageId, accountId } = params;
+  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
+  if (!account.configured) return false;
+
+  const client = createFeishuClient(account);
+  try {
+    await client.im.message.get({ path: { message_id: userMessageId } });
+    return false; // Message still exists
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    // 230011 = message not found / withdrawn
+    if (code === 230011) return true;
+    return false;
+  }
+}

--- a/extensions/feishu/src/recall-handler.ts
+++ b/extensions/feishu/src/recall-handler.ts
@@ -5,27 +5,83 @@
  * messages that were sent in response to the recalled user message.
  *
  * Architecture:
- * - user_message_id → bot_reply_message_id[] mapping is stored in memory
- * - On outbound send: registerMapping(userMsgId, botMsgId)
+ * - user_message_id → { botReplyIds: string[], timestamp: number } mapping is stored in memory
+ * - On outbound send: registerBotReply(userMsgId, botMsgId, viaReplyPath)
  * - On recall event: deleteBotReplies(userMsgId)
+ * - TTL eviction: mappings expire after 24h to prevent memory leaks
  */
 
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 
-// In-memory mapping: user message ID → bot reply message IDs
-// One user message may trigger multiple bot replies
-const userToBotMessageMap = new Map<string, string[]>();
+const MESSAGE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface MappingEntry {
+  botReplyIds: string[];
+  timestamp: number;
+  viaReplyPath: boolean; // true only if sent via im.message.reply (user can recall)
+}
+
+// In-memory mapping: user message ID → { botReplyIds, timestamp, viaReplyPath }
+// One user message may trigger multiple bot replies.
+// viaReplyPath=false entries are from fallback direct sends (user can't recall those).
+const userToBotMessageMap = new Map<string, MappingEntry>();
+
+/**
+ * Evict expired entries to prevent memory leaks.
+ * Call this periodically or on each registerBotReply call.
+ */
+function evictExpiredMappings(): void {
+  const now = Date.now();
+  for (const [userMsgId, entry] of userToBotMessageMap.entries()) {
+    if (now - entry.timestamp > MESSAGE_TTL_MS) {
+      userToBotMessageMap.delete(userMsgId);
+    }
+  }
+}
 
 /**
  * Register that bot sent a reply to a user message.
- * Call this after sendMessageFeishu() succeeds.
+ * Call this after sendMessageFeishu() succeeds via the reply path.
+ *
+ * @param userMessageId  - The user's message ID this bot is replying to
+ * @param botMessageId   - The bot's newly sent message ID
+ * @param viaReplyPath   - True if sent via im.message.reply (user CAN recall).
+ *                         False if fell back to direct send (user CANNOT recall).
+ *                         Defaults to true for backward compatibility.
+ * @returns true if registered, false if not registered (e.g., fallback path)
  */
-export function registerBotReply(userMessageId: string, botMessageId: string): void {
-  const existing = userToBotMessageMap.get(userMessageId) ?? [];
-  existing.push(botMessageId);
-  userToBotMessageMap.set(userMessageId, existing);
+export function registerBotReply(
+  userMessageId: string,
+  botMessageId: string,
+  viaReplyPath = true,
+): boolean {
+  // Only register mappings for true reply-path sends.
+  // Fallback direct sends cannot be recalled by the user.
+  if (!viaReplyPath) {
+    return false;
+  }
+
+  // Periodically evict old entries (every ~100 calls)
+  if (userToBotMessageMap.size > 100 && userToBotMessageMap.size % 100 === 0) {
+    evictExpiredMappings();
+  }
+
+  const existing = userToBotMessageMap.get(userMessageId);
+  if (existing) {
+    existing.botReplyIds.push(botMessageId);
+    // Keep newest timestamp and true viaReplyPath
+    existing.timestamp = Date.now();
+    existing.viaReplyPath = existing.viaReplyPath && viaReplyPath;
+  } else {
+    userToBotMessageMap.set(userMessageId, {
+      botReplyIds: [botMessageId],
+      timestamp: Date.now(),
+      viaReplyPath,
+    });
+  }
+  return true;
 }
 
 /**
@@ -39,10 +95,19 @@ export async function deleteBotReplies(params: {
   log?: (msg: string) => void;
 }): Promise<void> {
   const { cfg, recalledUserMessageId, accountId, log = console.log } = params;
-  const botMessageIds = userToBotMessageMap.get(recalledUserMessageId);
+  const entry = userToBotMessageMap.get(recalledUserMessageId);
 
-  if (!botMessageIds || botMessageIds.length === 0) {
+  if (!entry || entry.botReplyIds.length === 0) {
     log(`feishu[recall]: no bot replies found for recalled message ${recalledUserMessageId}`);
+    return;
+  }
+
+  // Skip non-reply-path entries (user can't recall fallback direct sends)
+  if (!entry.viaReplyPath) {
+    log(
+      `feishu[recall]: message ${recalledUserMessageId} was sent via fallback, cannot be recalled`,
+    );
+    userToBotMessageMap.delete(recalledUserMessageId);
     return;
   }
 
@@ -56,20 +121,32 @@ export async function deleteBotReplies(params: {
   let deletedCount = 0;
   let failedCount = 0;
 
-  for (const botMessageId of botMessageIds) {
+  for (const botMessageId of entry.botReplyIds) {
     try {
-      await client.im.message.delete({
+      const response = await client.im.message.delete({
         path: { message_id: botMessageId },
       });
-      deletedCount++;
-      log(`feishu[recall]: deleted bot reply ${botMessageId}`);
+      // Treat non-zero code as failure (not just thrown errors)
+      if (response.code !== undefined && response.code !== 0) {
+        if (response.code === 230011 || response.code === 231003) {
+          // Already gone
+          deletedCount++;
+          log(`feishu[recall]: bot reply ${botMessageId} already deleted (code ${response.code})`);
+        } else {
+          failedCount++;
+          log(
+            `feishu[recall]: failed to delete ${botMessageId}: code ${response.code} ${response.msg ?? ""}`,
+          );
+        }
+      } else {
+        deletedCount++;
+        log(`feishu[recall]: deleted bot reply ${botMessageId}`);
+      }
     } catch (err) {
-      // 230011 = message not found / already deleted, 231003 = withdrawn
       const code = (err as { code?: number }).code;
       if (code === 230011 || code === 231003) {
-        // Already gone, treat as success
         deletedCount++;
-        log(`feishu[recall]: bot reply ${botMessageId} already deleted (code ${code})`);
+        log(`feishu[recall]: bot reply ${botMessageId} already deleted (caught code ${code})`);
       } else {
         failedCount++;
         log(`feishu[recall]: failed to delete ${botMessageId}: ${String(err)}`);
@@ -93,7 +170,7 @@ export async function deleteBotReplies(params: {
 
 /**
  * Check if a user message has been recalled by querying the message.
- * Returns true if the message no longer exists or returns a recall error.
+ * Returns true if the message no longer exists or returns a recall error code.
  */
 export async function isMessageRecalled(params: {
   cfg: ClawdbotConfig;
@@ -106,11 +183,15 @@ export async function isMessageRecalled(params: {
 
   const client = createFeishuClient(account);
   try {
-    await client.im.message.get({ path: { message_id: userMessageId } });
+    const response = await client.im.message.get({ path: { message_id: userMessageId } });
+    // Feishu API can return resolved response with non-zero code
+    if (response.code !== undefined && response.code !== 0) {
+      if (response.code === 230011) return true; // message not found / withdrawn
+      return false;
+    }
     return false; // Message still exists
   } catch (err) {
     const code = (err as { code?: number }).code;
-    // 230011 = message not found / withdrawn
     if (code === 230011) return true;
     return false;
   }

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -18,12 +18,15 @@ export function assertFeishuMessageApiSuccess(
 export function toFeishuSendResult(
   response: FeishuMessageApiResponse,
   chatId: string,
+  viaReplyPath = true,
 ): {
   messageId: string;
   chatId: string;
+  viaReplyPath: boolean;
 } {
   return {
     messageId: response.data?.message_id ?? "unknown",
     chatId,
+    viaReplyPath,
   };
 }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -4,6 +4,7 @@ import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
 import { parsePostContent } from "./post.js";
+import { registerBotReply } from "./recall-handler.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
@@ -460,7 +461,7 @@ export async function sendMessageFeishu(
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 
   const directParams = { receiveId, receiveIdType, content, msgType };
-  return sendReplyOrFallbackDirect(client, {
+  const result = await sendReplyOrFallbackDirect(client, {
     replyToMessageId,
     replyInThread,
     content,
@@ -469,6 +470,11 @@ export async function sendMessageFeishu(
     directErrorPrefix: "Feishu send failed",
     replyErrorPrefix: "Feishu reply failed",
   });
+  // Register bot reply for recall tracking
+  if (replyToMessageId && result.messageId) {
+    registerBotReply(replyToMessageId, result.messageId);
+  }
+  return result;
 }
 
 export type SendFeishuCardParams = {
@@ -487,7 +493,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   const content = JSON.stringify(card);
 
   const directParams = { receiveId, receiveIdType, content, msgType: "interactive" };
-  return sendReplyOrFallbackDirect(client, {
+  const result = await sendReplyOrFallbackDirect(client, {
     replyToMessageId,
     replyInThread,
     content,
@@ -496,6 +502,11 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     directErrorPrefix: "Feishu card send failed",
     replyErrorPrefix: "Feishu card reply failed",
   });
+  // Register bot reply for recall tracking
+  if (replyToMessageId && result.messageId) {
+    registerBotReply(replyToMessageId, result.messageId);
+  }
+  return result;
 }
 
 export async function editMessageFeishu(params: {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -116,7 +116,7 @@ async function sendFallbackDirect(
     },
   });
   assertFeishuMessageApiSuccess(response, errorPrefix);
-  return toFeishuSendResult(response, params.receiveId);
+  return toFeishuSendResult(response, params.receiveId, false); // false = viaReplyPath
 }
 
 async function sendReplyOrFallbackDirect(
@@ -137,7 +137,10 @@ async function sendReplyOrFallbackDirect(
   },
 ): Promise<FeishuSendResult> {
   if (!params.replyToMessageId) {
-    return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
+    return {
+      ...(await sendFallbackDirect(client, params.directParams, params.directErrorPrefix)),
+      viaReplyPath: false,
+    };
   }
 
   const threadReplyFallbackError = params.replyInThread
@@ -172,7 +175,7 @@ async function sendReplyOrFallbackDirect(
     return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
   }
   assertFeishuMessageApiSuccess(response, params.replyErrorPrefix);
-  return toFeishuSendResult(response, params.directParams.receiveId);
+  return toFeishuSendResult(response, params.directParams.receiveId, true);
 }
 
 function parseInteractiveCardContent(parsed: unknown): string {
@@ -471,8 +474,9 @@ export async function sendMessageFeishu(
     replyErrorPrefix: "Feishu reply failed",
   });
   // Register bot reply for recall tracking
-  if (replyToMessageId && result.messageId) {
-    registerBotReply(replyToMessageId, result.messageId);
+  // Only register if sent via true reply path (not fallback direct send)
+  if (replyToMessageId && result.messageId && result.viaReplyPath === true) {
+    registerBotReply(replyToMessageId, result.messageId, true);
   }
   return result;
 }
@@ -503,8 +507,9 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     replyErrorPrefix: "Feishu card reply failed",
   });
   // Register bot reply for recall tracking
-  if (replyToMessageId && result.messageId) {
-    registerBotReply(replyToMessageId, result.messageId);
+  // Only register if sent via true reply path (not fallback direct send)
+  if (replyToMessageId && result.messageId && result.viaReplyPath === true) {
+    registerBotReply(replyToMessageId, result.messageId, true);
   }
   return result;
 }

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -58,6 +58,7 @@ export type FeishuMessageContext = {
 export type FeishuSendResult = {
   messageId: string;
   chatId: string;
+  viaReplyPath?: boolean; // true if sent via im.message.reply (user can recall)
 };
 
 export type FeishuChatType = "p2p" | "group" | "private";


### PR DESCRIPTION
## Problem
Feishu recall events are not handled — bot may reply to recalled messages or leave orphan replies.
## Solution
- Subscribe to im.message.recall_v1 in Feishu Open Platform
- Track user_message_id → bot_reply_message_id mapping
- On recall: delete bot reply messages
- On pre-reply check: verify message still exists
## Acceptance Criteria
- [ ] Bot skips reply if user recalls before bot responds
- [ ] Bot deletes reply if user recalls after bot responds
- [ ] Duplicate recalls handled idempotently
- [ ] One-to-many replies (multiple bot msgs per user msg) all deleted