### PR TITLE
fix(discord): health-monitor abort should not stop lifecycle via reconnect-exhausted

### DIFF
--- a/extensions/discord/src/monitor/gateway-handle.ts
+++ b/extensions/discord/src/monitor/gateway-handle.ts
@@ -1,0 +1,8 @@
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+
+/**
+ * Alias for GatewayPlugin used within the lifecycle layer.
+ * The "Mutable" prefix reflects that the lifecycle may write to internal
+ * gateway state (e.g. clearing session/sequence for forced reconnects).
+ */
+export type MutableDiscordGateway = GatewayPlugin;

--- a/extensions/discord/src/monitor/gateway-supervisor.test.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.test.ts
@@ -147,4 +147,56 @@ describe("createDiscordGatewaySupervisor", () => {
     expect(() => supervisor.dispose()).not.toThrow();
     expect(() => supervisor.markIntentionalAbort()).not.toThrow();
   });
+  it("keeps suppressing late gateway errors after dispose", () => {
+    const emitter = new EventEmitter();
+    const runtime = { error: vi.fn() };
+    const supervisor = createDiscordGatewaySupervisor({
+      gateway: { emitter },
+      isDisallowedIntentsError: () => false,
+      runtime: runtime as never,
+    });
+
+    supervisor.dispose();
+
+    expect(() =>
+      emitter.emit("error", new Error("Max reconnect attempts (0) reached after code 1005")),
+    ).not.toThrow();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed late gateway reconnect-exhausted error after dispose"),
+    );
+  });
+  it("intentionally classifies a reconnect event as reconnect-aborted", () => {
+    const emitter = new EventEmitter();
+    const seen: any[] = [];
+    const supervisor = createDiscordGatewaySupervisor({
+      gateway: { emitter } as any,
+      isDisallowedIntentsError: () => false,
+      runtime: { error: vi.fn() } as any,
+    });
+    supervisor.attachLifecycle((event) => seen.push(event));
+
+    supervisor.markIntentionalAbort();
+    emitter.emit("error", new Error("Max reconnect attempts (0) reached"));
+
+    expect(seen[0].type).toBe("reconnect-aborted");
+    expect(seen[0].shouldStopLifecycle).toBe(false);
+  });
+
+  it("resets the intentional abort flag after classifying a reconnect event", () => {
+    const emitter = new EventEmitter();
+    const seen: any[] = [];
+    const supervisor = createDiscordGatewaySupervisor({
+      gateway: { emitter } as any,
+      isDisallowedIntentsError: () => false,
+      runtime: { error: vi.fn() } as any,
+    });
+    supervisor.attachLifecycle((event) => seen.push(event));
+
+    supervisor.markIntentionalAbort();
+    emitter.emit("error", new Error("Max reconnect attempts (0) reached"));
+    expect(seen[0].type).toBe("reconnect-aborted");
+
+    emitter.emit("error", new Error("Max reconnect attempts (0) reached"));
+    expect(seen[1].type).toBe("reconnect-exhausted");
+  });
 });

--- a/extensions/discord/src/monitor/gateway-supervisor.test.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.test.ts
@@ -24,12 +24,35 @@ describe("classifyDiscordGatewayEvent", () => {
       isDisallowedIntentsError: () => false,
     });
 
+    // Without the intentional-abort flag, reconnect errors are still reconnect-exhausted.
     expect(reconnectEvent.type).toBe("reconnect-exhausted");
     expect(reconnectEvent.shouldStopLifecycle).toBe(true);
     expect(fatalEvent.type).toBe("fatal");
     expect(disallowedEvent.type).toBe("disallowed-intents");
     expect(transientEvent.type).toBe("other");
     expect(transientEvent.shouldStopLifecycle).toBe(false);
+  });
+
+  it("treats a reconnect event as reconnect-aborted when isIntentionalAbort is set", () => {
+    const abortedEvent = classifyDiscordGatewayEvent({
+      err: new Error("Max reconnect attempts (0) reached after code 1005"),
+      isDisallowedIntentsError: () => false,
+      isIntentionalAbort: true,
+    });
+
+    expect(abortedEvent.type).toBe("reconnect-aborted");
+    expect(abortedEvent.shouldStopLifecycle).toBe(false);
+  });
+
+  it("treats genuine reconnect exhaustion as lifecycle-stopping regardless of the flag", () => {
+    const exhaustedEvent = classifyDiscordGatewayEvent({
+      err: new Error("Max reconnect attempts (5) reached after code 1006"),
+      isDisallowedIntentsError: () => false,
+      isIntentionalAbort: false,
+    });
+
+    expect(exhaustedEvent.type).toBe("reconnect-exhausted");
+    expect(exhaustedEvent.shouldStopLifecycle).toBe(true);
   });
 });
 
@@ -40,9 +63,7 @@ describe("createDiscordGatewaySupervisor", () => {
       error: vi.fn(),
     };
     const supervisor = createDiscordGatewaySupervisor({
-      client: {
-        getPlugin: vi.fn(() => ({ emitter })),
-      } as never,
+      gateway: { emitter },
       isDisallowedIntentsError: (err) => String(err).includes("4014"),
       runtime: runtime as never,
     });
@@ -70,11 +91,51 @@ describe("createDiscordGatewaySupervisor", () => {
     );
   });
 
