### PR TITLE
fix(agents): include received keys in missing-param error for write tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Agents/tools: include value-shape hints in missing-parameter tool errors so dropped, empty-string, and wrong-type write payloads are easier to diagnose from logs. (#55317) Thanks @priyansh19.
+
 ## 2026.4.2-beta.1
 
 ### Breaking

--- a/src/agents/pi-tools.params.test.ts
+++ b/src/agents/pi-tools.params.test.ts
@@ -22,6 +22,7 @@ describe("assertRequiredParams", () => {
     const tool = wrapToolParamNormalization(
       {
         name: "write",
+        label: "write",
         description: "write a file",
         parameters: {},
         execute: vi.fn(),

--- a/src/agents/pi-tools.params.test.ts
+++ b/src/agents/pi-tools.params.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./pi-tools.js";
+
+const { assertRequiredParams } = __testing;
+
+describe("assertRequiredParams", () => {
+  it("includes received keys in error when some params are present but content is missing", () => {
+    expect(() =>
+      assertRequiredParams(
+        { file_path: "test.txt" },
+        [
+          { keys: ["path", "file_path"], label: "path alias" },
+          { keys: ["content"], label: "content" },
+        ],
+        "write",
+      ),
+    ).toThrow(/\(received: file_path\)/);
+  });
+
+  it("includes multiple received keys when several params are present", () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "/tmp/a.txt", extra: "yes" },
+        [
+          { keys: ["path", "file_path"], label: "path alias" },
+          { keys: ["content"], label: "content" },
+        ],
+        "write",
+      ),
+    ).toThrow(/\(received: path, extra\)/);
+  });
+
+  it("omits received hint when the record is empty", () => {
+    const err = (() => {
+      try {
+        assertRequiredParams({}, [{ keys: ["content"], label: "content" }], "write");
+      } catch (e) {
+        return e instanceof Error ? e.message : "";
+      }
+      return "";
+    })();
+    expect(err).not.toMatch(/received:/);
+    expect(err).toMatch(/Missing required parameter: content/);
+  });
+
+  it("does not throw when all required params are present", () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "a.txt", content: "hello" },
+        [
+          { keys: ["path", "file_path"], label: "path alias" },
+          { keys: ["content"], label: "content" },
+        ],
+        "write",
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/agents/pi-tools.params.test.ts
+++ b/src/agents/pi-tools.params.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { __testing } from "./pi-tools.js";
+import { CLAUDE_PARAM_GROUPS } from "./pi-tools.params.js";
 
-const { assertRequiredParams } = __testing;
+const { assertRequiredParams, wrapToolParamNormalization } = __testing;
 
 describe("assertRequiredParams", () => {
   it("includes received keys in error when some params are present but content is missing", () => {
@@ -15,6 +16,34 @@ describe("assertRequiredParams", () => {
         "write",
       ),
     ).toThrow(/\(received: file_path\)/);
+  });
+
+  it("shows normalized key in hint when called through wrapToolParamNormalization (file_path alias -> path)", async () => {
+    const tool = wrapToolParamNormalization(
+      {
+        name: "write",
+        description: "write a file",
+        parameters: {},
+        execute: vi.fn(),
+      },
+      CLAUDE_PARAM_GROUPS.write,
+    );
+    await expect(
+      tool.execute("id", { file_path: "test.txt" }, new AbortController().signal, vi.fn()),
+    ).rejects.toThrow(/\(received: path\)/);
+  });
+
+  it("excludes null and undefined values from received hint", () => {
+    expect(() =>
+      assertRequiredParams(
+        { file_path: "test.txt", content: null },
+        [
+          { keys: ["path", "file_path"], label: "path alias" },
+          { keys: ["content"], label: "content" },
+        ],
+        "write",
+      ),
+    ).toThrow(/\(received: file_path\)[^,]/);
   });
 
   it("includes multiple received keys when several params are present", () => {

--- a/src/agents/pi-tools.params.test.ts
+++ b/src/agents/pi-tools.params.test.ts
@@ -47,6 +47,40 @@ describe("assertRequiredParams", () => {
     ).toThrow(/\(received: file_path\)[^,]/);
   });
 
+  it("shows empty-string values for present params that still fail validation", () => {
+    expect(() =>
+      assertRequiredParams(
+        { path: "/tmp/a.txt", content: "   " },
+        [
+          { keys: ["path", "file_path"], label: "path alias" },
+          { keys: ["content"], label: "content" },
+        ],
+        "write",
+      ),
+    ).toThrow(/\(received: path, content=<empty-string>\)/);
+  });
+
+  it("shows wrong-type values for present params that still fail validation", async () => {
+    const tool = wrapToolParamNormalization(
+      {
+        name: "write",
+        label: "write",
+        description: "write a file",
+        parameters: {},
+        execute: vi.fn(),
+      },
+      CLAUDE_PARAM_GROUPS.write,
+    );
+    await expect(
+      tool.execute(
+        "id",
+        { file_path: "test.txt", content: { unexpected: true } },
+        new AbortController().signal,
+        vi.fn(),
+      ),
+    ).rejects.toThrow(/\(received: (?:path, content=<object>|content=<object>, path)\)/);
+  });
+
   it("includes multiple received keys when several params are present", () => {
     expect(() =>
       assertRequiredParams(

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -13,6 +13,39 @@ function parameterValidationError(message: string): Error {
   return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
 }
 
+function describeReceivedParamValue(value: unknown, allowEmpty = false): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "string") {
+    if (allowEmpty || value.trim().length > 0) {
+      return undefined;
+    }
+    return "<empty-string>";
+  }
+  if (Array.isArray(value)) {
+    return "<array>";
+  }
+  return `<${typeof value}>`;
+}
+
+function formatReceivedParamHint(
+  record: Record<string, unknown>,
+  groups: readonly RequiredParamGroup[],
+): string {
+  const allowEmptyKeys = new Set(
+    groups.filter((group) => group.allowEmpty).flatMap((group) => group.keys),
+  );
+  const received = Object.keys(record).flatMap((key) => {
+    const detail = describeReceivedParamValue(record[key], allowEmptyKeys.has(key));
+    if (record[key] === undefined || record[key] === null) {
+      return [];
+    }
+    return [detail ? `${key}=${detail}` : key];
+  });
+  return received.length > 0 ? ` (received: ${received.join(", ")})` : "";
+}
+
 export const CLAUDE_PARAM_GROUPS = {
   read: [{ keys: ["path", "file_path", "filePath", "file"], label: "path alias" }],
   write: [
@@ -275,10 +308,7 @@ export function assertRequiredParams(
   if (missingLabels.length > 0) {
     const joined = missingLabels.join(", ");
     const noun = missingLabels.length === 1 ? "parameter" : "parameters";
-    const receivedKeys = Object.keys(record).filter(
-      (k) => record[k] !== undefined && record[k] !== null,
-    );
-    const receivedHint = receivedKeys.length > 0 ? ` (received: ${receivedKeys.join(", ")})` : "";
+    const receivedHint = formatReceivedParamHint(record, groups);
     throw parameterValidationError(`Missing required ${noun}: ${joined}${receivedHint}`);
   }
 }

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -275,7 +275,11 @@ export function assertRequiredParams(
   if (missingLabels.length > 0) {
     const joined = missingLabels.join(", ");
     const noun = missingLabels.length === 1 ? "parameter" : "parameters";
-    throw parameterValidationError(`Missing required ${noun}: ${joined}`);
+    const receivedKeys = Object.keys(record).filter(
+      (k) => record[k] !== undefined && record[k] !== null,
+    );
+    const receivedHint = receivedKeys.length > 0 ? ` (received: ${receivedKeys.join(", ")})` : "";
+    throw parameterValidationError(`Missing required ${noun}: ${joined}${receivedHint}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** When the `write` tool (or any tool using `assertRequiredParams`) fails due to a missing required parameter, the error only names the missing parameter — it gives no indication of what was actually received. This makes silent parameter-drop bugs (#55224, #55287) completely invisible in logs.
- **Why it matters:** In long sessions where `content` or `file_path` is silently dropped before reaching the tool, the error `"Missing required parameter: content"` gives no diagnostic information to help distinguish between "never sent", "sent as empty string", or "sent as wrong type". Operators and developers have no way to diagnose the root cause from logs alone.
- **What changed:** `assertRequiredParams` in `src/agents/pi-tools.params.ts` now appends `(received: <keys>)` to the error message when at least one non-null key was present in the call. Empty records produce no hint.
- **What did NOT change:** No change to tool behavior, parameter validation logic, or the `Supply correct parameters before retrying.` suffix.

## Change Type
- [x] Bug fix

## Scope
- [x] Skills / tool execution

## Linked Issue/PR
- Closes #55229
- Related #55224
- Related #55287
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- **Root cause:** `assertRequiredParams` was introduced to validate required parameter groups and throw a descriptive error when they are missing. However, the error message was designed only to name the *missing* label — it never included any representation of what was *received*. When the AI model sends `{ file_path: "foo.txt" }` with no `content`, the resulting error is identical to a call where nothing was sent at all.
- **Missing detection / guardrail:** No test asserted the error message format beyond the parameter label and the retry suffix. The received-shape gap was never tested.
- **Why this regressed now:** This is a pre-existing diagnostic gap, not a regression; surfaced by #55224/#55287 which showed that parameter drops happen silently in long sessions and the error gives no useful signal.

## Regression Test Plan

- Coverage level: Unit test
- Target: `src/agents/pi-tools.params.test.ts` (new colocated test file)
- 4 test cases:
  1. Single key present, one missing → error includes `(received: file_path)`
  2. Multiple keys present, one missing → error includes all present keys
  3. Empty record → error has no `received:` hint (clean message)
  4. All required params present → no error thrown
- Why this is the smallest reliable guardrail: directly exercises `assertRequiredParams` without going through a full tool execution stack.

## User-visible / Behavior Changes

Write, edit, and read tool validation errors now include `(received: <keys>)` when at least one parameter was present. Example:

```
Before:
Missing required parameter: content. Supply correct parameters before retrying.

After:
Missing required parameter: content (received: file_path). Supply correct parameters before retrying.
```

## Diagram

```
Before:
AI sends { file_path: "a.txt" }  →  "Missing required parameter: content."
AI sends {}                       →  "Missing required parameter: content."
(indistinguishable in logs)

After:
AI sends { file_path: "a.txt" }  →  "Missing required parameter: content (received: file_path)."
AI sends {}                       →  "Missing required parameter: content."
(drop is now visible)
```

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No — error message text only; validation logic is unchanged
- Data access scope changed? No

## Repro + Verification

### Steps
1. In a long session, trigger a write tool call where `content` is dropped (see #55224 for reproduction)
2. Observe the tool error in logs

### Expected (after fix)
`Missing required parameter: content (received: file_path). Supply correct parameters before retrying.`

### Actual (before fix)
`Missing required parameter: content. Supply correct parameters before retrying.`

## Evidence
- [x] 4/4 new `src/agents/pi-tools.params.test.ts` tests pass
- [x] 26/26 existing `pi-tools.create-openclaw-coding-tools` tests pass (no regression)
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format:check` — clean

## Human Verification
- Verified scenarios: Traced `assertRequiredParams` call path from `wrapToolParamNormalization` through the write/edit/read tool wrappers; confirmed the hint only appears when keys are non-null.
- Edge cases checked: `null` values excluded from hint (record[k] !== null filter), empty record produces no hint, all params present never reaches the error branch.
- What I did **not** verify: Live reproduction of the parameter-drop bug in a long session (that requires specific session length conditions per #55224).

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Any code that pattern-matches on the exact error message text could break.
  - Mitigation: Searched the entire codebase — no code parses the `assertRequiredParams` error string. The existing tests use `/Missing required parameter/` regex, not exact string matches, and still pass.

> 🤖 AI-assisted (Claude Code / claude-sonnet-4-6) — fully tested, author reviewed every changed line.