### PR TITLE
Gateway: align HTTP session history scopes

### DIFF
--- a/src/gateway/http-auth-helpers.ts
+++ b/src/gateway/http-auth-helpers.ts
@@ -2,7 +2,9 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import { sendGatewayAuthFailure } from "./http-common.js";
-import { getBearerToken } from "./http-utils.js";
+import { getBearerToken, getHeader } from "./http-utils.js";
+
+const OPERATOR_SCOPES_HEADER = "x-openclaw-scopes";
 
 export async function authorizeGatewayBearerRequestOrReply(params: {
   req: IncomingMessage;
@@ -26,4 +28,15 @@ export async function authorizeGatewayBearerRequestOrReply(params: {
     return false;
   }
   return true;
+}
+
+export function resolveGatewayRequestedOperatorScopes(req: IncomingMessage): string[] {
+  const raw = getHeader(req, OPERATOR_SCOPES_HEADER)?.trim();
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((scope) => scope.trim())
+    .filter((scope) => scope.length > 0);
 }

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -5,14 +5,17 @@ import { afterEach, describe, expect, test } from "vitest";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import { testState } from "./test-helpers.mocks.js";
 import {
+  connectReq,
   createGatewaySuiteHarness,
   installGatewayTestHooks,
+  rpcReq,
   writeSessionStore,
 } from "./test-helpers.server.js";
 
 installGatewayTestHooks();
 
 const AUTH_HEADER = { Authorization: "Bearer test-gateway-token-1234567890" };
+const READ_SCOPE_HEADER = { "x-openclaw-scopes": "operator.read" };
 const cleanupDirs: string[] = [];
 
 afterEach(async () => {
@@ -93,7 +96,7 @@ describe("session history HTTP endpoints", () => {
       const res = await fetch(
         `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history`,
         {
-          headers: AUTH_HEADER,
+          headers: { ...AUTH_HEADER, ...READ_SCOPE_HEADER },
         },
       );
 
@@ -127,7 +130,7 @@ describe("session history HTTP endpoints", () => {
       const res = await fetch(
         `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:missing")}/history`,
         {
-          headers: AUTH_HEADER,
+          headers: { ...AUTH_HEADER, ...READ_SCOPE_HEADER },
         },
       );
 
@@ -195,7 +198,7 @@ describe("session history HTTP endpoints", () => {
       const res = await fetch(
         `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history`,
         {
-          headers: AUTH_HEADER,
+          headers: { ...AUTH_HEADER, ...READ_SCOPE_HEADER },
         },
       );
 
@@ -231,7 +234,7 @@ describe("session history HTTP endpoints", () => {
       const firstPage = await fetch(
         `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history?limit=2`,
         {
-          headers: AUTH_HEADER,
+          headers: { ...AUTH_HEADER, ...READ_SCOPE_HEADER },
         },
       );
       expect(firstPage.status).toBe(200);
@@ -254,7 +257,7 @@ describe("session history HTTP endpoints", () => {
       const secondPage = await fetch(
         `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history?limit=2&cursor=${encodeURIComponent(firstBody.nextCursor ?? "")}`,
         {
-          headers: AUTH_HEADER,
+          headers: { ...AUTH_HEADER, ...READ_SCOPE_HEADER },
         },
       );
       expect(secondPage.status).toBe(200);
@@ -291,6 +294,7 @@ describe("session history HTTP endpoints", () => {
         {
           headers: {
             ...AUTH_HEADER,
+            ...READ_SCOPE_HEADER,
             Accept: "text/event-stream",
           },
         },
@@ -337,6 +341,7 @@ describe("session history HTTP endpoints", () => {
         {
           headers: {
             ...AUTH_HEADER,
+            ...READ_SCOPE_HEADER,
             Accept: "text/event-stream",
           },
         },
@@ -392,6 +397,48 @@ describe("session history HTTP endpoints", () => {
 
       await reader?.cancel();
     } finally {
+      await harness.close();
+    }
+  });
+
+  test("rejects session history when operator.read is not requested", async () => {
+    await seedSession({ text: "scope-guarded history" });
+
+    const harness = await createGatewaySuiteHarness();
+    const ws = await harness.openWs();
+    try {
+      const connect = await connectReq(ws, {
+        token: "test-gateway-token-1234567890",
+        scopes: ["operator.approvals"],
+      });
+      expect(connect.ok).toBe(true);
+
+      const wsHistory = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+        sessionKey: "agent:main:main",
+        limit: 1,
+      });
+      expect(wsHistory.ok).toBe(false);
+      expect(wsHistory.error?.message).toBe("missing scope: operator.read");
+
+      const httpHistory = await fetch(
+        `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history?limit=1`,
+        {
+          headers: {
+            ...AUTH_HEADER,
+            "x-openclaw-scopes": "operator.approvals",
+          },
+        },
+      );
+      expect(httpHistory.status).toBe(403);
+      await expect(httpHistory.json()).resolves.toMatchObject({
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: "missing scope: operator.read",
+        },
+      });
+    } finally {
+      ws.close();
       await harness.close();
     }
   });

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -437,6 +437,21 @@ describe("session history HTTP endpoints", () => {
           message: "missing scope: operator.read",
         },
       });
+
+      const httpHistoryWithoutScopes = await fetch(
+        `http://127.0.0.1:${harness.port}/sessions/${encodeURIComponent("agent:main:main")}/history?limit=1`,
+        {
+          headers: AUTH_HEADER,
+        },
+      );
+      expect(httpHistoryWithoutScopes.status).toBe(403);
+      await expect(httpHistoryWithoutScopes.json()).resolves.toMatchObject({
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: "missing scope: operator.read",
+        },
+      });
     } finally {
       ws.close();
       await harness.close();

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -6,7 +6,10 @@ import { loadSessionStore } from "../config/sessions.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
+import {
+  authorizeGatewayBearerRequestOrReply,
+  resolveGatewayRequestedOperatorScopes,
+} from "./http-auth-helpers.js";
 import {
   sendInvalidRequest,
   sendJson,
@@ -14,6 +17,7 @@ import {
   setSseHeaders,
 } from "./http-common.js";
 import { getHeader } from "./http-utils.js";
+import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import {
   attachOpenClawTranscriptMeta,
   readSessionMessages,
@@ -23,7 +27,6 @@ import {
 } from "./session-utils.js";
 
 const MAX_SESSION_HISTORY_LIMIT = 1000;
-
 function resolveSessionHistoryPath(req: IncomingMessage): string | null {
   const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
   const match = url.pathname.match(/^\/sessions\/([^/]+)\/history$/);
@@ -164,6 +167,21 @@ export async function handleSessionHistoryHttpRequest(
     rateLimiter: opts.rateLimiter,
   });
   if (!ok) {
+    return true;
+  }
+
+  // HTTP callers must declare the same least-privilege operator scopes they
+  // intend to use over WS so both transport surfaces enforce the same gate.
+  const requestedScopes = resolveGatewayRequestedOperatorScopes(req);
+  const scopeAuth = authorizeOperatorScopesForMethod("chat.history", requestedScopes);
+  if (!scopeAuth.allowed) {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: `missing scope: ${scopeAuth.missingScope}`,
+      },
+    });
     return true;
   }
 


### PR DESCRIPTION
## Summary

- Problem: the HTTP session history route accepted gateway bearer auth but did not apply the same requested operator scope gate as `chat.history`
- Why it matters: transport callers that intentionally connected with narrower scopes could get different authorization results between HTTP and WS session history reads
- What changed: the HTTP history route now parses requested operator scopes from `x-openclaw-scopes` and reuses the existing `chat.history` scope authorization check before returning transcript data
- What did NOT change (scope boundary): bearer auth behavior for other HTTP routes and the underlying transcript loading logic

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #43
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the HTTP history endpoint stopped after bearer authentication and never reused the operator method-scope check that the WS `chat.history` path already enforced
- Missing detection / guardrail: the session-history HTTP tests only covered authenticated success paths, not transport parity for narrower requested scopes
- Prior context (`git blame`, prior PR, issue, or refactor if known): introduced in `7b61ca1b06` when the direct session history HTTP/SSE route was added for dashboard APIs
- Why this regressed now: the HTTP surface was added beside the existing WS path without carrying over the scope gate
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/sessions-history-http.test.ts`
- Scenario the test should lock in: approvals-only operator requests are rejected for HTTP session history just like WS `chat.history`, while explicit read scope still succeeds
- Why this is the smallest reliable guardrail: it exercises the real gateway auth and transport handlers without requiring broader app wiring
- Existing test that already covers this (if any): existing REST/SSE history tests cover the success path after auth
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- HTTP session history requests now need to declare requested operator scopes via `x-openclaw-scopes`
- Requests without `operator.read` (or `operator.write` / `operator.admin`) now receive `403 missing scope: operator.read`

## Diagram (if applicable)

```text
Before:
HTTP history request -> bearer auth only -> transcript returned
WS chat.history -> bearer auth + requested scope check -> missing scope error

After:
HTTP history request -> bearer auth + requested scope check -> transcript or missing scope error
WS chat.history -> bearer auth + requested scope check -> transcript or missing scope error
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: HTTP session history now honors the same requested read-scope gate as WS `chat.history`, reducing transcript exposure for intentionally narrower operator sessions

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway HTTP + WS
- Relevant config (redacted): gateway test harness with bearer token auth

### Steps

1. Seed a session transcript and connect over WS with `operator.approvals`
2. Request `chat.history` over WS and `/sessions/:sessionKey/history` over HTTP with matching requested scopes
3. Repeat the HTTP request with `operator.read`

### Expected

- WS and HTTP reject approvals-only history reads the same way
- HTTP history succeeds when `operator.read` is requested

### Actual

- Matches expected locally

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: scoped `src/gateway/sessions-history-http.test.ts`, `pnpm build`, and the required local `/review` pass
- Edge cases checked: REST, SSE, pagination, unknown session 404s, and approvals-only rejection parity against WS `chat.history`
- What you did **not** verify: external dashboard clients outside the in-repo gateway test harness

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) Yes
- If yes, exact upgrade steps: send the requested operator scopes for HTTP session history requests via `x-openclaw-scopes` so the route can apply the same least-privilege gate as WS `chat.history`

## Risks and Mitigations

- Risk: existing HTTP history callers that relied on bearer auth alone will now receive 403s
  - Mitigation: the route now uses the same requested-scope contract as WS and the regression test locks in both the reject and allow paths
