### PR TITLE
Persist refreshed Twitch tokens and fix OpenProse fast-loop exits

### DIFF
--- a/extensions/open-prose/skills/prose/examples/46-run-endpoint-ux-test-fast.prose
+++ b/extensions/open-prose/skills/prose/examples/46-run-endpoint-ux-test-fast.prose
@@ -105,43 +105,43 @@ if observation.blocking_error:
   # Skip if low confidence (needs human)
   if diagnosis.confidence == "low":
     output { status: "needs_human", diagnosis }
+  else:
+    # Auto-triage
+    let triage_result = session: triage
+      prompt: """Triage: {diagnosis}"""
+      context: diagnosis
 
-  # Auto-triage
-  let triage_result = session: triage
-    prompt: """Triage: {diagnosis}"""
-    context: diagnosis
+    if triage_result.decision == "bigger":
+      # Bigger changes need human oversight
+      output { status: "needs_planning", diagnosis, triage: triage_result }
+    else:
+      # Quick fix: implement + test + deploy in one flow
+      let fix = session: fixer
+        prompt: """Fix this issue:
 
-  if triage_result.decision == "bigger":
-    # Bigger changes need human oversight
-    output { status: "needs_planning", diagnosis, triage: triage_result }
+        DIAGNOSIS: {diagnosis}
+        APPROACH: {diagnosis.fix_approach}
 
-  # Quick fix: implement + test + deploy in one flow
-  let fix = session: fixer
-    prompt: """Fix this issue:
+        Implement, test, self-review, commit."""
+        context: diagnosis
 
-    DIAGNOSIS: {diagnosis}
-    APPROACH: {diagnosis.fix_approach}
+      if not fix.tests_pass:
+        output { status: "fix_failed", diagnosis, fix }
+      else:
+        # Deploy (auto if tests pass)
+        let deploy = session "Deploy"
+          prompt: """Deploy per docs/DEPLOYMENT.md. Verify health endpoint."""
+          retry: 2
 
-    Implement, test, self-review, commit."""
-    context: diagnosis
+        # Quick smoke test
+        let smoke = http.get("{API_URL}/health")
 
-  if not fix.tests_pass:
-    output { status: "fix_failed", diagnosis, fix }
-
-  # Deploy (auto if tests pass)
-  let deploy = session "Deploy"
-    prompt: """Deploy per docs/DEPLOYMENT.md. Verify health endpoint."""
-    retry: 2
-
-  # Quick smoke test
-  let smoke = http.get("{API_URL}/health")
-
-  output {
-    status: smoke.status == "ok" ? "fixed" : "deploy_failed",
-    diagnosis,
-    fix,
-    deploy
-  }
+        output {
+          status: smoke.status == "ok" ? "fixed" : "deploy_failed",
+          diagnosis,
+          fix,
+          deploy
+        }
 
 else:
   # No blocking error - just output UX feedback

