### PR TITLE
agents: add per-agent MCP server configuration

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -48,6 +48,7 @@ type ResolvedAgentConfig = {
   subagents?: AgentEntry["subagents"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
+  mcpServers?: AgentEntry["mcpServers"];
 };
 
 let defaultAgentWarned = false;
@@ -153,6 +154,7 @@ export function resolveAgentConfig(
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,
+    mcpServers: entry.mcpServers,
   };
 }
 

--- a/src/agents/embedded-pi-mcp.test.ts
+++ b/src/agents/embedded-pi-mcp.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { normalizeConfiguredMcpServers } from "../config/mcp-config.js";
+
+/**
+ * Tests the per-agent MCP allowlist filtering logic.
+ *
+ * The logic in loadEmbeddedPiMcpConfig is:
+ *   1. Merge bundle + global servers (same as before).
+ *   2. If agentMcpServers is set and does NOT contain "*",
+ *      filter to only keep servers whose names are in the list.
+ */
+
+function applyAllowlistFilter(
+  allServers: Record<string, Record<string, unknown>>,
+  allowlist: string[] | undefined,
+): Record<string, unknown> {
+  if (!allowlist || allowlist.length === 0 || allowlist.includes("*")) {
+    return { ...allServers };
+  }
+  const allowSet = new Set(allowlist);
+  return Object.fromEntries(Object.entries(allServers).filter(([name]) => allowSet.has(name)));
+}
+
+describe("per-agent MCP allowlist filtering", () => {
+  const allServers = {
+    filesystem: { command: "npx", args: ["@mcp/server-filesystem"] },
+    "brave-search": { command: "npx", args: ["@mcp/server-brave-search"] },
+    github: { command: "npx", args: ["@mcp/server-github"] },
+  };
+
+  it("no allowlist (undefined) → all servers pass through", () => {
+    const result = applyAllowlistFilter(allServers, undefined);
+    expect(Object.keys(result).toSorted()).toEqual(["brave-search", "filesystem", "github"]);
+  });
+
+  it('["*"] allowlist → all servers pass through', () => {
+    const result = applyAllowlistFilter(allServers, ["*"]);
+    expect(Object.keys(result).toSorted()).toEqual(["brave-search", "filesystem", "github"]);
+  });
+
+  it("empty allowlist → all servers pass through", () => {
+    const result = applyAllowlistFilter(allServers, []);
+    expect(Object.keys(result).toSorted()).toEqual(["brave-search", "filesystem", "github"]);
+  });
+
+  it("specific allowlist → only listed servers remain", () => {
+    const result = applyAllowlistFilter(allServers, ["filesystem", "github"]);
+    expect(Object.keys(result).toSorted()).toEqual(["filesystem", "github"]);
+  });
+
+  it("single-server allowlist → only that server remains", () => {
+    const result = applyAllowlistFilter(allServers, ["brave-search"]);
+    expect(Object.keys(result)).toEqual(["brave-search"]);
+  });
+
+  it("allowlist with unknown names → silently ignored", () => {
+    const result = applyAllowlistFilter(allServers, ["filesystem", "nonexistent"]);
+    expect(Object.keys(result)).toEqual(["filesystem"]);
+  });
+});
+
+describe("normalizeConfiguredMcpServers passthrough", () => {
+  it("returns empty record for undefined input", () => {
+    expect(normalizeConfiguredMcpServers(undefined)).toEqual({});
+  });
+
+  it("passes through valid server records", () => {
+    const servers = {
+      test: { command: "echo", args: ["hello"] },
+    };
+    const result = normalizeConfiguredMcpServers(servers);
+    expect(result).toHaveProperty("test");
+  });
+});

