### PR TITLE
fix(discord): prefer guild name slug over guild ID in GroupSpace for readable session display names

### DIFF
--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -384,7 +384,7 @@ async function dispatchDiscordComponentEvent(params: {
     GroupSubject: groupSubject,
     GroupChannel: groupChannel,
     GroupSystemPrompt: interactionCtx.isDirectMessage ? undefined : groupSystemPrompt,
-    GroupSpace: guildInfo?.id ?? guildInfo?.slug ?? interactionCtx.rawGuildId ?? undefined,
+    GroupSpace: guildInfo?.slug ?? guildInfo?.id ?? interactionCtx.rawGuildId ?? undefined,
     OwnerAllowFrom: ownerAllowFrom,
     Provider: "discord" as const,
     Surface: "discord" as const,

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -384,7 +384,7 @@ export async function processDiscordMessage(
     GroupChannel: groupChannel,
     UntrustedContext: untrustedContext,
     GroupSystemPrompt: isGuildMessage ? groupSystemPrompt : undefined,
-    GroupSpace: isGuildMessage ? (guildInfo?.id ?? guildSlug) || undefined : undefined,
+    GroupSpace: isGuildMessage ? (guildSlug || guildInfo?.id) || undefined : undefined,
     OwnerAllowFrom: ownerAllowFrom,
     Provider: "discord" as const,
     Surface: "discord" as const,


### PR DESCRIPTION
## Problem

Discord session display names in the Control UI show numeric guild IDs instead of human-readable guild names:

- **Before:** `discord:1465877362506727609#maintenance`
- **After:** `discord:openclawserver#maintenance`

This happens because `GroupSpace` is set to `guildInfo.id` (numeric ID) with `guildSlug` (normalized guild name) as fallback. Since `guildInfo.id` is always available, the readable slug is never used.

## Solution

Swap the priority so `guildSlug` (human-readable) is preferred over `guildInfo.id` (numeric), falling back to the ID only when the guild name is unavailable.

### Changes

- `extensions/discord/src/monitor/message-handler.process.ts`: `guildSlug || guildInfo?.id` instead of `guildInfo?.id ?? guildSlug`
- `extensions/discord/src/monitor/agent-components.ts`: `guildInfo?.slug ?? guildInfo?.id` instead of `guildInfo?.id ?? guildInfo?.slug`

### Impact

- **Display only** — session keys and `groupId` fields still use channel IDs for routing/deduplication
- **No behavioral change** — only affects how sessions appear in the Control UI and `sessions.json` `displayName`
- **Backward compatible** — falls back to guild ID when name is unavailable

Fixes the dashboard session list readability for single-server and multi-server setups alike.