### PR TITLE
feat(whatsapp): add systemPrompt support for accounts and groups 

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -36638,6 +36638,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.accounts.*.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.accounts.*.groups.*.tools",
       "kind": "channel",
       "type": "object",
@@ -36936,6 +36946,16 @@
       "path": "channels.whatsapp.accounts.*.sendReadReceipts",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.accounts.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,
@@ -37335,6 +37355,16 @@
       "hasChildren": false
     },
     {
+      "path": "channels.whatsapp.groups.*.systemPrompt",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.whatsapp.groups.*.tools",
       "kind": "channel",
       "type": "object",
@@ -37629,6 +37659,16 @@
       "path": "channels.whatsapp.sendReadReceipts",
       "kind": "channel",
       "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.whatsapp.systemPrompt",
+      "kind": "channel",
+      "type": "string",
       "required": false,
       "deprecated": false,
       "sensitive": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5645}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5649}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3306,6 +3306,7 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3336,6 +3337,7 @@
 {"recordType":"path","path":"channels.whatsapp.accounts.*.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.selfChatMode","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.sendReadReceipts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.accounts.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.accounts.*.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.ackReaction","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.ackReaction.direct","kind":"channel","type":"boolean","required":true,"defaultValue":true,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3371,6 +3373,7 @@
 {"recordType":"path","path":"channels.whatsapp.groups","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.requireMention","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.groups.*.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools.allow","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.whatsapp.groups.*.tools.allow.*","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -3400,6 +3403,7 @@
 {"recordType":"path","path":"channels.whatsapp.responsePrefix","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.selfChatMode","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"WhatsApp Self-Phone Mode","help":"Same-phone setup (bot uses your personal WhatsApp number).","hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.sendReadReceipts","kind":"channel","type":"boolean","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.whatsapp.systemPrompt","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.whatsapp.textChunkLimit","kind":"channel","type":"integer","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.zalo","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["channels","network"],"label":"Zalo","help":"Vietnam-focused messaging platform with Bot API.","hasChildren":true}
 {"recordType":"path","path":"channels.zalo.accounts","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -378,6 +378,45 @@ The agent system prompt includes a group intro on the first turn of a new group 
 - List chats: `imsg chats --limit 20`.
 - Group replies always go back to the same `chat_id`.
 
+## WhatsApp system prompts for groups
+
+WhatsApp supports per-account and per-group system prompts. For group messages, the final prompt delivered to the agent is the account prompt and group prompt joined with a blank line (either part is omitted if not set).
+
+Resolution hierarchy:
+
+1. **Account system prompt** (`channels.whatsapp.systemPrompt` or `accounts.<id>.systemPrompt`): the root value applies to all accounts; an account-level value overrides it for that account.
+2. **Group system prompt** (`groups["<groupId>"].systemPrompt` or `groups["*"].systemPrompt`): the specific group entry is used if it defines a `systemPrompt`; falls back to `groups["*"].systemPrompt` for groups with no specific entry. Account `groups` fully overrides root `groups` (same override semantics as Telegram). This means root `groups["*"]` applies automatically when an account defines no `groups` of its own, but is replaced entirely once an account defines any `groups` entry.
+
+Example:
+
+```json5
+{
+  channels: {
+    whatsapp: {
+      systemPrompt: "Respond in English only.",
+      groups: {
+        // Applies to all accounts that do not define their own groups map.
+        "*": { systemPrompt: "Default prompt for all groups." },
+      },
+      accounts: {
+        work: {
+          systemPrompt: "You are a work assistant.",
+          groups: {
+            // This account defines its own groups, so root groups are fully
+            // replaced. To keep a wildcard, define "*" explicitly here too.
+            "120363406415684625@g.us": {
+              requireMention: false,
+              systemPrompt: "Focus on project management.",
+            },
+            "*": { systemPrompt: "Default prompt for work groups." },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
 ## WhatsApp specifics
 
 See [Group messages](/channels/group-messages) for WhatsApp-only behavior (history injection, mention handling details).

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -71,4 +71,33 @@ describe("resolveWhatsAppAuthDir", () => {
     expect(resolved.messagePrefix).toBe("[root]");
     expect(resolved.debounceMs).toBe(250);
   });
+
+  it("account groups override root groups (no deep merge)", () => {
+    // An account setting groups: {} or a subset must fully override root.groups
+    // so that routing/gating and prompt surfaces see a consistent picture.
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            groups: {
+              "*": { systemPrompt: "Root wildcard prompt" },
+              "120363406415684625@g.us": { requireMention: true },
+            },
+            accounts: {
+              work: {
+                groups: {
+                  "120363406415684625@g.us": { requireMention: false },
+                },
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    // Account groups replace root groups entirely — root "*" must not bleed in.
+    expect(resolved.groups?.["*"]).toBeUndefined();
+    expect(resolved.groups?.["120363406415684625@g.us"]).toEqual({ requireMention: false });
+  });
 });

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -34,6 +34,7 @@ export type ResolvedWhatsAppAccount = {
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   groups?: WhatsAppAccountConfig["groups"];
   debounceMs?: number;
+  systemPrompt?: string;
 };
 
 export const DEFAULT_WHATSAPP_MEDIA_MAX_MB = 50;
@@ -156,6 +157,7 @@ export function resolveWhatsAppAccount(params: {
     ackReaction: merged.ackReaction,
     groups: merged.groups,
     debounceMs: merged.debounceMs,
+    systemPrompt: merged.systemPrompt,
   };
 }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -32,6 +32,7 @@ import {
   resolveDmGroupAccessWithCommandGate,
 } from "openclaw/plugin-sdk/security-runtime";
 import { jidToE164, normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
+import { resolveWhatsAppGroupSystemPrompt } from "openclaw/plugin-sdk/whatsapp-shared";
 import { resolveWhatsAppAccount } from "../../accounts.js";
 import {
   getPrimaryIdentityId,
@@ -306,6 +307,16 @@ export async function processMessage(params: {
         )
       : undefined;
 
+  const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.route.accountId });
+  // Resolve combined system prompt (account-level + group-level if applicable)
+  const groupSystemPrompt =
+    params.msg.chatType === "group"
+      ? resolveWhatsAppGroupSystemPrompt({
+          accountConfig: account,
+          groupId: conversationId,
+        })
+      : undefined;
+
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     BodyForAgent: params.msg.body,
@@ -336,6 +347,7 @@ export async function processMessage(params: {
     SenderE164: sender.e164 ?? undefined,
     CommandAuthorized: commandAuthorized,
     WasMentioned: params.msg.wasMentioned,
+    GroupSystemPrompt: groupSystemPrompt,
     ...(params.msg.location ? toLocationContext(params.msg.location) : {}),
     Provider: "whatsapp",
     Surface: "whatsapp",

--- a/src/channels/plugins/whatsapp-shared.test.ts
+++ b/src/channels/plugins/whatsapp-shared.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import { resolveWhatsAppGroupSystemPrompt } from "./whatsapp-shared.js";
+
+describe("resolveWhatsAppGroupSystemPrompt", () => {
+  it("returns undefined when no systemPrompt is configured", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {},
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns account-level systemPrompt when only account systemPrompt is set", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: { systemPrompt: "You are a helpful assistant for this WhatsApp account." },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are a helpful assistant for this WhatsApp account.");
+  });
+
+  it("returns account-level systemPrompt from specific account config", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: { systemPrompt: "You are my personal assistant." },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are my personal assistant.");
+  });
+
+  it("returns group-level systemPrompt when only group systemPrompt is set", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        groups: { "123@g.us": { systemPrompt: "You are helping with group discussions." } },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helping with group discussions.");
+  });
+
+  it("combines account and group systemPrompts with double newlines", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are a helpful assistant for this WhatsApp account.",
+        groups: {
+          "123@g.us": { systemPrompt: "This is a work group, keep responses professional." },
+        },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe(
+      "You are a helpful assistant for this WhatsApp account.\n\nThis is a work group, keep responses professional.",
+    );
+  });
+
+  it("combines account-specific and group systemPrompts", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are a work assistant.",
+        groups: { "456@g.us": { systemPrompt: "Focus on project management topics." } },
+      },
+      groupId: "456@g.us",
+    });
+
+    expect(result).toBe("You are a work assistant.\n\nFocus on project management topics.");
+  });
+
+  it("trims whitespace from systemPrompts", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "  You are helpful  ",
+        groups: { "123@g.us": { systemPrompt: "  Keep it brief  " } },
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helpful\n\nKeep it brief");
+  });
+
+  it("ignores empty systemPrompts after trimming", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are helpful",
+        groups: { "123@g.us": { systemPrompt: "   " } }, // Only whitespace
+      },
+      groupId: "123@g.us",
+    });
+
+    expect(result).toBe("You are helpful");
+  });
+
+  it("returns account-level systemPrompt when groupId is not provided", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are helpful",
+        groups: { "123@g.us": { systemPrompt: "Group specific prompt" } },
+      },
+      groupId: undefined,
+    });
+
+    expect(result).toBe("You are helpful");
+  });
+
+  it("returns account systemPrompt when group doesn't exist", () => {
+    const result = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "You are helpful",
+        groups: { "123@g.us": { systemPrompt: "Group specific prompt" } },
+      },
+      groupId: "999@g.us", // Non-existent group
+    });
+
+    expect(result).toBe("You are helpful");
+  });
+
+  it("handles pre-resolved account configs with group entries", () => {
+    // Account with its own systemPrompt (as resolved by the caller)
+    const personalResult = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "Personal assistant",
+        groups: { "123@g.us": { systemPrompt: "Family group" } },
+      },
+      groupId: "123@g.us",
+    });
+    expect(personalResult).toBe("Personal assistant\n\nFamily group");
+
+    // Account with systemPrompt inherited from root (already resolved by caller)
+    const workResult = resolveWhatsAppGroupSystemPrompt({
+      accountConfig: {
+        systemPrompt: "Root assistant",
+        groups: { "456@g.us": { systemPrompt: "Work group" } },
+      },
+      groupId: "456@g.us",
+    });
+    expect(workResult).toBe("Root assistant\n\nWork group");
+  });
+
+  it("falls back to wildcard '*' group when specific group is not configured", () => {
+    const accountConfig = {
+      systemPrompt: "Root prompt",
+      groups: {
+        "*": { systemPrompt: "Default group prompt" },
+        "123@g.us": { systemPrompt: "Specific group prompt" },
+      },
+    };
+
+    // Specific group config takes precedence
+    expect(resolveWhatsAppGroupSystemPrompt({ accountConfig, groupId: "123@g.us" })).toBe(
+      "Root prompt\n\nSpecific group prompt",
+    );
+
+    // Unknown group falls back to "*"
+    expect(resolveWhatsAppGroupSystemPrompt({ accountConfig, groupId: "999@g.us" })).toBe(
+      "Root prompt\n\nDefault group prompt",
+    );
+  });
+
+  it("falls back to wildcard '*' in account-level groups", () => {
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        accountConfig: {
+          systemPrompt: "Work assistant",
+          groups: { "*": { systemPrompt: "Default work group prompt" } },
+        },
+        groupId: "456@g.us",
+      }),
+    ).toBe("Work assistant\n\nDefault work group prompt");
+  });
+
+  it("uses wildcard systemPrompt when specific group entry has no systemPrompt", () => {
+    // Should still get wildcard's systemPrompt even though group entry exists
+    expect(
+      resolveWhatsAppGroupSystemPrompt({
+        accountConfig: {
+          systemPrompt: "Root prompt",
+          groups: {
+            "*": { systemPrompt: "Default group prompt" },
+            "123@g.us": {}, // Group entry exists but only sets non-prompt fields (e.g. requireMention)
+          },
+        },
+        groupId: "123@g.us",
+      }),
+    ).toBe("Root prompt\n\nDefault group prompt");
+  });
+});

--- a/src/channels/plugins/whatsapp-shared.ts
+++ b/src/channels/plugins/whatsapp-shared.ts
@@ -7,6 +7,68 @@ import type { ChannelOutboundAdapter } from "./types.js";
 export const WHATSAPP_GROUP_INTRO_HINT =
   "WhatsApp IDs: SenderId is the participant JID (group participant id).";
 
+export type WhatsAppGroupSystemPromptParams = {
+  /** Pre-resolved merged account config (systemPrompt + groups). Mirrors Telegram's groupConfig param style. */
+  accountConfig?: {
+    systemPrompt?: string;
+    groups?: Record<string, { systemPrompt?: string }>;
+  } | null;
+  groupId?: string | null;
+};
+
+/**
+ * Resolves and combines WhatsApp system prompts from a pre-resolved account config slice.
+ * Follows the same pattern as Telegram's resolveTelegramGroupPromptSettings: the caller
+ * resolves the account config first, then passes the relevant slice here.
+ *
+ * Resolution hierarchy for group messages:
+ *
+ * 1. Account system prompt (channels.whatsapp.systemPrompt or
+ *    accounts.<id>.systemPrompt):
+ *    - Root value applies to all accounts.
+ *    - Account-level value overrides root for that account.
+ *
+ * 2. Group system prompt (groups["<groupId>"].systemPrompt or
+ *    groups["*"].systemPrompt):
+ *    - The specific group entry is used if it defines a systemPrompt.
+ *    - Falls back to groups["*"].systemPrompt for groups with no specific entry.
+ *    - resolveWhatsAppAccount uses the same override semantics as the shared
+ *      resolveChannelGroups helper: account groups replace root groups entirely
+ *      (no deep merge). The resolved account config therefore already contains
+ *      root groups (including "*") whenever the account defines no groups of its
+ *      own, mirroring Telegram's resolveTelegramGroupPromptSettings pattern.
+ *
+ * 3. Final prompt delivered to the agent for group messages:
+ *    accountSystemPrompt + "\n\n" + groupSystemPrompt
+ *    (either part is omitted if not configured)
+ */
+export function resolveWhatsAppGroupSystemPrompt(
+  params: WhatsAppGroupSystemPromptParams,
+): string | undefined {
+  const accountSystemPrompt = params.accountConfig?.systemPrompt?.trim() || undefined;
+
+  // Get group-level systemPrompt if groupId is provided.
+  // Resolve per-field: use the specific group's systemPrompt if set, otherwise
+  // fall back to the wildcard "*" entry so default prompts still apply even when
+  // the specific group entry only defines non-prompt settings (e.g. requireMention).
+  let groupSystemPrompt: string | undefined;
+  if (params.groupId) {
+    const groups = params.accountConfig?.groups;
+    // Resolution order: specific group entry → wildcard "*" entry.
+    // Root groups naturally reach here when the account defines no groups of its
+    // own (resolveWhatsAppAccount uses override-not-merge semantics, same as
+    // resolveChannelGroups: accountGroups ?? rootGroups).
+    groupSystemPrompt =
+      groups?.[params.groupId]?.systemPrompt?.trim() ||
+      groups?.["*"]?.systemPrompt?.trim() ||
+      undefined;
+  }
+
+  // Combine prompts following Telegram's pattern
+  const systemPrompts = [accountSystemPrompt, groupSystemPrompt].filter(Boolean);
+  return systemPrompts.length > 0 ? systemPrompts.join("\n\n") : undefined;
+}
+
 export function resolveWhatsAppGroupIntroHint(): string {
   return WHATSAPP_GROUP_INTRO_HINT;
 }

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -21,6 +21,8 @@ export type WhatsAppGroupConfig = {
   requireMention?: boolean;
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
+  /** Optional system prompt for this group. */
+  systemPrompt?: string;
 };
 
 export type WhatsAppAckReactionConfig = {
@@ -108,6 +110,8 @@ export type WhatsAppConfig = WhatsAppConfigCore &
     defaultAccount?: string;
     /** Per-action tool gating (default: true for all). */
     actions?: WhatsAppActionConfig;
+    /** Optional system prompt for all accounts (global default). */
+    systemPrompt?: string;
   };
 
 export type WhatsAppAccountConfig = WhatsAppConfigCore &
@@ -118,4 +122,6 @@ export type WhatsAppAccountConfig = WhatsAppConfigCore &
     enabled?: boolean;
     /** Override auth directory (Baileys multi-file auth state). */
     authDir?: string;
+    /** Optional system prompt for this account (global for all groups). */
+    systemPrompt?: string;
   };

--- a/src/config/zod-schema.providers-whatsapp.test.ts
+++ b/src/config/zod-schema.providers-whatsapp.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { WhatsAppConfigSchema, WhatsAppAccountSchema } from "./zod-schema.providers-whatsapp.js";
+
+describe("WhatsApp systemPrompt Zod validation", () => {
+  it("validates root-level systemPrompt", () => {
+    const config = {
+      systemPrompt: "You are a helpful assistant",
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.systemPrompt).toBe("You are a helpful assistant");
+    }
+  });
+
+  it("validates account-level systemPrompt", () => {
+    const config = {
+      accounts: {
+        personal: {
+          systemPrompt: "You are my personal assistant",
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.accounts?.personal?.systemPrompt).toBe("You are my personal assistant");
+    }
+  });
+
+  it("validates group-level systemPrompt", () => {
+    const config = {
+      groups: {
+        "123@g.us": {
+          systemPrompt: "This is a work group",
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.groups?.["123@g.us"]?.systemPrompt).toBe("This is a work group");
+    }
+  });
+
+  it("validates combined account and group systemPrompts", () => {
+    const config = {
+      systemPrompt: "Global assistant",
+      accounts: {
+        work: {
+          systemPrompt: "Work assistant",
+          groups: {
+            "456@g.us": {
+              systemPrompt: "Project team",
+            },
+          },
+        },
+      },
+    };
+
+    const result = WhatsAppConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.systemPrompt).toBe("Global assistant");
+      expect(result.data.accounts?.work?.systemPrompt).toBe("Work assistant");
+      expect(result.data.accounts?.work?.groups?.["456@g.us"]?.systemPrompt).toBe("Project team");
+    }
+  });
+
+  it("validates WhatsAppAccountSchema directly", () => {
+    const accountConfig = {
+      name: "Personal Account",
+      systemPrompt: "You are my personal WhatsApp assistant",
+      groups: {
+        "family@g.us": {
+          systemPrompt: "Keep responses family-friendly",
+        },
+      },
+    };
+
+    const result = WhatsAppAccountSchema.safeParse(accountConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.systemPrompt).toBe("You are my personal WhatsApp assistant");
+      expect(result.data.groups?.["family@g.us"]?.systemPrompt).toBe(
+        "Keep responses family-friendly",
+      );
+    }
+  });
+});

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -19,6 +19,7 @@ const WhatsAppGroupEntrySchema = z
     requireMention: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
+    systemPrompt: z.string().optional(),
   })
   .strict()
   .optional();
@@ -60,6 +61,7 @@ const WhatsAppSharedSchema = z.object({
   debounceMs: z.number().int().nonnegative().optional().default(0),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   healthMonitor: ChannelHealthMonitorSchema,
+  systemPrompt: z.string().optional(),
 });
 
 function enforceOpenDmPolicyAllowFromStar(params: {

--- a/src/plugin-sdk/whatsapp-shared.ts
+++ b/src/plugin-sdk/whatsapp-shared.ts
@@ -3,8 +3,10 @@ export type { DmPolicy, GroupPolicy, WhatsAppAccountConfig } from "../config/typ
 export {
   createWhatsAppOutboundBase,
   resolveWhatsAppGroupIntroHint,
+  resolveWhatsAppGroupSystemPrompt,
   resolveWhatsAppMentionStripRegexes,
 } from "../channels/plugins/whatsapp-shared.js";
+export type { WhatsAppGroupSystemPromptParams } from "../channels/plugins/whatsapp-shared.js";
 export {
   looksLikeWhatsAppTargetId,
   normalizeWhatsAppAllowFromEntries,


### PR DESCRIPTION
## Summary

Feature: Extends WhatsApp systemPrompt support from root to account and group levels, enabling fine-grained prompt customization for group conversations.

- Problem: WhatsApp group chats could not apply channel-configured `systemPrompt` instructions at the account or group level.
- Why it matters: users could not tailor WhatsApp group reply behavior per account or per group, including wildcard defaults for groups without their own prompt.
- What changed: added WhatsApp `systemPrompt` support to config types/schema, merged account resolution, group prompt composition, tests, and docs.
- What did NOT change (scope boundary): no changes to non-WhatsApp channels, no change to WhatsApp config hot-reload behavior, and no change to group allowlist or mention-gating semantics.

Github copilot used.

### Resolution hierarchy:

1. **Account system prompt** (`channels.whatsapp.systemPrompt` or `accounts.<id>.systemPrompt`): the root value applies to all accounts; an account-level value overrides it for that account.
2. **Group system prompt** (`groups["<groupId>"].systemPrompt` or `groups["*"].systemPrompt`): the specific group entry is used if it defines a `systemPrompt`; falls back to `groups["*"].systemPrompt` for groups with no specific entry. Account `groups` fully overrides root `groups` (same override semantics as Telegram). This means root `groups["*"]` applies automatically when an account defines no `groups` of its own, but is replaced entirely once an account defines any `groups` entry.

Example:

```json5
{
  channels: {
    whatsapp: {
      systemPrompt: "Respond in English only.",
      groups: {
        // Applies to all accounts that do not define their own groups map.
        "*": { systemPrompt: "Default prompt for all groups." },
      },
      accounts: {
        work: {
          systemPrompt: "You are a work assistant.",
          groups: {
            // This account defines its own groups, so root groups are fully
            // replaced. To keep a wildcard, define "*" explicitly here too.
            "120363406415684625@g.us": {
              requireMention: false,
              systemPrompt: "Focus on project management.",
            },
            "*": { systemPrompt: "Default prompt for work groups." },
          },
        },
      },
    },
  },
}
```

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
Addresses [#7011](https://github.com/openclaw/openclaw/issues/7011) (WhatsApp group prompt enhancement)

- Related #
I'm submitting this PR as a more focused PR instead of my previous PR [#40250](https://github.com/openclaw/openclaw/pull/40250)(WhatsApp: Add account/group systemPrompt hierarchy & fix group policy gating) which I'll subsequently close.

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- WhatsApp now supports `systemPrompt` at:
  - `channels.whatsapp.systemPrompt`
  - `channels.whatsapp.accounts.<id>.systemPrompt`
  - `channels.whatsapp.groups.<groupId>.systemPrompt`
  - `channels.whatsapp.accounts.<id>.groups.<groupId>.systemPrompt`
- For WhatsApp group messages, the final injected prompt is the account prompt plus the resolved group prompt joined with a blank line.
- Group prompt resolution prefers the specific group entry, then wildcard `"*"` within the active groups map.
- Account `groups` override root `groups`; they do not merge.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local gateway via `pnpm openclaw --dev gateway run --bind loopback --port 19001 --force`
- Model/provider: `google/gemini-3.1-pro-preview`
- Integration/channel: WhatsApp group chat
- Relevant config detailed in tests below

## Human Verification (required)

### Steps

1. Prepare configuration for test
2. Restart gateway (dev)
3. Send Hello or \new to group
4. Check response correctly combines instructions from system prompts

### Test 1: Account Prompt + Specific Group Prompt
config:
```
    "whatsapp": {
      "enabled": true,
      "groupPolicy": "allowlist",
      "systemPrompt": "Add ROOT at the beginning of every response.",
      "groups": {
        "*": { "systemPrompt": "Add GHH at the end of every response." }
      },
      "accounts": {
        "test": {
          "systemPrompt": "Add AHH in the beginning of every response.",
          "allowFrom": [
            "+9725xxxxxxxx",
            "+9728yyyyyyyy"
          ],
          "groupPolicy": "allowlist",
          "groups": {
            "120363406415684625@g.us": {
              "requireMention": false,
              "systemPrompt": "Write in uppercase only."
            },
            "*": { "systemPrompt": "Add +++++ at the middle of every response." }
          },
          "name": "Test Account"
        }
      }
    }
```

#### Expected

- account systemPrompt overrides root's, and combined with specific group system prompt

#### Actual

- as expected;  AHH added as prefix, message is all caps.

#### Evidence

> AHH HELLO THERE! I AM READY TO HELP. WHAT WOULD YOU LIKE TO DO TODAY?

### Test 2: Root Prompt Fallback When Account Prompt Removed
config:
```
    "whatsapp": {
      "enabled": true,
      "groupPolicy": "allowlist",
      "systemPrompt": "Add ROOT at the beginning of every response.",
      "groups": {
        "*": { "systemPrompt": "Add GHH at the end of every response." }
      },
      "accounts": {
        "test": {
          "allowFrom": [
            "+9725xxxxxxxx",
            "+9728yyyyyyyy"
          ],
          "groupPolicy": "allowlist",
          "groups": {
            "120363406415684625@g.us": {
              "requireMention": false,
              "systemPrompt": "Write in uppercase only."
            },
            "*": { "systemPrompt": "Add +++++ at the middle of every response." }
          },
          "name": "Test Account"
        }
      }
    }
```

#### Expected

- root systemPrompt combined with specific group system prompt

#### Actual

- as expected;  ROOT added as prefix, message is all caps.

#### Evidence

> ROOT HELLO RON! HOW CAN I HELP YOU TODAY?

### Test 3: Account Wildcard Group Prompt Fallback
config:
```
    "whatsapp": {
      "enabled": true,
      "groupPolicy": "allowlist",
      "systemPrompt": "Add ROOT at the beginning of every response.",
      "groups": {
        "*": { "systemPrompt": "Add GHH at the end of every response." }
      },
      "accounts": {
        "test": {
          "allowFrom": [
            "+9725xxxxxxxx",
            "+9728yyyyyyyy"
          ],
          "groupPolicy": "allowlist",
          "groups": {
            "120363406415684625@g.us": {
              "requireMention": false,
            },
            "*": { "systemPrompt": "Add +++++ at the middle of every response." }
          },
          "name": "Test Account"
        }
      }
    }
```

#### Expected

- root systemPrompt combined with wildcard group system prompt

#### Actual

- as expected;  ROOT added as prefix, '+++++' added in middle.

#### Evidence

> ROOT Hello everyone, I'm ready to help out! +++++ What would you like to do today?

### Test 4: Account Groups Replace Root Groups
config
```
    "whatsapp": {
      "enabled": true,
      "groupPolicy": "allowlist",
      "systemPrompt": "Add ROOT at the beginning of every response.",
      "groups": {
        "*": { "systemPrompt": "Add GHH at the end of every response.",
        "requireMention": false 
        }
      },
      "accounts": {
        "test": {
          "systemPrompt": "Add AHH in the beginning of every response.",
          "allowFrom": [
            "+9725xxxxxxxx",
            "+9728yyyyyyyy"
          ],
          "name": "Test Account"
        }
      }
    }
```

#### Expected

- account systemPrompt combined with wildcard group system prompt

#### Actual

- as expected;  AHH added as prefix, GHH as suffix

#### Evidence

> AHH Hello Ron! How can I help you today? GHH


### Test screenshot:

<img width="1281" height="709" alt="Screenshot 2026-03-26 at 19 52 04" src="https://github.com/user-attachments/assets/a0cdbfb0-125c-4702-b689-dd21d42b00ef" />



What you personally verified (not just CI), and how:

- Verified scenarios:
  - root vs account prompt precedence
  - specific-group vs wildcard group precedence
  - account-group override vs root-group fallback
- Edge cases checked:
  - specific group entry without `systemPrompt`
  - wildcard fallback
  - account `groups` map suppressing root `groups`
- What you did **not** verify:
  - no change to WhatsApp config hot-reload behavior; restart requirement was observed during local manual testing only


## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

None
