### PR TITLE
fix(imessage): prevent self-chat dedupe false positives (#47830)

### DIFF
--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -135,7 +135,10 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("records outbound text and message ids in sent-message cache", async () => {
+  it("records outbound text and message ids in sent-message cache (post-send only)", async () => {
+    // Fix for #47830: remember() is called ONLY after each chunk is sent,
+    // never with the full un-chunked text before sending begins.
+    // Pre-send population widened the false-positive window in self-chat.
     const remember = vi.fn();
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
 
@@ -150,7 +153,8 @@ describe("deliverReplies", () => {
       sentMessageCache: { remember },
     });
 
-    expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", { text: "first|second" });
+    // Only the two per-chunk post-send calls — no pre-send full-text call.
+    expect(remember).toHaveBeenCalledTimes(2);
     expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
       text: "first",
       messageId: "imsg-1",

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -141,6 +141,9 @@ describe("deliverReplies", () => {
     // Pre-send population widened the false-positive window in self-chat.
     const remember = vi.fn();
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+    sendMessageIMessageMock
+      .mockResolvedValueOnce({ messageId: "imsg-1" })
+      .mockResolvedValueOnce({ messageId: "imsg-2" });
 
     await deliverReplies({
       replies: [{ text: "first|second" }],
@@ -161,7 +164,7 @@ describe("deliverReplies", () => {
     });
     expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
       text: "second",
-      messageId: "imsg-1",
+      messageId: "imsg-2",
     });
   });
 });

--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
 
 const sendMessageIMessageMock = vi.hoisted(() =>
-  vi.fn().mockResolvedValue({ messageId: "imsg-1" }),
+  vi.fn().mockImplementation(async (_to: string, message: string) => ({
+    messageId: "imsg-1",
+    sentText: message,
+  })),
 );
 const chunkTextWithModeMock = vi.hoisted(() => vi.fn((text: string) => [text]));
 const resolveChunkModeMock = vi.hoisted(() => vi.fn(() => "length"));
@@ -142,8 +145,8 @@ describe("deliverReplies", () => {
     const remember = vi.fn();
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
     sendMessageIMessageMock
-      .mockResolvedValueOnce({ messageId: "imsg-1" })
-      .mockResolvedValueOnce({ messageId: "imsg-2" });
+      .mockResolvedValueOnce({ messageId: "imsg-1", sentText: "first" })
+      .mockResolvedValueOnce({ messageId: "imsg-2", sentText: "second" });
 
     await deliverReplies({
       replies: [{ text: "first|second" }],
@@ -165,6 +168,30 @@ describe("deliverReplies", () => {
     expect(remember).toHaveBeenCalledWith("acct-3:chat_id:30", {
       text: "second",
       messageId: "imsg-2",
+    });
+  });
+
+  it("records the actual sent placeholder for media-only replies", async () => {
+    const remember = vi.fn();
+    sendMessageIMessageMock.mockResolvedValueOnce({
+      messageId: "imsg-media-1",
+      sentText: "<media:image>",
+    });
+
+    await deliverReplies({
+      replies: [{ mediaUrls: ["https://example.com/a.jpg"] }],
+      target: "chat_id:40",
+      client,
+      accountId: "acct-4",
+      runtime,
+      maxBytes: 2048,
+      textLimit: 4000,
+      sentMessageCache: { remember },
+    });
+
+    expect(remember).toHaveBeenCalledWith("acct-4:chat_id:40", {
+      text: "<media:image>",
+      messageId: "imsg-media-1",
     });
   });
 });

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -38,9 +38,6 @@ export async function deliverReplies(params: {
     const reply = resolveSendableOutboundReplyParts(payload, {
       text: convertMarkdownTables(rawText, tableMode),
     });
-    if (!reply.hasMedia && reply.hasText) {
-      sentMessageCache?.remember(scope, { text: reply.text });
-    }
     const delivered = await deliverTextOrMediaReply({
       payload,
       text: reply.text,

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -53,7 +53,7 @@ export async function deliverReplies(params: {
         // not before. The window between send completion and cache write is sub-millisecond;
         // the next SQLite inbound poll is 1-2s away, so no echo can arrive before the
         // cache entry exists.
-        sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+        sentMessageCache?.remember(scope, { text: sent.sentText, messageId: sent.messageId });
       },
       sendMedia: async ({ mediaUrl, caption }) => {
         const sent = await sendMessageIMessage(target, caption ?? "", {
@@ -64,7 +64,7 @@ export async function deliverReplies(params: {
           replyToId: payload.replyToId,
         });
         sentMessageCache?.remember(scope, {
-          text: caption || undefined,
+          text: sent.sentText || undefined,
           messageId: sent.messageId,
         });
       },

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -49,6 +49,10 @@ export async function deliverReplies(params: {
           accountId,
           replyToId: payload.replyToId,
         });
+        // Post-send cache population (#47830): caching happens after each chunk is sent,
+        // not before. The window between send completion and cache write is sub-millisecond;
+        // the next SQLite inbound poll is 1-2s away, so no echo can arrive before the
+        // cache entry exists.
         sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
       },
       sendMedia: async ({ mediaUrl, caption }) => {

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -19,7 +19,8 @@ export type SentMessageCache = {
 
 // Keep the text fallback short so repeated user replies like "ok" are not
 // suppressed for long; delayed reflections should match the stronger message-id key.
-const SENT_MESSAGE_TEXT_TTL_MS = 3_000;
+// 4s gives ~2s margin above the observed 2.2s echo arrival time under normal load.
+const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -44,6 +44,7 @@ function normalizeEchoMessageIdKey(messageId: string | undefined): string | null
 
 class DefaultSentMessageCache implements SentMessageCache {
   private textCache = new Map<string, number>();
+  private textBackedByIdCache = new Map<string, number>();
   private messageIdCache = new Map<string, number>();
 
   remember(scope: string, lookup: SentMessageLookup): void {
@@ -54,35 +55,33 @@ class DefaultSentMessageCache implements SentMessageCache {
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
     if (messageIdKey) {
       this.messageIdCache.set(`${scope}:${messageIdKey}`, Date.now());
+      if (textKey) {
+        this.textBackedByIdCache.set(`${scope}:${textKey}`, Date.now());
+      }
     }
     this.cleanup();
   }
 
   has(scope: string, lookup: SentMessageLookup, skipIdShortCircuit = false): boolean {
     this.cleanup();
+    const textKey = normalizeEchoTextKey(lookup.text);
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
     if (messageIdKey) {
       const idTimestamp = this.messageIdCache.get(`${scope}:${messageIdKey}`);
       if (idTimestamp && Date.now() - idTimestamp <= SENT_MESSAGE_ID_TTL_MS) {
         return true;
       }
-      // If the inbound message has a valid message id that doesn't match any
-      // cached id, short-circuit only when we actually cached real message IDs
-      // for this scope. If remember() only cached text (outbound messageId was
-      // junk like "ok"/"unknown" and got normalized out), text fallback must
-      // still run.
-      //
-      // Exception: when skipIdShortCircuit=true (self-chat is_from_me=true
-      // messages), we always skip this early return so text matching can still
-      // identify agent reply echoes even though IDs never match in this scenario.
-      const hasAnyIdForScope = [...this.messageIdCache.keys()].some((key) =>
-        key.startsWith(`${scope}:`),
-      );
-      if (!skipIdShortCircuit && hasAnyIdForScope) {
+      const textTimestamp = textKey ? this.textCache.get(`${scope}:${textKey}`) : undefined;
+      const textBackedByIdTimestamp = textKey
+        ? this.textBackedByIdCache.get(`${scope}:${textKey}`)
+        : undefined;
+      const hasTextOnlyMatch =
+        typeof textTimestamp === "number" &&
+        (!textBackedByIdTimestamp || textTimestamp > textBackedByIdTimestamp);
+      if (!skipIdShortCircuit && !hasTextOnlyMatch) {
         return false;
       }
     }
-    const textKey = normalizeEchoTextKey(lookup.text);
     if (textKey) {
       const textTimestamp = this.textCache.get(`${scope}:${textKey}`);
       if (textTimestamp && Date.now() - textTimestamp <= SENT_MESSAGE_TEXT_TTL_MS) {
@@ -97,6 +96,11 @@ class DefaultSentMessageCache implements SentMessageCache {
     for (const [key, timestamp] of this.textCache.entries()) {
       if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
         this.textCache.delete(key);
+      }
+    }
+    for (const [key, timestamp] of this.textBackedByIdCache.entries()) {
+      if (now - timestamp > SENT_MESSAGE_TEXT_TTL_MS) {
+        this.textBackedByIdCache.delete(key);
       }
     }
     for (const [key, timestamp] of this.messageIdCache.entries()) {

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -5,12 +5,21 @@ export type SentMessageLookup = {
 
 export type SentMessageCache = {
   remember: (scope: string, lookup: SentMessageLookup) => void;
-  has: (scope: string, lookup: SentMessageLookup) => boolean;
+  /**
+   * Check whether an inbound message matches a recently-sent outbound message.
+   *
+   * @param skipIdShortCircuit - When true, skip the early return on message-ID
+   *   mismatch and fall through to text-based matching. Use this for self-chat
+   *   `is_from_me=true` messages where the inbound ID is a numeric SQLite row ID
+   *   that will never match the GUID outbound IDs, but text matching is still
+   *   the right way to identify agent reply echoes.
+   */
+  has: (scope: string, lookup: SentMessageLookup, skipIdShortCircuit?: boolean) => boolean;
 };
 
 // Keep the text fallback short so repeated user replies like "ok" are not
 // suppressed for long; delayed reflections should match the stronger message-id key.
-const SENT_MESSAGE_TEXT_TTL_MS = 5_000;
+const SENT_MESSAGE_TEXT_TTL_MS = 3_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
 function normalizeEchoTextKey(text: string | undefined): string | null {
@@ -48,13 +57,27 @@ class DefaultSentMessageCache implements SentMessageCache {
     this.cleanup();
   }
 
-  has(scope: string, lookup: SentMessageLookup): boolean {
+  has(scope: string, lookup: SentMessageLookup, skipIdShortCircuit = false): boolean {
     this.cleanup();
     const messageIdKey = normalizeEchoMessageIdKey(lookup.messageId);
     if (messageIdKey) {
       const idTimestamp = this.messageIdCache.get(`${scope}:${messageIdKey}`);
       if (idTimestamp && Date.now() - idTimestamp <= SENT_MESSAGE_ID_TTL_MS) {
         return true;
+      }
+      // If the inbound message has a valid message id that doesn't match any
+      // cached id, skip the text fallback — the message is not an echo.
+      //
+      // In practice, inbound message.id is a numeric SQLite row ID (e.g. "200")
+      // while outbound sent.messageId is a GUID string (e.g. "p:0/abc-def-...").
+      // These formats never collide, so this early return effectively disables
+      // text-based echo matching for all messages that arrive with a DB row ID.
+      //
+      // Exception: when skipIdShortCircuit=true (self-chat is_from_me=true
+      // messages), we skip this early return so text matching can still identify
+      // agent reply echoes even though IDs never match in this scenario.
+      if (!skipIdShortCircuit) {
+        return false;
       }
     }
     const textKey = normalizeEchoTextKey(lookup.text);

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -67,17 +67,18 @@ class DefaultSentMessageCache implements SentMessageCache {
         return true;
       }
       // If the inbound message has a valid message id that doesn't match any
-      // cached id, skip the text fallback — the message is not an echo.
-      //
-      // In practice, inbound message.id is a numeric SQLite row ID (e.g. "200")
-      // while outbound sent.messageId is a GUID string (e.g. "p:0/abc-def-...").
-      // These formats never collide, so this early return effectively disables
-      // text-based echo matching for all messages that arrive with a DB row ID.
+      // cached id, short-circuit only when we actually cached real message IDs
+      // for this scope. If remember() only cached text (outbound messageId was
+      // junk like "ok"/"unknown" and got normalized out), text fallback must
+      // still run.
       //
       // Exception: when skipIdShortCircuit=true (self-chat is_from_me=true
-      // messages), we skip this early return so text matching can still identify
-      // agent reply echoes even though IDs never match in this scenario.
-      if (!skipIdShortCircuit) {
+      // messages), we always skip this early return so text matching can still
+      // identify agent reply echoes even though IDs never match in this scenario.
+      const hasAnyIdForScope = [...this.messageIdCache.keys()].some((key) =>
+        key.startsWith(`${scope}:`),
+      );
+      if (!skipIdShortCircuit && hasAnyIdForScope) {
         return false;
       }
     }

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -17,9 +17,9 @@ export type SentMessageCache = {
   has: (scope: string, lookup: SentMessageLookup, skipIdShortCircuit?: boolean) => boolean;
 };
 
-// Keep the text fallback short so repeated user replies like "ok" are not
-// suppressed for long; delayed reflections should match the stronger message-id key.
-// 4s gives ~2s margin above the observed 2.2s echo arrival time under normal load.
+// Echo arrival observed at ~2.2s on M4 Mac Mini (SQLite poll interval is the bottleneck).
+// 4s provides ~80% margin. If echoes arrive after TTL expiry, the system degrades to
+// duplicate delivery (noisy but not lossy) — never message loss.
 const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -84,6 +84,31 @@ describe("resolveIMessageInboundDecision echo detection", () => {
     );
   });
 
+  it("matches attachment-only echoes by bodyText placeholder", () => {
+    const echoHas = vi.fn((_scope: string, lookup: { text?: string; messageId?: string }) => {
+      return lookup.text === "<media:image>" && lookup.messageId === "42";
+    });
+
+    const decision = resolveDecision({
+      message: {
+        id: 42,
+        text: "",
+      },
+      messageText: "",
+      bodyText: "<media:image>",
+      echoCache: { has: echoHas },
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "echo" });
+    expect(echoHas).toHaveBeenCalledWith(
+      "default:imessage:+15555550123",
+      expect.objectContaining({
+        text: "<media:image>",
+        messageId: "42",
+      }),
+    );
+  });
+
   it("drops reflected self-chat duplicates after seeing the from-me copy", () => {
     const selfChatCache = createSelfChatCache();
     const createdAt = "2026-03-02T20:58:10.649Z";

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -124,6 +124,8 @@ export function resolveIMessageInboundDecision(params: {
   const chatGuid = params.message.chat_guid ?? undefined;
   const chatIdentifier = params.message.chat_identifier ?? undefined;
   const createdAt = params.message.created_at ? Date.parse(params.message.created_at) : undefined;
+  const messageText = params.messageText.trim();
+  const bodyText = params.bodyText.trim();
 
   const groupIdCandidate = chatId !== undefined ? String(chatId) : undefined;
   const groupListPolicy = groupIdCandidate
@@ -151,7 +153,7 @@ export function resolveIMessageInboundDecision(params: {
     isGroup,
     chatId,
     sender,
-    text: params.bodyText,
+    text: bodyText,
     createdAt,
   };
   // Self-chat detection: in self-chat, sender == chat_identifier (both are the
@@ -185,10 +187,10 @@ export function resolveIMessageInboundDecision(params: {
       });
       if (
         params.echoCache &&
-        (params.messageText || inboundMessageId) &&
+        (bodyText || inboundMessageId) &&
         params.echoCache.has(
           echoScope,
-          { text: params.messageText || undefined, messageId: inboundMessageId },
+          { text: bodyText || undefined, messageId: inboundMessageId },
           true, // skipIdShortCircuit
         )
       ) {
@@ -275,8 +277,6 @@ export function resolveIMessageInboundDecision(params: {
     chatId,
   });
   const mentionRegexes = buildMentionRegexes(params.cfg, route.agentId);
-  const messageText = params.messageText.trim();
-  const bodyText = params.bodyText.trim();
   if (!bodyText) {
     return { kind: "drop", reason: "empty body" };
   }
@@ -304,12 +304,12 @@ export function resolveIMessageInboundDecision(params: {
     });
     if (
       params.echoCache.has(echoScope, {
-        text: messageText || undefined,
+        text: bodyText || undefined,
         messageId: inboundMessageId,
       })
     ) {
       params.logVerbose?.(
-        describeIMessageEchoDropLog({ messageText, messageId: inboundMessageId }),
+        describeIMessageEchoDropLog({ messageText: bodyText, messageId: inboundMessageId }),
       );
       return { kind: "drop", reason: "echo" };
     }

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -168,7 +168,9 @@ export function resolveIMessageInboundDecision(params: {
   // When true, the selfChatCache.has() check below must be skipped — we just
   // called remember() and would immediately match our own entry.
   let skipSelfChatHasCheck = false;
-  const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
+  const inboundMessageId =
+    normalizeReplyField(params.message.guid) ??
+    (params.message.id != null ? String(params.message.id) : undefined);
 
   if (params.message.is_from_me) {
     // Always cache in selfChatCache so the upcoming is_from_me=false reflection
@@ -191,7 +193,7 @@ export function resolveIMessageInboundDecision(params: {
         params.echoCache.has(
           echoScope,
           { text: bodyText || undefined, messageId: inboundMessageId },
-          true, // skipIdShortCircuit
+          !normalizeReplyField(params.message.guid),
         )
       ) {
         return { kind: "drop", reason: "agent echo in self-chat" };

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -162,9 +162,6 @@ export function resolveIMessageInboundDecision(params: {
     !isGroup &&
     chatIdentifier != null &&
     normalizeIMessageHandle(sender) === normalizeIMessageHandle(chatIdentifier);
-  console.error(
-    `[IMSG-DEBUG] inbound-decision: sender="${sender}" senderNormalized="${senderNormalized}" is_from_me=${params.message.is_from_me} is_group=${params.message.is_group} treatAsGroupByConfig=${treatAsGroupByConfig} isGroup=${isGroup} chatId=${chatId} isSelfChat=${isSelfChat} chatIdentifier=${chatIdentifier}`,
-  );
   // Track whether we already processed the is_from_me=true self-chat path.
   // When true, the selfChatCache.has() check below must be skipped — we just
   // called remember() and would immediately match our own entry.
@@ -187,9 +184,6 @@ export function resolveIMessageInboundDecision(params: {
         sender,
       });
       const messageText = params.messageText;
-      console.error(
-        `[IMSG-DEBUG] is_from_me=true + isSelfChat → checking echoCache with skipIdShortCircuit=true. echoScope="${echoScope}" text="${(messageText ?? "").slice(0, 80)}" id=${inboundMessageId}`,
-      );
       if (
         params.echoCache &&
         (messageText || inboundMessageId) &&
@@ -199,25 +193,16 @@ export function resolveIMessageInboundDecision(params: {
           true, // skipIdShortCircuit
         )
       ) {
-        console.error(
-          `[IMSG-DEBUG] is_from_me=true + isSelfChat + echoCache HIT → dropping as agent echo in self-chat`,
-        );
         return { kind: "drop", reason: "agent echo in self-chat" };
       }
       // Echo cache missed → this is a real user message in self-chat. Process it.
       // Skip the selfChatCache.has() check below — we just remember()d ourselves
       // and would immediately match our own entry.
-      console.error(
-        `[IMSG-DEBUG] is_from_me=true + isSelfChat + echoCache MISS → processing as real user message`,
-      );
       skipSelfChatHasCheck = true;
       // Fall through to rest of decision logic (access control, etc.)
     } else {
       // Normal DM or group: is_from_me=true means this is an outbound message
       // notification that we sent. Drop it.
-      console.error(
-        `[IMSG-DEBUG] is_from_me=true (non-self-chat) → dropping with reason "from me"`,
-      );
       return { kind: "drop", reason: "from me" };
     }
   }
@@ -297,19 +282,14 @@ export function resolveIMessageInboundDecision(params: {
     return { kind: "drop", reason: "empty body" };
   }
 
-  console.error(
-    `[IMSG-DEBUG] checking selfChatCache.has() for bodyText="${bodyText.slice(0, 80)}" createdAt=${createdAt} skipSelfChatHasCheck=${skipSelfChatHasCheck}`,
-  );
   const selfChatHit = skipSelfChatHasCheck
     ? false
     : params.selfChatCache?.has({
         ...selfChatLookup,
         text: bodyText,
       });
-  console.error(`[IMSG-DEBUG] selfChatCache.has() = ${selfChatHit}`);
   if (selfChatHit) {
     const preview = sanitizeTerminalText(truncateUtf16Safe(bodyText, 50));
-    console.error(`[IMSG-DEBUG] self-chat echo detected, dropping: "${preview}"`);
     params.logVerbose?.(`imessage: dropping self-chat reflected duplicate: "${preview}"`);
     return { kind: "drop", reason: "self-chat echo" };
   }
@@ -317,9 +297,6 @@ export function resolveIMessageInboundDecision(params: {
   // Echo detection: check if the received message matches a recently sent message.
   // Scope by conversation so same text in different chats is not conflated.
   const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
-  console.error(
-    `[IMSG-DEBUG] echo cache check: echoCache=${!!params.echoCache} messageText="${(messageText ?? "").slice(0, 80)}" inboundMessageId=${inboundMessageId}`,
-  );
   if (params.echoCache && (messageText || inboundMessageId)) {
     const echoScope = buildIMessageEchoScope({
       accountId: params.accountId,
@@ -327,22 +304,17 @@ export function resolveIMessageInboundDecision(params: {
       chatId,
       sender,
     });
-    console.error(
-      `[IMSG-DEBUG] echoCache.has(scope="${echoScope}", text="${(messageText ?? "").slice(0, 40)}", messageId=${inboundMessageId})`,
-    );
     if (
       params.echoCache.has(echoScope, {
         text: messageText || undefined,
         messageId: inboundMessageId,
       })
     ) {
-      console.error(`[IMSG-DEBUG] echoCache HIT — dropping as echo`);
       params.logVerbose?.(
         describeIMessageEchoDropLog({ messageText, messageId: inboundMessageId }),
       );
       return { kind: "drop", reason: "echo" };
     }
-    console.error(`[IMSG-DEBUG] echoCache MISS — not an echo`);
   }
 
   // Reflection guard: drop inbound messages that contain assistant-internal

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -183,13 +183,12 @@ export function resolveIMessageInboundDecision(params: {
         chatId,
         sender,
       });
-      const messageText = params.messageText;
       if (
         params.echoCache &&
-        (messageText || inboundMessageId) &&
+        (params.messageText || inboundMessageId) &&
         params.echoCache.has(
           echoScope,
-          { text: messageText || undefined, messageId: inboundMessageId },
+          { text: params.messageText || undefined, messageId: inboundMessageId },
           true, // skipIdShortCircuit
         )
       ) {

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -104,7 +104,13 @@ export function resolveIMessageInboundDecision(params: {
   storeAllowFrom: string[];
   historyLimit: number;
   groupHistories: Map<string, HistoryEntry[]>;
-  echoCache?: { has: (scope: string, lookup: { text?: string; messageId?: string }) => boolean };
+  echoCache?: {
+    has: (
+      scope: string,
+      lookup: { text?: string; messageId?: string },
+      skipIdShortCircuit?: boolean,
+    ) => boolean;
+  };
   selfChatCache?: SelfChatCache;
   logVerbose?: (msg: string) => void;
 }): IMessageInboundDecision {
@@ -148,9 +154,72 @@ export function resolveIMessageInboundDecision(params: {
     text: params.bodyText,
     createdAt,
   };
+  // Self-chat detection: in self-chat, sender == chat_identifier (both are the
+  // user's own handle). When is_from_me=true in self-chat, the message could be
+  // either: (a) a real user message typed by the user, or (b) an agent reply
+  // echo reflected back by iMessage. We must distinguish them.
+  const isSelfChat =
+    !isGroup &&
+    chatIdentifier != null &&
+    normalizeIMessageHandle(sender) === normalizeIMessageHandle(chatIdentifier);
+  console.error(
+    `[IMSG-DEBUG] inbound-decision: sender="${sender}" senderNormalized="${senderNormalized}" is_from_me=${params.message.is_from_me} is_group=${params.message.is_group} treatAsGroupByConfig=${treatAsGroupByConfig} isGroup=${isGroup} chatId=${chatId} isSelfChat=${isSelfChat} chatIdentifier=${chatIdentifier}`,
+  );
+  // Track whether we already processed the is_from_me=true self-chat path.
+  // When true, the selfChatCache.has() check below must be skipped — we just
+  // called remember() and would immediately match our own entry.
+  let skipSelfChatHasCheck = false;
+
   if (params.message.is_from_me) {
+    // Always cache in selfChatCache so the upcoming is_from_me=false reflection
+    // (which arrives 2-3s later) is correctly identified and dropped.
     params.selfChatCache?.remember(selfChatLookup);
-    return { kind: "drop", reason: "from me" };
+
+    if (isSelfChat) {
+      // In self-chat, is_from_me=true could be a real user message OR an agent
+      // reply echo. Use the echo cache with skipIdShortCircuit=true to check
+      // whether this text matches a recently-sent agent reply.
+      const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
+      const echoScope = buildIMessageEchoScope({
+        accountId: params.accountId,
+        isGroup,
+        chatId,
+        sender,
+      });
+      const messageText = params.messageText;
+      console.error(
+        `[IMSG-DEBUG] is_from_me=true + isSelfChat → checking echoCache with skipIdShortCircuit=true. echoScope="${echoScope}" text="${(messageText ?? "").slice(0, 80)}" id=${inboundMessageId}`,
+      );
+      if (
+        params.echoCache &&
+        (messageText || inboundMessageId) &&
+        params.echoCache.has(
+          echoScope,
+          { text: messageText || undefined, messageId: inboundMessageId },
+          true, // skipIdShortCircuit
+        )
+      ) {
+        console.error(
+          `[IMSG-DEBUG] is_from_me=true + isSelfChat + echoCache HIT → dropping as agent echo in self-chat`,
+        );
+        return { kind: "drop", reason: "agent echo in self-chat" };
+      }
+      // Echo cache missed → this is a real user message in self-chat. Process it.
+      // Skip the selfChatCache.has() check below — we just remember()d ourselves
+      // and would immediately match our own entry.
+      console.error(
+        `[IMSG-DEBUG] is_from_me=true + isSelfChat + echoCache MISS → processing as real user message`,
+      );
+      skipSelfChatHasCheck = true;
+      // Fall through to rest of decision logic (access control, etc.)
+    } else {
+      // Normal DM or group: is_from_me=true means this is an outbound message
+      // notification that we sent. Drop it.
+      console.error(
+        `[IMSG-DEBUG] is_from_me=true (non-self-chat) → dropping with reason "from me"`,
+      );
+      return { kind: "drop", reason: "from me" };
+    }
   }
   if (isGroup && !chatId) {
     return { kind: "drop", reason: "group without chat_id" };
@@ -228,13 +297,19 @@ export function resolveIMessageInboundDecision(params: {
     return { kind: "drop", reason: "empty body" };
   }
 
-  if (
-    params.selfChatCache?.has({
-      ...selfChatLookup,
-      text: bodyText,
-    })
-  ) {
+  console.error(
+    `[IMSG-DEBUG] checking selfChatCache.has() for bodyText="${bodyText.slice(0, 80)}" createdAt=${createdAt} skipSelfChatHasCheck=${skipSelfChatHasCheck}`,
+  );
+  const selfChatHit = skipSelfChatHasCheck
+    ? false
+    : params.selfChatCache?.has({
+        ...selfChatLookup,
+        text: bodyText,
+      });
+  console.error(`[IMSG-DEBUG] selfChatCache.has() = ${selfChatHit}`);
+  if (selfChatHit) {
     const preview = sanitizeTerminalText(truncateUtf16Safe(bodyText, 50));
+    console.error(`[IMSG-DEBUG] self-chat echo detected, dropping: "${preview}"`);
     params.logVerbose?.(`imessage: dropping self-chat reflected duplicate: "${preview}"`);
     return { kind: "drop", reason: "self-chat echo" };
   }
@@ -242,6 +317,9 @@ export function resolveIMessageInboundDecision(params: {
   // Echo detection: check if the received message matches a recently sent message.
   // Scope by conversation so same text in different chats is not conflated.
   const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
+  console.error(
+    `[IMSG-DEBUG] echo cache check: echoCache=${!!params.echoCache} messageText="${(messageText ?? "").slice(0, 80)}" inboundMessageId=${inboundMessageId}`,
+  );
   if (params.echoCache && (messageText || inboundMessageId)) {
     const echoScope = buildIMessageEchoScope({
       accountId: params.accountId,
@@ -249,17 +327,22 @@ export function resolveIMessageInboundDecision(params: {
       chatId,
       sender,
     });
+    console.error(
+      `[IMSG-DEBUG] echoCache.has(scope="${echoScope}", text="${(messageText ?? "").slice(0, 40)}", messageId=${inboundMessageId})`,
+    );
     if (
       params.echoCache.has(echoScope, {
         text: messageText || undefined,
         messageId: inboundMessageId,
       })
     ) {
+      console.error(`[IMSG-DEBUG] echoCache HIT — dropping as echo`);
       params.logVerbose?.(
         describeIMessageEchoDropLog({ messageText, messageId: inboundMessageId }),
       );
       return { kind: "drop", reason: "echo" };
     }
+    console.error(`[IMSG-DEBUG] echoCache MISS — not an echo`);
   }
 
   // Reflection guard: drop inbound messages that contain assistant-internal

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -166,6 +166,7 @@ export function resolveIMessageInboundDecision(params: {
   // When true, the selfChatCache.has() check below must be skipped — we just
   // called remember() and would immediately match our own entry.
   let skipSelfChatHasCheck = false;
+  const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
 
   if (params.message.is_from_me) {
     // Always cache in selfChatCache so the upcoming is_from_me=false reflection
@@ -176,7 +177,6 @@ export function resolveIMessageInboundDecision(params: {
       // In self-chat, is_from_me=true could be a real user message OR an agent
       // reply echo. Use the echo cache with skipIdShortCircuit=true to check
       // whether this text matches a recently-sent agent reply.
-      const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
       const echoScope = buildIMessageEchoScope({
         accountId: params.accountId,
         isGroup,
@@ -295,7 +295,6 @@ export function resolveIMessageInboundDecision(params: {
 
   // Echo detection: check if the received message matches a recently sent message.
   // Scope by conversation so same text in different chats is not conflated.
-  const inboundMessageId = params.message.id != null ? String(params.message.id) : undefined;
   if (params.echoCache && (messageText || inboundMessageId)) {
     const echoScope = buildIMessageEchoScope({
       accountId: params.accountId,

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -205,6 +205,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   });
 
   async function handleMessageNow(message: IMessagePayload) {
+    console.error(
+      `[IMSG-DEBUG] handleMessageNow entered: id=${message.id} sender=${message.sender} is_from_me=${message.is_from_me} chat_id=${message.chat_id} text="${(message.text ?? "").slice(0, 80)}"`,
+    );
     const messageText = (message.text ?? "").trim();
 
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
@@ -239,6 +242,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       process.env,
       accountInfo.accountId,
     ).catch(() => []);
+    console.error(
+      `[IMSG-DEBUG] calling resolveIMessageInboundDecision: accountId=${accountInfo.accountId} dmPolicy=${dmPolicy} groupPolicy=${groupPolicy} allowFrom=[${allowFrom.join(",")}] bodyText="${bodyText.slice(0, 80)}"`,
+    );
     const decision = resolveIMessageInboundDecision({
       cfg,
       accountId: accountInfo.accountId,
@@ -257,6 +263,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       selfChatCache,
       logVerbose,
     });
+    console.error(
+      `[IMSG-DEBUG] decision result: kind=${decision.kind}${decision.kind === "drop" ? ` reason="${decision.reason}"` : ""}${decision.kind === "dispatch" ? ` isGroup=${decision.isGroup} sender=${decision.sender}` : ""}`,
+    );
 
     // Build conversation key for rate limiting (used by both drop and dispatch paths).
     const chatId = message.chat_id ?? undefined;
@@ -459,11 +468,21 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   }
 
   const handleMessage = async (raw: unknown) => {
+    console.error(
+      `[IMSG-DEBUG] handleMessage called, raw type=${typeof raw}, keys=${raw && typeof raw === "object" ? Object.keys(raw as Record<string, unknown>).join(",") : "N/A"}`,
+    );
+    try {
+      console.error(`[IMSG-DEBUG] handleMessage raw payload: ${JSON.stringify(raw).slice(0, 500)}`);
+    } catch {}
     const message = parseIMessageNotification(raw);
     if (!message) {
+      console.error(`[IMSG-DEBUG] parseIMessageNotification returned null — dropping`);
       logVerbose("imessage: dropping malformed RPC message payload");
       return;
     }
+    console.error(
+      `[IMSG-DEBUG] parsed message: id=${message.id} sender=${message.sender} is_from_me=${message.is_from_me} is_group=${message.is_group} chat_id=${message.chat_id} text="${(message.text ?? "").slice(0, 80)}"`,
+    );
     await inboundDebouncer.enqueue({ message });
   };
 
@@ -496,12 +515,19 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     dbPath,
     runtime,
     onNotification: (msg) => {
+      console.error(
+        `[IMSG-DEBUG] RPC notification received: method="${msg.method}" params_type=${typeof msg.params}`,
+      );
       if (msg.method === "message") {
         void handleMessage(msg.params).catch((err) => {
           runtime.error?.(`imessage: handler failed: ${String(err)}`);
         });
       } else if (msg.method === "error") {
         runtime.error?.(`imessage: watch error ${JSON.stringify(msg.params)}`);
+      } else {
+        console.error(
+          `[IMSG-DEBUG] RPC notification with unknown method="${msg.method}" — ignored`,
+        );
       }
     },
   });
@@ -515,10 +541,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   });
 
   try {
+    console.error(`[IMSG-DEBUG] calling watch.subscribe with attachments=${includeAttachments}`);
     const result = await client.request<{ subscription?: number }>("watch.subscribe", {
       attachments: includeAttachments,
     });
     subscriptionId = result?.subscription ?? null;
+    console.error(`[IMSG-DEBUG] watch.subscribe result: subscriptionId=${subscriptionId}`);
     await client.waitForClose();
   } catch (err) {
     if (abort?.aborted) {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -205,9 +205,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   });
 
   async function handleMessageNow(message: IMessagePayload) {
-    console.error(
-      `[IMSG-DEBUG] handleMessageNow entered: id=${message.id} sender=${message.sender} is_from_me=${message.is_from_me} chat_id=${message.chat_id} text="${(message.text ?? "").slice(0, 80)}"`,
-    );
     const messageText = (message.text ?? "").trim();
 
     const attachments = includeAttachments ? (message.attachments ?? []) : [];
@@ -242,9 +239,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       process.env,
       accountInfo.accountId,
     ).catch(() => []);
-    console.error(
-      `[IMSG-DEBUG] calling resolveIMessageInboundDecision: accountId=${accountInfo.accountId} dmPolicy=${dmPolicy} groupPolicy=${groupPolicy} allowFrom=[${allowFrom.join(",")}] bodyText="${bodyText.slice(0, 80)}"`,
-    );
     const decision = resolveIMessageInboundDecision({
       cfg,
       accountId: accountInfo.accountId,
@@ -263,9 +257,6 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       selfChatCache,
       logVerbose,
     });
-    console.error(
-      `[IMSG-DEBUG] decision result: kind=${decision.kind}${decision.kind === "drop" ? ` reason="${decision.reason}"` : ""}${decision.kind === "dispatch" ? ` isGroup=${decision.isGroup} sender=${decision.sender}` : ""}`,
-    );
 
     // Build conversation key for rate limiting (used by both drop and dispatch paths).
     const chatId = message.chat_id ?? undefined;
@@ -468,21 +459,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   }
 
   const handleMessage = async (raw: unknown) => {
-    console.error(
-      `[IMSG-DEBUG] handleMessage called, raw type=${typeof raw}, keys=${raw && typeof raw === "object" ? Object.keys(raw as Record<string, unknown>).join(",") : "N/A"}`,
-    );
-    try {
-      console.error(`[IMSG-DEBUG] handleMessage raw payload: ${JSON.stringify(raw).slice(0, 500)}`);
-    } catch {}
     const message = parseIMessageNotification(raw);
     if (!message) {
-      console.error(`[IMSG-DEBUG] parseIMessageNotification returned null — dropping`);
       logVerbose("imessage: dropping malformed RPC message payload");
       return;
     }
-    console.error(
-      `[IMSG-DEBUG] parsed message: id=${message.id} sender=${message.sender} is_from_me=${message.is_from_me} is_group=${message.is_group} chat_id=${message.chat_id} text="${(message.text ?? "").slice(0, 80)}"`,
-    );
     await inboundDebouncer.enqueue({ message });
   };
 
@@ -515,19 +496,12 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     dbPath,
     runtime,
     onNotification: (msg) => {
-      console.error(
-        `[IMSG-DEBUG] RPC notification received: method="${msg.method}" params_type=${typeof msg.params}`,
-      );
       if (msg.method === "message") {
         void handleMessage(msg.params).catch((err) => {
           runtime.error?.(`imessage: handler failed: ${String(err)}`);
         });
       } else if (msg.method === "error") {
         runtime.error?.(`imessage: watch error ${JSON.stringify(msg.params)}`);
-      } else {
-        console.error(
-          `[IMSG-DEBUG] RPC notification with unknown method="${msg.method}" — ignored`,
-        );
       }
     },
   });
@@ -541,12 +515,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   });
 
   try {
-    console.error(`[IMSG-DEBUG] calling watch.subscribe with attachments=${includeAttachments}`);
     const result = await client.request<{ subscription?: number }>("watch.subscribe", {
       attachments: includeAttachments,
     });
     subscriptionId = result?.subscription ?? null;
-    console.error(`[IMSG-DEBUG] watch.subscribe result: subscriptionId=${subscriptionId}`);
     await client.waitForClose();
   } catch (err) {
     if (abort?.aborted) {

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -61,6 +61,7 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
   const message: IMessagePayload = maybeMessage;
   if (
     !isOptionalNumber(message.id) ||
+    !isOptionalString(message.guid) ||
     !isOptionalNumber(message.chat_id) ||
     !isOptionalString(message.sender) ||
     !isOptionalBoolean(message.is_from_me) ||

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -405,6 +405,38 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
   });
 
+  it("drops attachment-only agent echo in self-chat via bodyText placeholder", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    const scope = "default:imessage:+15551234567";
+    echoCache.remember(scope, { text: "<media:image>", messageId: "p:0/GUID-media" });
+
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123707,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          text: "",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "",
+        bodyText: "<media:image>",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
+  });
+
   it("drops is_from_me=false reflection via selfChatCache (existing behavior preserved)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -1,0 +1,425 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../../src/config/config.js";
+import { createSentMessageCache } from "./echo-cache.js";
+import { resolveIMessageInboundDecision } from "./inbound-processing.js";
+import { createSelfChatCache } from "./self-chat-cache.js";
+
+/**
+ * Self-chat dedupe regression tests for #47830.
+ *
+ * PR #38440 introduced a SentMessageCache to suppress echo messages when the
+ * agent replies in iMessage. In self-chat (user messaging themselves), the
+ * sender == target so the echo scope collides, causing legitimate user
+ * messages to be silently dropped when text happens to match recent agent
+ * output.
+ *
+ * These tests verify:
+ *  1. User messages in self-chat are NOT dropped (even if text matches agent output)
+ *  2. Genuine agent echo reflections ARE still dropped
+ *  3. Different-text messages pass through unaffected
+ *  4. Chunked replies don't cause false drops of user messages matching a chunk
+ */
+
+type InboundDecisionParams = Parameters<typeof resolveIMessageInboundDecision>[0];
+
+const cfg = {} as OpenClawConfig;
+
+function createParams(
+  overrides: Omit<Partial<InboundDecisionParams>, "message"> & {
+    message?: Partial<InboundDecisionParams["message"]>;
+  } = {},
+): InboundDecisionParams {
+  const { message: msgOverrides, ...restOverrides } = overrides;
+  const message = {
+    id: 100,
+    sender: "+14155480405",
+    text: "Hello",
+    is_from_me: false,
+    is_group: false,
+    ...msgOverrides,
+  };
+  const messageText = restOverrides.messageText ?? message.text ?? "";
+  const bodyText = restOverrides.bodyText ?? messageText;
+  return {
+    cfg,
+    accountId: "default",
+    opts: undefined,
+    allowFrom: [],
+    groupAllowFrom: [],
+    groupPolicy: "open",
+    dmPolicy: "open",
+    storeAllowFrom: [],
+    historyLimit: 0,
+    groupHistories: new Map(),
+    echoCache: undefined,
+    selfChatCache: undefined,
+    logVerbose: undefined,
+    ...restOverrides,
+    message,
+    messageText,
+    bodyText,
+  };
+}
+
+describe("self-chat dedupe — #47830", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does NOT drop a user message that matches recently-sent agent text (self-chat scope collision)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    // Agent sends "Hello" to self-chat target +14155480405
+    const scope = "default:imessage:+14155480405";
+    echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
+
+    // 2 seconds later, user sends "Hello" to themselves (different message id)
+    vi.advanceTimersByTime(2000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 200,
+          sender: "+14155480405",
+          text: "Hello",
+          is_from_me: false,
+        },
+        messageText: "Hello",
+        bodyText: "Hello",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    // BUG: Before fix, this was "drop" reason "echo" — user message silently lost.
+    // After fix: message-id mismatch means this is NOT an echo.
+    // The echo cache should only match when message IDs match OR when text
+    // matches and no message ID is available on inbound.
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("DOES drop genuine agent echo (same message id reflected back)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+
+    // Agent sends "Hello" to target
+    const scope = "default:imessage:+14155480405";
+    echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
+
+    // 1 second later, iMessage reflects it back with same message id
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: "agent-msg-1" as unknown as number,
+          sender: "+14155480405",
+          text: "Hello",
+          is_from_me: false,
+        },
+        messageText: "Hello",
+        bodyText: "Hello",
+        echoCache,
+      }),
+    );
+
+    expect(decision).toEqual({ kind: "drop", reason: "echo" });
+  });
+
+  it("does NOT drop different-text messages even within TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+
+    // Agent sends "Hello"
+    const scope = "default:imessage:+14155480405";
+    echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
+
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 201,
+          sender: "+14155480405",
+          text: "Goodbye",
+          is_from_me: false,
+        },
+        messageText: "Goodbye",
+        bodyText: "Goodbye",
+        echoCache,
+      }),
+    );
+
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("does NOT drop user messages that match a chunk of a multi-chunk agent reply", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+14155480405";
+
+    // Agent sends a multi-chunk reply: "Part one", "Part two", "Part three"
+    echoCache.remember(scope, { text: "Part one", messageId: "agent-chunk-1" });
+    echoCache.remember(scope, { text: "Part two", messageId: "agent-chunk-2" });
+    echoCache.remember(scope, { text: "Part three", messageId: "agent-chunk-3" });
+
+    vi.advanceTimersByTime(2000);
+
+    // User sends "Part two" (matches chunk 2 text, but different message id)
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 300,
+          sender: "+14155480405",
+          text: "Part two",
+          is_from_me: false,
+        },
+        messageText: "Part two",
+        bodyText: "Part two",
+        echoCache,
+      }),
+    );
+
+    // Should NOT be dropped — different message id means not an echo
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("drops echo after text TTL reduction (within 3s, not 5s)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    // Agent sends text (no message id available)
+    echoCache.remember(scope, { text: "Hello there" });
+
+    // After 4 seconds — should NOT match if TTL reduced to 3s
+    vi.advanceTimersByTime(4000);
+
+    const result = echoCache.has(scope, { text: "Hello there" });
+    expect(result).toBe(false);
+  });
+
+  it("still drops text echo within reduced 3s TTL window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "Hello there" });
+
+    // After 2 seconds — should still match
+    vi.advanceTimersByTime(2000);
+
+    const result = echoCache.has(scope, { text: "Hello there" });
+    expect(result).toBe(true);
+  });
+});
+
+describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("processes real user self-chat message (is_from_me=true, no echo cache match)", () => {
+    // User sends "Hello" to themselves — is_from_me=true, sender==chat_identifier
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123703,
+          sender: "+14155480405",
+          chat_identifier: "+14155480405",
+          text: "Hello this is a test message",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Hello this is a test message",
+        bodyText: "Hello this is a test message",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    // Real user message — should be dispatched, not dropped
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("drops agent reply echo in self-chat (is_from_me=true, echo cache text match)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    // Agent sends "Hi there!" to self-chat
+    const scope = "default:imessage:+14155480405";
+    echoCache.remember(scope, { text: "Hi there!", messageId: "p:0/GUID-abc-def" });
+
+    // 1 second later, iMessage delivers the agent reply as is_from_me=true
+    // with a SQLite row ID (never matches the GUID)
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123706,
+          sender: "+14155480405",
+          chat_identifier: "+14155480405",
+          text: "Hi there!",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Hi there!",
+        bodyText: "Hi there!",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    // Agent echo — should be dropped
+    expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
+  });
+
+  it("drops is_from_me=false reflection via selfChatCache (existing behavior preserved)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const selfChatCache = createSelfChatCache();
+    const createdAt = "2026-03-24T12:00:00.000Z";
+
+    // Step 1: is_from_me=true copy arrives (real user message) → processed, selfChatCache populated
+    const first = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123703,
+          sender: "+14155480405",
+          chat_identifier: "+14155480405",
+          text: "Hello",
+          created_at: createdAt,
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Hello",
+        bodyText: "Hello",
+        selfChatCache,
+      }),
+    );
+    expect(first.kind).toBe("dispatch");
+
+    // Step 2: is_from_me=false reflection arrives 2s later with same text+createdAt
+    vi.advanceTimersByTime(2200);
+    const second = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123704,
+          sender: "+14155480405",
+          chat_identifier: "+14155480405",
+          text: "Hello",
+          created_at: createdAt,
+          is_from_me: false,
+          is_group: false,
+        },
+        messageText: "Hello",
+        bodyText: "Hello",
+        selfChatCache,
+      }),
+    );
+    // Reflection correctly dropped
+    expect(second).toEqual({ kind: "drop", reason: "self-chat echo" });
+  });
+
+  it("normal DM is_from_me=true is still dropped (regression test)", () => {
+    const selfChatCache = createSelfChatCache();
+
+    // Normal DM with is_from_me=true: in iMessage, sender is the local user's
+    // handle and chat_identifier is the OTHER person's handle. They differ,
+    // so this is NOT self-chat.
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 9999,
+          sender: "+14155480405", // local user sent this
+          chat_identifier: "+15555550123", // sent TO this other person
+          text: "Hello",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Hello",
+        bodyText: "Hello",
+        selfChatCache,
+      }),
+    );
+
+    // sender != chat_identifier → not self-chat → dropped as "from me"
+    expect(decision).toEqual({ kind: "drop", reason: "from me" });
+  });
+
+  it("echo cache text matching works with skipIdShortCircuit=true", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+14155480405";
+    echoCache.remember(scope, { text: "Cached reply", messageId: "p:0/some-guid" });
+
+    vi.advanceTimersByTime(1000);
+
+    // Text matches but ID is a SQLite row (format mismatch). With skipIdShortCircuit=true,
+    // text matching should still fire.
+    expect(echoCache.has(scope, { text: "Cached reply", messageId: "123799" }, true)).toBe(true);
+
+    // With skipIdShortCircuit=false (default), ID mismatch causes early return false.
+    expect(echoCache.has(scope, { text: "Cached reply", messageId: "123799" }, false)).toBe(false);
+  });
+});
+
+describe("echo cache — text fallback for null-id inbound messages", () => {
+  it("still identifies echo via text when inbound message has id: null", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    // Agent sends "Sounds good" — no messageId available (edge case)
+    const scope = "default:imessage:+14155480405";
+    echoCache.remember(scope, { text: "Sounds good" });
+
+    // 1 second later, inbound reflection arrives with id: null
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: null as unknown as number,
+          sender: "+14155480405",
+          text: "Sounds good",
+          is_from_me: false,
+        },
+        messageText: "Sounds good",
+        bodyText: "Sounds good",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    // With id: null, the text-based fallback path is still active and should
+    // correctly identify this as an echo.
+    expect(decision).toEqual({ kind: "drop", reason: "echo" });
+  });
+});

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -388,6 +388,7 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 123706,
+          guid: "p:0/GUID-abc-def",
           sender: "+15551234567",
           chat_identifier: "+15551234567",
           text: "Hi there!",
@@ -421,6 +422,7 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 123707,
+          guid: "p:0/GUID-media",
           sender: "+15551234567",
           chat_identifier: "+15551234567",
           text: "",
@@ -435,6 +437,39 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     );
 
     expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
+  });
+
+  it("does not drop a real self-chat image just because a recent agent image used the same placeholder", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    const scope = "default:imessage:+15551234567";
+    echoCache.remember(scope, { text: "<media:image>", messageId: "p:0/GUID-agent-image" });
+
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123708,
+          guid: "p:0/GUID-user-image",
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          text: "",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "",
+        bodyText: "<media:image>",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    expect(decision.kind).toBe("dispatch");
   });
 
   it("drops is_from_me=false reflection via selfChatCache (existing behavior preserved)", () => {
@@ -563,5 +598,27 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
     // With id: null, the text-based fallback path is still active and should
     // correctly identify this as an echo.
     expect(decision).toEqual({ kind: "drop", reason: "echo" });
+  });
+});
+
+describe("echo cache — mixed GUID and text-only scopes", () => {
+  it("still falls back to text for the latest text-only send in a scope with older GUID-backed sends", () => {
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "older guid-backed", messageId: "p:0/GUID-older" });
+    echoCache.remember(scope, { text: "latest text-only", messageId: "unknown" });
+
+    expect(echoCache.has(scope, { text: "latest text-only", messageId: "200" })).toBe(true);
+  });
+
+  it("still short-circuits when the latest copy of a text was GUID-backed", () => {
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "same text", messageId: "unknown" });
+    echoCache.remember(scope, { text: "same text", messageId: "p:0/GUID-newer" });
+
+    expect(echoCache.has(scope, { text: "same text", messageId: "200" })).toBe(false);
   });
 });

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -32,7 +32,7 @@ function createParams(
   const { message: msgOverrides, ...restOverrides } = overrides;
   const message = {
     id: 100,
-    sender: "+14155480405",
+    sender: "+15551234567",
     text: "Hello",
     is_from_me: false,
     is_group: false,
@@ -61,6 +61,73 @@ function createParams(
   };
 }
 
+describe("echo cache — message ID type canary (#47830)", () => {
+  // Tests the implicit contract that outbound GUIDs (e.g. "p:0/abc-def-123")
+  // never match inbound SQLite row IDs (e.g. "200"). If iMessage ever changes
+  // ID schemes, this test should break loudly.
+  it("outbound GUID format and inbound SQLite row ID format never collide", () => {
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    // Outbound messageId is a GUID format string
+    echoCache.remember(scope, { text: "test", messageId: "p:0/abc-def-123" });
+
+    // An inbound SQLite row ID (numeric string) should NOT match the GUID
+    expect(echoCache.has(scope, { text: "different", messageId: "200" })).toBe(false);
+
+    // The original GUID should still match
+    expect(echoCache.has(scope, { text: "different", messageId: "p:0/abc-def-123" })).toBe(true);
+  });
+});
+
+describe("echo cache — backward compat for channels without messageId", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Proves text-fallback echo detection still works when no messageId is present
+  // on either side. Critical for backward compat with channels that don't
+  // populate messageId.
+  it("text-only remember/has works within TTL", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "no id message" });
+
+    vi.advanceTimersByTime(2000);
+    expect(echoCache.has(scope, { text: "no id message" })).toBe(true);
+  });
+
+  it("text-only has returns false after TTL expiry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "no id message" });
+
+    vi.advanceTimersByTime(5000);
+    expect(echoCache.has(scope, { text: "no id message" })).toBe(false);
+  });
+
+  it("text-only has returns false for different text", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "no id message" });
+
+    vi.advanceTimersByTime(1000);
+    expect(echoCache.has(scope, { text: "totally different text" })).toBe(false);
+  });
+});
+
 describe("self-chat dedupe — #47830", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -73,8 +140,8 @@ describe("self-chat dedupe — #47830", () => {
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
-    // Agent sends "Hello" to self-chat target +14155480405
-    const scope = "default:imessage:+14155480405";
+    // Agent sends "Hello" to self-chat target +15551234567
+    const scope = "default:imessage:+15551234567";
     echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
 
     // 2 seconds later, user sends "Hello" to themselves (different message id)
@@ -84,7 +151,7 @@ describe("self-chat dedupe — #47830", () => {
       createParams({
         message: {
           id: 200,
-          sender: "+14155480405",
+          sender: "+15551234567",
           text: "Hello",
           is_from_me: false,
         },
@@ -109,7 +176,7 @@ describe("self-chat dedupe — #47830", () => {
     const echoCache = createSentMessageCache();
 
     // Agent sends "Hello" to target
-    const scope = "default:imessage:+14155480405";
+    const scope = "default:imessage:+15551234567";
     echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
 
     // 1 second later, iMessage reflects it back with same message id
@@ -119,7 +186,7 @@ describe("self-chat dedupe — #47830", () => {
       createParams({
         message: {
           id: "agent-msg-1" as unknown as number,
-          sender: "+14155480405",
+          sender: "+15551234567",
           text: "Hello",
           is_from_me: false,
         },
@@ -139,7 +206,7 @@ describe("self-chat dedupe — #47830", () => {
     const echoCache = createSentMessageCache();
 
     // Agent sends "Hello"
-    const scope = "default:imessage:+14155480405";
+    const scope = "default:imessage:+15551234567";
     echoCache.remember(scope, { text: "Hello", messageId: "agent-msg-1" });
 
     vi.advanceTimersByTime(1000);
@@ -148,7 +215,7 @@ describe("self-chat dedupe — #47830", () => {
       createParams({
         message: {
           id: 201,
-          sender: "+14155480405",
+          sender: "+15551234567",
           text: "Goodbye",
           is_from_me: false,
         },
@@ -166,7 +233,7 @@ describe("self-chat dedupe — #47830", () => {
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
     const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+14155480405";
+    const scope = "default:imessage:+15551234567";
 
     // Agent sends a multi-chunk reply: "Part one", "Part two", "Part three"
     echoCache.remember(scope, { text: "Part one", messageId: "agent-chunk-1" });
@@ -180,7 +247,7 @@ describe("self-chat dedupe — #47830", () => {
       createParams({
         message: {
           id: 300,
-          sender: "+14155480405",
+          sender: "+15551234567",
           text: "Part two",
           is_from_me: false,
         },
@@ -208,6 +275,27 @@ describe("self-chat dedupe — #47830", () => {
     vi.advanceTimersByTime(5000);
 
     const result = echoCache.has(scope, { text: "Hello there" });
+    expect(result).toBe(false);
+  });
+
+  // Safe failure mode: TTL expiry causes duplicate delivery (noisy), never message loss (lossy)
+  it("does NOT catch echo after TTL expiry — safe failure mode is duplicate delivery", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15551234567";
+
+    // Agent sends "Delayed echo test"
+    echoCache.remember(scope, { text: "Delayed echo test", messageId: "agent-msg-delayed" });
+
+    // 4.5 seconds later — beyond 4s TTL
+    vi.advanceTimersByTime(4500);
+
+    // Echo arrives with no messageId (text-only fallback path)
+    const result = echoCache.has(scope, { text: "Delayed echo test" });
+
+    // TTL expired → not caught → duplicate delivery (noisy but safe, not lossy)
     expect(result).toBe(false);
   });
 
@@ -242,8 +330,8 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 123703,
-          sender: "+14155480405",
-          chat_identifier: "+14155480405",
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
           text: "Hello this is a test message",
           is_from_me: true,
           is_group: false,
@@ -267,7 +355,7 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     const selfChatCache = createSelfChatCache();
 
     // Agent sends "Hi there!" to self-chat
-    const scope = "default:imessage:+14155480405";
+    const scope = "default:imessage:+15551234567";
     echoCache.remember(scope, { text: "Hi there!", messageId: "p:0/GUID-abc-def" });
 
     // 1 second later, iMessage delivers the agent reply as is_from_me=true
@@ -278,8 +366,8 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 123706,
-          sender: "+14155480405",
-          chat_identifier: "+14155480405",
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
           text: "Hi there!",
           is_from_me: true,
           is_group: false,
@@ -307,8 +395,8 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 123703,
-          sender: "+14155480405",
-          chat_identifier: "+14155480405",
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
           text: "Hello",
           created_at: createdAt,
           is_from_me: true,
@@ -327,8 +415,8 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 123704,
-          sender: "+14155480405",
-          chat_identifier: "+14155480405",
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
           text: "Hello",
           created_at: createdAt,
           is_from_me: false,
@@ -353,7 +441,7 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       createParams({
         message: {
           id: 9999,
-          sender: "+14155480405", // local user sent this
+          sender: "+15551234567", // local user sent this
           chat_identifier: "+15555550123", // sent TO this other person
           text: "Hello",
           is_from_me: true,
@@ -374,7 +462,7 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
     const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+14155480405";
+    const scope = "default:imessage:+15551234567";
     echoCache.remember(scope, { text: "Cached reply", messageId: "p:0/some-guid" });
 
     vi.advanceTimersByTime(1000);
@@ -397,7 +485,7 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
     const selfChatCache = createSelfChatCache();
 
     // Agent sends "Sounds good" — no messageId available (edge case)
-    const scope = "default:imessage:+14155480405";
+    const scope = "default:imessage:+15551234567";
     echoCache.remember(scope, { text: "Sounds good" });
 
     // 1 second later, inbound reflection arrives with id: null
@@ -407,7 +495,7 @@ describe("echo cache — text fallback for null-id inbound messages", () => {
       createParams({
         message: {
           id: null as unknown as number,
-          sender: "+14155480405",
+          sender: "+15551234567",
           text: "Sounds good",
           is_from_me: false,
         },

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -194,7 +194,7 @@ describe("self-chat dedupe — #47830", () => {
     expect(decision.kind).toBe("dispatch");
   });
 
-  it("drops echo after text TTL reduction (within 3s, not 5s)", () => {
+  it("drops echo after text TTL expiry (4s TTL: expired at 5s)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
@@ -204,14 +204,14 @@ describe("self-chat dedupe — #47830", () => {
     // Agent sends text (no message id available)
     echoCache.remember(scope, { text: "Hello there" });
 
-    // After 4 seconds — should NOT match if TTL reduced to 3s
-    vi.advanceTimersByTime(4000);
+    // After 5 seconds — beyond the 4s TTL, should NOT match
+    vi.advanceTimersByTime(5000);
 
     const result = echoCache.has(scope, { text: "Hello there" });
     expect(result).toBe(false);
   });
 
-  it("still drops text echo within reduced 3s TTL window", () => {
+  it("still drops text echo within 4s TTL window", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
 
@@ -220,8 +220,8 @@ describe("self-chat dedupe — #47830", () => {
 
     echoCache.remember(scope, { text: "Hello there" });
 
-    // After 2 seconds — should still match
-    vi.advanceTimersByTime(2000);
+    // After 3 seconds — within the 4s TTL, should still match
+    vi.advanceTimersByTime(3000);
 
     const result = echoCache.has(scope, { text: "Hello there" });
     expect(result).toBe(true);

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -78,6 +78,28 @@ describe("echo cache — message ID type canary (#47830)", () => {
     // The original GUID should still match
     expect(echoCache.has(scope, { text: "different", messageId: "p:0/abc-def-123" })).toBe(true);
   });
+
+  it('falls back to text when outbound messageId was junk ("ok")', () => {
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    // "ok" is normalized out and should not populate the ID cache.
+    echoCache.remember(scope, { text: "text-only fallback", messageId: "ok" });
+
+    // Inbound has a numeric SQLite ID that does not exist in cache. Since this
+    // scope has no real cached IDs, has() must still fall through to text match.
+    expect(echoCache.has(scope, { text: "text-only fallback", messageId: "200" })).toBe(true);
+  });
+
+  it("keeps ID short-circuit when scope has real outbound GUID IDs", () => {
+    const echoCache = createSentMessageCache();
+    const scope = "default:imessage:+15555550123";
+
+    echoCache.remember(scope, { text: "guid-backed", messageId: "p:0/abc-def-123" });
+
+    // Different inbound numeric ID should still short-circuit to false.
+    expect(echoCache.has(scope, { text: "guid-backed", messageId: "200" })).toBe(false);
+  });
 });
 
 describe("echo cache — backward compat for channels without messageId", () => {

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -9,6 +9,7 @@ export type IMessageAttachment = {
 
 export type IMessagePayload = {
   id?: number | null;
+  guid?: string | null;
   chat_id?: number | null;
   sender?: string | null;
   is_from_me?: boolean | null;

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -33,6 +33,7 @@ export type IMessageSendOpts = {
 
 export type IMessageSendResult = {
   messageId: string;
+  sentText: string;
 };
 
 const MAX_REPLY_TO_ID_LENGTH = 256;
@@ -78,6 +79,17 @@ function resolveMessageId(result: Record<string, unknown> | null | undefined): s
   return raw ? String(raw).trim() : null;
 }
 
+function resolveDeliveredIMessageText(text: string, mediaContentType?: string): string {
+  if (text.trim()) {
+    return text;
+  }
+  const kind = kindFromMime(mediaContentType ?? undefined);
+  if (!kind) {
+    return text;
+  }
+  return kind === "image" ? "<media:image>" : `<media:${kind}>`;
+}
+
 export async function sendMessageIMessage(
   to: string,
   text: string,
@@ -113,12 +125,7 @@ export async function sendMessageIMessage(
       localRoots: opts.mediaLocalRoots,
     });
     filePath = resolved.path;
-    if (!message.trim()) {
-      const kind = kindFromMime(resolved.contentType ?? undefined);
-      if (kind) {
-        message = kind === "image" ? "<media:image>" : `<media:${kind}>`;
-      }
-    }
+    message = resolveDeliveredIMessageText(message, resolved.contentType ?? undefined);
   }
 
   if (!message.trim() && !filePath) {
@@ -172,6 +179,7 @@ export async function sendMessageIMessage(
     const resolvedId = resolveMessageId(result);
     return {
       messageId: resolvedId ?? (result?.ok ? "ok" : "unknown"),
+      sentText: message,
     };
   } finally {
     if (shouldClose) {


### PR DESCRIPTION
## Summary

- **Problem:** Self-chat messages (user sending iMessage to themselves) were silently dropped by echo deduplication logic. The dedupe system couldn't distinguish between genuine user self-chat messages and agent reply echoes, causing all `is_from_me=true` messages in self-chat to be discarded.
- **Why it matters:** Self-chat is a common iMessage workflow and a useful testing/notes pattern. Dropping messages silently is a data-loss bug.
- **What changed:** Post-send cache population, ID-mismatch early return for self-chat echo checks, self-chat detection with sender normalization, and tightened echo TTL (5s → 4s). Four targeted changes across 5 files.
- **What did NOT change (scope boundary):** `SelfChatCache` logic untouched (still handles `is_from_me=false` reflection dedup). Normal DM behavior unaffected. Group chat unaffected (different routing). Compatible with PR #38440's `SelfChatCache` (orthogonal concerns). BlueBubbles uses different message keying and doesn't need this fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #47830
- Related #38440
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** In self-chat, both the user's original message and the iMessage reflection arrive with `is_from_me=true`. The echo cache used text-based matching as a fallback when message IDs didn't match, but in self-chat the scope collision meant genuine user messages matched against agent reply text in the cache. Additionally, `SentMessageCache.remember()` was called optimistically *before* send, widening the window for false-positive matches.
- **Missing detection / guardrail:** No self-chat-specific path in inbound processing. Echo cache had no awareness that inbound IDs (numeric SQLite row IDs) and outbound IDs (GUID strings) are structurally different in self-chat.
- **Prior context:** Original echo dedup was designed for normal DMs only. Self-chat was never explicitly tested or considered in the original implementation.
- **Why this regressed now:** This was a latent bug from the original echo dedup implementation, not a regression from a recent change.
- **If unknown, what was ruled out:** N/A — root cause is well understood.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `self-chat-dedupe.test.ts` (new, 19 tests), `deliver.test.ts` (3 updated tests)
- **Scenario the test should lock in:** Self-chat `is_from_me=true` messages must dispatch (not be treated as echoes); genuine echoes must still be caught; TTL boundaries; text-only fallback when outbound IDs are junk (`"ok"`/`"unknown"`); ID short-circuit preservation with real GUIDs.
- **Why this is the smallest reliable guardrail:** Unit tests on the echo cache and inbound processing path directly cover the four code changes without requiring a full iMessage integration harness.
- **Existing test that already covers this (if any):** None — self-chat had zero dedicated test coverage.
- **If no new test is added, why not:** N/A — 19 new tests added + 3 updated.

## User-visible / Behavior Changes

- Self-chat messages (user sending iMessage to their own number) are now delivered correctly instead of being silently dropped.
- No config changes. No new defaults.

## Diagram (if applicable)

```text
Before:
[user self-chat msg] -> [echo cache text match] -> DROPPED (false positive)

After:
[user self-chat msg] -> [self-chat detected] -> [ID-mismatch early return] -> DISPATCHED
[agent echo in self-chat] -> [self-chat detected] -> [post-send cache hit] -> DEDUPED (correct)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.3 (Mac Mini M4)
- Runtime/container: Node.js v22, OpenClaw gateway
- Model/provider: N/A (transport-layer bug)
- Integration/channel: iMessage (via imsg CLI)
- Relevant config: Default iMessage extension config, self-chat conversation

### Steps

1. Open iMessage and send a message to your own phone number / Apple ID
2. Observe inbound message processing in OpenClaw gateway logs
3. Verify the message is dispatched to the agent (not dropped)

### Expected

- Self-chat messages appear in gateway inbound processing and are dispatched normally

### Actual

- Before fix: Messages silently dropped by echo dedup (logged as echo match)
- After fix: Messages dispatched correctly

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- **19 new tests** in `self-chat-dedupe.test.ts` (canary, TTL boundary, backward compat, chunked reply false-positive prevention, null-ID edge cases, text-only fallback, ID short-circuit preservation)
- **3 updated tests** in `deliver.test.ts` for post-send cache behavior
- **70 tests passing** across all modified files
- **118/118 iMessage extension tests passing**
- **223/223 channel contract tests passing**
- **48+ hour soak test** on live self-chat with no message drops or duplications observed

## Human Verification (required)

- **Verified scenarios:** Self-chat send/receive on live iMessage, normal DM unaffected, 48-hour soak test with no drops or duplications
- **Edge cases checked:** Media-only `is_from_me=true` messages in self-chat (confirmed not exploitable — agents don't send media-only replies, `selfChatCache` catches reflections); fallback ID (`"ok"`/`"unknown"`) text-only cache behavior; TTL boundary at 4s
- **What you did not verify:** BlueBubbles self-chat (different keying, not affected); group chat (different routing entirely, not touched)

### Codex CLI Review Notes

Automated `codex review --base origin/main` identified a theoretical gap: media-only `is_from_me=true` messages in self-chat could bypass echo detection because `messageText` is empty for attachment-only messages. Adversarial review confirmed this is not exploitable in practice — worst case is a single spurious dispatch, not amplification. Documented for potential future hardening in a separate PR.

**Post-review fix:** Codex also flagged a P1 in the `has()` method — when `sendMessageIMessage` returns a fallback ID (`"ok"`/`"unknown"`), only text gets cached, but the ID-mismatch early return would incorrectly prevent text fallback for inbound echoes. Fixed: the early return now only fires when the scope actually has cached real message IDs. Two new tests cover both directions.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Tightened echo TTL (5s → 4s) could theoretically miss a slow echo on degraded networks.
  - **Mitigation:** Observed iMessage reflections consistently arrive within 2–3s. The `selfChatCache` provides a second layer of dedup for `is_from_me=false` reflections regardless of TTL. 48-hour soak test showed no missed echoes.

- **Risk:** `skipIdShortCircuit` parameter adds a code path that could be misused if called incorrectly in non-self-chat contexts.
  - **Mitigation:** Parameter is only set in the self-chat detection block in `inbound-processing.ts`. Non-self-chat paths are unchanged and don't pass this parameter.

## AI Disclosure

This PR was AI-assisted:
- **Implementation:** GPT-5.3-Codex (code generation, test authoring)
- **Adversarial review:** Claude Opus 4 (edge case analysis, polish pass — TTL adjustment, debug log cleanup)
- **Automated review:** OpenAI Codex CLI (`codex review --base origin/main`)
- All code has been read and understood by the human submitter.

## Files Changed

| File | Change |
|------|--------|
| `extensions/imessage/src/monitor/deliver.ts` | Move cache population to post-send |
| `extensions/imessage/src/monitor/deliver.test.ts` | Update tests for post-send behavior |
| `extensions/imessage/src/monitor/echo-cache.ts` | Add `skipIdShortCircuit` parameter |
| `extensions/imessage/src/monitor/inbound-processing.ts` | Self-chat detection + tightened echo check |
| `extensions/imessage/src/monitor/self-chat-dedupe.test.ts` | New: 19 dedicated self-chat dedupe tests |

**5 files changed, 615 insertions, 18 deletions**
