### PR TITLE
fix: suppress write/edit failed warning for response timeout errors

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -287,11 +287,11 @@ describe("buildEmbeddedRunPayloads", () => {
     {
       name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",
       payload: {
-        lastToolError: { toolName: "write", error: "connection timeout" },
+        lastToolError: { toolName: "write", error: "permission denied" },
         config: { messages: { suppressToolErrors: true } },
       },
       title: "Write",
-      absentDetail: "connection timeout",
+      absentDetail: "permission denied",
     },
     {
       name: "shows recoverable tool errors for mutating tools",
@@ -364,6 +364,27 @@ describe("buildEmbeddedRunPayloads", () => {
     });
 
     expectSinglePayloadSummary(payloads, { text: warningText ?? "" });
+  });
+
+  it.each([
+    { toolName: "write", error: "invoke timed out", label: "write invoke timed out" },
+    { toolName: "edit", error: "Response timeout", label: "edit response timeout" },
+    {
+      toolName: "write",
+      error: "connection timed out waiting for response",
+      label: "write connection timed out",
+    },
+  ])("suppresses mutating tool warning for response timeout: $label", ({ toolName, error }) => {
+    expectNoPayloads({
+      lastToolError: { toolName, error },
+    });
+  });
+
+  it("still shows mutating tool warning for non-timeout errors", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "write", error: "disk full" },
+    });
+    expectSingleToolErrorPayload(payloads, { title: "Write", absentDetail: "disk full" });
   });
 
   it("includes non-recoverable tool error details when verbose mode is on", () => {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -49,6 +49,12 @@ function isRecoverableToolError(error: string | undefined): boolean {
   return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
 }
 
+/** Response-layer timeout — the tool action likely succeeded but the ack never arrived. */
+function isToolResponseTimeoutError(error: string | undefined): boolean {
+  const msg = (error ?? "").toLowerCase();
+  return msg.includes("timed out") || msg.includes("timeout");
+}
+
 function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
   return level === "on" || level === "full";
 }
@@ -77,6 +83,11 @@ function resolveToolErrorWarningPolicy(params: {
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
+    // Suppress warnings for response timeouts on mutating tools — the operation
+    // likely succeeded even though the ack timed out (#55424).
+    if (isToolResponseTimeoutError(params.lastToolError.error)) {
+      return { showWarning: false, includeDetails };
+    }
     return { showWarning: true, includeDetails };
   }
   if (params.suppressToolErrors) {


### PR DESCRIPTION
## Summary
- Fixes #55424: "Write failed" / "Edit failed" warning shown to users even though the file was actually saved successfully
- When tool response times out at the ack layer, the write has already completed on disk — the timeout-based `isError=true` was incorrectly triggering a mutating-tool warning
- Added `isToolResponseTimeoutError()` check in `resolveToolErrorWarningPolicy()` to suppress warnings for timeout errors on mutating tools, since the operation likely succeeded

## Test plan
- [x] Added parameterized tests for write/edit timeout suppression (`invoke timed out`, `Response timeout`, `connection timed out waiting for response`)
- [x] Added test confirming non-timeout mutating errors (e.g. `disk full`) still show warnings
- [x] Updated existing test case that used `write` + `connection timeout` (now correctly suppressed)
- [x] All 33 error tests pass (`pnpm test -- src/agents/pi-embedded-runner/run/payloads.errors.test.ts`)
- [x] All 8 main payload tests pass (`pnpm test -- src/agents/pi-embedded-runner/run/payloads.test.ts`)