### PR TITLE
Fix channel registry loader pinning for outbound adapters

### DIFF
--- a/src/channels/plugins/outbound/load.test.ts
+++ b/src/channels/plugins/outbound/load.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  pinActivePluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../../plugins/runtime.js";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { loadChannelOutboundAdapter } from "./load.js";
+
+describe("loadChannelOutboundAdapter", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("uses pinned channel registry while active registry swaps", async () => {
+    const startupAdapter = { deliveryMode: "gateway" };
+    const startup = createEmptyPluginRegistry();
+    startup.channels = [
+      {
+        plugin: {
+          id: "slack",
+          outbound: startupAdapter,
+        } as never,
+      } as never,
+    ];
+
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    expect(await loadChannelOutboundAdapter("slack")).toBe(startupAdapter);
+
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(replacement);
+
+    expect(await loadChannelOutboundAdapter("slack")).toBe(startupAdapter);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { requireActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -13,7 +13,7 @@ export function createChannelRegistryLoader<TValue>(
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
+    const registry = requireActivePluginChannelRegistry();
     if (registry !== lastRegistry) {
       cache.clear();
       lastRegistry = registry;


### PR DESCRIPTION
## Summary

Fixes a bug where channel outbound adapter loading used the unpinned active plugin registry, so outbound lookups could incorrectly fall back to a later registry loaded via transient `setActivePluginRegistry()` calls (e.g. config-schema load), causing:

- "Outbound not configured for channel: slack" when Slack is present only in the startup registry.

## Changes

- In `src/channels/plugins/registry-loader.ts`, switch `createChannelRegistryLoader` to read from `requireActivePluginChannelRegistry()` instead of `getActivePluginRegistry()`.
- Add regression test `src/channels/plugins/outbound/load.test.ts` to ensure pinned channel registry is respected after active registry swaps.

## Why

`pinActivePluginChannelRegistry()` keeps a startup snapshot for channel plugin resolution while transient registry updates occur. The loader must respect this same pinned view.

## References

- openclaw/openclaw#55382
- #14188

## Verification

Could not run tests in this environment because Vitest was not available in this local tool environment (pnpm could not resolve `vitest` binary). Changes are covered by the new unit test.
