### PR TITLE
fix(agents): ignore mixed subagent tool-call replies

### DIFF
--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -7,12 +7,14 @@ import {
 } from "../config/sessions.js";
 import { callGateway } from "../gateway/call.js";
 import { extractTextFromChatContent } from "../shared/chat-content.js";
+import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
 import { readLatestAssistantReply } from "./tools/agent-step.js";
 import { sanitizeTextContent, extractAssistantText } from "./tools/sessions-helpers.js";
 import { isAnnounceSkip } from "./tools/sessions-send-helpers.js";
 
 const FAST_TEST_MODE = process.env.OPENCLAW_TEST_FAST === "1";
 const FAST_TEST_RETRY_INTERVAL_MS = 8;
+const FINAL_REPLY_BLOCK_RE = /<\s*final\s*>([\s\S]*?)<\s*\/\s*final\s*>/gi;
 
 type ToolResultMessage = {
   role?: unknown;
@@ -95,6 +97,27 @@ function extractInlineTextContent(content: unknown): string {
   );
 }
 
+function extractExplicitFinalAssistantText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const content = (message as { content?: unknown }).content;
+  const rawText =
+    typeof content === "string"
+      ? content
+      : (extractTextFromChatContent(content, {
+          joinWith: "",
+          normalizeText: (text) => text,
+        }) ?? "");
+  if (!rawText) {
+    return undefined;
+  }
+  const parts = Array.from(rawText.matchAll(FINAL_REPLY_BLOCK_RE))
+    .map((match) => sanitizeUserFacingText(sanitizeTextContent(match[1] ?? "")).trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join("\n").trim() : undefined;
+}
+
 function extractSubagentOutputText(message: unknown): string {
   if (!message || typeof message !== "object") {
     return "";
@@ -162,7 +185,8 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     }
     const role = (message as { role?: unknown }).role;
     if (role === "assistant") {
-      snapshot.toolCallCount += countAssistantToolCalls((message as { content?: unknown }).content);
+      const toolCallCount = countAssistantToolCalls((message as { content?: unknown }).content);
+      snapshot.toolCallCount += toolCallCount;
       const text = extractSubagentOutputText(message).trim();
       if (!text) {
         continue;
@@ -174,7 +198,14 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
         continue;
       }
       snapshot.latestSilentText = undefined;
-      snapshot.latestAssistantText = text;
+      if (toolCallCount === 0) {
+        snapshot.latestAssistantText = text;
+      } else {
+        const explicitFinalText = extractExplicitFinalAssistantText(message)?.trim();
+        if (explicitFinalText) {
+          snapshot.latestAssistantText = explicitFinalText;
+        }
+      }
       snapshot.assistantFragments.push(text);
       continue;
     }
@@ -186,10 +217,17 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
   return snapshot;
 }
 
+function shouldUseSubagentPartialProgress(outcome?: SubagentRunOutcome): boolean {
+  return outcome?.status === "timeout" || outcome?.status === "error";
+}
+
 function formatSubagentPartialProgress(
   snapshot: SubagentOutputSnapshot,
   outcome?: SubagentRunOutcome,
 ): string | undefined {
+  if (!shouldUseSubagentPartialProgress(outcome)) {
+    return undefined;
+  }
   if (snapshot.latestSilentText) {
     return undefined;
   }
@@ -235,9 +273,13 @@ export async function readSubagentOutput(
     params: { sessionKey, limit: 100 },
   });
   const messages = Array.isArray(history?.messages) ? history.messages : [];
