### PR TITLE
fix: deprecate interrupt queue mode and remove 'wait' from abort triggers

### DIFF
--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -30,7 +30,7 @@ Inbound messages can steer the current run, wait for a followup turn, or do both
 - `followup`: enqueue for the next agent turn after the current run ends.
 - `collect`: coalesce all queued messages into a **single** followup turn (default). If messages target different channels/threads, they drain individually to preserve routing.
 - `steer-backlog` (aka `steer+backlog`): steer now **and** preserve the message for a followup turn.
-- `interrupt` (legacy): abort the active run for that session, then run the newest message.
+- `interrupt` (deprecated): previously aborted the active run; now remapped to `collect` to avoid confusing "Agent was aborted" messages when users send follow-up messages.
 - `queue` (legacy alias): same as `steer`.
 
 Steer-backlog means you can get a followup response after the steered run, so

--- a/src/auto-reply/reply/abort-primitives.ts
+++ b/src/auto-reply/reply/abort-primitives.ts
@@ -4,7 +4,6 @@ const ABORT_TRIGGERS = new Set([
   "stop",
   "esc",
   "abort",
-  "wait",
   "exit",
   "interrupt",
   "detente",

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -227,7 +227,6 @@ describe("abort detection", () => {
       "stop",
       "esc",
       "abort",
-      "wait",
       "exit",
       "interrupt",
       "stop openclaw",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -486,10 +486,12 @@ export async function runPreparedReply(
   } = await loadPiEmbeddedRuntime();
   const sessionLaneKey = resolveEmbeddedSessionLane(sessionKey ?? sessionIdFinal);
   const laneSize = getQueueSize(sessionLaneKey);
+  // Note: "interrupt" mode is deprecated and now maps to "collect" in normalizeQueueMode.
+  // The lane-clearing behavior here is preserved only as a safety net but should never trigger.
   if (resolvedQueue.mode === "interrupt" && laneSize > 0) {
-    const cleared = clearCommandLane(sessionLaneKey);
-    const aborted = abortEmbeddedPiRun(sessionIdFinal);
-    logVerbose(`Interrupting ${sessionLaneKey} (cleared ${cleared}, aborted=${aborted})`);
+    logVerbose(
+      `Interrupt mode is deprecated; treating as collect for ${sessionLaneKey} (laneSize=${laneSize})`,
+    );
   }
   const queueKey = sessionKey ?? sessionIdFinal;
   const isActive = isEmbeddedPiRunActive(sessionIdFinal);

--- a/src/auto-reply/reply/queue-policy.test.ts
+++ b/src/auto-reply/reply/queue-policy.test.ts
@@ -45,4 +45,15 @@ describe("resolveActiveRunQueueAction", () => {
       }),
     ).toBe("enqueue-followup");
   });
+
+  it("enqueues interrupt mode runs instead of running concurrently (deprecated)", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: true,
+        isHeartbeat: false,
+        shouldFollowup: false,
+        queueMode: "interrupt",
+      }),
+    ).toBe("enqueue-followup");
+  });
 });

--- a/src/auto-reply/reply/queue-policy.ts
+++ b/src/auto-reply/reply/queue-policy.ts
@@ -14,7 +14,9 @@ export function resolveActiveRunQueueAction(params: {
   if (params.isHeartbeat) {
     return "drop";
   }
-  if (params.shouldFollowup || params.queueMode === "steer") {
+  // "interrupt" is deprecated and remapped to "collect" upstream, but if it
+  // somehow arrives here, enqueue instead of running concurrently.
+  if (params.shouldFollowup || params.queueMode === "steer" || params.queueMode === "interrupt") {
     return "enqueue-followup";
   }
   return "run-now";

--- a/src/auto-reply/reply/queue/normalize.ts
+++ b/src/auto-reply/reply/queue/normalize.ts
@@ -9,7 +9,9 @@ export function normalizeQueueMode(raw?: string): QueueMode | undefined {
     return "steer";
   }
   if (cleaned === "interrupt" || cleaned === "interrupts" || cleaned === "abort") {
-    return "interrupt";
+    // Deprecated: interrupt mode caused confusing "Agent was aborted" messages
+    // when users sent follow-up messages. Now treated as collect (queue silently).
+    return "collect";
   }
   if (cleaned === "steer" || cleaned === "steering") {
     return "steer";


### PR DESCRIPTION
## Problem

When users send follow-up messages while the agent is still working, they see **"⚙️ Agent was aborted."** — confusing UX for non-technical users who just want to add more context to their request.

Two issues were identified:
1. The `interrupt` queue mode aborts the running agent whenever a new message arrives, instead of queuing it
2. The word "wait" is in the abort trigger list, but "wait" typically means "hold on, I want to add something" — not "stop everything"

## Changes

### Deprecate `interrupt` queue mode
- `normalizeQueueMode()` now remaps `interrupt` → `collect` (queue messages silently, process together after current run)
- Removed lane-clearing + abort behavior in `get-reply-run.ts` for interrupt mode (now just logs a deprecation warning)
- Added safety net in `queue-policy.ts`: if `interrupt` somehow reaches the active run handler, enqueue as followup instead of running concurrently

### Remove `wait` from abort triggers
- Removed "wait" from `ABORT_TRIGGERS` in `abort-primitives.ts`
- All explicit stop commands (`/stop`, "stop", "abort", "halt", etc.) still work as before

### Tests & docs
- Updated queue-policy test to verify interrupt mode enqueues instead of running concurrently
- Updated abort test to remove "wait" from positive matches
- Updated queue.md docs to mark interrupt as deprecated

## User-facing impact
- Follow-up messages no longer abort the running agent — they queue silently and are processed after the current run finishes
- Saying "wait" no longer kills the current run
- Explicit stop commands still work exactly as before
- The default queue mode (`collect`) is unchanged

## Source
Support thread from Martin: follow-up messages causing unexpected aborts