### PR TITLE
chore: remove stale README-header.png packlist entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "CHANGELOG.md",
     "LICENSE",
     "openclaw.mjs",
-    "README-header.png",
     "README.md",
     "assets/",
     "dist/",


### PR DESCRIPTION
## Summary

- Problem: root `package.json` includes `README-header.png` in `files`, but that file is not present in the repository
- Why it matters: the entry is inert, but misleading for packaging and maintenance
- What changed: removed the stale `README-header.png` entry from the root `files` array
- What did NOT change (scope boundary): no runtime behavior, build logic, docs content, or published functionality changed

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: a stale file reference remained in the package manifest after the asset was removed or renamed
- Missing detection / guardrail: there does not appear to be a guard validating that each root `files` entry exists
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown
- Why this regressed now: N/A
- If unknown, what was ruled out: this is not tied to runtime behavior or a packaging failure in CI

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: this is a non-functional manifest cleanup
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: no behavior changed; this only removes an inert reference to a non-existent file

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

```text
Before:
[npm package manifest] -> [stale README-header.png entry]

After:
[npm package manifest] -> [entry removed] -> [manifest matches repository contents]