### PR TITLE
fix: allow memory_search and memory_get in sub-agent sessions (#55385)

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -99,6 +99,22 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("sessions_send", policy)).toBe(false);
   });
 
+  it("applies configured deny to memory tools even though they are allowed by default", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+      tools: {
+        subagents: {
+          tools: {
+            deny: ["memory_search", "memory_get"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const policy = resolveSubagentToolPolicy(cfg, 1);
+    expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
+  });
+
   it("does not create a restrictive allowlist when only alsoAllow is configured", () => {
     const cfg = {
       agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
@@ -129,12 +145,12 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("sessions_history", policy)).toBe(true);
   });
 
-  it("depth-1 orchestrator still denies gateway, cron, memory", () => {
+  it("depth-1 orchestrator still denies gateway and cron but allows memory tools", () => {
     const policy = resolveSubagentToolPolicy(baseCfg, 1);
     expect(isToolAllowedByPolicyName("gateway", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("cron", policy)).toBe(false);
-    expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
-    expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(true);
+    expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(true);
   });
 
   it("depth-2 leaf denies sessions_spawn", () => {
@@ -206,6 +222,8 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     const policy = resolveSubagentToolPolicyForSession(cfg, "agent:main:subagent:flat-leaf");
     expect(isToolAllowedByPolicyName("sessions_spawn", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("subagents", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(true);
+    expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(true);
   });
 
   it("defaults to leaf behavior when no depth is provided", () => {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -30,8 +30,6 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   // Status/scheduling - main agent coordinates
   "session_status",
   "cron",
-  // Memory - pass relevant info in spawn prompt instead
-  // (removed: memory_search, memory_get — read-only, essential for multi-agent setups)
   // Direct session sends - subagents communicate through announce chain
   "sessions_send",
 ];

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -31,8 +31,7 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   "session_status",
   "cron",
   // Memory - pass relevant info in spawn prompt instead
-  "memory_search",
-  "memory_get",
+  // (removed: memory_search, memory_get — read-only, essential for multi-agent setups)
   // Direct session sends - subagents communicate through announce chain
   "sessions_send",
 ];

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -29,6 +29,7 @@ let getActiveTaskCount: CommandQueueModule["getActiveTaskCount"];
 let getQueueSize: CommandQueueModule["getQueueSize"];
 let markGatewayDraining: CommandQueueModule["markGatewayDraining"];
 let resetAllLanes: CommandQueueModule["resetAllLanes"];
+let resetCommandQueueStateForTest: CommandQueueModule["resetCommandQueueStateForTest"];
 let setCommandLaneConcurrency: CommandQueueModule["setCommandLaneConcurrency"];
 let waitForActiveTasks: CommandQueueModule["waitForActiveTasks"];
 
@@ -67,10 +68,11 @@ describe("command queue", () => {
       getQueueSize,
       markGatewayDraining,
       resetAllLanes,
+      resetCommandQueueStateForTest,
       setCommandLaneConcurrency,
       waitForActiveTasks,
     } = await import("./command-queue.js"));
-    resetAllLanes();
+    resetCommandQueueStateForTest();
     // Queue state is global across module instances, so reset main lane
     // concurrency explicitly to avoid cross-file leakage.
     setCommandLaneConcurrency(CommandLane.Main, 1);

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -255,6 +255,18 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
 }
 
 /**
+ * Test-only hard reset that discards all queue state, including preserved
+ * queued work from previous generations. Use this when a suite needs an
+ * isolated baseline across shared-worker runs.
+ */
+export function resetCommandQueueStateForTest(): void {
+  const queueState = getQueueState();
+  queueState.gatewayDraining = false;
+  queueState.lanes.clear();
+  queueState.nextTaskId = 1;
+}
+
+/**
  * Reset all lane runtime state to idle. Used after SIGUSR1 in-process
  * restarts where interrupted tasks' finally blocks may not run, leaving
  * stale active task IDs that permanently block new work from draining.


### PR DESCRIPTION
## Summary

Remove `memory_search` and `memory_get` from `SUBAGENT_TOOL_DENY_ALWAYS` in `src/agents/pi-tools.policy.ts`.

These read-only tools are currently hardcoded in the sub-agent deny list, blocking all sub-agent sessions from using memory — regardless of agent config or global settings.

## Why this change

1. **Read-only tools**: `memory_search` and `memory_get` have no side effects. They cannot modify state, send messages, or affect external systems.

2. **Essential for multi-agent setups**: Any multi-agent deployment relying on shared memory (lessons, decisions, context) depends on memory tools for context retrieval in sub-agent sessions.

3. **Consistency**: Other read-only tools like `read`, `web_search`, `web_fetch` are already available to sub-agents by default. Memory tools serve the same purpose (information retrieval).

4. **Config contradicts behavior**: When `memorySearch.enabled: true` is configured, users reasonably expect memory tools to be available everywhere — but the hardcoded deny silently blocks them in sub-agents.

## The workaround (and why it's not enough)

The current workaround requires explicit configuration:

```json
{
  "tools": {
    "subagents": {
      "tools": {
        "alsoAllow": ["memory_search", "memory_get"]
      }
    }
  }
}
```

This works but contradicts the default expectation and requires manual opt-in for what should be standard behavior.

Fixes #55385