--- a/extensions/twitch/src/token-writeback.test.ts
+++ b/extensions/twitch/src/token-writeback.test.ts
@@ -1,0 +1,192 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readConfigFileSnapshotForWrite = vi.fn();
+const writeConfigFile = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
+  return {
+    ...actual,
+    readConfigFileSnapshotForWrite,
+    writeConfigFile,
+  };
+});
+
+describe("persistRefreshedTwitchTokens", () => {
+  let persistRefreshedTwitchTokens: typeof import("./token-writeback.js").persistRefreshedTwitchTokens;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ persistRefreshedTwitchTokens } = await import("./token-writeback.js"));
+    readConfigFileSnapshotForWrite.mockReset();
+    writeConfigFile.mockReset();
+  });
+
+  it("updates base-level default account tokens when the default account is config-backed", async () => {
+    readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: {
+        config: {
+          channels: {
+            twitch: {
+              username: "bot",
+              channel: "channel",
+              clientId: "client-id",
+              accessToken: "oauth:old-access",
+              refreshToken: "old-refresh",
+              expiresIn: 1200,
+              obtainmentTimestamp: 100,
+            },
+          },
+        } satisfies OpenClawConfig,
+      },
+      writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+    });
+
+    await persistRefreshedTwitchTokens({
+      accountId: "default",
+      tokenSource: "config",
+      token: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresIn: 3600,
+        obtainmentTimestamp: 200,
+      },
+    });
+
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: {
+          twitch: expect.objectContaining({
+            accessToken: "oauth:new-access",
+            refreshToken: "new-refresh",
+            expiresIn: 3600,
+            obtainmentTimestamp: 200,
+          }),
+        },
+      }),
+      expect.objectContaining({ expectedConfigPath: "/tmp/openclaw.json" }),
+    );
+  });
+
+  it("updates accounts.default when the default account token lives in accounts", async () => {
+    readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: {
+        config: {
+          channels: {
+            twitch: {
+              username: "bot",
+              channel: "channel",
+              clientId: "client-id",
+              accounts: {
+                default: {
+                  accessToken: "oauth:old-access",
+                  refreshToken: "old-refresh",
+                  expiresIn: 1200,
+                  obtainmentTimestamp: 100,
+                },
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+      },
+      writeOptions: {},
+    });
+
+    await persistRefreshedTwitchTokens({
+      accountId: "default",
+      tokenSource: "config",
+      token: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresIn: 3600,
+        obtainmentTimestamp: 200,
+      },
+    });
+
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: {
+          twitch: expect.objectContaining({
+            accounts: {
+              default: expect.objectContaining({
+                accessToken: "oauth:new-access",
+                refreshToken: "new-refresh",
+                expiresIn: 3600,
+                obtainmentTimestamp: 200,
+              }),
+            },
+          }),
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("updates named account tokens in the accounts map", async () => {
+    readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot: {
+        config: {
+          channels: {
+            twitch: {
+              accounts: {
+                alerts: {
+                  accessToken: "oauth:old-access",
+                  refreshToken: "old-refresh",
+                  expiresIn: 1200,
+                  obtainmentTimestamp: 100,
+                },
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+      },
+      writeOptions: {},
+    });
+
+    await persistRefreshedTwitchTokens({
+      accountId: "alerts",
+      tokenSource: "config",
+      token: {
+        accessToken: "oauth:new-access",
+        refreshToken: "new-refresh",
+        expiresIn: 3600,
+        obtainmentTimestamp: 200,
+      },
+    });
+
+    expect(writeConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: {
+          twitch: {
+            accounts: {
+              alerts: expect.objectContaining({
+                accessToken: "oauth:new-access",
+                refreshToken: "new-refresh",
+                expiresIn: 3600,
+                obtainmentTimestamp: 200,
+              }),
+            },
+          },
+        },
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("skips config writes for env-backed tokens", async () => {
+    await persistRefreshedTwitchTokens({
+      accountId: "default",
+      tokenSource: "env",
+      token: {
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+        expiresIn: 3600,
+        obtainmentTimestamp: 200,
+      },
+    });
+
+    expect(readConfigFileSnapshotForWrite).not.toHaveBeenCalled();
+    expect(writeConfigFile).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/twitch/src/token-writeback.ts
+++ b/extensions/twitch/src/token-writeback.ts
@@ -1,0 +1,115 @@
+import {
+  readConfigFileSnapshotForWrite,
+  writeConfigFile,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
+import { DEFAULT_ACCOUNT_ID } from "./config.js";
+
+type TwitchTokenSource = "config" | "env" | "none";
+
+export type RefreshedTwitchToken = {
+  accessToken: string;
+  refreshToken?: string | null;
+  expiresIn?: number | null;
+  obtainmentTimestamp?: number | null;
+};
+
+function asObjectRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function ensureObjectRecord(holder: Record<string, unknown>, key: string): Record<string, unknown> {
+  const existing = asObjectRecord(holder[key]);
+  if (existing) {
+    return existing;
+  }
+  const next: Record<string, unknown> = {};
+  holder[key] = next;
+  return next;
+}
+
+function normalizeStoredAccessToken(accessToken: string): string {
+  const trimmed = accessToken.trim();
+  return trimmed.startsWith("oauth:") ? trimmed : `oauth:${trimmed}`;
+}
+
+function updateTokenFields(holder: Record<string, unknown>, token: RefreshedTwitchToken): boolean {
+  let changed = false;
+  const nextAccessToken = normalizeStoredAccessToken(token.accessToken);
+  if (holder.accessToken !== nextAccessToken) {
+    holder.accessToken = nextAccessToken;
+    changed = true;
+  }
+
+  if (typeof token.refreshToken === "string" && token.refreshToken.trim()) {
+    const nextRefreshToken = token.refreshToken.trim();
+    if (holder.refreshToken !== nextRefreshToken) {
+      holder.refreshToken = nextRefreshToken;
+      changed = true;
+    }
+  }
+
+  const nextExpiresIn = typeof token.expiresIn === "number" ? token.expiresIn : null;
+  if (holder.expiresIn !== nextExpiresIn) {
+    holder.expiresIn = nextExpiresIn;
+    changed = true;
+  }
+
+  const nextObtainmentTimestamp =
+    typeof token.obtainmentTimestamp === "number" ? token.obtainmentTimestamp : Date.now();
+  if (holder.obtainmentTimestamp !== nextObtainmentTimestamp) {
+    holder.obtainmentTimestamp = nextObtainmentTimestamp;
+    changed = true;
+  }
+
+  return changed;
+}
+
+function resolveDefaultAccountHolder(twitch: Record<string, unknown>): Record<string, unknown> {
+  if (typeof twitch.accessToken === "string" && twitch.accessToken.trim()) {
+    return twitch;
+  }
+  const accounts = ensureObjectRecord(twitch, "accounts");
+  return ensureObjectRecord(accounts, DEFAULT_ACCOUNT_ID);
+}
+
+function resolveAccountHolder(cfg: OpenClawConfig, accountId: string): Record<string, unknown> {
+  const root = cfg as Record<string, unknown>;
+  const channels = ensureObjectRecord(root, "channels");
+  const twitch = ensureObjectRecord(channels, "twitch");
+
+  if (accountId === DEFAULT_ACCOUNT_ID) {
+    return resolveDefaultAccountHolder(twitch);
+  }
+
+  const accounts = ensureObjectRecord(twitch, "accounts");
+  return ensureObjectRecord(accounts, accountId);
+}
+
+export async function persistRefreshedTwitchTokens(params: {
+  accountId?: string | null;
+  tokenSource: TwitchTokenSource;
+  token: RefreshedTwitchToken;
+}): Promise<boolean> {
+  if (params.tokenSource !== "config") {
+    return false;
+  }
+
+  if (!params.token.accessToken.trim()) {
+    return false;
+  }
+
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  const nextConfig = structuredClone(snapshot.config ?? {}) as OpenClawConfig;
+  const holder = resolveAccountHolder(nextConfig, params.accountId?.trim() || DEFAULT_ACCOUNT_ID);
+  const changed = updateTokenFields(holder, params.token);
+  if (!changed) {
+    return false;
+  }
+
+  await writeConfigFile(nextConfig, writeOptions);
+  return true;
+}

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -36,6 +36,9 @@ const mockOnMessage = vi.fn((handler: any) => {
 const mockAddUserForToken = vi.fn().mockResolvedValue("123456");
 const mockOnRefresh = vi.fn();
 const mockOnRefreshFailure = vi.fn();
+const { mockPersistRefreshedTwitchTokens } = vi.hoisted(() => ({
+  mockPersistRefreshedTwitchTokens: vi.fn().mockResolvedValue(false),
+}));
 
 vi.mock("@twurple/chat", () => ({
   ChatClient: class {
@@ -79,6 +82,10 @@ vi.mock("./token.js", () => ({
     source: "config" as const,
   })),
   DEFAULT_ACCOUNT_ID: "default",
+}));
+
+vi.mock("./token-writeback.js", () => ({
+  persistRefreshedTwitchTokens: mockPersistRefreshedTwitchTokens,
 }));
 
 describe("TwitchClientManager", () => {
@@ -409,6 +416,50 @@ describe("TwitchClientManager", () => {
 
       expect(result.ok).toBe(true);
       expect(mockConnect.mock.calls.length).toBeGreaterThan(connectCallCountBefore);
+    });
+  });
+
+  describe("token refresh persistence", () => {
+    it("persists refreshed tokens for config-backed accounts", async () => {
+      const refreshingAccount: TwitchAccountConfig = {
+        ...testAccount,
+        clientSecret: "client-secret",
+        refreshToken: "refresh-token",
+      };
+
+      await manager.getClient(refreshingAccount, undefined, "alerts");
+
+      const refreshHandler = mockOnRefresh.mock.calls[0]?.[0] as
+        | ((
+            userId: string,
+            token: {
+              accessToken: string;
+              refreshToken?: string;
+              expiresIn?: number | null;
+              obtainmentTimestamp?: number;
+            },
+          ) => Promise<void>)
+        | undefined;
+
+      expect(refreshHandler).toBeDefined();
+
+      await refreshHandler?.("123456", {
+        accessToken: "new-access-token",
+        refreshToken: "new-refresh-token",
+        expiresIn: 3600,
+        obtainmentTimestamp: 123456789,
+      });
+
+      expect(mockPersistRefreshedTwitchTokens).toHaveBeenCalledWith({
+        accountId: "alerts",
+        tokenSource: "config",
+        token: {
+          accessToken: "new-access-token",
+          refreshToken: "new-refresh-token",
+          expiresIn: 3600,
+          obtainmentTimestamp: 123456789,
+        },
+      });
     });
   });
 

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -1,7 +1,8 @@
 import { RefreshingAuthProvider, StaticAuthProvider } from "@twurple/auth";
 import { ChatClient, LogLevel } from "@twurple/chat";
 import type { OpenClawConfig } from "../runtime-api.js";
-import { resolveTwitchToken } from "./token.js";
+import { persistRefreshedTwitchTokens } from "./token-writeback.js";
+import { resolveTwitchToken, type TwitchTokenSource } from "./token.js";
 import type { ChannelLogSink, TwitchAccountConfig, TwitchChatMessage } from "./types.js";
 import { normalizeToken } from "./utils/twitch.js";
 
@@ -20,6 +21,10 @@ export class TwitchClientManager {
   private async createAuthProvider(
     account: TwitchAccountConfig,
     normalizedToken: string,
+    options: {
+      accountId?: string;
+      tokenSource: TwitchTokenSource;
+    },
   ): Promise<StaticAuthProvider | RefreshingAuthProvider> {
     if (!account.clientId) {
       throw new Error("Missing Twitch client ID");
@@ -49,10 +54,27 @@ export class TwitchClientManager {
           );
         });
 
-      authProvider.onRefresh((userId, token) => {
+      authProvider.onRefresh(async (userId, token) => {
         this.logger.info(
           `Access token refreshed for user ${userId} (expires in ${token.expiresIn ? `${token.expiresIn}s` : "unknown"})`,
         );
+
+        try {
+          await persistRefreshedTwitchTokens({
+            accountId: options.accountId,
+            tokenSource: options.tokenSource,
+            token: {
+              accessToken: token.accessToken,
+              refreshToken: token.refreshToken,
+              expiresIn: token.expiresIn,
+              obtainmentTimestamp: token.obtainmentTimestamp,
+            },
+          });
+        } catch (error) {
+          this.logger.warn(
+            `Failed to persist refreshed Twitch token for ${account.username}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
       });
 
       authProvider.onRefreshFailure((userId, error) => {
@@ -106,7 +128,10 @@ export class TwitchClientManager {
 
     const normalizedToken = normalizeToken(tokenResolution.token);
 
-    const authProvider = await this.createAuthProvider(account, normalizedToken);
+    const authProvider = await this.createAuthProvider(account, normalizedToken, {
+      accountId,
+      tokenSource: tokenResolution.source,
+    });
 
     const client = new ChatClient({
       authProvider,


### PR DESCRIPTION
## Summary
- persist refreshed Twitch OAuth tokens back to config for config-backed Twitch accounts, covering both base-level default config and named account entries
- add Twitch unit coverage for refresh writeback and `onRefresh` persistence wiring
- fix the OpenProse fast-loop example so terminal `output` branches do not fall through into triage, fixer, or deploy steps

## Test plan
- [x] `pnpm test -- extensions/twitch/src/twitch-client.test.ts extensions/twitch/src/token-writeback.test.ts`
- [x] `pnpm check && pnpm build`
- [x] Manually verified `extensions/open-prose/skills/prose/examples/46-run-endpoint-ux-test-fast.prose` now uses exclusive `else` branches for terminal outcomes; a runnable local `prose compile` CLI entrypoint was not available in this checkout

Made with [Cursor](https://cursor.com)