### PR TITLE
docs(agent-loop): correct default timeoutSeconds from 600s to 172800s (48h)

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -145,7 +145,7 @@ See [Plugin hooks](/plugins/architecture#provider-runtime-hooks) for the hook AP
 ## Timeouts
 
 - `agent.wait` default: 30s (just the wait). `timeoutMs` param overrides.
-- Agent runtime: `agents.defaults.timeoutSeconds` default 172800s (48 hours); enforced in `runEmbeddedPiAgent` abort timer. Use `0` to disable the timeout entirely.
+- Agent runtime: `agents.defaults.timeoutSeconds` default 172800s (48 hours); enforced in `runEmbeddedPiAgent` abort timer.
 
 ## Where things can end early
 

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -145,7 +145,7 @@ See [Plugin hooks](/plugins/architecture#provider-runtime-hooks) for the hook AP
 ## Timeouts
 
 - `agent.wait` default: 30s (just the wait). `timeoutMs` param overrides.
-- Agent runtime: `agents.defaults.timeoutSeconds` default 600s; enforced in `runEmbeddedPiAgent` abort timer.
+- Agent runtime: `agents.defaults.timeoutSeconds` default 172800s (48 hours); enforced in `runEmbeddedPiAgent` abort timer. Use `0` to disable the timeout entirely.
 
 ## Where things can end early
 

--- a/docs/zh-CN/concepts/agent-loop.md
+++ b/docs/zh-CN/concepts/agent-loop.md
@@ -136,7 +136,7 @@ OpenClaw 有两个钩子系统：
 ## 超时
 
 - `agent.wait` 默认：30 秒（仅等待）。`timeoutMs` 参数可覆盖。
-- 智能体运行时：`agents.defaults.timeoutSeconds` 默认 600 秒；在 `runEmbeddedPiAgent` 中止计时器中强制执行。
+- 智能体运行时：`agents.defaults.timeoutSeconds` 默认 172800 秒（48 小时）；在 `runEmbeddedPiAgent` 中止计时器中强制执行。使用 `0` 可完全禁用超时。
 
 ## 可能提前结束的情况
 


### PR DESCRIPTION
## Problem

Closes #55380

`docs/concepts/agent-loop.md` and `docs/zh-CN/concepts/agent-loop.md` both state that `agents.defaults.timeoutSeconds` defaults to **600s**, but the actual default in `src/agents/timeout.ts` is **172,800s (48 hours)** since PR #51874 (merged 2026-03-21).

This caused confusion: the reporter believed the 600s timeout was not being enforced, when in fact a 36-minute stuck run is completely within the new 48-hour default window.

## Fix

- `docs/concepts/agent-loop.md`: 600s → 172800s (48 hours), with a note that `0` disables the timeout
- `docs/zh-CN/concepts/agent-loop.md`: same correction in Chinese

No code changes.