### PR TITLE
ci: optimize windows test shard fanout

### DIFF
--- a/scripts/test-planner/planner.mjs
+++ b/scripts/test-planner/planner.mjs
@@ -1015,9 +1015,16 @@ export function buildCIExecutionManifest(scopeInput = {}, options = {}) {
     targetDurationMs: 12_000,
     targetFilesPerShard: 30,
     minShards: 1,
+    maxShards: 6,
+  });
+  const macosNodeShardCount = resolveDynamicShardCount({
+    estimatedDurationMs: sumKnownManifestDurationsMs(context.unitTimingManifest),
+    fileCount: context.catalog.allKnownUnitFiles.length,
+    targetDurationMs: 12_000,
+    targetFilesPerShard: 30,
+    minShards: 1,
     maxShards: 9,
   });
-  const macosNodeShardCount = windowsShardCount;
   const bunShardCount = resolveDynamicShardCount({
     estimatedDurationMs: sumKnownManifestDurationsMs(context.unitTimingManifest),
     fileCount: context.catalog.allKnownUnitFiles.length,

--- a/scripts/test-planner/planner.mjs
+++ b/scripts/test-planner/planner.mjs
@@ -1015,7 +1015,7 @@ export function buildCIExecutionManifest(scopeInput = {}, options = {}) {
     targetDurationMs: 12_000,
     targetFilesPerShard: 30,
     minShards: 1,
-    maxShards: 6,
+    maxShards: 3,
   });
   const macosNodeShardCount = resolveDynamicShardCount({
     estimatedDurationMs: sumKnownManifestDurationsMs(context.unitTimingManifest),

--- a/scripts/test-planner/planner.mjs
+++ b/scripts/test-planner/planner.mjs
@@ -1015,7 +1015,7 @@ export function buildCIExecutionManifest(scopeInput = {}, options = {}) {
     targetDurationMs: 12_000,
     targetFilesPerShard: 30,
     minShards: 1,
-    maxShards: 4,
+    maxShards: 6,
   });
   const macosNodeShardCount = resolveDynamicShardCount({
     estimatedDurationMs: sumKnownManifestDurationsMs(context.unitTimingManifest),

--- a/scripts/test-planner/planner.mjs
+++ b/scripts/test-planner/planner.mjs
@@ -1015,7 +1015,7 @@ export function buildCIExecutionManifest(scopeInput = {}, options = {}) {
     targetDurationMs: 12_000,
     targetFilesPerShard: 30,
     minShards: 1,
-    maxShards: 3,
+    maxShards: 4,
   });
   const macosNodeShardCount = resolveDynamicShardCount({
     estimatedDurationMs: sumKnownManifestDurationsMs(context.unitTimingManifest),

--- a/test/scripts/test-planner.test.ts
+++ b/test/scripts/test-planner.test.ts
@@ -283,10 +283,10 @@ describe("test planner", () => {
     expect(manifest.jobs.buildArtifacts.enabled).toBe(true);
     expect(manifest.shardCounts.unit).toBe(4);
     expect(manifest.shardCounts.channels).toBe(3);
-    expect(manifest.shardCounts.windows).toBe(9);
+    expect(manifest.shardCounts.windows).toBe(6);
     expect(manifest.shardCounts.macosNode).toBe(9);
     expect(manifest.jobs.checks.matrix.include).toHaveLength(7);
-    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(9);
+    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(6);
     expect(manifest.jobs.macosNode.matrix.include).toHaveLength(9);
     expect(manifest.jobs.macosSwift.enabled).toBe(true);
     expect(manifest.requiredCheckNames).toContain("macos-swift");

--- a/test/scripts/test-planner.test.ts
+++ b/test/scripts/test-planner.test.ts
@@ -283,10 +283,10 @@ describe("test planner", () => {
     expect(manifest.jobs.buildArtifacts.enabled).toBe(true);
     expect(manifest.shardCounts.unit).toBe(4);
     expect(manifest.shardCounts.channels).toBe(3);
-    expect(manifest.shardCounts.windows).toBe(6);
+    expect(manifest.shardCounts.windows).toBe(3);
     expect(manifest.shardCounts.macosNode).toBe(9);
     expect(manifest.jobs.checks.matrix.include).toHaveLength(7);
-    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(6);
+    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(3);
     expect(manifest.jobs.macosNode.matrix.include).toHaveLength(9);
     expect(manifest.jobs.macosSwift.enabled).toBe(true);
     expect(manifest.requiredCheckNames).toContain("macos-swift");

--- a/test/scripts/test-planner.test.ts
+++ b/test/scripts/test-planner.test.ts
@@ -283,10 +283,10 @@ describe("test planner", () => {
     expect(manifest.jobs.buildArtifacts.enabled).toBe(true);
     expect(manifest.shardCounts.unit).toBe(4);
     expect(manifest.shardCounts.channels).toBe(3);
-    expect(manifest.shardCounts.windows).toBe(4);
+    expect(manifest.shardCounts.windows).toBe(6);
     expect(manifest.shardCounts.macosNode).toBe(9);
     expect(manifest.jobs.checks.matrix.include).toHaveLength(7);
-    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(4);
+    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(6);
     expect(manifest.jobs.macosNode.matrix.include).toHaveLength(9);
     expect(manifest.jobs.macosSwift.enabled).toBe(true);
     expect(manifest.requiredCheckNames).toContain("macos-swift");

--- a/test/scripts/test-planner.test.ts
+++ b/test/scripts/test-planner.test.ts
@@ -283,10 +283,10 @@ describe("test planner", () => {
     expect(manifest.jobs.buildArtifacts.enabled).toBe(true);
     expect(manifest.shardCounts.unit).toBe(4);
     expect(manifest.shardCounts.channels).toBe(3);
-    expect(manifest.shardCounts.windows).toBe(3);
+    expect(manifest.shardCounts.windows).toBe(4);
     expect(manifest.shardCounts.macosNode).toBe(9);
     expect(manifest.jobs.checks.matrix.include).toHaveLength(7);
-    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(3);
+    expect(manifest.jobs.checksWindows.matrix.include).toHaveLength(4);
     expect(manifest.jobs.macosNode.matrix.include).toHaveLength(9);
     expect(manifest.jobs.macosSwift.enabled).toBe(true);
     expect(manifest.requiredCheckNames).toContain("macos-swift");


### PR DESCRIPTION
## Summary
- keep the planner-owned Windows node test shard cap at 6
- record the lower-bound experiments at 4 and 3 as boundary-finding probes, not chosen configs
- keep macOS Node independent from Windows so the experiment history stays attributable

## Experiment Log
### Goal
Balance CI load so the main required lanes finish in roughly the same window while keeping normal lane duration under about 4 to 5 minutes when possible.

### Clarified optimization target
The working goal is healthy system-wide CI load, not simply the fewest shards.

That means optimizing the trade among:
- concurrent runner demand
- repeated setup / checkout overhead
- critical-path wall clock
- per-job memory and stability risk

A lower shard count is only better if it reduces system pressure without creating oversized jobs, retries, or OOM boundaries.

### Baseline from recent successful `main` CI runs
Measured from:
- [23602363970](https://github.com/openclaw/openclaw/actions/runs/23602363970)
- [23603004654](https://github.com/openclaw/openclaw/actions/runs/23603004654)
- [23603102055](https://github.com/openclaw/openclaw/actions/runs/23603102055)

| lane family | avg total/job | avg setup before test | avg test step | setup share | test share |
|---|---:|---:|---:|---:|---:|
| Windows node test | 147.3s | 65.7s | 64.6s | 44.6% | 43.7% |
| Linux node test | 119.3s | 33.4s | 78.8s | 27.5% | 66.4% |
| Linux channels | 200.1s | 19.1s | 174.0s | 9.8% | 86.7% |

Interpretation: Windows spends about as much time preparing each shard as running tests, which strongly suggests oversharding and unnecessary runner pressure.

### Phase 1 experiment: 9 -> 6 Windows shards
Observed in two green runs on this PR:
- normal Windows shards finished in roughly the same window as the long Linux lanes
- remaining late tails were driven by checkout / scheduling variance rather than oversized test payloads
- this established that 6 was a better load / latency trade than 9 under the earlier 5 to 6 minute target

Supporting comments:
- [run 1 outcome](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136305538)
- [run 2 control note](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136328008)
- [run 2 outcome](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136395375)

### Tighter target snapshot: 4 to 5 minutes
Recommendation-only optimizer snapshot at a 300 second ceiling:
- Windows node test: current 9, recommended 3, predicted total/job `288.5s`
- Linux node test: current 4, recommended 2, predicted total/job `177.1s`
- Linux channels: current 3, recommended 2, predicted total/job `287.5s`

Interpretation: the optimizer was useful for finding lower bounds, but not sufficient to prove a safe operating point by itself.

### Phase 2 experiment: 6 -> 3 Windows shards
Run: [23606498181](https://github.com/openclaw/openclaw/actions/runs/23606498181)

Observed outcome:
- Windows shard completion landed inside the timing target
- `checks-windows-node-test-3` failed with a Vitest worker OOM near the 6 GiB heap limit
- conclusion: 3 is fast enough, but too aggressive for Windows memory safety on this workload

Supporting comments:
- [3-shard hypothesis](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136525954)
- [3-shard graph shape](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136532722)
- [3-shard outcome](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136568617)

### Phase 3 experiment: 6 -> 4 Windows shards
Observed across stale-base and rebased runs:
- 4 moved Windows off the OOM boundary seen at 3
- but `checks-windows-node-test-2` reproduced a Windows-specific failure in [`src/process/exec.test.ts`](/Users/thoffman/openclaw4/src/process/exec.test.ts) on current `main`
- repeated failure signature:
  - `expected null to be 0`
  - timeout in the npm fallback path
- conclusion: 4 is safer than 3 on memory, but still not a clean healthy point for Windows CI on current `main`

Supporting comments:
- [4-shard outcome on stale base](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136686232)
- [healthy system-load framing](https://github.com/openclaw/openclaw/pull/55261#issuecomment-4136619115)

### Current conclusion
- 6 is the lowest empirically healthy Windows shard cap demonstrated in this experiment
- 3 and 4 were useful lower-bound probes, but neither is an acceptable operating point
- from an operational policy perspective, 6 is the current decision point even if it is not a mathematically proven optimum

### Current experiment state
- Windows shard count restored to 6
- macOS Node remains unchanged
- Linux node test remains at 4
- Linux channels remain at 3

### Success criteria
- Reduce concurrent Windows runner demand versus the old cap of 9
- Keep Windows completion reasonably aligned with the other long required lanes
- Avoid the Windows OOM boundary seen at 3 shards
- Avoid the repeated Windows-specific failure seen at 4 shards
- Avoid regressions in PR wall-clock that outweigh the runner savings

## Validation
- `pnpm vitest run test/scripts/test-planner.test.ts test/scripts/test-parallel.test.ts`
- commit hook `pnpm check`
