### PR TITLE
fix(plugins): apply bundled allowlist compat in plugin status report

### DIFF
--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -63,6 +63,23 @@ describe("buildPluginStatusReport", () => {
     } = await import("./status.js"));
   });
 
+  it("applies bundled allowlist compat so default bundled plugins are not excluded when plugins.allow is configured", () => {
+    buildPluginStatusReport({
+      config: { plugins: { allow: ["some-external-plugin"] } },
+      workspaceDir: "/workspace",
+    });
+
+    const call = loadOpenClawPluginsMock.mock.calls[0]?.[0] as {
+      config?: { plugins?: { allow?: string[] } };
+    };
+    // Bundled-by-default plugins should be injected into the allow list so
+    // the CLI status matches what the gateway actually loads at runtime.
+    expect(call?.config?.plugins?.allow).toContain("anthropic");
+    expect(call?.config?.plugins?.allow).toContain("openai");
+    expect(call?.config?.plugins?.allow).toContain("google");
+    expect(call?.config?.plugins?.allow).toContain("some-external-plugin");
+  });
+
   it("forwards an explicit env to plugin loading", () => {
     const env = { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv;
 

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -141,11 +141,10 @@ export function buildPluginStatusReport(params?: {
   const rawConfig = params?.config ?? loadConfig();
   // Apply bundled allowlist compat so bundled-by-default plugins are not shown
   // as disabled when plugins.allow is configured, matching gateway runtime behavior.
-  const config =
-    withBundledPluginAllowlistCompat({
-      config: rawConfig,
-      pluginIds: [...BUNDLED_ENABLED_BY_DEFAULT],
-    }) ?? rawConfig;
+  const config = withBundledPluginAllowlistCompat({
+    config: rawConfig,
+    pluginIds: [...BUNDLED_ENABLED_BY_DEFAULT],
+  });
   const workspaceDir = params?.workspaceDir
     ? params.workspaceDir
     : (resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config)) ??

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -6,7 +6,8 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 import { inspectBundleLspRuntimeSupport } from "./bundle-lsp.js";
 import { inspectBundleMcpRuntimeSupport } from "./bundle-mcp.js";
-import { normalizePluginsConfig } from "./config-state.js";
+import { withBundledPluginAllowlistCompat } from "./bundled-compat.js";
+import { BUNDLED_ENABLED_BY_DEFAULT, normalizePluginsConfig } from "./config-state.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
 import type { PluginRegistry } from "./registry.js";
@@ -137,7 +138,14 @@ export function buildPluginStatusReport(params?: {
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
 }): PluginStatusReport {
-  const config = params?.config ?? loadConfig();
+  const rawConfig = params?.config ?? loadConfig();
+  // Apply bundled allowlist compat so bundled-by-default plugins are not shown
+  // as disabled when plugins.allow is configured, matching gateway runtime behavior.
+  const config =
+    withBundledPluginAllowlistCompat({
+      config: rawConfig,
+      pluginIds: [...BUNDLED_ENABLED_BY_DEFAULT],
+    }) ?? rawConfig;
   const workspaceDir = params?.workspaceDir
     ? params.workspaceDir
     : (resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config)) ??


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw plugins list` reports bundled-by-default plugins (anthropic, openai, google, and all other entries in `BUNDLED_ENABLED_BY_DEFAULT`) as **disabled** whenever `plugins.allow` is configured, even though the gateway loads them normally.
- **Why it matters:** Users who configure `plugins.allow` to restrict plugins see a completely misleading status report — the CLI says the plugins are off but the gateway is actually running them.
- **What changed:** `buildPluginStatusReport` in `src/plugins/status.ts` now calls `withBundledPluginAllowlistCompat` before passing config to the loader, matching what every other plugin-loading call site already does.
- **What did NOT change:** No change to runtime plugin loading, gateway behavior, or any other code path.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX

## Linked Issue/PR
- Closes #55267
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- **Root cause:** `buildPluginStatusReport` (the backing function for `openclaw plugins list`) passed the raw config directly to `loadOpenClawPlugins`. When `plugins.allow` is non-empty, `resolveEnableState` in `config-state.ts:296` short-circuits at the allowlist check before reaching the bundled-by-default branch at line 302, causing every bundled-default plugin to be flagged as `"not in allowlist"` / disabled.
- **Missing detection / guardrail:** `buildPluginStatusReport` was never tested with an explicit `plugins.allow` config, so this divergence from runtime behavior was never caught.
- **Prior context:** The `withBundledPluginAllowlistCompat` guard exists and is already applied at every other call site:
  - `src/plugins/providers.runtime.ts:38`
  - `src/plugins/web-search-providers.shared.ts:96`
  - `src/config/validation.ts:387`
  The status report path was simply missed.
- **Why this regressed now:** The compat guard was added incrementally to runtime paths but was never retrofitted to the CLI status path.

## Regression Test Plan

- Coverage level: Unit test
- Target: `src/plugins/status.test.ts`
- New test: *"applies bundled allowlist compat so default bundled plugins are not excluded when plugins.allow is configured"*
- Scenario: calls `buildPluginStatusReport` with `config: { plugins: { allow: ["some-external-plugin"] } }`, then asserts that `loadOpenClawPlugins` received a config whose `plugins.allow` contains `"anthropic"`, `"openai"`, `"google"`, and the original `"some-external-plugin"`.
- Why this is the smallest reliable guardrail: directly verifies the compat injection reaches the loader without requiring a full plugin load.

## User-visible / Behavior Changes

`openclaw plugins list` now correctly shows bundled-by-default plugins as **loaded** when `plugins.allow` is configured, matching what the gateway actually runs.

## Diagram

```
Before:
plugins.allow = ["openrouter"]
  → buildPluginStatusReport → loadOpenClawPlugins(rawConfig)
  → resolveEnableState("anthropic") → "not in allowlist" → disabled ✗

After:
plugins.allow = ["openrouter"]
  → withBundledPluginAllowlistCompat → allow = ["openrouter","anthropic","openai","google",...]
  → buildPluginStatusReport → loadOpenClawPlugins(compatConfig)
  → resolveEnableState("anthropic") → loaded ✓
```

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — the compat only adds IDs to the allow list for the status report query; it does not change runtime plugin activation.

## Repro + Verification

### Steps
1. Add `"plugins": { "allow": ["openrouter"] }` to `openclaw.json`
2. Run `openclaw plugins list`

### Expected
- `anthropic`, `openai`, `google`, and all other `BUNDLED_ENABLED_BY_DEFAULT` plugins show as `loaded`

### Actual (before fix)
- All bundled-default plugins show as `disabled` with reason `"not in allowlist"`

## Evidence
- [x] 12/12 `src/plugins/status.test.ts` pass (including new regression test)
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean

## Human Verification
- Verified scenarios: Traced the full call path from `buildPluginStatusReport` → `loadOpenClawPlugins` → `resolveEnableState`; confirmed the compat function only modifies the config when `plugins.allow` is non-empty.
- Edge cases checked: Empty allow list (compat is a no-op; unchanged behavior), no `plugins` config (compat is a no-op).
- What I did **not** verify: Live `openclaw plugins list` with a real running gateway.

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: The injected allow list is broader than what `plugins.allow` specifies, potentially changing what config reaches `loadOpenClawPlugins` for status reporting.
  - Mitigation: This is the intended behavior — it mirrors exactly what the runtime does. The existing test *"forwards an explicit env to plugin loading"* (empty config, no allow list) still passes unchanged, confirming the no-allow-list path is unaffected.

> 🤖 AI-assisted (Claude Code / claude-sonnet-4-6) — fully tested, author reviewed every changed line.