### PR TITLE
fix: gateway start should bootstrap service if not loaded

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -190,15 +190,16 @@ export async function runServiceStart(params: {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createDaemonActionContext({ action: "start", json });
 
-  if (
-    (await resolveServiceLoadedOrFail({
-      serviceNoun: params.serviceNoun,
-      service: params.service,
-      fail,
-    })) === null
-  ) {
+  // Check if service check fails (throws exception), but don't fail on "not loaded".
+  // startGatewayService will handle the "installed but not loaded" case by calling
+  // restartLaunchAgent which has bootstrap logic.
+  try {
+    await params.service.isLoaded({ env: process.env });
+  } catch (err) {
+    fail(`${params.serviceNoun} service check failed: ${String(err)}`);
     return;
   }
+
   // Pre-flight config validation (#35862) — run for both loaded and not-loaded
   // to prevent launching from invalid config in any start path.
   {


### PR DESCRIPTION
## Summary

- Fixes `gateway start` failing after `gateway stop` due to launchd service being completely unloaded
- Removes early return on "not loaded" status in `runServiceStart`, allowing `startGatewayService` to call `restartLaunchAgent` which has bootstrap logic

## Problem

When `gateway stop` is called, it uses `launchctl bootout` to completely unload the service. However, `gateway start` was checking `isLoaded` and returning early with "service not loaded" message instead of attempting to bootstrap the service.

The `restartLaunchAgent` function already has logic to handle this case (by calling `bootstrapLaunchAgentOrThrow` when `kickstart` fails due to service not being loaded), but this code path was never reached because `runServiceStart` returned early.

## Solution

Removed the early return on "not loaded" status in `runServiceStart`. Now when the service is installed but not loaded, `startGatewayService` will call `restartLaunchAgent` which will properly bootstrap the service if needed.

## Test Plan

1. Run `openclaw gateway install`
2. Run `openclaw gateway stop`
3. Run `openclaw gateway start` - should now successfully start the service

Fixes #55222

🤖 Generated with [Claude Code](https://claude.com/claude-code)