### PR TITLE
fix(gateway): survive transient network/TLS errors in uncaughtException handler

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -149,7 +149,7 @@ export async function runCli(argv: string[] = process.argv) {
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();
-    const { installUnhandledRejectionHandler, isAbortError, isTransientNetworkError } =
+    const { installUnhandledRejectionHandler, isAbortError, isStrictTransientNetworkError } =
       await import("../infra/unhandled-rejections.js");
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
@@ -161,7 +161,7 @@ export async function runCli(argv: string[] = process.argv) {
         console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
         return;
       }
-      if (isTransientNetworkError(error)) {
+      if (isStrictTransientNetworkError(error)) {
         console.warn(
           "[openclaw] Non-fatal uncaught exception (continuing):",
           formatUncaughtError(error),

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -149,9 +149,8 @@ export async function runCli(argv: string[] = process.argv) {
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();
-    const { installUnhandledRejectionHandler, isAbortError, isTransientNetworkError } = await import(
-      "../infra/unhandled-rejections.js"
-    );
+    const { installUnhandledRejectionHandler, isAbortError, isTransientNetworkError } =
+      await import("../infra/unhandled-rejections.js");
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
     // These log the error and exit gracefully instead of crashing without trace.

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -149,13 +149,26 @@ export async function runCli(argv: string[] = process.argv) {
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();
-    const { installUnhandledRejectionHandler } = await import("../infra/unhandled-rejections.js");
+    const { installUnhandledRejectionHandler, isAbortError, isTransientNetworkError } = await import(
+      "../infra/unhandled-rejections.js"
+    );
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
     // These log the error and exit gracefully instead of crashing without trace.
     installUnhandledRejectionHandler();
 
     process.on("uncaughtException", (error) => {
+      if (isAbortError(error)) {
+        console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
+        return;
+      }
+      if (isTransientNetworkError(error)) {
+        console.warn(
+          "[openclaw] Non-fatal uncaught exception (continuing):",
+          formatUncaughtError(error),
+        );
+        return;
+      }
       console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
       process.exit(1);
     });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1024,6 +1024,12 @@ export function attachGatewayUpgradeHandler(opts: {
     rateLimiter,
   } = opts;
   httpServer.on("upgrade", (req, socket, head) => {
+    // prevent TLS/network errors on the raw socket from becoming uncaught exceptions
+    if (!socket.listenerCount("error")) {
+      socket.on("error", (_err) => {
+        socket.destroy();
+      });
+    }
     void (async () => {
       const configSnapshot = loadConfig();
       const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1026,7 +1026,8 @@ export function attachGatewayUpgradeHandler(opts: {
   httpServer.on("upgrade", (req, socket, head) => {
     // prevent TLS/network errors on the raw socket from becoming uncaught exceptions
     if (!socket.listenerCount("error")) {
-      socket.on("error", (_err) => {
+      socket.on("error", (err) => {
+        console.warn("[openclaw] Upgrade socket error (destroying):", err.message);
         socket.destroy();
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,11 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatUncaughtError } from "./infra/errors.js";
 import { isMainModule } from "./infra/is-main.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isAbortError,
+  isTransientNetworkError,
+} from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
   installGaxiosFetchCompat: () => Promise<void>;
@@ -92,6 +96,20 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    // transient network/TLS errors should not crash the gateway — log and continue.
+    // these errors occur in the I/O layer and do not corrupt application state,
+    // mirroring the same logic used in the unhandledRejection handler.
+    if (isAbortError(error)) {
+      console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
+      return;
+    }
+    if (isTransientNetworkError(error)) {
+      console.warn(
+        "[openclaw] Non-fatal uncaught exception (continuing):",
+        formatUncaughtError(error),
+      );
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { isMainModule } from "./infra/is-main.js";
 import {
   installUnhandledRejectionHandler,
   isAbortError,
-  isTransientNetworkError,
+  isStrictTransientNetworkError,
 } from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
@@ -103,7 +103,7 @@ if (isMain) {
       console.warn("[openclaw] Suppressed uncaught AbortError:", formatUncaughtError(error));
       return;
     }
-    if (isTransientNetworkError(error)) {
+    if (isStrictTransientNetworkError(error)) {
       console.warn(
         "[openclaw] Non-fatal uncaught exception (continuing):",
         formatUncaughtError(error),

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -227,6 +227,18 @@ describe("isStrictTransientNetworkError", () => {
     expect(isStrictTransientNetworkError(new Error("network error"))).toBe(false);
   });
 
+  it("returns false for TimeoutError (used in application-level control flow)", () => {
+    const error = new Error("request timed out");
+    error.name = "TimeoutError";
+    expect(isStrictTransientNetworkError(error)).toBe(false);
+  });
+
+  it("returns true for ConnectTimeoutError", () => {
+    const error = new Error("connect timed out");
+    error.name = "ConnectTimeoutError";
+    expect(isStrictTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false for regular errors", () => {
     expect(isStrictTransientNetworkError(new Error("Something went wrong"))).toBe(false);
     expect(isStrictTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isStrictTransientNetworkError,
+  isTransientNetworkError,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -185,5 +189,50 @@ describe("isTransientNetworkError", () => {
   it("returns false for AggregateError with only non-network errors", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
+  });
+});
+
+describe("isStrictTransientNetworkError", () => {
+  it("returns true for errors with transient network codes", () => {
+    const error = Object.assign(new Error("test"), { code: "ECONNRESET" });
+    expect(isStrictTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for TLS socket disconnection message", () => {
+    const error = new Error(
+      "Client network socket disconnected before secure TLS connection was established",
+    );
+    expect(isStrictTransientNetworkError(error)).toBe(true);
+  });
+
+  it("returns true for socket hang up", () => {
+    expect(isStrictTransientNetworkError(new Error("socket hang up"))).toBe(true);
+  });
+
+  it("returns true for SSL routines errors", () => {
+    expect(isStrictTransientNetworkError(new Error("ssl routines:OPENSSL_internal"))).toBe(true);
+  });
+
+  it("returns true for error codes embedded in message", () => {
+    expect(isStrictTransientNetworkError(new Error("connect ECONNREFUSED 127.0.0.1:443"))).toBe(
+      true,
+    );
+  });
+
+  it("returns false for broad 'fetch failed' messages", () => {
+    expect(isStrictTransientNetworkError(new TypeError("fetch failed"))).toBe(false);
+  });
+
+  it("returns false for broad 'network error' messages", () => {
+    expect(isStrictTransientNetworkError(new Error("network error"))).toBe(false);
+  });
+
+  it("returns false for regular errors", () => {
+    expect(isStrictTransientNetworkError(new Error("Something went wrong"))).toBe(false);
+    expect(isStrictTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);
+  });
+
+  it.each([null, undefined, "string error", 42])("returns false for non-error input %#", (v) => {
+    expect(isStrictTransientNetworkError(v)).toBe(false);
   });
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -146,6 +146,69 @@ function isConfigError(err: unknown): boolean {
  * Checks if an error is a transient network error that shouldn't crash the gateway.
  * These are typically temporary connectivity issues that will resolve on their own.
  */
+// Strict subset of message snippets that are unambiguously I/O-layer TLS/socket
+// errors. Used by the uncaughtException handler where continuing after a false
+// positive is riskier than in the unhandledRejection path.
+const STRICT_NETWORK_MESSAGE_SNIPPETS = [
+  "client network socket disconnected before secure tls connection was established",
+  "socket hang up",
+  "tlsv1 alert",
+  "ssl routines",
+  "write eproto",
+];
+
+/**
+ * Stricter variant of isTransientNetworkError for the uncaughtException path.
+ * Only matches error codes, error names, and unambiguous TLS/socket messages.
+ * Does NOT match broad patterns like "fetch failed" or "network error" that
+ * could mask application-level bugs.
+ */
+export function isStrictTransientNetworkError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => {
+    const nested: Array<unknown> = [
+      current.cause,
+      current.reason,
+      current.original,
+      current.error,
+      current.data,
+    ];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    return nested;
+  })) {
+    const code = extractErrorCodeOrErrno(candidate);
+    if (code && TRANSIENT_NETWORK_CODES.has(code)) {
+      return true;
+    }
+
+    const name = readErrorName(candidate);
+    if (name && TRANSIENT_NETWORK_ERROR_NAMES.has(name)) {
+      return true;
+    }
+
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const rawMessage = (candidate as { message?: unknown }).message;
+    const message = typeof rawMessage === "string" ? rawMessage.toLowerCase().trim() : "";
+    if (!message) {
+      continue;
+    }
+    if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
+      return true;
+    }
+    if (STRICT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function isTransientNetworkError(err: unknown): boolean {
   if (!err) {
     return false;

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -149,6 +149,15 @@ function isConfigError(err: unknown): boolean {
 // Strict subset of message snippets that are unambiguously I/O-layer TLS/socket
 // errors. Used by the uncaughtException handler where continuing after a false
 // positive is riskier than in the unhandledRejection path.
+// Strict subset of error names that are unambiguously network-layer.
+// Excludes TimeoutError (used for application-level control flow) and
+// AbortError (handled separately by isAbortError).
+const STRICT_NETWORK_ERROR_NAMES = new Set([
+  "ConnectTimeoutError",
+  "HeadersTimeoutError",
+  "BodyTimeoutError",
+]);
+
 const STRICT_NETWORK_MESSAGE_SNIPPETS = [
   "client network socket disconnected before secure tls connection was established",
   "socket hang up",
@@ -186,7 +195,7 @@ export function isStrictTransientNetworkError(err: unknown): boolean {
     }
 
     const name = readErrorName(candidate);
-    if (name && TRANSIENT_NETWORK_ERROR_NAMES.has(name)) {
+    if (name && STRICT_NETWORK_ERROR_NAMES.has(name)) {
       return true;
     }
 


### PR DESCRIPTION
## Summary

The `uncaughtException` handler exits unconditionally on any error, but transient network/TLS errors (e.g. `Client network socket disconnected before secure TLS connection was established`) are non-fatal I/O failures that should not crash the gateway.

The `unhandledRejection` handler already classifies these via `isTransientNetworkError()` and continues gracefully — this PR applies the same logic to `uncaughtException` for symmetry.

### Changes

- **`src/index.ts`**: Add `isTransientNetworkError()` and `isAbortError()` checks to the `uncaughtException` handler, logging a warning instead of exiting. These errors occur in the I/O layer and do not corrupt application state, so continuing is safe.
- **`src/gateway/server-http.ts`**: Attach a fallback `error` listener on raw upgrade sockets to prevent TLS errors from bubbling up as uncaught exceptions in the first place.

## Test plan

- [x] Existing `isTransientNetworkError` / `isAbortError` unit tests pass (33/33)
- [x] All pre-commit checks (lint, format, type-check, boundary checks) pass
- [ ] Verify gateway no longer crashes when network is unstable (manual test with network interruption)

Closes #36585
Closes #35257