### PR TITLE
telegram: recover when polling startup stalls before first getUpdates

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -201,7 +201,7 @@ describe("TelegramPollingSession", () => {
     expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
   });
 
-  it("forces a restart when polling stalls without getUpdates activity", async () => {
+  it("forces a restart when polling startup stalls before first getUpdates", async () => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);
     const firstRunnerStop = vi.fn(async () => undefined);
@@ -268,7 +268,9 @@ describe("TelegramPollingSession", () => {
       expect(runMock).toHaveBeenCalledTimes(2);
       expect(firstRunnerStop).toHaveBeenCalledTimes(1);
       expect(botStop).toHaveBeenCalled();
-      expect(log).toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining("Polling startup stalled before first getUpdates"),
+      );
       expect(log).toHaveBeenCalledWith(expect.stringContaining("polling stall detected"));
     } finally {
       watchdogHarness.restore();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -296,7 +296,7 @@ export class TelegramPollingSession {
           ? now - lastGetUpdatesAt
           : 0;
       if (startupElapsed > POLL_STARTUP_TIMEOUT_MS && runner.isRunning()) {
-        this.#discardTransportOnRestart = true;
+        this.#transportState.markDirty();
         stalledRestart = true;
         this.opts.log(
           "[telegram] Polling startup stalled before first getUpdates; forcing restart.",

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -209,7 +209,6 @@ export class TelegramPollingSession {
     let lastGetUpdatesError: string | null = null;
     let lastGetUpdatesOffset: number | null = null;
     let inFlightGetUpdates = 0;
-    let stopSequenceLogged = false;
     let stallDiagLoggedAt = 0;
 
     bot.api.config.use(async (prev, method, payload, signal) => {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -17,6 +17,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
+const POLL_STARTUP_TIMEOUT_MS = 10_000;
 const POLL_STOP_GRACE_MS = 15_000;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
@@ -291,6 +292,32 @@ export class TelegramPollingSession {
       }
 
       const now = Date.now();
+      const startupElapsed =
+        inFlightGetUpdates === 0 && lastGetUpdatesOutcome === "not-started"
+          ? now - lastGetUpdatesAt
+          : 0;
+      if (startupElapsed > POLL_STARTUP_TIMEOUT_MS && runner.isRunning()) {
+        this.#discardTransportOnRestart = true;
+        stalledRestart = true;
+        this.opts.log(
+          "[telegram] Polling startup stalled before first getUpdates; forcing restart.",
+        );
+        void stopRunner();
+        void stopBot();
+        if (!forceCycleTimer) {
+          forceCycleTimer = setTimeout(() => {
+            if (this.opts.abortSignal?.aborted) {
+              return;
+            }
+            this.opts.log(
+              `[telegram] Polling runner stop timed out after ${formatDurationPrecise(POLL_STOP_GRACE_MS)}; forcing restart cycle.`,
+            );
+            forceCycleResolve?.();
+          }, POLL_STOP_GRACE_MS);
+        }
+        return;
+      }
+
       const activeElapsed =
         inFlightGetUpdates > 0 && lastGetUpdatesStartedAt != null
           ? now - lastGetUpdatesStartedAt
@@ -335,15 +362,18 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
+      const forceRestarted = this.#forceRestarted;
       const reason = stalledRestart
         ? "polling stall detected"
-        : this.#forceRestarted
+        : forceRestarted
           ? "unhandled network error"
           : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
-      this.opts.log(
-        `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
-      );
+      if (stalledRestart || forceRestarted || lastGetUpdatesOutcome === "error") {
+        this.opts.log(
+          `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}`,
+        );
+      }
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
       );


### PR DESCRIPTION
## Summary
- recover Telegram polling when startup stalls before the first `getUpdates`
- rebuild transport explicitly on startup-stall restarts
- reduce diagnostic log noise by keeping detailed cycle-finished logs on abnormal paths only

## Problem
After Gateway restarts, Telegram polling could sometimes enter a startup dead-start state:
- polling cycle reached the pre-poll phase
- no `getUpdates` ever actually started
- the cycle remained in an effective `not-started` state until the watchdog/restart path kicked in

In practice this produced repeated restart loops after Gateway restart even though the transport/bot creation path appeared to succeed.

## Root cause addressed here
This PR treats **startup stall before the first `getUpdates`** as a separate failure mode from mid-poll stalls:
- add a dedicated startup watchdog (`POLL_STARTUP_TIMEOUT_MS = 10s`)
- on startup stall, mark transport dirty and force a restart cycle
- make the rebuild path more explicit/safe when choosing the next transport instance

## Logging
The prior diagnostic logging was also too noisy on healthy cycles. This PR keeps the detailed `polling cycle finished` diagnostic line only for abnormal paths (stall / forced restart / error), while preserving the user-visible restart reason lines.

## Validation
- unit tests updated and passing:
  - `pnpm vitest run extensions/telegram/src/polling-session.test.ts`
- local validation after deployment showed the previous post-restart `not-started` startup-stall pattern stopped reproducing

## Still not fixed in this PR
This PR **does not fully solve** the separate runtime issue where an already-started `getUpdates` request can hang for a long time and only later fail with:
- `Network request for 'getUpdates' failed!`

That remaining issue appears to be a different failure mode:
- polling has already started successfully
- `active getUpdates` later hangs for an extended period
- eventually the watchdog detects the stuck in-flight request and restarts polling

So this PR is intentionally scoped to the **startup dead-start after restart** problem only.
