### PR TITLE
fix(plugins): deduplicate tool registration on startup

### DIFF
--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -290,6 +290,21 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
 
     const normalized = names.map((name) => name.trim()).filter(Boolean);
+
+    // Deduplicate: skip if any of the tool names are already registered by this plugin
+    const alreadyRegistered = normalized.filter((name) =>
+      registry.tools.some((t) => t.pluginId === record.id && t.names.includes(name)),
+    );
+    if (alreadyRegistered.length > 0) {
+      pushDiagnostic({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `tool already registered, skipping: ${alreadyRegistered.join(", ")}`,
+      });
+      return;
+    }
+
     if (normalized.length > 0) {
       record.toolNames.push(...normalized);
     }


### PR DESCRIPTION
## Summary

Fixes #55429

- Add deduplication guard to `registerTool` in `src/plugins/registry.ts` that skips re-registration when the same tool name is already registered by the same plugin, matching the existing pattern used by `registerHook`
- Emits a `warn`-level diagnostic when a duplicate registration is skipped, aiding debuggability

## Root Cause

The gateway startup's deferred channel plugin reload pattern (`loadGatewayStartupPlugins` → `reloadDeferredGatewayPlugins`) can call a plugin's `register()` function multiple times. While `registerTool` was gated on `registrationMode === "full"`, plugins loaded in `"full"` mode on both passes (e.g., when they lack `startupDeferConfiguredChannelFullLoadUntilAfterListen`) would register their tools twice. Unlike `registerHook`, `registerTool` had no uniqueness check.

## Test plan

- [x] Verified existing `src/plugins/tools.optional.test.ts` (8 tests) pass
- [x] Verified existing `src/plugins/loader.test.ts` (57 tests) pass
- [x] Verified existing `src/plugins/runtime.test.ts` and `src/plugins/voice-call.plugin.test.ts` (12 tests) pass
- [x] `pnpm check` passes (format, lint, typecheck, all boundary checks)
- [ ] Manual: confirm Feishu tools appear once in gateway logs on startup