### PR TITLE
fix(outbound): bootstrap missing requested channel in outbound resolution

### DIFF
--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   resolveTarget: vi.fn(),
   getChannelPlugin: vi.fn(),
   getActivePluginChannelRegistryVersion: vi.fn(() => 1),
+  getActivePluginRegistry: vi.fn(() => ({ channels: [] })),
+  getActivePluginRegistryKey: vi.fn(() => "target-resolver-test"),
 }));
 
 beforeEach(async () => {
@@ -26,13 +28,19 @@ beforeEach(async () => {
   mocks.resolveTarget.mockReset();
   mocks.getChannelPlugin.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReset();
+  mocks.getActivePluginRegistry.mockReset();
+  mocks.getActivePluginRegistryKey.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReturnValue(1);
+  mocks.getActivePluginRegistry.mockReturnValue({ channels: [] });
+  mocks.getActivePluginRegistryKey.mockReturnValue("target-resolver-test");
   vi.doMock("../../channels/plugins/index.js", () => ({
     getChannelPlugin: (...args: unknown[]) => mocks.getChannelPlugin(...args),
     normalizeChannelId: (value: string) => value,
   }));
   vi.doMock("../../plugins/runtime.js", () => ({
     getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
+    getActivePluginRegistry: () => mocks.getActivePluginRegistry(),
+    getActivePluginRegistryKey: () => mocks.getActivePluginRegistryKey(),
   }));
   ({ resetDirectoryCache, resolveMessagingTarget, formatTargetDisplay } =
     await import("./target-resolver.js"));
@@ -215,6 +223,45 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     if (result.ok) {
       expect(result.target.to).toBe("channel:C123ABC");
       expect(result.target.display).toBeUndefined();
+    }
+  });
+
+  it("bootstraps the requested channel when the active registry is non-empty but missing it", async () => {
+    const entry: ChannelDirectoryEntry = { kind: "group", id: "123456789", name: "support" };
+    const plugin = {
+      directory: {
+        listPeers: mocks.listPeers,
+        listPeersLive: mocks.listPeersLive,
+        listGroups: mocks.listGroups,
+        listGroupsLive: mocks.listGroupsLive,
+      },
+      messaging: {
+        targetResolver: {
+          resolveTarget: mocks.resolveTarget,
+        },
+      },
+    };
+    mocks.getActivePluginRegistry.mockReturnValue({
+      channels: [{ plugin: { id: "discord" } }],
+    } as unknown as ReturnType<typeof mocks.getActivePluginRegistry>);
+    mocks.getChannelPlugin
+      .mockReturnValueOnce(undefined)
+      .mockReturnValue(plugin)
+      .mockReturnValue(plugin)
+      .mockReturnValue(plugin);
+    mocks.listGroups.mockResolvedValue([]);
+    mocks.listGroupsLive.mockResolvedValue([entry]);
+
+    const result = await resolveMessagingTarget({
+      cfg,
+      channel: "telegram",
+      input: "support",
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target.source).toBe("directory");
+      expect(result.target.to).toBe("123456789");
     }
   });
 

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
+import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { buildDirectoryCacheKey, DirectoryCache } from "./directory-cache.js";
 import { ambiguousTargetError, unknownTargetError } from "./target-errors.js";
 import {
@@ -390,6 +391,13 @@ export async function resolveMessagingTarget(params: {
   if (!raw) {
     return { ok: false, error: new Error("Target is required") };
   }
+  // Ensure the requested channel plugin is bootstrapped before any
+  // getChannelPlugin calls in this resolution path.  When the active plugin
+  // registry is non-empty but missing the requested channel,
+  // resolveOutboundChannelPlugin triggers the same bootstrap path used by the
+  // outbound send flow, preventing "Unknown channel" / "Unknown target" errors.
+  // See: https://github.com/openclaw/openclaw/issues/55338
+  resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
   const plugin = getChannelPlugin(params.channel);
   const providerLabel = plugin?.meta?.label ?? params.channel;
   const hint = plugin?.messaging?.targetResolver?.hint;
@@ -513,6 +521,9 @@ export async function lookupDirectoryDisplay(params: {
   runtime?: RuntimeEnv;
 }): Promise<string | undefined> {
   const normalized = normalizeTargetForProvider(params.channel, params.targetId) ?? params.targetId;
+
+  // Ensure the channel plugin is available before directory lookups.
+  resolveOutboundChannelPlugin({ channel: params.channel, cfg: params.cfg });
 
   // Targets can resolve to either peers (DMs) or groups. Try both.
   const [groups, users] = await Promise.all([


### PR DESCRIPTION
## Problem

Fixes #55338

When the active plugin registry is non-empty but missing the requested channel plugin, `resolveMessagingTarget()` and `lookupDirectoryDisplay()` would fail with `Unknown channel` / `Unknown target` errors. This happened because `getChannelPlugin()` was called before the channel had been bootstrapped into the registry.

## Fix

Call `resolveOutboundChannelPlugin()` at the entry point of both `resolveMessagingTarget()` and `lookupDirectoryDisplay()` before any `getChannelPlugin` calls. This reuses the same bootstrap path used by the outbound send flow.

The `bootstrapAttempts` Set inside `resolveOutboundChannelPlugin` ensures multiple calls within the same resolution are idempotent.

## Tests

Added regression test in `target-resolver.test.ts` covering the exact scenario: active registry contains one channel (discord), requested channel (telegram) is missing → should bootstrap and resolve successfully.

```
pnpm test -- src/infra/outbound/channel-resolution.test.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/message.test.ts

✓ src/infra/outbound/message.test.ts (3 tests)
✓ src/infra/outbound/channel-resolution.test.ts (6 tests)
✓ src/infra/outbound/target-resolver.test.ts (7 tests)
Tests: 16 passed (16)
```