### PR TITLE
fix(discord): suppress expected reconnect-exhausted shutdown errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify Codex accountId token extraction failures as auth errors so model fallback continues to the next configured candidate. (#55206) Thanks @cosmicnet.
 - Talk/macOS: stop direct system-voice failures from replaying system speech, use app-locale fallback for shared watchdog timing, and add regression coverage for the macOS fallback route and language-aware timeout policy. (#53511) thanks @hongsw.
 - Discord/gateway cleanup: keep late Carbon reconnect-exhausted errors suppressed through startup/dispose cleanup so Discord monitor shutdown no longer crashes on late gateway close events. (#55373) Thanks @Takhoffman.
+- Discord/gateway shutdown: treat expected reconnect-exhausted events during intentional lifecycle stop as clean shutdowns so startup-abort cleanup no longer surfaces false gateway failures. (#55324) Thanks @joelnishanth.
 
 ## 2026.3.24
 

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -801,6 +801,51 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("suppresses reconnect-exhausted as expected during intentional shutdown", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+    const abortController = new AbortController();
+
+    const emitter = new EventEmitter();
+    const gateway = {
+      isConnected: true,
+      options: { reconnect: { maxAttempts: 50 } },
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    // Start lifecycle; it yields at execApprovalsHandler.start(). We then
+    // queue a reconnect-exhausted event and abort. The lifecycle resumes,
+    // drains the event (with lifecycleStopping=true), and exits cleanly
+    // without reaching waitForDiscordGatewayStop.
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (0) reached after code 1005",
+      ),
+    );
+    abortController.abort();
+
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
+    );
+  });
+
   it("does not push connected: true when abortSignal is already aborted", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const emitter = new EventEmitter();

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -486,6 +486,15 @@ export async function runDiscordGatewayLifecycle(params: {
       );
       return "stop";
     }
+    // When we deliberately set maxAttempts=0 and disconnected (health-monitor
+    // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
+    // is expected — log at info instead of error to avoid false alarms.
+    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+      params.runtime.log?.(
+        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+      );
+      return "stop";
+    }
     params.runtime.error?.(danger(`discord gateway error: ${event.message}`));
     return event.shouldStopLifecycle ? "stop" : "continue";
   };
