### PR TITLE
feat: add support for extra headers in Tavily API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Docs: add `pnpm docs:check-links:anchors` for Mintlify anchor validation while keeping `scripts/docs-link-audit.mjs` as the stable link-audit entrypoint. (#55912) Thanks @velvet-shark.
 - Plugins/hooks: add async `requireApproval` to `before_tool_call` hooks, letting plugins pause tool execution and prompt the user for approval via the exec approval overlay, Telegram buttons, Discord interactions, or the `/approve` command on any channel. The `/approve` command now handles both exec and plugin approvals with automatic fallback. (#55339) Thanks @vaclavbelak and @joshavant.
 - ACP/channels: add current-conversation ACP binds for Discord, BlueBubbles, and iMessage so `/acp spawn codex --bind here` can turn the current chat into a Codex-backed workspace without creating a child thread, and document the distinction between chat surface, ACP session, and runtime workspace.
+- Tavily: mark outbound API requests with `X-Client-Source: openclaw` so Tavily can attribute OpenClaw-originated traffic. (#55335) Thanks @lakshyaag-tavily.
 
 ### Fixes
 

--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture every call to postTrustedWebToolsJson so we can assert on extraHeaders.
+const postTrustedWebToolsJson = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/provider-web-search", () => ({
+  DEFAULT_CACHE_TTL_MINUTES: 5,
+  normalizeCacheKey: (k: string) => k,
+  postTrustedWebToolsJson,
+  readCache: () => undefined,
+  resolveCacheTtlMs: () => 300_000,
+  writeCache: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
+  wrapExternalContent: (v: string) => v,
+  wrapWebContent: (v: string) => v,
+}));
+
+vi.mock("./config.js", () => ({
+  DEFAULT_TAVILY_BASE_URL: "https://api.tavily.com",
+  resolveTavilyApiKey: () => "test-key",
+  resolveTavilyBaseUrl: () => "https://api.tavily.com",
+  resolveTavilySearchTimeoutSeconds: () => 30,
+  resolveTavilyExtractTimeoutSeconds: () => 60,
+}));
+
+describe("tavily client X-Client-Source header", () => {
+  let runTavilySearch: typeof import("./tavily-client.js").runTavilySearch;
+  let runTavilyExtract: typeof import("./tavily-client.js").runTavilyExtract;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    postTrustedWebToolsJson.mockReset();
+    postTrustedWebToolsJson.mockImplementation(
+      async (_params: unknown, parse: (r: Response) => Promise<unknown>) =>
+        parse(Response.json({ results: [] })),
+    );
+
+    ({ runTavilySearch, runTavilyExtract } = await import("./tavily-client.js"));
+  });
+
+  it("runTavilySearch sends X-Client-Source: openclaw", async () => {
+    await runTavilySearch({ query: "test query" });
+
+    expect(postTrustedWebToolsJson).toHaveBeenCalledOnce();
+    const params = postTrustedWebToolsJson.mock.calls[0][0];
+    expect(params.extraHeaders).toEqual({ "X-Client-Source": "openclaw" });
+  });
+
+  it("runTavilyExtract sends X-Client-Source: openclaw", async () => {
+    await runTavilyExtract({ urls: ["https://example.com"] });
+
+    expect(postTrustedWebToolsJson).toHaveBeenCalledOnce();
+    const params = postTrustedWebToolsJson.mock.calls[0][0];
+    expect(params.extraHeaders).toEqual({ "X-Client-Source": "openclaw" });
+  });
+});

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -119,6 +119,7 @@ export async function runTavilySearch(
       apiKey,
       body,
       errorLabel: "Tavily Search",
+      extraHeaders: { "X-Client-Source": "openclaw" },
     },
     async (response) => (await response.json()) as Record<string, unknown>,
   );
@@ -200,6 +201,7 @@ export async function runTavilyExtract(
       apiKey,
       body,
       errorLabel: "Tavily Extract",
+      extraHeaders: { "X-Client-Source": "openclaw" },
     },
     async (response) => (await response.json()) as Record<string, unknown>,
   );