-  const selected = selectSubagentOutputText(summarizeSubagentOutputHistory(messages), outcome);
+  const snapshot = summarizeSubagentOutputHistory(messages);
+  const selected = selectSubagentOutputText(snapshot, outcome);
   if (selected?.trim()) {
     return selected;
+  }
+  if (snapshot.toolCallCount > 0 && !shouldUseSubagentPartialProgress(outcome)) {
+    return undefined;
   }
   const latestAssistant = await readLatestAssistantReply({ sessionKey, limit: 100 });
   return latestAssistant?.trim() ? latestAssistant : undefined;

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -1,4 +1,5 @@
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { isToolCallContentType } from "../chat/tool-content.js";
 import { loadConfig } from "../config/config.js";
 import {
   loadSessionStore,
@@ -161,12 +162,11 @@ function countAssistantToolCalls(content: unknown): number {
       continue;
     }
     const type = (block as { type?: unknown }).type;
+    const normalizedType = typeof type === "string" ? type.toLowerCase() : "";
     if (
-      type === "toolCall" ||
-      type === "tool_use" ||
-      type === "toolUse" ||
-      type === "functionCall" ||
-      type === "function_call"
+      isToolCallContentType(type) ||
+      normalizedType === "functioncall" ||
+      normalizedType === "function_call"
     ) {
       count += 1;
     }
@@ -187,6 +187,12 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
     if (role === "assistant") {
       const toolCallCount = countAssistantToolCalls((message as { content?: unknown }).content);
       snapshot.toolCallCount += toolCallCount;
+      const explicitFinalText =
+        toolCallCount > 0 ? extractExplicitFinalAssistantText(message)?.trim() : undefined;
+      if (toolCallCount > 0) {
+        // Mixed assistant/tool-call turns should not carry forward stale prior assistant text.
+        snapshot.latestAssistantText = explicitFinalText;
+      }
       const text = extractSubagentOutputText(message).trim();
       if (!text) {
         continue;
@@ -200,11 +206,8 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       snapshot.latestSilentText = undefined;
       if (toolCallCount === 0) {
         snapshot.latestAssistantText = text;
-      } else {
-        const explicitFinalText = extractExplicitFinalAssistantText(message)?.trim();
-        if (explicitFinalText) {
-          snapshot.latestAssistantText = explicitFinalText;
-        }
+      } else if (explicitFinalText) {
+        snapshot.latestAssistantText = explicitFinalText;
       }
       snapshot.assistantFragments.push(text);
       continue;

--- a/src/agents/subagent-announce.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce.capture-completion-reply.test.ts
@@ -98,8 +98,9 @@ describe("captureSubagentCompletionReply", () => {
     vi.useRealTimers();
   });
 
-  it("returns partial assistant progress when the latest assistant turn is tool-only", async () => {
-    chatHistoryMock.mockResolvedValueOnce({
+  it("does not freeze mixed assistant + tool-call progress as a completion reply", async () => {
+    vi.useFakeTimers();
+    chatHistoryMock.mockResolvedValue({
       messages: [
         {
           role: "assistant",
@@ -115,8 +116,32 @@ describe("captureSubagentCompletionReply", () => {
       ],
     });
 
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("keeps explicit <final> content from mixed assistant + tool-call turns", async () => {
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I'll write the file in parts.\n<final>Overview page updated.</final>",
+            },
+            { type: "toolCall", id: "call-1", name: "write", arguments: {} },
+          ],
+        },
+      ],
+    });
+
     const result = await captureSubagentCompletionReply("agent:main:subagent:child");
 
-    expect(result).toBe("Mapped the modules.");
+    expect(result).toBe("Overview page updated.");
   });
 });

--- a/src/agents/subagent-announce.capture-completion-reply.test.ts
+++ b/src/agents/subagent-announce.capture-completion-reply.test.ts
@@ -124,6 +124,54 @@ describe("captureSubagentCompletionReply", () => {
     vi.useRealTimers();
   });
 
+  it("does not reuse stale assistant output after later mixed tool-call progress", async () => {
+    vi.useFakeTimers();
+    chatHistoryMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Initial analysis complete." }],
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Let me also verify..." },
+            { type: "toolCall", id: "call-1", name: "read", arguments: {} },
+          ],
+        },
+      ],
+    });
+
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("treats normalized tool_call blocks as mixed turns", async () => {
+    vi.useFakeTimers();
+    chatHistoryMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Reading the remaining files." },
+            { type: "tool_call", id: "call-1", name: "read", input: {} },
+          ],
+        },
+      ],
+    });
+
+    const pending = captureSubagentCompletionReply("agent:main:subagent:child");
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result).toBeUndefined();
+    vi.useRealTimers();
+  });
+
   it("keeps explicit <final> content from mixed assistant + tool-call turns", async () => {
     chatHistoryMock.mockResolvedValueOnce({
       messages: [


### PR DESCRIPTION
## Summary

- Problem: subagent completion capture can freeze assistant text from mixed `assistant + toolCall` messages and later announce that planning/scaffolding text as the child result.
- Why it matters: parent sessions can receive internal work-in-progress text like "I'll write the file in parts" instead of a real final result.
- What changed: final-result selection now ignores mixed assistant/tool-call text unless the message contains explicit `<final>...</final>` content, while timeout/error partial-progress handling remains intact.
- What did NOT change (scope boundary): this PR does not change normal assistant-only completion selection, delivery routing, or timeout/error announcement formatting outside this filter.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55381
- Related #55381
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `summarizeSubagentOutputHistory()` promoted assistant text from mixed `assistant + toolCall` turns into `latestAssistantText`, so `captureSubagentCompletionReply()` could freeze that scaffolding text as the run result.
- Missing detection / guardrail: completion selection had no distinction between assistant-only final text and assistant text attached to in-flight tool use.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #55381 traced the leak through `frozenResultText` and announce-back flows.
- Why this regressed now: subagent completion capture treated any latest assistant text as eligible final output even when the same message still contained tool calls.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-announce.capture-completion-reply.test.ts`
- Scenario the test should lock in: mixed assistant/tool-call messages should not freeze planning text as completion output, but explicit `<final>` content in the same message should still be captured.
- Why this is the smallest reliable guardrail: it exercises the exact completion-selection seam used to populate `frozenResultText` without needing a full subagent lifecycle harness.
- Existing test that already covers this (if any): `src/agents/subagent-announce.timeout.test.ts` still covers timeout partial-progress behavior that this change must preserve.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Subagent auto-announce no longer promotes mixed tool-use planning text as the final child result.
- Mixed assistant/tool-call turns only contribute completion output when they include explicit `<final>...</final>` content.

## Diagram (if applicable)

```text
Before:
[mixed assistant text + toolCall] -> [latestAssistantText] -> [frozenResultText] -> [announce leaked planning text]

After:
[mixed assistant text + toolCall] -> [ignored for final result unless <final>] -> [no frozen planning leak]
``` 

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): subagent announce / completion capture
- Relevant config (redacted): default test config

### Steps

1. Record subagent history containing assistant text plus one or more tool calls in the same assistant message.
2. Capture completion output for that child session.
3. Observe whether the mixed-turn text is frozen as the completion reply.

### Expected

- Mixed tool-use scaffolding text is not frozen as the final completion reply.
- Explicit `<final>...</final>` content in a mixed turn is still captured.

### Actual

- Before this change, mixed tool-use scaffolding text could be frozen and later auto-announced as the subagent result.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted completion-capture regression tests and timeout partial-progress tests.
- Edge cases checked: mixed tool-use turn with no `<final>` returns no completion reply; mixed turn with explicit `<final>` still produces the final text.
- What you did **not** verify: full-suite CI and live subagent messaging channels.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: providers that intentionally mix tool calls with final user-visible text but do not use `<final>` may no longer surface that text as the frozen completion result.
  - Mitigation: assistant-only final messages continue to work unchanged, and explicit `<final>` is preserved for mixed turns.
