### PR TITLE
fix(discord): avoid core stringEnum import

### DIFF
--- a/extensions/discord/src/message-tool-schema.ts
+++ b/extensions/discord/src/message-tool-schema.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox";
-import { stringEnum } from "openclaw/plugin-sdk/core";
+import { stringEnum } from "openclaw/plugin-sdk/channel-actions";
 
 const discordComponentEmojiSchema = Type.Object({
   name: Type.String(),

--- a/src/plugin-sdk/channel-actions.ts
+++ b/src/plugin-sdk/channel-actions.ts
@@ -6,6 +6,7 @@ export { resolveReactionMessageId } from "../channels/plugins/actions/reaction-m
 import { Type } from "@sinclair/typebox";
 import type { TSchema } from "@sinclair/typebox";
 import { stringEnum } from "../agents/schema/typebox.js";
+export { optionalStringEnum, stringEnum } from "../agents/schema/typebox.js";
 
 /** Schema helper for channels that expose button rows on the shared `message` tool. */
 export function createMessageToolButtonsSchema(): TSchema {

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -574,6 +574,7 @@ describe("plugin-sdk subpath exports", () => {
   it("keeps runtime entry subpaths importable", async () => {
     const [
       coreSdk,
+      channelActionsSdk,
       textRuntimeSdk,
       pluginEntrySdk,
       channelLifecycleSdk,
@@ -582,6 +583,7 @@ describe("plugin-sdk subpath exports", () => {
       ...representativeModules
     ] = await Promise.all([
       importResolvedPluginSdkSubpath("openclaw/plugin-sdk/core"),
+      importResolvedPluginSdkSubpath("openclaw/plugin-sdk/channel-actions"),
       importResolvedPluginSdkSubpath("openclaw/plugin-sdk/text-runtime"),
       importResolvedPluginSdkSubpath("openclaw/plugin-sdk/plugin-entry"),
       importResolvedPluginSdkSubpath("openclaw/plugin-sdk/channel-lifecycle"),
@@ -593,7 +595,10 @@ describe("plugin-sdk subpath exports", () => {
     ]);
 
     expect(coreSdk.definePluginEntry).toBe(pluginEntrySdk.definePluginEntry);
+    expect(typeof coreSdk.stringEnum).toBe("function");
     expect(typeof coreSdk.optionalStringEnum).toBe("function");
+    expect(typeof channelActionsSdk.stringEnum).toBe("function");
+    expect(typeof channelActionsSdk.optionalStringEnum).toBe("function");
     expect(typeof textRuntimeSdk.createScopedExpiringIdCache).toBe("function");
     expect(typeof textRuntimeSdk.resolveGlobalMap).toBe("function");
     expect(typeof textRuntimeSdk.resolveGlobalSingleton).toBe("function");


### PR DESCRIPTION
## Summary

- Problem: `extensions/discord/src/message-tool-schema.ts` imported `stringEnum` through the broad `openclaw/plugin-sdk/core` barrel, and the Windows `master` test job failed with `TypeError: stringEnum is not a function`
- Why it matters: the Discord message-tool schema crashes at runtime before the relevant tests can execute, breaking current `master`
- What changed: the Discord schema now imports `stringEnum` from the narrower public `openclaw/plugin-sdk/channel-actions` subpath, that subpath now re-exports `stringEnum` and `optionalStringEnum`, and the plugin-sdk subpath smoke test now asserts both are callable
- What did NOT change (scope boundary): no Discord behavior, schema shape, or core `stringEnum` implementation changed

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Discord’s message-tool schema depended on a tiny helper through the broad `openclaw/plugin-sdk/core` barrel instead of a narrower public seam
- Missing detection / guardrail: the existing plugin-sdk subpath smoke test checked `optionalStringEnum` but did not explicitly assert `stringEnum`
- Prior context (`git blame`, prior PR, issue, or refactor if known): `extensions/discord/src/message-tool-schema.ts` was added in `b48194a07e` using the `core` import after `stringEnum` had been re-exported from `core` in `5b2c5ee2bc`
- Why this regressed now: current `master` exposed a runtime path where that broad barrel import was not safe in the failing Discord/Windows lane
- If unknown, what was ruled out: local source imports, built package imports, and targeted macOS tests all worked, so the exact runtime failure appears environment-specific even though the fragile import seam was real

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/subpaths.test.ts`
- Scenario the test should lock in: both `openclaw/plugin-sdk/core` and `openclaw/plugin-sdk/channel-actions` expose callable `stringEnum`/`optionalStringEnum` exports at runtime
- Why this is the smallest reliable guardrail: it checks the public package seams directly without needing a full Discord monitor boot
- Existing test that already covers this (if any): the same subpath smoke test already covered importability and `optionalStringEnum`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm 10
- Model/provider: N/A
- Integration/channel (if any): Discord plugin SDK seam
- Relevant config (redacted): N/A

### Steps

1. Import `extensions/discord/src/message-tool-schema.ts` through the Discord message-action path
2. Exercise plugin-sdk runtime subpath imports for `openclaw/plugin-sdk/core` and `openclaw/plugin-sdk/channel-actions`
3. Run targeted Discord tests and repo guardrails

### Expected

- `stringEnum` resolves to a callable runtime export and Discord schema discovery does not crash

### Actual

- `master` Windows CI reported `TypeError: stringEnum is not a function` from the Discord message-tool schema path

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm check`, `pnpm build`, `pnpm test -- src/plugin-sdk/subpaths.test.ts -t "keeps runtime entry subpaths importable"`, `pnpm test -- extensions/discord/src/channel-actions.test.ts`, and `pnpm test -- extensions/discord/src/monitor/provider.proxy.test.ts`
- Edge cases checked: built package imports for both `openclaw/plugin-sdk/core` and `openclaw/plugin-sdk/channel-actions` expose callable `stringEnum`
- What you did **not** verify: exact reproduction of the Windows-only failure locally

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `channel-actions` now re-exports two general schema helpers that are not specific to action gating
  - Mitigation: this is a narrow public seam already used by adjacent message-tool schema code, and the runtime smoke test now locks the export contract in
