### PR TITLE
fix(discord): prioritize final replies over tool summaries

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -37,6 +37,14 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
+    sendToolResult: (payload: {
+      text?: string;
+      isReasoning?: boolean;
+      channelData?: unknown;
+      isError?: boolean;
+      mediaUrl?: string;
+      mediaUrls?: string[];
+    }) => boolean | Promise<boolean>;
     sendBlockReply: (payload: {
       text?: string;
       isReasoning?: boolean;
@@ -127,7 +135,10 @@ vi.spyOn(replyRuntimeModule, "createReplyDispatcherWithTyping").mockImplementati
   deliver: (payload: unknown, info: { kind: string }) => Promise<void> | void;
 }) => ({
   dispatcher: {
-    sendToolResult: vi.fn(() => true),
+    sendToolResult: vi.fn((payload: unknown) => {
+      void opts.deliver(payload as never, { kind: "tool" });
+      return true;
+    }),
     sendBlockReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "block" });
       return true;
@@ -276,6 +287,13 @@ function createMockDraftStreamForTest() {
   const draftStream = createMockDraftStream();
   createDiscordDraftStream.mockReturnValueOnce(draftStream);
   return draftStream;
+}
+
+function getDeliveredReplyTexts(): Array<string | undefined> {
+  return deliveryMocks.deliverDiscordReply.mock.calls.map((call) => {
+    const params = call[0] as { replies?: Array<{ text?: string }> } | undefined;
+    return params?.replies?.[0]?.text;
+  });
 }
 
 function expectSinglePreviewEdit() {
@@ -667,6 +685,24 @@ describe("processDiscordMessage draft streaming", () => {
     await processStreamOffDiscordMessage();
 
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers the final reply before deferred text-only tool summaries", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendToolResult({ text: "🔧 exec: rate lookup" });
+      await params?.dispatcher.sendFinalReply({ text: "USD/KRW is 1400" });
+      return { queuedFinal: true, counts: { final: 1, tool: 1, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      ...createDirectMessageContextOverrides(),
+      discordConfig: { streamMode: "off" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getDeliveredReplyTexts()).toEqual(["USD/KRW is 1400", "🔧 exec: rate lookup"]);
   });
 
   it("streams block previews using draft chunking", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -225,7 +225,8 @@ beforeEach(() => {
   sendMocks.reactMessageDiscord.mockClear();
   sendMocks.removeReactionDiscord.mockClear();
   editMessageDiscord.mockClear();
-  deliverDiscordReply.mockClear();
+  deliverDiscordReply.mockReset();
+  deliverDiscordReply.mockResolvedValue(undefined);
   createDiscordDraftStream.mockClear();
   dispatchInboundMessage.mockClear();
   recordInboundSession.mockClear();
@@ -703,6 +704,83 @@ describe("processDiscordMessage draft streaming", () => {
     await processDiscordMessage(ctx as any);
 
     expect(getDeliveredReplyTexts()).toEqual(["USD/KRW is 1400", "🔧 exec: rate lookup"]);
+  });
+
+  it("drops deferred tool summaries when dispatch fails before a final reply", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendToolResult({ text: "🔧 exec: rate lookup" });
+      throw new Error("simulated dispatch failure");
+    });
+
+    const ctx = await createBaseContext({
+      ...createDirectMessageContextOverrides(),
+      discordConfig: { streamMode: "off" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await expect(processDiscordMessage(ctx as any)).rejects.toThrow("simulated dispatch failure");
+
+    expect(getDeliveredReplyTexts()).toEqual([]);
+  });
+
+  it("continues flushing later deferred tool summaries after one send fails", async () => {
+    deliverDiscordReply.mockImplementation(async (params: unknown) => {
+      const text = (params as { replies?: Array<{ text?: string }> })?.replies?.[0]?.text;
+      if (text === "first deferred") {
+        throw new Error("simulated deferred send failure");
+      }
+    });
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendToolResult({ text: "first deferred" });
+      await params?.dispatcher.sendToolResult({ text: "second deferred" });
+      await params?.dispatcher.sendFinalReply({ text: "final first" });
+      return { queuedFinal: true, counts: { final: 1, tool: 2, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      ...createDirectMessageContextOverrides(),
+      discordConfig: { streamMode: "off" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getDeliveredReplyTexts()).toEqual(["final first", "first deferred", "second deferred"]);
+  });
+
+  it("bounds deferred tool summaries and appends an overflow notice", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      for (let index = 1; index <= 13; index += 1) {
+        await params?.dispatcher.sendToolResult({ text: `tool ${index}` });
+      }
+      await params?.dispatcher.sendFinalReply({ text: "final first" });
+      return { queuedFinal: true, counts: { final: 1, tool: 13, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      ...createDirectMessageContextOverrides(),
+      discordConfig: { streamMode: "off" },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(getDeliveredReplyTexts()).toEqual([
+      "final first",
+      "tool 1",
+      "tool 2",
+      "tool 3",
+      "tool 4",
+      "tool 5",
+      "tool 6",
+      "tool 7",
+      "tool 8",
+      "tool 9",
+      "tool 10",
+      "tool 11",
+      "tool 12",
+      "Note: 1 additional tool update was suppressed to keep Discord delivery bounded.",
+    ]);
   });
 
   it("streams block previews using draft chunking", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -498,11 +498,15 @@ export async function processDiscordMessage(
       : undefined;
   const shouldSplitPreviewMessages = discordStreamMode === "block";
   const draftChunker = draftChunking ? new EmbeddedBlockChunker(draftChunking) : undefined;
+  const MAX_DEFERRED_TOOL_SUMMARIES = 12;
+  const MAX_DEFERRED_TOOL_SUMMARY_CHARS = 12_000;
   let lastPartialText = "";
   let draftText = "";
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
   const deferredToolSummaries: ReplyPayload[] = [];
+  let deferredToolSummaryChars = 0;
+  let suppressedDeferredToolSummaries = 0;
 
   const resolvePreviewFinalText = (text?: string) => {
     if (typeof text !== "string") {
@@ -609,6 +613,12 @@ export async function processDiscordMessage(
     await draftStream.flush();
   };
 
+  const clearDeferredToolSummaries = () => {
+    deferredToolSummaries.length = 0;
+    deferredToolSummaryChars = 0;
+    suppressedDeferredToolSummaries = 0;
+  };
+
   const shouldDeferToolSummary = (payload: ReplyPayload, kind: "tool" | "block" | "final") => {
     if (kind !== "tool" || payload.isError) {
       return false;
@@ -654,13 +664,51 @@ export async function processDiscordMessage(
     }
   };
 
+  const queueDeferredToolSummary = (payload: ReplyPayload) => {
+    const nextText = payload.text ?? "";
+    if (
+      deferredToolSummaries.length >= MAX_DEFERRED_TOOL_SUMMARIES ||
+      deferredToolSummaryChars + nextText.length > MAX_DEFERRED_TOOL_SUMMARY_CHARS
+    ) {
+      suppressedDeferredToolSummaries += 1;
+      return;
+    }
+    deferredToolSummaries.push(payload);
+    deferredToolSummaryChars += nextText.length;
+  };
+
   const flushDeferredToolSummaries = async () => {
-    if (deferredToolSummaries.length === 0 || isProcessAborted(abortSignal)) {
+    if (
+      (deferredToolSummaries.length === 0 && suppressedDeferredToolSummaries === 0) ||
+      isProcessAborted(abortSignal)
+    ) {
+      clearDeferredToolSummaries();
       return;
     }
     const pendingPayloads = deferredToolSummaries.splice(0);
+    deferredToolSummaryChars = 0;
+    const suppressedCount = suppressedDeferredToolSummaries;
+    suppressedDeferredToolSummaries = 0;
     for (const payload of pendingPayloads) {
-      await deliverImmediatePayload(payload, false);
+      try {
+        await deliverImmediatePayload(payload, false);
+      } catch (err) {
+        logVerbose(`discord: deferred tool summary delivery failed: ${String(err)}`);
+      }
+    }
+    if (suppressedCount > 0) {
+      const nounSuffix = suppressedCount === 1 ? "" : "s";
+      const verb = suppressedCount === 1 ? "was" : "were";
+      try {
+        await deliverImmediatePayload(
+          {
+            text: `Note: ${suppressedCount} additional tool update${nounSuffix} ${verb} suppressed to keep Discord delivery bounded.`,
+          },
+          false,
+        );
+      } catch (err) {
+        logVerbose(`discord: deferred tool summary overflow notice failed: ${String(err)}`);
+      }
     }
   };
 
@@ -689,7 +737,7 @@ export async function processDiscordMessage(
           return;
         }
         if (shouldDeferToolSummary(payload, info.kind)) {
-          deferredToolSummaries.push(payload);
+          queueDeferredToolSummary(payload);
           return;
         }
         if (draftStream && isFinal) {
@@ -880,10 +928,10 @@ export async function processDiscordMessage(
     } finally {
       markRunComplete();
       markDispatchIdle();
-      try {
+      if (dispatchError || dispatchAborted) {
+        clearDeferredToolSummaries();
+      } else {
         await flushDeferredToolSummaries();
-      } catch (err) {
-        logVerbose(`discord: deferred tool summary delivery failed: ${String(err)}`);
       }
     }
     if (statusReactionsEnabled) {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -502,6 +502,7 @@ export async function processDiscordMessage(
   let draftText = "";
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
+  const deferredToolSummaries: ReplyPayload[] = [];
 
   const resolvePreviewFinalText = (text?: string) => {
     if (typeof text !== "string") {
@@ -608,6 +609,61 @@ export async function processDiscordMessage(
     await draftStream.flush();
   };
 
+  const shouldDeferToolSummary = (payload: ReplyPayload, kind: "tool" | "block" | "final") => {
+    if (kind !== "tool" || payload.isError) {
+      return false;
+    }
+    const execApproval =
+      payload.channelData &&
+      typeof payload.channelData === "object" &&
+      !Array.isArray(payload.channelData)
+        ? payload.channelData.execApproval
+        : undefined;
+    if (execApproval && typeof execApproval === "object" && !Array.isArray(execApproval)) {
+      return false;
+    }
+    return !resolveSendableOutboundReplyParts(payload).hasMedia;
+  };
+
+  const deliverImmediatePayload = async (payload: ReplyPayload, isFinal: boolean) => {
+    const replyToId = replyReference.use();
+    if (isFinal) {
+      notifyFinalReplyStart();
+    }
+    await deliverDiscordReply({
+      cfg,
+      replies: [payload],
+      target: deliverTarget,
+      token,
+      accountId,
+      rest: client.rest,
+      runtime,
+      replyToId,
+      replyToMode,
+      textLimit,
+      maxLinesPerMessage,
+      tableMode,
+      chunkMode,
+      sessionKey: ctxPayload.SessionKey,
+      threadBindings,
+      mediaLocalRoots,
+    });
+    replyReference.markSent();
+    if (isFinal) {
+      observer?.onFinalReplyDelivered?.();
+    }
+  };
+
+  const flushDeferredToolSummaries = async () => {
+    if (deferredToolSummaries.length === 0 || isProcessAborted(abortSignal)) {
+      return;
+    }
+    const pendingPayloads = deferredToolSummaries.splice(0);
+    for (const payload of pendingPayloads) {
+      await deliverImmediatePayload(payload, false);
+    }
+  };
+
   // When draft streaming is active, suppress block streaming to avoid double-streaming.
   const disableBlockStreamingForDraft = draftStream ? true : undefined;
   let finalReplyStartNotified = false;
@@ -630,6 +686,10 @@ export async function processDiscordMessage(
         const isFinal = info.kind === "final";
         if (payload.isReasoning) {
           // Reasoning/thinking payloads should not be delivered to Discord.
+          return;
+        }
+        if (shouldDeferToolSummary(payload, info.kind)) {
+          deferredToolSummaries.push(payload);
           return;
         }
         if (draftStream && isFinal) {
@@ -713,33 +773,7 @@ export async function processDiscordMessage(
         if (isProcessAborted(abortSignal)) {
           return;
         }
-
-        const replyToId = replyReference.use();
-        if (isFinal) {
-          notifyFinalReplyStart();
-        }
-        await deliverDiscordReply({
-          cfg,
-          replies: [payload],
-          target: deliverTarget,
-          token,
-          accountId,
-          rest: client.rest,
-          runtime,
-          replyToId,
-          replyToMode,
-          textLimit,
-          maxLinesPerMessage,
-          tableMode,
-          chunkMode,
-          sessionKey: ctxPayload.SessionKey,
-          threadBindings,
-          mediaLocalRoots,
-        });
-        replyReference.markSent();
-        if (isFinal) {
-          observer?.onFinalReplyDelivered?.();
-        }
+        await deliverImmediatePayload(payload, isFinal);
       },
       onError: (err, info) => {
         runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));
@@ -846,6 +880,11 @@ export async function processDiscordMessage(
     } finally {
       markRunComplete();
       markDispatchIdle();
+      try {
+        await flushDeferredToolSummaries();
+      } catch (err) {
+        logVerbose(`discord: deferred tool summary delivery failed: ${String(err)}`);
+      }
     }
     if (statusReactionsEnabled) {
       if (dispatchAborted) {


### PR DESCRIPTION
## Summary

- Problem: Discord could show text-only tool summaries before the main reply, which made short lookup-style answers feel late even after the final answer was ready.
- Why it matters: the visible chat result should land as soon as the answer is ready, especially for fast Discord turns.
- What changed: Discord now defers non-error, text-only tool summaries until after the final reply is delivered, while keeping media payloads and exec-approval prompts on the immediate path.
- What did NOT change (scope boundary): block reply handling, draft preview finalization, and immediate delivery for media-bearing or approval-bearing tool payloads.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55236
- Related #11044
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Discord serialized tool and final outbound delivery in a single ordered path, and the channel-specific delivery logic had no local escape hatch for non-critical text-only tool summaries. That let the visible final reply wait behind earlier tool-summary sends.
- Missing detection / guardrail: there was no Discord regression test asserting that a final reply becomes visible before deferred text-only tool summaries.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the shared tool-result serialization exists to preserve ordering and avoid races noted in #11044.
- Why this regressed now: the ordering guarantee is useful in general, but Discord needed a narrower rule for quick-answer UX once tool summaries are enabled on DM/forum-style turns.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/message-handler.process.test.ts`
- Scenario the test should lock in: when Discord emits a text-only tool summary and then the final reply in the same turn, the final reply is delivered first.
- Why this is the smallest reliable guardrail: this file already exercises the Discord message-processing seam where tool summaries and final delivery meet.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord DMs and similar tool-summary flows now show the main reply before deferred text-only tool summaries.
- Media tool outputs and exec-approval prompts still deliver immediately.

## Diagram (if applicable)

```text
Before:
[text-only tool summary] -> [Discord send] -> [final answer waits] -> [final answer visible]

After:
[text-only tool summary] -> [defer locally] -> [final answer visible] -> [tool summary visible]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin
- Runtime/container: local Node 22+ repo workflow
- Model/provider: not model-specific; Discord outbound delivery path
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord tool-summary-enabled flow

### Steps

1. Trigger a Discord turn that emits a text-only tool summary and then a short final answer.
2. Observe the order of outbound Discord delivery.
3. Re-run the regression test and repo validation commands.

### Expected

- The final reply becomes visible before deferred text-only tool summaries.

### Actual

- Before this fix, the final reply could wait behind earlier text-only tool-summary sends.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: added and ran the Discord regression test; ran `pnpm check`; ran `pnpm build`; ran full `pnpm test`.
- Edge cases checked: media-bearing tool payloads and exec-approval payloads stay on the immediate delivery path by code guard.
- What you did **not** verify: live Discord roundtrip against a production bot account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: deferred text-only tool summaries now appear after the final reply on Discord.
  - Mitigation: the deferral is intentionally limited to non-error, text-only tool payloads; media and exec-approval flows remain immediate.

## AI Assistance

- AI-assisted: yes
- Testing degree: fully tested (`pnpm check`, `pnpm build`, `pnpm test`, and targeted regression coverage)
- I reviewed the change and understand what the code does.

Made with [Cursor](https://cursor.com)