### PR TITLE
fix(discord): treat reconnect-exhausted as graceful stop, not crash

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -813,7 +813,7 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("does not suppress reconnect-exhausted already queued before shutdown", async () => {
+  it("gracefully stops on reconnect-exhausted queued before shutdown (no crash)", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const pendingGatewayEvents: DiscordGatewayEvent[] = [];
     const abortController = new AbortController();
@@ -828,16 +828,16 @@ describe("runDiscordGatewayLifecycle", () => {
     };
     getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
 
-    const { lifecycleParams, runtimeLog, runtimeError } = createLifecycleHarness({
-      gateway,
-      pendingGatewayEvents,
-    });
+    const { lifecycleParams, runtimeError, start, stop, threadStop, gatewaySupervisor } =
+      createLifecycleHarness({
+        gateway,
+        pendingGatewayEvents,
+      });
     lifecycleParams.abortSignal = abortController.signal;
 
-    // Start lifecycle; it yields at execApprovalsHandler.start(). We then
-    // queue a reconnect-exhausted event and abort. The lifecycle resumes and
-    // drains the queued fatal event before shutdown teardown flips
-    // lifecycleStopping, so the event still rejects the run.
+    // Start lifecycle; queue a reconnect-exhausted event before shutdown.
+    // Previously this would throw (crash the gateway). Now it gracefully
+    // stops — the health monitor handles reconnection (#55421).
     const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
 
     pendingGatewayEvents.push(
@@ -848,13 +848,15 @@ describe("runDiscordGatewayLifecycle", () => {
     );
     abortController.abort();
 
-    await expect(lifecyclePromise).rejects.toThrow(
-      "Max reconnect attempts (0) reached after code 1005",
-    );
-    expect(runtimeLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
-    );
+    await expect(lifecyclePromise).resolves.toBeUndefined();
     expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      gatewaySupervisor,
+    });
   });
 
   it("does not push connected: true when abortSignal is already aborted", async () => {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -82,13 +82,13 @@ export async function runDiscordGatewayLifecycle(params: {
       if (decision !== "stop") {
         return "continue";
       }
-      // Don't throw for expected shutdown events — intentional disconnect
-      // (reconnect-exhausted with maxAttempts=0) and disallowed-intents are
-      // both handled without crashing the provider.
-      if (
-        event.type === "disallowed-intents" ||
-        (lifecycleStopping && event.type === "reconnect-exhausted")
-      ) {
+      // Don't throw for expected shutdown events. disallowed-intents and
+      // reconnect-exhausted are both handled without crashing the provider.
+      // reconnect-exhausted must never throw: when the health monitor aborts a
+      // stale socket it sets maxAttempts=0 and disconnects, but lifecycleStopping
+      // may not be true yet (race). Even for unexpected WS drops the right
+      // response is a graceful stop — the health monitor handles reconnection.
+      if (event.type === "disallowed-intents" || event.type === "reconnect-exhausted") {
         return "stop";
       }
       throw event.err;


### PR DESCRIPTION
## Summary

- **Fixes** #55421 — Discord WebSocket crash: "Max reconnect attempts (0) reached after code 1005"
- `reconnect-exhausted` events in `drainPendingGatewayErrors()` now always return `"stop"` instead of conditionally throwing based on `lifecycleStopping`
- Root cause: race condition where the health monitor's `onAbort()` sets `maxAttempts=0` and disconnects, but `lifecycleStopping` isn't set until the `finally` block — so the queued `reconnect-exhausted` event would throw an uncaught exception

## Changes

In `extensions/discord/src/monitor/provider.lifecycle.ts`:
- Removed `lifecycleStopping &&` guard from the `reconnect-exhausted` check in `drainPendingGatewayErrors()`, so reconnect-exhausted always gracefully stops the lifecycle instead of crashing
- The health monitor already handles reconnection — throwing here was never the right behavior

In `extensions/discord/src/monitor/provider.lifecycle.test.ts`:
- Updated the "reconnect-exhausted queued before shutdown" test to expect graceful resolution instead of a thrown error

## Test plan

- [x] `pnpm test -- extensions/discord/src/monitor/gateway-supervisor.test.ts extensions/discord/src/monitor/provider.lifecycle.test.ts` — 25/25 pass
- [x] All pre-commit checks pass (format, lint, typecheck, boundary checks)