### PR TITLE
fix(memory): harden builtin sync and reindex semantics

### DIFF
--- a/src/memory/index.test.ts
+++ b/src/memory/index.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-runtime-mocks.js";
 import type { MemoryIndexManager } from "./index.js";
+import { MemorySyncError } from "./manager-sync-ops.js";
 
 type MemoryIndexModule = typeof import("./index.js");
 
@@ -15,16 +16,18 @@ let closeAllMemorySearchManagers: MemoryIndexModule["closeAllMemorySearchManager
 let embedBatchCalls = 0;
 let embedBatchInputCalls = 0;
 let providerCalls: Array<{ provider?: string; model?: string; outputDimensionality?: number }> = [];
+let embedBatchOverride: ((texts: string[]) => Promise<number[][]>) | undefined;
+
+function embedText(text: string): number[] {
+  const lower = text.toLowerCase();
+  const alpha = lower.split("alpha").length - 1;
+  const beta = lower.split("beta").length - 1;
+  const image = lower.split("image").length - 1;
+  const audio = lower.split("audio").length - 1;
+  return [alpha, beta, image, audio];
+}
 
 vi.mock("./embeddings.js", () => {
-  const embedText = (text: string) => {
-    const lower = text.toLowerCase();
-    const alpha = lower.split("alpha").length - 1;
-    const beta = lower.split("beta").length - 1;
-    const image = lower.split("image").length - 1;
-    const audio = lower.split("audio").length - 1;
-    return [alpha, beta, image, audio];
-  };
   return {
     createEmbeddingProvider: async (options: {
       provider?: string;
@@ -46,6 +49,9 @@ vi.mock("./embeddings.js", () => {
           embedQuery: async (text: string) => embedText(text),
           embedBatch: async (texts: string[]) => {
             embedBatchCalls += 1;
+            if (embedBatchOverride) {
+              return await embedBatchOverride(texts);
+            }
             return texts.map(embedText);
           },
           ...(providerId === "gemini"
@@ -169,6 +175,7 @@ describe("memory index", () => {
     embedBatchCalls = 0;
     embedBatchInputCalls = 0;
     providerCalls = [];
+    embedBatchOverride = undefined;
 
     mkdirSync(memoryDir, { recursive: true });
 
@@ -512,128 +519,6 @@ describe("memory index", () => {
     }
   });
 
-  it("targets explicit session files during post-compaction sync", async () => {
-    const stateDir = path.join(fixtureRoot, `state-targeted-${randomUUID()}`);
-    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
-    const firstSessionPath = path.join(sessionDir, "targeted-first.jsonl");
-    const secondSessionPath = path.join(sessionDir, "targeted-second.jsonl");
-    const storePath = path.join(workspaceDir, `index-targeted-${randomUUID()}.sqlite`);
-    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
-    process.env.OPENCLAW_STATE_DIR = stateDir;
-
-    await fs.mkdir(sessionDir, { recursive: true });
-    await fs.writeFile(
-      firstSessionPath,
-      `${JSON.stringify({
-        type: "message",
-        message: { role: "user", content: [{ type: "text", text: "first transcript v1" }] },
-      })}\n`,
-    );
-    await fs.writeFile(
-      secondSessionPath,
-      `${JSON.stringify({
-        type: "message",
-        message: { role: "user", content: [{ type: "text", text: "second transcript v1" }] },
-      })}\n`,
-    );
-
-    try {
-      const result = await getMemorySearchManager({
-        cfg: createCfg({
-          storePath,
-          sources: ["sessions"],
-          sessionMemory: true,
-        }),
-        agentId: "main",
-      });
-      const manager = requireManager(result);
-      await manager.sync?.({ reason: "test" });
-
-      const db = (
-        manager as unknown as {
-          db: {
-            prepare: (sql: string) => {
-              get: (path: string, source: string) => { hash: string } | undefined;
-              all?: (...args: unknown[]) => unknown;
-            };
-          };
-        }
-      ).db;
-      const getSessionHash = (sessionPath: string) =>
-        db
-          .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
-          .get(sessionPath, "sessions")?.hash;
-
-      const firstOriginalHash = getSessionHash("sessions/targeted-first.jsonl");
-      const secondOriginalHash = getSessionHash("sessions/targeted-second.jsonl");
-
-      await fs.writeFile(
-        firstSessionPath,
-        `${JSON.stringify({
-          type: "message",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "first transcript v2 after compaction" }],
-          },
-        })}\n`,
-      );
-      await fs.writeFile(
-        secondSessionPath,
-        `${JSON.stringify({
-          type: "message",
-          message: {
-            role: "user",
-            content: [{ type: "text", text: "second transcript v2 should stay untouched" }],
-          },
-        })}\n`,
-      );
-
-      const originalPrepare = db.prepare.bind(db);
-      let bulkSessionStateAllCalls = 0;
-      let perFileSessionHashPrepareCalls = 0;
-      db.prepare = ((sql: string) => {
-        const statement = originalPrepare(sql);
-        if (sql === `SELECT path, hash FROM files WHERE source = ?`) {
-          if (!statement.all) {
-            throw new Error("expected sqlite statement.all for bulk session state query");
-          }
-          const bulkAll = statement.all.bind(statement);
-          return {
-            ...statement,
-            all: (...args: unknown[]) => {
-              bulkSessionStateAllCalls += 1;
-              return bulkAll(...args);
-            },
-          };
-        }
-        if (sql === `SELECT hash FROM files WHERE path = ? AND source = ?`) {
-          perFileSessionHashPrepareCalls += 1;
-        }
-        return statement;
-      }) as typeof db.prepare;
-
-      await manager.sync?.({
-        reason: "post-compaction",
-        sessionFiles: [firstSessionPath],
-      });
-
-      db.prepare = originalPrepare;
-
-      expect(getSessionHash("sessions/targeted-first.jsonl")).not.toBe(firstOriginalHash);
-      expect(getSessionHash("sessions/targeted-second.jsonl")).toBe(secondOriginalHash);
-      expect(bulkSessionStateAllCalls).toBe(0);
-      expect(perFileSessionHashPrepareCalls).toBeGreaterThan(0);
-      await manager.close?.();
-    } finally {
-      if (previousStateDir === undefined) {
-        delete process.env.OPENCLAW_STATE_DIR;
-      } else {
-        process.env.OPENCLAW_STATE_DIR = previousStateDir;
-      }
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
-  });
-
   it("preserves unrelated dirty sessions after targeted post-compaction sync", async () => {
     const stateDir = path.join(fixtureRoot, `state-targeted-dirty-${randomUUID()}`);
     const sessionDir = path.join(stateDir, "agents", "main", "sessions");
@@ -730,6 +615,227 @@ describe("memory index", () => {
       await manager.sync({ reason: "test" });
 
       expect(getSessionHash("sessions/targeted-dirty-second.jsonl")).not.toBe(secondOriginalHash);
+      await manager.close?.();
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(storePath, { force: true });
+    }
+  });
+
+  it("surfaces failed targeted session refreshes and retries them later", async () => {
+    const stateDir = path.join(fixtureRoot, `state-targeted-retry-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const sessionPath = path.join(sessionDir, "targeted-retry.jsonl");
+    const storePath = path.join(workspaceDir, `index-targeted-retry-${randomUUID()}.sqlite`);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      sessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "retry transcript v1" }] },
+      })}\n`,
+    );
+
+    try {
+      const manager = requireManager(
+        await getMemorySearchManager({
+          cfg: createCfg({
+            storePath,
+            sources: ["sessions"],
+            sessionMemory: true,
+          }),
+          agentId: "main",
+        }),
+      );
+      await manager.sync({ reason: "test" });
+
+      const db = (
+        manager as unknown as {
+          db: {
+            prepare: (sql: string) => {
+              get: (path: string, source: string) => { hash: string } | undefined;
+            };
+          };
+        }
+      ).db;
+      const getSessionHash = (sessionRelPath: string) =>
+        db
+          .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
+          .get(sessionRelPath, "sessions")?.hash;
+      const originalHash = getSessionHash("sessions/targeted-retry.jsonl");
+
+      await fs.writeFile(
+        sessionPath,
+        `${JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "retry failure trigger after compaction" }],
+          },
+        })}\n`,
+      );
+
+      const internal = manager as unknown as {
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+        db: {
+          prepare: (sql: string) => {
+            run?: (...args: unknown[]) => unknown;
+          };
+        };
+      };
+      const originalPrepare = internal.db.prepare.bind(internal.db);
+      internal.db.prepare = ((sql: string) => {
+        const statement = originalPrepare(sql);
+        if (sql.includes("INSERT INTO chunks") && statement.run) {
+          const originalRun = statement.run.bind(statement);
+          return {
+            ...statement,
+            run: (...args: unknown[]) => {
+              if (args[1] === "sessions/targeted-retry.jsonl" && args[2] === "sessions") {
+                throw new Error("session write failure");
+              }
+              return originalRun(...args);
+            },
+          };
+        }
+        return statement;
+      }) as typeof internal.db.prepare;
+
+      await expect(
+        manager.sync({
+          reason: "post-compaction",
+          sessionFiles: [sessionPath],
+        }),
+      ).rejects.toThrow("session refresh failed");
+
+      expect(getSessionHash("sessions/targeted-retry.jsonl")).toBe(originalHash);
+      expect(internal.sessionsDirtyFiles.has(sessionPath)).toBe(true);
+      expect(internal.sessionsDirty).toBe(true);
+
+      internal.db.prepare = originalPrepare;
+      await manager.sync({ reason: "test" });
+
+      expect(getSessionHash("sessions/targeted-retry.jsonl")).not.toBe(originalHash);
+      expect(internal.sessionsDirtyFiles.has(sessionPath)).toBe(false);
+      expect(internal.sessionsDirty).toBe(false);
+      await manager.close?.();
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(storePath, { force: true });
+    }
+  });
+
+  it("keeps the old session row when a renamed replacement fails during regular sync", async () => {
+    const stateDir = path.join(fixtureRoot, `state-regular-rename-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const beforeSessionPath = path.join(sessionDir, "regular-rename-before.jsonl");
+    const afterSessionPath = path.join(sessionDir, "regular-rename-after.jsonl");
+    const deletedSessionPath = path.join(sessionDir, "regular-unrelated-deleted.jsonl");
+    const storePath = path.join(workspaceDir, `index-regular-rename-${randomUUID()}.sqlite`);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      beforeSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "rename transcript v1" }] },
+      })}\n`,
+    );
+    await fs.writeFile(
+      deletedSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "deleted transcript v1" }] },
+      })}\n`,
+    );
+
+    try {
+      const manager = requireManager(
+        await getMemorySearchManager({
+          cfg: createCfg({
+            storePath,
+            sources: ["sessions"],
+            sessionMemory: true,
+          }),
+          agentId: "main",
+        }),
+      );
+      await manager.sync({ reason: "test" });
+
+      const db = (
+        manager as unknown as {
+          db: {
+            prepare: (sql: string) => {
+              get: (path: string, source: string) => { hash: string } | undefined;
+            };
+          };
+        }
+      ).db;
+      const getSessionHash = (sessionRelPath: string) =>
+        db
+          .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
+          .get(sessionRelPath, "sessions")?.hash;
+      const originalHash = getSessionHash("sessions/regular-rename-before.jsonl");
+      const deletedHash = getSessionHash("sessions/regular-unrelated-deleted.jsonl");
+      expect(originalHash).toBeDefined();
+      expect(deletedHash).toBeDefined();
+
+      await fs.rename(beforeSessionPath, afterSessionPath);
+      await fs.rm(deletedSessionPath, { force: true });
+      await fs.writeFile(
+        afterSessionPath,
+        `${JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "rename transcript v2 after failure" }],
+          },
+        })}\n`,
+      );
+
+      const internal = manager as unknown as {
+        indexFile: (
+          entry: { path: string },
+          options: { source: "memory" | "sessions" },
+        ) => Promise<void>;
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+      };
+      const originalIndexFile = internal.indexFile.bind(manager);
+      internal.indexFile = async (entry, options) => {
+        if (options.source === "sessions" && entry.path === "sessions/regular-rename-after.jsonl") {
+          throw new Error("session write failure");
+        }
+        await originalIndexFile(entry, options);
+      };
+      internal.sessionsDirty = true;
+      internal.sessionsDirtyFiles.add(afterSessionPath);
+
+      await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
+
+      expect(getSessionHash("sessions/regular-rename-before.jsonl")).toBe(originalHash);
+      expect(getSessionHash("sessions/regular-rename-after.jsonl")).toBeUndefined();
+      expect(getSessionHash("sessions/regular-unrelated-deleted.jsonl")).toBeUndefined();
+      expect(internal.sessionsDirtyFiles.has(afterSessionPath)).toBe(true);
+      expect(internal.sessionsDirty).toBe(true);
+
+      internal.indexFile = originalIndexFile;
       await manager.close?.();
     } finally {
       if (previousStateDir === undefined) {
@@ -869,11 +975,10 @@ describe("memory index", () => {
       await manager.sync({ reason: "test" });
 
       const internal = manager as unknown as {
-        syncSessionFiles: (params: {
-          targetSessionFiles?: string[];
-          needsFullReindex: boolean;
-        }) => Promise<void>;
-        shouldFallbackOnError: (message: string) => boolean;
+        indexFile: (
+          entry: { path: string },
+          options: { source: "memory" | "sessions" },
+        ) => Promise<void>;
         activateFallbackProvider: (reason: string) => Promise<boolean>;
         runUnsafeReindex: (params: {
           reason?: string;
@@ -881,18 +986,30 @@ describe("memory index", () => {
           progress?: unknown;
         }) => Promise<void>;
       };
-      const originalSyncSessionFiles = internal.syncSessionFiles.bind(manager);
-      const originalShouldFallbackOnError = internal.shouldFallbackOnError.bind(manager);
+      const originalIndexFile = internal.indexFile.bind(manager);
       const originalActivateFallbackProvider = internal.activateFallbackProvider.bind(manager);
       const originalRunUnsafeReindex = internal.runUnsafeReindex.bind(manager);
 
-      internal.syncSessionFiles = async (params) => {
-        if (params.targetSessionFiles?.length) {
-          throw new Error("embedding backend failed");
+      await fs.writeFile(
+        sessionPath,
+        `${JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "fallback transcript v2" }],
+          },
+        })}\n`,
+      );
+
+      internal.indexFile = async (entry, options) => {
+        if (options.source === "sessions" && entry.path === "sessions/targeted-fallback.jsonl") {
+          throw new MemorySyncError({
+            kind: "provider",
+            message: "embedding backend failed",
+          });
         }
-        return await originalSyncSessionFiles(params);
+        await originalIndexFile(entry, options);
       };
-      internal.shouldFallbackOnError = () => true;
       const activateFallbackProvider = vi.fn(async () => true);
       internal.activateFallbackProvider = activateFallbackProvider;
       const runUnsafeReindex = vi.fn(async () => {});
@@ -910,10 +1027,342 @@ describe("memory index", () => {
         progress: undefined,
       });
 
-      internal.syncSessionFiles = originalSyncSessionFiles;
-      internal.shouldFallbackOnError = originalShouldFallbackOnError;
+      internal.indexFile = originalIndexFile;
       internal.activateFallbackProvider = originalActivateFallbackProvider;
       internal.runUnsafeReindex = originalRunUnsafeReindex;
+      await manager.close?.();
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(storePath, { force: true });
+    }
+  });
+
+  it("does not activate fallback for local embedding cache write failures", async () => {
+    const memoryPath = path.join(memoryDir, "2026-01-15.md");
+    await fs.writeFile(memoryPath, "# Cache\nAlpha cache v1.");
+
+    const manager = await getPersistentManager(
+      createCfg({
+        storePath: path.join(workspaceDir, `index-cache-local-failure-${randomUUID()}.sqlite`),
+        cacheEnabled: true,
+        onSearch: false,
+      }),
+    );
+    const db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            get: (path: string, source: string) => { hash: string } | undefined;
+            run?: (...args: unknown[]) => unknown;
+          };
+        };
+      }
+    ).db;
+    const getMemoryHash = (filePath: string) =>
+      db.prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`).get(filePath, "memory")
+        ?.hash;
+
+    await manager.sync({ reason: "seed" });
+    const originalHash = getMemoryHash("memory/2026-01-15.md");
+    expect(originalHash).toBeDefined();
+
+    await fs.writeFile(memoryPath, "# Cache\nAlpha cache v2.");
+    (manager as unknown as { dirty: boolean }).dirty = true;
+
+    const internal = manager as unknown as {
+      db: {
+        prepare: (sql: string) => {
+          run?: (...args: unknown[]) => unknown;
+        };
+      };
+      activateFallbackProvider: (reason: string) => Promise<boolean>;
+    };
+    const originalPrepare = internal.db.prepare.bind(internal.db);
+    const originalActivateFallbackProvider = internal.activateFallbackProvider.bind(manager);
+    const activateFallbackProvider = vi.fn(async () => false);
+    internal.activateFallbackProvider = activateFallbackProvider;
+    internal.db.prepare = ((sql: string) => {
+      const statement = originalPrepare(sql);
+      if (sql.includes("INSERT INTO embedding_cache") && statement.run) {
+        return {
+          ...statement,
+          run: (..._args: unknown[]) => {
+            throw new Error("cache write failure");
+          },
+        };
+      }
+      return statement;
+    }) as typeof internal.db.prepare;
+
+    await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
+    expect(activateFallbackProvider).not.toHaveBeenCalled();
+    expect(manager.status().dirty).toBe(true);
+    expect(getMemoryHash("memory/2026-01-15.md")).toBe(originalHash);
+
+    internal.db.prepare = originalPrepare;
+    internal.activateFallbackProvider = originalActivateFallbackProvider;
+  });
+
+  it("rethrows readonly cache write failures during incremental sync", async () => {
+    const memoryPath = path.join(memoryDir, "2026-01-16.md");
+    await fs.writeFile(memoryPath, "# Cache\nAlpha readonly v1.");
+
+    const manager = await getPersistentManager(
+      createCfg({
+        storePath: path.join(workspaceDir, `index-cache-readonly-${randomUUID()}.sqlite`),
+        cacheEnabled: true,
+        onSearch: false,
+      }),
+    );
+
+    await manager.sync({ reason: "seed" });
+    await fs.writeFile(memoryPath, "# Cache\nAlpha readonly v2.");
+
+    const internal = manager as unknown as {
+      dirty: boolean;
+      db: {
+        prepare: (sql: string) => {
+          run?: (...args: unknown[]) => unknown;
+        };
+      };
+      runSync: (params?: {
+        reason?: string;
+        force?: boolean;
+        sessionFiles?: string[];
+      }) => Promise<void>;
+    };
+    internal.dirty = true;
+
+    const originalPrepare = internal.db.prepare.bind(internal.db);
+    internal.db.prepare = ((sql: string) => {
+      const statement = originalPrepare(sql);
+      if (sql.includes("INSERT INTO embedding_cache") && statement.run) {
+        return {
+          ...statement,
+          run: (..._args: unknown[]) => {
+            throw new Error("attempt to write a readonly database");
+          },
+        };
+      }
+      return statement;
+    }) as typeof internal.db.prepare;
+
+    await expect(internal.runSync({ reason: "test" })).rejects.toThrow(
+      "attempt to write a readonly database",
+    );
+    expect(manager.status().dirty).toBe(true);
+
+    internal.db.prepare = originalPrepare;
+  });
+
+  it("stops targeted session refreshes after the first provider error", async () => {
+    const stateDir = path.join(fixtureRoot, `state-targeted-stop-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const firstSessionPath = path.join(sessionDir, "targeted-stop-first.jsonl");
+    const secondSessionPath = path.join(sessionDir, "targeted-stop-second.jsonl");
+    const thirdSessionPath = path.join(sessionDir, "targeted-stop-third.jsonl");
+    const storePath = path.join(workspaceDir, `index-targeted-stop-${randomUUID()}.sqlite`);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      firstSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "stop first v1" }] },
+      })}\n`,
+    );
+    await fs.writeFile(
+      secondSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "stop second v1" }] },
+      })}\n`,
+    );
+    await fs.writeFile(
+      thirdSessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "stop third v1" }] },
+      })}\n`,
+    );
+
+    try {
+      const manager = requireManager(
+        await getMemorySearchManager({
+          cfg: createCfg({
+            storePath,
+            sources: ["sessions"],
+            sessionMemory: true,
+          }),
+          agentId: "main",
+        }),
+      );
+      await manager.sync({ reason: "test" });
+
+      await fs.writeFile(
+        firstSessionPath,
+        `${JSON.stringify({
+          type: "message",
+          message: { role: "user", content: [{ type: "text", text: "stop first v2" }] },
+        })}\n`,
+      );
+      await fs.writeFile(
+        secondSessionPath,
+        `${JSON.stringify({
+          type: "message",
+          message: { role: "user", content: [{ type: "text", text: "stop second v2" }] },
+        })}\n`,
+      );
+      await fs.writeFile(
+        thirdSessionPath,
+        `${JSON.stringify({
+          type: "message",
+          message: { role: "user", content: [{ type: "text", text: "stop third v2" }] },
+        })}\n`,
+      );
+
+      const internal = manager as unknown as {
+        indexFile: (
+          entry: { path: string },
+          options: { source: "memory" | "sessions" },
+        ) => Promise<void>;
+        getIndexConcurrency: () => number;
+      };
+      const originalIndexFile = internal.indexFile.bind(manager);
+      const originalGetIndexConcurrency = internal.getIndexConcurrency.bind(manager);
+      const attemptedPaths: string[] = [];
+
+      internal.getIndexConcurrency = () => 1;
+      internal.indexFile = async (entry, options) => {
+        if (options.source !== "sessions") {
+          await originalIndexFile(entry, options);
+          return;
+        }
+        attemptedPaths.push(entry.path);
+        if (entry.path === "sessions/targeted-stop-first.jsonl") {
+          throw new MemorySyncError({
+            kind: "provider",
+            message: "embedding backend failed",
+          });
+        }
+        await originalIndexFile(entry, options);
+      };
+
+      await expect(
+        manager.sync({
+          reason: "post-compaction",
+          sessionFiles: [firstSessionPath, secondSessionPath, thirdSessionPath],
+        }),
+      ).rejects.toMatchObject({
+        kind: "provider",
+        message: "embedding backend failed",
+      });
+      expect(attemptedPaths).toEqual(["sessions/targeted-stop-first.jsonl"]);
+
+      internal.indexFile = originalIndexFile;
+      internal.getIndexConcurrency = originalGetIndexConcurrency;
+      await manager.close?.();
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+      await fs.rm(storePath, { force: true });
+    }
+  });
+
+  it.each([
+    {
+      mode: "targeted",
+      reason: "post-compaction",
+      makeStateDir: () => path.join(fixtureRoot, `state-targeted-deleted-${randomUUID()}`),
+      fileName: "targeted-deleted.jsonl",
+      makeSyncArgs: (sessionPath: string) => ({
+        reason: "post-compaction" as const,
+        sessionFiles: [sessionPath],
+      }),
+    },
+    {
+      mode: "regular",
+      reason: "test",
+      makeStateDir: () => path.join(fixtureRoot, `state-regular-deleted-${randomUUID()}`),
+      fileName: "regular-deleted.jsonl",
+      makeSyncArgs: () => ({ reason: "test" as const }),
+    },
+  ])("clears deleted dirty session files during $mode sync", async (testCase) => {
+    const stateDir = testCase.makeStateDir();
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const sessionPath = path.join(sessionDir, testCase.fileName);
+    const sessionRelPath = `sessions/${testCase.fileName}`;
+    const storePath = path.join(
+      workspaceDir,
+      `index-${testCase.mode}-deleted-${randomUUID()}.sqlite`,
+    );
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      sessionPath,
+      `${JSON.stringify({
+        type: "message",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: `${testCase.mode} deleted transcript v1` }],
+        },
+      })}\n`,
+    );
+
+    try {
+      const manager = requireManager(
+        await getMemorySearchManager({
+          cfg: createCfg({
+            storePath,
+            sources: ["sessions"],
+            sessionMemory: true,
+          }),
+          agentId: "main",
+        }),
+      );
+      await manager.sync({ reason: "test" });
+
+      const db = (
+        manager as unknown as {
+          db: {
+            prepare: (sql: string) => {
+              get: (path: string, source: string) => { hash: string } | undefined;
+            };
+          };
+        }
+      ).db;
+      const getSessionHash = (pathRel: string) =>
+        db.prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`).get(pathRel, "sessions")
+          ?.hash;
+      expect(getSessionHash(sessionRelPath)).toBeDefined();
+
+      await fs.rm(sessionPath, { force: true });
+
+      const internal = manager as unknown as {
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+      };
+      internal.sessionsDirty = true;
+      internal.sessionsDirtyFiles.add(sessionPath);
+
+      await manager.sync(testCase.makeSyncArgs(sessionPath));
+
+      expect(getSessionHash(sessionRelPath)).toBeUndefined();
+      expect(internal.sessionsDirtyFiles.has(sessionPath)).toBe(false);
+      expect(internal.sessionsDirty).toBe(false);
       await manager.close?.();
     } finally {
       if (previousStateDir === undefined) {
@@ -1041,7 +1490,7 @@ describe("memory index", () => {
     let selectSourceFileStatePrepareCalls = 0;
     let perFileHashPrepareCalls = 0;
     db.prepare = ((sql: string) => {
-      if (sql === `SELECT path, hash FROM files WHERE source = ?`) {
+      if (sql === `SELECT path, hash, identity_key FROM files WHERE source = ?`) {
         selectSourceFileStatePrepareCalls += 1;
       }
       if (sql === `SELECT hash FROM files WHERE path = ? AND source = ?`) {
@@ -1260,6 +1709,147 @@ describe("memory index", () => {
 
     await manager.sync({ force: true });
     expect(embedBatchCalls).toBe(afterFirst);
+  });
+
+  it("keeps failed memory files dirty for a later retry", async () => {
+    const memoryPath = path.join(memoryDir, "2026-01-13.md");
+    const stalePath = path.join(memoryDir, "same-path-unrelated-stale.md");
+    await fs.writeFile(memoryPath, "# Bad\nGamma v1.");
+    await fs.writeFile(stalePath, "# Deleted\nThis unrelated stale note should be pruned.");
+
+    const manager = await getPersistentManager(
+      createCfg({
+        storePath: path.join(workspaceDir, `index-skip-failure-${randomUUID()}.sqlite`),
+        onSearch: false,
+      }),
+    );
+    const db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            get: (path: string, source: string) => { hash: string } | undefined;
+          };
+        };
+      }
+    ).db;
+    const getMemoryHash = (memoryPath: string) =>
+      db.prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`).get(memoryPath, "memory")
+        ?.hash;
+    const listMemoryPaths = () =>
+      (
+        db.prepare(`SELECT path FROM files WHERE source = ? ORDER BY path`) as unknown as {
+          all: (source: string) => Array<{ path: string }>;
+        }
+      )
+        .all("memory")
+        .map((row) => row.path);
+
+    await manager.sync({ reason: "seed" });
+    const originalHash = getMemoryHash("memory/2026-01-13.md");
+    expect(originalHash).toBeDefined();
+    expect(listMemoryPaths()).toContain("memory/same-path-unrelated-stale.md");
+    await fs.writeFile(memoryPath, "# Bad\nGamma failure trigger.");
+    await fs.rm(stalePath, { force: true });
+    (manager as unknown as { dirty: boolean }).dirty = true;
+
+    const internal = manager as unknown as {
+      db: {
+        prepare: (sql: string) => {
+          run?: (...args: unknown[]) => unknown;
+        };
+      };
+    };
+    const originalPrepare = internal.db.prepare.bind(internal.db);
+    internal.db.prepare = ((sql: string) => {
+      const statement = originalPrepare(sql);
+      if (sql.includes("INSERT INTO chunks") && statement.run) {
+        const originalRun = statement.run.bind(statement);
+        return {
+          ...statement,
+          run: (...args: unknown[]) => {
+            if (args[1] === "memory/2026-01-13.md" && args[2] === "memory") {
+              throw new Error("file write failure");
+            }
+            return originalRun(...args);
+          },
+        };
+      }
+      return statement;
+    }) as typeof internal.db.prepare;
+
+    await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
+    expect(manager.status().dirty).toBe(true);
+    expect(getMemoryHash("memory/2026-01-13.md")).toBe(originalHash);
+    expect(listMemoryPaths()).not.toContain("memory/same-path-unrelated-stale.md");
+
+    internal.db.prepare = originalPrepare;
+    await manager.sync({ reason: "retry" });
+
+    expect(manager.status().dirty).toBe(false);
+    expect(getMemoryHash("memory/2026-01-13.md")).not.toBe(originalHash);
+  });
+
+  it("keeps the old memory row when a renamed replacement fails to index", async () => {
+    await fs.writeFile(
+      path.join(memoryDir, "unrelated-stale.md"),
+      "# Deleted\nThis stale note should be pruned.",
+    );
+    const manager = await getPersistentManager(
+      createCfg({
+        storePath: path.join(workspaceDir, `index-rename-retry-${randomUUID()}.sqlite`),
+        onSearch: false,
+      }),
+    );
+    const db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            all: (source: string) => Array<{ path: string }>;
+          };
+        };
+      }
+    ).db;
+    const listMemoryPaths = () =>
+      db
+        .prepare(`SELECT path FROM files WHERE source = ? ORDER BY path`)
+        .all("memory")
+        .map((row) => row.path);
+
+    await manager.sync({ reason: "seed" });
+    expect(listMemoryPaths()).toContain("memory/2026-01-12.md");
+    expect(listMemoryPaths()).toContain("memory/unrelated-stale.md");
+
+    await fs.rename(path.join(memoryDir, "2026-01-12.md"), path.join(memoryDir, "2026-01-14.md"));
+    await fs.rm(path.join(memoryDir, "unrelated-stale.md"), { force: true });
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-14.md"),
+      "# Log\nAlpha memory line.\nZebra memory line.",
+    );
+    (manager as unknown as { dirty: boolean }).dirty = true;
+
+    const internal = manager as unknown as {
+      indexFile: (
+        entry: { path: string },
+        options: { source: "memory" | "sessions" },
+      ) => Promise<void>;
+    };
+    const originalIndexFile = internal.indexFile.bind(manager);
+    internal.indexFile = async (entry, options) => {
+      if (options.source === "memory" && entry.path === "memory/2026-01-14.md") {
+        throw new Error("replacement write failed");
+      }
+      await originalIndexFile(entry, options);
+    };
+
+    await expect(manager.sync({ reason: "test" })).resolves.toBeUndefined();
+
+    expect(listMemoryPaths()).toContain("memory/2026-01-12.md");
+    expect(listMemoryPaths()).not.toContain("memory/2026-01-14.md");
+    expect(listMemoryPaths()).not.toContain("memory/unrelated-stale.md");
+    expect(manager.status().dirty).toBe(true);
+
+    internal.indexFile = originalIndexFile;
+    await manager.close?.();
   });
 
   it.skip("finds keyword matches via hybrid search when query embedding is zero", async () => {

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -20,6 +20,7 @@ export type MemoryFileEntry = {
   mtimeMs: number;
   size: number;
   hash: string;
+  identityKey: string | null;
   dataHash?: string;
   kind?: "markdown" | "multimodal";
   contentText?: string;
@@ -185,6 +186,16 @@ export function hashText(value: string): string {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+export function buildFileIdentityKey(stat: {
+  dev?: number | bigint;
+  ino?: number | bigint;
+}): string | null {
+  if (stat.dev === undefined || stat.ino === undefined) {
+    return null;
+  }
+  return `${String(stat.dev)}:${String(stat.ino)}`;
+}
+
 export async function buildFileEntry(
   absPath: string,
   workspaceDir: string,
@@ -200,6 +211,7 @@ export async function buildFileEntry(
     throw err;
   }
   const normalizedPath = path.relative(workspaceDir, absPath).replace(/\\/g, "/");
+  const identityKey = buildFileIdentityKey(stat);
   const multimodalSettings = multimodal ?? DISABLED_MULTIMODAL_SETTINGS;
   const modality = classifyMemoryMultimodalPath(absPath, multimodalSettings);
   if (modality) {
@@ -235,6 +247,7 @@ export async function buildFileEntry(
       mtimeMs: stat.mtimeMs,
       size: stat.size,
       hash: chunkHash,
+      identityKey,
       dataHash,
       kind: "multimodal",
       contentText,
@@ -258,6 +271,7 @@ export async function buildFileEntry(
     mtimeMs: stat.mtimeMs,
     size: stat.size,
     hash,
+    identityKey,
     kind: "markdown",
   };
 }

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -23,7 +23,7 @@ import {
   type MemoryChunk,
   type MemoryFileEntry,
 } from "./internal.js";
-import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
+import { MemoryManagerSyncOps, MemorySyncError } from "./manager-sync-ops.js";
 import type { SessionFileEntry } from "./session-files.js";
 import type { MemorySource } from "./types.js";
 
@@ -51,6 +51,30 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureLastError?: string;
   protected abstract batchFailureLastProvider?: string;
   protected abstract batchFailureLock: Promise<void>;
+
+  private asProviderSyncError(err: unknown): MemorySyncError {
+    if (err instanceof MemorySyncError) {
+      return err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return new MemorySyncError({
+      kind: "provider",
+      message,
+      cause: err,
+    });
+  }
+
+  private asLocalSyncError(err: unknown): MemorySyncError {
+    if (err instanceof MemorySyncError) {
+      return err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return new MemorySyncError({
+      kind: "local",
+      message,
+      cause: err,
+    });
+  }
 
   private buildEmbeddingBatches(chunks: MemoryChunk[]): MemoryChunk[][] {
     const batches: MemoryChunk[][] = [];
@@ -106,20 +130,24 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
 
     const out = new Map<string, number[]>();
-    const baseParams = [this.provider.id, this.provider.model, this.providerKey];
-    const batchSize = 400;
-    for (let start = 0; start < unique.length; start += batchSize) {
-      const batch = unique.slice(start, start + batchSize);
-      const placeholders = batch.map(() => "?").join(", ");
-      const rows = this.db
-        .prepare(
-          `SELECT hash, embedding FROM ${EMBEDDING_CACHE_TABLE}\n` +
-            ` WHERE provider = ? AND model = ? AND provider_key = ? AND hash IN (${placeholders})`,
-        )
-        .all(...baseParams, ...batch) as Array<{ hash: string; embedding: string }>;
-      for (const row of rows) {
-        out.set(row.hash, parseEmbedding(row.embedding));
+    try {
+      const baseParams = [this.provider.id, this.provider.model, this.providerKey];
+      const batchSize = 400;
+      for (let start = 0; start < unique.length; start += batchSize) {
+        const batch = unique.slice(start, start + batchSize);
+        const placeholders = batch.map(() => "?").join(", ");
+        const rows = this.db
+          .prepare(
+            `SELECT hash, embedding FROM ${EMBEDDING_CACHE_TABLE}\n` +
+              ` WHERE provider = ? AND model = ? AND provider_key = ? AND hash IN (${placeholders})`,
+          )
+          .all(...baseParams, ...batch) as Array<{ hash: string; embedding: string }>;
+        for (const row of rows) {
+          out.set(row.hash, parseEmbedding(row.embedding));
+        }
       }
+    } catch (err) {
+      throw this.asLocalSyncError(err);
     }
     return out;
   }
@@ -131,26 +159,30 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (entries.length === 0) {
       return;
     }
-    const now = Date.now();
-    const stmt = this.db.prepare(
-      `INSERT INTO ${EMBEDDING_CACHE_TABLE} (provider, model, provider_key, hash, embedding, dims, updated_at)\n` +
-        ` VALUES (?, ?, ?, ?, ?, ?, ?)\n` +
-        ` ON CONFLICT(provider, model, provider_key, hash) DO UPDATE SET\n` +
-        `   embedding=excluded.embedding,\n` +
-        `   dims=excluded.dims,\n` +
-        `   updated_at=excluded.updated_at`,
-    );
-    for (const entry of entries) {
-      const embedding = entry.embedding ?? [];
-      stmt.run(
-        this.provider.id,
-        this.provider.model,
-        this.providerKey,
-        entry.hash,
-        JSON.stringify(embedding),
-        embedding.length,
-        now,
+    try {
+      const now = Date.now();
+      const stmt = this.db.prepare(
+        `INSERT INTO ${EMBEDDING_CACHE_TABLE} (provider, model, provider_key, hash, embedding, dims, updated_at)\n` +
+          ` VALUES (?, ?, ?, ?, ?, ?, ?)\n` +
+          ` ON CONFLICT(provider, model, provider_key, hash) DO UPDATE SET\n` +
+          `   embedding=excluded.embedding,\n` +
+          `   dims=excluded.dims,\n` +
+          `   updated_at=excluded.updated_at`,
       );
+      for (const entry of entries) {
+        const embedding = entry.embedding ?? [];
+        stmt.run(
+          this.provider.id,
+          this.provider.model,
+          this.providerKey,
+          entry.hash,
+          JSON.stringify(embedding),
+          embedding.length,
+          now,
+        );
+      }
+    } catch (err) {
+      throw this.asLocalSyncError(err);
     }
   }
 
@@ -162,24 +194,28 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!max || max <= 0) {
       return;
     }
-    const row = this.db.prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`).get() as
-      | { c: number }
-      | undefined;
-    const count = row?.c ?? 0;
-    if (count <= max) {
-      return;
+    try {
+      const row = this.db.prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`).get() as
+        | { c: number }
+        | undefined;
+      const count = row?.c ?? 0;
+      if (count <= max) {
+        return;
+      }
+      const excess = count - max;
+      this.db
+        .prepare(
+          `DELETE FROM ${EMBEDDING_CACHE_TABLE}\n` +
+            ` WHERE rowid IN (\n` +
+            `   SELECT rowid FROM ${EMBEDDING_CACHE_TABLE}\n` +
+            `   ORDER BY updated_at ASC\n` +
+            `   LIMIT ?\n` +
+            ` )`,
+        )
+        .run(excess);
+    } catch (err) {
+      throw this.asLocalSyncError(err);
     }
-    const excess = count - max;
-    this.db
-      .prepare(
-        `DELETE FROM ${EMBEDDING_CACHE_TABLE}\n` +
-          ` WHERE rowid IN (\n` +
-          `   SELECT rowid FROM ${EMBEDDING_CACHE_TABLE}\n` +
-          `   ORDER BY updated_at ASC\n` +
-          `   LIMIT ?\n` +
-          ` )`,
-      )
-      .run(excess);
   }
 
   private async embedChunksInBatches(chunks: MemoryChunk[]): Promise<number[][]> {
@@ -204,9 +240,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       const inputs = batch.map((chunk) => chunk.embeddingInput ?? { text: chunk.text });
       const hasStructuredInputs = inputs.some((input) => hasNonTextEmbeddingParts(input));
       if (hasStructuredInputs && !provider.embedBatchInputs) {
-        throw new Error(
-          `Embedding provider "${provider.id}" does not support multimodal memory inputs.`,
-        );
+        throw new MemorySyncError({
+          kind: "provider",
+          message: `Embedding provider "${provider.id}" does not support multimodal memory inputs.`,
+        });
       }
       const batchEmbeddings = hasStructuredInputs
         ? await this.embedBatchInputsWithRetry(inputs)
@@ -219,9 +256,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           toCache.push({ hash: item.chunk.hash, embedding });
         }
       }
+      this.upsertEmbeddingCache(toCache);
+      toCache.length = 0;
       cursor += batch.length;
     }
-    this.upsertEmbeddingCache(toCache);
     return embeddings;
   }
 
@@ -546,7 +584,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         if (!this.isRetryableEmbeddingError(message) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
-          throw err;
+          throw this.asProviderSyncError(err);
         }
         await this.waitForEmbeddingRetry(delayMs, "retrying");
         delayMs *= 2;
@@ -580,7 +618,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         if (!this.isRetryableEmbeddingError(message) || attempt >= EMBEDDING_RETRY_MAX_ATTEMPTS) {
-          throw err;
+          throw this.asProviderSyncError(err);
         }
         await this.waitForEmbeddingRetry(delayMs, "retrying structured batch");
         delayMs *= 2;
@@ -712,11 +750,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         try {
           return await params.run();
         } catch (retryErr) {
-          (retryErr as { batchAttempts?: number }).batchAttempts = 2;
-          throw retryErr;
+          const wrapped = this.asProviderSyncError(retryErr);
+          (wrapped as { batchAttempts?: number }).batchAttempts = 2;
+          throw wrapped;
         }
       }
-      throw err;
+      throw this.asProviderSyncError(err);
     }
   }
 
@@ -780,14 +819,15 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   private upsertFileRecord(entry: MemoryFileEntry | SessionFileEntry, source: MemorySource): void {
     this.db
       .prepare(
-        `INSERT INTO files (path, source, hash, mtime, size) VALUES (?, ?, ?, ?, ?)
+        `INSERT INTO files (path, source, hash, identity_key, mtime, size) VALUES (?, ?, ?, ?, ?, ?)
          ON CONFLICT(path) DO UPDATE SET
            source=excluded.source,
            hash=excluded.hash,
+           identity_key=excluded.identity_key,
            mtime=excluded.mtime,
            size=excluded.size`,
       )
-      .run(entry.path, source, entry.hash, entry.mtimeMs, entry.size);
+      .run(entry.path, source, entry.hash, entry.identityKey, entry.mtimeMs, entry.size);
   }
 
   private deleteFileRecord(pathname: string, source: MemorySource): void {
@@ -812,6 +852,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       });
       return;
     }
+    const provider = this.provider;
 
     let chunks: MemoryChunk[];
     let structuredInputBytes: number | undefined;
@@ -827,7 +868,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     } else {
       const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
       chunks = enforceEmbeddingMaxInputTokens(
-        this.provider,
+        provider,
         chunkMarkdown(content, this.settings.chunking).filter(
           (chunk) => chunk.text.trim().length > 0,
         ),
@@ -852,74 +893,81 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         log.warn("memory embeddings: skipping multimodal file rejected as too large", {
           path: entry.path,
           bytes: structuredInputBytes,
-          provider: this.provider.id,
-          model: this.provider.model,
+          provider: provider.id,
+          model: provider.model,
           error: message,
         });
-        this.clearIndexedFileData(entry.path, options.source);
-        this.upsertFileRecord(entry, options.source);
+        this.withIndexWriteSavepoint(() => {
+          this.clearIndexedFileData(entry.path, options.source);
+          this.upsertFileRecord(entry, options.source);
+        });
         return;
       }
-      throw err;
+      if (err instanceof MemorySyncError) {
+        throw err;
+      }
+      throw this.asLocalSyncError(err);
     }
     const sample = embeddings.find((embedding) => embedding.length > 0);
     const vectorReady = sample ? await this.ensureVectorReady(sample.length) : false;
     const now = Date.now();
-    this.clearIndexedFileData(entry.path, options.source);
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      const embedding = embeddings[i] ?? [];
-      const id = hashText(
-        `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${this.provider.model}`,
-      );
-      this.db
-        .prepare(
-          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(id) DO UPDATE SET
-             hash=excluded.hash,
-             model=excluded.model,
-             text=excluded.text,
-             embedding=excluded.embedding,
-             updated_at=excluded.updated_at`,
-        )
-        .run(
-          id,
-          entry.path,
-          options.source,
-          chunk.startLine,
-          chunk.endLine,
-          chunk.hash,
-          this.provider.model,
-          chunk.text,
-          JSON.stringify(embedding),
-          now,
+    this.withIndexWriteSavepoint(() => {
+      this.clearIndexedFileData(entry.path, options.source);
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
+        const embedding = embeddings[i] ?? [];
+        const id = hashText(
+          `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${provider.model}`,
         );
-      if (vectorReady && embedding.length > 0) {
-        try {
-          this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
-        } catch {}
-        this.db
-          .prepare(`INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`)
-          .run(id, vectorToBlob(embedding));
-      }
-      if (this.fts.enabled && this.fts.available) {
         this.db
           .prepare(
-            `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
-              ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               hash=excluded.hash,
+               model=excluded.model,
+               text=excluded.text,
+               embedding=excluded.embedding,
+               updated_at=excluded.updated_at`,
           )
           .run(
-            chunk.text,
             id,
             entry.path,
             options.source,
-            this.provider.model,
             chunk.startLine,
             chunk.endLine,
+            chunk.hash,
+            provider.model,
+            chunk.text,
+            JSON.stringify(embedding),
+            now,
           );
+        if (vectorReady && embedding.length > 0) {
+          try {
+            this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
+          } catch {}
+          this.db
+            .prepare(`INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`)
+            .run(id, vectorToBlob(embedding));
+        }
+        if (this.fts.enabled && this.fts.available) {
+          this.db
+            .prepare(
+              `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
+                ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            )
+            .run(
+              chunk.text,
+              id,
+              entry.path,
+              options.source,
+              provider.model,
+              chunk.startLine,
+              chunk.endLine,
+            );
+        }
       }
-    }
-    this.upsertFileRecord(entry, options.source);
+      this.upsertFileRecord(entry, options.source);
+    });
   }
 }

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -27,6 +27,7 @@ import {
 } from "./embeddings.js";
 import { isFileMissingError } from "./fs-utils.js";
 import {
+  buildFileIdentityKey,
   buildFileEntry,
   ensureDir,
   hashText,
@@ -69,6 +70,54 @@ type MemorySyncProgressState = {
   report: (update: MemorySyncProgressUpdate) => void;
 };
 
+export class MemorySyncError extends Error {
+  readonly kind: "provider" | "local";
+
+  constructor(params: { kind: "provider" | "local"; message: string; cause?: unknown }) {
+    super(params.message, params.cause === undefined ? undefined : { cause: params.cause });
+    this.name = "MemorySyncError";
+    this.kind = params.kind;
+  }
+}
+
+type MemoryFileSyncResult = {
+  syncedPaths: Set<string>;
+  deletedPaths: Set<string>;
+  retryableLocalFailures: Set<string>;
+  localFailureError?: Error;
+  fatalProviderError?: MemorySyncError;
+  allowCommit: boolean;
+};
+
+type SessionFileSyncResult = {
+  syncedFiles: Set<string>;
+  failedFiles: Set<string>;
+  localFailureError?: Error;
+  fatalProviderError?: MemorySyncError;
+  allowCommit: boolean;
+};
+
+type ReindexVerdict = {
+  allowCommit: boolean;
+  error?: Error;
+};
+
+type IndexedFileStateRow = {
+  path: string;
+  hash: string;
+  identityKey: string | null;
+};
+
+type FailedRefreshCandidate = {
+  replacementPath?: string;
+};
+
+type IndexedFileState = {
+  rows: IndexedFileStateRow[];
+  byPath: Map<string, IndexedFileStateRow>;
+  byIdentityKey: Map<string, IndexedFileStateRow[]>;
+};
+
 const META_KEY = "memory_index_meta_v1";
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
@@ -98,6 +147,122 @@ export function runDetachedMemorySync(sync: () => Promise<void>, reason: "interv
   void sync().catch((err) => {
     log.warn(`memory sync failed (${reason}): ${String(err)}`);
   });
+}
+
+function isProviderSyncError(err: unknown): err is MemorySyncError {
+  if (err instanceof MemorySyncError) {
+    return err.kind === "provider";
+  }
+  return (
+    err instanceof Error &&
+    (err as { name?: unknown; kind?: unknown }).name === "MemorySyncError" &&
+    (err as { kind?: unknown }).kind === "provider"
+  );
+}
+
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+function collectErrorSignals(err: unknown): string[] {
+  const values = new Set<string>();
+  const queue: unknown[] = [err];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      continue;
+    }
+    if (typeof current === "string") {
+      const trimmed = current.trim();
+      if (trimmed) {
+        values.add(trimmed);
+      }
+      continue;
+    }
+    if (current instanceof Error) {
+      if (current.message.trim()) {
+        values.add(current.message);
+      }
+      if (current.name.trim()) {
+        values.add(current.name);
+      }
+      const withCode = current as Error & { code?: unknown; cause?: unknown };
+      if (typeof withCode.code === "string" && withCode.code.trim()) {
+        values.add(withCode.code);
+      }
+      if (withCode.cause) {
+        queue.push(withCode.cause);
+      }
+      continue;
+    }
+    if (typeof current === "object") {
+      const record = current as Record<string, unknown>;
+      for (const key of ["message", "code", "name"]) {
+        const value = record[key];
+        if (typeof value === "string" && value.trim()) {
+          values.add(value);
+        }
+      }
+      if (record.cause) {
+        queue.push(record.cause);
+      }
+    }
+  }
+  return [...values];
+}
+
+function shouldPropagateLocalSyncError(err: unknown): boolean {
+  const signal = collectErrorSignals(err).join("\n");
+  return /SQLITE_|readonly database|read-only|database is locked|database or disk is full|disk full|disk i\/o|ENOSPC/i.test(
+    signal,
+  );
+}
+
+function buildIndexedFileState(rows: IndexedFileStateRow[]): IndexedFileState {
+  const byPath = new Map<string, IndexedFileStateRow>();
+  const byIdentityKey = new Map<string, IndexedFileStateRow[]>();
+  for (const row of rows) {
+    byPath.set(row.path, row);
+    if (!row.identityKey) {
+      continue;
+    }
+    const matches = byIdentityKey.get(row.identityKey);
+    if (matches) {
+      matches.push(row);
+    } else {
+      byIdentityKey.set(row.identityKey, [row]);
+    }
+  }
+  return { rows, byPath, byIdentityKey };
+}
+
+function resolveReplacementPath(params: {
+  currentPath: string;
+  currentIdentityKey: string | null | undefined;
+  existingState?: IndexedFileState | null;
+}): string | undefined {
+  if (!params.currentIdentityKey || !params.existingState) {
+    return undefined;
+  }
+  const matches = params.existingState.byIdentityKey.get(params.currentIdentityKey);
+  if (!matches || matches.length !== 1) {
+    return undefined;
+  }
+  const [match] = matches;
+  if (!match || match.path === params.currentPath) {
+    return undefined;
+  }
+  return match.path;
+}
+
+function selectProtectedStalePaths(failedRefreshes: FailedRefreshCandidate[]): Set<string> {
+  const protectedPaths = new Set<string>();
+  for (const failure of failedRefreshes) {
+    if (failure.replacementPath) {
+      protectedPaths.add(failure.replacementPath);
+    }
+  }
+  return protectedPaths;
 }
 
 export abstract class MemoryManagerSyncOps {
@@ -149,6 +314,7 @@ export abstract class MemoryManagerSyncOps {
     string,
     { lastSize: number; pendingBytes: number; pendingMessages: number }
   >();
+  private indexWriteSavepointCounter = 0;
   private lastMetaSerialized: string | null = null;
 
   protected abstract readonly cache: { enabled: boolean; maxEntries?: number };
@@ -172,6 +338,24 @@ export abstract class MemoryManagerSyncOps {
     entry: MemoryFileEntry | SessionFileEntry,
     options: { source: MemorySource; content?: string },
   ): Promise<void>;
+
+  protected withIndexWriteSavepoint<T>(action: () => T): T {
+    const savepointName = `memory_index_write_${this.indexWriteSavepointCounter++}`;
+    this.db.exec(`SAVEPOINT ${savepointName}`);
+    try {
+      const result = action();
+      this.db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+      return result;
+    } catch (err) {
+      try {
+        this.db.exec(`ROLLBACK TO SAVEPOINT ${savepointName}`);
+      } catch {}
+      try {
+        this.db.exec(`RELEASE SAVEPOINT ${savepointName}`);
+      } catch {}
+      throw err;
+    }
+  }
 
   protected async ensureVectorReady(dimensions?: number): Promise<boolean> {
     if (!this.vector.enabled) {
@@ -649,6 +833,134 @@ export abstract class MemoryManagerSyncOps {
     this.sessionsDirty = this.sessionsDirtyFiles.size > 0;
   }
 
+  private markSessionFilesDirty(sessionFiles?: Iterable<string> | null) {
+    if (!sessionFiles) {
+      return;
+    }
+    for (const sessionFile of sessionFiles) {
+      this.sessionsDirtyFiles.add(sessionFile);
+    }
+    this.sessionsDirty = this.sessionsDirtyFiles.size > 0;
+  }
+
+  private applySessionSyncResult(result: SessionFileSyncResult) {
+    this.markSessionFilesDirty(result.failedFiles);
+    this.clearSyncedSessionFiles(result.syncedFiles);
+  }
+
+  private createReindexVerdict(params: {
+    memoryResult?: MemoryFileSyncResult;
+    sessionResult?: SessionFileSyncResult;
+  }): ReindexVerdict {
+    if (params.memoryResult?.fatalProviderError) {
+      return {
+        allowCommit: false,
+        error: params.memoryResult.fatalProviderError,
+      };
+    }
+    if (params.sessionResult?.fatalProviderError) {
+      return {
+        allowCommit: false,
+        error: params.sessionResult.fatalProviderError,
+      };
+    }
+    if (params.memoryResult && !params.memoryResult.allowCommit) {
+      return {
+        allowCommit: false,
+        error: params.memoryResult.localFailureError ?? new Error("memory reindex failed"),
+      };
+    }
+    if (params.sessionResult && !params.sessionResult.allowCommit) {
+      return {
+        allowCommit: false,
+        error: params.sessionResult.localFailureError ?? new Error("session reindex failed"),
+      };
+    }
+    return { allowCommit: true };
+  }
+
+  private snapshotSyncState(): {
+    dirty: boolean;
+    sessionsDirty: boolean;
+    sessionsDirtyFiles: Set<string>;
+    sessionDeltas: Map<string, { lastSize: number; pendingBytes: number; pendingMessages: number }>;
+    lastMetaSerialized: string | null;
+    vectorDims: number | undefined;
+  } {
+    return {
+      dirty: this.dirty,
+      sessionsDirty: this.sessionsDirty,
+      sessionsDirtyFiles: new Set(this.sessionsDirtyFiles),
+      sessionDeltas: new Map(
+        Array.from(this.sessionDeltas, ([sessionFile, state]) => [sessionFile, { ...state }]),
+      ),
+      lastMetaSerialized: this.lastMetaSerialized,
+      vectorDims: this.vector.dims,
+    };
+  }
+
+  private mergeSessionDeltas(
+    snapshot: ReturnType<MemoryManagerSyncOps["snapshotSyncState"]>["sessionDeltas"],
+    live: ReturnType<MemoryManagerSyncOps["snapshotSyncState"]>["sessionDeltas"],
+  ) {
+    const merged = new Map(
+      Array.from(snapshot, ([sessionFile, state]) => [sessionFile, { ...state }]),
+    );
+    for (const [sessionFile, liveState] of live) {
+      const snapshotState = merged.get(sessionFile);
+      if (!snapshotState) {
+        merged.set(sessionFile, { ...liveState });
+        continue;
+      }
+      merged.set(sessionFile, {
+        // Prefer the older baseline so a rolled-back reindex cannot discard bytes/messages
+        // that arrived while the rebuild was running.
+        lastSize: Math.min(snapshotState.lastSize, liveState.lastSize),
+        pendingBytes: Math.max(snapshotState.pendingBytes, liveState.pendingBytes),
+        pendingMessages: Math.max(snapshotState.pendingMessages, liveState.pendingMessages),
+      });
+    }
+    return merged;
+  }
+
+  private restoreSyncState(
+    snapshot: ReturnType<MemoryManagerSyncOps["snapshotSyncState"]>,
+    liveState?: ReturnType<MemoryManagerSyncOps["snapshotSyncState"]>,
+  ) {
+    this.dirty = snapshot.dirty || liveState?.dirty === true;
+    const mergedDirtyFiles = new Set(snapshot.sessionsDirtyFiles);
+    for (const sessionFile of liveState?.sessionsDirtyFiles ?? []) {
+      mergedDirtyFiles.add(sessionFile);
+    }
+    this.sessionsDirtyFiles = mergedDirtyFiles;
+    this.sessionsDirty =
+      snapshot.sessionsDirty || liveState?.sessionsDirty === true || mergedDirtyFiles.size > 0;
+    this.sessionDeltas = liveState
+      ? this.mergeSessionDeltas(snapshot.sessionDeltas, liveState.sessionDeltas)
+      : new Map(
+          Array.from(snapshot.sessionDeltas, ([sessionFile, state]) => [sessionFile, { ...state }]),
+        );
+    this.lastMetaSerialized = snapshot.lastMetaSerialized;
+    this.vector.dims = snapshot.vectorDims;
+  }
+
+  private restoreRetryStateAfterReindexRollback(params: {
+    memoryReindexStarted?: boolean;
+    sessionReindexStarted?: boolean;
+    sessionResult?: SessionFileSyncResult;
+  }) {
+    if (params.memoryReindexStarted) {
+      this.dirty = true;
+    }
+    if (params.sessionReindexStarted) {
+      this.sessionsDirty = true;
+    }
+    if (params.sessionResult) {
+      this.markSessionFilesDirty(params.sessionResult.syncedFiles);
+      this.markSessionFilesDirty(params.sessionResult.failedFiles);
+    }
+  }
+
   protected ensureIntervalSync() {
     const minutes = this.settings.sync.intervalMinutes;
     if (!minutes || minutes <= 0 || this.intervalTimer) {
@@ -693,21 +1005,31 @@ export abstract class MemoryManagerSyncOps {
     if (needsFullReindex) {
       return true;
     }
-    return this.sessionsDirty && this.sessionsDirtyFiles.size > 0;
+    return this.sessionsDirty;
   }
 
   private async syncMemoryFiles(params: {
     needsFullReindex: boolean;
     progress?: MemorySyncProgressState;
-  }) {
+  }): Promise<MemoryFileSyncResult> {
     // FTS-only mode: skip embedding sync (no provider)
     if (!this.provider) {
       log.debug("Skipping memory file sync in FTS-only mode (no embedding provider)");
-      return;
+      return {
+        syncedPaths: new Set<string>(),
+        deletedPaths: new Set<string>(),
+        retryableLocalFailures: new Set<string>(),
+        allowCommit: true,
+      };
     }
-    const selectSourceFileState = this.db.prepare(`SELECT path, hash FROM files WHERE source = ?`);
+    const selectSourceFileState = this.db.prepare(
+      `SELECT path, hash, identity_key FROM files WHERE source = ?`,
+    );
     const deleteFileByPathAndSource = this.db.prepare(
       `DELETE FROM files WHERE path = ? AND source = ?`,
+    );
+    const updateFileIdentityByPathAndSource = this.db.prepare(
+      `UPDATE files SET identity_key = ?, mtime = ?, size = ? WHERE path = ? AND source = ?`,
     );
     const deleteChunksByPathAndSource = this.db.prepare(
       `DELETE FROM chunks WHERE path = ? AND source = ?`,
@@ -728,27 +1050,72 @@ export abstract class MemoryManagerSyncOps {
       this.settings.extraPaths,
       this.settings.multimodal,
     );
-    const fileEntries = (
-      await runWithConcurrency(
-        files.map(
-          (file) => async () =>
-            await buildFileEntry(file, this.workspaceDir, this.settings.multimodal),
-        ),
-        this.getIndexConcurrency(),
-      )
-    ).filter((entry): entry is MemoryFileEntry => entry !== null);
+    const existingState = buildIndexedFileState(
+      (
+        selectSourceFileState.all("memory") as Array<{
+          path: string;
+          hash: string;
+          identity_key: string | null;
+        }>
+      ).map((row) => ({
+        path: row.path,
+        hash: row.hash,
+        identityKey: row.identity_key,
+      })),
+    );
+    const existingRows = existingState.rows;
+    const fileEntries: MemoryFileEntry[] = [];
+    const activePaths = new Set<string>();
+    const syncedPaths = new Set<string>();
+    const deletedPaths = new Set<string>();
+    const retryableLocalFailures = new Set<string>();
+    const failedRefreshes: FailedRefreshCandidate[] = [];
+    let localFailureError: Error | undefined;
+    let fatalProviderError: MemorySyncError | undefined;
+    let allowPrune = true;
+    await runWithConcurrency(
+      files.map((file) => async () => {
+        try {
+          const entry = await buildFileEntry(file, this.workspaceDir, this.settings.multimodal);
+          if (!entry) {
+            return;
+          }
+          activePaths.add(entry.path);
+          fileEntries.push(entry);
+        } catch (err) {
+          const relPath = path.relative(this.workspaceDir, file).replace(/\\/g, "/");
+          try {
+            const stat = await fs.stat(file);
+            activePaths.add(relPath);
+            retryableLocalFailures.add(relPath);
+            localFailureError ??= toError(err);
+            const replacementPath = resolveReplacementPath({
+              currentPath: relPath,
+              currentIdentityKey: buildFileIdentityKey(stat),
+              existingState,
+            });
+            failedRefreshes.push({
+              replacementPath,
+            });
+            log.warn("memory sync: skipping memory file after read failure", {
+              path: relPath,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          } catch (statErr) {
+            if (!isFileMissingError(statErr)) {
+              throw statErr;
+            }
+          }
+        }
+      }),
+      this.getIndexConcurrency(),
+    );
     log.debug("memory sync: indexing memory files", {
       files: fileEntries.length,
       needsFullReindex: params.needsFullReindex,
       batch: this.batch.enabled,
       concurrency: this.getIndexConcurrency(),
     });
-    const existingRows = selectSourceFileState.all("memory") as Array<{
-      path: string;
-      hash: string;
-    }>;
-    const existingHashes = new Map(existingRows.map((row) => [row.path, row.hash]));
-    const activePaths = new Set(fileEntries.map((entry) => entry.path));
     if (params.progress) {
       params.progress.total += fileEntries.length;
       params.progress.report({
@@ -758,18 +1125,7 @@ export abstract class MemoryManagerSyncOps {
       });
     }
 
-    const tasks = fileEntries.map((entry) => async () => {
-      if (!params.needsFullReindex && existingHashes.get(entry.path) === entry.hash) {
-        if (params.progress) {
-          params.progress.completed += 1;
-          params.progress.report({
-            completed: params.progress.completed,
-            total: params.progress.total,
-          });
-        }
-        return;
-      }
-      await this.indexFile(entry, { source: "memory" });
+    const reportProgress = () => {
       if (params.progress) {
         params.progress.completed += 1;
         params.progress.report({
@@ -777,42 +1133,127 @@ export abstract class MemoryManagerSyncOps {
           total: params.progress.total,
         });
       }
+    };
+    const tasks = fileEntries.map((entry) => async () => {
+      try {
+        const existingRow = existingState.byPath.get(entry.path);
+        if (!params.needsFullReindex && existingRow?.hash === entry.hash) {
+          if (existingRow.identityKey !== entry.identityKey) {
+            updateFileIdentityByPathAndSource.run(
+              entry.identityKey,
+              entry.mtimeMs,
+              entry.size,
+              entry.path,
+              "memory",
+            );
+          }
+          syncedPaths.add(entry.path);
+          return;
+        }
+        try {
+          await this.indexFile(entry, { source: "memory" });
+          syncedPaths.add(entry.path);
+        } catch (err) {
+          if (isProviderSyncError(err)) {
+            fatalProviderError ??= err;
+            allowPrune = false;
+            // Rethrow so runWithConcurrency stops scheduling more files.
+            throw err;
+          }
+          if (shouldPropagateLocalSyncError(err)) {
+            throw err;
+          }
+          const reason = err instanceof Error ? err.message : String(err);
+          retryableLocalFailures.add(entry.path);
+          localFailureError ??= toError(err);
+          const replacementPath = resolveReplacementPath({
+            currentPath: entry.path,
+            currentIdentityKey: entry.identityKey,
+            existingState,
+          });
+          failedRefreshes.push({
+            replacementPath,
+          });
+          log.warn("memory sync: skipping memory file after index failure", {
+            path: entry.path,
+            error: reason,
+          });
+        }
+      } finally {
+        reportProgress();
+      }
     });
-    await runWithConcurrency(tasks, this.getIndexConcurrency());
+    try {
+      await runWithConcurrency(tasks, this.getIndexConcurrency());
+    } catch (err) {
+      if (!isProviderSyncError(err)) {
+        throw err;
+      }
+      fatalProviderError ??= err;
+      allowPrune = false;
+    }
 
-    for (const stale of existingRows) {
-      if (activePaths.has(stale.path)) {
-        continue;
-      }
-      deleteFileByPathAndSource.run(stale.path, "memory");
-      if (deleteVectorRowsByPathAndSource) {
-        try {
-          deleteVectorRowsByPathAndSource.run(stale.path, "memory");
-        } catch {}
-      }
-      deleteChunksByPathAndSource.run(stale.path, "memory");
-      if (deleteFtsRowsByPathSourceAndModel) {
-        try {
-          deleteFtsRowsByPathSourceAndModel.run(stale.path, "memory", this.provider.model);
-        } catch {}
+    if (allowPrune) {
+      const staleRows = existingRows.filter((stale) => !activePaths.has(stale.path));
+      const protectedStalePaths = selectProtectedStalePaths(failedRefreshes);
+      for (const stale of staleRows) {
+        if (protectedStalePaths.has(stale.path)) {
+          continue;
+        }
+        deleteFileByPathAndSource.run(stale.path, "memory");
+        if (deleteVectorRowsByPathAndSource) {
+          try {
+            deleteVectorRowsByPathAndSource.run(stale.path, "memory");
+          } catch {}
+        }
+        deleteChunksByPathAndSource.run(stale.path, "memory");
+        if (deleteFtsRowsByPathSourceAndModel) {
+          try {
+            deleteFtsRowsByPathSourceAndModel.run(stale.path, "memory", this.provider.model);
+          } catch {}
+        }
+        deletedPaths.add(stale.path);
       }
     }
+
+    return {
+      syncedPaths,
+      deletedPaths,
+      retryableLocalFailures,
+      localFailureError,
+      fatalProviderError,
+      allowCommit: !fatalProviderError && retryableLocalFailures.size === 0,
+    };
   }
 
   private async syncSessionFiles(params: {
     needsFullReindex: boolean;
     targetSessionFiles?: string[];
     progress?: MemorySyncProgressState;
-  }) {
+  }): Promise<SessionFileSyncResult> {
+    const syncedFiles = new Set<string>();
+    const failedFiles = new Set<string>();
+    const failedRefreshes: FailedRefreshCandidate[] = [];
+    let localFailureError: Error | undefined;
+    let fatalProviderError: MemorySyncError | undefined;
+    let allowPrune = true;
     // FTS-only mode: skip embedding sync (no provider)
     if (!this.provider) {
       log.debug("Skipping session file sync in FTS-only mode (no embedding provider)");
-      return;
+      return { syncedFiles, failedFiles, allowCommit: true };
     }
-    const selectFileHash = this.db.prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`);
-    const selectSourceFileState = this.db.prepare(`SELECT path, hash FROM files WHERE source = ?`);
+    const providerModel = this.provider.model;
+    const selectFileHash = this.db.prepare(
+      `SELECT hash, identity_key FROM files WHERE path = ? AND source = ?`,
+    );
+    const selectSourceFileState = this.db.prepare(
+      `SELECT path, hash, identity_key FROM files WHERE source = ?`,
+    );
     const deleteFileByPathAndSource = this.db.prepare(
       `DELETE FROM files WHERE path = ? AND source = ?`,
+    );
+    const updateFileIdentityByPathAndSource = this.db.prepare(
+      `UPDATE files SET identity_key = ?, mtime = ?, size = ? WHERE path = ? AND source = ?`,
     );
     const deleteChunksByPathAndSource = this.db.prepare(
       `DELETE FROM chunks WHERE path = ? AND source = ?`,
@@ -837,15 +1278,23 @@ export abstract class MemoryManagerSyncOps {
     const activePaths = targetSessionFiles
       ? null
       : new Set(files.map((file) => sessionPathForFile(file)));
-    const existingRows =
+    const existingState =
       activePaths === null
         ? null
-        : (selectSourceFileState.all("sessions") as Array<{
-            path: string;
-            hash: string;
-          }>);
-    const existingHashes =
-      existingRows === null ? null : new Map(existingRows.map((row) => [row.path, row.hash]));
+        : buildIndexedFileState(
+            (
+              selectSourceFileState.all("sessions") as Array<{
+                path: string;
+                hash: string;
+                identity_key: string | null;
+              }>
+            ).map((row) => ({
+              path: row.path,
+              hash: row.hash,
+              identityKey: row.identity_key,
+            })),
+          );
+    const existingRows = existingState?.rows ?? null;
     const indexAll =
       params.needsFullReindex || Boolean(targetSessionFiles) || this.sessionsDirtyFiles.size === 0;
     log.debug("memory sync: indexing session files", {
@@ -865,50 +1314,7 @@ export abstract class MemoryManagerSyncOps {
       });
     }
 
-    const tasks = files.map((absPath) => async () => {
-      if (!indexAll && !this.sessionsDirtyFiles.has(absPath)) {
-        if (params.progress) {
-          params.progress.completed += 1;
-          params.progress.report({
-            completed: params.progress.completed,
-            total: params.progress.total,
-          });
-        }
-        return;
-      }
-      const entry = await buildSessionEntry(absPath);
-      if (!entry) {
-        if (params.progress) {
-          params.progress.completed += 1;
-          params.progress.report({
-            completed: params.progress.completed,
-            total: params.progress.total,
-          });
-        }
-        return;
-      }
-      const existingHash =
-        existingHashes?.get(entry.path) ??
-        (
-          selectFileHash.get(entry.path, "sessions") as
-            | {
-                hash: string;
-              }
-            | undefined
-        )?.hash;
-      if (!params.needsFullReindex && existingHash === entry.hash) {
-        if (params.progress) {
-          params.progress.completed += 1;
-          params.progress.report({
-            completed: params.progress.completed,
-            total: params.progress.total,
-          });
-        }
-        this.resetSessionDelta(absPath, entry.size);
-        return;
-      }
-      await this.indexFile(entry, { source: "sessions", content: entry.content });
-      this.resetSessionDelta(absPath, entry.size);
+    const reportProgress = () => {
       if (params.progress) {
         params.progress.completed += 1;
         params.progress.report({
@@ -916,32 +1322,172 @@ export abstract class MemoryManagerSyncOps {
           total: params.progress.total,
         });
       }
+    };
+    const tasks = files.map((absPath) => async () => {
+      try {
+        if (!indexAll && !this.sessionsDirtyFiles.has(absPath)) {
+          return;
+        }
+        const entry = await buildSessionEntry(absPath);
+        if (!entry) {
+          try {
+            const stat = await fs.stat(absPath);
+            failedFiles.add(absPath);
+            localFailureError ??= new Error(`Failed reading session file ${absPath}`);
+            const sessionPath = sessionPathForFile(absPath);
+            const replacementPath = resolveReplacementPath({
+              currentPath: sessionPath,
+              currentIdentityKey: buildFileIdentityKey(stat),
+              existingState,
+            });
+            failedRefreshes.push({
+              replacementPath,
+            });
+          } catch (err) {
+            if (!isFileMissingError(err)) {
+              throw err;
+            }
+            const sessionPath = sessionPathForFile(absPath);
+            deleteFileByPathAndSource.run(sessionPath, "sessions");
+            if (deleteVectorRowsByPathAndSource) {
+              try {
+                deleteVectorRowsByPathAndSource.run(sessionPath, "sessions");
+              } catch {}
+            }
+            deleteChunksByPathAndSource.run(sessionPath, "sessions");
+            if (deleteFtsRowsByPathSourceAndModel) {
+              try {
+                deleteFtsRowsByPathSourceAndModel.run(sessionPath, "sessions", providerModel);
+              } catch {}
+            }
+            this.sessionDeltas.delete(absPath);
+            syncedFiles.add(absPath);
+          }
+          return;
+        }
+        const existingRow =
+          existingState?.byPath.get(entry.path) ??
+          (() => {
+            const row = selectFileHash.get(entry.path, "sessions") as
+              | {
+                  hash: string;
+                  identity_key: string | null;
+                }
+              | undefined;
+            if (!row) {
+              return undefined;
+            }
+            return {
+              path: entry.path,
+              hash: row.hash,
+              identityKey: row.identity_key,
+            };
+          })();
+        if (!params.needsFullReindex && existingRow?.hash === entry.hash) {
+          if (!existingState || existingRow.identityKey !== entry.identityKey) {
+            updateFileIdentityByPathAndSource.run(
+              entry.identityKey,
+              entry.mtimeMs,
+              entry.size,
+              entry.path,
+              "sessions",
+            );
+          }
+          this.resetSessionDelta(absPath, entry.size);
+          syncedFiles.add(absPath);
+          return;
+        }
+        try {
+          await this.indexFile(entry, { source: "sessions", content: entry.content });
+          this.resetSessionDelta(absPath, entry.size);
+          syncedFiles.add(absPath);
+        } catch (err) {
+          if (isProviderSyncError(err)) {
+            fatalProviderError ??= err;
+            allowPrune = false;
+            // Rethrow so runWithConcurrency stops scheduling more files.
+            throw err;
+          }
+          if (shouldPropagateLocalSyncError(err)) {
+            throw err;
+          }
+          const reason = err instanceof Error ? err.message : String(err);
+          failedFiles.add(absPath);
+          localFailureError ??= toError(err);
+          const replacementPath = resolveReplacementPath({
+            currentPath: entry.path,
+            currentIdentityKey: entry.identityKey,
+            existingState,
+          });
+          failedRefreshes.push({
+            replacementPath,
+          });
+          log.warn("memory sync: skipping session file after index failure", {
+            path: entry.path,
+            error: reason,
+          });
+        }
+      } finally {
+        reportProgress();
+      }
     });
-    await runWithConcurrency(tasks, this.getIndexConcurrency());
+    try {
+      await runWithConcurrency(tasks, this.getIndexConcurrency());
+    } catch (err) {
+      if (!isProviderSyncError(err)) {
+        throw err;
+      }
+      fatalProviderError ??= err;
+      allowPrune = false;
+    }
 
     if (activePaths === null) {
       // Targeted syncs only refresh the requested transcripts and should not
       // prune unrelated session rows without a full directory enumeration.
-      return;
+      return {
+        syncedFiles,
+        failedFiles,
+        localFailureError,
+        fatalProviderError,
+        allowCommit: !fatalProviderError && failedFiles.size === 0,
+      };
     }
 
-    for (const stale of existingRows ?? []) {
-      if (activePaths.has(stale.path)) {
-        continue;
-      }
-      deleteFileByPathAndSource.run(stale.path, "sessions");
-      if (deleteVectorRowsByPathAndSource) {
-        try {
-          deleteVectorRowsByPathAndSource.run(stale.path, "sessions");
-        } catch {}
-      }
-      deleteChunksByPathAndSource.run(stale.path, "sessions");
-      if (deleteFtsRowsByPathSourceAndModel) {
-        try {
-          deleteFtsRowsByPathSourceAndModel.run(stale.path, "sessions", this.provider.model);
-        } catch {}
+    if (allowPrune) {
+      const staleRows = (existingRows ?? []).filter((stale) => !activePaths.has(stale.path));
+      const protectedStalePaths = selectProtectedStalePaths(failedRefreshes);
+      for (const stale of staleRows) {
+        if (protectedStalePaths.has(stale.path)) {
+          continue;
+        }
+        const staleAbsPath = path.join(
+          resolveSessionTranscriptsDirForAgent(this.agentId),
+          path.basename(stale.path),
+        );
+        deleteFileByPathAndSource.run(stale.path, "sessions");
+        if (deleteVectorRowsByPathAndSource) {
+          try {
+            deleteVectorRowsByPathAndSource.run(stale.path, "sessions");
+          } catch {}
+        }
+        deleteChunksByPathAndSource.run(stale.path, "sessions");
+        if (deleteFtsRowsByPathSourceAndModel) {
+          try {
+            deleteFtsRowsByPathSourceAndModel.run(stale.path, "sessions", providerModel);
+          } catch {}
+        }
+        this.sessionDeltas.delete(staleAbsPath);
+        syncedFiles.add(staleAbsPath);
       }
     }
+
+    return {
+      syncedFiles,
+      failedFiles,
+      localFailureError,
+      fatalProviderError,
+      allowCommit: !fatalProviderError && failedFiles.size === 0,
+    };
   }
 
   private createSyncProgress(
@@ -993,16 +1539,24 @@ export abstract class MemoryManagerSyncOps {
       // Post-compaction refreshes should only update the explicit transcript files and
       // leave broader reindex/dirty-work decisions to the regular sync path.
       try {
-        await this.syncSessionFiles({
+        const result = await this.syncSessionFiles({
           needsFullReindex: false,
           targetSessionFiles: Array.from(targetSessionFiles),
           progress: progress ?? undefined,
         });
-        this.clearSyncedSessionFiles(targetSessionFiles);
+        if (result.fatalProviderError) {
+          throw result.fatalProviderError;
+        }
+        this.applySessionSyncResult(result);
+        if (result.failedFiles.size > 0) {
+          throw new MemorySyncError({
+            kind: "local",
+            message: "session refresh failed",
+          });
+        }
       } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
         const activated =
-          this.shouldFallbackOnError(reason) && (await this.activateFallbackProvider(reason));
+          isProviderSyncError(err) && (await this.activateFallbackProvider(err.message));
         if (activated) {
           if (
             process.env.OPENCLAW_TEST_FAST === "1" &&
@@ -1064,27 +1618,34 @@ export abstract class MemoryManagerSyncOps {
       const shouldSyncSessions = this.shouldSyncSessions(params, needsFullReindex);
 
       if (shouldSyncMemory) {
-        await this.syncMemoryFiles({ needsFullReindex, progress: progress ?? undefined });
-        this.dirty = false;
+        const result = await this.syncMemoryFiles({
+          needsFullReindex,
+          progress: progress ?? undefined,
+        });
+        if (result.fatalProviderError) {
+          throw result.fatalProviderError;
+        }
+        this.dirty = result.retryableLocalFailures.size > 0;
       }
 
       if (shouldSyncSessions) {
-        await this.syncSessionFiles({
+        const result = await this.syncSessionFiles({
           needsFullReindex,
           targetSessionFiles: targetSessionFiles ? Array.from(targetSessionFiles) : undefined,
           progress: progress ?? undefined,
         });
-        this.sessionsDirty = false;
-        this.sessionsDirtyFiles.clear();
+        if (result.fatalProviderError) {
+          throw result.fatalProviderError;
+        }
+        this.applySessionSyncResult(result);
       } else if (this.sessionsDirtyFiles.size > 0) {
         this.sessionsDirty = true;
       } else {
         this.sessionsDirty = false;
       }
     } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
       const activated =
-        this.shouldFallbackOnError(reason) && (await this.activateFallbackProvider(reason));
+        isProviderSyncError(err) && (await this.activateFallbackProvider(err.message));
       if (activated) {
         await this.runSafeReindex({
           reason: params?.reason ?? "fallback",
@@ -1095,10 +1656,6 @@ export abstract class MemoryManagerSyncOps {
       }
       throw err;
     }
-  }
-
-  private shouldFallbackOnError(message: string): boolean {
-    return /embedding|embeddings|batch/i.test(message);
   }
 
   protected resolveBatchConfig(): {
@@ -1198,6 +1755,7 @@ export abstract class MemoryManagerSyncOps {
       vectorDims: this.vector.dims,
       vectorReady: this.vectorReady,
     };
+    const originalSyncState = this.snapshotSyncState();
 
     const restoreOriginalState = () => {
       if (originalDbClosed) {
@@ -1223,6 +1781,10 @@ export abstract class MemoryManagerSyncOps {
     this.ensureSchema();
 
     let nextMeta: MemoryIndexMeta | null = null;
+    let memoryResult: MemoryFileSyncResult | undefined;
+    let sessionResult: SessionFileSyncResult | undefined;
+    let memoryReindexStarted = false;
+    let sessionReindexStarted = false;
 
     try {
       this.seedEmbeddingCache(originalDb);
@@ -1233,14 +1795,35 @@ export abstract class MemoryManagerSyncOps {
       );
 
       if (shouldSyncMemory) {
-        await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
-        this.dirty = false;
+        memoryReindexStarted = true;
+        memoryResult = await this.syncMemoryFiles({
+          needsFullReindex: true,
+          progress: params.progress,
+        });
       }
 
       if (shouldSyncSessions) {
-        await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
-        this.sessionsDirty = false;
-        this.sessionsDirtyFiles.clear();
+        sessionReindexStarted = true;
+        sessionResult = await this.syncSessionFiles({
+          needsFullReindex: true,
+          progress: params.progress,
+        });
+      }
+
+      const verdict = this.createReindexVerdict({
+        memoryResult,
+        sessionResult,
+      });
+      if (!verdict.allowCommit) {
+        throw verdict.error;
+      }
+
+      if (memoryResult) {
+        this.dirty = memoryResult.retryableLocalFailures.size > 0;
+      }
+
+      if (sessionResult) {
+        this.applySessionSyncResult(sessionResult);
       } else if (this.sessionsDirtyFiles.size > 0) {
         this.sessionsDirty = true;
       } else {
@@ -1280,11 +1863,18 @@ export abstract class MemoryManagerSyncOps {
       this.ensureSchema();
       this.vector.dims = nextMeta?.vectorDims;
     } catch (err) {
+      const liveSyncState = this.snapshotSyncState();
       try {
         this.db.close();
       } catch {}
       await this.removeIndexFiles(tempDbPath);
       restoreOriginalState();
+      this.restoreSyncState(originalSyncState, liveSyncState);
+      this.restoreRetryStateAfterReindexRollback({
+        memoryReindexStarted,
+        sessionReindexStarted,
+        sessionResult,
+      });
       throw err;
     }
   }
@@ -1296,44 +1886,87 @@ export abstract class MemoryManagerSyncOps {
   }): Promise<void> {
     // Perf: for test runs, skip atomic temp-db swapping. The index is isolated
     // under the per-test HOME anyway, and this cuts substantial fs+sqlite churn.
-    this.resetIndex();
+    const originalSyncState = this.snapshotSyncState();
+    let memoryResult: MemoryFileSyncResult | undefined;
+    let sessionResult: SessionFileSyncResult | undefined;
+    let memoryReindexStarted = false;
+    let sessionReindexStarted = false;
 
-    const shouldSyncMemory = this.sources.has("memory");
-    const shouldSyncSessions = this.shouldSyncSessions(
-      { reason: params.reason, force: params.force },
-      true,
-    );
+    this.db.exec("BEGIN");
+    try {
+      this.resetIndex();
 
-    if (shouldSyncMemory) {
-      await this.syncMemoryFiles({ needsFullReindex: true, progress: params.progress });
-      this.dirty = false;
+      const shouldSyncMemory = this.sources.has("memory");
+      const shouldSyncSessions = this.shouldSyncSessions(
+        { reason: params.reason, force: params.force },
+        true,
+      );
+
+      if (shouldSyncMemory) {
+        memoryReindexStarted = true;
+        memoryResult = await this.syncMemoryFiles({
+          needsFullReindex: true,
+          progress: params.progress,
+        });
+      }
+
+      if (shouldSyncSessions) {
+        sessionReindexStarted = true;
+        sessionResult = await this.syncSessionFiles({
+          needsFullReindex: true,
+          progress: params.progress,
+        });
+      }
+
+      const verdict = this.createReindexVerdict({
+        memoryResult,
+        sessionResult,
+      });
+      if (!verdict.allowCommit) {
+        throw verdict.error;
+      }
+
+      if (memoryResult) {
+        this.dirty = memoryResult.retryableLocalFailures.size > 0;
+      }
+
+      if (sessionResult) {
+        this.applySessionSyncResult(sessionResult);
+      } else if (this.sessionsDirtyFiles.size > 0) {
+        this.sessionsDirty = true;
+      } else {
+        this.sessionsDirty = false;
+      }
+
+      const nextMeta: MemoryIndexMeta = {
+        model: this.provider?.model ?? "fts-only",
+        provider: this.provider?.id ?? "none",
+        providerKey: this.providerKey!,
+        sources: this.resolveConfiguredSourcesForMeta(),
+        scopeHash: this.resolveConfiguredScopeHash(),
+        chunkTokens: this.settings.chunking.tokens,
+        chunkOverlap: this.settings.chunking.overlap,
+      };
+      if (this.vector.available && this.vector.dims) {
+        nextMeta.vectorDims = this.vector.dims;
+      }
+
+      this.writeMeta(nextMeta);
+      this.pruneEmbeddingCacheIfNeeded?.();
+      this.db.exec("COMMIT");
+    } catch (err) {
+      const liveSyncState = this.snapshotSyncState();
+      try {
+        this.db.exec("ROLLBACK");
+      } catch {}
+      this.restoreSyncState(originalSyncState, liveSyncState);
+      this.restoreRetryStateAfterReindexRollback({
+        memoryReindexStarted,
+        sessionReindexStarted,
+        sessionResult,
+      });
+      throw err;
     }
-
-    if (shouldSyncSessions) {
-      await this.syncSessionFiles({ needsFullReindex: true, progress: params.progress });
-      this.sessionsDirty = false;
-      this.sessionsDirtyFiles.clear();
-    } else if (this.sessionsDirtyFiles.size > 0) {
-      this.sessionsDirty = true;
-    } else {
-      this.sessionsDirty = false;
-    }
-
-    const nextMeta: MemoryIndexMeta = {
-      model: this.provider?.model ?? "fts-only",
-      provider: this.provider?.id ?? "none",
-      providerKey: this.providerKey!,
-      sources: this.resolveConfiguredSourcesForMeta(),
-      scopeHash: this.resolveConfiguredScopeHash(),
-      chunkTokens: this.settings.chunking.tokens,
-      chunkOverlap: this.settings.chunking.overlap,
-    };
-    if (this.vector.available && this.vector.dims) {
-      nextMeta.vectorDims = this.vector.dims;
-    }
-
-    this.writeMeta(nextMeta);
-    this.pruneEmbeddingCacheIfNeeded?.();
   }
 
   private resetIndex() {

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -80,6 +80,10 @@ export class MemorySyncError extends Error {
   }
 }
 
+const isPromiseLike = (value: unknown): value is PromiseLike<unknown> =>
+  ((typeof value === "object" && value !== null) || typeof value === "function") &&
+  typeof (value as { then?: unknown }).then === "function";
+
 type MemoryFileSyncResult = {
   syncedPaths: Set<string>;
   deletedPaths: Set<string>;
@@ -344,6 +348,9 @@ export abstract class MemoryManagerSyncOps {
     this.db.exec(`SAVEPOINT ${savepointName}`);
     try {
       const result = action();
+      if (isPromiseLike(result)) {
+        throw new Error("withIndexWriteSavepoint only supports synchronous actions");
+      }
       this.db.exec(`RELEASE SAVEPOINT ${savepointName}`);
       return result;
     } catch (err) {
@@ -956,6 +963,13 @@ export abstract class MemoryManagerSyncOps {
       this.sessionsDirty = true;
     }
     if (params.sessionResult) {
+      if (params.sessionResult.fatalProviderError) {
+        // A provider interruption can stop scheduling mid-reindex, so the partial
+        // synced/failed sets are not a trustworthy coverage list for the next retry.
+        this.sessionsDirtyFiles.clear();
+        this.sessionsDirty = true;
+        return;
+      }
       this.markSessionFilesDirty(params.sessionResult.syncedFiles);
       this.markSessionFilesDirty(params.sessionResult.failedFiles);
     }

--- a/src/memory/manager.atomic-reindex.test.ts
+++ b/src/memory/manager.atomic-reindex.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -5,11 +6,12 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { OpenClawConfig } from "../config/config.js";
 import type { MemoryIndexManager } from "./index.js";
 
-let shouldFail = false;
+let failPattern: string | null = null;
 
 type EmbeddingTestMocksModule = typeof import("./embedding.test-mocks.js");
 type TestManagerHelpersModule = typeof import("./test-manager-helpers.js");
 type MemoryIndexModule = typeof import("./index.js");
+type TestMemorySource = "memory" | "sessions";
 
 describe("memory manager atomic reindex", () => {
   let fixtureRoot = "";
@@ -35,9 +37,9 @@ describe("memory manager atomic reindex", () => {
     ({ closeAllMemorySearchManagers } = await import("./index.js"));
     vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "0");
     resetEmbeddingMocks();
-    shouldFail = false;
+    failPattern = null;
     embedBatch.mockImplementation(async (texts: string[]) => {
-      if (shouldFail) {
+      if (failPattern && texts.some((text) => text.includes(failPattern!))) {
         throw new Error("embedding failure");
       }
       return texts.map((_, index) => [index + 1, 0, 0]);
@@ -47,6 +49,7 @@ describe("memory manager atomic reindex", () => {
     indexPath = path.join(workspaceDir, "index.sqlite");
     await fs.mkdir(path.join(workspaceDir, "memory"));
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Hello memory.");
+    await fs.writeFile(path.join(workspaceDir, "memory", "broken.md"), "Broken memory.");
   });
 
   afterEach(async () => {
@@ -65,8 +68,8 @@ describe("memory manager atomic reindex", () => {
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 
-  it("keeps the prior index when a full reindex fails", async () => {
-    const cfg = {
+  const createCfg = (params?: { sources?: TestMemorySource[] }) =>
+    ({
       agents: {
         defaults: {
           workspace: workspaceDir,
@@ -78,22 +81,359 @@ describe("memory manager atomic reindex", () => {
             // Perf: keep test indexes to a single chunk to reduce sqlite work.
             chunking: { tokens: 4000, overlap: 0 },
             sync: { watch: false, onSessionStart: false, onSearch: false },
+            ...(params?.sources
+              ? {
+                  sources: params.sources,
+                  experimental: { sessionMemory: true },
+                }
+              : {}),
           },
         },
         list: [{ id: "main", default: true }],
       },
-    } as OpenClawConfig;
+    }) as OpenClawConfig;
 
-    manager = await getRequiredMemoryIndexManager({ cfg, agentId: "main" });
+  const createManager = async (params?: { sources?: TestMemorySource[] }) => {
+    manager = await getRequiredMemoryIndexManager({
+      cfg: createCfg(params),
+      agentId: "main",
+    });
+    return manager;
+  };
+
+  const writeTranscript = async (filePath: string, text: string) => {
+    await fs.writeFile(
+      filePath,
+      `${JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text }] },
+      })}\n`,
+    );
+  };
+
+  it("preserves the previous index when a safe full reindex fails", async () => {
+    manager = await createManager();
 
     await manager.sync({ force: true });
     const beforeStatus = manager.status();
+    expect(beforeStatus.files).toBe(2);
     expect(beforeStatus.chunks).toBeGreaterThan(0);
 
-    shouldFail = true;
+    await fs.writeFile(path.join(workspaceDir, "memory", "broken.md"), "Broken failure trigger.");
+    failPattern = "failure trigger";
     await expect(manager.sync({ force: true })).rejects.toThrow("embedding failure");
 
     const afterStatus = manager.status();
+    expect(afterStatus.files).toBe(2);
     expect(afterStatus.chunks).toBeGreaterThan(0);
+  });
+
+  it("rolls back unsafe full reindexes when fast-test mode hits a partial failure", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_TEST_MEMORY_UNSAFE_REINDEX", "1");
+
+    manager = await createManager();
+
+    await manager.sync({ force: true });
+    const beforeStatus = manager.status();
+    expect(beforeStatus.files).toBe(2);
+    expect(beforeStatus.chunks).toBeGreaterThan(0);
+
+    await fs.writeFile(path.join(workspaceDir, "memory", "broken.md"), "Broken failure trigger.");
+    failPattern = "failure trigger";
+    await expect(manager.sync({ force: true })).rejects.toThrow("embedding failure");
+
+    const afterStatus = manager.status();
+    expect(afterStatus.files).toBe(2);
+    expect(afterStatus.chunks).toBeGreaterThan(0);
+  });
+
+  it("retries rolled-back memory work after an aborted safe forced reindex", async () => {
+    const stateDir = path.join(fixtureRoot, `state-rollback-memory-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const sessionPath = path.join(sessionDir, "rollback-memory.jsonl");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      await fs.mkdir(sessionDir, { recursive: true });
+      await writeTranscript(sessionPath, "rollback memory session v1");
+
+      manager = await createManager({ sources: ["memory", "sessions"] });
+
+      await manager.sync({ force: true });
+
+      const internal = manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            get: (path: string, source: string) => { hash: string } | undefined;
+          };
+        };
+        indexFile: (
+          entry: { path: string },
+          options: { source: "memory" | "sessions" },
+        ) => Promise<void>;
+      };
+      const getMemoryHash = (memoryRelPath: string) =>
+        internal.db
+          .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
+          .get(memoryRelPath, "memory")?.hash;
+      const brokenMemoryRelPath = "memory/broken.md";
+      const originalBrokenHash = getMemoryHash(brokenMemoryRelPath);
+
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", "broken.md"),
+        "Broken memory updated before rolled-back reindex.",
+      );
+
+      const originalIndexFile = internal.indexFile.bind(manager);
+      internal.indexFile = async (entry, options) => {
+        if (options.source === "sessions") {
+          throw new Error("local session reindex failure");
+        }
+        await originalIndexFile(entry, options);
+      };
+
+      await expect(manager.sync({ force: true })).rejects.toThrow("local session reindex failure");
+
+      expect(getMemoryHash(brokenMemoryRelPath)).toBe(originalBrokenHash);
+      expect(manager.status().dirty).toBe(true);
+
+      internal.indexFile = originalIndexFile;
+      await manager.sync({ reason: "retry" });
+
+      expect(getMemoryHash(brokenMemoryRelPath)).not.toBe(originalBrokenHash);
+      expect(manager.status().dirty).toBe(false);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("retries all rolled-back session files after an aborted safe forced reindex", async () => {
+    const stateDir = path.join(fixtureRoot, `state-rollback-sessions-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const firstSessionPath = path.join(sessionDir, "rollback-first.jsonl");
+    const secondSessionPath = path.join(sessionDir, "rollback-second.jsonl");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      await fs.mkdir(sessionDir, { recursive: true });
+      await writeTranscript(firstSessionPath, "rollback first transcript v1");
+      await writeTranscript(secondSessionPath, "rollback second transcript v1");
+
+      manager = await createManager({ sources: ["sessions"] });
+
+      await manager.sync({ force: true });
+
+      const internal = manager as unknown as {
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+        db: {
+          prepare: (sql: string) => {
+            get: (path: string, source: string) => { hash: string } | undefined;
+          };
+        };
+        indexFile: (
+          entry: { path: string },
+          options: { source: "memory" | "sessions" },
+        ) => Promise<void>;
+      };
+      const getSessionHash = (sessionRelPath: string) =>
+        internal.db
+          .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
+          .get(sessionRelPath, "sessions")?.hash;
+      const firstSessionRelPath = "sessions/rollback-first.jsonl";
+      const secondSessionRelPath = "sessions/rollback-second.jsonl";
+      const firstOriginalHash = getSessionHash(firstSessionRelPath);
+      const secondOriginalHash = getSessionHash(secondSessionRelPath);
+
+      await writeTranscript(firstSessionPath, "rollback first transcript v2");
+      await writeTranscript(secondSessionPath, "rollback second transcript v2");
+
+      const attemptedSessionPaths = new Set<string>();
+      const originalIndexFile = internal.indexFile.bind(manager);
+      let sessionAttemptCount = 0;
+      internal.indexFile = async (entry, options) => {
+        if (options.source === "sessions") {
+          attemptedSessionPaths.add(entry.path);
+          sessionAttemptCount += 1;
+          if (sessionAttemptCount === 2) {
+            throw new Error("local session reindex failure");
+          }
+        }
+        await originalIndexFile(entry, options);
+      };
+
+      await expect(manager.sync({ force: true })).rejects.toThrow("local session reindex failure");
+
+      expect(attemptedSessionPaths).toEqual(new Set([firstSessionRelPath, secondSessionRelPath]));
+      expect(getSessionHash(firstSessionRelPath)).toBe(firstOriginalHash);
+      expect(getSessionHash(secondSessionRelPath)).toBe(secondOriginalHash);
+      expect(internal.sessionsDirtyFiles.has(firstSessionPath)).toBe(true);
+      expect(internal.sessionsDirtyFiles.has(secondSessionPath)).toBe(true);
+      expect(internal.sessionsDirty).toBe(true);
+
+      internal.indexFile = originalIndexFile;
+      await manager.sync({ reason: "retry" });
+
+      expect(getSessionHash(firstSessionRelPath)).not.toBe(firstOriginalHash);
+      expect(getSessionHash(secondSessionRelPath)).not.toBe(secondOriginalHash);
+      expect(internal.sessionsDirtyFiles.has(firstSessionPath)).toBe(false);
+      expect(internal.sessionsDirtyFiles.has(secondSessionPath)).toBe(false);
+      expect(internal.sessionsDirty).toBe(false);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps session reindex dirty after an aborted safe forced reindex before a result is produced", async () => {
+    const stateDir = path.join(fixtureRoot, `state-rollback-sessions-early-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const sessionPath = path.join(sessionDir, "rollback-early.jsonl");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      await fs.mkdir(sessionDir, { recursive: true });
+      await writeTranscript(sessionPath, "rollback early transcript v1");
+
+      manager = await createManager({ sources: ["sessions"] });
+
+      await manager.sync({ force: true });
+
+      const internal = manager as unknown as {
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+        db: {
+          prepare: (sql: string) => {
+            get: (path: string, source: string) => { hash: string } | undefined;
+          };
+        };
+        syncSessionFiles: (params: {
+          needsFullReindex: boolean;
+          progress?: unknown;
+        }) => Promise<unknown>;
+      };
+      const getSessionHash = (sessionRelPath: string) =>
+        internal.db
+          .prepare(`SELECT hash FROM files WHERE path = ? AND source = ?`)
+          .get(sessionRelPath, "sessions")?.hash;
+      const sessionRelPath = "sessions/rollback-early.jsonl";
+      const originalHash = getSessionHash(sessionRelPath);
+
+      await writeTranscript(sessionPath, "rollback early transcript v2");
+
+      const originalSyncSessionFiles = internal.syncSessionFiles.bind(manager);
+      internal.syncSessionFiles = async (params) => {
+        if (params.needsFullReindex) {
+          throw new Error("session reindex aborted early");
+        }
+        return await originalSyncSessionFiles(params);
+      };
+
+      await expect(manager.sync({ force: true })).rejects.toThrow("session reindex aborted early");
+
+      expect(getSessionHash(sessionRelPath)).toBe(originalHash);
+      expect(internal.sessionsDirty).toBe(true);
+      expect(internal.sessionsDirtyFiles.size).toBe(0);
+
+      internal.syncSessionFiles = originalSyncSessionFiles;
+      await manager.sync({ reason: "retry" });
+
+      expect(getSessionHash(sessionRelPath)).not.toBe(originalHash);
+      expect(internal.sessionsDirty).toBe(false);
+      expect(internal.sessionsDirtyFiles.size).toBe(0);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves dirty updates that arrive while a safe forced reindex is rolling back", async () => {
+    const stateDir = path.join(fixtureRoot, `state-rollback-live-updates-${randomUUID()}`);
+    const sessionDir = path.join(stateDir, "agents", "main", "sessions");
+    const firstSessionPath = path.join(sessionDir, "rollback-live-first.jsonl");
+    const secondSessionPath = path.join(sessionDir, "rollback-live-second.jsonl");
+    const lateSessionPath = path.join(sessionDir, "rollback-live-late.jsonl");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      await fs.mkdir(sessionDir, { recursive: true });
+      await writeTranscript(firstSessionPath, "rollback live first v1");
+      await writeTranscript(secondSessionPath, "rollback live second v1");
+
+      manager = await createManager({ sources: ["sessions"] });
+
+      await manager.sync({ force: true });
+      await writeTranscript(firstSessionPath, "rollback live first v2");
+      await writeTranscript(secondSessionPath, "rollback live second v2");
+
+      const internal = manager as unknown as {
+        dirty: boolean;
+        sessionsDirty: boolean;
+        sessionsDirtyFiles: Set<string>;
+        sessionDeltas: Map<
+          string,
+          { lastSize: number; pendingBytes: number; pendingMessages: number }
+        >;
+        indexFile: (
+          entry: { path: string },
+          options: { source: "memory" | "sessions" },
+        ) => Promise<void>;
+      };
+      const originalIndexFile = internal.indexFile.bind(manager);
+
+      internal.indexFile = async (entry, options) => {
+        if (options.source === "sessions" && entry.path === "sessions/rollback-live-second.jsonl") {
+          await writeTranscript(lateSessionPath, "rollback live late update");
+          internal.dirty = true;
+          internal.sessionsDirty = true;
+          internal.sessionsDirtyFiles.add(lateSessionPath);
+          internal.sessionDeltas.set(lateSessionPath, {
+            lastSize: 0,
+            pendingBytes: 32,
+            pendingMessages: 1,
+          });
+          throw new Error("local session reindex failure");
+        }
+        await originalIndexFile(entry, options);
+      };
+
+      await expect(manager.sync({ force: true })).rejects.toThrow("local session reindex failure");
+
+      expect(manager.status().dirty).toBe(true);
+      expect(internal.sessionsDirty).toBe(true);
+      expect(internal.sessionsDirtyFiles.has(lateSessionPath)).toBe(true);
+      expect(internal.sessionDeltas.get(lateSessionPath)).toEqual({
+        lastSize: 0,
+        pendingBytes: 32,
+        pendingMessages: 1,
+      });
+
+      internal.indexFile = originalIndexFile;
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/memory/manager.embedding-batches.test.ts
+++ b/src/memory/manager.embedding-batches.test.ts
@@ -129,6 +129,36 @@ describe("memory embedding batches", () => {
     expect(calls).toBe(2);
   }, 10000);
 
+  it("persists successful batch embeddings to cache before a later batch fails", async () => {
+    const memoryDir = fx.getMemoryDir();
+    const managerLarge = fx.getManagerLarge();
+    const line = "f".repeat(4200);
+    const content = [line, line].join("\n");
+    await fs.writeFile(path.join(memoryDir, "2026-01-09.md"), content);
+
+    let calls = 0;
+    fx.embedBatch.mockImplementation(async (texts: string[]) => {
+      calls += 1;
+      if (calls === 2) {
+        throw new Error("embedding failure");
+      }
+      return texts.map(() => [0, 1, 0]);
+    });
+
+    await expect(managerLarge.sync({ reason: "test" })).rejects.toThrow("embedding failure");
+    expect(calls).toBe(2);
+
+    fx.resetManager(managerLarge);
+    fx.embedBatch.mockImplementation(async (texts: string[]) => {
+      calls += 1;
+      return texts.map(() => [0, 1, 0]);
+    });
+
+    await managerLarge.sync({ reason: "test" });
+
+    expect(calls).toBe(3);
+  });
+
   it("skips empty chunks so embeddings input stays valid", async () => {
     const memoryDir = fx.getMemoryDir();
     const managerSmall = fx.getManagerSmall();

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -18,6 +18,7 @@ export function ensureMemoryIndexSchema(params: {
       path TEXT PRIMARY KEY,
       source TEXT NOT NULL DEFAULT 'memory',
       hash TEXT NOT NULL,
+      identity_key TEXT,
       mtime INTEGER NOT NULL,
       size INTEGER NOT NULL
     );
@@ -78,9 +79,11 @@ export function ensureMemoryIndexSchema(params: {
   }
 
   ensureColumn(params.db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
+  ensureColumn(params.db, "files", "identity_key", "TEXT");
   ensureColumn(params.db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);`);
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_files_identity_key ON files(identity_key);`);
 
   return { ftsAvailable, ...(ftsError ? { ftsError } : {}) };
 }

--- a/src/memory/session-files.ts
+++ b/src/memory/session-files.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { hashText } from "./internal.js";
+import { buildFileIdentityKey, hashText } from "./internal.js";
 
 const log = createSubsystemLogger("memory");
 
@@ -13,6 +13,7 @@ export type SessionFileEntry = {
   mtimeMs: number;
   size: number;
   hash: string;
+  identityKey: string | null;
   content: string;
   /** Maps each content line (0-indexed) to its 1-indexed JSONL source line. */
   lineMap: number[];
@@ -121,6 +122,7 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       mtimeMs: stat.mtimeMs,
       size: stat.size,
       hash: hashText(content + "\n" + lineMap.join(",")),
+      identityKey: buildFileIdentityKey(stat),
       content,
       lineMap,
     };

--- a/src/memory/test-embeddings-mock.ts
+++ b/src/memory/test-embeddings-mock.ts
@@ -1,7 +1,10 @@
+import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
+
 export function createOpenAIEmbeddingProviderMock(params: {
   embedQuery: (input: string) => Promise<number[]>;
   embedBatch: (input: string[]) => Promise<number[][]>;
 }) {
+  const baseUrl = "https://api.openai.com/v1";
   return {
     requestedProvider: "openai",
     provider: {
@@ -11,8 +14,9 @@ export function createOpenAIEmbeddingProviderMock(params: {
       embedBatch: params.embedBatch,
     },
     openAi: {
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl,
       headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
+      ssrfPolicy: buildRemoteBaseUrlPolicy(baseUrl),
       model: "text-embedding-3-small",
     },
   };


### PR DESCRIPTION
## Summary

- Problem: builtin memory sync and reindex currently mix three different contracts behind the same fail-fast control flow: background incremental sync, targeted post-compaction refresh, and full reindex. That makes transient provider failures, per-file local failures, stale-row pruning, and rollback state restoration interact incorrectly, so one failure can either discard useful progress or leave retry/state semantics inconsistent.
- Why it matters: background sync should preserve the last good searchable state and retry later, targeted refresh should act as a freshness barrier instead of silently succeeding, and full reindex must remain atomic even when some work completed before the run ultimately rolls back.
- What changed: this PR splits those semantics explicitly in builtin memory indexing. It adds typed provider-vs-local sync errors, per-file SQLite savepoints for multi-table writes, immediate per-batch embedding-cache persistence, rollback state restoration for safe/unsafe full reindex, and stable file identity tracking so failed refreshes/renames do not prune the last good row by mistake.
- What did NOT change (scope boundary): no new config surface for retry/rate-limit tuning, no checkpoint/resume design, no changes to QMD behavior, and no changes to remote async batch API contracts beyond preserving existing fallback/retry behavior.
- AI-assisted: fully tested locally for the touched builtin memory paths, and verified against the current `src/memory/*` implementation plus targeted/manual repros.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related [#1151](https://github.com/openclaw/openclaw/issues/1151)
- Related [#10324](https://github.com/openclaw/openclaw/issues/10324)
- Related [#10863](https://github.com/openclaw/openclaw/issues/10863)
- Related [#17576](https://github.com/openclaw/openclaw/issues/17576)
- Related [#20680](https://github.com/openclaw/openclaw/pull/20680)
- Related [#25561](https://github.com/openclaw/openclaw/pull/25561)
- Related [#28667](https://github.com/openclaw/openclaw/issues/28667)
- Related [#28919](https://github.com/openclaw/openclaw/issues/28919)
- Related [#31961](https://github.com/openclaw/openclaw/pull/31961)
- Related [#39377](https://github.com/openclaw/openclaw/pull/39377)
- Related [#42578](https://github.com/openclaw/openclaw/pull/42578)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: builtin memory sync was relying on exception propagation to define behavior across multiple modes that actually need different contracts. `syncMemoryFiles()` / `syncSessionFiles()` decide not only whether a file is indexed, but also whether stale rows are pruned, whether targeted session refresh counts as complete, whether a full reindex may commit, and which dirty/session-dirty work must be restored after rollback. At the same time, `indexFile()` performs multi-table delete/rewrite work (`files`, `chunks`, vector rows, FTS rows) without a per-file atomic boundary, so "continue on error" is only safe if partial writes cannot leak through.
- Missing detection / guardrail: there was no regression coverage locking in the distinction between background best-effort sync, targeted refresh, and atomic full reindex. There was also no regression test asserting that successful earlier embedding batches must survive a later failure, and no test covering rollback-state restoration for work that completed inside a reindex that later aborts.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this follows the same reliability thread as [#1151](https://github.com/openclaw/openclaw/issues/1151) (atomic indexing), [#10324](https://github.com/openclaw/openclaw/issues/10324) (multi-write paths lacking transaction wrappers), [#10863](https://github.com/openclaw/openclaw/issues/10863) (dirty-state semantics), [#25561](https://github.com/openclaw/openclaw/pull/25561) (mode-aware post-compaction session reindexing), [#31961](https://github.com/openclaw/openclaw/pull/31961) (continue on embedding errors), and [#42578](https://github.com/openclaw/openclaw/pull/42578) (per-batch cache persistence). It also extends the provider error taxonomy direction already accepted in [#39377](https://github.com/openclaw/openclaw/pull/39377).
- Why this regressed now: once per-file failures stop being immediate process-level failures, the implicit state machine becomes visible. Catching and recording failures changes pruning, commit eligibility, rollback, and retry semantics unless those rules are made explicit.
- If unknown, what was ruled out: this is not limited to remote async batch mode; the reproduced failure happens on direct embedding with `Batch: disabled`. It is also not just a retry-pattern issue, because retry-only changes do not fix partial-write hazards, rollback-state loss, or targeted refresh false positives.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/memory/index.test.ts`
  - `src/memory/manager.atomic-reindex.test.ts`
  - `src/memory/manager.embedding-batches.test.ts`
- Scenario the test should lock in:
  - Background incremental sync keeps the last good memory/session rows when a single file hits a retryable local failure, marks that work dirty again, and continues indexing healthy files.
  - Targeted post-compaction session refresh fails explicitly when a requested file cannot be refreshed, instead of silently succeeding.
  - Safe and unsafe full reindex either commit completely or roll back completely, while restoring dirty/session-dirty retry state for work lost in the rollback.
  - Successful earlier embedding batches are written to cache before a later batch fails, so a retry reuses already-computed embeddings.
  - Failed refreshes caused by rename/replacement scenarios do not prune the last good indexed row.
- Why this is the smallest reliable guardrail: the bug is in builtin memory sync control flow, SQLite write atomicity, and retry-state restoration. These are deterministic local behaviors that can be exercised with targeted tests without live providers, gateway orchestration, or full CLI E2E runs.
- Existing test that already covers this (if any):
  - N/A. Existing atomic-reindex coverage only protected the old "keep the previous index on failure" invariant; it did not cover mode-aware sync semantics, rollback retry restoration, or per-batch cache durability.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Background builtin memory sync is now safe best-effort for retryable single-file local failures: healthy files continue indexing, the last good searchable state is preserved for failed files, and failed work stays dirty for retry.
- Targeted post-compaction session refresh now behaves like a freshness barrier: if the requested transcript refresh cannot complete cleanly, the caller gets an explicit failure instead of a false-success partial refresh.
- Full builtin reindex remains atomic in both safe and test-only unsafe paths: either the rebuild commits completely, or it rolls back completely and re-queues rolled-back work for retry.
- Successful embedding batches are now persisted to the embedding cache immediately after each batch succeeds, reducing repeated provider work after transient failures.
- Failed refreshes caused by moved/renamed files now preserve the last good indexed row instead of pruning it as stale during the same sync.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: OpenAI-compatible remote embeddings (`provider: openai`, `model: BAAI/bge-m3`)
- Integration/channel (if any): CLI / builtin memory index
- Relevant config (redacted):
  - `memorySearch.provider: "openai"`
  - `memorySearch.model: "BAAI/bge-m3"`
  - `memorySearch.extraPaths: [<Obsidian vault>]`
  - `memorySearch.cache.enabled: true`
  - `memorySearch.remote.batch.enabled: false`

### Steps

1. Use a large `memorySearch.extraPaths` corpus and a rate-limited remote embedding provider.
2. Run `openclaw memory index --force`.
3. Trigger a transient provider-side `429` during indexing.
4. Check `openclaw memory status`.
5. Re-run `openclaw memory index`.

### Expected

- A transient provider failure should not permanently waste successful earlier batch work.
- Retryable per-file failures should not destroy the last good indexed state for unrelated healthy files.
- Full reindex should only commit if the rebuild reaches a coherent final state; otherwise the previous committed index should remain available.
- Follow-up indexing should converge instead of repeatedly restarting from zero useful progress.

### Actual

Before this change:
- `openclaw memory index --force` failed with a provider `429`.
- `openclaw memory status` showed `Indexed: 0/2343 files · 0 chunks` and an empty embedding cache.

After this change and rebuild:
- `openclaw memory index --force` completed substantial work instead of failing the whole run at the first provider interruption.
- `openclaw memory status` showed `Indexed: 2331/2343 files · 9726 chunks` and `Embedding cache: enabled (8913 entries)`.
- A follow-up `openclaw memory index` completed the remaining files to `Indexed: 2343/2343 files · 10033 chunks`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

### CLI before

```text
❯ openclaw memory index --force

🦞 OpenClaw 2026.3.24 (4cb8dde)
   Powered by open source, sustained by spite and good documentation.

│
...
13:32:05+08:00 [memory] embeddings rate limited; retrying in 524ms
◇
Memory index failed (main): openai embeddings failed: 429 {"message":"Request was rejected due to rate limiting. Details: TPM limit reached.","data":null}

❯ openclaw memory status

🦞 OpenClaw 2026.3.24 (4cb8dde)
   Your personal assistant, minus the passive-aggressive calendar reminders.

Memory Search (main)
Provider: openai (requested: openai)
Model: BAAI/bge-m3
Sources: memory
Extra paths: ~/.../Notebook
Indexed: 0/2343 files · 0 chunks
Dirty: yes
Store: ~/.openclaw/memory/main.sqlite
Workspace: ~/.openclaw/workspace
By source:
  memory · 0/2343 files · 0 chunks
Vector: ready
Vector path: ~/openclaw/node_modules/sqlite-vec-darwin-arm64/vec0.dylib
FTS: ready
Embedding cache: enabled (0 entries)
Cache cap: 500000
Batch: disabled (failures 0/2)
```

### CLI after rebuild with this patch

```text
❯ openclaw memory index --force

🦞 OpenClaw 2026.3.24 (4cb8dde)
   I'm not saying your workflow is chaotic... I'm just bringing a linter and a helmet.

│
...
◇
Memory index updated (main).

❯ openclaw memory status

🦞 OpenClaw 2026.3.24 (4cb8dde)
   Your personal assistant, minus the passive-aggressive calendar reminders.

Memory Search (main)
Provider: openai (requested: openai)
Model: BAAI/bge-m3
Sources: memory
Extra paths: ~/.../Notebook
Indexed: 2331/2343 files · 9726 chunks
Dirty: no
Store: ~/.openclaw/memory/main.sqlite
Workspace: ~/.openclaw/workspace
By source:
  memory · 2331/2343 files · 9726 chunks
Vector: ready
Vector dims: 1024
Vector path: ~/openclaw/node_modules/sqlite-vec-darwin-arm64/vec0.dylib
FTS: ready
Embedding cache: enabled (8913 entries)
Cache cap: 500000
Batch: disabled (failures 0/2)

❯ openclaw memory index

Indexed: 2343/2343 files · 10033 chunks
```

### Local targeted tests

```bash
pnpm test -- src/memory/manager.atomic-reindex.test.ts src/memory/index.test.ts src/memory/manager.embedding-batches.test.ts
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified `openclaw memory index --force` previously failed on a real rate-limited corpus with `Indexed: 0/...`.
- Verified the patched build completed substantial force-reindex work without discarding healthy-file progress.
- Verified `openclaw memory status` showed substantial indexed file/chunk counts and a populated embedding cache after the patched run.
- Verified a follow-up incremental `openclaw memory index` completed the remaining files.
- Verified the new focused regression tests pass locally.

- Edge cases checked:
  - retryable single-file local failures keep old searchable rows and remain dirty for retry
  - targeted post-compaction session refresh surfaces failure instead of silently partial-refreshing
  - safe full reindex rollback preserves the previous committed index and restores retry state
  - successful early embedding batches are reused after a later batch failure
  - failed rename/replacement refreshes do not prune the last good row
- What you did **not** verify:
  - live provider matrix across Gemini / Voyage / local embeddings
  - async provider Batch API flows
  - multi-process concurrent indexing behavior

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR
- Files/config to restore:
  - `src/memory/manager-sync-ops.ts`
  - `src/memory/manager-embedding-ops.ts`
  - `src/memory/internal.ts`
  - `src/memory/session-files.ts`
  - `src/memory/memory-schema.ts`
- Known bad symptoms reviewers should watch for:
  - silently skipped files without enough warning context
  - targeted session refreshes succeeding when they should fail
  - rolled-back reindex work not returning to dirty/session-dirty retry state
  - renamed memory/session files disappearing from search after a failed refresh

## Risks and Mitigations

- Risk: background sync now intentionally completes with some retryable local file failures instead of failing the whole run.
  - Mitigation: only retryable single-file local failures are skipped; provider failures still surface, DB/disk class failures still abort, and failed files remain dirty for retry with warning logs.
- Risk: the new rollback-state merge could accidentally lose or duplicate dirty/session-dirty work across aborted reindexes.
  - Mitigation: focused atomic-reindex tests cover rolled-back memory and session work plus merge-with-live-state behavior.
- Risk: adding `identity_key` expands the builtin memory schema and stale-prune logic.
  - Mitigation: the schema change is additive, existing rows backfill lazily, and tests lock in the specific rename/replacement failure case that motivated the change.
- Risk: per-file savepoints add some SQLite overhead on heavy indexing runs.
  - Mitigation: savepoints are narrowly scoped to single-file write boundaries and are only used to guarantee consistency when best-effort continuation is allowed.
