### PR TITLE
Fix: treat HTTP 500 as a transient failover error

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -70,8 +70,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 499 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
     expect(resolveFailoverReasonFromError({ status: 422 })).toBe("format");
-    // Keep the status-only path behavior-preserving and conservative.
-    expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
+    // Transient server errors (500/502/503/504) should trigger failover as timeout.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -494,7 +494,7 @@ export function classifyFailoverReasonFromHttpStatus(
     }
     return "timeout";
   }
-  if (status === 502 || status === 504) {
+  if (status === 500 || status === 502 || status === 504) {
     return "timeout";
   }
   if (status === 529) {


### PR DESCRIPTION
## Summary
- HTTP 500 (Internal Server Error) was not triggering model fallback, causing agents to fail outright instead of trying the next candidate model
- `resolveFailoverReasonFromError()` in `failover-error.ts` only handled 502/503/504 as transient server errors, but not 500
- This is inconsistent with `TRANSIENT_HTTP_ERROR_CODES` in `errors.ts` which already includes 500
- Adds 500 to the direct status code check and updates tests

## Context
When a model provider (e.g. Ollama proxying to MiniMax cloud) returns HTTP 500, agents should fall back to the next configured model. Instead, the error was rethrown immediately, leaving agents stuck with no response.

## Test plan
- [x] Updated `failover-error.test.ts` to assert `status: 500` maps to `"timeout"` reason
- [x] All 8 tests pass (`pnpm test -- src/agents/failover-error.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)