### PR TITLE
Gateway: degrade startup secret failures

### DIFF
--- a/src/config/merge-patch.ts
+++ b/src/config/merge-patch.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { isPlainObject } from "../utils.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 
@@ -94,4 +95,43 @@ export function applyMergePatch(
   }
 
   return result;
+}
+
+/**
+ * Compute an RFC 7396 merge-patch that transforms `base` into `target`.
+ * Applying the returned patch to `base` via applyMergePatch reproduces `target`.
+ */
+export function createMergePatch(base: unknown, target: unknown): unknown {
+  if (!isPlainObject(base) || !isPlainObject(target)) {
+    return structuredClone(target);
+  }
+
+  const patch: Record<string, unknown> = {};
+  const keys = new Set([...Object.keys(base), ...Object.keys(target)]);
+  for (const key of keys) {
+    const hasBase = key in base;
+    const hasTarget = key in target;
+    if (!hasTarget) {
+      patch[key] = null;
+      continue;
+    }
+    const targetValue = target[key];
+    if (!hasBase) {
+      patch[key] = structuredClone(targetValue);
+      continue;
+    }
+    const baseValue = base[key];
+    if (isPlainObject(baseValue) && isPlainObject(targetValue)) {
+      const childPatch = createMergePatch(baseValue, targetValue);
+      if (isPlainObject(childPatch) && Object.keys(childPatch).length === 0) {
+        continue;
+      }
+      patch[key] = childPatch;
+      continue;
+    }
+    if (!isDeepStrictEqual(baseValue, targetValue)) {
+      patch[key] = structuredClone(targetValue);
+    }
+  }
+  return patch;
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -63,6 +63,7 @@ import {
   resolveCommandSecretsFromActiveRuntimeSnapshot,
   type CommandSecretAssignment,
 } from "../secrets/runtime-command-secrets.js";
+import { SecretRefResolutionError } from "../secrets/resolve.js";
 import {
   GATEWAY_AUTH_SURFACE_PATHS,
   evaluateGatewayAuthSurfaceStates,
@@ -263,6 +264,99 @@ function applyGatewayAuthOverridesForStartupPreflight(
       auth: mergeGatewayAuthConfig(config.gateway?.auth, overrides.auth),
       tailscale: mergeGatewayTailscaleConfig(config.gateway?.tailscale, overrides.tailscale),
     },
+  };
+}
+
+function disableChannelsForStartupDegrade(
+  config: OpenClawConfig,
+  channelIds: readonly string[],
+): OpenClawConfig {
+  if (channelIds.length === 0 || !config.channels) {
+    return config;
+  }
+  const next = structuredClone(config);
+  const nextChannels = next.channels!;
+  for (const channelId of channelIds) {
+    const channel = nextChannels[channelId];
+    if (!channel || typeof channel !== "object") {
+      continue;
+    }
+    nextChannels[channelId] = {
+      ...(channel as Record<string, unknown>),
+      enabled: false,
+    };
+  }
+  return next;
+}
+
+function isSecretResolutionAvailabilityError(error: unknown): boolean {
+  if (error instanceof SecretRefResolutionError) {
+    return error.source === "env" && /is missing or empty\.?$/i.test(error.message);
+  }
+  return false;
+}
+
+async function prepareStartupChannelDegradedSnapshot(params: { config: OpenClawConfig }): Promise<{
+  prepared: Awaited<ReturnType<typeof prepareSecretsRuntimeSnapshot>>;
+  disabledChannelIds: string[];
+} | null> {
+  const channelEntries = Object.entries(params.config.channels ?? {}).filter(
+    ([, value]) =>
+      value && typeof value === "object" && (value as { enabled?: boolean }).enabled !== false,
+  );
+  if (channelEntries.length === 0) {
+    return null;
+  }
+
+  const allChannelIds = channelEntries.map(([channelId]) => channelId);
+  try {
+    await prepareSecretsRuntimeSnapshot({
+      config: disableChannelsForStartupDegrade(params.config, allChannelIds),
+    });
+  } catch {
+    // Non-channel surfaces are still unresolved, so startup must keep failing.
+    return null;
+  }
+
+  const disabledChannelIds: string[] = [];
+  for (const [channelId] of channelEntries) {
+    const isolatedConfig = disableChannelsForStartupDegrade(
+      params.config,
+      allChannelIds.filter((candidateId) => candidateId !== channelId),
+    );
+    try {
+      await prepareSecretsRuntimeSnapshot({ config: isolatedConfig });
+    } catch (err) {
+      if (!isSecretResolutionAvailabilityError(err)) {
+        return null;
+      }
+      disabledChannelIds.push(channelId);
+    }
+  }
+  if (disabledChannelIds.length === 0) {
+    return null;
+  }
+
+  const degradedConfig = disableChannelsForStartupDegrade(params.config, disabledChannelIds);
+  let prepared: Awaited<ReturnType<typeof prepareSecretsRuntimeSnapshot>>;
+  try {
+    prepared = await prepareSecretsRuntimeSnapshot({ config: degradedConfig });
+  } catch {
+    return null;
+  }
+  return {
+    prepared: {
+      ...prepared,
+      // recoveryConfig holds the original (pre-degradation) config so that
+      // secrets.reload can attempt to recover disabled channels once their
+      // env-backed refs become available. sourceConfig intentionally stays as
+      // degradedConfig so the writeConfigFile merge-patch invariant holds:
+      // runtimeConfigSnapshot and runtimeConfigSourceSnapshot must agree on
+      // which channels are enabled, preventing operator writes from being
+      // silently dropped as empty patches.
+      recoveryConfig: structuredClone(params.config),
+    },
+    disabledChannelIds,
   };
 }
 
