### PR TITLE
fix(discord): guard gateway cleanup races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: reconcile `sessions.json.compactionCount` after a late embedded auto-compaction success so persisted session counts catch up once the handler reports completion. (#45493) Thanks @jackal092927.
 - Agents/failover: classify Codex accountId token extraction failures as auth errors so model fallback continues to the next configured candidate. (#55206) Thanks @cosmicnet.
 - Talk/macOS: stop direct system-voice failures from replaying system speech, use app-locale fallback for shared watchdog timing, and add regression coverage for the macOS fallback route and language-aware timeout policy. (#53511) thanks @hongsw.
+- Discord/gateway cleanup: keep late Carbon reconnect-exhausted errors suppressed through startup/dispose cleanup so Discord monitor shutdown no longer crashes on late gateway close events. (#55373) Thanks @Takhoffman.
 
 ## 2026.3.24
 

--- a/extensions/discord/src/monitor/gateway-supervisor.test.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.test.ts
@@ -85,4 +85,25 @@ describe("createDiscordGatewaySupervisor", () => {
     expect(() => supervisor.dispose()).not.toThrow();
     expect(() => supervisor.dispose()).not.toThrow();
   });
+
+  it("keeps suppressing late gateway errors after dispose", () => {
+    const emitter = new EventEmitter();
+    const runtime = { error: vi.fn() };
+    const supervisor = createDiscordGatewaySupervisor({
+      client: {
+        getPlugin: vi.fn(() => ({ emitter })),
+      } as never,
+      isDisallowedIntentsError: () => false,
+      runtime: runtime as never,
+    });
+
+    supervisor.dispose();
+
+    expect(() =>
+      emitter.emit("error", new Error("Max reconnect attempts (0) reached after code 1005")),
+    ).not.toThrow();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed late gateway reconnect-exhausted error after dispose"),
+    );
+  });
 });

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -96,7 +96,9 @@ export function createDiscordGatewaySupervisor(params: {
   };
   const logLateDisposedEvent = (event: DiscordGatewayEvent) => {
     params.runtime.error?.(
-      danger(`discord: suppressed late gateway ${event.type} error after dispose: ${event.message}`),
+      danger(
+        `discord: suppressed late gateway ${event.type} error after dispose: ${event.message}`,
+      ),
     );
   };
   const onGatewayError = (err: unknown) => {

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -94,14 +94,20 @@ export function createDiscordGatewaySupervisor(params: {
       ),
     );
   };
+  const logLateDisposedEvent = (event: DiscordGatewayEvent) => {
+    params.runtime.error?.(
+      danger(`discord: suppressed late gateway ${event.type} error after dispose: ${event.message}`),
+    );
+  };
   const onGatewayError = (err: unknown) => {
-    if (disposed) {
-      return;
-    }
     const event = classifyDiscordGatewayEvent({
       err,
       isDisallowedIntentsError: params.isDisallowedIntentsError,
     });
+    if (phase === "disposed") {
+      logLateDisposedEvent(event);
+      return;
+    }
     if (phase === "active" && lifecycleHandler) {
       lifecycleHandler(event);
       return;
@@ -145,7 +151,6 @@ export function createDiscordGatewaySupervisor(params: {
       lifecycleHandler = undefined;
       phase = "disposed";
       pending.length = 0;
-      emitter.removeListener("error", onGatewayError);
     },
   };
 }

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -225,10 +225,13 @@ describe("monitorDiscordProvider", () => {
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("disconnects the gateway when startup fails before lifecycle begins after client creation", async () => {
+  it("disconnects the shared gateway and suppresses late gateway errors when startup fails before lifecycle begins", async () => {
     const disconnect = vi.fn();
+    const emitter = new EventEmitter();
+    const gateway = { emitter, disconnect, isConnected: false };
+    const runtime = baseRuntime();
     clientGetPluginMock.mockImplementation((name: string) =>
-      name === "gateway" ? { emitter: new EventEmitter(), disconnect, isConnected: false } : undefined,
+      name === "gateway" ? gateway : undefined,
     );
     createDiscordMessageHandlerMock.mockImplementationOnce(() => {
       throw new Error("handler init failed");
@@ -237,12 +240,18 @@ describe("monitorDiscordProvider", () => {
     await expect(
       monitorDiscordProvider({
         config: baseConfig(),
-        runtime: baseRuntime(),
+        runtime,
       }),
     ).rejects.toThrow("handler init failed");
 
     expect(monitorLifecycleMock).not.toHaveBeenCalled();
     expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(() =>
+      emitter.emit("error", new Error("Max reconnect attempts (0) reached after code 1005")),
+    ).not.toThrow();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("suppressed late gateway reconnect-exhausted error after dispose"),
+    );
   });
 
   it("does not double-stop thread bindings when lifecycle performs cleanup", async () => {

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -225,6 +225,26 @@ describe("monitorDiscordProvider", () => {
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
+  it("disconnects the gateway when startup fails before lifecycle begins after client creation", async () => {
+    const disconnect = vi.fn();
+    clientGetPluginMock.mockImplementation((name: string) =>
+      name === "gateway" ? { emitter: new EventEmitter(), disconnect, isConnected: false } : undefined,
+    );
+    createDiscordMessageHandlerMock.mockImplementationOnce(() => {
+      throw new Error("handler init failed");
+    });
+
+    await expect(
+      monitorDiscordProvider({
+        config: baseConfig(),
+        runtime: baseRuntime(),
+      }),
+    ).rejects.toThrow("handler init failed");
+
+    expect(monitorLifecycleMock).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
   it("does not double-stop thread bindings when lifecycle performs cleanup", async () => {
     await monitorDiscordProvider({
       config: baseConfig(),

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -797,6 +797,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let gatewaySupervisor: ReturnType<typeof createDiscordGatewaySupervisor> | undefined;
   let deactivateMessageHandler: (() => void) | undefined;
   let autoPresenceController: ReturnType<typeof createDiscordAutoPresenceController> | null = null;
+  let lifecycleGateway: GatewayPlugin | undefined;
   let earlyGatewayEmitter = gatewaySupervisor?.emitter;
   let onEarlyGatewayDebug: ((msg: unknown) => void) | undefined;
   try {
@@ -954,7 +955,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       runtime,
     });
 
-    const lifecycleGateway = client.getPlugin<GatewayPlugin>("gateway");
+    lifecycleGateway = client.getPlugin<GatewayPlugin>("gateway");
     earlyGatewayEmitter = gatewaySupervisor.emitter;
     onEarlyGatewayDebug = (msg: unknown) => {
       if (!(isVerboseForTesting ?? isVerbose)()) {
@@ -1180,6 +1181,13 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
     opts.setStatus?.({ connected: false });
     if (onEarlyGatewayDebug) {
       earlyGatewayEmitter?.removeListener("debug", onEarlyGatewayDebug);
+    }
+    if (!lifecycleStarted) {
+      try {
+        lifecycleGateway?.disconnect();
+      } catch (err) {
+        runtime.error?.(danger(`discord: failed to disconnect gateway during startup cleanup: ${String(err)}`));
+      }
     }
     gatewaySupervisor?.dispose();
     if (!lifecycleStarted) {

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -1186,7 +1186,9 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       try {
         lifecycleGateway?.disconnect();
       } catch (err) {
-        runtime.error?.(danger(`discord: failed to disconnect gateway during startup cleanup: ${String(err)}`));
+        runtime.error?.(
+          danger(`discord: failed to disconnect gateway during startup cleanup: ${String(err)}`),
+        );
       }
     }
     gatewaySupervisor?.dispose();

--- a/test/scripts/test-parallel.test.ts
+++ b/test/scripts/test-parallel.test.ts
@@ -23,6 +23,12 @@ const clearPlannerShardEnv = (env) => {
   delete nextEnv.OPENCLAW_TEST_FORCE_FORKS;
   delete nextEnv.OPENCLAW_TEST_DISABLE_THREAD_EXPANSION;
   delete nextEnv.OPENCLAW_TEST_SHOW_POOL_DECISION;
+  delete nextEnv.OPENCLAW_TEST_PROFILE;
+  delete nextEnv.OPENCLAW_TEST_WORKERS;
+  delete nextEnv.OPENCLAW_TEST_SKIP_DEFAULT;
+  delete nextEnv.OPENCLAW_TEST_INCLUDE_EXTENSIONS;
+  delete nextEnv.OPENCLAW_TEST_INCLUDE_CHANNELS;
+  delete nextEnv.OPENCLAW_TEST_INCLUDE_GATEWAY;
   return nextEnv;
 };
 
@@ -262,9 +268,9 @@ describe("scripts/test-parallel lane planning", () => {
     expect(output).toMatch(/extensions(?:-batch-1)? filters=all maxWorkers=/);
   });
 
-  it("uses fewer shared extension batches on high-memory local hosts", () => {
+  it("uses higher shared extension worker counts on high-memory local hosts", () => {
     const repoRoot = path.resolve(import.meta.dirname, "../..");
-    const output = execFileSync(
+    const highMemoryOutput = execFileSync(
       "node",
       ["scripts/test-parallel.mjs", "--plan", "--surface", "extensions"],
       {
@@ -281,11 +287,29 @@ describe("scripts/test-parallel lane planning", () => {
         encoding: "utf8",
       },
     );
+    const midMemoryOutput = execFileSync(
+      "node",
+      ["scripts/test-parallel.mjs", "--plan", "--surface", "extensions"],
+      {
+        cwd: repoRoot,
+        env: {
+          ...clearPlannerShardEnv(process.env),
+          CI: "",
+          GITHUB_ACTIONS: "",
+          RUNNER_OS: "macOS",
+          OPENCLAW_TEST_HOST_CPU_COUNT: "10",
+          OPENCLAW_TEST_HOST_MEMORY_GIB: "64",
+          OPENCLAW_TEST_LOAD_AWARE: "0",
+        },
+        encoding: "utf8",
+      },
+    );
 
-    expect(output).toContain("extensions-batch-1 filters=all maxWorkers=5");
-    expect(output).toContain("extensions-batch-2 filters=all maxWorkers=5");
-    expect(output).toContain("extensions-batch-2");
-    expect(output).not.toContain("extensions-batch-3");
+    expect(midMemoryOutput).toContain("extensions-batch-1 filters=all maxWorkers=3");
+    expect(midMemoryOutput).toContain("extensions-batch-3 filters=all maxWorkers=3");
+    expect(highMemoryOutput).toContain("extensions-batch-1 filters=all maxWorkers=5");
+    expect(highMemoryOutput).toContain("extensions-batch-3 filters=all maxWorkers=5");
+    expect(highMemoryOutput).not.toContain("extensions-batch-4");
   });
 
   it("starts isolated channel lanes before shared extension batches on high-memory local hosts", () => {


### PR DESCRIPTION
## Summary
- keep Discord gateway late error handling active through cleanup so reconnect-exhausted close events do not crash the process
- log post-dispose gateway errors instead of silently dropping them
- disconnect the Carbon gateway during startup cleanup if lifecycle never started, with regression coverage for both paths

## Testing
- pnpm vitest run extensions/discord/src/monitor/gateway-supervisor.test.ts extensions/discord/src/monitor/provider.test.ts extensions/discord/src/monitor.gateway.test.ts extensions/discord/src/monitor/provider.lifecycle.test.ts