### PR TITLE
feat: stamp session_key, message_channel, context_limit into LiteLLM request metadata

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2439,6 +2439,29 @@ export async function runEmbeddedAttempt(
         );
       }
 
+      // ── Inject session metadata into outbound LLM requests ───────────────
+      // Stamps session_key, message_channel, and context_limit into
+      // options.metadata on every model call so LiteLLM callbacks can read
+      // them directly from kwargs — eliminating timestamp-correlation hacks
+      // in downstream spend alerting and channel attribution.
+      if (params.sessionKey || params.messageChannel || params.contextTokenBudget) {
+        const sessionMetadata: Record<string, unknown> = {};
+        if (params.sessionKey) sessionMetadata["session_key"] = params.sessionKey;
+        if (params.messageChannel) sessionMetadata["message_channel"] = params.messageChannel;
+        if (params.contextTokenBudget) sessionMetadata["context_limit"] = params.contextTokenBudget;
+        const innerWithMeta = activeSession.agent.streamFn;
+        activeSession.agent.streamFn = (model, context, options) => {
+          const enrichedOptions = {
+            ...options,
+            metadata: {
+              ...(options as Record<string, unknown>)?.["metadata"] as Record<string, unknown>,
+              ...sessionMetadata,
+            },
+          };
+          return innerWithMeta(model, context, enrichedOptions as typeof options);
+        };
+      }
+
       try {
         const prior = await sanitizeSessionHistory({
           messages: activeSession.messages,


### PR DESCRIPTION
## Problem

OpenClaw tracks session context internally (session key, channel, context token budget) but doesn't forward it to outbound LiteLLM requests. This forces downstream tooling — spend alerting, channel attribution — to correlate calls via fragile timestamp heuristics that break for long-running sessions.

## Solution

Inject three fields into `options.metadata` on every outbound model call, via a `streamFn` wrapper added at the end of `runEmbeddedAttempt`:

| Field | Example value |
|---|---|
| `session_key` | `agent:main:discord:channel:1480528231286181948` |
| `message_channel` | `discord` / `telegram` |
| `context_limit` | `200000` |

LiteLLM passes `options.metadata` through to custom callbacks as `kwargs['litellm_params']['metadata']`, making these fields immediately available with no correlation needed.

## What this enables

- **Exact channel attribution** in spend logs: `session_key` encodes agent + platform + channel ID — no timestamp matching required
- **Accurate context window %** in spend alerts: `context_limit` + `prompt_tokens` from the response gives real utilization
- **Eliminates `session-channel-tagger`** background polling approach, which has inherent lag for active sessions
- **Correct routing** of spend alerts to the right platform (Discord alert for Discord sessions, Telegram for Telegram sessions)

## Implementation

Single `streamFn` wrapper added after all existing wrappers in `runEmbeddedAttempt`, only when at least one metadata field is available. Zero overhead when fields are absent. No new dependencies.

```typescript
// src/agents/pi-embedded-runner/run/attempt.ts
if (params.sessionKey || params.messageChannel || params.contextTokenBudget) {
  const sessionMetadata: Record<string, unknown> = {};
  if (params.sessionKey) sessionMetadata["session_key"] = params.sessionKey;
  if (params.messageChannel) sessionMetadata["message_channel"] = params.messageChannel;
  if (params.contextTokenBudget) sessionMetadata["context_limit"] = params.contextTokenBudget;
  const innerWithMeta = activeSession.agent.streamFn;
  activeSession.agent.streamFn = (model, context, options) => {
    const enrichedOptions = {
      ...options,
      metadata: {
        ...(options as Record<string, unknown>)?.["metadata"] as Record<string, unknown>,
        ...sessionMetadata,
      },
    };
    return innerWithMeta(model, context, enrichedOptions as typeof options);
  };
}
```

## Testing

Verified `options.metadata` flows through to LiteLLM callbacks via `kwargs['litellm_params']['metadata']` in a local LiteLLM 1.82.4 deployment. Fields appear correctly for both Anthropic (via Anthropic provider) and OpenAI-compat (via LiteLLM proxy) routes.