### PR TITLE
Fix/ for UI cannot save raw configuration closes(#55322)

### DIFF
--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -5,7 +5,6 @@ import type { ThemeTransitionContext } from "../theme-transition.ts";
 import type { ThemeMode, ThemeName } from "../theme.ts";
 import type { ConfigUiHints } from "../types.ts";
 import {
-  countSensitiveConfigValues,
   humanize,
   isSensitiveConfigPath,
   pathKey,
@@ -1075,12 +1074,6 @@ export function renderConfig(props: ConfigProps) {
                 }
               `
                 : (() => {
-                    const sensitiveCount = countSensitiveConfigValues(
-                      props.formValue,
-                      [],
-                      props.uiHints,
-                    );
-                    const blurred = sensitiveCount > 0 && !cvs.rawRevealed;
                     return html`
                     ${
                       formUnsafe
@@ -1095,40 +1088,14 @@ export function renderConfig(props: ConfigProps) {
                     <div class="field config-raw-field">
                       <span style="display:flex;align-items:center;gap:8px;">
                         Raw config (JSON/JSON5)
-                        ${
-                          sensitiveCount > 0
-                            ? html`
-                              <span class="pill pill--sm">${sensitiveCount} secret${sensitiveCount === 1 ? "" : "s"} ${blurred ? "redacted" : "visible"}</span>
-                              <button
-                                class="btn btn--icon config-raw-toggle ${blurred ? "" : "active"}"
-                                title=${
-                                  blurred ? "Reveal sensitive values" : "Hide sensitive values"
-                                }
-                                aria-label="Toggle raw config redaction"
-                                aria-pressed=${!blurred}
-                                @click=${() => {
-                                  cvs.rawRevealed = !cvs.rawRevealed;
-                                  requestUpdate();
-                                }}
-                              >
-                                ${blurred ? icons.eyeOff : icons.eye}
-                              </button>
-                            `
-                            : nothing
-                        }
                       </span>
-                      <textarea
-                        class="${blurred ? "config-raw-redacted" : ""}"
-                        placeholder=${blurred ? REDACTED_PLACEHOLDER : "Raw config (JSON/JSON5)"}
-                        .value=${blurred ? "" : props.raw}
-                        ?readonly=${blurred}
-                        @input=${(e: Event) => {
-                          if (blurred) {
-                            return;
-                          }
-                          props.onRawChange((e.target as HTMLTextAreaElement).value);
-                        }}
-                      ></textarea>
+              <textarea
+                placeholder="Raw config (JSON/JSON5)"
+                .value=${props.raw}
+                @input=${(e: Event) => {
+                  props.onRawChange((e.target as HTMLTextAreaElement).value);
+                }}
+              ></textarea>
                     </div>
                   `;
                   })()


### PR DESCRIPTION
## Summary

* Problem:
  Raw config textarea was blocked or inconsistent due to redaction logic interfering with editing.
* Why it matters:
  Users could not reliably edit config in raw mode, especially when sensitive values were present.
* What changed:
  Simplified raw textarea to always bind directly to `props.raw` and removed conditional redaction/readonly behavior.
* What did NOT change (scope boundary):
  No changes to backend config handling, validation, or schema logic.

## Change Type (select all)

* [x] Bug fix
* [ ] Feature
* [ ] Refactor required for the fix
* [ ] Docs
* [ ] Security hardening
* [ ] Chore/infra

## Scope (select all touched areas)

* [ ] Gateway / orchestration
* [ ] Skills / tool execution
* [ ] Auth / tokens
* [ ] Memory / storage
* [ ] Integrations
* [ ] API / contracts
* [x] UI / DX
* [ ] CI/CD / infra

## Linked Issue/PR

* Closes #55322 
* Related #55276, #55345
* [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

* Root cause:
  Raw editor logic mixed redaction state with editability, causing textarea to be empty or non-editable.
* Missing detection / guardrail:
  No UI test ensuring raw mode remains editable when sensitive values exist.
* Prior context:
  Redaction feature introduced conditional placeholder + value clearing.
* Why this regressed now:
  Redaction logic overreached into editing flow.
* If unknown, what was ruled out:
  N/A

## Regression Test Plan (if applicable)

* Coverage level that should have caught this:

  * [ ] Unit test
  * [ ] Seam / integration test
  * [x] End-to-end test
  * [ ] Existing coverage already sufficient
* Target test or file:
  Config UI raw editor
* Scenario the test should lock in:
  Editing raw config with sensitive values present still updates state correctly.
* Why this is the smallest reliable guardrail:
  Requires UI interaction and state binding validation.
* Existing test that already covers this (if any):
  None
* If no new test is added, why not:
  UI fix validated manually

## User-visible / Behavior Changes

* Raw config textarea is always editable
* Sensitive values are no longer auto-hidden in the textarea

## Diagram (if applicable)

```text
Before:
[user edits raw config] -> [textarea empty/blocked] -> [cannot save]

After:
[user edits raw config] -> [textarea reflects input] -> [can save/apply]
```

## Security Impact (required)

* New permissions/capabilities? (No)
* Secrets/tokens handling changed? (Yes)
* New/changed network calls? (No)
* Command/tool execution surface changed? (No)
* Data access scope changed? (No)
* If any Yes, explain risk + mitigation:
  Sensitive values are now visible in raw editor. This matches expected raw editing behavior; no persistence or exposure changes.

## Repro + Verification

### Environment

* OS: Linux
* Runtime/container: local dev
* Model/provider: N/A
* Integration/channel: N/A
* Relevant config: standard local config

### Steps

1. Open config UI
2. Switch to raw mode
3. Edit config containing sensitive fields

### Expected

* Textarea shows full config and updates on input

### Actual

* Previously blank or non-editable

## Evidence

* [ ] Failing test/log before + passing after
* [ ] Trace/log snippets
* [ ] Screenshot/recording
* [ ] Perf numbers (if relevant)

## Human Verification (required)

* Verified scenarios:
  Raw editing works, changes detected, save/apply enabled
* Edge cases checked:
  Sensitive values present, switching modes
* What you did not verify:
  All schema edge cases

## Review Conversations

* [x] I replied to or resolved every bot review conversation I addressed in this PR.
* [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

* Backward compatible? (Yes)
* Config/env changes? (No)
* Migration needed? (No)

## Risks and Mitigations

* Risk:
  Sensitive values visible in UI

  * Mitigation:
    Raw mode is explicitly for direct editing; behavior is intentional