### PR TITLE
fix(plugins): apply bundled allowlist compat in plugin status report

### DIFF
--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -27,6 +27,14 @@ vi.mock("./loader.js", () => ({
   loadOpenClawPlugins: (...args: unknown[]) => loadOpenClawPluginsMock(...args),
 }));
 
+vi.mock("./manifest-registry.js", () => ({
+  loadPluginManifestRegistry: () => ({ plugins: [] }),
+}));
+
+vi.mock("./bundled-compat.js", () => ({
+  withBundledPluginAllowlistCompat: (params: { config: unknown }) => params.config,
+}));
+
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentWorkspaceDir: () => undefined,
   resolveDefaultAgentId: () => "default",

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -11,7 +11,7 @@ import {
 
 const loadConfigMock = vi.fn();
 const loadOpenClawPluginsMock = vi.fn();
-const loadPluginManifestRegistryMock = vi.fn();
+const resolveBundledProviderCompatPluginIdsMock = vi.fn();
 const withBundledPluginAllowlistCompatMock = vi.fn();
 let buildPluginStatusReport: typeof import("./status.js").buildPluginStatusReport;
 let buildPluginInspectReport: typeof import("./status.js").buildPluginInspectReport;
@@ -29,8 +29,9 @@ vi.mock("./loader.js", () => ({
   loadOpenClawPlugins: (...args: unknown[]) => loadOpenClawPluginsMock(...args),
 }));
 
-vi.mock("./manifest-registry.js", () => ({
-  loadPluginManifestRegistry: (...args: unknown[]) => loadPluginManifestRegistryMock(...args),
+vi.mock("./providers.js", () => ({
+  resolveBundledProviderCompatPluginIds: (...args: unknown[]) =>
+    resolveBundledProviderCompatPluginIdsMock(...args),
 }));
 
 vi.mock("./bundled-compat.js", () => ({
@@ -61,10 +62,10 @@ describe("buildPluginStatusReport", () => {
     vi.resetModules();
     loadConfigMock.mockReset();
     loadOpenClawPluginsMock.mockReset();
-    loadPluginManifestRegistryMock.mockReset();
+    resolveBundledProviderCompatPluginIdsMock.mockReset();
     withBundledPluginAllowlistCompatMock.mockReset();
     loadConfigMock.mockReturnValue({});
-    loadPluginManifestRegistryMock.mockReturnValue({ plugins: [] });
+    resolveBundledProviderCompatPluginIdsMock.mockReturnValue([]);
     withBundledPluginAllowlistCompatMock.mockImplementation(
       (params: { config: unknown }) => params.config,
     );
@@ -98,16 +99,10 @@ describe("buildPluginStatusReport", () => {
     );
   });
 
-  it("applies bundled allowlist compat before loading plugins", () => {
+  it("applies bundled provider allowlist compat before loading plugins", () => {
     const config = { plugins: { allow: ["telegram"] } };
     loadConfigMock.mockReturnValue(config);
-    loadPluginManifestRegistryMock.mockReturnValue({
-      plugins: [
-        { id: "anthropic", origin: "bundled" },
-        { id: "openai", origin: "bundled" },
-        { id: "my-custom-plugin", origin: "workspace" },
-      ],
-    });
+    resolveBundledProviderCompatPluginIdsMock.mockReturnValue(["anthropic", "openai"]);
     const compatConfig = { plugins: { allow: ["telegram", "anthropic", "openai"] } };
     withBundledPluginAllowlistCompatMock.mockReturnValue(compatConfig);
 

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -11,6 +11,8 @@ import {
 
 const loadConfigMock = vi.fn();
 const loadOpenClawPluginsMock = vi.fn();
+const loadPluginManifestRegistryMock = vi.fn();
+const withBundledPluginAllowlistCompatMock = vi.fn();
 let buildPluginStatusReport: typeof import("./status.js").buildPluginStatusReport;
 let buildPluginInspectReport: typeof import("./status.js").buildPluginInspectReport;
 let buildAllPluginInspectReports: typeof import("./status.js").buildAllPluginInspectReports;
@@ -28,11 +30,12 @@ vi.mock("./loader.js", () => ({
 }));
 
 vi.mock("./manifest-registry.js", () => ({
-  loadPluginManifestRegistry: () => ({ plugins: [] }),
+  loadPluginManifestRegistry: (...args: unknown[]) => loadPluginManifestRegistryMock(...args),
 }));
 
 vi.mock("./bundled-compat.js", () => ({
-  withBundledPluginAllowlistCompat: (params: { config: unknown }) => params.config,
+  withBundledPluginAllowlistCompat: (...args: unknown[]) =>
+    withBundledPluginAllowlistCompatMock(...args),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -58,7 +61,13 @@ describe("buildPluginStatusReport", () => {
     vi.resetModules();
     loadConfigMock.mockReset();
     loadOpenClawPluginsMock.mockReset();
+    loadPluginManifestRegistryMock.mockReset();
+    withBundledPluginAllowlistCompatMock.mockReset();
     loadConfigMock.mockReturnValue({});
+    loadPluginManifestRegistryMock.mockReturnValue({ plugins: [] });
+    withBundledPluginAllowlistCompatMock.mockImplementation(
+      (params: { config: unknown }) => params.config,
+    );
     setPluginLoadResult({ plugins: [] });
     ({
       buildAllPluginInspectReports,
@@ -86,6 +95,30 @@ describe("buildPluginStatusReport", () => {
         workspaceDir: "/workspace",
         env,
       }),
+    );
+  });
+
+  it("applies bundled allowlist compat before loading plugins", () => {
+    const config = { plugins: { allow: ["telegram"] } };
+    loadConfigMock.mockReturnValue(config);
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        { id: "anthropic", origin: "bundled" },
+        { id: "openai", origin: "bundled" },
+        { id: "my-custom-plugin", origin: "workspace" },
+      ],
+    });
+    const compatConfig = { plugins: { allow: ["telegram", "anthropic", "openai"] } };
+    withBundledPluginAllowlistCompatMock.mockReturnValue(compatConfig);
+
+    buildPluginStatusReport({ config });
+
+    expect(withBundledPluginAllowlistCompatMock).toHaveBeenCalledWith({
+      config,
+      pluginIds: ["anthropic", "openai"],
+    });
+    expect(loadOpenClawPluginsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ config: compatConfig }),
     );
   });
 

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -10,7 +10,7 @@ import { withBundledPluginAllowlistCompat } from "./bundled-compat.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import { resolveBundledProviderCompatPluginIds } from "./providers.js";
 import type { PluginRegistry } from "./registry.js";
 import type { PluginDiagnostic, PluginHookName } from "./types.js";
 
@@ -145,21 +145,20 @@ export function buildPluginStatusReport(params?: {
     : (resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config)) ??
       resolveDefaultAgentWorkspaceDir());
 
-  // Apply bundled-allowlist compat so that `plugins list` and `doctor` report
-  // the same loaded/disabled status the gateway uses at runtime.  Without this,
-  // bundled plugins are incorrectly shown as "disabled" when `plugins.allow` is
-  // set because the allowlist check runs before the bundled-default-enable check.
-  const manifestRegistry = loadPluginManifestRegistry({
+  // Apply bundled-provider allowlist compat so that `plugins list` and `doctor`
+  // report the same loaded/disabled status the gateway uses at runtime.  Without
+  // this, bundled provider plugins are incorrectly shown as "disabled" when
+  // `plugins.allow` is set because the allowlist check runs before the
+  // bundled-default-enable check.  Scoped to bundled providers only (not all
+  // bundled plugins) to match the runtime compat surface in providers.runtime.ts.
+  const bundledProviderIds = resolveBundledProviderCompatPluginIds({
     config,
     workspaceDir,
     env: params?.env,
   });
-  const bundledPluginIds = manifestRegistry.plugins
-    .filter((plugin) => plugin.origin === "bundled")
-    .map((plugin) => plugin.id);
   const effectiveConfig = withBundledPluginAllowlistCompat({
     config,
-    pluginIds: bundledPluginIds,
+    pluginIds: bundledProviderIds,
   });
 
   const registry = loadOpenClawPlugins({

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -6,9 +6,11 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { inspectBundleLspRuntimeSupport } from "./bundle-lsp.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
+import { withBundledPluginAllowlistCompat } from "./bundled-compat.js";
 import { normalizePluginsConfig } from "./config-state.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
 import type { PluginRegistry } from "./registry.js";
 import type { PluginDiagnostic, PluginHookName } from "./types.js";
 
@@ -143,8 +145,25 @@ export function buildPluginStatusReport(params?: {
     : (resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config)) ??
       resolveDefaultAgentWorkspaceDir());
 
-  const registry = loadOpenClawPlugins({
+  // Apply bundled-allowlist compat so that `plugins list` and `doctor` report
+  // the same loaded/disabled status the gateway uses at runtime.  Without this,
+  // bundled plugins are incorrectly shown as "disabled" when `plugins.allow` is
+  // set because the allowlist check runs before the bundled-default-enable check.
+  const manifestRegistry = loadPluginManifestRegistry({
     config,
+    workspaceDir,
+    env: params?.env,
+  });
+  const bundledPluginIds = manifestRegistry.plugins
+    .filter((plugin) => plugin.origin === "bundled")
+    .map((plugin) => plugin.id);
+  const effectiveConfig = withBundledPluginAllowlistCompat({
+    config,
+    pluginIds: bundledPluginIds,
+  });
+
+  const registry = loadOpenClawPlugins({
+    config: effectiveConfig,
     workspaceDir,
     env: params?.env,
     logger: createPluginLoaderLogger(log),


### PR DESCRIPTION
## Problem

When `plugins.allow` is configured, `openclaw plugins list` and `openclaw doctor` incorrectly report bundled plugins as **disabled**, even though the gateway loads them normally at runtime.

For example, with `plugins.allow: ["telegram", "acpx", "feishu", "openclaw-weixin"]`, CLI reports:
```
Loaded: 5  Disabled: 76
```
But the gateway runtime loads all bundled plugins correctly (anthropic, openai, etc.).

## Root Cause

`buildPluginStatusReport()` in `src/plugins/status.ts` calls `loadOpenClawPlugins()` without applying `withBundledPluginAllowlistCompat()`. The allowlist check in `resolveEffectiveEnableState()` runs **before** the bundled-default-enable check, so bundled plugins not in the explicit allowlist are marked disabled.

The gateway runtime applies this compat via `providers.runtime.ts`, so actual runtime behavior differs from what CLI diagnostics report.

## Fix

Apply `withBundledPluginAllowlistCompat()` in `buildPluginStatusReport()` before calling `loadOpenClawPlugins()`, matching the gateway runtime behavior. All bundled plugin IDs are resolved from the manifest registry and added to the effective allowlist.

## Testing

- All 11 existing tests in `status.test.ts` pass
- Added mocks for the new `manifest-registry` and `bundled-compat` imports