### PR TITLE
fix: refresh persisted skills snapshots after restart

### DIFF
--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -18,6 +18,13 @@ async function loadFreshRefreshModuleForTest() {
 }
 
 describe("ensureSkillsWatcher", () => {
+  it("starts snapshot version above zero so long-lived sessions refresh after restart", async () => {
+    await loadFreshRefreshModuleForTest();
+    expect(refreshModule.getSkillsSnapshotVersion()).toBe(1);
+    expect(refreshModule.getSkillsSnapshotVersion("/tmp/workspace")).toBe(1);
+    await refreshModule.resetSkillsRefreshForTest();
+  });
+
   beforeEach(async () => {
     watchMock.mockClear();
     await loadFreshRefreshModuleForTest();

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -24,7 +24,7 @@ const log = createSubsystemLogger("gateway/skills");
 const listeners = new Set<(event: SkillsChangeEvent) => void>();
 const workspaceVersions = new Map<string, number>();
 const watchers = new Map<string, SkillsWatchState>();
-let globalVersion = 0;
+let globalVersion = 1;
 
 export const DEFAULT_SKILLS_WATCH_IGNORED: RegExp[] = [
   /(^|[\\/])\.git([\\/]|$)/,


### PR DESCRIPTION
## Summary
- start the global skills snapshot version at `1` so persisted session snapshots are invalidated after a gateway restart
- add a regression test covering the non-zero initial snapshot version

## Why
Long-lived sessions persist `skillsSnapshot.version`, but the in-memory version counter used for refresh checks used to reset back to `0` on restart. That meant existing sessions could keep stale `available_skills` entries forever after a gateway restart.

By starting the global counter above zero, the first post-restart turn sees a newer snapshot version and rebuilds the workspace skill snapshot for persisted sessions.

## Testing
- `pnpm test -- src/agents/skills/refresh.test.ts`
