### PR TITLE
telegram: recover when polling restarts without starting getUpdates

### DIFF
--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -186,7 +186,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       const onShutdown = () => abortWith(shutdownSignal as AbortSignal);
       const method = extractTelegramApiMethod(input);
       const requestTimeoutMs =
-        method === "getupdates" ? TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS : undefined;
+        method === "getupdates" ? TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS : 30_000;
       let requestTimeout: ReturnType<typeof setTimeout> | undefined;
       let onRequestAbort: (() => void) | undefined;
       if (shutdownSignal?.aborted) {

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -186,7 +186,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       const onShutdown = () => abortWith(shutdownSignal as AbortSignal);
       const method = extractTelegramApiMethod(input);
       const requestTimeoutMs =
-        method === "getupdates" ? TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS : 30_000;
+        method === "getupdates" ? TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS : undefined;
       let requestTimeout: ReturnType<typeof setTimeout> | undefined;
       let onRequestAbort: (() => void) | undefined;
       if (shutdownSignal?.aborted) {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -91,8 +91,10 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     const activeRunner = pollingSession?.activeRunner;
     if (isNetworkError && isTelegramPollingError && activeRunner && activeRunner.isRunning()) {
       pollingSession?.markForceRestarted();
+      pollingSession?.markTransportDirty();
       pollingSession?.abortActiveFetch();
       void activeRunner.stop().catch(() => {});
+      log("[telegram][diag] marking transport dirty after polling network failure");
       log(
         `[telegram] Restarting polling after unhandled network error: ${formatErrorMessage(err)}`,
       );
@@ -180,9 +182,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     }
 
     // Create transport once to preserve sticky IPv4 fallback state across polling restarts
-    const telegramTransport = resolveTelegramTransport(proxyFetch, {
-      network: account.config.network,
-    });
+    const createTelegramTransportForPolling = () =>
+      resolveTelegramTransport(proxyFetch, {
+        network: account.config.network,
+      });
+    const telegramTransport = createTelegramTransportForPolling();
 
     pollingSession = new TelegramPollingSession({
       token,
@@ -196,6 +200,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       persistUpdateId,
       log,
       telegramTransport,
+      createTelegramTransport: createTelegramTransportForPolling,
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -91,10 +91,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     const activeRunner = pollingSession?.activeRunner;
     if (isNetworkError && isTelegramPollingError && activeRunner && activeRunner.isRunning()) {
       pollingSession?.markForceRestarted();
-      pollingSession?.markTransportDirty();
       pollingSession?.abortActiveFetch();
       void activeRunner.stop().catch(() => {});
-      log("[telegram][diag] marking transport dirty after polling network failure");
       log(
         `[telegram] Restarting polling after unhandled network error: ${formatErrorMessage(err)}`,
       );
@@ -182,11 +180,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     }
 
     // Create transport once to preserve sticky IPv4 fallback state across polling restarts
-    const createTelegramTransportForPolling = () =>
-      resolveTelegramTransport(proxyFetch, {
-        network: account.config.network,
-      });
-    const telegramTransport = createTelegramTransportForPolling();
+    const telegramTransport = resolveTelegramTransport(proxyFetch, {
+      network: account.config.network,
+    });
 
     pollingSession = new TelegramPollingSession({
       token,
@@ -200,7 +196,6 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       persistUpdateId,
       log,
       telegramTransport,
-      createTelegramTransport: createTelegramTransportForPolling,
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -50,6 +50,8 @@ type TelegramPollingSessionOpts = {
   log: (line: string) => void;
   /** Pre-resolved Telegram transport to reuse across bot instances */
   telegramTransport?: TelegramTransport;
+  /** Rebuild Telegram transport after stall/network recovery when marked dirty. */
+  createTelegramTransport?: () => TelegramTransport;
 };
 
 export class TelegramPollingSession {
@@ -58,8 +60,12 @@ export class TelegramPollingSession {
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
+  #telegramTransport: TelegramTransport | undefined;
+  #discardTransportOnRestart = false;
 
-  constructor(private readonly opts: TelegramPollingSessionOpts) {}
+  constructor(private readonly opts: TelegramPollingSessionOpts) {
+    this.#telegramTransport = opts.telegramTransport;
+  }
 
   get activeRunner() {
     return this.#activeRunner;
@@ -67,6 +73,10 @@ export class TelegramPollingSession {
 
   markForceRestarted() {
     this.#forceRestarted = true;
+  }
+
+  markTransportDirty() {
+    this.#discardTransportOnRestart = true;
   }
 
   abortActiveFetch() {
@@ -126,6 +136,15 @@ export class TelegramPollingSession {
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
+    const shouldRebuildTransport = this.#discardTransportOnRestart || !this.#telegramTransport;
+    const telegramTransport = shouldRebuildTransport
+      ? (this.opts.createTelegramTransport?.() ?? this.#telegramTransport)
+      : this.#telegramTransport;
+    if (shouldRebuildTransport && telegramTransport) {
+      this.opts.log("[telegram][diag] rebuilding transport for next polling cycle");
+    }
+    this.#telegramTransport = telegramTransport;
+    this.#discardTransportOnRestart = false;
     try {
       return createTelegramBot({
         token: this.opts.token,
@@ -138,7 +157,7 @@ export class TelegramPollingSession {
           lastUpdateId: this.opts.getLastUpdateId(),
           onUpdateId: this.opts.persistUpdateId,
         },
-        telegramTransport: this.opts.telegramTransport,
+        telegramTransport,
       });
     } catch (err) {
       await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");
@@ -186,11 +205,49 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    bot.api.config.use((prev, method, payload, signal) => {
-      if (method === "getUpdates") {
-        lastGetUpdatesAt = Date.now();
+    let lastGetUpdatesStartedAt: number | null = null;
+    let lastGetUpdatesFinishedAt: number | null = null;
+    let lastGetUpdatesDurationMs: number | null = null;
+    let lastGetUpdatesOutcome = "not-started";
+    let lastGetUpdatesError: string | null = null;
+    let lastGetUpdatesOffset: number | null = null;
+    let inFlightGetUpdates = 0;
+    let stopSequenceLogged = false;
+    let stallDiagLoggedAt = 0;
+
+    bot.api.config.use(async (prev, method, payload, signal) => {
+      if (method !== "getUpdates") {
+        return prev(method, payload, signal);
       }
-      return prev(method, payload, signal);
+
+      const startedAt = Date.now();
+      lastGetUpdatesAt = startedAt;
+      lastGetUpdatesStartedAt = startedAt;
+      lastGetUpdatesOffset =
+        payload && typeof payload === "object" && "offset" in payload
+          ? ((payload as { offset?: number }).offset ?? null)
+          : null;
+      inFlightGetUpdates += 1;
+      lastGetUpdatesOutcome = "started";
+      lastGetUpdatesError = null;
+
+      try {
+        const result = await prev(method, payload, signal);
+        const finishedAt = Date.now();
+        lastGetUpdatesFinishedAt = finishedAt;
+        lastGetUpdatesDurationMs = finishedAt - startedAt;
+        lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
+        return result;
+      } catch (err) {
+        const finishedAt = Date.now();
+        lastGetUpdatesFinishedAt = finishedAt;
+        lastGetUpdatesDurationMs = finishedAt - startedAt;
+        lastGetUpdatesOutcome = "error";
+        lastGetUpdatesError = formatErrorMessage(err);
+        throw err;
+      } finally {
+        inFlightGetUpdates = Math.max(0, inFlightGetUpdates - 1);
+      }
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -236,11 +293,26 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
-      const elapsed = Date.now() - lastGetUpdatesAt;
+
+      const now = Date.now();
+      const activeElapsed =
+        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null ? now - lastGetUpdatesStartedAt : 0;
+      const idleElapsed = inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
+      const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
+
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+        if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {
+          return;
+        }
+        stallDiagLoggedAt = now;
+        this.#discardTransportOnRestart = true;
         stalledRestart = true;
+        const elapsedLabel =
+          inFlightGetUpdates > 0
+            ? `active getUpdates stuck for ${formatDurationPrecise(elapsed)}`
+            : `no completed getUpdates for ${formatDurationPrecise(elapsed)}`;
         this.opts.log(
-          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
+          `[telegram] Polling stall detected (${elapsedLabel}); forcing restart. [diag inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
         );
         void stopRunner();
         void stopBot();
@@ -270,6 +342,9 @@ export class TelegramPollingSession {
           ? "unhandled network error"
           : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
+      this.opts.log(
+        `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
+      );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
       );
@@ -284,11 +359,17 @@ export class TelegramPollingSession {
         this.#webhookCleared = false;
       }
       const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
+      if (isConflict || isRecoverable) {
+        this.#discardTransportOnRestart = true;
+      }
       if (!isConflict && !isRecoverable) {
         throw err;
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
       const errMsg = formatErrorMessage(err);
+      this.opts.log(
+        `[telegram][diag] polling cycle error reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"} err=${errMsg}${lastGetUpdatesError ? ` lastGetUpdatesError=${lastGetUpdatesError}` : ""}`,
+      );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
       );

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -17,7 +17,6 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
-const POLL_STARTUP_TIMEOUT_MS = 10_000;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -297,11 +296,8 @@ export class TelegramPollingSession {
 
       const now = Date.now();
       const activeElapsed =
-        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null
-          ? now - lastGetUpdatesStartedAt
-          : 0;
-      const idleElapsed =
-        inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
+        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null ? now - lastGetUpdatesStartedAt : 0;
+      const idleElapsed = inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
       const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
 
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
@@ -335,32 +331,6 @@ export class TelegramPollingSession {
     }, POLL_WATCHDOG_INTERVAL_MS);
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
-
-    const startupWatchdog = setTimeout(() => {
-      if (this.opts.abortSignal?.aborted) {
-        return;
-      }
-      if (inFlightGetUpdates === 0 && lastGetUpdatesOutcome === "not-started") {
-        this.opts.log(
-          `[telegram][diag] polling startup stalled before first getUpdates; forcing restart`,
-        );
-        this.#discardTransportOnRestart = true;
-        stalledRestart = true;
-        void stopRunner();
-        if (!forceCycleTimer) {
-          forceCycleTimer = setTimeout(() => {
-            if (this.opts.abortSignal?.aborted) {
-              return;
-            }
-            this.opts.log(
-              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
-            );
-            forceCycleResolve?.();
-          }, POLL_STOP_GRACE_MS);
-        }
-      }
-    }, POLL_STARTUP_TIMEOUT_MS);
-
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {
@@ -405,7 +375,6 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
-      clearTimeout(startupWatchdog);
       clearInterval(watchdog);
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -50,8 +50,6 @@ type TelegramPollingSessionOpts = {
   log: (line: string) => void;
   /** Pre-resolved Telegram transport to reuse across bot instances */
   telegramTransport?: TelegramTransport;
-  /** Rebuild Telegram transport after stall/network recovery when marked dirty. */
-  createTelegramTransport?: () => TelegramTransport;
 };
 
 export class TelegramPollingSession {
@@ -60,12 +58,8 @@ export class TelegramPollingSession {
   #forceRestarted = false;
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
-  #telegramTransport: TelegramTransport | undefined;
-  #discardTransportOnRestart = false;
 
-  constructor(private readonly opts: TelegramPollingSessionOpts) {
-    this.#telegramTransport = opts.telegramTransport;
-  }
+  constructor(private readonly opts: TelegramPollingSessionOpts) {}
 
   get activeRunner() {
     return this.#activeRunner;
@@ -73,10 +67,6 @@ export class TelegramPollingSession {
 
   markForceRestarted() {
     this.#forceRestarted = true;
-  }
-
-  markTransportDirty() {
-    this.#discardTransportOnRestart = true;
   }
 
   abortActiveFetch() {
@@ -136,15 +126,6 @@ export class TelegramPollingSession {
   async #createPollingBot(): Promise<TelegramBot | undefined> {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
-    const shouldRebuildTransport = this.#discardTransportOnRestart || !this.#telegramTransport;
-    const telegramTransport = shouldRebuildTransport
-      ? (this.opts.createTelegramTransport?.() ?? this.#telegramTransport)
-      : this.#telegramTransport;
-    if (shouldRebuildTransport && telegramTransport) {
-      this.opts.log("[telegram][diag] rebuilding transport for next polling cycle");
-    }
-    this.#telegramTransport = telegramTransport;
-    this.#discardTransportOnRestart = false;
     try {
       return createTelegramBot({
         token: this.opts.token,
@@ -157,7 +138,7 @@ export class TelegramPollingSession {
           lastUpdateId: this.opts.getLastUpdateId(),
           onUpdateId: this.opts.persistUpdateId,
         },
-        telegramTransport,
+        telegramTransport: this.opts.telegramTransport,
       });
     } catch (err) {
       await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");
@@ -205,49 +186,11 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
-    let lastGetUpdatesStartedAt: number | null = null;
-    let lastGetUpdatesFinishedAt: number | null = null;
-    let lastGetUpdatesDurationMs: number | null = null;
-    let lastGetUpdatesOutcome = "not-started";
-    let lastGetUpdatesError: string | null = null;
-    let lastGetUpdatesOffset: number | null = null;
-    let inFlightGetUpdates = 0;
-    let stopSequenceLogged = false;
-    let stallDiagLoggedAt = 0;
-
-    bot.api.config.use(async (prev, method, payload, signal) => {
-      if (method !== "getUpdates") {
-        return prev(method, payload, signal);
+    bot.api.config.use((prev, method, payload, signal) => {
+      if (method === "getUpdates") {
+        lastGetUpdatesAt = Date.now();
       }
-
-      const startedAt = Date.now();
-      lastGetUpdatesAt = startedAt;
-      lastGetUpdatesStartedAt = startedAt;
-      lastGetUpdatesOffset =
-        payload && typeof payload === "object" && "offset" in payload
-          ? ((payload as { offset?: number }).offset ?? null)
-          : null;
-      inFlightGetUpdates += 1;
-      lastGetUpdatesOutcome = "started";
-      lastGetUpdatesError = null;
-
-      try {
-        const result = await prev(method, payload, signal);
-        const finishedAt = Date.now();
-        lastGetUpdatesFinishedAt = finishedAt;
-        lastGetUpdatesDurationMs = finishedAt - startedAt;
-        lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
-        return result;
-      } catch (err) {
-        const finishedAt = Date.now();
-        lastGetUpdatesFinishedAt = finishedAt;
-        lastGetUpdatesDurationMs = finishedAt - startedAt;
-        lastGetUpdatesOutcome = "error";
-        lastGetUpdatesError = formatErrorMessage(err);
-        throw err;
-      } finally {
-        inFlightGetUpdates = Math.max(0, inFlightGetUpdates - 1);
-      }
+      return prev(method, payload, signal);
     });
 
     const runner = run(bot, this.opts.runnerOptions);
@@ -293,26 +236,11 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return;
       }
-
-      const now = Date.now();
-      const activeElapsed =
-        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null ? now - lastGetUpdatesStartedAt : 0;
-      const idleElapsed = inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
-      const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
-
+      const elapsed = Date.now() - lastGetUpdatesAt;
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
-        if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {
-          return;
-        }
-        stallDiagLoggedAt = now;
-        this.#discardTransportOnRestart = true;
         stalledRestart = true;
-        const elapsedLabel =
-          inFlightGetUpdates > 0
-            ? `active getUpdates stuck for ${formatDurationPrecise(elapsed)}`
-            : `no completed getUpdates for ${formatDurationPrecise(elapsed)}`;
         this.opts.log(
-          `[telegram] Polling stall detected (${elapsedLabel}); forcing restart. [diag inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
+          `[telegram] Polling stall detected (no getUpdates for ${formatDurationPrecise(elapsed)}); forcing restart.`,
         );
         void stopRunner();
         void stopBot();
@@ -342,9 +270,6 @@ export class TelegramPollingSession {
           ? "unhandled network error"
           : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
-      this.opts.log(
-        `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
-      );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
       );
@@ -359,17 +284,11 @@ export class TelegramPollingSession {
         this.#webhookCleared = false;
       }
       const isRecoverable = isRecoverableTelegramNetworkError(err, { context: "polling" });
-      if (isConflict || isRecoverable) {
-        this.#discardTransportOnRestart = true;
-      }
       if (!isConflict && !isRecoverable) {
         throw err;
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
       const errMsg = formatErrorMessage(err);
-      this.opts.log(
-        `[telegram][diag] polling cycle error reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"} err=${errMsg}${lastGetUpdatesError ? ` lastGetUpdatesError=${lastGetUpdatesError}` : ""}`,
-      );
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
       );

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -17,6 +17,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
+const POLL_STARTUP_TIMEOUT_MS = 10_000;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -296,8 +297,11 @@ export class TelegramPollingSession {
 
       const now = Date.now();
       const activeElapsed =
-        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null ? now - lastGetUpdatesStartedAt : 0;
-      const idleElapsed = inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
+        inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null
+          ? now - lastGetUpdatesStartedAt
+          : 0;
+      const idleElapsed =
+        inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
       const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
 
       if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
@@ -331,6 +335,32 @@ export class TelegramPollingSession {
     }, POLL_WATCHDOG_INTERVAL_MS);
 
     this.opts.abortSignal?.addEventListener("abort", stopOnAbort, { once: true });
+
+    const startupWatchdog = setTimeout(() => {
+      if (this.opts.abortSignal?.aborted) {
+        return;
+      }
+      if (inFlightGetUpdates === 0 && lastGetUpdatesOutcome === "not-started") {
+        this.opts.log(
+          `[telegram][diag] polling startup stalled before first getUpdates; forcing restart`,
+        );
+        this.#discardTransportOnRestart = true;
+        stalledRestart = true;
+        void stopRunner();
+        if (!forceCycleTimer) {
+          forceCycleTimer = setTimeout(() => {
+            if (this.opts.abortSignal?.aborted) {
+              return;
+            }
+            this.opts.log(
+              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+            );
+            forceCycleResolve?.();
+          }, POLL_STOP_GRACE_MS);
+        }
+      }
+    }, POLL_STARTUP_TIMEOUT_MS);
+
     try {
       await Promise.race([runner.task(), forceCyclePromise]);
       if (this.opts.abortSignal?.aborted) {
@@ -375,6 +405,7 @@ export class TelegramPollingSession {
       );
       return shouldRestart ? "continue" : "exit";
     } finally {
+      clearTimeout(startupWatchdog);
       clearInterval(watchdog);
       if (forceCycleTimer) {
         clearTimeout(forceCycleTimer);


### PR DESCRIPTION
## Summary

This change hardens Telegram polling recovery after Telegram connectivity interruptions by detecting polling cycles that stall **before the first `getUpdates` even starts**.

In real deployment testing, after a stuck or failed `getUpdates` request was detected and the polling bot was rebuilt, the next cycle could enter `before-race` but never start a new `getUpdates` call at all. Without additional protection, recovery could then wait for the full 90s watchdog on every dead-start cycle.

This patch adds a dedicated startup watchdog so those false-alive cycles are recycled quickly.

## Problem

Observed recovery pattern:

1. Telegram connectivity interruption causes a long-stuck or failed `getUpdates`
2. stall watchdog forces restart
3. transport/bot rebuild succeeds
4. new polling cycle starts
5. cycle never begins the first `getUpdates`
6. state remains `inFlight=0`, `outcome=not-started`
7. recovery would otherwise stall until the normal 90s watchdog fires

Representative logs from the deployment:

```text
2026-03-27T02:56:01.773+08:00 [telegram] Polling stall detected (active getUpdates stuck for 452.69s); forcing restart. [diag inFlight=1 outcome=started ...]
2026-03-27T02:56:01.784+08:00 [telegram] [diag] polling cycle finished reason=polling stall detected inFlight=0 outcome=error ... error=Network request for 'getUpdates' failed!

2026-03-27T02:56:04.114+08:00 [telegram] [diag] createPollingBot success rebuild=true hasTransport=true lastUpdateId=661064689
2026-03-27T02:56:09.222+08:00 [telegram] [diag] runPollingCycle before-race
2026-03-27T02:56:14.225+08:00 [telegram] [diag] polling startup stalled before first getUpdates; forcing restart
2026-03-27T02:56:29.234+08:00 [telegram] [diag] polling cycle finished reason=polling stall detected inFlight=0 outcome=not-started startedAt=n/a finishedAt=n/a durationMs=n/a offset=n/a
```

The same startup stall was reproduced again by blocking only Telegram connectivity at the router level:

```text
2026-03-27T06:19:31.385+08:00 [telegram] [diag] createPollingBot success rebuild=true hasTransport=true lastUpdateId=661064701
2026-03-27T06:19:36.497+08:00 [telegram] [diag] runPollingCycle before-race
2026-03-27T06:19:41.501+08:00 [telegram] [diag] polling startup stalled before first getUpdates; forcing restart
2026-03-27T06:19:56.508+08:00 [telegram] [diag] polling cycle finished reason=polling stall detected inFlight=0 outcome=not-started startedAt=n/a finishedAt=n/a durationMs=n/a offset=n/a
```

This makes the issue more convincing because it is reproducible with Telegram-specific connectivity loss, not only full-network outages.

## What changed

### 1. Add startup watchdog for dead-start polling cycles

In `polling-session.ts`:

- introduce `POLL_STARTUP_TIMEOUT_MS = 10_000`
- when entering a new polling cycle, start a short startup timer
- if after the timer:
  - `inFlightGetUpdates === 0`
  - `lastGetUpdatesOutcome === "not-started"`
- then:
  - log a dedicated startup-stall diagnostic
  - discard transport for the next cycle
  - stop the runner
  - force restart if stop does not complete within the normal grace window

This prevents a cycle that never actually begins polling from sitting around until the 90s general watchdog expires.

### 2. Add default timeout for non-`getUpdates` Telegram API requests

In `bot.ts`:

- keep the existing `getUpdates` timeout behavior
- add a default `30_000ms` request timeout for other Telegram API calls

This is a defensive hardening step to avoid unrelated API calls hanging indefinitely in degraded network conditions.

## Why this approach

The issue is not only "stuck active request" recovery; there is also a separate post-restart state where the new cycle appears started but has not actually launched its first `getUpdates`.

The normal stall watchdog is too coarse for that state because it waits much longer than necessary. A short startup watchdog is a better fit:

- active request stalls still use the existing state-aware stall detection
- dead-start cycles are recycled quickly
- transport is rebuilt aggressively for the next attempt

## Testing

Tested locally in a real deployment using repeated connectivity interruption and recovery.

### Reproduction steps

1. start Telegram polling with diagnostics
2. interrupt connectivity
   - either disconnect the network long enough to force polling failure, or
   - block Telegram connectivity specifically at the router level
3. restore connectivity
4. observe restart/recovery logs and external Telegram health probe

### Observed with patch

- active stuck `getUpdates` requests are still detected as before
- dead-start cycles are now detected in ~10s instead of waiting ~90s
- repeated `not-started` recovery loops no longer burn full stall windows
- once Telegram connectivity is truly back, Telegram health returns promptly and polling resumes

External probe evidence during the router-level Telegram-block test:

```text
[2026-03-27 06:25:19] #5335 HEALTH_FAIL elapsed=5.08s error=URLError desc=<urlopen error [Errno 54] Connection reset by peer>
[2026-03-27 06:29:10] #5336 HEALTH_OK elapsed=2.165s username=sinogello7799bot
[2026-03-27 06:29:22] #5337 HEALTH_OK elapsed=1.106s username=sinogello7799bot
```

## Follow-up

This patch improves recovery semantics and avoids long false-alive windows, but it may still be worth investigating the deeper underlying cause of why some runner cycles can remain in `not-started` after transport/bot rebuild.