@@ -514,6 +608,21 @@ export async function startGatewayServer(
         }
         secretsDegraded = true;
         if (params.reason === "startup") {
+          const degraded = await prepareStartupChannelDegradedSnapshot({ config });
+          if (degraded) {
+            const disabledSummary = degraded.disabledChannelIds.join(", ");
+            logSecrets.warn(
+              `[SECRETS_STARTUP_CHANNELS_DISABLED] Disabled channels with unresolved startup secrets: ${disabledSummary}`,
+            );
+            if (params.activate) {
+              activateSecretsRuntimeSnapshot(degraded.prepared);
+              logGatewayAuthSurfaceDiagnostics(degraded.prepared);
+            }
+            for (const warning of degraded.prepared.warnings) {
+              logSecrets.warn(`[${warning.code}] ${warning.message}`);
+            }
+            return degraded.prepared;
+          }
           throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
             cause: err,
           });
@@ -1233,7 +1342,13 @@ export async function startGatewayServer(
         if (!active) {
           throw new Error("Secrets runtime snapshot is not active.");
         }
-        const prepared = await activateRuntimeSecrets(active.sourceConfig, {
+        // When the runtime was degraded at startup (channels disabled due to
+        // missing secrets), use recoveryConfig — the original pre-degradation
+        // source config — so we attempt to re-enable those channels.
+        // For non-degraded snapshots, recoveryConfig is undefined and
+        // sourceConfig is the correct baseline to reload from.
+        const reloadConfig = active.recoveryConfig ?? active.sourceConfig;
+        const prepared = await activateRuntimeSecrets(reloadConfig, {
           reason: "reload",
           activate: true,
         });

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { drainSystemEvents } from "../infra/system-events.js";
+import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import {
   TALK_TEST_PROVIDER_API_KEY_PATH,
   TALK_TEST_PROVIDER_ID,
@@ -175,6 +176,7 @@ describe("gateway hot reload", () => {
   let prevSkipProviders: string | undefined;
   let prevOpenAiApiKey: string | undefined;
   let prevGeminiApiKey: string | undefined;
+  let prevDiscordBotToken: string | undefined;
 
   beforeEach(() => {
     prevSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
@@ -182,6 +184,7 @@ describe("gateway hot reload", () => {
     prevSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
     prevOpenAiApiKey = process.env.OPENAI_API_KEY;
     prevGeminiApiKey = process.env.GEMINI_API_KEY;
+    prevDiscordBotToken = process.env.DISCORD_BOT_TOKEN;
     process.env.OPENCLAW_SKIP_CHANNELS = "0";
     delete process.env.OPENCLAW_SKIP_GMAIL_WATCHER;
     delete process.env.OPENCLAW_SKIP_PROVIDERS;
@@ -213,6 +216,11 @@ describe("gateway hot reload", () => {
     } else {
       process.env.GEMINI_API_KEY = prevGeminiApiKey;
     }
+    if (prevDiscordBotToken === undefined) {
+      delete process.env.DISCORD_BOT_TOKEN;
+    } else {
+      process.env.DISCORD_BOT_TOKEN = prevDiscordBotToken;
+    }
   });
 
   async function writeEnvRefConfig() {
@@ -234,6 +242,34 @@ describe("gateway hot reload", () => {
       channels: {
         telegram: {
           botToken: { source: "env", provider: "default", id: "TELEGRAM_BOT_TOKEN" },
+        },
+      },
+    });
+  }
+
+  async function writeDiscordChannelEnvRefConfig() {
+    await writeConfigFile({
+      channels: {
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+        },
+      },
+    });
+  }
+
+  async function writeDiscordChannelEnvRefAllowlistViolationConfig() {
+    await writeConfigFile({
+      channels: {
+        discord: {
+          token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+        },
+      },
+      secrets: {
+        providers: {
+          default: {
+            source: "env",
+            allowlist: ["SOME_OTHER_TOKEN"],
+          },
         },
       },
     });
@@ -583,6 +619,73 @@ describe("gateway hot reload", () => {
     await expect(withGatewayServer(async () => {})).resolves.toBeUndefined();
   });
 
+  it("degrades startup when active channel secret refs are unresolved", async () => {
+    await writeDiscordChannelEnvRefConfig();
+    delete process.env.DISCORD_BOT_TOKEN;
+
+    await withGatewayServer(async () => {
+      const snapshot = getActiveSecretsRuntimeSnapshot();
+      expect(snapshot?.sourceConfig.channels?.discord).toMatchObject({
+        enabled: false,
+        token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+      });
+      expect(snapshot?.config.channels?.discord).toMatchObject({
+        enabled: false,
+        token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+      });
+      expect(snapshot?.recoveryConfig?.channels?.discord).toMatchObject({
+        token: { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" },
+      });
+      expect(
+        (snapshot?.recoveryConfig?.channels?.discord as Record<string, unknown> | undefined)
+          ?.enabled,
+      ).not.toBe(false);
+    });
+  });
+
+  it("recovers degraded channel via secrets.reload once secret becomes available", async () => {
+    await writeDiscordChannelEnvRefConfig();
+    delete process.env.DISCORD_BOT_TOKEN;
+
+    const { server, ws } = await startServerWithClient();
+    try {
+      await connectOk(ws);
+
+      // Confirm we started in degraded state.
+      const degraded = getActiveSecretsRuntimeSnapshot();
+      expect(
+        (degraded?.recoveryConfig?.channels?.discord as Record<string, unknown> | undefined)
+          ?.enabled,
+      ).not.toBe(false);
+
+      // Now make the secret available and trigger reload.
+      process.env.DISCORD_BOT_TOKEN = "test-bot-token"; // pragma: allowlist secret
+      const result = await rpcReq(ws, "secrets.reload", {});
+      expect(result).toMatchObject({ ok: true });
+
+      // After recovery the snapshot should no longer carry recoveryConfig.
+      const recovered = getActiveSecretsRuntimeSnapshot();
+      expect("recoveryConfig" in (recovered ?? {})).toBe(false);
+      expect(recovered?.config.channels?.discord).toMatchObject({
+        token: expect.any(String),
+      });
+      expect(
+        (recovered?.config.channels?.discord as Record<string, unknown> | undefined)?.enabled,
+      ).not.toBe(false);
+    } finally {
+      ws.close();
+      await server.close();
+    }
+  });
+
+  it("fails startup when an active channel env ref violates provider allowlist policy", async () => {
+    await writeDiscordChannelEnvRefAllowlistViolationConfig();
+    process.env.DISCORD_BOT_TOKEN = "test-bot-token"; // pragma: allowlist secret
+    await expect(withGatewayServer(async () => {})).rejects.toThrow(
+      /allowlist|not allowed|DISCORD_BOT_TOKEN/i,
+    );
+  });
+
   it("fails startup when an active exec ref id contains traversal segments", async () => {
     await writeGatewayTraversalExecRefConfig();
     const previousGatewayAuth = testState.gatewayAuth;
@@ -645,6 +748,7 @@ describe("gateway hot reload", () => {
       const onHotReload = hoisted.getOnHotReload();
       expect(onHotReload).toBeTypeOf("function");
       const sessionKey = resolveMainSessionKeyFromConfig();
+      expect(drainSystemEvents(sessionKey)).toEqual([]);
       const plan = {
         changedPaths: ["models.providers.openai.apiKey"],
         restartGateway: false,

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -17,6 +17,7 @@ import {
   setRuntimeConfigSnapshot,
   type OpenClawConfig,
 } from "../config/config.js";
+import { applyMergePatch, createMergePatch } from "../config/merge-patch.js";
 import type { PluginOrigin } from "../plugins/types.js";
 import { resolveUserPath } from "../utils.js";
 import { type SecretResolverWarning } from "./runtime-shared.js";
@@ -35,6 +36,14 @@ export type PreparedSecretsRuntimeSnapshot = {
   authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
   warnings: SecretResolverWarning[];
   webTools: RuntimeWebToolsMetadata;
+  /**
+   * When startup degraded by disabling channels whose secrets were unavailable,
+   * this holds the original (pre-degradation) source config. The secrets.reload
+   * path uses this to attempt full recovery once secrets become available.
+   * Must NOT be used as the sourceConfig for writeConfigFile merge-patch logic;
+   * sourceConfig always reflects the config that produced this snapshot.
+   */
+  recoveryConfig?: OpenClawConfig;
 };
 
 type SecretsRuntimeRefreshContext = {
@@ -86,6 +95,9 @@ function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecret
     })),
     warnings: snapshot.warnings.map((warning) => ({ ...warning })),
     webTools: structuredClone(snapshot.webTools),
+    ...(snapshot.recoveryConfig !== undefined
+      ? { recoveryConfig: structuredClone(snapshot.recoveryConfig) }
+      : undefined),
   };
 }
 
@@ -270,6 +282,19 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
       if (!activeSnapshot || !activeRefreshContext) {
         return false;
       }
+      // Preserve recoveryConfig across in-process config writes (e.g. control-UI
+      // origin seeding at startup). prepareSecretsRuntimeSnapshot builds a fresh
+      // snapshot from sourceConfig and never sets recoveryConfig; without this,
+      // any writeConfigFile call during degraded startup drops the field and
+      // secrets.reload falls back to the degraded sourceConfig, so recovered env
+      // secrets never re-enable the channel until a manual config change or restart.
+      //
+      // Forward operator edits made while secrets are still missing: compute the
+      // delta from the previous sourceConfig to the incoming sourceConfig and apply
+      // it to recoveryConfig so that config.set changes are not silently replayed
+      // over by the stale startup snapshot when secrets.reload eventually fires.
+      const prevSourceConfig = activeSnapshot.sourceConfig;
+      const existingRecoveryConfig = activeSnapshot.recoveryConfig;
       const refreshed = await prepareSecretsRuntimeSnapshot({
         config: sourceConfig,
         env: activeRefreshContext.env,
@@ -277,6 +302,19 @@ export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeS
         loadAuthStore: activeRefreshContext.loadAuthStore,
         loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
       });
+      if (existingRecoveryConfig !== undefined && refreshed.recoveryConfig === undefined) {
+        // Build a patch from old sourceConfig → new sourceConfig so that any
+        // operator writes (config.set etc.) are forwarded into recoveryConfig.
+        // applyMergePatch returns unknown; cast to OpenClawConfig via the same
+        // pattern used in io.ts (coerce-as-object, treat non-object as empty).
+        const delta = createMergePatch(prevSourceConfig, sourceConfig);
+        const updated = applyMergePatch(existingRecoveryConfig, delta);
+        refreshed.recoveryConfig = (
+          updated && typeof updated === "object" && !Array.isArray(updated)
+            ? updated
+            : existingRecoveryConfig
+        ) as OpenClawConfig;
+      }
       activateSecretsRuntimeSnapshot(refreshed);
       return true;
     },


### PR DESCRIPTION
## Summary

  - Problem: gateway startup treated unresolved secret refs on active channels as fatal, so a single missing channel token could block the entire gateway from starting.
  - Why it matters: channel-local secret outages should degrade that channel, not take down unrelated gateway surfaces or other integrations.
  - What changed: startup now isolates channel secret failures, disables only the affected channels, keeps the original source config for later recovery on secrets.reload, adds a regression test for
    this path, and enables sourcemaps plus OPENCLAW_INSPECT support in the node runner for easier debugging.
  - What did NOT change: unresolved non-channel secret refs still fail startup, and reload/recovery behavior outside this degraded-startup path was not widened.

  ## Change Type

  - [x] Bug fix
  - [ ] Feature
  - [x] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [x] Chore/infra

  ## Scope

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #
  - [x] This PR fixes a bug or regression

  ## Root Cause / Regression History

  - Root cause: startup secret activation used an all-or-nothing snapshot, so unresolved env-backed refs on active channels were treated the same as core required secret failures.
  - Missing detection / guardrail: there was coverage for fatal startup secret failures and disabled surfaces, but not for the case where only active channel secrets were missing and should degrade
    instead of aborting startup.
  - Prior context (git blame, prior PR, issue, or refactor if known): Unknown.
  - Why this regressed now: the stricter startup secret preflight made startup correctness better overall, but it did not preserve the existing channel-level degradation expectation.
  - If unknown, what was ruled out: this is not caused by traversal validation or inactive-surface secret handling; those paths still behave as intended.

  ## Regression Test Plan

  - Coverage level that should have caught this:
      - [x] Seam / integration test
      - [ ] Unit test
      - [ ] End-to-end test
      - [ ] Existing coverage already sufficient
  - Target test or file: src/gateway/server.reload.test.ts
  - Scenario the test should lock in: with an active channel configured from an env secret ref and that env var missing, gateway startup should succeed with that channel forced to enabled: false in the
    active runtime snapshot while preserving the original sourceConfig.
  - Why this is the smallest reliable guardrail: the behavior depends on real startup secret snapshot preparation and activation, so a unit test would miss the integration boundary that actually
    regressed.
  - Existing test that already covers this (if any): existing startup tests covered fatal unresolved refs and unresolved refs on disabled surfaces, but not active-channel-only degradation.
  - If no new test is added, why not: N/A.

  ## User-visible / Behavior Changes

  - Gateway can now start in a degraded state when only active channel secret refs are unresolved.
  - Affected channels are auto-disabled at startup and logged explicitly instead of crashing the full gateway.
  - Developers can now opt into node inspector startup for scripts/run-node.mjs via OPENCLAW_INSPECT, and build output now includes sourcemaps.

  ## Security Impact

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No
  - If any Yes, explain risk + mitigation: N/A

  ## Repro + Verification

  ### Environment

  - OS: Linux
  - Runtime/container: Node 25.x, pnpm workspace
  - Model/provider: N/A
  - Integration/channel (if any): Discord channel config using env-backed token ref
  - Relevant config (redacted): channels.discord.token = { source: "env", provider: "default", id: "DISCORD_BOT_TOKEN" }

  ### Steps

  1. Configure an active channel with an env-backed secret ref.
  2. Leave the referenced env var unset.
  3. Start the gateway.

  ### Expected

  - Gateway starts.
  - Only the affected channel is disabled in the runtime snapshot.
  - Original source config is preserved so a later reload can recover once the env var exists.

  ### Actual

  - Before this change, startup failed with Startup failed: required secrets are unavailable.
  - After this change, startup degrades that channel instead of aborting.

  ## Evidence

  - [x] Trace/log snippets
  - [x] Perf numbers (if relevant)

  Build verification:

  - pnpm build passed.

  Local targeted test status:

  - Added regression coverage in src/gateway/server.reload.test.ts.
  - pnpm test -- src/gateway/server.reload.test.ts -t "degrades startup when active channel secret refs are unresolved" is currently blocked in this environment by an existing local toolchain issue
    where Node 25 tries to execute the pnpm ELF binary as JavaScript and fails before Vitest runs.

  ## Human Verification

  - Verified scenarios: reviewed the startup secret activation flow, confirmed the new degraded path only disables failing active channels, and confirmed the prepared snapshot preserves original
    sourceConfig for later recovery.
  - Edge cases checked: no-channel config, already-disabled channels, and unresolved non-channel secrets still remaining fatal.
  - What you did not verify: full end-to-end gateway startup on a clean local test run was not completed because the targeted Vitest invocation is blocked by the existing pnpm/Node environment issue
    above.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No
  - If yes, exact upgrade steps: N/A

  ## Failure Recovery

  - How to disable/revert this change quickly: revert the startup degradation helper and fall back to the previous fatal-startup behavior for unresolved active-channel secrets.
  - Files/config to restore: src/gateway/server.impl.ts, src/gateway/server.reload.test.ts, scripts/run-node.mjs, tsdown.config.ts
  - Known bad symptoms reviewers should watch for: gateway starting when it should still fail for non-channel secret errors, or channels staying disabled after secrets become available and reload runs.

  ## Risks and Mitigations

  - Risk: channel isolation during startup could accidentally suppress a non-channel secret failure.
      - Mitigation: the implementation first proves startup succeeds with all channels disabled before isolating per-channel failures; if non-channel surfaces are still unresolved, startup still fails.
  - Risk: disabled-channel recovery could be lost if the degraded snapshot overwrote the source config.
      - Mitigation: the fix explicitly preserves the original sourceConfig so later secrets.reload can re-enable recovered channels.
  - Risk: enabling sourcemaps and inspect args could change local debug startup behavior.
      - Mitigation: OPENCLAW_INSPECT is opt-in, and sourcemaps only affect debugging/build output rather than runtime logic.