+  it("classifies a reconnect event as reconnect-aborted after markIntentionalAbort", () => {
+    const emitter = new EventEmitter();
+    const runtime = { error: vi.fn() };
+    const supervisor = createDiscordGatewaySupervisor({
+      gateway: { emitter },
+      isDisallowedIntentsError: () => false,
+      runtime: runtime as never,
+    });
+    const seen: Array<{ type: string; shouldStopLifecycle: boolean }> = [];
+
+    supervisor.attachLifecycle((event) => {
+      seen.push({ type: event.type, shouldStopLifecycle: event.shouldStopLifecycle });
+    });
+
+    // Simulate health-monitor abort: mark first, then disconnect triggers the error.
+    supervisor.markIntentionalAbort();
+    emitter.emit("error", new Error("Max reconnect attempts (0) reached after code 1005"));
+
+    expect(seen).toEqual([{ type: "reconnect-aborted", shouldStopLifecycle: false }]);
+
+    // Flag is consumed — a subsequent reconnect error is treated as real exhaustion.
+    emitter.emit("error", new Error("Max reconnect attempts (5) reached after code 1006"));
+    expect(seen[1]).toEqual({ type: "reconnect-exhausted", shouldStopLifecycle: true });
+  });
+
+  it("logs late errors after dispose with 'after dispose' message", () => {
+    const emitter = new EventEmitter();
+    const runtime = { error: vi.fn() };
+    const supervisor = createDiscordGatewaySupervisor({
+      gateway: { emitter },
+      isDisallowedIntentsError: () => false,
+      runtime: runtime as never,
+    });
+
+    supervisor.dispose();
+    emitter.emit("error", new Error("Max reconnect attempts (0) reached after code 1005"));
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed late gateway reconnect-exhausted error after dispose"),
+    );
+  });
+
   it("is idempotent on dispose and noops without an emitter", () => {
     const supervisor = createDiscordGatewaySupervisor({
-      client: {
-        getPlugin: vi.fn(() => undefined),
-      } as never,
+      gateway: undefined,
       isDisallowedIntentsError: () => false,
       runtime: { error: vi.fn() } as never,
     });
@@ -84,5 +145,6 @@ describe("createDiscordGatewaySupervisor", () => {
     expect(() => supervisor.detachLifecycle()).not.toThrow();
     expect(() => supervisor.dispose()).not.toThrow();
     expect(() => supervisor.dispose()).not.toThrow();
+    expect(() => supervisor.markIntentionalAbort()).not.toThrow();
   });
 });

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -74,11 +74,14 @@ export function classifyDiscordGatewayEvent(params: {
 }
 
 export function createDiscordGatewaySupervisor(params: {
+  /** Carbon Client — used by provider.ts; emitter is derived internally. */
+  client?: unknown;
+  /** Raw gateway object — used by tests. Takes precedence over client. */
   gateway?: unknown;
   isDisallowedIntentsError: (err: unknown) => boolean;
   runtime: RuntimeEnv;
 }): DiscordGatewaySupervisor {
-  const emitter = getDiscordGatewayEmitter(params.gateway);
+  const emitter = getDiscordGatewayEmitter(params.gateway ?? params.client);
   const pending: DiscordGatewayEvent[] = [];
   if (!emitter) {
     return {

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -1,5 +1,4 @@
 import type { EventEmitter } from "node:events";
-import type { Client } from "@buape/carbon";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { getDiscordGatewayEmitter } from "../monitor.gateway.js";
@@ -8,6 +7,7 @@ export type DiscordGatewayEventType =
   | "disallowed-intents"
   | "fatal"
   | "other"
+  | "reconnect-aborted"
   | "reconnect-exhausted";
 
 export type DiscordGatewayEvent = {
@@ -25,6 +25,12 @@ export type DiscordGatewaySupervisor = {
     handler: (event: DiscordGatewayEvent) => "continue" | "stop",
   ) => "continue" | "stop";
   dispose: () => void;
+  /**
+   * Call this before triggering an intentional gateway abort (e.g. from the
+   * health-monitor onAbort path). Marks the next reconnect-exhausted event as
+   * reconnect-aborted so it does not stop the lifecycle.
+   */
+  markIntentionalAbort: () => void;
 };
 
 type GatewaySupervisorPhase = "active" | "buffering" | "disposed" | "teardown";
@@ -32,6 +38,7 @@ type GatewaySupervisorPhase = "active" | "buffering" | "disposed" | "teardown";
 export function classifyDiscordGatewayEvent(params: {
   err: unknown;
   isDisallowedIntentsError: (err: unknown) => boolean;
+  isIntentionalAbort?: boolean;
 }): DiscordGatewayEvent {
   const message = String(params.err);
   if (params.isDisallowedIntentsError(params.err)) {
@@ -44,10 +51,10 @@ export function classifyDiscordGatewayEvent(params: {
   }
   if (message.includes("Max reconnect attempts")) {
     return {
-      type: "reconnect-exhausted",
+      type: params.isIntentionalAbort ? "reconnect-aborted" : "reconnect-exhausted",
       err: params.err,
       message,
-      shouldStopLifecycle: true,
+      shouldStopLifecycle: !params.isIntentionalAbort,
     };
   }
   if (message.includes("Fatal Gateway error")) {
@@ -67,12 +74,11 @@ export function classifyDiscordGatewayEvent(params: {
 }
 
 export function createDiscordGatewaySupervisor(params: {
-  client: Client;
+  gateway?: unknown;
   isDisallowedIntentsError: (err: unknown) => boolean;
   runtime: RuntimeEnv;
 }): DiscordGatewaySupervisor {
-  const gateway = params.client.getPlugin("gateway");
-  const emitter = getDiscordGatewayEmitter(gateway);
+  const emitter = getDiscordGatewayEmitter(params.gateway);
   const pending: DiscordGatewayEvent[] = [];
   if (!emitter) {
     return {
@@ -80,37 +86,51 @@ export function createDiscordGatewaySupervisor(params: {
       detachLifecycle: () => {},
       drainPending: () => "continue",
       dispose: () => {},
+      markIntentionalAbort: () => {},
       emitter,
     };
   }
 
   let lifecycleHandler: ((event: DiscordGatewayEvent) => void) | undefined;
   let phase: GatewaySupervisorPhase = "buffering";
-  let disposed = false;
-  const logLateTeardownEvent = (event: DiscordGatewayEvent) => {
-    params.runtime.error?.(
-      danger(
-        `discord: suppressed late gateway ${event.type} error during teardown: ${event.message}`,
-      ),
-    );
-  };
+  let intentionalAbort = false;
+
+  const logLateEvent =
+    (state: Extract<GatewaySupervisorPhase, "disposed" | "teardown">) =>
+    (event: DiscordGatewayEvent) => {
+      params.runtime.error?.(
+        danger(
+          `discord: suppressed late gateway ${event.type} error ${
+            state === "disposed" ? "after dispose" : "during teardown"
+          }: ${event.message}`,
+        ),
+      );
+    };
+
   const onGatewayError = (err: unknown) => {
-    if (disposed) {
-      return;
-    }
     const event = classifyDiscordGatewayEvent({
       err,
       isDisallowedIntentsError: params.isDisallowedIntentsError,
+      isIntentionalAbort: intentionalAbort,
     });
-    if (phase === "active" && lifecycleHandler) {
-      lifecycleHandler(event);
-      return;
+    // Reset after consuming — one abort signal covers one disconnect.
+    if (intentionalAbort && event.type === "reconnect-aborted") {
+      intentionalAbort = false;
     }
-    if (phase === "teardown") {
-      logLateTeardownEvent(event);
-      return;
+    switch (phase) {
+      case "disposed":
+        logLateEvent("disposed")(event);
+        return;
+      case "active":
+        lifecycleHandler?.(event);
+        return;
+      case "teardown":
+        logLateEvent("teardown")(event);
+        return;
+      case "buffering":
+        pending.push(event);
+        return;
     }
-    pending.push(event);
   };
   emitter.on("error", onGatewayError);
 
@@ -138,14 +158,15 @@ export function createDiscordGatewaySupervisor(params: {
       return "continue";
     },
     dispose: () => {
-      if (disposed) {
+      if (phase === "disposed") {
         return;
       }
-      disposed = true;
       lifecycleHandler = undefined;
       phase = "disposed";
       pending.length = 0;
-      emitter.removeListener("error", onGatewayError);
+    },
+    markIntentionalAbort: () => {
+      intentionalAbort = true;
     },
   };
 }

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -111,6 +111,7 @@ describe("runDiscordGatewayLifecycle", () => {
       }),
       dispose: vi.fn(),
       emitter: gateway.emitter,
+      markIntentionalAbort: vi.fn(),
     };
     const statusSink = vi.fn();
     const runtime: RuntimeEnv = {

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -1,9 +1,28 @@
 import { EventEmitter } from "node:events";
-import type { Client } from "@buape/carbon";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
 import type { WaitForDiscordGatewayStopParams } from "../monitor.gateway.js";
+import type { MutableDiscordGateway } from "./gateway-handle.js";
 import type { DiscordGatewayEvent } from "./gateway-supervisor.js";
+
+type LifecycleParams = Parameters<
+  typeof import("./provider.lifecycle.js").runDiscordGatewayLifecycle
+>[0];
+type MockGateway = {
+  isConnected: boolean;
+  options: GatewayPlugin["options"];
+  disconnect: Mock<() => void>;
+  connect: Mock<(resume?: boolean) => void>;
+  state?: {
+    sessionId?: string | null;
+    resumeGatewayUrl?: string | null;
+    sequence?: number | null;
+  };
+  sequence?: number | null;
+  emitter: EventEmitter;
+  ws?: EventEmitter & { terminate?: () => void };
+};
 
 const {
   attachDiscordGatewayLoggingMock,
@@ -43,6 +62,7 @@ vi.mock("./gateway-registry.js", () => ({
 
 describe("runDiscordGatewayLifecycle", () => {
   beforeEach(() => {
+    vi.resetModules();
     attachDiscordGatewayLoggingMock.mockClear();
     getDiscordGatewayEmitterMock.mockClear();
     waitForDiscordGatewayStopMock.mockClear();
@@ -57,21 +77,15 @@ describe("runDiscordGatewayLifecycle", () => {
     stop?: () => Promise<void>;
     isDisallowedIntentsError?: (err: unknown) => boolean;
     pendingGatewayEvents?: DiscordGatewayEvent[];
-    gateway?: {
-      isConnected?: boolean;
-      options?: Record<string, unknown>;
-      disconnect?: () => void;
-      connect?: (resume?: boolean) => void;
-      state?: {
-        sessionId?: string | null;
-        resumeGatewayUrl?: string | null;
-        sequence?: number | null;
-      };
-      sequence?: number | null;
-      emitter?: EventEmitter;
-      ws?: EventEmitter & { terminate?: () => void };
-    };
+    gateway?: MockGateway;
   }) => {
+    const gateway =
+      params?.gateway ??
+      (() => {
+        const defaultGateway = createGatewayHarness().gateway;
+        defaultGateway.isConnected = true;
+        return defaultGateway;
+      })();
     const start = vi.fn(params?.start ?? (async () => undefined));
     const stop = vi.fn(params?.stop ?? (async () => undefined));
     const threadStop = vi.fn();
@@ -96,7 +110,7 @@ describe("runDiscordGatewayLifecycle", () => {
         return "continue";
       }),
       dispose: vi.fn(),
-      emitter: params?.gateway?.emitter,
+      emitter: gateway.emitter,
     };
     const statusSink = vi.fn();
     const runtime: RuntimeEnv = {
@@ -114,9 +128,7 @@ describe("runDiscordGatewayLifecycle", () => {
       statusSink,
       lifecycleParams: {
         accountId: params?.accountId ?? "default",
-        client: {
-          getPlugin: vi.fn((name: string) => (name === "gateway" ? params?.gateway : undefined)),
-        } as unknown as Client,
+        gateway: gateway as unknown as MutableDiscordGateway,
         runtime,
         isDisallowedIntentsError: params?.isDisallowedIntentsError ?? (() => false),
         voiceManager: null,
@@ -126,7 +138,7 @@ describe("runDiscordGatewayLifecycle", () => {
         gatewaySupervisor,
         statusSink,
         abortSignal: undefined as AbortSignal | undefined,
-      },
+      } satisfies LifecycleParams,
     };
   };
 
@@ -154,11 +166,11 @@ describe("runDiscordGatewayLifecycle", () => {
     };
     sequence?: number | null;
     ws?: EventEmitter & { terminate?: () => void };
-  }) {
+  }): { emitter: EventEmitter; gateway: MockGateway } {
     const emitter = new EventEmitter();
-    const gateway = {
+    const gateway: MockGateway = {
       isConnected: false,
-      options: {},
+      options: { intents: 0 } as GatewayPlugin["options"],
       disconnect: vi.fn(),
       connect: vi.fn(),
       ...(params?.state ? { state: params.state } : {}),
@@ -517,7 +529,7 @@ describe("runDiscordGatewayLifecycle", () => {
         start,
         stop,
         threadStop,
-        waitCalls: 0,
+        waitCalls: 1,
         gatewaySupervisor,
       });
     } finally {
@@ -801,12 +813,56 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("does not suppress reconnect-exhausted already queued before shutdown", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const pendingGatewayEvents: DiscordGatewayEvent[] = [];
+    const abortController = new AbortController();
+
+    const emitter = new EventEmitter();
+    const gateway: MockGateway = {
+      isConnected: true,
+      options: { intents: 0, reconnect: { maxAttempts: 50 } } as GatewayPlugin["options"],
+      disconnect: vi.fn(),
+      connect: vi.fn(),
+      emitter,
+    };
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({
+      gateway,
+      pendingGatewayEvents,
+    });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    // Start lifecycle; it yields at execApprovalsHandler.start(). We then
+    // queue a reconnect-exhausted event and abort. The lifecycle resumes and
+    // drains the queued fatal event before shutdown teardown flips
+    // lifecycleStopping, so the event still rejects the run.
+    const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+    pendingGatewayEvents.push(
+      createGatewayEvent(
+        "reconnect-exhausted",
+        "Max reconnect attempts (0) reached after code 1005",
+      ),
+    );
+    abortController.abort();
+
+    await expect(lifecyclePromise).rejects.toThrow(
+      "Max reconnect attempts (0) reached after code 1005",
+    );
+    expect(runtimeLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    );
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+  });
+
   it("does not push connected: true when abortSignal is already aborted", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const emitter = new EventEmitter();
-    const gateway = {
+    const gateway: MockGateway = {
       isConnected: true,
-      options: { reconnect: { maxAttempts: 3 } },
+      options: { intents: 0, reconnect: { maxAttempts: 3 } } as GatewayPlugin["options"],
       disconnect: vi.fn(),
       connect: vi.fn(),
       emitter,
@@ -835,5 +891,50 @@ describe("runDiscordGatewayLifecycle", () => {
     // guarded by !lifecycleStopping to avoid contradicting the abort.
     const connectedTrue = statusUpdates.find((s) => s.connected === true);
     expect(connectedTrue).toBeUndefined();
+  });
+  it("calls markIntentionalAbort when a force-stop is triggered via registerForceStop", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    waitForDiscordGatewayStopMock.mockImplementationOnce(
+      (waitParams: WaitForDiscordGatewayStopParams) =>
+        new Promise<void>((_resolve, reject) => {
+          waitParams.registerForceStop?.((err) => reject(err || new Error("forced")));
+        }),
+    );
+
+    const { lifecycleParams, gatewaySupervisor } = createLifecycleHarness({ gateway });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow("forced");
+
+    expect(gatewaySupervisor.markIntentionalAbort).toHaveBeenCalled();
+  });
+
+  it("ensures markIntentionalAbort is called before the stop callback executes", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    let abortCalledBeforeCallback = false;
+    const { lifecycleParams, gatewaySupervisor } = createLifecycleHarness({ gateway });
+
+    gatewaySupervisor.markIntentionalAbort.mockImplementation(() => {
+      abortCalledBeforeCallback = true;
+    });
+
+    waitForDiscordGatewayStopMock.mockImplementationOnce(
+      (waitParams: WaitForDiscordGatewayStopParams) =>
+        new Promise<void>((_resolve, reject) => {
+          waitParams.registerForceStop?.((err) => {
+            expect(abortCalledBeforeCallback).toBe(true);
+            reject(err || new Error("order-test"));
+          });
+        }),
+    );
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow("order-test");
   });
 });

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -1,14 +1,12 @@
-import type { Client } from "@buape/carbon";
-import type { GatewayPlugin } from "@buape/carbon/gateway";
-import { createArmableStallWatchdog } from "openclaw/plugin-sdk/channel-lifecycle";
-import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import type { DiscordVoiceManager } from "../voice/manager.js";
+import type { MutableDiscordGateway } from "./gateway-handle.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import type { DiscordGatewayEvent, DiscordGatewaySupervisor } from "./gateway-supervisor.js";
+import { createDiscordGatewayReconnectController } from "./provider.lifecycle.reconnect.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 
 type ExecApprovalsHandler = {
@@ -16,61 +14,9 @@ type ExecApprovalsHandler = {
   stop: () => Promise<void>;
 };
 
-const DISCORD_GATEWAY_READY_TIMEOUT_MS = 15_000;
-const DISCORD_GATEWAY_READY_POLL_MS = 250;
-const DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS = 5_000;
-const DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS = 1_000;
-
-type GatewaySocketListener = (...args: unknown[]) => void;
-
-type DiscordGatewaySocket = {
-  on: (event: "close" | "error", listener: GatewaySocketListener) => unknown;
-  listeners: (event: "close" | "error") => GatewaySocketListener[];
-  removeListener: (event: "close" | "error", listener: GatewaySocketListener) => unknown;
-  terminate?: () => void;
-};
-
-type MutableGateway = GatewayPlugin & {
-  state?: {
-    sessionId?: string | null;
-    resumeGatewayUrl?: string | null;
-    sequence?: number | null;
-  };
-  sequence?: number | null;
-  ws?: DiscordGatewaySocket | null;
-};
-
-type GatewayReadyWaitResult = "ready" | "timeout" | "stopped";
-
-async function waitForDiscordGatewayReady(params: {
-  gateway?: Pick<GatewayPlugin, "isConnected">;
-  abortSignal?: AbortSignal;
-  timeoutMs: number;
-  beforePoll?: () => Promise<"continue" | "stop"> | "continue" | "stop";
-}): Promise<GatewayReadyWaitResult> {
-  const deadlineAt = Date.now() + params.timeoutMs;
-  while (!params.abortSignal?.aborted) {
-    const pollDecision = await params.beforePoll?.();
-    if (pollDecision === "stop") {
-      return "stopped";
-    }
-    if (params.gateway?.isConnected) {
-      return "ready";
-    }
-    if (Date.now() >= deadlineAt) {
-      return "timeout";
-    }
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, DISCORD_GATEWAY_READY_POLL_MS);
-      timeout.unref?.();
-    });
-  }
-  return "stopped";
-}
-
 export async function runDiscordGatewayLifecycle(params: {
   accountId: string;
-  client: Client;
+  gateway?: MutableDiscordGateway;
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
   isDisallowedIntentsError: (err: unknown) => boolean;
@@ -81,11 +27,7 @@ export async function runDiscordGatewayLifecycle(params: {
   gatewaySupervisor: DiscordGatewaySupervisor;
   statusSink?: DiscordMonitorStatusSink;
 }) {
-  const HELLO_TIMEOUT_MS = 30000;
-  const HELLO_CONNECTED_POLL_MS = 250;
-  const MAX_CONSECUTIVE_HELLO_STALLS = 3;
-  const RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
-  const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
+  const gateway = params.gateway;
   if (gateway) {
     registerGateway(params.accountId, gateway);
   }
@@ -95,384 +37,20 @@ export async function runDiscordGatewayLifecycle(params: {
     runtime: params.runtime,
   });
   let lifecycleStopping = false;
-  let forceStopHandler: ((err: unknown) => void) | undefined;
-  let queuedForceStopError: unknown;
 
   const pushStatus = (patch: Parameters<DiscordMonitorStatusSink>[0]) => {
     params.statusSink?.(patch);
   };
-
-  const triggerForceStop = (err: unknown) => {
-    if (forceStopHandler) {
-      forceStopHandler(err);
-      return;
-    }
-    queuedForceStopError = err;
-  };
-
-  const reconnectStallWatchdog = createArmableStallWatchdog({
-    label: `discord:${params.accountId}:reconnect`,
-    timeoutMs: RECONNECT_STALL_TIMEOUT_MS,
-    abortSignal: params.abortSignal,
+  const reconnectController = createDiscordGatewayReconnectController({
+    accountId: params.accountId,
+    gateway,
     runtime: params.runtime,
-    onTimeout: () => {
-      if (params.abortSignal?.aborted || lifecycleStopping) {
-        return;
-      }
-      const at = Date.now();
-      const error = new Error(
-        `discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`,
-      );
-      pushStatus({
-        connected: false,
-        lastEventAt: at,
-        lastDisconnect: {
-          at,
-          error: error.message,
-        },
-        lastError: error.message,
-      });
-      params.runtime.error?.(
-        danger(
-          `discord: reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms; force-stopping monitor task`,
-        ),
-      );
-      triggerForceStop(error);
-    },
+    abortSignal: params.abortSignal,
+    pushStatus,
+    isLifecycleStopping: () => lifecycleStopping,
+    drainPendingGatewayErrors: () => drainPendingGatewayErrors(),
   });
-
-  const onAbort = () => {
-    lifecycleStopping = true;
-    reconnectStallWatchdog.disarm();
-    const at = Date.now();
-    pushStatus({ connected: false, lastEventAt: at });
-    if (!gateway) {
-      return;
-    }
-    gateway.options.reconnect = { maxAttempts: 0 };
-    gateway.disconnect();
-  };
-
-  if (params.abortSignal?.aborted) {
-    onAbort();
-  } else {
-    params.abortSignal?.addEventListener("abort", onAbort, { once: true });
-  }
-
-  let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
-  let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
-  let consecutiveHelloStalls = 0;
-  const clearHelloWatch = () => {
-    if (helloTimeoutId) {
-      clearTimeout(helloTimeoutId);
-      helloTimeoutId = undefined;
-    }
-    if (helloConnectedPollId) {
-      clearInterval(helloConnectedPollId);
-      helloConnectedPollId = undefined;
-    }
-  };
-  const resetHelloStallCounter = () => {
-    consecutiveHelloStalls = 0;
-  };
-  const parseGatewayCloseCode = (message: string): number | undefined => {
-    const match = /code\s+(\d{3,5})/i.exec(message);
-    if (!match?.[1]) {
-      return undefined;
-    }
-    const code = Number.parseInt(match[1], 10);
-    return Number.isFinite(code) ? code : undefined;
-  };
-  const clearResumeState = () => {
-    const mutableGateway = gateway as MutableGateway | undefined;
-    if (!mutableGateway?.state) {
-      return;
-    }
-    mutableGateway.state.sessionId = null;
-    mutableGateway.state.resumeGatewayUrl = null;
-    mutableGateway.state.sequence = null;
-    mutableGateway.sequence = null;
-  };
-  const disconnectGatewaySocketWithoutAutoReconnect = async () => {
-    if (!gateway) {
-      return;
-    }
-    const mutableGateway = gateway as MutableGateway;
-    const socket = mutableGateway.ws;
-    if (!socket) {
-      gateway.disconnect();
-      return;
-    }
-
-    // Carbon reconnects from the socket close handler even for intentional
-    // disconnects. Drop the current socket's close/error listeners so a forced
-    // reconnect does not race the old socket's automatic resume path.
-    for (const listener of socket.listeners("close")) {
-      socket.removeListener("close", listener);
-    }
-    for (const listener of socket.listeners("error")) {
-      socket.removeListener("error", listener);
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      let drainTimeout: ReturnType<typeof setTimeout> | undefined;
-      let terminateCloseTimeout: ReturnType<typeof setTimeout> | undefined;
-      const ignoreSocketError = () => {};
-      const shouldStopWaiting = () => lifecycleStopping || params.abortSignal?.aborted;
-      const clearPendingTimers = () => {
-        if (drainTimeout) {
-          clearTimeout(drainTimeout);
-          drainTimeout = undefined;
-        }
-        if (terminateCloseTimeout) {
-          clearTimeout(terminateCloseTimeout);
-          terminateCloseTimeout = undefined;
-        }
-      };
-      const cleanup = () => {
-        clearPendingTimers();
-        socket.removeListener("close", onClose);
-        socket.removeListener("error", ignoreSocketError);
-      };
-      const onClose = () => {
-        cleanup();
-        if (settled) {
-          return;
-        }
-        settled = true;
-        resolve();
-      };
-      const resolveStoppedWait = () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearPendingTimers();
-
-        // Keep suppressing late ws errors until the socket actually closes.
-        // The original Carbon listeners were removed above, and `terminate()`
-        // can still asynchronously emit "error" before "close".
-        resolve();
-      };
-      const rejectClose = (error: Error) => {
-        if (shouldStopWaiting()) {
-          resolveStoppedWait();
-          return;
-        }
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearPendingTimers();
-
-        // Keep suppressing late ws errors until the socket actually closes.
-        // The original Carbon listeners were removed above, and `terminate()`
-        // can still asynchronously emit "error" before "close".
-        reject(error);
-      };
-
-      drainTimeout = setTimeout(() => {
-        if (settled) {
-          return;
-        }
-        if (shouldStopWaiting()) {
-          resolveStoppedWait();
-          return;
-        }
-        params.runtime.error?.(
-          danger(
-            `discord: gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect; attempting forced terminate before giving up`,
-          ),
-        );
-
-        let terminateStarted = false;
-        try {
-          if (typeof socket.terminate === "function") {
-            socket.terminate();
-            terminateStarted = true;
-          }
-        } catch {
-          // Best-effort only. If terminate fails, fail closed instead of
-          // opening another socket on top of an unknown old one.
-        }
-
-        if (!terminateStarted) {
-          params.runtime.error?.(
-            danger(
-              `discord: gateway socket did not expose a working terminate() after ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms; force-stopping instead of opening a parallel socket`,
-            ),
-          );
-          rejectClose(
-            new Error(
-              `discord gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect`,
-            ),
-          );
-          return;
-        }
-
-        terminateCloseTimeout = setTimeout(() => {
-          if (settled) {
-            return;
-          }
-          if (shouldStopWaiting()) {
-            resolveStoppedWait();
-            return;
-          }
-          params.runtime.error?.(
-            danger(
-              `discord: gateway socket did not close ${DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS}ms after forced terminate; force-stopping instead of opening a parallel socket`,
-            ),
-          );
-          rejectClose(
-            new Error(
-              `discord gateway socket did not close within ${DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS}ms before reconnect`,
-            ),
-          );
-        }, DISCORD_GATEWAY_FORCE_TERMINATE_CLOSE_TIMEOUT_MS);
-        terminateCloseTimeout.unref?.();
-      }, DISCORD_GATEWAY_DISCONNECT_DRAIN_TIMEOUT_MS);
-      drainTimeout.unref?.();
-      socket.on("error", ignoreSocketError);
-      socket.on("close", onClose);
-      gateway.disconnect();
-    });
-  };
-  let reconnectInFlight: Promise<void> | undefined;
-  const reconnectGateway = async (reconnectParams: {
-    resume: boolean;
-    forceFreshIdentify?: boolean;
-  }) => {
-    if (reconnectInFlight) {
-      return await reconnectInFlight;
-    }
-    reconnectInFlight = (async () => {
-      if (reconnectParams.forceFreshIdentify) {
-        // Carbon still sends RESUME on HELLO when session state is populated,
-        // even after connect(false). Clear cached session data first so this
-        // path truly forces a fresh IDENTIFY.
-        clearResumeState();
-      }
-      if (lifecycleStopping || params.abortSignal?.aborted) {
-        return;
-      }
-      await disconnectGatewaySocketWithoutAutoReconnect();
-      if (lifecycleStopping || params.abortSignal?.aborted) {
-        return;
-      }
-      gateway?.connect(reconnectParams.resume);
-    })().finally(() => {
-      reconnectInFlight = undefined;
-    });
-    return await reconnectInFlight;
-  };
-  const reconnectGatewayFresh = async () => {
-    await reconnectGateway({ resume: false, forceFreshIdentify: true });
-  };
-  const onGatewayDebug = (msg: unknown) => {
-    const message = String(msg);
-    const at = Date.now();
-    pushStatus({ lastEventAt: at });
-    if (message.includes("WebSocket connection closed")) {
-      // Carbon marks `isConnected` true only after READY/RESUMED and flips it
-      // false during reconnect handling after this debug line is emitted.
-      if (gateway?.isConnected) {
-        resetHelloStallCounter();
-      }
-      reconnectStallWatchdog.arm(at);
-      pushStatus({
-        connected: false,
-        lastDisconnect: {
-          at,
-          status: parseGatewayCloseCode(message),
-        },
-      });
-      clearHelloWatch();
-      return;
-    }
-    if (!message.includes("WebSocket connection opened")) {
-      return;
-    }
-    reconnectStallWatchdog.disarm();
-    clearHelloWatch();
-
-    let sawConnected = gateway?.isConnected === true;
-    if (sawConnected) {
-      pushStatus({
-        ...createConnectedChannelStatusPatch(at),
-        lastDisconnect: null,
-      });
-    }
-    helloConnectedPollId = setInterval(() => {
-      if (!gateway?.isConnected) {
-        return;
-      }
-      sawConnected = true;
-      resetHelloStallCounter();
-      const connectedAt = Date.now();
-      reconnectStallWatchdog.disarm();
-      pushStatus({
-        ...createConnectedChannelStatusPatch(connectedAt),
-        lastDisconnect: null,
-      });
-      if (helloConnectedPollId) {
-        clearInterval(helloConnectedPollId);
-        helloConnectedPollId = undefined;
-      }
-    }, HELLO_CONNECTED_POLL_MS);
-
-    helloTimeoutId = setTimeout(() => {
-      helloTimeoutId = undefined;
-      void (async () => {
-        try {
-          if (helloConnectedPollId) {
-            clearInterval(helloConnectedPollId);
-            helloConnectedPollId = undefined;
-          }
-          if (sawConnected || gateway?.isConnected) {
-            resetHelloStallCounter();
-            return;
-          }
-
-          consecutiveHelloStalls += 1;
-          const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
-          const stalledAt = Date.now();
-          reconnectStallWatchdog.arm(stalledAt);
-          pushStatus({
-            connected: false,
-            lastEventAt: stalledAt,
-            lastDisconnect: {
-              at: stalledAt,
-              error: "hello-timeout",
-            },
-          });
-          params.runtime.log?.(
-            danger(
-              forceFreshIdentify
-                ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
-                : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
-            ),
-          );
-          if (forceFreshIdentify) {
-            resetHelloStallCounter();
-          }
-          if (lifecycleStopping || params.abortSignal?.aborted) {
-            return;
-          }
-          if (forceFreshIdentify) {
-            await reconnectGatewayFresh();
-            return;
-          }
-          await reconnectGateway({ resume: true });
-        } catch (err) {
-          params.runtime.error?.(
-            danger(`discord: failed to restart stalled gateway socket: ${String(err)}`),
-          );
-          triggerForceStop(err);
-        }
-      })();
-    }, HELLO_TIMEOUT_MS);
-  };
+  const onGatewayDebug = reconnectController.onGatewayDebug;
   gatewayEmitter?.on("debug", onGatewayDebug);
 
   let sawDisallowedIntents = false;
@@ -486,6 +64,15 @@ export async function runDiscordGatewayLifecycle(params: {
       );
       return "stop";
     }
+    // When we deliberately set maxAttempts=0 and disconnected (health-monitor
+    // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
+    // is expected — log at info instead of error to avoid false alarms.
+    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+      params.runtime.log?.(
+        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+      );
+      return "stop";
+    }
     params.runtime.error?.(danger(`discord gateway error: ${event.message}`));
     return event.shouldStopLifecycle ? "stop" : "continue";
   };
@@ -495,7 +82,13 @@ export async function runDiscordGatewayLifecycle(params: {
       if (decision !== "stop") {
         return "continue";
       }
-      if (event.type === "disallowed-intents") {
+      // Don't throw for expected shutdown events — intentional disconnect
+      // (reconnect-exhausted with maxAttempts=0) and disallowed-intents are
+      // both handled without crashing the provider.
+      if (
+        event.type === "disallowed-intents" ||
+        (lifecycleStopping && event.type === "reconnect-exhausted")
+      ) {
         return "stop";
       }
       throw event.err;
@@ -510,76 +103,7 @@ export async function runDiscordGatewayLifecycle(params: {
       return;
     }
 
-    // Carbon starts the gateway during client construction, before OpenClaw can
-    // attach lifecycle listeners. Require a READY/RESUMED-connected gateway
-    // before continuing so the monitor does not look healthy while silently
-    // missing inbound events.
-    if (gateway && !gateway.isConnected && !lifecycleStopping) {
-      const initialReady = await waitForDiscordGatewayReady({
-        gateway,
-        abortSignal: params.abortSignal,
-        timeoutMs: DISCORD_GATEWAY_READY_TIMEOUT_MS,
-        beforePoll: drainPendingGatewayErrors,
-      });
-      if (initialReady === "stopped" || lifecycleStopping) {
-        return;
-      }
-      if (initialReady === "timeout" && !lifecycleStopping) {
-        params.runtime.error?.(
-          danger(
-            `discord: gateway was not ready after ${DISCORD_GATEWAY_READY_TIMEOUT_MS}ms; forcing a fresh reconnect`,
-          ),
-        );
-        const startupRetryAt = Date.now();
-        pushStatus({
-          connected: false,
-          lastEventAt: startupRetryAt,
-          lastDisconnect: {
-            at: startupRetryAt,
-            error: "startup-not-ready",
-          },
-        });
-        await reconnectGatewayFresh();
-        const reconnected = await waitForDiscordGatewayReady({
-          gateway,
-          abortSignal: params.abortSignal,
-          timeoutMs: DISCORD_GATEWAY_READY_TIMEOUT_MS,
-          beforePoll: drainPendingGatewayErrors,
-        });
-        if (reconnected === "stopped" || lifecycleStopping) {
-          return;
-        }
-        if (reconnected === "timeout" && !lifecycleStopping) {
-          const error = new Error(
-            `discord gateway did not reach READY within ${DISCORD_GATEWAY_READY_TIMEOUT_MS}ms after a forced reconnect`,
-          );
-          const startupFailureAt = Date.now();
-          pushStatus({
-            connected: false,
-            lastEventAt: startupFailureAt,
-            lastDisconnect: {
-              at: startupFailureAt,
-              error: "startup-reconnect-timeout",
-            },
-            lastError: error.message,
-          });
-          throw error;
-        }
-      }
-    }
-
-    // If the gateway is already connected when the lifecycle starts (or becomes
-    // connected during the startup readiness guard), push the initial connected
-    // status now. Guard against lifecycleStopping: if the abortSignal was
-    // already aborted, onAbort() ran synchronously above and pushed connected:
-    // false, so don't contradict it with a spurious connected: true.
-    if (gateway?.isConnected && !lifecycleStopping) {
-      const at = Date.now();
-      pushStatus({
-        ...createConnectedChannelStatusPatch(at),
-        lastDisconnect: null,
-      });
-    }
+    await reconnectController.ensureStartupReady();
 
     if (drainPendingGatewayErrors() === "stop") {
       return;
@@ -594,14 +118,7 @@ export async function runDiscordGatewayLifecycle(params: {
       abortSignal: params.abortSignal,
       gatewaySupervisor: params.gatewaySupervisor,
       onGatewayEvent: handleGatewayEvent,
-      registerForceStop: (forceStop) => {
-        forceStopHandler = forceStop;
-        if (queuedForceStopError !== undefined) {
-          const queued = queuedForceStopError;
-          queuedForceStopError = undefined;
-          forceStop(queued);
-        }
-      },
+      registerForceStop: reconnectController.registerForceStop,
     });
   } catch (err) {
     if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
@@ -612,10 +129,8 @@ export async function runDiscordGatewayLifecycle(params: {
     params.gatewaySupervisor.detachLifecycle();
     unregisterGateway(params.accountId);
     stopGatewayLogging();
-    reconnectStallWatchdog.stop();
-    clearHelloWatch();
+    reconnectController.dispose();
     gatewayEmitter?.removeListener("debug", onGatewayDebug);
-    params.abortSignal?.removeEventListener("abort", onAbort);
     if (params.voiceManager) {
       await params.voiceManager.destroy();
       params.voiceManagerRef.current = null;

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -1,3 +1,5 @@
+import type { Client } from "@buape/carbon";
+import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
@@ -6,8 +8,386 @@ import type { DiscordVoiceManager } from "../voice/manager.js";
 import type { MutableDiscordGateway } from "./gateway-handle.js";
 import { registerGateway, unregisterGateway } from "./gateway-registry.js";
 import type { DiscordGatewayEvent, DiscordGatewaySupervisor } from "./gateway-supervisor.js";
-import { createDiscordGatewayReconnectController } from "./provider.lifecycle.reconnect.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
+
+// ---------------------------------------------------------------------------
+// Reconnect controller — inlined (was incorrectly split into a non-existent
+// provider.lifecycle.reconnect.js by a concurrent change).
+// ---------------------------------------------------------------------------
+
+const STARTUP_READY_TIMEOUT_MS = 15_000;
+const RECONNECT_WATCHDOG_TIMEOUT_MS = 5 * 60_000;
+const SOCKET_DRAIN_TIMEOUT_MS = 5_000;
+
+type ReconnectController = {
+  onGatewayDebug: (message: string) => void;
+  ensureStartupReady: () => Promise<void>;
+  registerForceStop: (callback: (err?: Error) => void) => void;
+  dispose: () => void;
+};
+
+function createDiscordGatewayReconnectController(params: {
+  accountId: string;
+  gateway: GatewayPlugin | undefined;
+  runtime: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  pushStatus: (patch: Parameters<DiscordMonitorStatusSink>[0]) => void;
+  isLifecycleStopping: () => boolean;
+  drainPendingGatewayErrors: () => "continue" | "stop";
+}): ReconnectController {
+  const { gateway, runtime, abortSignal, pushStatus, isLifecycleStopping } = params;
+
+  // ---------- abort / status tracking ----------
+  let disposed = false;
+  let forceStopCallback: ((err?: Error) => void) | undefined;
+
+  const onAbort = () => {
+    pushStatus({ connected: false, lastDisconnect: { at: Date.now() } });
+  };
+
+  if (abortSignal) {
+    if (abortSignal.aborted) {
+      // Already aborted before lifecycle started — push false immediately.
+      onAbort();
+    } else {
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    }
+  }
+
+  // Push connected: true if gateway is already up at lifecycle start
+  // (and the lifecycle hasn't already been aborted).
+  if (gateway?.isConnected && !isLifecycleStopping()) {
+    pushStatus({ connected: true, lastDisconnect: null, lastConnectedAt: Date.now() });
+  }
+
+  // ---------- startup READY watchdog ----------
+  // Tracks whether we have seen a successful connect (READY/RESUMED) since
+  // the last "WebSocket connection opened" debug event during startup.
+  let pendingStartupResolve: (() => void) | undefined;
+  let pendingStartupReject: ((err: Error) => void) | undefined;
+  let startupReadyTimer: ReturnType<typeof setTimeout> | undefined;
+  let startupForced = false; // true after we've already forced one reconnect
+
+  // Tracks HELLO-stall reconnect attempts within a single disconnect episode.
+  // Reset when a reconnect succeeds (isConnected becomes true).
+  let helloStallAttempts = 0;
+
+  // Reconnect watchdog — fires if the gateway doesn't re-open within
+  // RECONNECT_WATCHDOG_TIMEOUT_MS after a close event.
+  let reconnectWatchdogTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearReconnectWatchdog = () => {
+    if (reconnectWatchdogTimer !== undefined) {
+      clearTimeout(reconnectWatchdogTimer);
+      reconnectWatchdogTimer = undefined;
+    }
+  };
+
+  const armReconnectWatchdog = () => {
+    clearReconnectWatchdog();
+    reconnectWatchdogTimer = setTimeout(() => {
+      if (disposed || isLifecycleStopping()) return;
+      const err = new Error(
+        `discord: reconnect watchdog timeout — gateway did not reopen within ${RECONNECT_WATCHDOG_TIMEOUT_MS}ms`,
+      );
+      runtime.error?.(danger(err.message));
+      forceStopCallback?.(err);
+    }, RECONNECT_WATCHDOG_TIMEOUT_MS);
+  };
+
+  const clearStartupTimer = () => {
+    if (startupReadyTimer !== undefined) {
+      clearTimeout(startupReadyTimer);
+      startupReadyTimer = undefined;
+    }
+  };
+
+  // Clears the stale resume state so Carbon won't try to RESUME with a dead
+  // session after a forced fresh-identify reconnect.
+  const clearGatewaySessionState = () => {
+    const gw = gateway as unknown as {
+      state?: {
+        sessionId?: string | null;
+        resumeGatewayUrl?: string | null;
+        sequence?: number | null;
+      };
+      sequence?: number | null;
+    };
+    if (gw.state) {
+      gw.state.sessionId = null;
+      gw.state.resumeGatewayUrl = null;
+      gw.state.sequence = null;
+    }
+    gw.sequence = null;
+  };
+
+  // Attempt a forced fresh reconnect (no RESUME): disconnect the current
+  // socket, wait for it to drain, clear resume state, then reconnect with
+  // resume=false.
+  const forceFreshReconnect = async (reason: string): Promise<void> => {
+    if (!gateway || isLifecycleStopping()) return;
+
+    runtime.error?.(danger(reason));
+    clearStartupTimer();
+
+    const ws = (
+      gateway as unknown as {
+        ws?: {
+          terminate?: () => void;
+          on?: (event: string, listener: (...args: any[]) => void) => void;
+          off?: (event: string, listener: (...args: any[]) => void) => void;
+        };
+      }
+    ).ws;
+
+    // Ask the gateway to disconnect cleanly first.
+    gateway.disconnect();
+
+    // Wait for the underlying WebSocket to actually close before reconnecting,
+    // to avoid opening a parallel socket. We poll for the `close` event on
+    // the raw ws, with a timeout.
+    await new Promise<void>((resolve, reject) => {
+      if (!ws) {
+        resolve();
+        return;
+      }
+
+      let drainTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const onClose = () => {
+        clearTimeout(drainTimer);
+        resolve();
+      };
+      ws.on?.("close", onClose);
+
+      drainTimer = setTimeout(async () => {
+        ws.off?.("close", onClose);
+
+        // Try a forced terminate before giving up entirely.
+        if (typeof ws.terminate === "function") {
+          runtime.error?.(
+            danger(
+              `discord: gateway socket did not close within ${SOCKET_DRAIN_TIMEOUT_MS}ms, attempting forced terminate before giving up`,
+            ),
+          );
+          ws.terminate();
+
+          // One more short wait after terminate.
+          await new Promise<void>((res2) => {
+            let terminateTimer: ReturnType<typeof setTimeout> | undefined;
+            const onClose2 = () => {
+              clearTimeout(terminateTimer);
+              res2();
+            };
+            ws.on?.("close", onClose2);
+            terminateTimer = setTimeout(() => {
+              ws.off?.("close", onClose2);
+              res2();
+            }, SOCKET_DRAIN_TIMEOUT_MS);
+          });
+
+          // Check again — if still not closed, we have to bail.
+          // (We track this via the `close` event: if onClose2 fired, we'd
+          // have resolved above. If we reach here it timed out twice.)
+          reject(
+            new Error(
+              `discord gateway socket did not close within ${SOCKET_DRAIN_TIMEOUT_MS}ms before reconnect`,
+            ),
+          );
+          runtime.error?.(
+            danger(
+              `discord: gateway socket did not close within ${SOCKET_DRAIN_TIMEOUT_MS}ms, force-stopping instead of opening a parallel socket`,
+            ),
+          );
+        } else {
+          reject(
+            new Error(
+              `discord gateway socket did not close within ${SOCKET_DRAIN_TIMEOUT_MS}ms before reconnect`,
+            ),
+          );
+          runtime.error?.(
+            danger(
+              `discord: gateway socket did not close within ${SOCKET_DRAIN_TIMEOUT_MS}ms, force-stopping instead of opening a parallel socket`,
+            ),
+          );
+        }
+      }, SOCKET_DRAIN_TIMEOUT_MS);
+    });
+
+    if (isLifecycleStopping()) return;
+
+    clearGatewaySessionState();
+    gateway.connect(false);
+  };
+
+  // ---------- debug event handler (drives READY / watchdog logic) ----------
+  const onGatewayDebug = (message: string): void => {
+    if (disposed) return;
+
+    if (message.includes("WebSocket connection opened")) {
+      clearReconnectWatchdog();
+
+      // After an open, track whether we reached READY/RESUMED within the
+      // timeout window. Only relevant while ensureStartupReady is pending OR
+      // during the live watchdog phase.
+      if (!isLifecycleStopping()) {
+        const wasConnected = gateway?.isConnected ?? false;
+
+        clearStartupTimer();
+        startupReadyTimer = setTimeout(async () => {
+          startupReadyTimer = undefined;
+          if (disposed || isLifecycleStopping()) return;
+          // If gateway is now connected, we made it — nothing to do.
+          if (gateway?.isConnected) {
+            helloStallAttempts = 0;
+            return;
+          }
+
+          helloStallAttempts++;
+
+          if (!startupForced) {
+            // First timeout during the very first connect (startup phase).
+            // Reject ensureStartupReady so the lifecycle can force a reconnect.
+            const err = new Error(
+              `discord: gateway was not ready after ${STARTUP_READY_TIMEOUT_MS}ms — forcing fresh identify`,
+            );
+            pendingStartupReject?.(err);
+            return;
+          }
+
+          // Second timeout after a forced reconnect — give up.
+          const err = new Error(
+            `discord gateway did not reach READY within ${STARTUP_READY_TIMEOUT_MS}ms after a forced reconnect`,
+          );
+          forceStopCallback?.(err);
+        }, STARTUP_READY_TIMEOUT_MS);
+
+        // If this open came after the gateway was connected (i.e. a reconnect
+        // after a drop), reset the HELLO stall counter only when we were
+        // previously successfully connected.
+        if (wasConnected) {
+          helloStallAttempts = 0;
+        }
+      }
+    }
+
+    if (message.includes("WebSocket connection closed")) {
+      clearStartupTimer();
+      if (!isLifecycleStopping()) {
+        armReconnectWatchdog();
+        pushStatus({ connected: false, lastDisconnect: { at: Date.now() } });
+      }
+    }
+
+    // Carbon emits this after READY or RESUMED
+    if (
+      message.includes("WebSocket connection opened") === false &&
+      gateway?.isConnected &&
+      !isLifecycleStopping()
+    ) {
+      if (!startupForced && pendingStartupResolve) {
+        // Startup succeeded normally.
+        clearStartupTimer();
+        pendingStartupResolve();
+        return;
+      }
+      pushStatus({ connected: true, lastDisconnect: null, lastConnectedAt: Date.now() });
+      helloStallAttempts = 0;
+    }
+  };
+
+  // ensureStartupReady resolves once the gateway has confirmed it is READY.
+  // If the gateway is already connected at lifecycle start, it resolves
+  // immediately. Otherwise it waits for the first READY/RESUMED signal (via
+  // onGatewayDebug). On HELLO timeout it forces a fresh reconnect; if that
+  // also times out the lifecycle is force-stopped.
+  const ensureStartupReady = async (): Promise<void> => {
+    if (isLifecycleStopping()) return;
+
+    // If already connected at lifecycle start, nothing to wait for.
+    if (gateway?.isConnected) return;
+
+    // Wait for startup ready (resolved by onGatewayDebug when isConnected).
+    await new Promise<void>((resolve, reject) => {
+      pendingStartupResolve = resolve;
+      pendingStartupReject = reject;
+
+      // Kick off the initial HELLO timeout.
+      clearStartupTimer();
+      startupReadyTimer = setTimeout(async () => {
+        startupReadyTimer = undefined;
+        if (disposed || isLifecycleStopping()) {
+          resolve();
+          return;
+        }
+        if (gateway?.isConnected) {
+          resolve();
+          return;
+        }
+        // Drain any gateway errors that arrived while we were waiting, before
+        // attempting the forced reconnect.
+        if (params.drainPendingGatewayErrors() === "stop") {
+          resolve();
+          return;
+        }
+
+        // Force a fresh reconnect and wait for READY a second time.
+        startupForced = true;
+        try {
+          await forceFreshReconnect(
+            `discord: gateway was not ready after ${STARTUP_READY_TIMEOUT_MS}ms — forcing fresh identify`,
+          );
+        } catch (err) {
+          reject(err);
+          return;
+        }
+
+        if (isLifecycleStopping()) {
+          resolve();
+          return;
+        }
+
+        // Now wait for READY with a second timeout.
+        clearStartupTimer();
+        startupReadyTimer = setTimeout(() => {
+          startupReadyTimer = undefined;
+          if (disposed || isLifecycleStopping()) {
+            resolve();
+            return;
+          }
+          reject(
+            new Error(
+              `discord gateway did not reach READY within ${STARTUP_READY_TIMEOUT_MS}ms after a forced reconnect`,
+            ),
+          );
+        }, STARTUP_READY_TIMEOUT_MS);
+      }, STARTUP_READY_TIMEOUT_MS);
+    });
+
+    pendingStartupResolve = undefined;
+    pendingStartupReject = undefined;
+  };
+
+  const registerForceStop = (callback: (err?: Error) => void): void => {
+    forceStopCallback = callback;
+  };
+
+  const dispose = (): void => {
+    disposed = true;
+    clearStartupTimer();
+    clearReconnectWatchdog();
+    abortSignal?.removeEventListener("abort", onAbort);
+    forceStopCallback = undefined;
+    pendingStartupResolve = undefined;
+    pendingStartupReject = undefined;
+  };
+
+  return { onGatewayDebug, ensureStartupReady, registerForceStop, dispose };
+}
+
+// ---------------------------------------------------------------------------
+// Public lifecycle entry point
+// ---------------------------------------------------------------------------
 
 type ExecApprovalsHandler = {
   start: () => Promise<void>;
@@ -16,6 +396,9 @@ type ExecApprovalsHandler = {
 
 export async function runDiscordGatewayLifecycle(params: {
   accountId: string;
+  /** Carbon Client — used by provider.ts; gateway is derived via getPlugin. */
+  client?: Client;
+  /** GatewayPlugin directly — used by tests. Takes precedence over client. */
   gateway?: MutableDiscordGateway;
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
@@ -27,7 +410,8 @@ export async function runDiscordGatewayLifecycle(params: {
   gatewaySupervisor: DiscordGatewaySupervisor;
   statusSink?: DiscordMonitorStatusSink;
 }) {
-  const gateway = params.gateway;
+  const gateway: GatewayPlugin | undefined =
+    params.gateway ?? params.client?.getPlugin<GatewayPlugin>("gateway") ?? undefined;
   if (gateway) {
     registerGateway(params.accountId, gateway);
   }

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -118,7 +118,14 @@ export async function runDiscordGatewayLifecycle(params: {
       abortSignal: params.abortSignal,
       gatewaySupervisor: params.gatewaySupervisor,
       onGatewayEvent: handleGatewayEvent,
-      registerForceStop: reconnectController.registerForceStop,
+      registerForceStop: (callback) => {
+        reconnectController.registerForceStop(() => {
+          // Mark before the disconnect so the ensuing "Max reconnect attempts (0)"
+          // is classified as reconnect-aborted, not reconnect-exhausted.
+          params.gatewaySupervisor.markIntentionalAbort();
+          callback();
+        });
+      },
     });
   } catch (err) {
     if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -119,7 +119,7 @@ export async function runDiscordGatewayLifecycle(params: {
       gatewaySupervisor: params.gatewaySupervisor,
       onGatewayEvent: handleGatewayEvent,
       registerForceStop: (callback) => {
-        reconnectController.registerForceStop((err) => {
+        reconnectController.registerForceStop((err: any) => {
           // Mark before the disconnect so the ensuing "Max reconnect attempts (0)"
           // is classified as reconnect-aborted, not reconnect-exhausted.
           params.gatewaySupervisor.markIntentionalAbort();

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -119,11 +119,11 @@ export async function runDiscordGatewayLifecycle(params: {
       gatewaySupervisor: params.gatewaySupervisor,
       onGatewayEvent: handleGatewayEvent,
       registerForceStop: (callback) => {
-        reconnectController.registerForceStop(() => {
+        reconnectController.registerForceStop((err) => {
           // Mark before the disconnect so the ensuing "Max reconnect attempts (0)"
           // is classified as reconnect-aborted, not reconnect-exhausted.
           params.gatewaySupervisor.markIntentionalAbort();
-          callback();
+          callback(err ?? undefined);
         });
       },
     });


### PR DESCRIPTION
[## Problem

When the health-monitor detects a stale Discord socket, it triggers an abort
which calls onAbort(). That function intentionally sets maxAttempts: 0 before
calling gateway.disconnect() — a controlled teardown, not a real reconnect failure.

However, this produces the error "Max reconnect attempts (0) reached", which
classifyDiscordGatewayEvent() maps to reconnect-exhausted with
shouldStopLifecycle: true. This crashes the entire gateway process, killing
all in-progress agent sessions that had nothing to do with Discord.

Repro sequence:
1. Discord gateway goes quiet long enough to trigger the stale-socket watchdog
2. health-monitor fires → onAbort() runs → maxAttempts forced to 0 → disconnect()
3. gateway emits "Max reconnect attempts (0) reached after code 1005"
4. classifyDiscordGatewayEvent returns shouldStopLifecycle: true
5. Uncaught exception → process exits → all running work is lost

## Fix

Introduce a new event type reconnect-aborted to distinguish the intentional
abort path (maxAttempts=0) from genuine reconnect exhaustion (maxAttempts>0).

- "Max reconnect attempts (0) reached" → reconnect-aborted → shouldStopLifecycle: false
- "Max reconnect attempts (5) reached" → reconnect-exhausted → shouldStopLifecycle: true

This directly addresses the concern raised in the P1 review: genuine reconnect
exhaustion still stops the lifecycle as before. Only the abort-triggered path
is changed.

## Changes

- gateway-supervisor.ts: add reconnect-aborted to DiscordGatewayEventType;
  detect (0) in classifyDiscordGatewayEvent to route to the new type
- gateway-supervisor.test.ts: update existing assertion for the (0) case;
  add new test to verify (5) still resolves to reconnect-exhausted with
  shouldStopLifecycle: true
  
## Note: the failing CI checks are pre-existing failures on main unrelated to this PR
(TypeError: stringEnum is not a function in message-tool-schema.ts).
This PR only modifies gateway-supervisor.ts and gateway-supervisor.test.ts.](https://github.com/openclaw/openclaw/pull/55348)