### PR TITLE
fix: clamp copilot auth refresh overflow hot loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Talk/macOS: stop direct system-voice failures from replaying system speech, use app-locale fallback for shared watchdog timing, and add regression coverage for the macOS fallback route and language-aware timeout policy. (#53511) thanks @hongsw.
 - Discord/gateway cleanup: keep late Carbon reconnect-exhausted errors suppressed through startup/dispose cleanup so Discord monitor shutdown no longer crashes on late gateway close events. (#55373) Thanks @Takhoffman.
 - Discord/gateway shutdown: treat expected reconnect-exhausted events during intentional lifecycle stop as clean shutdowns so startup-abort cleanup no longer surfaces false gateway failures. (#55324) Thanks @joelnishanth.
+- GitHub Copilot/auth refresh: treat large `expires_at` values as seconds epochs and clamp far-future runtime auth refresh timers so Copilot token refresh cannot fall into a `setTimeout` overflow hot loop. (#55360) Thanks @michael-abdo.
 
 ## 2026.3.24
 

--- a/src/agents/github-copilot-token.test.ts
+++ b/src/agents/github-copilot-token.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveCopilotApiToken } from "./github-copilot-token.js";
+
+describe("resolveCopilotApiToken", () => {
+  it("treats 11-digit expires_at values as seconds epochs", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        token: "copilot-token",
+        expires_at: 12_345_678_901,
+      }),
+    }));
+
+    const result = await resolveCopilotApiToken({
+      githubToken: "github-token",
+      cachePath: "/tmp/github-copilot-token-test.json",
+      loadJsonFileImpl: () => undefined,
+      saveJsonFileImpl: () => undefined,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.expiresAt).toBe(12_345_678_901_000);
+  });
+});

--- a/src/agents/github-copilot-token.ts
+++ b/src/agents/github-copilot-token.ts
@@ -36,15 +36,16 @@ function parseCopilotTokenResponse(value: unknown): {
   }
 
   // GitHub returns a unix timestamp (seconds), but we defensively accept ms too.
+  // Use a 1e11 threshold so large seconds-epoch values are not misread as ms.
   let expiresAtMs: number;
   if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
-    expiresAtMs = expiresAt > 10_000_000_000 ? expiresAt : expiresAt * 1000;
+    expiresAtMs = expiresAt < 100_000_000_000 ? expiresAt * 1000 : expiresAt;
   } else if (typeof expiresAt === "string" && expiresAt.trim().length > 0) {
     const parsed = Number.parseInt(expiresAt, 10);
     if (!Number.isFinite(parsed)) {
       throw new Error("Copilot token response has invalid expires_at");
     }
-    expiresAtMs = parsed > 10_000_000_000 ? parsed : parsed * 1000;
+    expiresAtMs = parsed < 100_000_000_000 ? parsed * 1000 : parsed;
   } else {
     throw new Error("Copilot token response missing expires_at");
   }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -63,6 +63,7 @@ import {
   parseImageSizeError,
   pickFallbackThinkingLevel,
 } from "../pi-embedded-helpers.js";
+import { clampRuntimeAuthRefreshDelayMs } from "../runtime-auth-refresh.js";
 import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { isLikelyMutatingToolName } from "../tool-mutation.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
