### PR TITLE
fix(matrix): mentions should work with displayName labels (with help from Antigravity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Docs: https://docs.openclaw.ai
 - Discord/Carbon beta: update `@buape/carbon` to the latest beta and pass the new `RateLimitError` request argument so Discord stays compatible with the upstream beta constructor change. (#55980) Thanks @ngutman.
 - Plugins/inbound claims: pass full inbound attachment arrays through `inbound_claim` hook metadata while keeping the legacy singular media attachment fields for compatibility. (#55452) Thanks @huntharo.
 - Plugins/Matrix: preserve sender filenames for inbound media by forwarding `originalFilename` to `saveMediaBuffer`. (#55692) thanks @esrehmki.
+- Matrix/mentions: recognize `matrix.to` mentions whose visible label uses the bot's room display name, so `requireMention: true` rooms respond correctly in modern Matrix clients. (#55393) thanks @nickludlam.
 
 ## 2026.3.24
 

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -428,6 +428,26 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(recordInboundSession).toHaveBeenCalled();
   });
 
+  it("does not fetch self displayName for plain-text room mentions", async () => {
+    const getMemberDisplayName = vi.fn(async () => "Tom Servo");
+    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
+      isDirectMessage: false,
+      mentionRegexes: [/\btom servo\b/i],
+      getMemberDisplayName,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixTextMessageEvent({
+        eventId: "$plain-text-mention",
+        body: "Tom Servo: hello",
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalled();
+    expect(getMemberDisplayName).not.toHaveBeenCalledWith("!room:example.org", "@bot:example.org");
+  });
+
   it("drops forged metadata-only mentions before agent routing", async () => {
     const { handler, recordInboundSession, resolveAgentRoute } = createMatrixHandlerTestHarness({
       isDirectMessage: false,

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -8,6 +8,7 @@ import { createMatrixRoomMessageHandler } from "./handler.js";
 import {
   createMatrixHandlerTestHarness,
   createMatrixReactionEvent,
+  createMatrixRoomMessageEvent,
   createMatrixTextMessageEvent,
 } from "./handler.test-helpers.js";
 import type { MatrixRawEvent } from "./types.js";
@@ -402,6 +403,29 @@ describe("matrix monitor handler pairing account scope", () => {
     );
 
     expect(recordInboundSession).not.toHaveBeenCalled();
+  });
+
+  it("processes room messages mentioned via displayName in formatted_body", async () => {
+    const recordInboundSession = vi.fn(async () => {});
+    const { handler } = createMatrixHandlerTestHarness({
+      isDirectMessage: false,
+      getMemberDisplayName: async () => "Tom Servo",
+      recordInboundSession,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixRoomMessageEvent({
+        eventId: "$display-name-mention",
+        content: {
+          msgtype: "m.text",
+          body: "Tom Servo: hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot:example.org">Tom Servo</a>: hello',
+        },
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalled();
   });
 
   it("drops forged metadata-only mentions before agent routing", async () => {

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -552,7 +552,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         resolveAgentRoute: core.channel.routing.resolveAgentRoute,
       });
       const agentMentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, _route.agentId);
-      const selfDisplayName = await getMemberDisplayName(roomId, selfUserId).catch(() => undefined);
+      const selfDisplayName = content.formatted_body
+        ? await getMemberDisplayName(roomId, selfUserId).catch(() => undefined)
+        : undefined;
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -552,9 +552,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         resolveAgentRoute: core.channel.routing.resolveAgentRoute,
       });
       const agentMentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, _route.agentId);
+      const selfDisplayName = await getMemberDisplayName(roomId, selfUserId).catch(() => undefined);
       const { wasMentioned, hasExplicitMention } = resolveMentions({
         content,
         userId: selfUserId,
+        displayName: selfDisplayName,
         text: mentionPrecheckText,
         mentionRegexes: agentMentionRegexes,
       });

--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -194,6 +194,21 @@ describe("resolveMentions", () => {
       expect(result.wasMentioned).toBe(true);
     });
 
+    it("detects mention when the visible label encodes the bot's displayName", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "R&D Bot: hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot:matrix.org">R&amp;D Bot</a>: hello',
+        },
+        userId,
+        displayName: "R&D Bot",
+        text: "R&D Bot: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+
     it("does not detect mention when displayName is spoofed", () => {
       const result = resolveMentions({
         content: {

--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -178,6 +178,36 @@ describe("resolveMentions", () => {
       });
       expect(result.wasMentioned).toBe(true);
     });
+
+    it("detects mention when the visible label matches the bot's displayName", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Wonderful Bot: hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot:matrix.org">Wonderful Bot</a>: hello',
+        },
+        userId,
+        displayName: "Wonderful Bot",
+        text: "Wonderful Bot: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+    });
+
+    it("does not detect mention when displayName is spoofed", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "Spoofed Bot: hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot:matrix.org">Spoofed Bot</a>: hello',
+        },
+        userId,
+        displayName: "Alice",
+        text: "Spoofed Bot: hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(false);
+    });
   });
 
   describe("regex patterns", () => {

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -1,10 +1,34 @@
 import { getMatrixRuntime } from "../../runtime.js";
 import type { RoomMessageEventContent } from "./types.js";
 
+const HTML_ENTITY_REPLACEMENTS: Readonly<Record<string, string>> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+};
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-f]+|\w+);/gi, (match, entity: string) => {
+    const normalized = entity.toLowerCase();
+    if (normalized.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalized.slice(2), 16);
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+    }
+    if (normalized.startsWith("#")) {
+      const codePoint = Number.parseInt(normalized.slice(1), 10);
+      return Number.isNaN(codePoint) ? match : String.fromCodePoint(codePoint);
+    }
+    return HTML_ENTITY_REPLACEMENTS[normalized] ?? match;
+  });
+}
+
 function normalizeVisibleMentionText(value: string): string {
-  return value
-    .replace(/<[^>]+>/g, " ")
-    .replace(/[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g, "")
+  return decodeHtmlEntities(
+    value.replace(/<[^>]+>/g, " ").replace(/[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g, ""),
+  )
     .replace(/\s+/g, " ")
     .trim()
     .toLowerCase();
@@ -41,13 +65,11 @@ function isVisibleMentionLabel(params: {
   }
   const localpart = resolveMatrixUserLocalpart(params.userId);
   const candidates = [
-    params.userId.trim().toLowerCase(),
-    localpart,
-    localpart ? `@${localpart}` : null,
+    extractVisibleMentionText(params.userId),
+    localpart ? extractVisibleMentionText(localpart) : null,
+    localpart ? extractVisibleMentionText(`@${localpart}`) : null,
     params.displayName ? extractVisibleMentionText(params.displayName) : null,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .map((value) => value.toLowerCase());
+  ].filter((value): value is string => Boolean(value));
   return candidates.includes(cleaned);
 }
 

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -30,6 +30,7 @@ function isVisibleMentionLabel(params: {
   text: string;
   userId: string;
   mentionRegexes: RegExp[];
+  displayName?: string | null;
 }): boolean {
   const cleaned = extractVisibleMentionText(params.text);
   if (!cleaned) {
@@ -43,6 +44,7 @@ function isVisibleMentionLabel(params: {
     params.userId.trim().toLowerCase(),
     localpart,
     localpart ? `@${localpart}` : null,
+    params.displayName ? extractVisibleMentionText(params.displayName) : null,
   ]
     .filter((value): value is string => Boolean(value))
     .map((value) => value.toLowerCase());
@@ -64,6 +66,7 @@ function hasVisibleRoomMention(value?: string): boolean {
 function checkFormattedBodyMention(params: {
   formattedBody?: string;
   userId: string;
+  displayName?: string | null;
   mentionRegexes: RegExp[];
 }): boolean {
   if (!params.formattedBody || !params.userId) {
@@ -87,6 +90,7 @@ function checkFormattedBodyMention(params: {
           text: visibleLabel,
           userId: params.userId,
           mentionRegexes: params.mentionRegexes,
+          displayName: params.displayName,
         })
       ) {
         return true;
@@ -101,6 +105,7 @@ function checkFormattedBodyMention(params: {
 export function resolveMentions(params: {
   content: RoomMessageEventContent;
   userId?: string | null;
+  displayName?: string | null;
   text?: string;
   mentionRegexes: RegExp[];
 }) {
@@ -120,6 +125,7 @@ export function resolveMentions(params: {
     ? checkFormattedBodyMention({
         formattedBody: params.content.formatted_body,
         userId: params.userId,
+        displayName: params.displayName,
         mentionRegexes: params.mentionRegexes,
       })
     : false;

--- a/extensions/matrix/src/matrix/monitor/room-info.test.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.test.ts
@@ -45,6 +45,51 @@ describe("createMatrixRoomInfoResolver", () => {
     expect(client.getRoomStateEvent).toHaveBeenCalledTimes(3);
   });
 
+  it("caches fallback user IDs when member display names are missing", async () => {
+    const client = {
+      getRoomStateEvent: vi.fn(
+        async (_roomId: string, eventType: string): Promise<Record<string, unknown>> => {
+          if (eventType === "m.room.member") {
+            return {};
+          }
+          return {};
+        },
+      ),
+    } as unknown as MatrixClient & {
+      getRoomStateEvent: ReturnType<typeof vi.fn>;
+    };
+    const resolver = createMatrixRoomInfoResolver(client);
+
+    await expect(
+      resolver.getMemberDisplayName("!room:example.org", "@alice:example.org"),
+    ).resolves.toBe("@alice:example.org");
+    await expect(
+      resolver.getMemberDisplayName("!room:example.org", "@alice:example.org"),
+    ).resolves.toBe("@alice:example.org");
+
+    expect(client.getRoomStateEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches fallback user IDs when member display-name lookups fail", async () => {
+    const client = {
+      getRoomStateEvent: vi.fn(async (): Promise<Record<string, unknown>> => {
+        throw new Error("member lookup failed");
+      }),
+    } as unknown as MatrixClient & {
+      getRoomStateEvent: ReturnType<typeof vi.fn>;
+    };
+    const resolver = createMatrixRoomInfoResolver(client);
+
+    await expect(
+      resolver.getMemberDisplayName("!room:example.org", "@alice:example.org"),
+    ).resolves.toBe("@alice:example.org");
+    await expect(
+      resolver.getMemberDisplayName("!room:example.org", "@alice:example.org"),
+    ).resolves.toBe("@alice:example.org");
+
+    expect(client.getRoomStateEvent).toHaveBeenCalledTimes(1);
+  });
+
   it("bounds cached room and member entries", async () => {
     const client = createClientStub();
     const resolver = createMatrixRoomInfoResolver(client);

--- a/extensions/matrix/src/matrix/monitor/room-info.ts
+++ b/extensions/matrix/src/matrix/monitor/room-info.ts
@@ -83,27 +83,21 @@ export function createMatrixRoomInfoResolver(client: MatrixClient) {
 
   const getMemberDisplayName = async (roomId: string, userId: string): Promise<string> => {
     const cacheKey = `${roomId}:${userId}`;
-    const cached = memberDisplayNameCache.get(cacheKey);
-    if (cached) {
-      return cached;
+    if (memberDisplayNameCache.has(cacheKey)) {
+      return memberDisplayNameCache.get(cacheKey) ?? userId;
     }
-    try {
-      const memberState = await client
-        .getRoomStateEvent(roomId, "m.room.member", userId)
-        .catch(() => null);
-      if (memberState && typeof memberState.displayname === "string") {
-        rememberBounded(
-          memberDisplayNameCache,
-          cacheKey,
-          memberState.displayname,
-          MAX_TRACKED_MEMBER_DISPLAY_NAMES,
-        );
-        return memberState.displayname;
-      }
-      return userId;
-    } catch {
-      return userId;
-    }
+    const memberState = await client
+      .getRoomStateEvent(roomId, "m.room.member", userId)
+      .catch(() => null);
+    const displayName =
+      memberState && typeof memberState.displayname === "string" ? memberState.displayname : userId;
+    rememberBounded(
+      memberDisplayNameCache,
+      cacheKey,
+      displayName,
+      MAX_TRACKED_MEMBER_DISPLAY_NAMES,
+    );
+    return displayName;
   };
 
   return {


### PR DESCRIPTION
## Summary

- Matrix direct mentions are parsed from HTML like `<a href="https://matrix.to/#/@botname:example.org">label</a>`
- The current system expects direct mentions to use localpart (botname) or MXID (@botname:example.org) as the anchor's label
- Newer Matrix clients will format mentions using the displayName (Bot Name) as the label
- This bug prevented Matrix groups where a setting of `requireMention: true` was used from working correctly
- The `checkFormattedBodyMention()` method now takes an additional `displayName` parameter to allow for this to match correctly

- **Problem:**
- Why it matters: Without this you cannot talk to bots in shared rooms correctly on Matrix where `requireMention` is set
- What changed: displayName has been added as a parameter to include it in the detection system
- What did NOT change (scope boundary): Nothing else in Matrix was touched

I've attached a file which logged out the variables as they are seen when a message with a mention comes through which I used during debugging.

[matrix_mention_detection_failure.txt](https://github.com/user-attachments/files/26289523/matrix_mention_detection_failure.txt)


## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [X] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The previous mention detection system did not cover modern formatting of mentions in Matrix clients  
- Missing detection / guardrail: checkFormattedBodyMention() did not have access to displayName
- Prior context (`git blame`, prior PR, issue, or refactor if known):
- Why this regressed now:
- If unknown, what was ruled out:

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: MacOS
- Runtime/container: Docker
- Model/provider: Kimi-K2.5
- Integration/channel (if any): Matrix
- Relevant config (redacted): None

### Steps

1. Invite a bot into a shared room with 3 or more people, and configure that room to require `requireMention: true`
2. Try to address the bot using Element Desktop or Element X on iOS
3. Observe the bot ignore your messages even when mentioned directly

### Expected

- The bot should respond when mentioned

### Actual

- The bot ignores the message because displayName was not factored into mention detection

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Verified using my instance when integrated with Matrix
- Edge cases checked: There is no edge case for this simple change
- What you did **not** verify: There are other outstanding issues with Matrix, namely the assumption that a two-person room is a direct conversation. There are separate PRs filed for this (not by me)

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

None