@@ -495,7 +504,13 @@ export async function runDiscordGatewayLifecycle(params: {
       if (decision !== "stop") {
         return "continue";
       }
-      if (event.type === "disallowed-intents") {
+      // Don't throw for expected shutdown events — intentional disconnect
+      // (reconnect-exhausted with maxAttempts=0) and disallowed-intents are
+      // both handled without crashing the provider.
+      if (
+        event.type === "disallowed-intents" ||
+        (lifecycleStopping && event.type === "reconnect-exhausted")
+      ) {
         return "stop";
       }
       throw event.err;

--- a/src/memory/search-manager.test.ts
+++ b/src/memory/search-manager.test.ts
@@ -102,7 +102,7 @@ vi.mock("../../extensions/memory-core/src/memory/qmd-manager.js", () => ({
   },
 }));
 
-vi.mock("./manager-runtime.js", () => ({
+vi.mock("../../extensions/memory-core/src/memory/manager-runtime.js", () => ({
   MemoryIndexManager: {
     get: mockMemoryIndexGet,
   },

--- a/src/memory/test-manager-helpers.ts
+++ b/src/memory/test-manager-helpers.ts
@@ -1,5 +1,5 @@
-import type { MemoryIndexManager } from "../../extensions/memory-core/src/memory/index.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type { MemoryIndexManager } from "../plugin-sdk/memory-core.js";
 
 export async function getRequiredMemoryIndexManager(params: {
   cfg: OpenClawConfig;
@@ -7,8 +7,7 @@ export async function getRequiredMemoryIndexManager(params: {
   purpose?: "default" | "status";
 }): Promise<MemoryIndexManager> {
   await import("./embedding.test-mocks.js");
-  const { getMemorySearchManager } =
-    await import("../../extensions/memory-core/src/memory/index.js");
+  const { getMemorySearchManager } = await import("../plugin-sdk/memory-core.js");
   const result = await getMemorySearchManager({
     cfg: params.cfg,
     agentId: params.agentId ?? "main",

--- a/src/memory/test-manager.ts
+++ b/src/memory/test-manager.ts
@@ -1,8 +1,6 @@
-import {
-  getMemorySearchManager,
-  type MemoryIndexManager,
-} from "../../extensions/memory-core/src/memory/index.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { getMemorySearchManager } from "../plugin-sdk/memory-core.js";
+import type { MemoryIndexManager } from "../plugin-sdk/memory-core.js";
 
 export async function createMemoryManagerOrThrow(
   cfg: OpenClawConfig,

--- a/src/plugin-sdk/channel-import-guardrails.test.ts
+++ b/src/plugin-sdk/channel-import-guardrails.test.ts
@@ -270,9 +270,11 @@ function collectCoreSourceFiles(): string[] {
   const normalizedPluginSdkDir = normalizePath(resolve(ROOT_DIR, "plugin-sdk"));
   coreSourceFilesCache = collectSourceFiles(coreSourceFilesCache, {
     rootDir: srcDir,
-    shouldSkipEntry: ({ normalizedFullPath }) =>
+    shouldSkipEntry: ({ entryName, normalizedFullPath }) =>
       normalizedFullPath.includes(".test.") ||
+      normalizedFullPath.includes(".test-harness.") ||
       normalizedFullPath.includes(".test-helpers.") ||
+      entryName === "test-manager-helpers.ts" ||
       normalizedFullPath.includes(".mock-harness.") ||
       normalizedFullPath.includes(".suite.") ||
       normalizedFullPath.includes(".spec.") ||

--- a/src/plugin-sdk/memory-core.ts
+++ b/src/plugin-sdk/memory-core.ts
@@ -14,7 +14,10 @@ export { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 export { loadConfig } from "../config/config.js";
 export { resolveStateDir } from "../config/paths.js";
 export { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
-export { getMemorySearchManager } from "../../extensions/memory-core/src/memory/index.js";
+export {
+  getMemorySearchManager,
+  MemoryIndexManager,
+} from "../../extensions/memory-core/src/memory/index.js";
 export { listMemoryFiles, normalizeExtraMemoryPaths } from "../memory/internal.js";
 export { readAgentMemoryFile } from "../memory/read-file.js";
 export { resolveMemoryBackendConfig } from "../memory/backend-config.js";


### PR DESCRIPTION
## Summary
- treat Discord `reconnect-exhausted` as expected during intentional lifecycle shutdown so startup-abort cleanup stops surfacing a false gateway failure
- keep the regression focused on the buffered pre-lifecycle window that `#55373` did not cover
- repair unrelated red tests on current `main` by fixing the moved memory search-manager mock seam and routing memory test helpers through the plugin-sdk bridge, plus exclude test harness files from the core-production guardrail scan

## Why this PR still matters after #55373
`#55373` already fixed the supervisor-side late-error handling in `gateway-supervisor.ts`, so that overlap was dropped from this branch.

The remaining bug is earlier: if the lifecycle is intentionally stopping before `waitForDiscordGatewayStop()` attaches the active lifecycle handler, Carbon can still buffer `reconnect-exhausted`, and `provider.lifecycle.ts` would log/rethrow it from `drainPendingGatewayErrors()` even though shutdown was deliberate.

## Changes
- `extensions/discord/src/monitor/provider.lifecycle.ts`
  - log buffered `reconnect-exhausted` at info level during intentional shutdown
  - return cleanly instead of rethrowing the expected shutdown event
- `extensions/discord/src/monitor/provider.lifecycle.test.ts`
  - add a regression covering the startup-abort / buffered-event window
- `src/memory/search-manager.test.ts`
  - point the runtime mock at the moved `extensions/memory-core` seam again
- `src/memory/test-manager.ts`
- `src/memory/test-manager-helpers.ts`
- `src/plugin-sdk/memory-core.ts`
  - use the plugin-sdk bridge for memory test helpers instead of direct extension private-src imports
- `src/plugin-sdk/channel-import-guardrails.test.ts`
  - skip test-only harness/helper files when enforcing the core-production import guardrail

## Testing
- `pnpm check`
- `pnpm build`
- `pnpm test`