@@ -507,7 +508,11 @@ export async function runEmbeddedPiAgent(
         clearRuntimeAuthRefreshTimer();
         const now = Date.now();
         const refreshAt = runtimeAuthState.expiresAt - RUNTIME_AUTH_REFRESH_MARGIN_MS;
-        const delayMs = Math.max(RUNTIME_AUTH_REFRESH_MIN_DELAY_MS, refreshAt - now);
+        const delayMs = clampRuntimeAuthRefreshDelayMs({
+          refreshAt,
+          now,
+          minDelayMs: RUNTIME_AUTH_REFRESH_MIN_DELAY_MS,
+        });
         const timer = setTimeout(() => {
           if (runtimeAuthRefreshCancelled) {
             return;

--- a/src/agents/runtime-auth-refresh.test.ts
+++ b/src/agents/runtime-auth-refresh.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { clampRuntimeAuthRefreshDelayMs } from "./runtime-auth-refresh.js";
+
+describe("clampRuntimeAuthRefreshDelayMs", () => {
+  it("clamps far-future refresh delays to a timer-safe ceiling", () => {
+    expect(
+      clampRuntimeAuthRefreshDelayMs({
+        refreshAt: 12_345_678_901_000,
+        now: 0,
+        minDelayMs: 60_000,
+      }),
+    ).toBe(2_147_483_647);
+  });
+
+  it("still respects the configured minimum delay", () => {
+    expect(
+      clampRuntimeAuthRefreshDelayMs({
+        refreshAt: 1_000,
+        now: 900,
+        minDelayMs: 60_000,
+      }),
+    ).toBe(60_000);
+  });
+});

--- a/src/agents/runtime-auth-refresh.ts
+++ b/src/agents/runtime-auth-refresh.ts
@@ -1,0 +1,9 @@
+const MAX_SAFE_TIMEOUT_MS = 2_147_483_647;
+
+export function clampRuntimeAuthRefreshDelayMs(params: {
+  refreshAt: number;
+  now: number;
+  minDelayMs: number;
+}): number {
+  return Math.min(MAX_SAFE_TIMEOUT_MS, Math.max(params.minDelayMs, params.refreshAt - params.now));
+}


### PR DESCRIPTION
## Summary

- Problem: GitHub Copilot `expires_at` values above `10_000_000_000` can still be seconds epochs, but current parsing treats them as milliseconds.
- Why it matters: that can schedule a `setTimeout` beyond Node's 32-bit ceiling, which overflows to `1ms` and creates a tight refresh/logging loop.
- What changed: raise the seconds-vs-ms threshold to `100_000_000_000`, clamp runtime auth refresh delays to `2_147_483_647ms`, and add focused regression tests.
- What did NOT change (scope boundary): no `vm-bridge` code from #55360; this PR extracts only the Copilot/runtime auth hotfix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #55360
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `src/agents/github-copilot-token.ts` used `10_000_000_000` as the cutoff, so 11-digit seconds epochs were parsed as milliseconds.
- Missing detection / guardrail: runtime auth refresh scheduling in `src/agents/pi-embedded-runner/run.ts` did not clamp the timer delay to a Node-safe max.
- Prior context (`git blame`, prior PR, issue, or refactor if known): extracted from #55360 after the broader PR was found to bundle unrelated `vm-bridge` work.
- Why this regressed now: Copilot returned larger seconds-epoch values than the heuristic assumed.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/github-copilot-token.test.ts`, `src/agents/runtime-auth-refresh.test.ts`
- Scenario the test should lock in: 11-digit `expires_at` stays in seconds, and far-future refresh delays clamp to the timer-safe ceiling.
- Why this is the smallest reliable guardrail: both failures live in pure value-conversion/scheduling seams.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Users with Copilot-backed auth refresh no longer hit `setTimeout` overflow hot loops from large `expires_at` values.

## Diagram (if applicable)

```text
Before:
[token response] -> [11-digit expires_at misread as ms] -> [huge timeout] -> [Node overflow to 1ms] -> [tight refresh loop]

After:
[token response] -> [11-digit expires_at kept as seconds] -> [safe timeout clamp] -> [normal refresh cadence]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm
- Model/provider: GitHub Copilot auth path
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Parse a Copilot token response with an 11-digit seconds-epoch `expires_at`.
2. Schedule runtime auth refresh for a far-future expiry.
3. Run focused tests and build.

### Expected

- `expires_at` converts to ms correctly.
- refresh delay stays within Node's timeout ceiling.

### Actual

- before fix: 11-digit seconds values could be misread as ms, feeding an overflowed timeout.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused regression tests pass; `pnpm build` passes.
- Edge cases checked: min-delay floor still preserved; far-future refresh clamped.
- What you did **not** verify: full `pnpm check` is currently red on untouched `extensions/discord/src/monitor/provider.lifecycle.test.ts` type errors already present on current `main`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: very-long refresh delays could mask future bad expiry parsing if the heuristic regresses again.
  - Mitigation: keep both the threshold fix and the delay clamp; tests cover both seams.
