### PR TITLE
fix(telegram): mark buttons schema as optional in message tool

### DIFF
--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -111,7 +111,7 @@ function describeTelegramMessageTool({
   if (discovery.buttonsEnabled) {
     schema.push({
       properties: {
-        buttons: createMessageToolButtonsSchema(),
+        buttons: Type.Optional(createMessageToolButtonsSchema()),
       },
     });
   }


### PR DESCRIPTION
## Summary

- The Telegram channel plugin's `describeTelegramMessageTool` adds a `buttons` property to the shared `message` tool schema without wrapping it in `Type.Optional()`, causing validation to reject **all** message tool calls (including `send` and `topic-create`) with: `Validation failed for tool "message": - buttons: must have required property 'buttons'`
- Both Discord (`components`) and Slack (`blocks`) correctly wrap their equivalent schema contributions in `Type.Optional()` — Telegram is the only channel that omits this

## Root cause

In `extensions/telegram/src/channel-actions.ts`, the buttons schema contribution is:

```ts
schema.push({
  properties: {
    buttons: createMessageToolButtonsSchema(), // NOT optional
  },
});
```

When this gets merged into the tool's `Type.Object(...)` via `buildMessageToolSchemaProps`, TypeBox treats any non-optional property as **required** in the generated JSON Schema. Since inline buttons default to enabled (scope: `"allowlist"`), this breaks the `message` tool for every Telegram user.

## Fix

Wrap in `Type.Optional()`, consistent with Discord and Slack:

```ts
buttons: Type.Optional(createMessageToolButtonsSchema()),
```

## Test plan

- [x] Verify `message(action="send", channel="telegram", target="...", message="...")` no longer fails validation
- [x] Verify `message(action="topic-create", channel="telegram", ...)` no longer fails validation
- [x] Verify buttons still work when explicitly provided
- [ ] Existing tests should still pass (the fix only affects schema optionality, not runtime behavior)