### PR TITLE
fix: use runtime model and per-agent thinking defaults in status (thanks @scoootscooob, @xaeon2026, @ysfbsf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ Docs: https://docs.openclaw.ai
 - Discord/gateway cleanup: keep late Carbon reconnect-exhausted errors suppressed through startup/dispose cleanup so Discord monitor shutdown no longer crashes on late gateway close events. (#55373) Thanks @Takhoffman.
 - Discord/gateway shutdown: treat expected reconnect-exhausted events during intentional lifecycle stop as clean shutdowns so startup-abort cleanup no longer surfaces false gateway failures. (#55324) Thanks @joelnishanth.
 - GitHub Copilot/auth refresh: treat large `expires_at` values as seconds epochs and clamp far-future runtime auth refresh timers so Copilot token refresh cannot fall into a `setTimeout` overflow hot loop. (#55360) Thanks @michael-abdo.
-- Agents/status: use the persisted runtime session model in `session_status` when no explicit override exists, and honor per-agent `thinkingDefault` in both `session_status` and `/status`. (#55425) thanks @scoootscooob
+- Agents/status: use the persisted runtime session model in `session_status` when no explicit override exists, and honor per-agent `thinkingDefault` in both `session_status` and `/status`. (#55425) Thanks @scoootscooob, @xaeon2026, and @ysfbsf.
 
 ## 2026.3.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - Discord/gateway cleanup: keep late Carbon reconnect-exhausted errors suppressed through startup/dispose cleanup so Discord monitor shutdown no longer crashes on late gateway close events. (#55373) Thanks @Takhoffman.
 - Discord/gateway shutdown: treat expected reconnect-exhausted events during intentional lifecycle stop as clean shutdowns so startup-abort cleanup no longer surfaces false gateway failures. (#55324) Thanks @joelnishanth.
 - GitHub Copilot/auth refresh: treat large `expires_at` values as seconds epochs and clamp far-future runtime auth refresh timers so Copilot token refresh cannot fall into a `setTimeout` overflow hot loop. (#55360) Thanks @michael-abdo.
+- Agents/status: use the persisted runtime session model in `session_status` when no explicit override exists, and honor per-agent `thinkingDefault` in both `session_status` and `/status`. (#55425) thanks @scoootscooob
 
 ## 2026.3.24
 

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -6,6 +6,7 @@ const loadSessionStoreMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
 const callGatewayMock = vi.fn();
 const loadCombinedSessionStoreForGatewayMock = vi.fn();
+const buildStatusMessageMock = vi.hoisted(() => vi.fn(() => "OpenClaw\n🧠 Model: GPT-5.4"));
 
 const createMockConfig = () => ({
   session: { mainKey: "main", scope: "per-sender" },
@@ -185,12 +186,13 @@ async function loadFreshOpenClawToolsForSessionStatusTest() {
     resolveQueueSettings: () => ({ mode: "interrupt" }),
   }));
   vi.doMock("../auto-reply/status.js", () => ({
-    buildStatusMessage: () => "OpenClaw\n🧠 Model: GPT-5.4",
+    buildStatusMessage: buildStatusMessageMock,
   }));
   ({ createSessionStatusTool } = await import("./tools/session-status-tool.js"));
 }
 
 function resetSessionStore(store: Record<string, SessionEntry>) {
+  buildStatusMessageMock.mockClear();
   loadSessionStoreMock.mockClear();
   updateSessionStoreMock.mockClear();
   callGatewayMock.mockClear();
@@ -287,6 +289,7 @@ function getSessionStatusTool(agentSessionKey = "main", options?: { sandboxed?: 
 
 describe("session_status tool", () => {
   beforeEach(async () => {
+    buildStatusMessageMock.mockClear();
     await loadFreshOpenClawToolsForSessionStatusTest();
   });
 
@@ -420,6 +423,106 @@ describe("session_status tool", () => {
         }),
       }),
     );
+  });
+
+  it("uses the runtime session model as the selected card model when no override is set", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "runtime-model",
+        updatedAt: 10,
+        modelProvider: "anthropic",
+        model: "claude-opus-4-6",
+      },
+    });
+
+    const tool = getSessionStatusTool();
+
+    await tool.execute("call-runtime-model", {});
+
+    expect(buildStatusMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          model: expect.objectContaining({
+            primary: "anthropic/claude-opus-4-6",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("preserves an unknown runtime provider in the selected status card model", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "legacy-runtime-model",
+        updatedAt: 10,
+        model: "legacy-runtime-model",
+      },
+    });
+
+    const tool = getSessionStatusTool();
+
+    await tool.execute("call-legacy-runtime-model", {});
+
+    expect(buildStatusMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          model: expect.objectContaining({
+            primary: "legacy-runtime-model",
+          }),
+        }),
+        sessionEntry: expect.objectContaining({
+          model: "legacy-runtime-model",
+          providerOverride: "",
+        }),
+        modelAuth: undefined,
+      }),
+    );
+  });
+
+  it("passes per-agent thinkingDefault through to the status card", async () => {
+    resetSessionStore({
+      "agent:kira:main": {
+        sessionId: "agent-thinking",
+        updatedAt: 10,
+      },
+    });
+    const savedConfig = mockConfig;
+    try {
+      mockConfig = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.4" },
+            models: {},
+          },
+          list: [
+            {
+              id: "kira",
+              model: "openai/gpt-5.4",
+              thinkingDefault: "xhigh",
+            },
+          ],
+        },
+        tools: {
+          agentToAgent: { enabled: false },
+        },
+      };
+
+      const tool = getSessionStatusTool("agent:kira:main");
+
+      await tool.execute("call-agent-thinking", {});
+
+      expect(buildStatusMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "kira",
+          agent: expect.objectContaining({
+            thinkingDefault: "xhigh",
+          }),
+        }),
+      );
+    } finally {
+      mockConfig = savedConfig;
+    }
   });
 
   it("resolves sessionId inputs", async () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -10,6 +10,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { resolveSessionModelIdentityRef } from "../../gateway/session-utils.js";
 import {
   formatUsageWindowSummary,
   loadProviderUsageSummary,
@@ -22,7 +23,7 @@ import {
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
-import { resolveAgentDir } from "../agent-scope.js";
+import { resolveAgentConfig, resolveAgentDir } from "../agent-scope.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { resolveModelAuthLabel } from "../model-auth-label.js";
 import { loadModelCatalog } from "../model-catalog.js";
@@ -413,7 +414,31 @@ export function createSessionStatusTool(opts?: {
       }
 
       const agentDir = resolveAgentDir(cfg, agentId);
-      const providerForCard = resolved.entry.providerOverride?.trim() || configured.provider;
+      const runtimeModelIdentity = resolveSessionModelIdentityRef(
+        cfg,
+        resolved.entry,
+        agentId,
+        `${configured.provider}/${configured.model}`,
+      );
+      const hasExplicitModelOverride = Boolean(
+        resolved.entry.providerOverride?.trim() || resolved.entry.modelOverride?.trim(),
+      );
+      const runtimeProviderForCard = runtimeModelIdentity.provider?.trim();
+      const runtimeModelForCard = runtimeModelIdentity.model.trim();
+      const defaultProviderForCard = hasExplicitModelOverride
+        ? configured.provider
+        : (runtimeProviderForCard ?? "");
+      const defaultModelForCard = hasExplicitModelOverride
+        ? configured.model
+        : (runtimeModelForCard || configured.model);
+      // Preserve the "provider unknown" case for legacy runtime-only sessions so the
+      // status card does not synthesize a configured provider/model pair that never ran.
+      const statusSessionEntry =
+        !hasExplicitModelOverride && !runtimeProviderForCard && runtimeModelForCard
+          ? { ...resolved.entry, providerOverride: "" }
+          : resolved.entry;
+      const providerOverrideForCard = statusSessionEntry.providerOverride?.trim();
+      const providerForCard = providerOverrideForCard ?? defaultProviderForCard;
       const usageProvider = resolveUsageProviderId(providerForCard);
       let usageLine: string | undefined;
       if (usageProvider) {
@@ -467,7 +492,10 @@ export function createSessionStatusTool(opts?: {
         : `🕒 Time zone: ${userTimezone}`;
 
       const agentDefaults = cfg.agents?.defaults ?? {};
-      const defaultLabel = `${configured.provider}/${configured.model}`;
+      const agentConfig = resolveAgentConfig(cfg, agentId);
+      const defaultLabel = defaultProviderForCard
+        ? `${defaultProviderForCard}/${defaultModelForCard}`
+        : defaultModelForCard;
       const agentModel =
         typeof agentDefaults.model === "object" && agentDefaults.model
           ? { ...agentDefaults.model, primary: defaultLabel }
@@ -477,20 +505,21 @@ export function createSessionStatusTool(opts?: {
         agent: {
           ...agentDefaults,
           model: agentModel,
+          thinkingDefault: agentConfig?.thinkingDefault ?? agentDefaults.thinkingDefault,
         },
         agentId,
         explicitConfiguredContextTokens:
           typeof agentDefaults.contextTokens === "number" && agentDefaults.contextTokens > 0
             ? agentDefaults.contextTokens
             : undefined,
-        sessionEntry: resolved.entry,
+        sessionEntry: statusSessionEntry,
         sessionKey: resolved.key,
         sessionStorePath: storePath,
         groupActivation,
         modelAuth: resolveModelAuthLabel({
           provider: providerForCard,
           cfg,
-          sessionEntry: resolved.entry,
+          sessionEntry: statusSessionEntry,
           agentDir,
         }),
         usageLine,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -430,7 +430,7 @@ export function createSessionStatusTool(opts?: {
         : (runtimeProviderForCard ?? "");
       const defaultModelForCard = hasExplicitModelOverride
         ? configured.model
-        : (runtimeModelForCard || configured.model);
+        : runtimeModelForCard || configured.model;
       // Preserve the "provider unknown" case for legacy runtime-only sessions so the
       // status card does not synthesize a configured provider/model pair that never ran.
       const statusSessionEntry =

--- a/src/auto-reply/reply/commands-status.thinking-default.test.ts
+++ b/src/auto-reply/reply/commands-status.thinking-default.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+vi.mock("../../agents/fast-mode.js", () => ({
+  resolveFastModeState: () => ({ enabled: false }),
+}));
+
+vi.mock("../../agents/model-auth-label.js", () => ({
+  resolveModelAuthLabel: () => "api-key",
+}));
+
+vi.mock("../../agents/subagent-registry.js", () => ({
+  listSubagentRunsForRequester: () => [],
+}));
+
+vi.mock("../../infra/provider-usage.js", () => ({
+  resolveUsageProviderId: () => undefined,
+  loadProviderUsageSummary: async () => ({
+    updatedAt: Date.now(),
+    providers: [],
+  }),
+  formatUsageWindowSummary: () => undefined,
+}));
+
+vi.mock("../group-activation.js", () => ({
+  normalizeGroupActivation: (value: unknown) => value,
+}));
+
+vi.mock("./queue.js", () => ({
+  getFollowupQueueDepth: () => 0,
+  resolveQueueSettings: () => ({ mode: "interrupt" }),
+}));
+
+const { buildStatusReply } = await import("./commands-status.js");
+
+describe("buildStatusReply", () => {
+  it("shows per-agent thinkingDefault in the status card", async () => {
+    const cfg = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.4",
+        },
+        list: [
+          {
+            id: "kira",
+            model: "openai/gpt-5.4",
+            thinkingDefault: "xhigh",
+          },
+        ],
+      },
+      channels: {
+        whatsapp: { allowFrom: ["*"] },
+      },
+    } as OpenClawConfig;
+
+    const reply = await buildStatusReply({
+      cfg,
+      command: {
+        isAuthorizedSender: true,
+        channel: "whatsapp",
+      } as never,
+      sessionKey: "agent:kira:main",
+      provider: "openai",
+      model: "gpt-5.4",
+      contextTokens: 0,
+      resolvedVerboseLevel: "off",
+      resolvedReasoningLevel: "off",
+      resolveDefaultThinkingLevel: async () => undefined,
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    expect(reply?.text).toContain("Think: xhigh");
+  });
+});

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAgentConfig,
   resolveAgentDir,
   resolveDefaultAgentId,
   resolveSessionAgentId,
@@ -224,6 +225,7 @@ export async function buildStatusReply(params: {
     ? (normalizeGroupActivation(sessionEntry?.groupActivation) ?? defaultGroupActivation())
     : undefined;
   const agentDefaults = cfg.agents?.defaults ?? {};
+  const agentConfig = resolveAgentConfig(cfg, statusAgentId);
   const effectiveFastMode =
     resolvedFastMode ??
     resolveFastModeState({
@@ -242,7 +244,7 @@ export async function buildStatusReply(params: {
         primary: `${provider}/${model}`,
       },
       contextTokens,
-      thinkingDefault: agentDefaults.thinkingDefault,
+      thinkingDefault: agentConfig?.thinkingDefault ?? agentDefaults.thinkingDefault,
       verboseDefault: agentDefaults.verboseDefault,
       elevatedDefault: agentDefaults.elevatedDefault,
     },


### PR DESCRIPTION
## Summary

- Problem: `session_status` showed the configured default model instead of the persisted runtime session model when no explicit override was set, and both `session_status` and `/status` ignored per-agent `thinkingDefault`.
- Why it matters: the status surfaces were misleading exactly when users were trying to debug model routing or agent defaults.
- What changed: `session_status` now uses the persisted runtime session model for the status card fallback, aligns auth/usage lookup to that selected provider, and both status paths now merge per-agent `thinkingDefault` before falling back to global defaults.
- What did NOT change (scope boundary): explicit session model override behavior is unchanged, and no new command, network, or config surface was added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #51526
- Closes #53826
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `session_status` built its selected model label from the configured default unless a session override existed, instead of using the persisted runtime model already stored on the session entry. Separately, both status paths only threaded `agents.defaults` into `buildStatusMessage`, which dropped per-agent `thinkingDefault`.
- Missing detection / guardrail: there was no regression coverage that asserted the rendered status card against a persisted runtime model or a per-agent `thinkingDefault`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): unknown.
- Why this regressed now: this appears to be a long-standing mismatch between runtime session state and status-card fallback logic rather than a new refactor regression.
- If unknown, what was ruled out: verified this was not caused by explicit override handling; that path is still preserved.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openclaw-tools.session-status.test.ts` and `src/auto-reply/reply/commands-status.thinking-default.test.ts`
- Scenario the test should lock in: a session entry with a persisted runtime model but no override should render that runtime model in `session_status`, and both `session_status` and `/status` should render a per-agent `thinkingDefault`.
- Why this is the smallest reliable guardrail: these tests exercise the real status-card builders at the session/tool seam without needing full channel or gateway end-to-end setup.
- Existing test that already covers this (if any): none for these exact regressions.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `session_status` now shows the persisted runtime model when it differs from the configured default and there is no explicit override.
- `session_status` and `/status` now show the selected agent’s `thinkingDefault` instead of falling back to global defaults only.

## Diagram (if applicable)

```text
Before:
[persisted runtime model != configured default] -> [status fallback uses configured default] -> [misleading model line]
[agent-specific thinkingDefault] -> [status builder reads only agents.defaults] -> [Think line falls back incorrectly]

After:
[persisted runtime model != configured default] -> [status fallback uses runtime session model] -> [model line matches runtime]
[agent-specific thinkingDefault] -> [status builder resolves per-agent config first] -> [Think line matches agent]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: `Darwin 24.1.0 arm64`
- Runtime/container: `node v25.2.1`, `pnpm 10.32.1`
- Model/provider: configured default `openai/gpt-5.4`; persisted runtime session model `custom/runtime-model`
- Integration/channel (if any): local built runtime, WhatsApp-shaped status path
- Relevant config (redacted): per-agent `thinkingDefault: xhigh` for agent `kira`

### Steps

1. Create a session entry with no explicit override, but with persisted runtime model fields set to `custom/runtime-model`.
2. Configure an agent-specific `thinkingDefault: xhigh`.
3. Run the real `session_status` tool and the `/status` builder.

### Expected

- `session_status` shows `custom/runtime-model` instead of the configured default.
- Both status outputs show `Think: xhigh`.

### Actual

- Before this fix, `session_status` fell back to the configured default model and both status outputs ignored the per-agent thinking default.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Built-runtime smoke on this branch:

```json
{
  "runtimeModelLine": "🧠 Model: custom/runtime-model · 🔑 unknown",
  "sessionStatusThinkLine": "⚙️ Runtime: direct · Think: xhigh · elevated",
  "statusReplyThinkLine": "⚙️ Runtime: direct · Think: xhigh · elevated"
}
```

Scoped verification commands:

- `pnpm test -- src/agents/openclaw-tools.session-status.test.ts`
- `pnpm test -- src/auto-reply/reply/commands-status.thinking-default.test.ts`
- `pnpm test -- src/auto-reply/status.test.ts -t "shows selected model and active runtime model when they differ"`
- `pnpm test -- src/gateway/session-utils.test.ts -t "prefers runtime model/provider from session entry"`
- `pnpm build`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the targeted tests above, built the repo, and ran a built-runtime smoke that exercised both `session_status` and `/status` against a real on-disk session store.
- Edge cases checked: no-override runtime-model fallback, per-agent thinking fallback, and provider/auth/usage lookup staying aligned to the selected provider in `session_status`.
- What you did **not** verify: full `pnpm check` / pre-commit stack on current `main` is currently blocked by unrelated `pnpm tsgo` errors in `extensions/discord/src/monitor/provider.lifecycle.test.ts`; `pnpm build` was green.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: status output could have changed for explicit override sessions.
  - Mitigation: the fallback switch only applies when there is no explicit session override; override handling is preserved and covered by adjacent existing behavior.
- Risk: status auth/usage labels could drift when the runtime provider differs from the configured default.
  - Mitigation: `session_status` now uses the same selected provider for the card, auth label, and usage-provider lookup.



## Acknowledgements

- Folded in the overlapping earlier fixes from #51610 and #53850.
- Thanks @xaeon2026 and @ysfbsf. Those PRs were opened earlier, and this branch now carries their overlapping fixes plus the follow-up review correction for legacy sessions where the runtime model is known but the provider is unknown.
