### PR TITLE
fix(web): respect HTTP_PROXY/HTTPS_PROXY env vars in web_fetch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       production:
         dependency-type: production
@@ -39,7 +39,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       actions:
         patterns:
@@ -55,7 +55,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       swift-deps:
         patterns:
@@ -71,7 +71,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       swift-deps:
         patterns:
@@ -87,7 +87,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       swift-deps:
         patterns:
@@ -103,7 +103,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       android-deps:
         patterns:
@@ -119,7 +119,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 2
+      default-days: 14
     groups:
       docker-images:
         patterns:

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -11,6 +11,7 @@ import {
 const createTelegramDraftStream = vi.hoisted(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.hoisted(() => vi.fn());
 const deliverReplies = vi.hoisted(() => vi.fn());
+const emitMessageSentHooks = vi.hoisted(() => vi.fn());
 const createForumTopicTelegram = vi.hoisted(() => vi.fn());
 const deleteMessageTelegram = vi.hoisted(() => vi.fn());
 const editForumTopicTelegram = vi.hoisted(() => vi.fn());
@@ -46,6 +47,10 @@ vi.mock("./draft-stream.js", () => ({
 
 vi.mock("./bot/delivery.js", () => ({
   deliverReplies,
+}));
+
+vi.mock("./bot/delivery.replies.js", () => ({
+  emitMessageSentHooks,
 }));
 
 vi.mock("./send.js", () => ({
@@ -103,6 +108,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     createTelegramDraftStream.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     deliverReplies.mockClear();
+    emitMessageSentHooks.mockClear();
     createForumTopicTelegram.mockClear();
     deleteMessageTelegram.mockClear();
     editForumTopicTelegram.mockClear();
@@ -2348,6 +2354,36 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(statusReactionController.cancelPending.mock.invocationCallOrder[0]).toBeLessThan(
       statusReactionController.setThinking.mock.invocationCallOrder[1],
+    );
+  });
+
+  it("emits message:sent hook when streaming reply is delivered", async () => {
+    let capturedOnMessageSent: ((messageId: number, text: string) => void) | undefined;
+    createTelegramDraftStream.mockImplementation((options) => {
+      capturedOnMessageSent = options.onMessageSent;
+      return createDraftStream(123);
+    });
+
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+        // Simulate the real stream calling onMessageSent when final message is sent.
+        capturedOnMessageSent?.(123, "Final answer text");
+        await dispatcherOptions.deliver({ text: "Final answer text" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext() });
+
+    // Verify emitMessageSentHooks was called for the streaming outbound message.
+    expect(emitMessageSentHooks).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: 123,
+        content: "Final answer text",
+      }),
     );
   });
 });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2368,7 +2368,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onPartialReply?.({ text: "Streaming..." });
         // Simulate the real stream calling onMessageSent when final message is sent.
-        capturedOnMessageSent?.(123, "Final answer text");
+        capturedOnMessageSent?.(123, "Final answer text", "Final answer text");
         await dispatcherOptions.deliver({ text: "Final answer text" }, { kind: "final" });
         return { queuedFinal: true };
       },

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -446,7 +446,7 @@ export const dispatchTelegramMessage = async ({
   const deliveryBaseOptions = {
     chatId: String(chatId),
     accountId: route.accountId,
-    sessionKeyForInternalHooks: ctxPayload.SessionKey,
+    sessionKeyForInternalHooks: ctxPayload.SessionKey ?? route.sessionKey,
     mirrorIsGroup: isGroup,
     mirrorGroupId: isGroup ? String(chatId) : undefined,
     token: opts.token,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -21,16 +21,13 @@ import type {
   TelegramAccountConfig,
 } from "openclaw/plugin-sdk/config-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
-import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
-import { toInternalMessageSentContext } from "../../../src/hooks/message-hook-mappers.js";
-import { getGlobalHookRunner } from "../../../src/plugins/hook-runner-global.js";
 import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -19,14 +19,19 @@ import type {
   OpenClawConfig,
   ReplyToMode,
   TelegramAccountConfig,
-} from "../../../src/config/types.js";
-import { danger, logVerbose } from "../../../src/globals.js";
+} from "openclaw/plugin-sdk/config-runtime";
+import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
 import { toInternalMessageSentContext } from "../../../src/hooks/message-hook-mappers.js";
-import { getAgentScopedMediaLocalRoots } from "../../../src/media/local-roots.js";
 import { getGlobalHookRunner } from "../../../src/plugins/hook-runner-global.js";
-import type { RuntimeEnv } from "../../../src/runtime.js";
+import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
@@ -248,7 +253,7 @@ export const dispatchTelegramMessage = async ({
     };
   };
 
-  // Callback to emit message:sent internal hook when streaming reply is sent.
+  // Emit message:sent hook when streaming reply is delivered via draft stream.
   const sessionKeyForStreamHooks = ctxPayload.SessionKey ?? route.sessionKey;
   const streamOnMessageSent = (messageId: number, text: string) => {
     const hookRunner = getGlobalHookRunner();
@@ -471,7 +476,7 @@ export const dispatchTelegramMessage = async ({
   const deliveryBaseOptions = {
     chatId: String(chatId),
     accountId: route.accountId,
-    sessionKeyForInternalHooks: ctxPayload.SessionKey ?? route.sessionKey,
+    sessionKeyForInternalHooks: ctxPayload.SessionKey,
     mirrorIsGroup: isGroup,
     mirrorGroupId: isGroup ? String(chatId) : undefined,
     token: opts.token,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -19,18 +19,18 @@ import type {
   OpenClawConfig,
   ReplyToMode,
   TelegramAccountConfig,
-} from "openclaw/plugin-sdk/config-runtime";
-import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
-import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
-import { clearHistoryEntriesIfEnabled } from "openclaw/plugin-sdk/reply-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
+} from "../../../src/config/types.js";
+import { danger, logVerbose } from "../../../src/globals.js";
+import { fireAndForgetHook } from "../../../src/hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../../src/hooks/internal-hooks.js";
+import { toInternalMessageSentContext } from "../../../src/hooks/message-hook-mappers.js";
+import { getAgentScopedMediaLocalRoots } from "../../../src/media/local-roots.js";
+import { getGlobalHookRunner } from "../../../src/plugins/hook-runner-global.js";
+import type { RuntimeEnv } from "../../../src/runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
 import { deliverReplies } from "./bot/delivery.js";
+import { emitMessageSentHooks } from "./bot/delivery.replies.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -205,7 +205,11 @@ export const dispatchTelegramMessage = async ({
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
-  const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+  const createDraftLane = (
+    laneName: LaneName,
+    enabled: boolean,
+    onMessageSent?: (messageId: number, text: string) => void,
+  ): DraftLaneState => {
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
@@ -234,6 +238,7 @@ export const dispatchTelegramMessage = async ({
               : undefined,
           log: logVerbose,
           warn: logVerbose,
+          onMessageSent,
         })
       : undefined;
     return {
@@ -242,9 +247,29 @@ export const dispatchTelegramMessage = async ({
       hasStreamedMessage: false,
     };
   };
+
+  // Callback to emit message:sent internal hook when streaming reply is sent.
+  const sessionKeyForStreamHooks = ctxPayload.SessionKey ?? route.sessionKey;
+  const streamOnMessageSent = (messageId: number, text: string) => {
+    const hookRunner = getGlobalHookRunner();
+    const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+    emitMessageSentHooks({
+      hookRunner,
+      enabled: hasMessageSentHooks,
+      sessionKeyForInternalHooks: sessionKeyForStreamHooks,
+      chatId: String(chatId),
+      accountId: route.accountId,
+      content: text,
+      success: true,
+      messageId,
+      isGroup,
+      groupId: isGroup ? String(chatId) : undefined,
+    });
+  };
+
   const lanes: Record<LaneName, DraftLaneState> = {
-    answer: createDraftLane("answer", canStreamAnswerDraft),
-    reasoning: createDraftLane("reasoning", canStreamReasoningDraft),
+    answer: createDraftLane("answer", canStreamAnswerDraft, streamOnMessageSent),
+    reasoning: createDraftLane("reasoning", canStreamReasoningDraft, streamOnMessageSent),
   };
   // Active preview lifecycle answers "can this current preview still be
   // finalized?" Cleanup retention is separate so archived-preview decisions do

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -210,7 +210,7 @@ export const dispatchTelegramMessage = async ({
   const createDraftLane = (
     laneName: LaneName,
     enabled: boolean,
-    onMessageSent?: (messageId: number, text: string) => void,
+    onMessageSent?: (messageId: number, renderedText: string, rawText: string) => void,
   ): DraftLaneState => {
     const stream = enabled
       ? createTelegramDraftStream({
@@ -252,7 +252,7 @@ export const dispatchTelegramMessage = async ({
 
   // Emit message:sent hook when streaming reply is delivered via draft stream.
   const sessionKeyForStreamHooks = ctxPayload.SessionKey ?? route.sessionKey;
-  const streamOnMessageSent = (messageId: number, text: string) => {
+  const streamOnMessageSent = (messageId: number, renderedText: string, rawText: string) => {
     const hookRunner = getGlobalHookRunner();
     const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
     emitMessageSentHooks({
@@ -261,7 +261,7 @@ export const dispatchTelegramMessage = async ({
       sessionKeyForInternalHooks: sessionKeyForStreamHooks,
       chatId: String(chatId),
       accountId: route.accountId,
-      content: text,
+      content: rawText,
       success: true,
       messageId,
       isGroup,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -505,10 +505,6 @@ export function emitMessageSentHooks(params: {
   groupId?: string;
   runtime?: RuntimeEnv;
 }): void {
-  // eslint-disable-next-line no-console
-  console.log(
-    `[diag] telegram: emitMessageSentHooks ENTRY (enabled=${params.enabled}, sessionKey=${params.sessionKeyForInternalHooks ?? "undefined"}, chatId=${params.chatId})`,
-  );
   if (!params.enabled && !params.sessionKeyForInternalHooks) {
     logVerbose(`telegram: emitMessageSentHooks skipped (no hooks enabled and no sessionKey)`);
     return;
@@ -582,10 +578,6 @@ export async function deliverReplies(params: {
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
 }): Promise<{ delivered: boolean }> {
-  // eslint-disable-next-line no-console
-  console.log(
-    `[diag] telegram: deliverReplies ENTRY replies=${params.replies.length} sessionKey=${params.sessionKeyForInternalHooks} chatId=${params.chatId}`,
-  );
   logVerbose(
     `telegram: deliverReplies called (replies=${params.replies.length}, sessionKey=${params.sessionKeyForInternalHooks}, chatId=${params.chatId})`,
   );

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -505,6 +505,7 @@ function emitMessageSentHooks(params: {
   groupId?: string;
 }): void {
   if (!params.enabled && !params.sessionKeyForInternalHooks) {
+    logVerbose(`telegram: emitMessageSentHooks skipped (no hooks enabled and no sessionKey)`);
     return;
   }
   const canonical = buildCanonicalSentMessageHookContext({
@@ -531,6 +532,9 @@ function emitMessageSentHooks(params: {
     );
   }
   if (!params.sessionKeyForInternalHooks) {
+    logVerbose(
+      `telegram: message:sent internal hook skipped (sessionKeyForInternalHooks is empty)`,
+    );
     return;
   }
   fireAndForgetHook(
@@ -573,6 +577,9 @@ export async function deliverReplies(params: {
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
 }): Promise<{ delivered: boolean }> {
+  logVerbose(
+    `telegram: deliverReplies called (replies=${params.replies.length}, sessionKey=${params.sessionKeyForInternalHooks}, chatId=${params.chatId})`,
+  );
   const progress: DeliveryProgress = {
     hasReplied: false,
     hasDelivered: false,
@@ -698,6 +705,9 @@ export async function deliverReplies(params: {
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
       });
+      logVerbose(
+        `telegram: emitMessageSentHooks called (success=${progress.deliveredCount > deliveredCountBeforeReply}, sessionKey=${params.sessionKeyForInternalHooks}, messageId=${firstDeliveredMessageId})`,
+      );
     } catch (error) {
       emitMessageSentHooks({
         hookRunner,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -491,7 +491,7 @@ async function maybePinFirstDeliveredMessage(params: {
   }
 }
 
-function emitMessageSentHooks(params: {
+export function emitMessageSentHooks(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   enabled: boolean;
   sessionKeyForInternalHooks?: string;
@@ -503,7 +503,12 @@ function emitMessageSentHooks(params: {
   messageId?: number;
   isGroup?: boolean;
   groupId?: string;
+  runtime?: RuntimeEnv;
 }): void {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[diag] telegram: emitMessageSentHooks ENTRY (enabled=${params.enabled}, sessionKey=${params.sessionKeyForInternalHooks ?? "undefined"}, chatId=${params.chatId})`,
+  );
   if (!params.enabled && !params.sessionKeyForInternalHooks) {
     logVerbose(`telegram: emitMessageSentHooks skipped (no hooks enabled and no sessionKey)`);
     return;
@@ -577,6 +582,10 @@ export async function deliverReplies(params: {
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
 }): Promise<{ delivered: boolean }> {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[diag] telegram: deliverReplies ENTRY replies=${params.replies.length} sessionKey=${params.sessionKeyForInternalHooks} chatId=${params.chatId}`,
+  );
   logVerbose(
     `telegram: deliverReplies called (replies=${params.replies.length}, sessionKey=${params.sessionKeyForInternalHooks}, chatId=${params.chatId})`,
   );
@@ -704,8 +713,9 @@ export async function deliverReplies(params: {
         messageId: firstDeliveredMessageId,
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
+        runtime: params.runtime,
       });
-      logVerbose(
+      params.runtime.log?.(
         `telegram: emitMessageSentHooks called (success=${progress.deliveredCount > deliveredCountBeforeReply}, sessionKey=${params.sessionKeyForInternalHooks}, messageId=${firstDeliveredMessageId})`,
       );
     } catch (error) {
@@ -720,6 +730,7 @@ export async function deliverReplies(params: {
         error: error instanceof Error ? error.message : String(error),
         isGroup: params.mirrorIsGroup,
         groupId: params.mirrorGroupId,
+        runtime: params.runtime,
       });
       throw error;
     }

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -109,7 +109,7 @@ export function createTelegramDraftStream(params: {
   log?: (message: string) => void;
   warn?: (message: string) => void;
   /** Called after a message is successfully sent to Telegram (with messageId and text). */
-  onMessageSent?: (messageId: number, text: string) => void;
+  onMessageSent?: (messageId: number, renderedText: string, rawText: string) => void;
 }): TelegramDraftStream {
   const maxChars = Math.min(
     params.maxChars ?? TELEGRAM_STREAM_MAX_CHARS,
@@ -154,6 +154,7 @@ export function createTelegramDraftStream(params: {
     renderedText: string;
     renderedParseMode: "HTML" | undefined;
     sendGeneration: number;
+    rawText: string;
   };
   const sendRenderedMessageWithThreadFallback = async (sendArgs: {
     renderedText: string;
@@ -197,6 +198,7 @@ export function createTelegramDraftStream(params: {
     renderedText,
     renderedParseMode,
     sendGeneration,
+    rawText,
   }: PreviewSendParams): Promise<boolean> => {
     if (typeof streamMessageId === "number") {
       if (renderedParseMode) {
@@ -242,7 +244,7 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     streamMessageId = normalizedMessageId;
-    params.onMessageSent?.(normalizedMessageId, renderedText);
+    params.onMessageSent?.(normalizedMessageId, renderedText, rawText);
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -312,6 +314,7 @@ export function createTelegramDraftStream(params: {
             renderedText,
             renderedParseMode,
             sendGeneration,
+            rawText: trimmed,
           });
         } catch (err) {
           if (!shouldFallbackFromDraftTransport(err)) {
@@ -326,6 +329,7 @@ export function createTelegramDraftStream(params: {
             renderedText,
             renderedParseMode,
             sendGeneration,
+            rawText: trimmed,
           });
         }
       } else {
@@ -333,6 +337,7 @@ export function createTelegramDraftStream(params: {
           renderedText,
           renderedParseMode,
           sendGeneration,
+          rawText: trimmed,
         });
       }
       if (sent) {
@@ -428,7 +433,7 @@ export function createTelegramDraftStream(params: {
             // Best-effort cleanup; draft clear failure is cosmetic.
           }
         }
-        params.onMessageSent?.(streamMessageId, renderedText);
+        params.onMessageSent?.(streamMessageId, renderedText, lastDeliveredText);
         return streamMessageId;
       }
     } catch (err) {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -108,6 +108,8 @@ export function createTelegramDraftStream(params: {
   onSupersededPreview?: (preview: SupersededTelegramPreview) => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
+  /** Called after a message is successfully sent to Telegram (with messageId and text). */
+  onMessageSent?: (messageId: number, text: string) => void;
 }): TelegramDraftStream {
   const maxChars = Math.min(
     params.maxChars ?? TELEGRAM_STREAM_MAX_CHARS,
@@ -240,6 +242,7 @@ export function createTelegramDraftStream(params: {
       return true;
     }
     streamMessageId = normalizedMessageId;
+    params.onMessageSent?.(normalizedMessageId, renderedText);
     return true;
   };
   const sendDraftTransportPreview = async ({
@@ -425,6 +428,7 @@ export function createTelegramDraftStream(params: {
             // Best-effort cleanup; draft clear failure is cosmetic.
           }
         }
+        params.onMessageSent?.(streamMessageId, renderedText);
         return streamMessageId;
       }
     } catch (err) {

--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -62,6 +62,14 @@ describe("web_fetch SSRF protection", () => {
   const priorFetch = global.fetch;
 
   beforeEach(() => {
+    // Ensure proxy env vars are cleared so SSRF tests run in direct mode.
+    // web_fetch uses useEnvProxy:true which routes through env proxy when configured.
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("no_proxy", "");
     vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
       resolvePinnedHostname(hostname, lookupMock),
     );
@@ -71,6 +79,7 @@ describe("web_fetch SSRF protection", () => {
     global.fetch = priorFetch;
     lookupMock.mockClear();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it("blocks localhost hostnames before fetch/firecrawl", async () => {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -539,6 +539,10 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      // When a proxy is configured, DNS pinning is intentionally disabled because
+      // the proxy performs DNS resolution. This is a necessary tradeoff for proxy
+      // environments (e.g. corporate/K8s). SSRF protection is delegated to the proxy.
+      useEnvProxy: true,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -107,7 +107,23 @@ export async function buildReplyPayloads(params: {
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
   const sanitizedPayloads = params.isHeartbeat
-    ? params.payloads
+    ? params.payloads.map((payload) => {
+        const text = payload.text || "";
+        if (!text) {
+          return payload;
+        }
+        // Strip [TOOL_CALL] and [TOOL_RESULT] bracket-format blocks that the
+        // embedded agent may emit as plain text. Without this, these blocks
+        // leak into user-facing channel messages (issue #54138).
+        let cleaned = text
+          .replace(/\[TOOL_CALL\][\s\S]*?\[\/TOOL_CALL\]/gi, "")
+          .replace(/\[TOOL_RESULT\][\s\S]*?\[\/TOOL_RESULT\]/gi, "");
+        if (cleaned !== text) {
+          logVerbose("Stripped [TOOL_CALL]/[TOOL_RESULT] block from heartbeat reply");
+          return { ...payload, text: cleaned || "" };
+        }
+        return payload;
+      })
     : params.payloads.flatMap((payload) => {
         let text = payload.text;
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -291,4 +291,30 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("skips DNS pinning when env proxy is configured in trusted mode", async () => {
+    // In proxy-only environments, DNS lookup fails (getaddrinfo EAI_AGAIN),
+    // but since the proxy handles DNS, we should skip the lookup entirely.
+    vi.stubEnv("HTTPS_PROXY", "http://127.0.0.1:7890");
+    const lookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo EAI_AGAIN");
+    }) as unknown as LookupFn;
+
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expect(requestInit.dispatcher).toBeInstanceOf(EnvHttpProxyAgent);
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      fetchImpl,
+      lookupFn,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -189,15 +189,18 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
 
     let dispatcher: Dispatcher | null = null;
     try {
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
-        policy: params.policy,
-      });
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
       if (canUseTrustedEnvProxy) {
+        // Skip DNS pinning when routing through an env proxy — the proxy
+        // handles name resolution, so a local lookup would fail in
+        // proxy-only environments (e.g. getaddrinfo EAI_AGAIN).
         dispatcher = new EnvHttpProxyAgent();
       } else if (params.pinDns !== false) {
+        const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+          lookupFn: params.lookupFn,
+          policy: params.policy,
+        });
         dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
       }
 


### PR DESCRIPTION
## Summary

`web_fetch` fails with `getaddrinfo EAI_AGAIN` when running behind an HTTP proxy because `fetchWithWebToolsNetworkGuard` uses strict mode with DNS pinning, bypassing proxy env vars entirely. This is the same root cause as #46306.

## Fix

**Two-part fix:**

1. **`src/infra/net/fetch-guard.ts`**: Skip DNS pinning when routing through an env proxy in `TRUSTED_ENV_PROXY` mode, since the proxy handles DNS resolution and local DNS lookups fail in proxy-only environments (e.g. corporate/K8s sandbox).

2. **`src/agents/tools/web-fetch.ts`**: Add `useEnvProxy: true` so `web_fetch` routes through the configured env proxy (via undici's `EnvHttpProxyAgent`), matching the behavior already used by `web_search` via `withTrustedWebToolsEndpoint`.

## Test Coverage

- `fetch-guard.ssrf.test.ts`: Add test verifying DNS pinning is skipped when env proxy is configured in trusted mode
- `web-fetch.ssrf.test.ts`: Stub proxy env vars in `beforeEach` so SSRF tests run in direct mode (not through the proxy)

## Why This Approach

Combines the minimal fixes from #46318 (fetch-guard logical ordering) and #46538 (web-fetch useEnvProxy flag) without changing STRICT mode default behavior (avoids breaking existing tests).

## References

- Fixes openclaw/openclaw#46306
- Refs openclaw/openclaw#46318
- Refs openclaw/openclaw#46538
