### PR TITLE
fix(feishu): inject proxy agent into HTTP API requests

### DIFF
--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -62,26 +62,33 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
 
 /**
  * Create an HTTP instance that delegates to the Lark SDK's default instance
- * but injects a default request timeout to prevent indefinite hangs
- * (e.g. when the Feishu API is slow, causing per-chat queue deadlocks).
+ * but injects a default request timeout and proxy agent to prevent indefinite hangs
+ * (e.g. when the Feishu API is slow, causing per-chat queue deadlocks)
+ * and ensure HTTP API requests respect proxy environment variables.
  */
 function createTimeoutHttpInstance(defaultTimeoutMs: number): Lark.HttpInstance {
   const base: Lark.HttpInstance =
     feishuClientSdk.defaultHttpInstance as unknown as Lark.HttpInstance;
 
-  function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
-    return { timeout: defaultTimeoutMs, ...opts } as Lark.HttpRequestOptions<D>;
+  const proxyAgent = getWsProxyAgent();
+
+  function injectDefaults<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
+    return {
+      timeout: defaultTimeoutMs,
+      ...(proxyAgent ? { httpAgent: proxyAgent, httpsAgent: proxyAgent } : {}),
+      ...opts,
+    } as Lark.HttpRequestOptions<D>;
   }
 
   return {
-    request: (opts) => base.request(injectTimeout(opts)),
-    get: (url, opts) => base.get(url, injectTimeout(opts)),
-    post: (url, data, opts) => base.post(url, data, injectTimeout(opts)),
-    put: (url, data, opts) => base.put(url, data, injectTimeout(opts)),
-    patch: (url, data, opts) => base.patch(url, data, injectTimeout(opts)),
-    delete: (url, opts) => base.delete(url, injectTimeout(opts)),
-    head: (url, opts) => base.head(url, injectTimeout(opts)),
-    options: (url, opts) => base.options(url, injectTimeout(opts)),
+    request: (opts) => base.request(injectDefaults(opts)),
+    get: (url, opts) => base.get(url, injectDefaults(opts)),
+    post: (url, data, opts) => base.post(url, data, injectDefaults(opts)),
+    put: (url, data, opts) => base.put(url, data, injectDefaults(opts)),
+    patch: (url, data, opts) => base.patch(url, data, injectDefaults(opts)),
+    delete: (url, opts) => base.delete(url, injectDefaults(opts)),
+    head: (url, opts) => base.head(url, injectDefaults(opts)),
+    options: (url, opts) => base.options(url, injectDefaults(opts)),
   };
 }
 


### PR DESCRIPTION
## 问题背景

使用 Feishu channel 时，设置了 http_proxy/https_proxy 环境变量，但发送消息报错：

```
[feishu] feishu[default] final reply failed: AxiosError: Request failed with status code 502
```

## 根因分析

Feishu 扩展有两类网络连接：

| 连接类型 | 用途 | 是否走代理 |
|---------|------|----------|
| WebSocket（WSClient） | 接收消息事件 | ✅ 已注入 proxy agent |
| HTTP API（Lark.Client） | 发消息、编辑卡片等 | ❌ 未注入 |

Lark.Client 内部使用 defaultHttpInstance（即 axios.create()），这是一个裸的 axios 实例，不会自动读取 http_proxy 环境变量。代码中的 createTimeoutHttpInstance 只包装了超时逻辑，没有注入 proxy agent，导致 HTTP API 请求直连飞书服务器，在需要代理的网络环境下返回 502。

## 修复方案

### 改动文件
`extensions/feishu/src/client.ts`

### 改动点
1. 在 `createTimeoutHttpInstance` 中新增 `proxyAgent`，复用已有的 `getWsProxyAgent()` 读取 proxy 环境变量
2. 将 `injectTimeout` 重命名为 `injectDefaults`，职责从"仅注入超时"扩展为"注入超时 + 代理"
3. 将 `httpAgent`/`httpsAgent` 注入到每个请求的 axios config 中

### 修复后
- WebSocket 和 HTTP API 两条链路均走代理
- 无代理环境下行为不变（`getWsProxyAgent()` 返回 undefined 时不注入）

## 测试

- [x] 在需要代理的环境下，HTTP API 请求成功
- [x] 在无代理环境下，行为不变