### PR TITLE
fix: fall back to copy when runtime file symlinks are denied

### DIFF
--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -34,8 +34,19 @@ function ensureSymlink(targetValue, targetPath, type) {
   fs.symlinkSync(targetValue, targetPath, type);
 }
 
+function isSymlinkPermissionFallbackError(error) {
+  return error?.code === "EPERM" || error?.code === "EACCES";
+}
+
 function symlinkPath(sourcePath, targetPath, type) {
-  ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+  try {
+    ensureSymlink(relativeSymlinkTarget(sourcePath, targetPath), targetPath, type);
+  } catch (error) {
+    if (!isSymlinkPermissionFallbackError(error)) {
+      throw error;
+    }
+    fs.copyFileSync(sourcePath, targetPath);
+  }
 }
 
 function shouldWrapRuntimeJsFile(sourcePath) {

--- a/src/plugins/stage-bundled-plugin-runtime.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime.test.ts
@@ -359,6 +359,41 @@ describe("stageBundledPluginRuntime", () => {
     expect(fs.existsSync(path.join(repoRoot, "dist-runtime"))).toBe(false);
   });
 
+  it("falls back to copying runtime files when file symlinks are denied", () => {
+    const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-copy-fallback-");
+    const distPluginDir = path.join(repoRoot, "dist", "extensions", "feishu");
+    const distSkillDir = path.join(distPluginDir, "skills", "feishu-doc");
+    fs.mkdirSync(distSkillDir, { recursive: true });
+    fs.writeFileSync(path.join(distPluginDir, "index.js"), "export default {}\n", "utf8");
+    fs.writeFileSync(path.join(distSkillDir, "SKILL.md"), "# Feishu Doc\n", "utf8");
+
+    const realSymlinkSync = fs.symlinkSync.bind(fs);
+    const symlinkSpy = vi.spyOn(fs, "symlinkSync").mockImplementation(((target, link, type) => {
+      const linkPath = String(link);
+      if (linkPath.endsWith(path.join("skills", "feishu-doc", "SKILL.md"))) {
+        const err = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+        throw err;
+      }
+      return realSymlinkSync(String(target), linkPath, type);
+    }) as typeof fs.symlinkSync);
+
+    expect(() => stageBundledPluginRuntime({ repoRoot })).not.toThrow();
+
+    const runtimeSkillPath = path.join(
+      repoRoot,
+      "dist-runtime",
+      "extensions",
+      "feishu",
+      "skills",
+      "feishu-doc",
+      "SKILL.md",
+    );
+    expect(fs.lstatSync(runtimeSkillPath).isSymbolicLink()).toBe(false);
+    expect(fs.readFileSync(runtimeSkillPath, "utf8")).toBe("# Feishu Doc\n");
+
+    symlinkSpy.mockRestore();
+  });
+
   it("tolerates EEXIST when an identical runtime symlink is materialized concurrently", () => {
     const repoRoot = makeRepoRoot("openclaw-stage-bundled-runtime-eexist-");
     const distPluginDir = path.join(repoRoot, "dist", "extensions", "feishu");


### PR DESCRIPTION
## Summary

Fall back to copying runtime overlay files when file symlink creation is denied during bundled plugin runtime staging. This keeps the symlink-first behavior for normal environments but unblocks Windows builds where creating file symlinks in `dist-runtime` fails with `EPERM`/`EACCES`.

## Changes

- catch file-symlink permission failures in `symlinkPath()`
- copy the source file into `dist-runtime` when symlink creation is denied
- add a focused regression test covering the fallback path

## Testing

- `pnpm exec vitest run --config vitest.unit.config.ts src/plugins/stage-bundled-plugin-runtime.test.ts`
- repository commit hook checks passed during commit (`format:check`, lint suite, config/schema checks, plugin boundary checks)

Fixes openclaw/openclaw#55454