--- a/src/agents/tools/web-search-provider-common.ts
+++ b/src/agents/tools/web-search-provider-common.ts
@@ -100,6 +100,7 @@ export async function postTrustedWebToolsJson<T>(
     body: Record<string, unknown>;
     errorLabel: string;
     maxErrorBytes?: number;
+    extraHeaders?: Record<string, string>;
   },
   parseResponse: (response: Response) => Promise<T>,
 ): Promise<T> {
@@ -110,6 +111,7 @@ export async function postTrustedWebToolsJson<T>(
       init: {
         method: "POST",
         headers: {
+          ...params.extraHeaders,
           Accept: "application/json",
           Authorization: `Bearer ${params.apiKey}`,
           "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

- Problem: Tavily has no way to identify which API requests originate from OpenClaw versus other clients.
- Why it matters: Tavily wants to track what requests originate from OpenClaw
- What changed: Added an optional `extraHeaders` param to the shared `postTrustedWebToolsJson()` helper, then used it to send `X-Client-Source: openclaw` on all outbound Tavily API requests (search and extract). 
- What did NOT change (scope boundary): No new config, no new dependencies, no changes to request bodies or response handling. Other web search providers and existing callers of `postTrustedWebToolsJson()` are unaffected (param is optional, defaults to no extra headers).

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

None. The header is added server-side on outbound API calls to Tavily and is invisible to users.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: A single static metadata header (`X-Client-Source: openclaw`) is added to existing Tavily API requests. No new endpoints are contacted. The header contains no secrets or user-identifiable information — just the product name.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun/Node
- Model/provider: N/A (web search provider)
- Integration/channel (if any): Tavily web search + extract
- Relevant config (redacted): N/A

### Steps

1. Configure a Tavily API key
2. Trigger a web search or extract via the Tavily provider
3. Observe outbound request headers

### Expected

- Requests to Tavily include `X-Client-Source: openclaw`

### Actual

- Confirmed via code inspection; both `runTavilySearch()` and `runTavilyExtract()` pass `extraHeaders: { "X-Client-Source": "openclaw" }` through `postTrustedWebToolsJson()`, which spreads it into the fetch headers.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Regression tests added in `extensions/tavily/src/tavily-client.test.ts`:
 - `runTavilySearch` and `runTavilyExtract` sends X-Client-Source: openclaw` - mocks `postTrustedWebToolsJson` at the SDK boundary and asserts `extraHeaders` is `{"X-Client-Source": "openclaw" }`

 Full test results:
 - `extensions/tavily/src/tavily-client.test.ts` — 2/2 passed (new)
 - `extensions/tavily/src/tavily-tools.test.ts` — 11/11 passed (existing, no regressions)
 - `extensions/firecrawl/` + `extensions/xai/` (other `postTrustedWebToolsJson` consumers) — 35/35 passed
 - `pnpm tsgo` — no type errors
 - `pnpm plugin-sdk:api:check` — `postTrustedWebToolsJson` is not tracked in the SDK baseline; no update needed

## Human Verification (required)

- Verified scenarios: Confirmed `postTrustedWebToolsJson()` is the sole HTTP bottleneck for both Tavily search and extract. Confirmed `extraHeaders` spreads before the base headers so it cannot accidentally override `Authorization` or `Content-Type` unless explicitly passed.
- Edge cases checked: Omitting `extraHeaders` (all other callers) leaves behavior unchanged — spreading `undefined` is a no-op.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `extraHeaders` lines from both call sites in `extensions/tavily/src/tavily-client.ts` and the param + spread from `src/agents/tools/web-search-provider-common.ts`.
- Files/config to restore: `extensions/tavily/src/tavily-client.ts`, `src/agents/tools/web-search-provider-common.ts`
- Known bad symptoms reviewers should watch for: Tavily API rejecting requests due to unrecognized header (extremely unlikely — the SDK itself sends this header).

## Risks and Mitigations

None