### PR TITLE
bluebubbles: honor reaction mention gating

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1658,6 +1658,19 @@ export async function processReaction(
   const peerId = reaction.isGroup
     ? (chatGuid ?? chatIdentifier ?? (chatId ? String(chatId) : "group"))
     : reaction.senderId;
+  const requireMention =
+    reaction.isGroup &&
+    core.channel.groups.resolveRequireMention({
+      cfg: config,
+      channel: "bluebubbles",
+      groupId: peerId,
+      accountId: account.accountId,
+    });
+
+  if (requireMention) {
+    logVerbose(core, runtime, "bluebubbles: skipping group reaction (requireMention=true)");
+    return;
+  }
 
   const route = core.channel.routing.resolveAgentRoute({
     cfg: config,

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1318,6 +1318,28 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockEnqueueSystemEvent).not.toHaveBeenCalled();
     });
 
+    it("skips group reactions when requireMention=true", async () => {
+      mockEnqueueSystemEvent.mockClear();
+      mockResolveRequireMention.mockReturnValue(true);
+
+      setupWebhookTarget({
+        account: createMockAccount({
+          groupPolicy: "open",
+        }),
+      });
+
+      const payload = createTimestampedMessageReactionPayloadForTest({
+        isGroup: true,
+        chatGuid: "iMessage;+;chat123456",
+        associatedMessageType: 2000,
+        handle: { address: "+15559999999" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      expect(mockEnqueueSystemEvent).not.toHaveBeenCalled();
+    });
+
     it("enqueues system event for reaction added", async () => {
       mockEnqueueSystemEvent.mockClear();
 
@@ -1325,6 +1347,31 @@ describe("BlueBubbles webhook monitor", () => {
 
       const payload = createTimestampedMessageReactionPayloadForTest({
         associatedMessageType: 2000, // Heart reaction added
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
+        expect.stringContaining("reacted with ❤️ [[reply_to:"),
+        expect.any(Object),
+      );
+    });
+
+    it("enqueues group reactions when requireMention=false", async () => {
+      mockEnqueueSystemEvent.mockClear();
+      mockResolveRequireMention.mockReturnValue(false);
+
+      setupWebhookTarget({
+        account: createMockAccount({
+          groupPolicy: "open",
+        }),
+      });
+
+      const payload = createTimestampedMessageReactionPayloadForTest({
+        isGroup: true,
+        chatGuid: "iMessage;+;chat123456",
+        associatedMessageType: 2000,
+        handle: { address: "+15559999999" },
       });
 
       await dispatchWebhookPayload(payload);


### PR DESCRIPTION
## Summary
- align BlueBubbles reaction handling with the existing group `requireMention` policy
- stop enqueuing group reaction system events when the group requires explicit mentions

## Changes
- resolve BlueBubbles group `requireMention` inside the reaction ingress path before routing the event
- add regression coverage for both the blocked and allowed group-reaction cases

## Validation
- Ran `pnpm test -- extensions/bluebubbles/src/monitor.test.ts`
- Ran `claude -p "/review"` and addressed the resulting review feedback

## Notes
- Residual risk or follow-up: group reactions do not carry mention text, so groups with `requireMention=true` now consistently ignore them rather than attempting a weaker fallback
