### PR TITLE
Plugins: keep bundled configured channels in startup resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/startup: keep configured bundled channels in startup resolution even when manifest-registry loading is narrowed by `plugins.allow`, so configured Slack and other bundled channels still boot without being explicitly allowlisted. (#55505) Thanks @soohoonc.
 - ACP/ACPX agent registry: align OpenClaw's ACPX built-in agent mirror with the latest `openclaw/acpx` command defaults and built-in aliases, pin versioned `npx` built-ins to exact versions, and stop unknown ACP agent ids from falling through to raw `--agent` command execution on the MCP-proxy path. (#28321) Thanks @m0nkmaster and @vincentkoc.
 - Control UI/config: keep sensitive raw config hidden by default, replace the blank blocked editor with an explicit reveal-to-edit state, and restore raw JSON editing without auto-exposing secrets. Fixes #55322.
 - WhatsApp: fix infinite echo loop in self-chat DM mode where the bot's own outbound replies were re-processed as new inbound user messages. (#54570) Thanks @joelnishanth

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -2,21 +2,30 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 
 const listPotentialConfiguredChannelIds = vi.hoisted(() => vi.fn());
+const listChatChannels = vi.hoisted(() => vi.fn());
 const loadPluginManifestRegistry = vi.hoisted(() => vi.fn());
 
 vi.mock("../channels/config-presence.js", () => ({
   listPotentialConfiguredChannelIds,
 }));
 
+vi.mock("../channels/registry.js", () => ({
+  listChatChannels,
+}));
+
 vi.mock("./manifest-registry.js", () => ({
   loadPluginManifestRegistry,
 }));
 
-import { resolveGatewayStartupPluginIds } from "./channel-plugin-ids.js";
+import {
+  resolveConfiguredChannelPluginIds,
+  resolveGatewayStartupPluginIds,
+} from "./channel-plugin-ids.js";
 
 describe("resolveGatewayStartupPluginIds", () => {
   beforeEach(() => {
     listPotentialConfiguredChannelIds.mockReset().mockReturnValue(["discord"]);
+    listChatChannels.mockReset().mockReturnValue([{ id: "slack" }, { id: "discord" }]);
     loadPluginManifestRegistry.mockReset().mockReturnValue({
       plugins: [
         {
@@ -88,6 +97,50 @@ describe("resolveGatewayStartupPluginIds", () => {
         env: process.env,
       }),
     ).toEqual(["discord", "anthropic", "diagnostics-otel", "custom-sidecar"]);
+  });
+
+  it("keeps bundled configured channels available when the manifest registry is narrowed by plugins.allow", () => {
+    listPotentialConfiguredChannelIds.mockReturnValue(["slack"]);
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "custom-sidecar",
+          channels: [],
+          origin: "global",
+          enabledByDefault: undefined,
+          providers: [],
+          cliBackends: [],
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const config = {
+      channels: {
+        slack: {
+          enabled: true,
+        },
+      },
+      plugins: {
+        allow: ["ouroboros"],
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolveConfiguredChannelPluginIds({
+        config,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["slack"]);
+
+    expect(
+      resolveGatewayStartupPluginIds({
+        config,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["slack"]);
   });
 
   it("does not pull default-on bundled non-channel plugins into startup", () => {

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -5,6 +5,7 @@ import {
   resolveModelRefFromString,
 } from "../agents/model-selection.js";
 import { listPotentialConfiguredChannelIds } from "../channels/config-presence.js";
+import { listChatChannels } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAgentModelFallbackValues,
@@ -235,6 +236,12 @@ function collectConfiguredActivationIds(config: OpenClawConfig): Set<string> {
   return activationIds;
 }
 
+function listBundledChannelPluginIds(): string[] {
+  return listChatChannels()
+    .map((channel) => channel.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+}
+
 export function resolveChannelPluginIds(params: {
   config: OpenClawConfig;
   workspaceDir?: string;
@@ -260,7 +267,22 @@ export function resolveConfiguredChannelPluginIds(params: {
   if (configuredChannelIds.size === 0) {
     return [];
   }
-  return resolveChannelPluginIds(params).filter((pluginId) => configuredChannelIds.has(pluginId));
+  const pluginIds = new Set<string>();
+  for (const pluginId of listBundledChannelPluginIds()) {
+    if (configuredChannelIds.has(pluginId)) {
+      pluginIds.add(pluginId);
+    }
+  }
+  for (const plugin of loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  }).plugins) {
+    if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
+      pluginIds.add(plugin.id);
+    }
+  }
+  return [...pluginIds];
 }
 
 export function resolveConfiguredDeferredChannelPluginIds(params: {
@@ -302,42 +324,42 @@ export function resolveGatewayStartupPluginIds(params: {
     env: params.env,
   });
   const configuredActivationIds = collectConfiguredActivationIds(params.config);
-  return manifestRegistry.plugins
-    .filter((plugin) => {
-      if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
-        return true;
-      }
-      if (plugin.channels.length > 0) {
-        return false;
-      }
-      const enabled = resolveEffectiveEnableState({
-        id: plugin.id,
-        origin: plugin.origin,
-        config: pluginsConfig,
-        rootConfig: params.config,
-        enabledByDefault: plugin.enabledByDefault,
-      }).enabled;
-      if (!enabled) {
-        return false;
-      }
-      if (plugin.origin !== "bundled") {
-        return true;
-      }
-      if (
-        plugin.providers.some((providerId) =>
-          configuredActivationIds.has(normalizeProviderId(providerId)),
-        ) ||
-        plugin.cliBackends.some((backendId) =>
-          configuredActivationIds.has(normalizeProviderId(backendId)),
-        )
-      ) {
-        return true;
-      }
-      return (
-        pluginsConfig.allow.includes(plugin.id) ||
-        pluginsConfig.entries[plugin.id]?.enabled === true ||
-        pluginsConfig.slots.memory === plugin.id
-      );
-    })
-    .map((plugin) => plugin.id);
+  const pluginIds = new Set(resolveConfiguredChannelPluginIds(params));
+  for (const plugin of manifestRegistry.plugins) {
+    if (plugin.channels.some((channelId) => configuredChannelIds.has(channelId))) {
+      pluginIds.add(plugin.id);
+      continue;
+    }
+    if (plugin.channels.length > 0) {
+      continue;
+    }
+    const enabled = resolveEffectiveEnableState({
+      id: plugin.id,
+      origin: plugin.origin,
+      config: pluginsConfig,
+      rootConfig: params.config,
+      enabledByDefault: plugin.enabledByDefault,
+    }).enabled;
+    if (!enabled) {
+      continue;
+    }
+    if (plugin.origin !== "bundled") {
+      pluginIds.add(plugin.id);
+      continue;
+    }
+    if (
+      plugin.providers.some((providerId) =>
+        configuredActivationIds.has(normalizeProviderId(providerId)),
+      ) ||
+      plugin.cliBackends.some((backendId) =>
+        configuredActivationIds.has(normalizeProviderId(backendId)),
+      ) ||
+      pluginsConfig.allow.includes(plugin.id) ||
+      pluginsConfig.entries[plugin.id]?.enabled === true ||
+      pluginsConfig.slots.memory === plugin.id
+    ) {
+      pluginIds.add(plugin.id);
+    }
+  }
+  return [...pluginIds];
 }


### PR DESCRIPTION
## Summary
- keep configured bundled channels available in startup resolution even when the manifest registry is narrowed by `plugins.allow`
- add a regression test for the `channels.slack` + restrictive `plugins.allow` case

## Problem
With a restrictive plugin allowlist, configured bundled channels like Slack can disappear from the startup plugin-id resolution path before gateway boot. That leaves `channels.slack` configured but not actually started.

## Testing
- `pnpm exec vitest run --config vitest.unit.config.ts src/plugins/channel-plugin-ids.test.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/cli/plugin-registry.test.ts`

## Notes
- AI-assisted: yes
- The repo pre-commit hook currently trips an unrelated baseline type error in `extensions/acpx/src/runtime.ts`; this PR was validated with the scoped tests above instead.
