### PR TITLE
gateway: require pairing for backend scope upgrades

### DIFF
--- a/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
+++ b/src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts
@@ -84,6 +84,68 @@ describe("gateway silent scope-upgrade reconnect", () => {
     }
   });
 
+  test("does not let backend reconnect bypass the paired scope baseline", async () => {
+    const started = await startServerWithClient("secret");
+    const paired = await issueOperatorToken({
+      name: "backend-scope-upgrade-reconnect-poc",
+      approvedScopes: ["operator.read"],
+      clientId: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientMode: GATEWAY_CLIENT_MODES.BACKEND,
+    });
+
+    let watcherWs: WebSocket | undefined;
+    let backendReconnectWs: WebSocket | undefined;
+
+    try {
+      watcherWs = await openTrackedWs(started.port);
+      await connectOk(watcherWs, { scopes: ["operator.admin"] });
+      const requestedEvent = onceMessage(
+        watcherWs,
+        (obj) => obj.type === "event" && obj.event === "device.pair.requested",
+      );
+
+      backendReconnectWs = await openTrackedWs(started.port);
+      const reconnectAttempt = await connectReq(backendReconnectWs, {
+        token: "secret",
+        deviceIdentityPath: paired.identityPath,
+        client: {
+          id: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+          version: "1.0.0",
+          platform: "node",
+          mode: GATEWAY_CLIENT_MODES.BACKEND,
+        },
+        role: "operator",
+        scopes: ["operator.admin"],
+      });
+      expect(reconnectAttempt.ok).toBe(false);
+      expect(reconnectAttempt.error?.message).toBe("pairing required");
+
+      const pending = await devicePairingModule.listDevicePairing();
+      expect(pending.pending).toHaveLength(1);
+      expect(
+        (reconnectAttempt.error?.details as { requestId?: unknown; code?: string })?.requestId,
+      ).toBe(pending.pending[0]?.requestId);
+
+      const requested = (await requestedEvent) as {
+        payload?: { requestId?: string; deviceId?: string; scopes?: string[] };
+      };
+      expect(requested.payload?.requestId).toBe(pending.pending[0]?.requestId);
+      expect(requested.payload?.deviceId).toBe(paired.deviceId);
+      expect(requested.payload?.scopes).toEqual(["operator.admin"]);
+
+      const afterAttempt = await getPairedDevice(paired.deviceId);
+      expect(afterAttempt?.approvedScopes).toEqual(["operator.read"]);
+      expect(afterAttempt?.tokens?.operator?.scopes).toEqual(["operator.read"]);
+      expect(afterAttempt?.tokens?.operator?.token).toBe(paired.token);
+    } finally {
+      watcherWs?.close();
+      backendReconnectWs?.close();
+      started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
   test("accepts local silent reconnect when pairing was concurrently approved", async () => {
     const started = await startServerWithClient("secret");
     const loaded = loadDeviceIdentity("silent-reconnect-race");

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
-import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
-import type { ConnectParams } from "../../protocol/index.js";
 import {
   BROWSER_ORIGIN_LOOPBACK_RATE_LIMIT_IP,
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
-  shouldSkipBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 
 function createRateLimiter(): AuthRateLimiter {
@@ -85,43 +82,6 @@ describe("handshake auth helpers", () => {
         isControlUi: false,
         isWebchat: false,
         reason: "metadata-upgrade",
-      }),
-    ).toBe(false);
-  });
-
-  it("skips backend self-pairing for local trusted backend clients", () => {
-    const connectParams = {
-      client: {
-        id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-        mode: GATEWAY_CLIENT_MODES.BACKEND,
-      },
-    } as ConnectParams;
-
-    expect(
-      shouldSkipBackendSelfPairing({
-        connectParams,
-        isLocalClient: true,
-        hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
-        authMethod: "token",
-      }),
-    ).toBe(true);
-    expect(
-      shouldSkipBackendSelfPairing({
-        connectParams,
-        isLocalClient: true,
-        hasBrowserOriginHeader: false,
-        sharedAuthOk: false,
-        authMethod: "device-token",
-      }),
-    ).toBe(true);
-    expect(
-      shouldSkipBackendSelfPairing({
-        connectParams,
-        isLocalClient: false,
-        hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
-        authMethod: "token",
       }),
     ).toBe(false);
   });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -3,7 +3,6 @@ import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult } from "../../auth.js";
 import { buildDeviceAuthPayload, buildDeviceAuthPayloadV3 } from "../../device-auth.js";
 import { isLoopbackAddress } from "../../net.js";
-import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../protocol/client-info.js";
 import type { ConnectParams } from "../../protocol/index.js";
 import type { AuthProvidedKind } from "./auth-messages.js";
 
@@ -57,31 +56,6 @@ export function shouldAllowSilentLocalPairing(params: {
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
     (params.reason === "not-paired" || params.reason === "scope-upgrade")
-  );
-}
-
-export function shouldSkipBackendSelfPairing(params: {
-  connectParams: ConnectParams;
-  isLocalClient: boolean;
-  hasBrowserOriginHeader: boolean;
-  sharedAuthOk: boolean;
-  authMethod: GatewayAuthResult["method"];
-}): boolean {
-  const isGatewayBackendClient =
-    params.connectParams.client.id === GATEWAY_CLIENT_IDS.GATEWAY_CLIENT &&
-    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.BACKEND;
-  if (!isGatewayBackendClient) {
-    return false;
-  }
-  const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
-  const usesDeviceTokenAuth = params.authMethod === "device-token";
-  // `authMethod === "device-token"` only reaches this helper after the caller
-  // has already accepted auth (`authOk === true`), so a separate
-  // `deviceTokenAuthOk` flag would be redundant here.
-  return (
-    params.isLocalClient &&
-    !params.hasBrowserOriginHeader &&
-    ((params.sharedAuthOk && usesSharedSecretAuth) || usesDeviceTokenAuth)
   );
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -91,7 +91,6 @@ import {
   resolveHandshakeBrowserSecurityContext,
   resolveUnauthorizedHandshakeContext,
   shouldAllowSilentLocalPairing,
-  shouldSkipBackendSelfPairing,
 } from "./handshake-auth-helpers.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
@@ -686,20 +685,12 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
-        const skipPairing =
-          shouldSkipBackendSelfPairing({
-            connectParams,
-            isLocalClient,
-            hasBrowserOriginHeader,
-            sharedAuthOk,
-            authMethod,
-          }) ||
-          shouldSkipControlUiPairing(
-            controlUiAuthPolicy,
-            role,
-            trustedProxyAuthOk,
-            resolvedAuth.mode,
-          );
+        const skipPairing = shouldSkipControlUiPairing(
+          controlUiAuthPolicy,
+          role,
+          trustedProxyAuthOk,
+          resolvedAuth.mode,
+        );
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {


### PR DESCRIPTION
## Summary
- requires paired backend reconnects to satisfy the same role and scope checks as other device reconnects
- removes the backend-specific pairing bypass that let local reconnects skip the stored scope baseline
- adds a regression test covering a backend client that tries to reconnect from `operator.read` to `operator.admin`

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Related #47
- [x] This PR fixes a bug or regression

## Root Cause / Regression History
- Root cause: backend reconnects could skip pairing enforcement before the paired device role/scope baseline was checked
- Missing detection / guardrail: there was no regression test covering backend-labeled reconnects against an existing non-admin pairing record
- Prior context (`git blame`, prior PR, issue, or refactor if known): the local backend self-pairing bypass was introduced in `8db6fcca77`
- Why this regressed now: the bypass trusted backend reconnect metadata more than the stored pairing baseline
- If unknown, what was ruled out: N/A

## Regression Test Plan
- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.silent-scope-upgrade-reconnect.poc.test.ts`
- Scenario the test should lock in: a backend-labeled paired device reconnecting with a wider scope set must receive `pairing required` and leave approved scopes unchanged
- Why this is the smallest reliable guardrail: the failure only appears after handshake auth, reconnect metadata, and paired-device scope enforcement are evaluated together
- Existing test that already covers this (if any): the same file already covered the non-backend shared-auth variant
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
Backend reconnects that request scopes outside their approved pairing baseline now require pairing approval instead of silently widening access.

## Diagram
```text
Before:
[paired backend reconnect requests wider scopes] -> [backend bypass skips pairing checks] -> [connection accepted]

After:
[paired backend reconnect requests wider scopes] -> [paired scope baseline checked] -> [pairing required]
```

## Security Impact
- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification
### Environment
- OS: Ubuntu
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway websocket reconnect flow
- Relevant config (redacted): test gateway shared secret

### Steps
1. Pair a backend-labeled device with `operator.read`.
2. Reconnect with the same device identity and request `operator.admin`.
3. Observe the reconnect result and pairing state.

### Expected
- reconnect is rejected with `pairing required`
- a pairing request is emitted for the widened scope request
- stored approved scopes remain unchanged

### Actual
- matches expected after this change

## Evidence
- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification
- Verified scenarios: focused gateway tests for the existing shared-auth reconnect case and the new backend reconnect case
- Edge cases checked: helper/unit coverage still passes after removing the bypass helper
- What you did **not** verify: full `pnpm test` suite

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations
- Risk: local backend reconnects that previously relied on the bypass may now need pairing when they request wider scopes than their stored baseline
- Mitigation: unchanged-scope reconnects continue to use the existing paired baseline, and the regression test locks the intended failure mode for widened requests