--- a/src/agents/embedded-pi-mcp.ts
+++ b/src/agents/embedded-pi-mcp.ts
@@ -11,6 +11,8 @@ export type EmbeddedPiMcpConfig = {
 export function loadEmbeddedPiMcpConfig(params: {
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  /** Agent-level MCP server allowlist. undefined or ["*"] = all; specific names = filter. */
+  agentMcpServers?: string[];
 }): EmbeddedPiMcpConfig {
   const bundleMcp = loadEnabledBundleMcpConfig({
     workspaceDir: params.workspaceDir,
@@ -18,12 +20,23 @@ export function loadEmbeddedPiMcpConfig(params: {
   });
   const configuredMcp = normalizeConfiguredMcpServers(params.cfg?.mcp?.servers);
 
+  // Merge bundle + global servers (global overrides bundle defaults).
+  let mcpServers: Record<string, BundleMcpServerConfig> = {
+    ...bundleMcp.config.mcpServers,
+    ...configuredMcp,
+  };
+
+  // Apply agent allowlist filter when a specific list is provided.
+  const allowlist = params.agentMcpServers;
+  if (allowlist && allowlist.length > 0 && !allowlist.includes("*")) {
+    const allowSet = new Set(allowlist);
+    mcpServers = Object.fromEntries(
+      Object.entries(mcpServers).filter(([name]) => allowSet.has(name)),
+    );
+  }
+
   return {
-    // OpenClaw config is the owner-managed layer, so it overrides bundle defaults.
-    mcpServers: {
-      ...bundleMcp.config.mcpServers,
-      ...configuredMcp,
-    },
+    mcpServers,
     diagnostics: bundleMcp.diagnostics,
   };
 }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -974,6 +974,7 @@ export async function compactEmbeddedPiSessionDirect(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
+        agentId: sessionAgentId,
       });
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2120,6 +2120,7 @@ export async function runEmbeddedAttempt(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
+        agentId: sessionAgentId,
       });
       applyPiAutoCompactionGuard({
         settingsManager,

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -9,6 +9,7 @@ import type { BundleMcpServerConfig } from "../plugins/bundle-mcp.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "../plugins/config-state.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { isRecord } from "../utils.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { loadEmbeddedPiMcpConfig } from "./embedded-pi-mcp.js";
 import { applyPiCompactionSettingsFromConfig } from "./pi-settings.js";
 
@@ -66,9 +67,25 @@ function loadBundleSettingsFile(params: {
   }
 }
 
+/**
+ * Resolves the per-agent MCP server allowlist from config, if an agentId is provided.
+ * Returns undefined (= all servers) or a string[] allowlist.
+ */
+function resolveAgentMcpServers(
+  cfg: OpenClawConfig | undefined,
+  agentId: string | undefined,
+): string[] | undefined {
+  if (!cfg || !agentId) {
+    return undefined;
+  }
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  return agentConfig?.mcpServers;
+}
+
 export function loadEnabledBundlePiSettingsSnapshot(params: {
   cwd: string;
   cfg?: OpenClawConfig;
+  agentMcpServers?: string[];
 }): PiSettingsSnapshot {
   const workspaceDir = params.cwd.trim();
   if (!workspaceDir) {
@@ -114,6 +131,7 @@ export function loadEnabledBundlePiSettingsSnapshot(params: {
   const embeddedPiMcp = loadEmbeddedPiMcpConfig({
     workspaceDir,
     cfg: params.cfg,
+    agentMcpServers: params.agentMcpServers,
   });
   for (const diagnostic of embeddedPiMcp.diagnostics) {
     log.warn(`bundle MCP skipped for ${diagnostic.pluginId}: ${diagnostic.message}`);
@@ -160,12 +178,14 @@ export function createEmbeddedPiSettingsManager(params: {
   cwd: string;
   agentDir: string;
   cfg?: OpenClawConfig;
+  agentMcpServers?: string[];
 }): SettingsManager {
   const fileSettingsManager = SettingsManager.create(params.cwd, params.agentDir);
   const policy = resolveEmbeddedPiProjectSettingsPolicy(params.cfg);
   const pluginSettings = loadEnabledBundlePiSettingsSnapshot({
     cwd: params.cwd,
     cfg: params.cfg,
+    agentMcpServers: params.agentMcpServers,
   });
   const hasPluginSettings = Object.keys(pluginSettings).length > 0;
   if (policy === "trusted" && !hasPluginSettings) {
@@ -184,8 +204,15 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
   cwd: string;
   agentDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
 }): SettingsManager {
-  const settingsManager = createEmbeddedPiSettingsManager(params);
+  const agentMcpServers = resolveAgentMcpServers(params.cfg, params.agentId);
+  const settingsManager = createEmbeddedPiSettingsManager({
+    cwd: params.cwd,
+    agentDir: params.agentDir,
+    cfg: params.cfg,
+    agentMcpServers,
+  });
   applyPiCompactionSettingsFromConfig({
     settingsManager,
     cfg: params.cfg,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4891,6 +4891,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                   },
                   additionalProperties: false,
                 },
+                mcpServers: {
+                  type: "array",
+                  items: {
+                    type: "string",
+                  },
+                },
                 runtime: {
                   anyOf: [
                     {

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -91,6 +91,8 @@ export type AgentConfig = {
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
   params?: Record<string, unknown>;
   tools?: AgentToolsConfig;
+  /** Optional MCP server allowlist. Omit or ["*"] = all global servers (default); specific names = only those servers. */
+  mcpServers?: string[];
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -801,6 +801,7 @@ export const AgentEntrySchema = z
     sandbox: AgentSandboxSchema,
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
+    mcpServers: z.array(z.string()).optional(),
     runtime: AgentRuntimeSchema,
   })
   .strict();


### PR DESCRIPTION
## Summary

Add support for per-agent MCP server allowlists, enabling agent-specific tool isolation.

MCP servers remain configured globally in `mcp.servers`. Each agent can now optionally specify which servers it has access to via a `mcpServers` allowlist field.

## Configuration

Each agent can specify:
- `mcpServers: ["*"]` (or omit entirely) — all global MCP servers are available (default, backward compatible)
- `mcpServers: ["server-a", "server-b"]` — only the listed servers are available to this agent

### Example

```json
{
  "mcp": {
    "servers": {
      "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"] },
      "brave-search": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-brave-search"] },
      "github": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"] }
    }
  },
  "agents": {
    "list": [
      { "id": "default" },
      { "id": "coder", "mcpServers": ["filesystem", "github"] },
      { "id": "researcher", "mcpServers": ["brave-search"] }
    ]
  }
}
```

- `default` agent: gets all 3 servers (no `mcpServers` → implicit `["*"]`)
- `coder`: only filesystem + github
- `researcher`: only brave-search

## Changes

### Config schema
- **`src/config/types.agents.ts`**: Added `mcpServers?: string[]` to `AgentConfig`.
- **`src/config/zod-schema.agent-runtime.ts`**: Added `mcpServers: z.array(z.string()).optional()` to `AgentEntrySchema`.
- **`src/config/schema.base.generated.ts`**: Regenerated.

### Agent resolution
- **`src/agents/agent-scope.ts`**: Exposed `mcpServers` in `ResolvedAgentConfig`.

### MCP loading
- **`src/agents/embedded-pi-mcp.ts`**: Added allowlist filtering after bundle+global merge. When `agentMcpServers` is specified and does not contain `"*"`, only matching servers are kept.
- **`src/agents/pi-project-settings.ts`**: Added `resolveAgentMcpServers()` helper; `createPreparedEmbeddedPiSettingsManager` resolves the agent allowlist from `agentId`.

### Callers
- **`src/agents/pi-embedded-runner/run/attempt.ts`**: Passes `agentId: sessionAgentId`.
- **`src/agents/pi-embedded-runner/compact.ts`**: Passes `agentId: sessionAgentId`.

### Tests
- **`src/agents/embedded-pi-mcp.test.ts`** (new): 8 tests covering allowlist filtering: wildcard, empty, specific, single, unknown names.

## Backward Compatibility

Fully backward compatible. When no `mcpServers` is defined on an agent, behavior is identical to before (all global + bundle servers are available).