### PR TITLE
fix(msteams): prevent path-to-regexp crash with express 5

### DIFF
--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createMSTeamsAdapter, type MSTeamsTeamsSdk } from "./sdk.js";
+import { createMSTeamsAdapter, createMSTeamsApp, type MSTeamsTeamsSdk } from "./sdk.js";
 import type { MSTeamsCredentials } from "./token.js";
 
 const originalFetch = globalThis.fetch;
@@ -35,6 +35,29 @@ function createSdkStub(): MSTeamsTeamsSdk {
     Client: ClientStub as unknown as MSTeamsTeamsSdk["Client"],
   };
 }
+
+describe("createMSTeamsApp", () => {
+  it("does not crash with express 5 path-to-regexp (#55161)", async () => {
+    // Regression test for: https://github.com/openclaw/openclaw/issues/55161
+    // The default HttpPlugin in @microsoft/teams.apps uses `express().use('/api*', ...)`
+    // which throws in express 5 (path-to-regexp v8+). createMSTeamsApp injects a no-op
+    // HTTP plugin stub to prevent the SDK from creating the default HttpPlugin.
+    const { App } = await import("@microsoft/teams.apps");
+    const { Client } = await import("@microsoft/teams.api");
+    const sdk: MSTeamsTeamsSdk = { App, Client };
+    const creds: MSTeamsCredentials = {
+      appId: "test-app-id",
+      appPassword: "test-secret",
+      tenantId: "test-tenant",
+    };
+
+    // This would throw "Missing parameter name at index 5: /api*" without the fix
+    const app = await createMSTeamsApp(creds, sdk);
+    expect(app).toBeDefined();
+    // Verify token methods are available (the reason we use the App class)
+    expect(typeof (app as unknown as Record<string, unknown>).getBotToken).toBe("function");
+  });
+});
 
 describe("createMSTeamsAdapter", () => {
   it("provides deleteActivity in proactive continueConversation contexts", async () => {

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -54,18 +54,71 @@ export async function loadMSTeamsSdk(): Promise<MSTeamsTeamsSdk> {
 }
 
 /**
+ * Create a lightweight no-op HTTP plugin stub that satisfies the Teams SDK's
+ * plugin discovery by name ("http") but does NOT spin up an Express server.
+ *
+ * The default HttpPlugin in @microsoft/teams.apps registers an Express
+ * middleware with the pattern `/api*`.  When the host application (OpenClaw)
+ * uses Express 5 — which depends on path-to-regexp v8 — that pattern is
+ * invalid and throws:
+ *
+ *   Missing parameter name at index 5: /api*
+ *
+ * OpenClaw manages its own Express server for the Teams webhook endpoint, so
+ * the SDK's built-in HTTP server is unnecessary.  Passing this stub prevents
+ * the SDK from creating the default HttpPlugin and avoids the crash.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/55161
+ */
+async function createNoOpHttpPlugin(): Promise<unknown> {
+  // Lazy-import reflect-metadata (required by the Teams SDK decorator system)
+  // and the decorator key constants so we can tag the stub class correctly.
+  await import("reflect-metadata");
+  const { PLUGIN_METADATA_KEY } =
+    await import("@microsoft/teams.apps/dist/types/plugin/decorators/plugin.js");
+  const { PLUGIN_DEPENDENCIES_METADATA_KEY } =
+    await import("@microsoft/teams.apps/dist/types/plugin/decorators/dependency.js");
+  const { PLUGIN_EVENTS_METADATA_KEY } =
+    await import("@microsoft/teams.apps/dist/types/plugin/decorators/event.js");
+
+  class NoOpHttpPlugin {
+    onInit() {}
+    async onStart() {}
+    onStop() {}
+  }
+
+  Reflect.defineMetadata(
+    PLUGIN_METADATA_KEY,
+    { name: "http", version: "0.0.0", description: "no-op stub (express 5 compat)" },
+    NoOpHttpPlugin,
+  );
+  Reflect.defineMetadata(PLUGIN_DEPENDENCIES_METADATA_KEY, [], NoOpHttpPlugin);
+  Reflect.defineMetadata(PLUGIN_EVENTS_METADATA_KEY, [], NoOpHttpPlugin);
+
+  return new NoOpHttpPlugin();
+}
+
+/**
  * Create a Teams SDK App instance from credentials. The App manages token
  * acquisition, JWT validation, and the HTTP server lifecycle.
  *
  * This replaces the previous CloudAdapter + MsalTokenProvider + authorizeJWT
  * from @microsoft/agents-hosting.
  */
-export function createMSTeamsApp(creds: MSTeamsCredentials, sdk: MSTeamsTeamsSdk): MSTeamsApp {
+export async function createMSTeamsApp(
+  creds: MSTeamsCredentials,
+  sdk: MSTeamsTeamsSdk,
+): Promise<MSTeamsApp> {
+  const noOpHttp = await createNoOpHttpPlugin();
+  // Use type assertion: the SDK's AppOptions generic narrows `plugins` to
+  // Array<TPlugin>, but our no-op stub satisfies the runtime contract without
+  // matching the decorator-heavy IPlugin type at compile time.
   return new sdk.App({
     clientId: creds.appId,
     clientSecret: creds.appPassword,
     tenantId: creds.tenantId,
-  });
+    plugins: [noOpHttp],
+  } as ConstructorParameters<MSTeamsTeamsSdk["App"]>[0]);
 }
 
 /**
@@ -396,7 +449,7 @@ export function createMSTeamsAdapter(app: MSTeamsApp, sdk: MSTeamsTeamsSdk): MST
 
 export async function loadMSTeamsSdkWithAuth(creds: MSTeamsCredentials) {
   const sdk = await loadMSTeamsSdk();
-  const app = createMSTeamsApp(creds, sdk);
+  const app = await createMSTeamsApp(creds, sdk);
   return { sdk, app };
 }
 


### PR DESCRIPTION
## Problem

The MS Teams channel crashes immediately on startup in 2026.3.24 with:

```
Missing parameter name at index 5: /api*
```

This is a crash-loop that makes the Teams channel completely non-functional.

## Root Cause

The Teams SDK (`@microsoft/teams.apps@2.0.5`) has a built-in `HttpPlugin` that registers an Express middleware with the pattern `/api*` in its constructor. This pattern was valid in Express 4 (which the SDK declares as its dependency: `express@^4.21.0`), but is invalid in Express 5 which uses `path-to-regexp@8.x`.

When installed in OpenClaw's monorepo, pnpm hoisting resolves the SDK's `express` import to the project's top-level `express@5.2.1` instead of Express 4, causing the crash.

**Crash chain:**
1. `monitor.ts` → `new sdk.App({...})`
2. `App` constructor auto-creates default `HttpPlugin`
3. `HttpPlugin` constructor: `express().use('/api*', express.json())`
4. Express 5 → `router@2.2.0` → `path-to-regexp@8.x` → 💥

## Fix

OpenClaw does not use the SDK's built-in HTTP server — it manages its own Express server for the Teams webhook endpoint. The SDK's `App` class is only used for token management (`getBotToken`/`getAppGraphToken`) and JWT validation.

This PR injects a no-op HTTP plugin stub (properly decorated with the SDK's metadata system) into the `App` constructor, preventing the default `HttpPlugin` from being created. This avoids the Express 5 incompatibility entirely.

### Changes
- `sdk.ts`: Add `createNoOpHttpPlugin()` — creates a decorator-tagged stub plugin named `"http"`
- `sdk.ts`: Make `createMSTeamsApp` async to support lazy imports of reflect-metadata
- `sdk.test.ts`: Add regression test verifying App creation succeeds with the real Teams SDK under Express 5

### Test results
- 2/2 sdk tests pass (including new regression test)
- 398/402 msteams extension tests pass (4 pre-existing SSRF test failures unrelated to this change, also fail on `main`)

Closes #55161