### PR TITLE
WIP feat(cli): sync local schema artifacts on startup

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -42,7 +42,9 @@ Pipe it into a file when you want to inspect or validate it with other tools:
 openclaw config schema > openclaw.schema.json
 ```
 
-### Paths
+On normal CLI runs, when `update.maintainConfigJsonSchema` is `true` (default), OpenClaw also keeps a local `openclaw_schema.json` beside `openclaw.json` and sets `$schema: "openclaw_schema.json"` when `$schema` is missing or empty. Set `update.maintainConfigJsonSchema: false` to opt out.
+
+#### Paths
 
 Paths use dot or bracket notation:
 

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -68,6 +68,7 @@ install method aligned:
 - `dev` → ensures a git checkout (default: `~/openclaw`, override with `OPENCLAW_GIT_DIR`),
   updates it, and installs the global CLI from that checkout.
 - `stable`/`beta` → installs from npm using the matching dist-tag.
+- When `update.maintainConfigJsonSchema` is `true` (default), CLI runs keep `openclaw_schema.json` updated beside `openclaw.json` and fill in `$schema: "openclaw_schema.json"` when the config leaves `$schema` empty.
 
 The Gateway core auto-updater (when enabled via config) reuses this same update path.
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -439,8 +439,10 @@ describe("config cli", () => {
       const raw = mockLog.mock.calls.at(-1)?.[0];
       expect(typeof raw).toBe("string");
       const payload = JSON.parse(String(raw)) as {
+        meta?: { version?: string };
         properties?: Record<string, unknown>;
       };
+      expect(typeof payload.meta?.version).toBe("string");
       expect(payload.properties?.$schema).toEqual({ type: "string" });
       expect(payload.properties?.channels).toEqual({
         type: "object",
@@ -488,8 +490,10 @@ describe("config cli", () => {
 
       expect(defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
       const payload = JSON.parse(String(mockLog.mock.calls.at(-1)?.[0])) as {
+        meta?: { version?: string };
         properties?: Record<string, unknown>;
       };
+      expect(typeof payload.meta?.version).toBe("string");
       expect(payload.properties?.$schema).toEqual({ type: "string" });
       expect(payload.properties?.channels).toBeTruthy();
       expect(payload.properties?.plugins).toBeUndefined();

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -6,7 +6,6 @@ import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-f
 import { CONFIG_PATH } from "../config/paths.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
-import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
 import {
   coerceSecretRef,
   isValidEnvSecretRefId,
@@ -1175,17 +1174,8 @@ export async function runConfigFile(opts: { runtime?: RuntimeEnv }) {
 }
 
 async function buildCliConfigSchema(): Promise<Record<string, unknown>> {
-  const schema = structuredClone((await readBestEffortRuntimeConfigSchema()).schema) as {
-    properties?: Record<string, unknown>;
-    required?: string[];
-  };
-
-  schema.properties = {
-    $schema: { type: "string" },
-    ...schema.properties,
-  };
-
-  return schema;
+  const { buildEditorConfigSchemaDocument } = await import("../config/local-json-schema.js");
+  return await buildEditorConfigSchemaDocument();
 }
 
 export async function runConfigSchema(opts: { runtime?: RuntimeEnv } = {}) {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -8,6 +8,7 @@ const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
 const routeLogsToStderrMock = vi.fn();
+const maintainLocalConfigJsonSchemaArtifactsMock = vi.fn(async () => {});
 
 const runtimeMock = {
   log: vi.fn(),
@@ -45,6 +46,14 @@ vi.mock("../plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
 }));
 
+vi.mock("../../config/local-json-schema.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/local-json-schema.js")>();
+  return {
+    ...actual,
+    maintainLocalConfigJsonSchemaArtifacts: maintainLocalConfigJsonSchemaArtifactsMock,
+  };
+});
+
 const mockedModuleIds = [
   "../../globals.js",
   "../../runtime.js",
@@ -52,6 +61,7 @@ const mockedModuleIds = [
   "../cli-name.js",
   "./config-guard.js",
   "../plugin-registry.js",
+  "../../config/local-json-schema.js",
 ];
 
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
@@ -325,6 +335,7 @@ describe("registerPreActionHooks", () => {
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(setVerboseMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(maintainLocalConfigJsonSchemaArtifactsMock).not.toHaveBeenCalled();
 
     vi.clearAllMocks();
     process.env.OPENCLAW_HIDE_BANNER = "1";
@@ -430,6 +441,30 @@ describe("registerPreActionHooks", () => {
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("maintains local schema artifacts after config guard succeeds", async () => {
+    await runPreAction({
+      parseArgv: ["agents", "list"],
+      processArgv: ["node", "openclaw", "agents", "list"],
+    });
+
+    expect(maintainLocalConfigJsonSchemaArtifactsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when local schema maintenance fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    maintainLocalConfigJsonSchemaArtifactsMock.mockRejectedValueOnce(new Error("schema-failed"));
+
+    await runPreAction({
+      parseArgv: ["agents", "list"],
+      processArgv: ["node", "openclaw", "agents", "list"],
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to maintain local config schema artifacts:"),
+    );
+    warnSpy.mockRestore();
   });
 
   it("bypasses config guard for backup create", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -65,6 +65,17 @@ function loadPluginRegistryModule() {
   return pluginRegistryModulePromise;
 }
 
+async function maintainLocalConfigSchemaArtifacts(): Promise<void> {
+  try {
+    const { maintainLocalConfigJsonSchemaArtifacts } =
+      await import("../../config/local-json-schema.js");
+    await maintainLocalConfigJsonSchemaArtifacts();
+  } catch (error) {
+    console.warn(`Failed to maintain local config schema artifacts: ${String(error)}`);
+    return;
+  }
+}
+
 function resolvePluginRegistryScope(commandPath: string[]): "channels" | "all" {
   return commandPath[0] === "status" || commandPath[0] === "health" ? "channels" : "all";
 }
@@ -155,6 +166,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       ...(allowInvalid ? { allowInvalid: true } : {}),
       ...(jsonOutputMode ? { suppressDoctorStdout: true } : {}),
     });
+    await maintainLocalConfigSchemaArtifacts();
     // Load plugins for commands that need channel access.
     // When --json output is active, temporarily route logs to stderr so plugin
     // registration messages don't corrupt the JSON payload on stdout.

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -9,6 +9,9 @@ const assertRuntimeMock = vi.hoisted(() => vi.fn());
 const closeActiveMemorySearchManagersMock = vi.hoisted(() => vi.fn(async () => {}));
 const outputRootHelpMock = vi.hoisted(() => vi.fn());
 const buildProgramMock = vi.hoisted(() => vi.fn());
+const maintainLocalConfigJsonSchemaArtifactsMock = vi.hoisted(() => vi.fn(async () => {}));
+const registerPluginCliCommandsMock = vi.hoisted(() => vi.fn());
+const loadValidatedConfigForPluginRegistrationMock = vi.hoisted(() => vi.fn(async () => undefined));
 const maybeRunCliInContainerMock = vi.hoisted(() =>
   vi.fn<
     (argv: string[]) => { handled: true; exitCode: number } | { handled: false; argv: string[] }
@@ -52,6 +55,20 @@ vi.mock("./program.js", () => ({
   buildProgram: buildProgramMock,
 }));
 
+vi.mock("../plugins/cli.js", () => ({
+  registerPluginCliCommands: registerPluginCliCommandsMock,
+}));
+
+vi.mock("./program/register.subclis.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./program/register.subclis.js")>()),
+  loadValidatedConfigForPluginRegistration: loadValidatedConfigForPluginRegistrationMock,
+}));
+
+vi.mock("../config/local-json-schema.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/local-json-schema.js")>()),
+  maintainLocalConfigJsonSchemaArtifacts: maintainLocalConfigJsonSchemaArtifactsMock,
+}));
+
 const { runCli } = await import("./run-main.js");
 
 describe("runCli exit behavior", () => {
@@ -88,6 +105,30 @@ describe("runCli exit behavior", () => {
     expect(closeActiveMemorySearchManagersMock).toHaveBeenCalledTimes(1);
     expect(exitSpy).not.toHaveBeenCalled();
     exitSpy.mockRestore();
+  });
+
+  it("maintains local schema artifacts on bare root invocation", async () => {
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    const parseAsyncMock = vi.fn(async () => {});
+    buildProgramMock.mockReturnValueOnce({ commands: [], parseAsync: parseAsyncMock });
+
+    await runCli(["node", "openclaw"]);
+
+    expect(maintainLocalConfigJsonSchemaArtifactsMock).toHaveBeenCalledTimes(1);
+    expect(buildProgramMock).toHaveBeenCalledTimes(1);
+    expect(parseAsyncMock).toHaveBeenCalledWith(["node", "openclaw"]);
+  });
+
+  it.each(["--version", "-v"])("does not maintain local schema artifacts for %s", async (flag) => {
+    tryRouteCliMock.mockResolvedValueOnce(false);
+    const parseAsyncMock = vi.fn(async () => {});
+    buildProgramMock.mockReturnValueOnce({ commands: [], parseAsync: parseAsyncMock });
+
+    await runCli(["node", "openclaw", flag]);
+
+    expect(maintainLocalConfigJsonSchemaArtifactsMock).not.toHaveBeenCalled();
+    expect(buildProgramMock).toHaveBeenCalledTimes(1);
+    expect(parseAsyncMock).toHaveBeenCalledWith(["node", "openclaw", flag]);
   });
 
   it("returns after a handled container-target invocation", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -11,6 +11,7 @@ import {
   getPrimaryCommand,
   hasHelpOrVersion,
   isRootHelpInvocation,
+  isRootVersionInvocation,
 } from "./argv.js";
 import { maybeRunCliInContainer, parseCliContainerArgs } from "./container-target.js";
 import { loadCliDotEnv } from "./dotenv.js";
@@ -24,6 +25,16 @@ async function closeCliMemoryManagers(): Promise<void> {
     await closeActiveMemorySearchManagers();
   } catch {
     // Best-effort teardown for short-lived CLI processes.
+  }
+}
+
+async function maintainRootLocalConfigSchemaArtifacts(): Promise<void> {
+  try {
+    const { maintainLocalConfigJsonSchemaArtifacts } =
+      await import("../config/local-json-schema.js");
+    await maintainLocalConfigJsonSchemaArtifacts();
+  } catch (error) {
+    console.warn(`Failed to maintain local config schema artifacts: ${String(error)}`);
   }
 }
 
@@ -148,6 +159,9 @@ export async function runCli(argv: string[] = process.argv) {
     // Register the primary command (builtin or subcli) so help and command parsing
     // are correct even with lazy command registration.
     const primary = getPrimaryCommand(parseArgv);
+    if (!primary && !isRootVersionInvocation(normalizedArgv)) {
+      await maintainRootLocalConfigSchemaArtifacts();
+    }
     if (primary) {
       const { getProgramContext } = await import("./program/program-context.js");
       const ctx = getProgramContext(program);

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -39,6 +39,26 @@ describe("$schema key in config (#14998)", () => {
   });
 });
 
+describe("update.maintainConfigJsonSchema", () => {
+  it("accepts the camelCase config key", () => {
+    const result = OpenClawSchema.safeParse({
+      update: {
+        maintainConfigJsonSchema: false,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects the legacy snake_case config key", () => {
+    const result = OpenClawSchema.safeParse({
+      update: {
+        maintain_config_json_schema: false,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("plugins.slots.contextEngine", () => {
   it("accepts a contextEngine slot id", () => {
     const result = OpenClawSchema.safeParse({

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1767,6 +1767,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         }
       }
     }
+    const {
+      LOCAL_CONFIG_SCHEMA_FILENAME,
+      withDefaultLocalConfigSchemaRef,
+      writeLocalConfigJsonSchemaFile,
+    } = await import("./local-json-schema.js");
+    outputConfig = withDefaultLocalConfigSchemaRef(outputConfig);
     // Do NOT apply runtime defaults when writing — user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
     const stampedOutputConfig = stampConfigVersion(outputConfig);
@@ -1898,6 +1904,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           });
           logConfigOverwrite();
           logConfigWriteAnomalies();
+          await writeLocalConfigJsonSchemaFile({
+            configPath,
+            config: stampedOutputConfig,
+            fsModule: deps.fs,
+          }).catch((error) => {
+            deps.logger.warn(`Failed to update ${LOCAL_CONFIG_SCHEMA_FILENAME}: ${String(error)}`);
+          });
           await appendWriteAudit("copy-fallback");
           return;
         }
@@ -1908,6 +1921,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       logConfigOverwrite();
       logConfigWriteAnomalies();
+      await writeLocalConfigJsonSchemaFile({
+        configPath,
+        config: stampedOutputConfig,
+        fsModule: deps.fs,
+      }).catch((error) => {
+        deps.logger.warn(`Failed to update ${LOCAL_CONFIG_SCHEMA_FILENAME}: ${String(error)}`);
+      });
       await appendWriteAudit("rename");
     } catch (err) {
       await appendWriteAudit("failed", err);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -156,6 +156,100 @@ describe("config io write", () => {
     });
   });
 
+  it("writes local schema file and defaults $schema when enabled", async () => {
+    await withSuiteHome(async (home) => {
+      const { configPath, io } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: { gateway: { mode: "local" } },
+      });
+
+      await io.writeConfigFile({ gateway: { mode: "local" } });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $schema?: string;
+      };
+      expect(persisted.$schema).toBe("openclaw_schema.json");
+
+      const schemaPath = path.join(home, ".openclaw", "openclaw_schema.json");
+      const schema = JSON.parse(await fs.readFile(schemaPath, "utf-8")) as {
+        meta?: { version?: string };
+        properties?: Record<string, unknown>;
+      };
+      expect(typeof schema.meta?.version).toBe("string");
+      expect(schema.properties?.$schema).toEqual({ type: "string" });
+    });
+  });
+
+  it("skips local schema maintenance when disabled", async () => {
+    await withSuiteHome(async (home) => {
+      const { configPath, io } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: {
+          gateway: { mode: "local" },
+          update: { maintainConfigJsonSchema: false },
+        },
+      });
+
+      await io.writeConfigFile({
+        gateway: { mode: "local" },
+        update: { maintainConfigJsonSchema: false },
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $schema?: string;
+      };
+      expect(persisted.$schema).toBeUndefined();
+
+      const schemaPath = path.join(home, ".openclaw", "openclaw_schema.json");
+      await expect(fs.access(schemaPath)).rejects.toThrow();
+    });
+  });
+
+  it("preserves a custom non-empty $schema value", async () => {
+    await withSuiteHome(async (home) => {
+      const customSchema = "https://example.com/openclaw.schema.json";
+      const { configPath, io } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: {
+          $schema: customSchema,
+          gateway: { mode: "local" },
+        },
+      });
+
+      await io.writeConfigFile({
+        $schema: customSchema,
+        gateway: { mode: "local" },
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $schema?: string;
+      };
+      expect(persisted.$schema).toBe(customSchema);
+    });
+  });
+
+  it("replaces a blank $schema value with the local schema file", async () => {
+    await withSuiteHome(async (home) => {
+      const { configPath, io } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: {
+          $schema: "   ",
+          gateway: { mode: "local" },
+        },
+      });
+
+      await io.writeConfigFile({
+        $schema: "   ",
+        gateway: { mode: "local" },
+      });
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        $schema?: string;
+      };
+      expect(persisted.$schema).toBe("openclaw_schema.json");
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "tightens world-writable state dir when writing the default config",
     async () => {

--- a/src/config/local-json-schema.test.ts
+++ b/src/config/local-json-schema.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readConfigFileSnapshotForWriteMock = vi.hoisted(() => vi.fn());
+const writeConfigFileMock = vi.hoisted(() => vi.fn(async () => {}));
+const readBestEffortRuntimeConfigSchemaMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    schema: {
+      type: "object",
+      properties: {
+        update: {
+          type: "object",
+          properties: {},
+        },
+      },
+    },
+    version: "9.9.9-test",
+  })),
+);
+
+vi.mock("./config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./config.js")>()),
+  readConfigFileSnapshotForWrite: readConfigFileSnapshotForWriteMock,
+  writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock("./runtime-schema.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./runtime-schema.js")>()),
+  readBestEffortRuntimeConfigSchema: readBestEffortRuntimeConfigSchemaMock,
+}));
+
+const { maintainLocalConfigJsonSchemaArtifacts } = await import("./local-json-schema.js");
+
+describe("maintainLocalConfigJsonSchemaArtifacts", () => {
+  let tempDir: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schema-maint-"));
+    configPath = path.join(tempDir, "openclaw.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("does not rewrite invalid existing config snapshots", async () => {
+    readConfigFileSnapshotForWriteMock.mockResolvedValueOnce({
+      snapshot: {
+        path: configPath,
+        exists: true,
+        raw: "{bad",
+        parsed: {},
+        resolved: {},
+        valid: false,
+        config: {},
+        issues: [{ path: "", message: "invalid" }],
+        warnings: [],
+        legacyIssues: [],
+      },
+      writeOptions: {
+        expectedConfigPath: configPath,
+      },
+    });
+
+    await maintainLocalConfigJsonSchemaArtifacts();
+
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    await expect(fs.access(path.join(tempDir, "openclaw_schema.json"))).rejects.toThrow();
+  });
+
+  it("avoids a second schema write when config write already handled sync", async () => {
+    readConfigFileSnapshotForWriteMock.mockResolvedValueOnce({
+      snapshot: {
+        path: configPath,
+        exists: true,
+        raw: '{"gateway":{"mode":"local"}}',
+        parsed: { gateway: { mode: "local" } },
+        resolved: { gateway: { mode: "local" } },
+        valid: true,
+        config: { gateway: { mode: "local" } },
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      },
+      writeOptions: {
+        expectedConfigPath: configPath,
+      },
+    });
+
+    await maintainLocalConfigJsonSchemaArtifacts();
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      {
+        gateway: { mode: "local" },
+        $schema: "openclaw_schema.json",
+      },
+      { expectedConfigPath: configPath },
+    );
+    await expect(fs.access(path.join(tempDir, "openclaw_schema.json"))).rejects.toThrow();
+  });
+});

--- a/src/config/local-json-schema.ts
+++ b/src/config/local-json-schema.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "./types.js";
+
+export const LOCAL_CONFIG_SCHEMA_FILENAME = "openclaw_schema.json";
+
+type JsonObject = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasNonEmptySchemaRef(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isConfigJsonSchemaMaintenanceEnabled(
+  config: Pick<OpenClawConfig, "update">,
+): boolean {
+  return config.update?.maintainConfigJsonSchema ?? true;
+}
+
+export function withDefaultLocalConfigSchemaRef(config: OpenClawConfig): OpenClawConfig {
+  if (!isConfigJsonSchemaMaintenanceEnabled(config) || hasNonEmptySchemaRef(config.$schema)) {
+    return config;
+  }
+  return {
+    ...config,
+    $schema: LOCAL_CONFIG_SCHEMA_FILENAME,
+  };
+}
+
+export function resolveLocalConfigSchemaPath(configPath: string): string {
+  return path.join(path.dirname(configPath), LOCAL_CONFIG_SCHEMA_FILENAME);
+}
+
+export async function buildEditorConfigSchemaDocument(): Promise<JsonObject> {
+  const { readBestEffortRuntimeConfigSchema } = await import("./runtime-schema.js");
+  const response = await readBestEffortRuntimeConfigSchema();
+  const schema = structuredClone(response.schema) as JsonObject & {
+    properties?: JsonObject;
+    meta?: JsonObject;
+  };
+  const properties = isPlainObject(schema.properties) ? schema.properties : {};
+  const meta = isPlainObject(schema.meta) ? schema.meta : {};
+  schema.properties = {
+    $schema: { type: "string" },
+    ...properties,
+  };
+  schema.meta = {
+    ...meta,
+    version: response.version,
+  };
+  return schema;
+}
+
+export async function writeLocalConfigJsonSchemaFile(params: {
+  configPath: string;
+  config: Pick<OpenClawConfig, "update">;
+  fsModule?: Pick<typeof fs, "promises">;
+}): Promise<boolean> {
+  if (!isConfigJsonSchemaMaintenanceEnabled(params.config)) {
+    return false;
+  }
+
+  const fsModule = params.fsModule ?? fs;
+  const schemaPath = resolveLocalConfigSchemaPath(params.configPath);
+  const nextDocument = await buildEditorConfigSchemaDocument();
+  const nextRaw = JSON.stringify(nextDocument, null, 2).trimEnd().concat("\n");
+
+  let currentRaw: string | null = null;
+  try {
+    currentRaw = await fsModule.promises.readFile(schemaPath, "utf-8");
+  } catch {
+    currentRaw = null;
+  }
+
+  if (currentRaw === nextRaw) {
+    return false;
+  }
+
+  await fsModule.promises.mkdir(path.dirname(schemaPath), { recursive: true, mode: 0o700 });
+  await fsModule.promises.writeFile(schemaPath, nextRaw, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+  return true;
+}
+
+export async function maintainLocalConfigJsonSchemaArtifacts(): Promise<void> {
+  const { readConfigFileSnapshotForWrite, writeConfigFile } = await import("./config.js");
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  if (snapshot.exists && !snapshot.valid) {
+    return;
+  }
+  const nextConfig = withDefaultLocalConfigSchemaRef(snapshot.config);
+  if (snapshot.exists && nextConfig !== snapshot.config) {
+    await writeConfigFile(nextConfig, writeOptions);
+    return;
+  }
+  await writeLocalConfigJsonSchemaFile({
+    configPath: snapshot.path,
+    config: nextConfig,
+  });
+}

--- a/src/config/schema-base.ts
+++ b/src/config/schema-base.ts
@@ -8,9 +8,11 @@ import { OpenClawSchema } from "./zod-schema.js";
 type ConfigSchema = Record<string, unknown>;
 
 type JsonSchemaObject = Record<string, unknown> & {
-  properties?: Record<string, JsonSchemaObject>;
+  title?: string;
+  default?: unknown;
+  properties?: Record<string, unknown>;
   required?: string[];
-  additionalProperties?: JsonSchemaObject | boolean;
+  additionalProperties?: unknown;
 };
 
 const asJsonSchemaObject = (value: unknown): JsonSchemaObject | null =>
@@ -59,8 +61,15 @@ function computeBaseConfigSchemaStablePayload(): BaseConfigSchemaStablePayload {
   const schema = OpenClawSchema.toJSONSchema({
     target: "draft-07",
     unrepresentable: "any",
-  });
+  }) as JsonSchemaObject;
   schema.title = "OpenClawConfig";
+  const updateSchema = asSchemaObject(schema.properties?.update);
+  const maintainConfigJsonSchemaSchema = asSchemaObject(
+    updateSchema?.properties?.maintainConfigJsonSchema,
+  );
+  if (maintainConfigJsonSchemaSchema) {
+    maintainConfigJsonSchemaSchema.default = true;
+  }
   const stablePayload = {
     schema: stripChannelSchema(schema),
     uiHints: applyDerivedTags(mapSensitivePaths(OpenClawSchema, "", buildBaseHints())),

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -343,6 +343,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
           checkOnStart: {
             type: "boolean",
           },
+          maintainConfigJsonSchema: {
+            type: "boolean",
+            default: true,
+          },
           auto: {
             type: "object",
             properties: {
@@ -11652,6 +11656,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Update Check on Start",
       help: "Check for npm updates when the gateway starts (default: true).",
       tags: ["automation"],
+    },
+    "update.maintainConfigJsonSchema": {
+      label: "Maintain Config JSON Schema",
+      help: "Keep a local openclaw_schema.json beside openclaw.json and default $schema to that file when missing or empty (default: true).",
+      tags: ["advanced"],
     },
     "update.auto.enabled": {
       label: "Auto Update Enabled",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -55,6 +55,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Update-channel and startup-check behavior for keeping OpenClaw runtime versions current. Use conservative channels in production and more experimental channels only in controlled environments.",
   "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
   "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
+  "update.maintainConfigJsonSchema":
+    "Keep a local openclaw_schema.json beside openclaw.json and default $schema to that file when missing or empty (default: true).",
   "update.auto.enabled": "Enable background auto-update for package installs (default: false).",
   "update.auto.stableDelayHours":
     "Minimum delay before stable-channel auto-apply starts (default: 6).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -31,6 +31,7 @@ export const FIELD_LABELS: Record<string, string> = {
   update: "Updates",
   "update.channel": "Update Channel",
   "update.checkOnStart": "Update Check on Start",
+  "update.maintainConfigJsonSchema": "Maintain Config JSON Schema",
   "update.auto.enabled": "Auto Update Enabled",
   "update.auto.stableDelayHours": "Auto Update Stable Delay (hours)",
   "update.auto.stableJitterHours": "Auto Update Stable Jitter (hours)",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -30,6 +30,7 @@ import type { SkillsConfig } from "./types.skills.js";
 import type { ToolsConfig } from "./types.tools.js";
 
 export type OpenClawConfig = {
+  $schema?: string;
   meta?: {
     /** Last OpenClaw version that wrote this config. */
     lastTouchedVersion?: string;
@@ -69,6 +70,7 @@ export type OpenClawConfig = {
     channel?: "stable" | "beta" | "dev";
     /** Check for updates on gateway start (npm installs only). */
     checkOnStart?: boolean;
+    maintainConfigJsonSchema?: boolean;
     /** Core auto-update policy for package installs. */
     auto?: {
       /** Enable background auto-update checks and apply logic. Default: false. */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -339,6 +339,7 @@ export const OpenClawSchema = z
       .object({
         channel: z.union([z.literal("stable"), z.literal("beta"), z.literal("dev")]).optional(),
         checkOnStart: z.boolean().optional(),
+        maintainConfigJsonSchema: z.boolean().optional(),
         auto: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: JSON schema for the config is should be manually set for new and existing configs and updated afterwards 
- Why it matters: It's inconvenient to bother about it
- What changed: Added local json schema for the config that is updated after release ver bumps (optional, true by default)
- What did NOT change (scope boundary): config or schema itself was not changed, only whe way how it's delivered to the end user

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Close #55235
- Close #22278
- Related #55002

## Root Cause / Regression History (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

in `openclaw.json`, the `$schema` field will appear that will point to the local file with the schema, and the schema file itself. This is optional and enabled by default.

if user has already set the schema path, then it **will not** be updated

if the new release is rolled out, then the schema **will** be updated

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
1. When no schema is present, it's added to the config, and a schema file is generated
2. On re-run, it's untouched
3. After the version change, the openclaw_schema file is updated
4. After openclaw.json is edited, it's explicitly noted to the user
 
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)

## AI Assistance

Pr was done with the assistance of Opencode + OMO, mostly with GPT 5.4 model
I understand what this code is doing


