### PR TITLE
Fix: allow active OpenRouter image media fallback

### DIFF
--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -28,7 +28,7 @@ describe("openrouter plugin", () => {
     expect(providers).toHaveLength(1);
     expect(providers.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(speechProviders).toHaveLength(0);
-    expect(mediaProviders).toHaveLength(0);
+    expect(mediaProviders.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(imageProviders).toHaveLength(0);
   });
 });

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -13,6 +13,7 @@ import {
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "openclaw/plugin-sdk/provider-stream";
+import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildOpenrouterProvider } from "./provider-catalog.js";
 
@@ -154,5 +155,6 @@ export default definePluginEntry({
       },
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
     });
+    api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
   },
 });

--- a/extensions/openrouter/media-understanding-provider.ts
+++ b/extensions/openrouter/media-understanding-provider.ts
@@ -1,0 +1,12 @@
+import {
+  describeImageWithModel,
+  describeImagesWithModel,
+  type MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+
+export const openrouterMediaUnderstandingProvider: MediaUnderstandingProvider = {
+  id: "openrouter",
+  capabilities: ["image"],
+  describeImage: describeImageWithModel,
+  describeImages: describeImagesWithModel,
+};

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -19,6 +19,9 @@
       "cliDescription": "OpenRouter API key"
     }
   ],
+  "contracts": {
+    "mediaUnderstandingProviders": ["openrouter"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -1,13 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  buildProviderRegistry,
-  createMediaAttachmentCache,
-  normalizeMediaAttachments,
-  resolveAutoImageModel,
-  runCapability,
-} from "./runner.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 
 const catalog = [
   {
@@ -90,6 +85,18 @@ describe("runCapability image skip", () => {
 
   it("uses active OpenRouter image models for auto image resolution", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.mediaUnderstandingProviders.push({
+      pluginId: "openrouter",
+      pluginName: "OpenRouter Provider",
+      source: "test",
+      provider: {
+        id: "openrouter",
+        capabilities: ["image"],
+        describeImage: async () => ({ text: "ok" }),
+      },
+    });
+    setActivePluginRegistry(pluginRegistry);
     try {
       await expect(
         resolveAutoImageModel({
@@ -101,6 +108,7 @@ describe("runCapability image skip", () => {
         model: "google/gemini-2.5-flash",
       });
     } finally {
+      setActivePluginRegistry(createEmptyPluginRegistry());
       vi.unstubAllEnvs();
     }
   });

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  buildProviderRegistry,
+  createMediaAttachmentCache,
+  normalizeMediaAttachments,
+  resolveAutoImageModel,
+  runCapability,
+} from "./runner.js";
 
 const catalog = [
   {
@@ -26,6 +33,7 @@ vi.mock("../agents/model-catalog.js", async () => {
 let buildProviderRegistry: typeof import("./runner.js").buildProviderRegistry;
 let createMediaAttachmentCache: typeof import("./runner.js").createMediaAttachmentCache;
 let normalizeMediaAttachments: typeof import("./runner.js").normalizeMediaAttachments;
+let resolveAutoImageModel: typeof import("./runner.js").resolveAutoImageModel;
 let runCapability: typeof import("./runner.js").runCapability;
 
 describe("runCapability image skip", () => {
@@ -44,6 +52,7 @@ describe("runCapability image skip", () => {
       buildProviderRegistry,
       createMediaAttachmentCache,
       normalizeMediaAttachments,
+      resolveAutoImageModel,
       runCapability,
     } = await import("./runner.js"));
     loadModelCatalog.mockClear();
@@ -76,6 +85,23 @@ describe("runCapability image skip", () => {
       );
     } finally {
       await cache.cleanup();
+    }
+  });
+
+  it("uses active OpenRouter image models for auto image resolution", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+    try {
+      await expect(
+        resolveAutoImageModel({
+          cfg: {} as OpenClawConfig,
+          activeModel: { provider: "openrouter", model: "google/gemini-2.5-flash" },
+        }),
+      ).resolves.toEqual({
+        provider: "openrouter",
+        model: "google/gemini-2.5-flash",
+      });
+    } finally {
+      vi.unstubAllEnvs();
     }
   });
 });

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -11309,6 +11309,9 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
           cliDescription: "OpenRouter API key",
         },
       ],
+      contracts: {
+        mediaUnderstandingProviders: ["openrouter"],
+      },
     },
   },
   {


### PR DESCRIPTION
#### Summary

AI-assisted PR. Register `openrouter` as an image-capable media-understanding provider so auto media understanding can reuse the active OpenRouter reply model when it supports images.

#### Repro Steps

1. Configure an OpenRouter vision-capable reply model.
2. Enable image media understanding without explicitly configuring `tools.media.image.models`.
3. Send an image attachment.
4. Before this change, active-model auto resolution skips `openrouter` because it is missing from the media-understanding provider registry.

#### Root Cause

`resolveAutoImageModel()` and the active-model media-understanding path rely on the media-understanding provider registry to decide whether the active provider supports image understanding. `openrouter` was missing from that registry even though the generic image execution path already supports it.

#### Behavior Changes

- Active OpenRouter reply models can now be reused for automatic image media understanding.
- The change is scoped to image capability only; it does not add OpenRouter defaults for audio, video, or key-only auto-detection.

#### Codebase and GitHub Search

- Checked `src/media-understanding/providers/index.ts`, `src/media-understanding/runner.ts`, and `src/media-understanding/runner.entries.ts` to confirm the active-model path depended on provider registration.
- Verified `src/agents/tools/image-tool.ts` uses a separate generic execution path, so the explicit `image` tool was not the right fix target.
- Cross-checked the related report in issue #55277 while narrowing the scope of the current bug. lobster-biscuit

#### Tests

- `pnpm test -- src/media-understanding/runner.vision-skip.test.ts`
- `pnpm check`
- `pnpm build`
- `pnpm test`

#### Manual Testing (omit if N/A)

N/A

**Sign-Off**

- Models used: GPT-5.4 via Cursor
- Submitter effort: agent-assisted, validated locally
- Agent notes: Added a narrow provider registration plus a regression test for `resolveAutoImageModel()` with an active OpenRouter vision model.

Made with [Cursor](https://cursor.com)