### PR TITLE
fix(gateway): prevent OOM and socket hang up via Claim Check pattern for large attachments [media://inbound/<id> contract]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/facades: guard bundled plugin facade loads with a cache-first sentinel so circular re-entry stops crashing `xai`, `sglang`, and `vllm` during gateway plugin startup. (#57508) Thanks @openperf.
 - Agents/MCP: dispose bundled MCP runtimes after one-shot `openclaw agent --local` runs finish, while preserving bundled MCP state across in-run retries so local JSON runs exit cleanly without restarting stateful MCP tools mid-run.
 - Gateway/OpenAI HTTP: restore default operator scopes for bearer-authenticated requests that omit `x-openclaw-scopes`, so headless `/v1/chat/completions` and session-history callers work again after the recent method-scope hardening. (#57596) Thanks @openperf.
+- Gateway/attachments: offload large inbound images without leaking `media://` markers into text-only runs, preserve mixed attachment order for model input/transcripts, and fail closed when model image capability cannot be resolved. (#55513) Thanks @Syysean.
 
 ## 2026.3.28
 

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { CliSessionBinding } from "../../config/sessions.js";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import type { CliBackendConfig } from "../../config/types.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { ResolvedCliBackend } from "../cli-backends.js";
 
 export type RunCliAgentParams = {
@@ -28,6 +29,7 @@ export type RunCliAgentParams = {
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
 };
 
 export type CliPreparedBackend = {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -368,6 +368,7 @@ export function runAgentAttempt(params: {
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
         images: params.isFallbackRetry ? undefined : params.opts.images,
+        imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionBinding?.sessionId).catch(async (err) => {
@@ -455,6 +456,7 @@ export function runAgentAttempt(params: {
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     images: params.isFallbackRetry ? undefined : params.opts.images,
+    imageOrder: params.isFallbackRetry ? undefined : params.opts.imageOrder,
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -2,6 +2,7 @@ import type { AgentInternalEvent } from "../../agents/internal-events.js";
 import type { ClientToolDefinition } from "../../agents/pi-embedded-runner/run/params.js";
 import type { SpawnedRunMetadata } from "../../agents/spawned-context.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 
 /** Image content block for Claude API multimodal messages. */
@@ -35,6 +36,8 @@ export type AgentCommandOpts = {
   message: string;
   /** Optional image attachments for multimodal messages. */
   images?: ImageContent[];
+  /** Original inline/offloaded attachment order for inbound images. */
+  imageOrder?: PromptImageOrderEntry[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
   /** Agent id override (must exist in config). */

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -506,6 +506,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            imageOrder: params.imageOrder,
             clientTools: params.clientTools,
             disableTools: params.disableTools,
             provider,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1477,6 +1477,7 @@ export async function runEmbeddedAttempt(
             workspaceDir: effectiveWorkspace,
             model: params.model,
             existingImages: params.images,
+            imageOrder: params.imageOrder,
             maxBytes: MAX_IMAGE_BYTES,
             maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
             workspaceOnly: effectiveFsWorkspaceOnly,

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -10,6 +10,7 @@ import {
   loadImageFromRef,
   mergePromptAttachmentImages,
   modelSupportsImages,
+  splitPromptAndAttachmentRefs,
 } from "./images.js";
 
 function expectNoPromptImages(result: { detectedRefs: unknown[]; images: unknown[] }) {
@@ -300,6 +301,34 @@ describe("detectAndLoadPromptImages", () => {
     expect(merged).toEqual([
       { type: "image", data: "large-a", mimeType: "image/jpeg" },
       { type: "image", data: "small-b", mimeType: "image/png" },
+    ]);
+  });
+
+  it("classifies trailing offloaded refs separately from prompt refs", () => {
+    const prompt =
+      "compare [media attached: media://inbound/prompt-ref.png] and ./prompt-b.png\n[media attached: media://inbound/att-b.png]";
+    const refs = detectImageReferences(prompt);
+
+    const split = splitPromptAndAttachmentRefs({
+      prompt,
+      refs,
+      imageOrder: ["inline", "offloaded"],
+    });
+
+    expect(split.promptRefs).toEqual([
+      {
+        raw: "media://inbound/prompt-ref.png",
+        type: "media-uri",
+        resolved: "media://inbound/prompt-ref.png",
+      },
+      { raw: "./prompt-b.png", type: "path", resolved: "./prompt-b.png" },
+    ]);
+    expect(split.attachmentRefs).toEqual([
+      {
+        raw: "media://inbound/att-b.png",
+        type: "media-uri",
+        resolved: "media://inbound/att-b.png",
+      },
     ]);
   });
 

--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -8,6 +8,7 @@ import {
   detectAndLoadPromptImages,
   detectImageReferences,
   loadImageFromRef,
+  mergePromptAttachmentImages,
   modelSupportsImages,
 } from "./images.js";
 
@@ -287,6 +288,19 @@ describe("detectAndLoadPromptImages", () => {
     });
 
     expectNoPromptImages(result);
+  });
+
+  it("preserves attachment order when offloaded refs and inline images are mixed", async () => {
+    const merged = mergePromptAttachmentImages({
+      imageOrder: ["offloaded", "inline"],
+      existingImages: [{ type: "image", data: "small-b", mimeType: "image/png" }],
+      offloadedImages: [{ type: "image", data: "large-a", mimeType: "image/jpeg" }],
+    });
+
+    expect(merged).toEqual([
+      { type: "image", data: "large-a", mimeType: "image/jpeg" },
+      { type: "image", data: "small-b", mimeType: "image/png" },
+    ]);
   });
 
   it("blocks prompt image refs outside workspace when sandbox workspaceOnly is enabled", async () => {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -45,7 +45,7 @@ const PATH_REGEX_SOURCE =
  * The ID segment may contain alphanumerics, hyphens, underscores, and dots
  * (e.g. "1c77ce17-20b9-4546-be64-6e36a9adcb2c.png").
  */
-const MEDIA_URI_REGEX = /\bmedia:\/\/inbound\/([A-Za-z0-9._-]+)/;
+const MEDIA_URI_REGEX = /\bmedia:\/\/inbound\/([^\]\s]+)/;
 
 /**
  * Result of detecting an image reference in text.

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
+import { resolveMediaBufferPath } from "../../../media/store.js";
 import { loadWebMedia } from "../../../media/web-media.js";
 import { resolveUserPath } from "../../../utils.js";
 import type { ImageSanitizationLimits } from "../../image-sanitization.js";
@@ -39,14 +40,22 @@ const PATH_REGEX_SOURCE =
   "(?:^|\\s|[\"'`(])((\\.\\.?/|[~/])[^\\s\"'`()\\[\\]]*\\.(?:" + IMAGE_EXTENSION_PATTERN + "))";
 
 /**
+ * Matches the opaque media URI written by the Gateway's claim-check offload:
+ *   media://inbound/<uuid-or-id>
+ * The ID segment may contain alphanumerics, hyphens, underscores, and dots
+ * (e.g. "1c77ce17-20b9-4546-be64-6e36a9adcb2c.png").
+ */
+const MEDIA_URI_REGEX = /\bmedia:\/\/inbound\/([A-Za-z0-9._-]+)/;
+
+/**
  * Result of detecting an image reference in text.
  */
 export interface DetectedImageRef {
   /** The raw matched string from the prompt */
   raw: string;
   /** The type of reference */
-  type: "path";
-  /** The resolved/normalized path */
+  type: "path" | "media-uri";
+  /** The resolved/normalized path, or the raw media URI for media-uri type */
   resolved: string;
 }
 
@@ -87,6 +96,7 @@ async function sanitizeImagesWithLog(
  * - Home paths: ~/Pictures/screenshot.png
  * - file:// URLs: file:///path/to/image.png
  * - Message attachments: [Image: source: /path/to/image.jpg]
+ * - Gateway claim-check URIs: [media attached: media://inbound/<id>]
  *
  * @param prompt The user prompt text to scan
  * @returns Array of detected image references
@@ -132,6 +142,20 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
 
     // Skip "[media attached: N files]" header lines
     if (/^\d+\s+files?$/i.test(content.trim())) {
+      continue;
+    }
+
+    // Check for a Gateway claim-check URI first (media://inbound/<id>).
+    // This must be tested before the extension-based path regex because the
+    // URI has no file extension suffix in its base form.
+    const mediaUriMatch = content.match(MEDIA_URI_REGEX);
+    if (mediaUriMatch) {
+      const uri = `media://inbound/${mediaUriMatch[1]}`;
+      const dedupeKey = normalizeRefForDedupe(uri);
+      if (!seen.has(dedupeKey)) {
+        seen.add(dedupeKey);
+        refs.push({ raw: uri, type: "media-uri", resolved: uri });
+      }
       continue;
     }
 
@@ -205,6 +229,40 @@ export async function loadImageFromRef(
     sandbox?: { root: string; bridge: SandboxFsBridge };
   },
 ): Promise<ImageContent | null> {
+  // Handle Gateway claim-check URIs (media://inbound/<id>).
+  // These are written by the Gateway's offload path and point to files that
+  // the Gateway has already validated and persisted. They are intentionally
+  // exempt from workspaceOnly checks because they live in the media store
+  // managed by the Gateway, not in the agent workspace.
+  if (ref.type === "media-uri") {
+    const uriMatch = ref.resolved.match(MEDIA_URI_REGEX);
+    if (!uriMatch) {
+      log.debug(`Native image: malformed media URI, skipping: ${ref.resolved}`);
+      return null;
+    }
+    const mediaId = uriMatch[1];
+    try {
+      // resolveMediaBufferPath must be exported from store.ts.
+      // It accepts the media ID (with optional extension) and returns the
+      // absolute path of the persisted file.
+      const physicalPath = await resolveMediaBufferPath(mediaId, "inbound");
+      const media = await loadWebMedia(physicalPath, { maxBytes: options?.maxBytes });
+      if (media.kind !== "image") {
+        log.debug(`Native image: media store entry is not an image: ${mediaId}`);
+        return null;
+      }
+      const mimeType = media.contentType ?? "image/jpeg";
+      const data = media.buffer.toString("base64");
+      log.debug(`Native image: loaded media-uri ${ref.resolved} -> ${physicalPath}`);
+      return { type: "image", data, mimeType };
+    } catch (err) {
+      log.debug(
+        `Native image: failed to load media-uri ${ref.resolved}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
   try {
     let targetPath = ref.resolved;
 

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -42,10 +42,28 @@ const PATH_REGEX_SOURCE =
 /**
  * Matches the opaque media URI written by the Gateway's claim-check offload:
  *   media://inbound/<uuid-or-id>
- * The ID segment may contain alphanumerics, hyphens, underscores, and dots
- * (e.g. "1c77ce17-20b9-4546-be64-6e36a9adcb2c.png").
+ *
+ * Uses an exclusion-based character class rather than a whitelist so that
+ * Unicode filenames (e.g. Chinese characters) preserved by sanitizeFilename
+ * in store.ts are matched correctly.
+ *
+ * Explicitly excluded from the ID segment:
+ *   ]      — closes the surrounding [media attached: ...] bracket
+ *   \s     — any whitespace (space, newline, tab) — terminates the token
+ *   /      — forward slash path separator (traversal prevention)
+ *   \      — back slash path separator (traversal prevention)
+ *   \x00   — null byte (path injection prevention)
+ *
+ * resolveMediaBufferPath applies its own guards against these characters, but
+ * excluding them here provides defence-in-depth at the parsing layer.
+ *
+ * Example valid IDs:
+ *   "1c77ce17-20b9-4546-be64-6e36a9adcb2c.png"
+ *   "photo---1c77ce17-20b9-4546-be64-6e36a9adcb2c.png"
+ *   "图片---1c77ce17-20b9-4546-be64-6e36a9adcb2c.png"
  */
-const MEDIA_URI_REGEX = /\bmedia:\/\/inbound\/([^\]\s]+)/;
+// eslint-disable-next-line no-control-regex
+const MEDIA_URI_REGEX = /\bmedia:\/\/inbound\/([^\]\s/\\\x00]+)/;
 
 /**
  * Result of detecting an image reference in text.
@@ -242,9 +260,10 @@ export async function loadImageFromRef(
     }
     const mediaId = uriMatch[1];
     try {
-      // resolveMediaBufferPath must be exported from store.ts.
-      // It accepts the media ID (with optional extension) and returns the
-      // absolute path of the persisted file.
+      // resolveMediaBufferPath accepts the media ID (with optional extension
+      // and original-filename prefix) and returns the absolute path of the
+      // persisted file. It applies its own guards against path traversal,
+      // symlinks, and null bytes.
       const physicalPath = await resolveMediaBufferPath(mediaId, "inbound");
       const media = await loadWebMedia(physicalPath, { maxBytes: options?.maxBytes });
       if (media.kind !== "image") {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
-import { resolveMediaBufferPath } from "../../../media/store.js";
+import { resolveMediaBufferPath, getMediaDir } from "../../../media/store.js";
 import { loadWebMedia } from "../../../media/web-media.js";
 import { resolveUserPath } from "../../../utils.js";
 import type { ImageSanitizationLimits } from "../../image-sanitization.js";
@@ -265,7 +265,10 @@ export async function loadImageFromRef(
       // persisted file. It applies its own guards against path traversal,
       // symlinks, and null bytes.
       const physicalPath = await resolveMediaBufferPath(mediaId, "inbound");
-      const media = await loadWebMedia(physicalPath, { maxBytes: options?.maxBytes });
+      const media = await loadWebMedia(physicalPath, { 
+        maxBytes: options?.maxBytes,
+        localRoots: [getMediaDir()]
+      });
       if (media.kind !== "image") {
         log.debug(`Native image: media store entry is not an image: ${mediaId}`);
         return null;

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
+import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import { resolveMediaBufferPath, getMediaDir } from "../../../media/store.js";
 import { loadWebMedia } from "../../../media/web-media.js";
 import { resolveUserPath } from "../../../utils.js";
@@ -87,6 +88,54 @@ function isImageExtension(filePath: string): boolean {
 
 function normalizeRefForDedupe(raw: string): string {
   return process.platform === "win32" ? raw.toLowerCase() : raw;
+}
+
+export function mergePromptAttachmentImages(params: {
+  imageOrder?: PromptImageOrderEntry[];
+  existingImages?: ImageContent[];
+  offloadedImages?: Array<ImageContent | null>;
+  promptRefImages?: ImageContent[];
+}): ImageContent[] {
+  const promptImages: ImageContent[] = [];
+  const existingImages = params.existingImages ?? [];
+  const offloadedImages = params.offloadedImages ?? [];
+
+  if (params.imageOrder && params.imageOrder.length > 0) {
+    let inlineIndex = 0;
+    let offloadedIndex = 0;
+    for (const entry of params.imageOrder) {
+      if (entry === "inline") {
+        const image = existingImages[inlineIndex++];
+        if (image) {
+          promptImages.push(image);
+        }
+        continue;
+      }
+      const image = offloadedImages[offloadedIndex++];
+      if (image) {
+        promptImages.push(image);
+      }
+    }
+    while (inlineIndex < existingImages.length) {
+      promptImages.push(existingImages[inlineIndex++]);
+    }
+    while (offloadedIndex < offloadedImages.length) {
+      const image = offloadedImages[offloadedIndex++];
+      if (image) {
+        promptImages.push(image);
+      }
+    }
+  } else {
+    promptImages.push(...existingImages);
+    for (const image of offloadedImages) {
+      if (image) {
+        promptImages.push(image);
+      }
+    }
+  }
+
+  promptImages.push(...(params.promptRefImages ?? []));
+  return promptImages;
 }
 
 async function sanitizeImagesWithLog(
@@ -265,9 +314,9 @@ export async function loadImageFromRef(
       // persisted file. It applies its own guards against path traversal,
       // symlinks, and null bytes.
       const physicalPath = await resolveMediaBufferPath(mediaId, "inbound");
-      const media = await loadWebMedia(physicalPath, { 
+      const media = await loadWebMedia(physicalPath, {
         maxBytes: options?.maxBytes,
-        localRoots: [getMediaDir()]
+        localRoots: [getMediaDir()],
       });
       if (media.kind !== "image") {
         log.debug(`Native image: media store entry is not an image: ${mediaId}`);
@@ -372,6 +421,7 @@ export async function detectAndLoadPromptImages(params: {
   workspaceDir: string;
   model: { input?: string[] };
   existingImages?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
   maxBytes?: number;
   maxDimensionPx?: number;
   workspaceOnly?: boolean;
@@ -406,26 +456,53 @@ export async function detectAndLoadPromptImages(params: {
   }
 
   log.debug(`Native image: detected ${allRefs.length} image refs in prompt`);
-
-  const promptImages: ImageContent[] = [...(params.existingImages ?? [])];
+  const offloadedCount = params.imageOrder?.filter((entry) => entry === "offloaded").length ?? 0;
+  const attachmentRefs =
+    offloadedCount > 0 ? allRefs.slice(Math.max(0, allRefs.length - offloadedCount)) : [];
+  const promptRefs =
+    offloadedCount > 0 ? allRefs.slice(0, Math.max(0, allRefs.length - offloadedCount)) : allRefs;
+  const promptRefImages: ImageContent[] = [];
+  const offloadedImages: Array<ImageContent | null> = [];
 
   let loadedCount = 0;
   let skippedCount = 0;
 
-  for (const ref of allRefs) {
+  for (const ref of promptRefs) {
     const image = await loadImageFromRef(ref, params.workspaceDir, {
       maxBytes: params.maxBytes,
       workspaceOnly: params.workspaceOnly,
       sandbox: params.sandbox,
     });
     if (image) {
-      promptImages.push(image);
+      promptRefImages.push(image);
       loadedCount++;
       log.debug(`Native image: loaded ${ref.type} ${ref.resolved}`);
     } else {
       skippedCount++;
     }
   }
+
+  for (const ref of attachmentRefs) {
+    const image = await loadImageFromRef(ref, params.workspaceDir, {
+      maxBytes: params.maxBytes,
+      workspaceOnly: params.workspaceOnly,
+      sandbox: params.sandbox,
+    });
+    offloadedImages.push(image);
+    if (image) {
+      loadedCount++;
+      log.debug(`Native image: loaded ${ref.type} ${ref.resolved}`);
+    } else {
+      skippedCount++;
+    }
+  }
+
+  const promptImages = mergePromptAttachmentImages({
+    imageOrder: params.imageOrder,
+    existingImages: params.existingImages,
+    offloadedImages,
+    promptRefImages,
+  });
 
   const imageSanitization: ImageSanitizationLimits = {
     maxDimensionPx: params.maxDimensionPx,

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -138,6 +138,57 @@ export function mergePromptAttachmentImages(params: {
   return promptImages;
 }
 
+function extractTrailingAttachmentMediaUris(prompt: string, count: number): string[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  const lines = prompt.split(/\r?\n/);
+  const uris: string[] = [];
+  for (let index = lines.length - 1; index >= 0 && uris.length < count; index--) {
+    const line = lines[index]?.trim();
+    if (!line || line.includes("\0")) {
+      break;
+    }
+    const match = line.match(/^\[media attached:\s*(media:\/\/inbound\/[^\]\s/\\]+)\]$/);
+    if (!match?.[1]) {
+      break;
+    }
+    uris.unshift(match[1]);
+  }
+  return uris;
+}
+
+export function splitPromptAndAttachmentRefs(params: {
+  prompt: string;
+  refs: DetectedImageRef[];
+  imageOrder?: PromptImageOrderEntry[];
+}): {
+  promptRefs: DetectedImageRef[];
+  attachmentRefs: DetectedImageRef[];
+} {
+  const offloadedCount = params.imageOrder?.filter((entry) => entry === "offloaded").length ?? 0;
+  if (offloadedCount === 0) {
+    return { promptRefs: params.refs, attachmentRefs: [] };
+  }
+
+  const attachmentUris = new Set(extractTrailingAttachmentMediaUris(params.prompt, offloadedCount));
+  if (attachmentUris.size === 0) {
+    return { promptRefs: params.refs, attachmentRefs: [] };
+  }
+
+  const promptRefs: DetectedImageRef[] = [];
+  const attachmentRefs: DetectedImageRef[] = [];
+  for (const ref of params.refs) {
+    if (ref.type === "media-uri" && attachmentUris.has(ref.resolved)) {
+      attachmentRefs.push(ref);
+      continue;
+    }
+    promptRefs.push(ref);
+  }
+  return { promptRefs, attachmentRefs };
+}
+
 async function sanitizeImagesWithLog(
   images: ImageContent[],
   label: string,
@@ -456,11 +507,11 @@ export async function detectAndLoadPromptImages(params: {
   }
 
   log.debug(`Native image: detected ${allRefs.length} image refs in prompt`);
-  const offloadedCount = params.imageOrder?.filter((entry) => entry === "offloaded").length ?? 0;
-  const attachmentRefs =
-    offloadedCount > 0 ? allRefs.slice(Math.max(0, allRefs.length - offloadedCount)) : [];
-  const promptRefs =
-    offloadedCount > 0 ? allRefs.slice(0, Math.max(0, allRefs.length - offloadedCount)) : allRefs;
+  const { promptRefs, attachmentRefs } = splitPromptAndAttachmentRefs({
+    prompt: params.prompt,
+    refs: allRefs,
+    imageOrder: params.imageOrder,
+  });
   const promptRefImages: ImageContent[] = [];
   const offloadedImages: Array<ImageContent | null> = [];
 

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -2,6 +2,7 @@ import type { ImageContent } from "@mariozechner/pi-ai";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { enqueueCommand } from "../../../process/command-queue.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { ExecElevatedDefaults, ExecToolDefaults } from "../../bash-tools.js";
@@ -76,6 +77,7 @@ export type RunEmbeddedPiAgentParams = {
   skillsSnapshot?: SkillSnapshot;
   prompt: string;
   images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
   /** Disable built-in tools for this run (LLM-only mode). */

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -552,7 +552,6 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
       // Hook errors are non-fatal — built-in scanner results still apply.
     }
   }
-
   // Warn when install is triggered from a non-bundled source.
   // Workspace/project/personal agent skills can contain attacker-controlled metadata.
   const trustedInstallSources = new Set(["openclaw-bundled", "openclaw-managed", "openclaw-extra"]);

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -37,12 +37,13 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
-    sourceInfo: createSyntheticSourceInfo(params.filePath, {
-      source: params.source,
-      baseDir: params.baseDir,
-      scope: "project",
-      origin: "top-level",
-    }),
+    sourceInfo: {
+     filePath: params.filePath,
+     source: params.source,
+     baseDir: params.baseDir,
+     scope: "project" as const,
+     origin: "top-level" as const,
+    },
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/agents/skills.test-helpers.ts
+++ b/src/agents/skills.test-helpers.ts
@@ -37,13 +37,12 @@ export function createCanonicalFixtureSkill(params: {
     filePath: params.filePath,
     baseDir: params.baseDir,
     source: params.source,
-    sourceInfo: {
-     filePath: params.filePath,
-     source: params.source,
-     baseDir: params.baseDir,
-     scope: "project" as const,
-     origin: "top-level" as const,
-    },
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+      scope: "project",
+      origin: "top-level",
+    }),
     disableModelInvocation: params.disableModelInvocation ?? false,
   };
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -316,6 +316,7 @@ export async function runAgentTurnWithFallback(params: {
                       bootstrapPromptWarningSignaturesSeen.length - 1
                     ],
                   images: params.opts?.images,
+                  imageOrder: params.opts?.imageOrder,
                 });
                 bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                   result.meta?.systemPromptReport,
@@ -416,6 +417,7 @@ export async function runAgentTurnWithFallback(params: {
                 bootstrapContextMode: params.opts?.bootstrapContextMode,
                 bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
                 images: params.opts?.images,
+                imageOrder: params.opts?.imageOrder,
                 abortSignal: params.opts?.abortSignal,
                 blockReplyBreak: params.resolvedBlockStreamingBreak,
                 blockReplyChunking: params.blockReplyChunking,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -1,5 +1,6 @@
 import type { ImageContent } from "@mariozechner/pi-ai";
 import type { InteractiveReply } from "../interactive/payload.js";
+import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { TypingController } from "./reply/typing.js";
 
 export type BlockReplyContext = {
@@ -28,6 +29,8 @@ export type GetReplyOptions = {
   abortSignal?: AbortSignal;
   /** Optional inbound images (used for webchat attachments). */
   images?: ImageContent[];
+  /** Original inline/offloaded attachment order for inbound images. */
+  imageOrder?: PromptImageOrderEntry[];
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
   onReplyStart?: () => Promise<void> | void;

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -30,8 +30,23 @@ type NormalizedAttachment = {
   mime: string;
   base64: string;
 };
+type SavedMedia = {
+  id: string;
+  path?: string; 
+};
 
 const OFFLOAD_THRESHOLD_BYTES = 2_000_000;
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/jpg":  ".jpg",
+  "image/png":  ".png",
+  "image/webp": ".webp",
+  "image/gif":  ".gif",
+  "image/avif": ".avif",
+  "image/bmp":  ".bmp",
+  "image/tiff": ".tiff",
+};
 
 function normalizeMime(mime?: string): string | undefined {
   if (!mime) return undefined;
@@ -49,6 +64,17 @@ function isValidBase64(value: string): boolean {
 
 function sanitizePathSegment(value: string): string {
   return value.replace(/[^a-zA-Z0-9.\-_]/g, "_");
+}
+
+function ensureExtension(label: string, mime: string): string {
+  if (/\.[a-zA-Z0-9]+$/.test(label)) return label;
+  const ext = MIME_TO_EXT[mime.toLowerCase()] ?? "";
+  return ext ? `${label}${ext}` : label;
+}
+
+function extractMediaPath(savedMedia: SavedMedia, fallbackLabel: string): string {
+  const raw = savedMedia.path ?? savedMedia.id ?? fallbackLabel;
+  return raw.replace(/\\/g, "/");
 }
 
 function normalizeAttachment(
@@ -133,6 +159,12 @@ export async function parseMessageWithAttachments(
       continue;
     }
 
+    if (sizeBytes > maxBytes) {
+      throw new Error(
+        `attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`,
+      );
+    }
+
     const providedMime = normalizeMime(mime);
     const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
 
@@ -145,7 +177,9 @@ export async function parseMessageWithAttachments(
       continue;
     }
     if (sniffedMime && providedMime && sniffedMime !== providedMime) {
-      log?.warn(`attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`);
+      log?.warn(
+        `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
+      );
     }
     const finalMime = sniffedMime ?? providedMime ?? mime;
 
@@ -154,31 +188,29 @@ export async function parseMessageWithAttachments(
     if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
       try {
         const buffer = Buffer.from(b64, "base64");
-        const savedMedia = await saveMediaBuffer(buffer, finalMime, "inbound");
-        // Use the path returned by the storage layer; fall back to a sanitized id only
-        // if the storage layer does not expose a resolved path.
-        const mediaPath = savedMedia.path ?? sanitizePathSegment(savedMedia.id || label);
+
+        const labelWithExt = ensureExtension(label, finalMime);
+
+        const savedMedia = (await saveMediaBuffer(
+          buffer,
+          finalMime,
+          "inbound",
+          labelWithExt,
+        )) as SavedMedia;
+
+        const mediaPath = extractMediaPath(savedMedia, labelWithExt);
 
         updatedMessage += `\n[media attached: ${mediaPath}]`;
         log?.info?.(`[Gateway] Intercepted large image payload. Saved to disk: ${mediaPath}`);
         isOffloaded = true;
       } catch (err) {
-        // Do not fall back to in-memory processing when the file also exceeds the hard
-        // memory limit — that would reintroduce the OOM risk this change is meant to fix.
-        if (sizeBytes > maxBytes) {
-          throw new Error(
-            `attachment ${label}: exceeds size limit and could not be offloaded to disk: ${err}`,
-          );
-        }
-        log?.warn(`[Gateway] Failed to save intercepted media to disk, falling back to memory: ${err}`);
+        log?.warn(
+          `[Gateway Error] Failed to save intercepted media to disk, falling back to memory: ${err}`,
+        );
       }
     }
 
     if (isOffloaded) continue;
-
-    if (sizeBytes > maxBytes) {
-      throw new Error(`attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`);
-    }
 
     images.push({ type: "image", data: b64, mimeType: finalMime });
   }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -44,7 +44,8 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/png": ".png",
   "image/webp": ".webp",
   "image/gif": ".gif",
-  "image/avif": ".avif",
+  // bmp/tiff excluded from isSupportedForOffload to avoid extension-loss
+  // bug in store.ts; entries kept here for future extension support
   "image/bmp": ".bmp",
   "image/tiff": ".tiff",
 };

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -29,6 +29,8 @@ export type OffloadedRef = {
   mediaRef: string;
   /** The raw media ID from SavedMedia.id, usable with resolveMediaBufferPath */
   id: string;
+  /** Absolute filesystem path returned by saveMediaBuffer — used for transcript MediaPath */
+  path: string;
   /** MIME type of the offloaded attachment */
   mimeType: string;
   /** The label / filename of the original attachment */
@@ -411,7 +413,13 @@ export async function parseMessageWithAttachments(
 
           // Record for transcript metadata — separate from `images` because
           // these are not passed inline to the model.
-          offloadedRefs.push({ mediaRef, id: savedMedia.id, mimeType: finalMime, label });
+          offloadedRefs.push({
+            mediaRef,
+            id: savedMedia.id,
+            path: savedMedia.path ?? "",
+            mimeType: finalMime,
+            label,
+          });
 
           isOffloaded = true;
         } catch (err) {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,5 +1,6 @@
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
+import { saveMediaBuffer } from "../media/store.js"; 
 
 export type ChatAttachment = {
   type?: string;
@@ -106,6 +107,7 @@ export async function parseMessageWithAttachments(
   }
 
   const images: ChatImageContent[] = [];
+  let updatedMessage = message; 
 
   for (const [idx, att] of attachments.entries()) {
     if (!att) {
@@ -120,6 +122,7 @@ export async function parseMessageWithAttachments(
 
     const providedMime = normalizeMime(mime);
     const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
+    
     if (sniffedMime && !isImageMime(sniffedMime)) {
       log?.warn(`attachment ${label}: detected non-image (${sniffedMime}), dropping`);
       continue;
@@ -133,15 +136,26 @@ export async function parseMessageWithAttachments(
         `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
       );
     }
+    const finalMime = sniffedMime ?? providedMime ?? mime;
+    try {
+      const buffer = Buffer.from(b64, "base64");
+      const savedMedia = await saveMediaBuffer(buffer, finalMime, "inbound");
+      const mediaId = savedMedia.id || label;
+      updatedMessage += `\n[media attached: inbound/${mediaId}]`;
+      log?.warn(`[Gateway] Intercepted large image payload. Saved to disk: inbound/${mediaId}`);
+      continue; 
+    } catch (err) {
+      log?.warn(`[Gateway Error] Failed to save intercepted media to disk. Falling back to memory payload: ${err}`);
+    }
 
     images.push({
       type: "image",
       data: b64,
-      mimeType: sniffedMime ?? providedMime ?? mime,
+      mimeType: finalMime,
     });
   }
 
-  return { message, images };
+  return { message: updatedMessage.trim(), images };
 }
 
 /**

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -30,6 +30,7 @@ type NormalizedAttachment = {
   mime: string;
   base64: string;
 };
+
 type SavedMedia = {
   id: string;
   path?: string;
@@ -49,7 +50,9 @@ const MIME_TO_EXT: Record<string, string> = {
 };
 
 function normalizeMime(mime?: string): string | undefined {
-  if (!mime) return undefined;
+  if (!mime) {
+    return undefined;
+  }
   const cleaned = mime.split(";")[0]?.trim().toLowerCase();
   return cleaned || undefined;
 }
@@ -62,12 +65,10 @@ function isValidBase64(value: string): boolean {
   return value.length > 0 && value.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(value);
 }
 
-function sanitizePathSegment(value: string): string {
-  return value.replace(/[^a-zA-Z0-9.\-_]/g, "_");
-}
-
 function ensureExtension(label: string, mime: string): string {
-  if (/\.[a-zA-Z0-9]+$/.test(label)) return label;
+  if (/\.[a-zA-Z0-9]+$/.test(label)) {
+    return label;
+  }
   const ext = MIME_TO_EXT[mime.toLowerCase()] ?? "";
   return ext ? `${label}${ext}` : label;
 }
@@ -140,7 +141,9 @@ export async function parseMessageWithAttachments(
   let updatedMessage = message;
 
   for (const [idx, att] of attachments.entries()) {
-    if (!att) continue;
+    if (!att) {
+      continue;
+    }
 
     const normalized = normalizeAttachment(att, idx, {
       stripDataUrlPrefix: true,
@@ -188,7 +191,6 @@ export async function parseMessageWithAttachments(
     if (sizeBytes > OFFLOAD_THRESHOLD_BYTES && isSupportedForOffload) {
       try {
         const buffer = Buffer.from(b64, "base64");
-
         const labelWithExt = ensureExtension(label, finalMime);
 
         const savedMedia = (await saveMediaBuffer(
@@ -205,13 +207,16 @@ export async function parseMessageWithAttachments(
         log?.info?.(`[Gateway] Intercepted large image payload. Saved to disk: ${mediaPath}`);
         isOffloaded = true;
       } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
         log?.warn(
-          `[Gateway Error] Failed to save intercepted media to disk, falling back to memory: ${err}`,
+          `[Gateway Error] Failed to save intercepted media to disk, falling back to memory: ${errorMessage}`,
         );
       }
     }
 
-    if (isOffloaded) continue;
+    if (isOffloaded) {
+      continue;
+    }
 
     images.push({ type: "image", data: b64, mimeType: finalMime });
   }
@@ -240,7 +245,9 @@ export function buildMessageWithAttachments(
   const blocks: string[] = [];
 
   for (const [idx, att] of attachments.entries()) {
-    if (!att) continue;
+    if (!att) {
+      continue;
+    }
 
     const normalized = normalizeAttachment(att, idx, {
       stripDataUrlPrefix: false,
@@ -253,7 +260,9 @@ export function buildMessageWithAttachments(
     blocks.push(`![${safeLabel}](data:${mime};base64,${base64})`);
   }
 
-  if (blocks.length === 0) return message;
+  if (blocks.length === 0) {
+    return message;
+  }
 
   const separator = message.trim().length > 0 ? "\n\n" : "";
   return `${message}${separator}${blocks.join("\n\n")}`;

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -15,9 +15,44 @@ export type ChatImageContent = {
   mimeType: string;
 };
 
+/**
+ * Metadata for an attachment that was offloaded to the media store.
+ *
+ * Included in ParsedMessageWithImages.offloadedRefs so that callers can
+ * persist structured media metadata for transcripts. Without this, consumers
+ * that derive MediaPath/MediaPaths from the `images` array (e.g.
+ * persistChatSendImages and buildChatSendTranscriptMessage in chat.ts) would
+ * silently omit all large attachments that were offloaded to disk.
+ */
+export type OffloadedMediaRef = {
+  /** Opaque media URI injected into the message, e.g. "media://inbound/<id>" */
+  mediaRef: string;
+  /** The raw media ID from SavedMedia.id, usable with resolveMediaBufferPath */
+  id: string;
+  /** MIME type of the offloaded attachment */
+  mimeType: string;
+  /** The label / filename of the original attachment */
+  label: string;
+};
+
 export type ParsedMessageWithImages = {
   message: string;
+  /** Small attachments (≤ OFFLOAD_THRESHOLD_BYTES) passed inline to the model */
   images: ChatImageContent[];
+  /**
+   * Large attachments (> OFFLOAD_THRESHOLD_BYTES) that were offloaded to the
+   * media store. Each entry corresponds to a `[media attached: media://inbound/<id>]`
+   * marker appended to `message`.
+   *
+   * Callers MUST persist this list separately for transcript media metadata.
+   * It is intentionally separate from `images` because downstream model calls
+   * do not receive these as inline image blocks.
+   *
+   * ⚠️  Call sites (chat.ts, agent.ts, server-node-events.ts) MUST also pass
+   * `supportsImages: modelSupportsImages(model)` so that text-only model runs
+   * do not inject unresolvable media:// markers into prompt text.
+   */
+  offloadedRefs: OffloadedMediaRef[];
 };
 
 type AttachmentLog = {
@@ -52,8 +87,11 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/tiff": ".tiff",
 };
 
-// Moved outside the loop and uses a Set for O(1) lookup instead of
-// rebuilding an array on every attachment iteration.
+// Module-level Set for O(1) lookup — not rebuilt on every attachment iteration.
+//
+// heic/heif are included only if store.ts's extensionForMime maps them to an
+// extension. If it does not (same extension-loss risk as bmp/tiff), remove
+// them from this set.
 const SUPPORTED_OFFLOAD_MIMES = new Set([
   "image/jpeg",
   "image/jpg",
@@ -67,8 +105,8 @@ const SUPPORTED_OFFLOAD_MIMES = new Set([
 /**
  * Raised when the Gateway cannot persist an attachment to the media store.
  *
- * This is distinct from ordinary input-validation errors so that Gateway
- * handlers can map it to a server-side 5xx status rather than a client 4xx.
+ * Distinct from ordinary input-validation errors so that Gateway handlers can
+ * map it to a server-side 5xx status rather than a client 4xx.
  *
  * Example causes: ENOSPC, EPERM, unexpected saveMediaBuffer return shape.
  */
@@ -97,10 +135,9 @@ function isValidBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }
-  // A full O(n) regex scan is safe because the regex has no overlapping
-  // quantifiers and fails linearly without catastrophic backtracking.
-  // This prevents adversarial payloads padded with megabytes of whitespace
-  // from bypassing length thresholds.
+  // A full O(n) regex scan is safe: no overlapping quantifiers, fails linearly.
+  // Prevents adversarial payloads padded with megabytes of whitespace from
+  // bypassing length thresholds.
   return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
 }
 
@@ -110,9 +147,12 @@ function isValidBase64(value: string): boolean {
  *
  * Node's Buffer.from silently drops invalid base64 characters rather than
  * throwing. A material size discrepancy means the source string contained
- * embedded garbage that was silently stripped, which would produce a
- * corrupted file on disk. ±3 bytes of slack accounts for base64 padding
- * rounding.
+ * embedded garbage that was silently stripped, which would produce a corrupted
+ * file on disk. ±3 bytes of slack accounts for base64 padding rounding.
+ *
+ * IMPORTANT: this is an input-validation check (4xx client error).
+ * It MUST be called OUTSIDE the MediaOffloadError try/catch so that
+ * corrupt-input errors are not misclassified as 5xx server errors.
  */
 function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {
   if (Math.abs(buffer.byteLength - estimatedBytes) > 3) {
@@ -138,10 +178,8 @@ function ensureExtension(label: string, mime: string): string {
  * - is a non-empty string
  * - contains no path separators (/ or \) or null bytes
  *
- * This provides defence-in-depth before the ID is embedded in a
- * media://inbound/<id> URI and later resolved by resolveMediaBufferPath
- * (which applies its own guards). Catching a bad shape here produces a
- * cleaner error message than a cryptic failure deeper in the stack.
+ * Catching a bad shape here produces a cleaner error than a cryptic failure
+ * deeper in the stack, and is treated as a 5xx infrastructure error.
  */
 function assertSavedMedia(value: unknown, label: string): SavedMedia {
   if (
@@ -209,34 +247,40 @@ function validateAttachmentBase64OrThrow(
 
 /**
  * Parse attachments and extract images as structured content blocks.
- * Returns the message text and an array of image content blocks
- * compatible with Claude API's image format.
+ * Returns the message text, inline image blocks, and offloaded media refs.
  *
+ * ## Offload behaviour
  * Attachments whose decoded size exceeds OFFLOAD_THRESHOLD_BYTES are saved to
  * disk via saveMediaBuffer and replaced with an opaque `media://inbound/<id>`
- * URI appended to the message. Downstream agents must resolve this URI via the
- * media store before forwarding to the model.
+ * URI appended to the message. The agent resolves these URIs via
+ * resolveMediaBufferPath before passing them to the model.
  *
- * Pass `supportsImages: false` for text-only model runs. In that case all
- * attachments are dropped cleanly and no media:// markers are injected into
- * the prompt, preventing internal path references from leaking into model input.
+ * ## Transcript metadata
+ * Callers MUST use `result.offloadedRefs` to persist structured media metadata
+ * for transcripts. These refs are intentionally excluded from `result.images`
+ * because they are not passed inline to the model.
  *
- * On any parse failure after one or more files have already been offloaded,
- * this function performs a best-effort cleanup of those files before rethrowing
- * so that malformed requests do not accumulate orphaned files on disk.
+ * ## Text-only model runs
+ * Pass `supportsImages: false` for text-only model runs so that no media://
+ * markers are injected into prompt text.
  *
- * Known limitation: when a mix of large (offloaded) and small (inline) images
- * is present, offloaded images appear as text markers appended to the message
- * while inline images are in the `images` array. The agent's
- * detectAndLoadPromptImages initialises from `existingImages` first, then
- * appends prompt-detected refs, so mixed batches may be delivered to the model
- * in a different order than the original attachment list. Prompts that rely on
- * attachment order (e.g. "first image") should be aware of this. A future
- * refactor should unify all image references into a single ordered list.
+ * ⚠️  Call sites in chat.ts, agent.ts, and server-node-events.ts MUST be
+ * updated to pass `supportsImages: modelSupportsImages(model)`. Until they do,
+ * text-only model runs receive unresolvable media:// markers in their prompt.
  *
- * @throws {MediaOffloadError} When a filesystem error prevents saving an
- * attachment to the media store. Callers should map this to a server-side
- * 5xx status rather than a client 4xx.
+ * ## Cleanup on failure
+ * On any parse failure after files have already been offloaded, best-effort
+ * cleanup is performed before rethrowing so that malformed requests do not
+ * accumulate orphaned files on disk ahead of the periodic TTL sweep.
+ *
+ * ## Known ordering limitation
+ * In mixed large/small batches, the model receives images in a different order
+ * than the original attachment list because detectAndLoadPromptImages
+ * initialises from existingImages first, then appends prompt-detected refs.
+ * A future refactor should unify all image references into a single ordered list.
+ *
+ * @throws {MediaOffloadError} Infrastructure failure saving to media store → 5xx.
+ * @throws {Error} Input validation failure → 4xx.
  */
 export async function parseMessageWithAttachments(
   message: string,
@@ -247,29 +291,27 @@ export async function parseMessageWithAttachments(
   const log = opts?.log;
 
   if (!attachments || attachments.length === 0) {
-    return { message, images: [] };
+    return { message, images: [], offloadedRefs: [] };
   }
 
-  // For text-only models, attachments cannot be used regardless of size.
-  // Drop them cleanly instead of saving files and injecting media:// markers
-  // that would never be resolved, which would leak internal path references
-  // into the model's prompt.
+  // For text-only models drop all attachments cleanly. Do not save files or
+  // inject media:// markers that would never be resolved and would leak
+  // internal path references into the model's prompt.
   if (opts?.supportsImages === false) {
     if (attachments.length > 0) {
       log?.warn(
         `parseMessageWithAttachments: ${attachments.length} attachment(s) dropped — model does not support images`,
       );
     }
-    return { message, images: [] };
+    return { message, images: [], offloadedRefs: [] };
   }
 
   const images: ChatImageContent[] = [];
+  const offloadedRefs: OffloadedMediaRef[] = [];
   let updatedMessage = message;
 
-  // Track IDs of files saved during this request so we can clean them up
-  // if a later attachment fails validation and the entire parse is aborted.
-  // Without this, repeated malformed multi-attachment requests can accumulate
-  // orphaned files on disk ahead of the periodic TTL sweep.
+  // Track IDs of files saved during this request for cleanup if a later
+  // attachment fails validation and the entire parse is aborted.
   const savedMediaIds: string[] = [];
 
   try {
@@ -318,23 +360,17 @@ export async function parseMessageWithAttachments(
         );
       }
 
-      // The third fallback normalises `mime` so that a raw un-normalised string
-      // (e.g. "IMAGE/JPEG" from the caller) does not silently bypass the
-      // SUPPORTED_OFFLOAD_MIMES check below. If normalisation still yields
-      // nothing, fall back to the raw string as a last resort.
+      // Third fallback normalises `mime` so a raw un-normalised string (e.g.
+      // "IMAGE/JPEG") does not silently bypass the SUPPORTED_OFFLOAD_MIMES check.
       const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
 
       let isOffloaded = false;
 
-      const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
-
       if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+        const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
+
         if (!isSupportedForOffload) {
-          // The attachment is above the offload threshold but its format cannot
-          // be offloaded (no guaranteed extension mapping in store.ts).
-          // Note: sizeBytes is between OFFLOAD_THRESHOLD_BYTES and maxBytes, so
-          // saying "exceeds size limit" would be misleading — the image IS within
-          // the declared limit but cannot safely be offloaded in this format.
+          // Passing this inline would reintroduce the OOM risk this PR prevents.
           throw new Error(
             `attachment ${label}: format ${finalMime} is too large to pass inline ` +
               `(${sizeBytes} > ${OFFLOAD_THRESHOLD_BYTES} bytes) and cannot be offloaded. ` +
@@ -342,14 +378,15 @@ export async function parseMessageWithAttachments(
           );
         }
 
+        // Decode and run input-validation BEFORE the MediaOffloadError try/catch.
+        // verifyDecodedSize is a 4xx client error and must not be wrapped as a
+        // 5xx MediaOffloadError.
+        const buffer = Buffer.from(b64, "base64");
+        verifyDecodedSize(buffer, sizeBytes, label);
+
+        // Only the storage operation is wrapped so callers can distinguish
+        // infrastructure failures (5xx) from input errors (4xx).
         try {
-          const buffer = Buffer.from(b64, "base64");
-
-          // Post-decode size validation for large payloads.
-          // Provides defense-in-depth against silent truncation by Buffer.from
-          // if any malformed characters somehow bypassed prior validation.
-          verifyDecodedSize(buffer, sizeBytes, label);
-
           const labelWithExt = ensureExtension(label, finalMime);
 
           const rawResult = await saveMediaBuffer(
@@ -360,26 +397,24 @@ export async function parseMessageWithAttachments(
             labelWithExt,
           );
 
-          // Validate shape and ID safety before trusting the result.
           const savedMedia = assertSavedMedia(rawResult, label);
 
-          // Track this ID for cleanup if a later attachment fails.
+          // Track for cleanup if a subsequent attachment fails.
           savedMediaIds.push(savedMedia.id);
 
-          // Use an opaque media URI instead of a physical filesystem path.
-          // This decouples the Gateway from the Agent's filesystem layout
-          // and is compatible with workspaceOnly sandboxes.
-          // The agent resolves media://inbound/<id> via resolveMediaBufferPath
-          // in store.ts before passing the image to the model.
+          // Opaque URI — compatible with workspaceOnly sandboxes and decouples
+          // the Gateway from the agent's filesystem layout.
           const mediaRef = `media://inbound/${savedMedia.id}`;
 
           updatedMessage += `\n[media attached: ${mediaRef}]`;
           log?.info?.(`[Gateway] Intercepted large image payload. Saved: ${mediaRef}`);
+
+          // Record for transcript metadata — separate from `images` because
+          // these are not passed inline to the model.
+          offloadedRefs.push({ mediaRef, id: savedMedia.id, mimeType: finalMime, label });
+
           isOffloaded = true;
         } catch (err) {
-          // Distinguish operational storage failures from input-validation errors
-          // so that Gateway handlers can map them to the correct HTTP status:
-          // catch MediaOffloadError → 5xx, catch Error → 4xx.
           const errorMessage = err instanceof Error ? err.message : String(err);
           throw new MediaOffloadError(
             `[Gateway Error] Failed to save intercepted media to disk: ${errorMessage}`,
@@ -395,10 +430,7 @@ export async function parseMessageWithAttachments(
       images.push({ type: "image", data: b64, mimeType: finalMime });
     }
   } catch (err) {
-    // Best-effort cleanup: delete any files that were successfully saved
-    // earlier in this request before re-throwing. This prevents malformed
-    // multi-attachment requests from accumulating orphaned files on disk
-    // ahead of the periodic TTL sweep.
+    // Best-effort cleanup before rethrowing.
     if (savedMediaIds.length > 0) {
       await Promise.allSettled(savedMediaIds.map((id) => deleteMediaBuffer(id, "inbound")));
     }
@@ -408,6 +440,7 @@ export async function parseMessageWithAttachments(
   return {
     message: updatedMessage !== message ? updatedMessage.trimEnd() : message,
     images,
+    offloadedRefs,
   };
 }
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -44,6 +44,8 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/png": ".png",
   "image/webp": ".webp",
   "image/gif": ".gif",
+  "image/heic": ".heic",
+  "image/heif": ".heif",
   // bmp/tiff excluded from SUPPORTED_OFFLOAD_MIMES to avoid extension-loss
   // bug in store.ts; entries kept here for future extension support
   "image/bmp": ".bmp",
@@ -58,6 +60,8 @@ const SUPPORTED_OFFLOAD_MIMES = new Set([
   "image/png",
   "image/webp",
   "image/gif",
+  "image/heic",
+  "image/heif",
 ]);
 
 function normalizeMime(mime?: string): string | undefined {
@@ -287,7 +291,7 @@ export async function parseMessageWithAttachments(
           buffer,
           finalMime,
           "inbound",
-          undefined,
+          maxBytes,
           labelWithExt,
         );
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -24,7 +24,7 @@ export type ChatImageContent = {
  * persistChatSendImages and buildChatSendTranscriptMessage in chat.ts) would
  * silently omit all large attachments that were offloaded to disk.
  */
-export type OffloadedMediaRef = {
+export type OffloadedRef = {
   /** Opaque media URI injected into the message, e.g. "media://inbound/<id>" */
   mediaRef: string;
   /** The raw media ID from SavedMedia.id, usable with resolveMediaBufferPath */
@@ -52,7 +52,7 @@ export type ParsedMessageWithImages = {
    * `supportsImages: modelSupportsImages(model)` so that text-only model runs
    * do not inject unresolvable media:// markers into prompt text.
    */
-  offloadedRefs: OffloadedMediaRef[];
+  offloadedRefs: OffloadedRef[];
 };
 
 type AttachmentLog = {
@@ -307,7 +307,7 @@ export async function parseMessageWithAttachments(
   }
 
   const images: ChatImageContent[] = [];
-  const offloadedRefs: OffloadedMediaRef[] = [];
+  const offloadedRefs: OffloadedRef[] = [];
   let updatedMessage = message;
 
   // Track IDs of files saved during this request for cleanup if a later

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -44,11 +44,21 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/png": ".png",
   "image/webp": ".webp",
   "image/gif": ".gif",
-  // bmp/tiff excluded from isSupportedForOffload to avoid extension-loss
+  // bmp/tiff excluded from SUPPORTED_OFFLOAD_MIMES to avoid extension-loss
   // bug in store.ts; entries kept here for future extension support
   "image/bmp": ".bmp",
   "image/tiff": ".tiff",
 };
+
+// Fix #1: Moved outside loop and use a Set for O(1) lookup instead of
+// rebuilding an array on every attachment iteration.
+const SUPPORTED_OFFLOAD_MIMES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+]);
 
 function normalizeMime(mime?: string): string | undefined {
   if (!mime) {
@@ -63,6 +73,9 @@ function isImageMime(mime?: string): boolean {
 }
 
 function isValidBase64(value: string): boolean {
+  // NOTE: This regex is O(n) over the full string length.
+  // For payloads near maxBytes (~5 MB / ~6.7 M chars) this is non-trivial.
+  // A future optimization could do a sampled spot-check for very large inputs.
   return value.length > 0 && value.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(value);
 }
 
@@ -74,9 +87,18 @@ function ensureExtension(label: string, mime: string): string {
   return ext ? `${label}${ext}` : label;
 }
 
-function extractMediaPath(savedMedia: SavedMedia, fallbackLabel: string): string {
-  const raw = savedMedia.path ?? savedMedia.id ?? fallbackLabel;
-  return raw.replace(/\\/g, "/");
+// Fix #2: Guard against unexpected shapes from saveMediaBuffer before
+// treating the result as SavedMedia, instead of blindly casting with `as`.
+function assertSavedMedia(value: unknown, label: string): SavedMedia {
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    "id" in value &&
+    typeof (value as Record<string, unknown>).id === "string"
+  ) {
+    return value as SavedMedia;
+  }
+  throw new Error(`attachment ${label}: saveMediaBuffer returned unexpected shape`);
 }
 
 function normalizeAttachment(
@@ -125,6 +147,20 @@ function validateAttachmentBase64OrThrow(
  * Parse attachments and extract images as structured content blocks.
  * Returns the message text and an array of image content blocks
  * compatible with Claude API's image format.
+ *
+ * Attachments whose decoded size exceeds OFFLOAD_THRESHOLD_BYTES are saved to
+ * disk via saveMediaBuffer and replaced with an opaque `media://inbound/<id>`
+ * URI appended to the message. Downstream agents must resolve this URI via the
+ * media store before forwarding to the model.
+ *
+ * Known limitation: when a mix of large (offloaded) and small (inline) images
+ * is present, offloaded images appear as text markers appended to the message
+ * while inline images are in the `images` array. The agent's
+ * detectAndLoadPromptImages initialises from `existingImages` first, then
+ * appends prompt-detected refs, so mixed batches may be delivered to the model
+ * in a different order than the original attachment list. Prompts that rely on
+ * attachment order (e.g. "first image") should be aware of this. A future
+ * refactor should unify all image references into a single ordered list.
  */
 export async function parseMessageWithAttachments(
   message: string,
@@ -183,35 +219,44 @@ export async function parseMessageWithAttachments(
         `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
       );
     }
-    const finalMime = sniffedMime ?? providedMime ?? mime;
+
+    // Fix #3: The third fallback normalizes `mime` so that a raw un-normalized
+    // string (e.g. "IMAGE/JPEG" from the caller) doesn't silently bypass the
+    // SUPPORTED_OFFLOAD_MIMES check below. If normalization still yields
+    // nothing, fall back to the raw string as a last resort.
+    const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
 
     let isOffloaded = false;
 
-    const isSupportedForOffload = [
-      "image/jpeg",
-      "image/jpg",
-      "image/png",
-      "image/webp",
-      "image/gif",
-    ].includes(finalMime);
+    // Fix #1 (continued): isSupportedForOffload now uses the module-level Set.
+    const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
 
     if (sizeBytes > OFFLOAD_THRESHOLD_BYTES && isSupportedForOffload) {
       try {
         const buffer = Buffer.from(b64, "base64");
         const labelWithExt = ensureExtension(label, finalMime);
 
-        const savedMedia = (await saveMediaBuffer(
+        const rawResult = await saveMediaBuffer(
           buffer,
           finalMime,
           "inbound",
           undefined,
           labelWithExt,
-        )) as SavedMedia;
+        );
 
-        const mediaPath = extractMediaPath(savedMedia, labelWithExt);
+        // Fix #2: validate shape before trusting the result.
+        const savedMedia = assertSavedMedia(rawResult, label);
 
-        updatedMessage += `\n[media attached: ${mediaPath}]`;
-        log?.info?.(`[Gateway] Intercepted large image payload. Saved to disk: ${mediaPath}`);
+        // Fix #4: Use an opaque media URI instead of a physical filesystem
+        // path. This decouples the Gateway from the Agent's filesystem layout
+        // and is compatible with workspaceOnly sandboxes.
+        // The agent side must resolve media://inbound/<id> via the media store
+        // before passing the image to the model. (Follow-up: implement
+        // resolveMediaUri in the agent runner.)
+        const mediaRef = `media://inbound/${savedMedia.id}`;
+
+        updatedMessage += `\n[media attached: ${mediaRef}]`;
+        log?.info?.(`[Gateway] Intercepted large image payload. Saved: ${mediaRef}`);
         isOffloaded = true;
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -32,7 +32,6 @@ type NormalizedAttachment = {
 };
 
 const OFFLOAD_THRESHOLD_BYTES = 2_000_000;
-const OFFLOAD_BASE_PATH = "/home/node/.openclaw/media/inbound";
 
 function normalizeMime(mime?: string): string | undefined {
   if (!mime) return undefined;
@@ -156,13 +155,21 @@ export async function parseMessageWithAttachments(
       try {
         const buffer = Buffer.from(b64, "base64");
         const savedMedia = await saveMediaBuffer(buffer, finalMime, "inbound");
-        const mediaId = sanitizePathSegment(savedMedia.id || label);
-        const mediaPath = `${OFFLOAD_BASE_PATH}/${mediaId}`;
+        // Use the path returned by the storage layer; fall back to a sanitized id only
+        // if the storage layer does not expose a resolved path.
+        const mediaPath = savedMedia.path ?? sanitizePathSegment(savedMedia.id || label);
 
         updatedMessage += `\n[media attached: ${mediaPath}]`;
         log?.info?.(`[Gateway] Intercepted large image payload. Saved to disk: ${mediaPath}`);
         isOffloaded = true;
       } catch (err) {
+        // Do not fall back to in-memory processing when the file also exceeds the hard
+        // memory limit — that would reintroduce the OOM risk this change is meant to fix.
+        if (sizeBytes > maxBytes) {
+          throw new Error(
+            `attachment ${label}: exceeds size limit and could not be offloaded to disk: ${err}`,
+          );
+        }
         log?.warn(`[Gateway] Failed to save intercepted media to disk, falling back to memory: ${err}`);
       }
     }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -231,7 +231,13 @@ export async function parseMessageWithAttachments(
     // Fix #1 (continued): isSupportedForOffload now uses the module-level Set.
     const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
 
-    if (sizeBytes > OFFLOAD_THRESHOLD_BYTES && isSupportedForOffload) {
+    if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+      if (!isSupportedForOffload) {
+        throw new Error(
+          `attachment ${label}: format ${finalMime} exceeds size limit (${sizeBytes} > ${OFFLOAD_THRESHOLD_BYTES} bytes) and is not supported by the model. Please convert to JPG, PNG, WEBP, or GIF.`,
+        );
+      }
+
       try {
         const buffer = Buffer.from(b64, "base64");
         const labelWithExt = ensureExtension(label, finalMime);
@@ -260,8 +266,9 @@ export async function parseMessageWithAttachments(
         isOffloaded = true;
       } catch (err) {
         const errorMessage = err instanceof Error ? err.message : String(err);
-        log?.warn(
-          `[Gateway Error] Failed to save intercepted media to disk, falling back to memory: ${errorMessage}`,
+        throw new Error(
+          `[Gateway Error] Failed to save intercepted media to disk: ${errorMessage}`,
+          { cause: err },
         );
       }
     }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -186,7 +186,13 @@ export async function parseMessageWithAttachments(
 
     let isOffloaded = false;
 
-    const isSupportedForOffload = ["image/jpeg", "image/jpg", "image/png", "image/webp", "image/gif"].includes(finalMime);
+    const isSupportedForOffload = [
+      "image/jpeg",
+      "image/jpg",
+      "image/png",
+      "image/webp",
+      "image/gif",
+    ].includes(finalMime);
 
     if (sizeBytes > OFFLOAD_THRESHOLD_BYTES && isSupportedForOffload) {
       try {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -32,19 +32,19 @@ type NormalizedAttachment = {
 };
 type SavedMedia = {
   id: string;
-  path?: string; 
+  path?: string;
 };
 
 const OFFLOAD_THRESHOLD_BYTES = 2_000_000;
 
 const MIME_TO_EXT: Record<string, string> = {
   "image/jpeg": ".jpg",
-  "image/jpg":  ".jpg",
-  "image/png":  ".png",
+  "image/jpg": ".jpg",
+  "image/png": ".png",
   "image/webp": ".webp",
-  "image/gif":  ".gif",
+  "image/gif": ".gif",
   "image/avif": ".avif",
-  "image/bmp":  ".bmp",
+  "image/bmp": ".bmp",
   "image/tiff": ".tiff",
 };
 
@@ -160,9 +160,7 @@ export async function parseMessageWithAttachments(
     }
 
     if (sizeBytes > maxBytes) {
-      throw new Error(
-        `attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`,
-      );
+      throw new Error(`attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`);
     }
 
     const providedMime = normalizeMime(mime);
@@ -185,7 +183,9 @@ export async function parseMessageWithAttachments(
 
     let isOffloaded = false;
 
-    if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+    const isSupportedForOffload = finalMime !== "image/avif";
+
+    if (sizeBytes > OFFLOAD_THRESHOLD_BYTES && isSupportedForOffload) {
       try {
         const buffer = Buffer.from(b64, "base64");
 
@@ -195,6 +195,7 @@ export async function parseMessageWithAttachments(
           buffer,
           finalMime,
           "inbound",
+          undefined,
           labelWithExt,
         )) as SavedMedia;
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -186,7 +186,7 @@ export async function parseMessageWithAttachments(
 
     let isOffloaded = false;
 
-    const isSupportedForOffload = finalMime !== "image/avif";
+    const isSupportedForOffload = ["image/jpeg", "image/jpg", "image/png", "image/webp", "image/gif"].includes(finalMime);
 
     if (sizeBytes > OFFLOAD_THRESHOLD_BYTES && isSupportedForOffload) {
       try {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -50,7 +50,7 @@ const MIME_TO_EXT: Record<string, string> = {
   "image/tiff": ".tiff",
 };
 
-// Fix #1: Moved outside loop and use a Set for O(1) lookup instead of
+// Moved outside the loop and uses a Set for O(1) lookup instead of
 // rebuilding an array on every attachment iteration.
 const SUPPORTED_OFFLOAD_MIMES = new Set([
   "image/jpeg",
@@ -72,11 +72,26 @@ function isImageMime(mime?: string): boolean {
   return typeof mime === "string" && mime.startsWith("image/");
 }
 
+// Threshold above which we switch from a full O(n) scan to a sampled
+// spot-check. Base64 of a 5 MB image is ~6.7 M chars; running a full regex
+// over the entire string blocks the event loop for a measurable duration per
+// attachment, especially when multiple large files are uploaded at once.
+const BASE64_FULL_SCAN_LIMIT = 4_096;
+
 function isValidBase64(value: string): boolean {
-  // NOTE: This regex is O(n) over the full string length.
-  // For payloads near maxBytes (~5 MB / ~6.7 M chars) this is non-trivial.
-  // A future optimization could do a sampled spot-check for very large inputs.
-  return value.length > 0 && value.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+  if (value.length === 0 || value.length % 4 !== 0) {
+    return false;
+  }
+  // Small strings: full scan is cheap and exact.
+  if (value.length <= BASE64_FULL_SCAN_LIMIT) {
+    return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+  }
+  // Large payloads: sample the head and tail to avoid blocking the event loop.
+  // - Head check catches non-base64 garbage early.
+  // - Tail check validates the padding region (= chars must only appear at end).
+  const head = value.slice(0, BASE64_FULL_SCAN_LIMIT);
+  const tail = value.slice(-BASE64_FULL_SCAN_LIMIT);
+  return /^[A-Za-z0-9+/]+$/.test(head) && /^[A-Za-z0-9+/]+={0,2}$/.test(tail);
 }
 
 function ensureExtension(label: string, mime: string): string {
@@ -87,8 +102,18 @@ function ensureExtension(label: string, mime: string): string {
   return ext ? `${label}${ext}` : label;
 }
 
-// Fix #2: Guard against unexpected shapes from saveMediaBuffer before
-// treating the result as SavedMedia, instead of blindly casting with `as`.
+/**
+ * Type guard for the return value of saveMediaBuffer.
+ *
+ * Also validates that the returned ID:
+ *   - is a non-empty string
+ *   - contains no path separators (/ or \) or null bytes
+ *
+ * This provides defence-in-depth before the ID is embedded in a
+ * media://inbound/<id> URI and later resolved by resolveMediaBufferPath
+ * (which applies its own guards). Catching a bad shape here produces a
+ * cleaner error message than a cryptic failure deeper in the stack.
+ */
 function assertSavedMedia(value: unknown, label: string): SavedMedia {
   if (
     value !== null &&
@@ -96,9 +121,19 @@ function assertSavedMedia(value: unknown, label: string): SavedMedia {
     "id" in value &&
     typeof (value as Record<string, unknown>).id === "string"
   ) {
+    const id = (value as Record<string, unknown>).id as string;
+    if (id.length === 0) {
+      throw new Error(`attachment ${label}: saveMediaBuffer returned an empty media ID`);
+    }
+    if (id.includes("/") || id.includes("\\") || id.includes("\0")) {
+      throw new Error(
+        `attachment ${label}: saveMediaBuffer returned an unsafe media ID ` +
+          `(contains path separator or null byte)`,
+      );
+    }
     return value as SavedMedia;
   }
-  throw new Error(`attachment ${label}: saveMediaBuffer returned unexpected shape`);
+  throw new Error(`attachment ${label}: saveMediaBuffer returned an unexpected shape`);
 }
 
 function normalizeAttachment(
@@ -220,21 +255,27 @@ export async function parseMessageWithAttachments(
       );
     }
 
-    // Fix #3: The third fallback normalizes `mime` so that a raw un-normalized
-    // string (e.g. "IMAGE/JPEG" from the caller) doesn't silently bypass the
-    // SUPPORTED_OFFLOAD_MIMES check below. If normalization still yields
+    // The third fallback normalises `mime` so that a raw un-normalised string
+    // (e.g. "IMAGE/JPEG" from the caller) does not silently bypass the
+    // SUPPORTED_OFFLOAD_MIMES check below. If normalisation still yields
     // nothing, fall back to the raw string as a last resort.
     const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
 
     let isOffloaded = false;
 
-    // Fix #1 (continued): isSupportedForOffload now uses the module-level Set.
     const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
 
     if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
       if (!isSupportedForOffload) {
+        // The attachment is above the offload threshold but its format cannot
+        // be offloaded (no guaranteed extension mapping in store.ts).
+        // Note: sizeBytes is between OFFLOAD_THRESHOLD_BYTES and maxBytes, so
+        // saying "exceeds size limit" would be misleading — the image IS within
+        // the declared limit but cannot safely be offloaded in this format.
         throw new Error(
-          `attachment ${label}: format ${finalMime} exceeds size limit (${sizeBytes} > ${OFFLOAD_THRESHOLD_BYTES} bytes) and is not supported by the model. Please convert to JPG, PNG, WEBP, or GIF.`,
+          `attachment ${label}: format ${finalMime} is too large to pass inline ` +
+            `(${sizeBytes} > ${OFFLOAD_THRESHOLD_BYTES} bytes) and cannot be offloaded. ` +
+            `Please convert to JPEG, PNG, WEBP, or GIF.`,
         );
       }
 
@@ -250,15 +291,14 @@ export async function parseMessageWithAttachments(
           labelWithExt,
         );
 
-        // Fix #2: validate shape before trusting the result.
+        // Validate shape and ID safety before trusting the result.
         const savedMedia = assertSavedMedia(rawResult, label);
 
-        // Fix #4: Use an opaque media URI instead of a physical filesystem
-        // path. This decouples the Gateway from the Agent's filesystem layout
+        // Use an opaque media URI instead of a physical filesystem path.
+        // This decouples the Gateway from the Agent's filesystem layout
         // and is compatible with workspaceOnly sandboxes.
-        // The agent side must resolve media://inbound/<id> via the media store
-        // before passing the image to the model. (Follow-up: implement
-        // resolveMediaUri in the agent runner.)
+        // The agent resolves media://inbound/<id> via resolveMediaBufferPath
+        // in store.ts before passing the image to the model.
         const mediaRef = `media://inbound/${savedMedia.id}`;
 
         updatedMessage += `\n[media attached: ${mediaRef}]`;

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,6 +1,6 @@
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
-import { saveMediaBuffer } from "../media/store.js";
+import { deleteMediaBuffer, saveMediaBuffer } from "../media/store.js";
 
 export type ChatAttachment = {
   type?: string;
@@ -64,6 +64,23 @@ const SUPPORTED_OFFLOAD_MIMES = new Set([
   "image/heif",
 ]);
 
+/**
+ * Raised when the Gateway cannot persist an attachment to the media store.
+ *
+ * This is distinct from ordinary input-validation errors so that Gateway
+ * handlers can map it to a server-side 5xx status rather than a client 4xx.
+ *
+ * Example causes: ENOSPC, EPERM, unexpected saveMediaBuffer return shape.
+ */
+export class MediaOffloadError extends Error {
+  readonly cause: unknown;
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "MediaOffloadError";
+    this.cause = options?.cause;
+  }
+}
+
 function normalizeMime(mime?: string): string | undefined {
   if (!mime) {
     return undefined;
@@ -76,26 +93,46 @@ function isImageMime(mime?: string): boolean {
   return typeof mime === "string" && mime.startsWith("image/");
 }
 
-// Threshold above which we switch from a full O(n) scan to a sampled
-// spot-check. Base64 of a 5 MB image is ~6.7 M chars; running a full regex
-// over the entire string blocks the event loop for a measurable duration per
-// attachment, especially when multiple large files are uploaded at once.
-const BASE64_FULL_SCAN_LIMIT = 4_096;
+// Base64 string length corresponding to OFFLOAD_THRESHOLD_BYTES.
+// Payloads above this threshold always go through the offload branch where
+// correctness is guaranteed by verifyDecodedSize (a post-decode size check
+// that catches embedded invalid chars dropped silently by Buffer.from).
+// Inline payloads below this threshold are small enough for a full O(n)
+// character-class scan without materially blocking the event loop.
+const BASE64_INLINE_SCAN_MAX = Math.ceil((OFFLOAD_THRESHOLD_BYTES * 4) / 3 / 4) * 4; // ~2,666,668
 
 function isValidBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }
-  // Small strings: full scan is cheap and exact.
-  if (value.length <= BASE64_FULL_SCAN_LIMIT) {
-    return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+  // Large payloads above BASE64_INLINE_SCAN_MAX always enter the offload branch
+  // where verifyDecodedSize provides a stronger post-decode guarantee.
+  // Skipping the O(n) scan here avoids blocking the event loop for payloads
+  // near maxBytes (~5 MB / ~6.7 M chars).
+  if (value.length > BASE64_INLINE_SCAN_MAX) {
+    return true;
   }
-  // Large payloads: sample the head and tail to avoid blocking the event loop.
-  // - Head check catches non-base64 garbage early.
-  // - Tail check validates the padding region (= chars must only appear at end).
-  const head = value.slice(0, BASE64_FULL_SCAN_LIMIT);
-  const tail = value.slice(-BASE64_FULL_SCAN_LIMIT);
-  return /^[A-Za-z0-9+/]+$/.test(head) && /^[A-Za-z0-9+/]+={0,2}$/.test(tail);
+  // Small inline payloads: full scan is cheap and exact.
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+}
+
+/**
+ * Confirms that the decoded buffer produced by Buffer.from(b64, 'base64')
+ * matches the pre-decode size estimate.
+ *
+ * Node's Buffer.from silently drops invalid base64 characters rather than
+ * throwing. A material size discrepancy means the source string contained
+ * embedded garbage that was silently stripped, which would produce a
+ * corrupted file on disk. ±3 bytes of slack accounts for base64 padding
+ * rounding.
+ */
+function verifyDecodedSize(buffer: Buffer, estimatedBytes: number, label: string): void {
+  if (Math.abs(buffer.byteLength - estimatedBytes) > 3) {
+    throw new Error(
+      `attachment ${label}: base64 contains invalid characters ` +
+        `(expected ~${estimatedBytes} bytes decoded, got ${buffer.byteLength})`,
+    );
+  }
 }
 
 function ensureExtension(label: string, mime: string): string {
@@ -192,6 +229,14 @@ function validateAttachmentBase64OrThrow(
  * URI appended to the message. Downstream agents must resolve this URI via the
  * media store before forwarding to the model.
  *
+ * Pass `supportsImages: false` for text-only model runs. In that case all
+ * attachments are dropped cleanly and no media:// markers are injected into
+ * the prompt, preventing internal path references from leaking into model input.
+ *
+ * On any parse failure after one or more files have already been offloaded,
+ * this function performs a best-effort cleanup of those files before rethrowing
+ * so that malformed requests do not accumulate orphaned files on disk.
+ *
  * Known limitation: when a mix of large (offloaded) and small (inline) images
  * is present, offloaded images appear as text markers appended to the message
  * while inline images are in the `images` array. The agent's
@@ -200,11 +245,15 @@ function validateAttachmentBase64OrThrow(
  * in a different order than the original attachment list. Prompts that rely on
  * attachment order (e.g. "first image") should be aware of this. A future
  * refactor should unify all image references into a single ordered list.
+ *
+ * @throws {MediaOffloadError} When a filesystem error prevents saving an
+ *   attachment to the media store. Callers should map this to a server-side
+ *   5xx status rather than a client 4xx.
  */
 export async function parseMessageWithAttachments(
   message: string,
   attachments: ChatAttachment[] | undefined,
-  opts?: { maxBytes?: number; log?: AttachmentLog },
+  opts?: { maxBytes?: number; log?: AttachmentLog; supportsImages?: boolean },
 ): Promise<ParsedMessageWithImages> {
   const maxBytes = opts?.maxBytes ?? 5_000_000;
   const log = opts?.log;
@@ -213,115 +262,160 @@ export async function parseMessageWithAttachments(
     return { message, images: [] };
   }
 
+  // For text-only models, attachments cannot be used regardless of size.
+  // Drop them cleanly instead of saving files and injecting media:// markers
+  // that would never be resolved, which would leak internal path references
+  // into the model's prompt.
+  if (opts?.supportsImages === false) {
+    if (attachments.length > 0) {
+      log?.warn(
+        `parseMessageWithAttachments: ${attachments.length} attachment(s) dropped — model does not support images`,
+      );
+    }
+    return { message, images: [] };
+  }
+
   const images: ChatImageContent[] = [];
   let updatedMessage = message;
 
-  for (const [idx, att] of attachments.entries()) {
-    if (!att) {
-      continue;
-    }
+  // Track IDs of files saved during this request so we can clean them up
+  // if a later attachment fails validation and the entire parse is aborted.
+  // Without this, repeated malformed multi-attachment requests can accumulate
+  // orphaned files on disk ahead of the periodic TTL sweep.
+  const savedMediaIds: string[] = [];
 
-    const normalized = normalizeAttachment(att, idx, {
-      stripDataUrlPrefix: true,
-      requireImageMime: false,
-    });
+  try {
+    for (const [idx, att] of attachments.entries()) {
+      if (!att) {
+        continue;
+      }
 
-    const { base64: b64, label, mime } = normalized;
+      const normalized = normalizeAttachment(att, idx, {
+        stripDataUrlPrefix: true,
+        requireImageMime: false,
+      });
 
-    if (!isValidBase64(b64)) {
-      throw new Error(`attachment ${label}: invalid base64 content`);
-    }
+      const { base64: b64, label, mime } = normalized;
 
-    const sizeBytes = estimateBase64DecodedBytes(b64);
-    if (sizeBytes <= 0) {
-      log?.warn(`attachment ${label}: estimated size is zero, dropping`);
-      continue;
-    }
+      if (!isValidBase64(b64)) {
+        throw new Error(`attachment ${label}: invalid base64 content`);
+      }
 
-    if (sizeBytes > maxBytes) {
-      throw new Error(`attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`);
-    }
+      const sizeBytes = estimateBase64DecodedBytes(b64);
+      if (sizeBytes <= 0) {
+        log?.warn(`attachment ${label}: estimated size is zero, dropping`);
+        continue;
+      }
 
-    const providedMime = normalizeMime(mime);
-    const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
-
-    if (sniffedMime && !isImageMime(sniffedMime)) {
-      log?.warn(`attachment ${label}: detected non-image (${sniffedMime}), dropping`);
-      continue;
-    }
-    if (!sniffedMime && !isImageMime(providedMime)) {
-      log?.warn(`attachment ${label}: unable to detect image mime type, dropping`);
-      continue;
-    }
-    if (sniffedMime && providedMime && sniffedMime !== providedMime) {
-      log?.warn(
-        `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
-      );
-    }
-
-    // The third fallback normalises `mime` so that a raw un-normalised string
-    // (e.g. "IMAGE/JPEG" from the caller) does not silently bypass the
-    // SUPPORTED_OFFLOAD_MIMES check below. If normalisation still yields
-    // nothing, fall back to the raw string as a last resort.
-    const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
-
-    let isOffloaded = false;
-
-    const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
-
-    if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
-      if (!isSupportedForOffload) {
-        // The attachment is above the offload threshold but its format cannot
-        // be offloaded (no guaranteed extension mapping in store.ts).
-        // Note: sizeBytes is between OFFLOAD_THRESHOLD_BYTES and maxBytes, so
-        // saying "exceeds size limit" would be misleading — the image IS within
-        // the declared limit but cannot safely be offloaded in this format.
+      if (sizeBytes > maxBytes) {
         throw new Error(
-          `attachment ${label}: format ${finalMime} is too large to pass inline ` +
-            `(${sizeBytes} > ${OFFLOAD_THRESHOLD_BYTES} bytes) and cannot be offloaded. ` +
-            `Please convert to JPEG, PNG, WEBP, or GIF.`,
+          `attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`,
         );
       }
 
-      try {
-        const buffer = Buffer.from(b64, "base64");
-        const labelWithExt = ensureExtension(label, finalMime);
+      const providedMime = normalizeMime(mime);
+      const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
 
-        const rawResult = await saveMediaBuffer(
-          buffer,
-          finalMime,
-          "inbound",
-          maxBytes,
-          labelWithExt,
-        );
-
-        // Validate shape and ID safety before trusting the result.
-        const savedMedia = assertSavedMedia(rawResult, label);
-
-        // Use an opaque media URI instead of a physical filesystem path.
-        // This decouples the Gateway from the Agent's filesystem layout
-        // and is compatible with workspaceOnly sandboxes.
-        // The agent resolves media://inbound/<id> via resolveMediaBufferPath
-        // in store.ts before passing the image to the model.
-        const mediaRef = `media://inbound/${savedMedia.id}`;
-
-        updatedMessage += `\n[media attached: ${mediaRef}]`;
-        log?.info?.(`[Gateway] Intercepted large image payload. Saved: ${mediaRef}`);
-        isOffloaded = true;
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : String(err);
-        throw new Error(
-          `[Gateway Error] Failed to save intercepted media to disk: ${errorMessage}`,
-          { cause: err },
+      if (sniffedMime && !isImageMime(sniffedMime)) {
+        log?.warn(`attachment ${label}: detected non-image (${sniffedMime}), dropping`);
+        continue;
+      }
+      if (!sniffedMime && !isImageMime(providedMime)) {
+        log?.warn(`attachment ${label}: unable to detect image mime type, dropping`);
+        continue;
+      }
+      if (sniffedMime && providedMime && sniffedMime !== providedMime) {
+        log?.warn(
+          `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
         );
       }
-    }
 
-    if (isOffloaded) {
-      continue;
-    }
+      // The third fallback normalises `mime` so that a raw un-normalised string
+      // (e.g. "IMAGE/JPEG" from the caller) does not silently bypass the
+      // SUPPORTED_OFFLOAD_MIMES check below. If normalisation still yields
+      // nothing, fall back to the raw string as a last resort.
+      const finalMime = sniffedMime ?? providedMime ?? normalizeMime(mime) ?? mime;
 
-    images.push({ type: "image", data: b64, mimeType: finalMime });
+      let isOffloaded = false;
+
+      const isSupportedForOffload = SUPPORTED_OFFLOAD_MIMES.has(finalMime);
+
+      if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+        if (!isSupportedForOffload) {
+          // The attachment is above the offload threshold but its format cannot
+          // be offloaded (no guaranteed extension mapping in store.ts).
+          // Note: sizeBytes is between OFFLOAD_THRESHOLD_BYTES and maxBytes, so
+          // saying "exceeds size limit" would be misleading — the image IS within
+          // the declared limit but cannot safely be offloaded in this format.
+          throw new Error(
+            `attachment ${label}: format ${finalMime} is too large to pass inline ` +
+              `(${sizeBytes} > ${OFFLOAD_THRESHOLD_BYTES} bytes) and cannot be offloaded. ` +
+              `Please convert to JPEG, PNG, WEBP, GIF, HEIC, or HEIF.`,
+          );
+        }
+
+        try {
+          const buffer = Buffer.from(b64, "base64");
+
+          // Post-decode size validation for large payloads.
+          // isValidBase64 skips the O(n) regex for strings above BASE64_INLINE_SCAN_MAX;
+          // Buffer.from silently drops invalid chars, so a size mismatch reveals
+          // that the source contained embedded garbage.
+          verifyDecodedSize(buffer, sizeBytes, label);
+
+          const labelWithExt = ensureExtension(label, finalMime);
+
+          const rawResult = await saveMediaBuffer(
+            buffer,
+            finalMime,
+            "inbound",
+            maxBytes,
+            labelWithExt,
+          );
+
+          // Validate shape and ID safety before trusting the result.
+          const savedMedia = assertSavedMedia(rawResult, label);
+
+          // Track this ID for cleanup if a later attachment fails.
+          savedMediaIds.push(savedMedia.id);
+
+          // Use an opaque media URI instead of a physical filesystem path.
+          // This decouples the Gateway from the Agent's filesystem layout
+          // and is compatible with workspaceOnly sandboxes.
+          // The agent resolves media://inbound/<id> via resolveMediaBufferPath
+          // in store.ts before passing the image to the model.
+          const mediaRef = `media://inbound/${savedMedia.id}`;
+
+          updatedMessage += `\n[media attached: ${mediaRef}]`;
+          log?.info?.(`[Gateway] Intercepted large image payload. Saved: ${mediaRef}`);
+          isOffloaded = true;
+        } catch (err) {
+          // Distinguish operational storage failures from input-validation errors
+          // so that Gateway handlers can map them to the correct HTTP status:
+          // catch MediaOffloadError → 5xx, catch Error → 4xx.
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          throw new MediaOffloadError(
+            `[Gateway Error] Failed to save intercepted media to disk: ${errorMessage}`,
+            { cause: err },
+          );
+        }
+      }
+
+      if (isOffloaded) {
+        continue;
+      }
+
+      images.push({ type: "image", data: b64, mimeType: finalMime });
+    }
+  } catch (err) {
+    // Best-effort cleanup: delete any files that were successfully saved
+    // earlier in this request before re-throwing. This prevents malformed
+    // multi-attachment requests from accumulating orphaned files on disk
+    // ahead of the periodic TTL sweep.
+    if (savedMediaIds.length > 0) {
+      await Promise.allSettled(savedMediaIds.map((id) => deleteMediaBuffer(id, "inbound")));
+    }
+    throw err;
   }
 
   return {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,4 +1,5 @@
 import { estimateBase64DecodedBytes } from "../media/base64.js";
+import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import { deleteMediaBuffer, saveMediaBuffer } from "../media/store.js";
 
@@ -41,6 +42,8 @@ export type ParsedMessageWithImages = {
   message: string;
   /** Small attachments (≤ OFFLOAD_THRESHOLD_BYTES) passed inline to the model */
   images: ChatImageContent[];
+  /** Original accepted attachment order after inline/offloaded split. */
+  imageOrder: PromptImageOrderEntry[];
   /**
    * Large attachments (> OFFLOAD_THRESHOLD_BYTES) that were offloaded to the
    * media store. Each entry corresponds to a `[media attached: media://inbound/<id>]`
@@ -293,7 +296,7 @@ export async function parseMessageWithAttachments(
   const log = opts?.log;
 
   if (!attachments || attachments.length === 0) {
-    return { message, images: [], offloadedRefs: [] };
+    return { message, images: [], imageOrder: [], offloadedRefs: [] };
   }
 
   // For text-only models drop all attachments cleanly. Do not save files or
@@ -305,10 +308,11 @@ export async function parseMessageWithAttachments(
         `parseMessageWithAttachments: ${attachments.length} attachment(s) dropped — model does not support images`,
       );
     }
-    return { message, images: [], offloadedRefs: [] };
+    return { message, images: [], imageOrder: [], offloadedRefs: [] };
   }
 
   const images: ChatImageContent[] = [];
+  const imageOrder: PromptImageOrderEntry[] = [];
   const offloadedRefs: OffloadedRef[] = [];
   let updatedMessage = message;
 
@@ -420,6 +424,7 @@ export async function parseMessageWithAttachments(
             mimeType: finalMime,
             label,
           });
+          imageOrder.push("offloaded");
 
           isOffloaded = true;
         } catch (err) {
@@ -436,6 +441,7 @@ export async function parseMessageWithAttachments(
       }
 
       images.push({ type: "image", data: b64, mimeType: finalMime });
+      imageOrder.push("inline");
     }
   } catch (err) {
     // Best-effort cleanup before rethrowing.
@@ -448,6 +454,7 @@ export async function parseMessageWithAttachments(
   return {
     message: updatedMessage !== message ? updatedMessage.trimEnd() : message,
     images,
+    imageOrder,
     offloadedRefs,
   };
 }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -93,26 +93,14 @@ function isImageMime(mime?: string): boolean {
   return typeof mime === "string" && mime.startsWith("image/");
 }
 
-// Base64 string length corresponding to OFFLOAD_THRESHOLD_BYTES.
-// Payloads above this threshold always go through the offload branch where
-// correctness is guaranteed by verifyDecodedSize (a post-decode size check
-// that catches embedded invalid chars dropped silently by Buffer.from).
-// Inline payloads below this threshold are small enough for a full O(n)
-// character-class scan without materially blocking the event loop.
-const BASE64_INLINE_SCAN_MAX = Math.ceil((OFFLOAD_THRESHOLD_BYTES * 4) / 3 / 4) * 4; // ~2,666,668
-
 function isValidBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false;
   }
-  // Large payloads above BASE64_INLINE_SCAN_MAX always enter the offload branch
-  // where verifyDecodedSize provides a stronger post-decode guarantee.
-  // Skipping the O(n) scan here avoids blocking the event loop for payloads
-  // near maxBytes (~5 MB / ~6.7 M chars).
-  if (value.length > BASE64_INLINE_SCAN_MAX) {
-    return true;
-  }
-  // Small inline payloads: full scan is cheap and exact.
+  // A full O(n) regex scan is safe because the regex has no overlapping
+  // quantifiers and fails linearly without catastrophic backtracking.
+  // This prevents adversarial payloads padded with megabytes of whitespace
+  // from bypassing length thresholds.
   return /^[A-Za-z0-9+/]+={0,2}$/.test(value);
 }
 
@@ -147,8 +135,8 @@ function ensureExtension(label: string, mime: string): string {
  * Type guard for the return value of saveMediaBuffer.
  *
  * Also validates that the returned ID:
- *   - is a non-empty string
- *   - contains no path separators (/ or \) or null bytes
+ * - is a non-empty string
+ * - contains no path separators (/ or \) or null bytes
  *
  * This provides defence-in-depth before the ID is embedded in a
  * media://inbound/<id> URI and later resolved by resolveMediaBufferPath
@@ -247,8 +235,8 @@ function validateAttachmentBase64OrThrow(
  * refactor should unify all image references into a single ordered list.
  *
  * @throws {MediaOffloadError} When a filesystem error prevents saving an
- *   attachment to the media store. Callers should map this to a server-side
- *   5xx status rather than a client 4xx.
+ * attachment to the media store. Callers should map this to a server-side
+ * 5xx status rather than a client 4xx.
  */
 export async function parseMessageWithAttachments(
   message: string,
@@ -358,9 +346,8 @@ export async function parseMessageWithAttachments(
           const buffer = Buffer.from(b64, "base64");
 
           // Post-decode size validation for large payloads.
-          // isValidBase64 skips the O(n) regex for strings above BASE64_INLINE_SCAN_MAX;
-          // Buffer.from silently drops invalid chars, so a size mismatch reveals
-          // that the source contained embedded garbage.
+          // Provides defense-in-depth against silent truncation by Buffer.from
+          // if any malformed characters somehow bypassed prior validation.
           verifyDecodedSize(buffer, sizeBytes, label);
 
           const labelWithExt = ensureExtension(label, finalMime);

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -1,6 +1,6 @@
 import { estimateBase64DecodedBytes } from "../media/base64.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
-import { saveMediaBuffer } from "../media/store.js"; 
+import { saveMediaBuffer } from "../media/store.js";
 
 export type ChatAttachment = {
   type?: string;
@@ -21,6 +21,7 @@ export type ParsedMessageWithImages = {
 };
 
 type AttachmentLog = {
+  info?: (message: string) => void;
   warn: (message: string) => void;
 };
 
@@ -30,10 +31,11 @@ type NormalizedAttachment = {
   base64: string;
 };
 
+const OFFLOAD_THRESHOLD_BYTES = 2_000_000;
+const OFFLOAD_BASE_PATH = "/home/node/.openclaw/media/inbound";
+
 function normalizeMime(mime?: string): string | undefined {
-  if (!mime) {
-    return undefined;
-  }
+  if (!mime) return undefined;
   const cleaned = mime.split(";")[0]?.trim().toLowerCase();
   return cleaned || undefined;
 }
@@ -43,8 +45,11 @@ function isImageMime(mime?: string): boolean {
 }
 
 function isValidBase64(value: string): boolean {
-  // Minimal validation; avoid full decode allocations for large payloads.
   return value.length > 0 && value.length % 4 === 0 && /^[A-Za-z0-9+/]+={0,2}$/.test(value);
+}
+
+function sanitizePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9.\-_]/g, "_");
 }
 
 function normalizeAttachment(
@@ -65,7 +70,6 @@ function normalizeAttachment(
 
   let base64 = content.trim();
   if (opts.stripDataUrlPrefix) {
-    // Strip data URL prefix if present (e.g., "data:image/jpeg;base64,...").
     const dataUrlMatch = /^data:[^;]+;base64,(.*)$/.exec(base64);
     if (dataUrlMatch) {
       base64 = dataUrlMatch[1];
@@ -100,29 +104,39 @@ export async function parseMessageWithAttachments(
   attachments: ChatAttachment[] | undefined,
   opts?: { maxBytes?: number; log?: AttachmentLog },
 ): Promise<ParsedMessageWithImages> {
-  const maxBytes = opts?.maxBytes ?? 5_000_000; // decoded bytes (5,000,000)
+  const maxBytes = opts?.maxBytes ?? 5_000_000;
   const log = opts?.log;
+
   if (!attachments || attachments.length === 0) {
     return { message, images: [] };
   }
 
   const images: ChatImageContent[] = [];
-  let updatedMessage = message; 
+  let updatedMessage = message;
 
   for (const [idx, att] of attachments.entries()) {
-    if (!att) {
-      continue;
-    }
+    if (!att) continue;
+
     const normalized = normalizeAttachment(att, idx, {
       stripDataUrlPrefix: true,
       requireImageMime: false,
     });
-    validateAttachmentBase64OrThrow(normalized, { maxBytes });
+
     const { base64: b64, label, mime } = normalized;
+
+    if (!isValidBase64(b64)) {
+      throw new Error(`attachment ${label}: invalid base64 content`);
+    }
+
+    const sizeBytes = estimateBase64DecodedBytes(b64);
+    if (sizeBytes <= 0) {
+      log?.warn(`attachment ${label}: estimated size is zero, dropping`);
+      continue;
+    }
 
     const providedMime = normalizeMime(mime);
     const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
-    
+
     if (sniffedMime && !isImageMime(sniffedMime)) {
       log?.warn(`attachment ${label}: detected non-image (${sniffedMime}), dropping`);
       continue;
@@ -132,30 +146,40 @@ export async function parseMessageWithAttachments(
       continue;
     }
     if (sniffedMime && providedMime && sniffedMime !== providedMime) {
-      log?.warn(
-        `attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`,
-      );
+      log?.warn(`attachment ${label}: mime mismatch (${providedMime} -> ${sniffedMime}), using sniffed`);
     }
     const finalMime = sniffedMime ?? providedMime ?? mime;
-    try {
-      const buffer = Buffer.from(b64, "base64");
-      const savedMedia = await saveMediaBuffer(buffer, finalMime, "inbound");
-      const mediaId = savedMedia.id || label;
-      updatedMessage += `\n[media attached: inbound/${mediaId}]`;
-      log?.warn(`[Gateway] Intercepted large image payload. Saved to disk: inbound/${mediaId}`);
-      continue; 
-    } catch (err) {
-      log?.warn(`[Gateway Error] Failed to save intercepted media to disk. Falling back to memory payload: ${err}`);
+
+    let isOffloaded = false;
+
+    if (sizeBytes > OFFLOAD_THRESHOLD_BYTES) {
+      try {
+        const buffer = Buffer.from(b64, "base64");
+        const savedMedia = await saveMediaBuffer(buffer, finalMime, "inbound");
+        const mediaId = sanitizePathSegment(savedMedia.id || label);
+        const mediaPath = `${OFFLOAD_BASE_PATH}/${mediaId}`;
+
+        updatedMessage += `\n[media attached: ${mediaPath}]`;
+        log?.info?.(`[Gateway] Intercepted large image payload. Saved to disk: ${mediaPath}`);
+        isOffloaded = true;
+      } catch (err) {
+        log?.warn(`[Gateway] Failed to save intercepted media to disk, falling back to memory: ${err}`);
+      }
     }
 
-    images.push({
-      type: "image",
-      data: b64,
-      mimeType: finalMime,
-    });
+    if (isOffloaded) continue;
+
+    if (sizeBytes > maxBytes) {
+      throw new Error(`attachment ${label}: exceeds size limit (${sizeBytes} > ${maxBytes} bytes)`);
+    }
+
+    images.push({ type: "image", data: b64, mimeType: finalMime });
   }
 
-  return { message: updatedMessage.trim(), images };
+  return {
+    message: updatedMessage !== message ? updatedMessage.trimEnd() : message,
+    images,
+  };
 }
 
 /**
@@ -167,7 +191,8 @@ export function buildMessageWithAttachments(
   attachments: ChatAttachment[] | undefined,
   opts?: { maxBytes?: number },
 ): string {
-  const maxBytes = opts?.maxBytes ?? 2_000_000; // 2 MB
+  const maxBytes = opts?.maxBytes ?? 2_000_000;
+
   if (!attachments || attachments.length === 0) {
     return message;
   }
@@ -175,24 +200,21 @@ export function buildMessageWithAttachments(
   const blocks: string[] = [];
 
   for (const [idx, att] of attachments.entries()) {
-    if (!att) {
-      continue;
-    }
+    if (!att) continue;
+
     const normalized = normalizeAttachment(att, idx, {
       stripDataUrlPrefix: false,
       requireImageMime: true,
     });
     validateAttachmentBase64OrThrow(normalized, { maxBytes });
+
     const { base64, label, mime } = normalized;
-
     const safeLabel = label.replace(/\s+/g, "_");
-    const dataUrl = `![${safeLabel}](data:${mime};base64,${base64})`;
-    blocks.push(dataUrl);
+    blocks.push(`![${safeLabel}](data:${mime};base64,${base64})`);
   }
 
-  if (blocks.length === 0) {
-    return message;
-  }
+  if (blocks.length === 0) return message;
+
   const separator = message.trim().length > 0 ? "\n\n" : "";
   return `${message}${separator}${blocks.join("\n\n")}`;
 }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -359,21 +359,30 @@ export const agentHandlers: GatewayRequestHandlers = {
           typeof request.sessionKey === "string" && request.sessionKey.trim()
             ? request.sessionKey.trim()
             : undefined;
+
+        let baseProvider: string | undefined;
+        let baseModel: string | undefined;
         if (requestedSessionKeyRaw) {
           const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
-          const catalog = await context.loadGatewayModelCatalog();
           const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
-          const effectiveModel = modelOverride || modelRef.model; 
+          baseProvider = modelRef.provider;
+          baseModel = modelRef.model;
+        }
+        const effectiveProvider = providerOverride || baseProvider;
+        const effectiveModel = modelOverride || baseModel;
+        if (effectiveModel) {
+          const catalog = await context.loadGatewayModelCatalog();
           const catalogModels: unknown[] = Array.isArray(catalog)
             ? catalog
             : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
               ? (catalog as { models: unknown[] }).models
               : [];
           const modelEntry = catalogModels.find(
-            (m): m is { id?: unknown; input?: unknown[] } =>
+            (m): m is { id?: unknown; provider?: unknown; input?: unknown[] } =>
               m !== null &&
               typeof m === "object" &&
-              (m as Record<string, unknown>).id === effectiveModel,
+              (m as Record<string, unknown>).id === effectiveModel &&
+              (!effectiveProvider || (m as Record<string, unknown>).provider === effectiveProvider),
           );
           if (modelEntry != null) {
             supportsImages =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -39,7 +39,7 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
-import { parseMessageWithAttachments } from "../chat-attachments.js";
+import { MediaOffloadError, parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
@@ -58,6 +58,7 @@ import {
   loadGatewaySessionRow,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
+  resolveSessionModelRef,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
@@ -347,15 +348,64 @@ export const agentHandlers: GatewayRequestHandlers = {
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
     if (normalizedAttachments.length > 0) {
+      // Determine whether the selected model supports image input so that large-
+      // attachment offload markers are only injected when the model can resolve
+      // them. We probe the catalog using the session key if available.
+      // Defaults to true when the catalog or session is unavailable (backwards-
+      // compatible: unknown models are treated as vision-capable).
+      let supportsImages = true;
+      try {
+        const requestedSessionKeyRaw =
+          typeof request.sessionKey === "string" && request.sessionKey.trim()
+            ? request.sessionKey.trim()
+            : undefined;
+        if (requestedSessionKeyRaw) {
+          const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
+          const catalog = await context.loadGatewayModelCatalog();
+          const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
+          const catalogModels: unknown[] = Array.isArray(catalog)
+            ? catalog
+            : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
+              ? (catalog as { models: unknown[] }).models
+              : [];
+          const modelEntry = catalogModels.find(
+            (m): m is { id?: unknown; input?: unknown[] } =>
+              m !== null &&
+              typeof m === "object" &&
+              (m as Record<string, unknown>).id === modelRef.model,
+          );
+          if (modelEntry != null) {
+            supportsImages =
+              Array.isArray(modelEntry.input) && modelEntry.input.includes("image");
+          }
+        }
+      } catch {
+        // Session/catalog unavailable — default to true.
+      }
+
       try {
         const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
           maxBytes: 5_000_000,
           log: context.logGateway,
+          supportsImages,
         });
         message = parsed.message.trim();
         images = parsed.images;
+        // offloadedRefs are appended as text markers to `message`; the agent
+        // runner will resolve them via detectAndLoadPromptImages.
       } catch (err) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+        // MediaOffloadError indicates a server-side storage fault (ENOSPC, EPERM,
+        // etc.). Map it to UNAVAILABLE so clients can retry without treating it as
+        // a bad request. All other errors are input-validation failures → 4xx.
+        const isServerFault = err instanceof MediaOffloadError;
+        respond(
+          false,
+          undefined,
+          errorShape(
+            isServerFault ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+            String(err),
+          ),
+        );
         return;
       }
     }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -363,6 +363,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
           const catalog = await context.loadGatewayModelCatalog();
           const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
+          const effectiveModel = modelOverride || modelRef.model; 
           const catalogModels: unknown[] = Array.isArray(catalog)
             ? catalog
             : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
@@ -372,7 +373,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             (m): m is { id?: unknown; input?: unknown[] } =>
               m !== null &&
               typeof m === "object" &&
-              (m as Record<string, unknown>).id === modelRef.model,
+              (m as Record<string, unknown>).id === effectiveModel,
           );
           if (modelEntry != null) {
             supportsImages =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -58,6 +58,7 @@ import {
   loadGatewaySessionRow,
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
+  resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -348,50 +349,26 @@ export const agentHandlers: GatewayRequestHandlers = {
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
     if (normalizedAttachments.length > 0) {
-      // Determine whether the selected model supports image input so that large-
-      // attachment offload markers are only injected when the model can resolve
-      // them. We probe the catalog using the session key if available.
-      // Defaults to true when the catalog or session is unavailable (backwards-
-      // compatible: unknown models are treated as vision-capable).
-      let supportsImages = true;
-      try {
-        const requestedSessionKeyRaw =
-          typeof request.sessionKey === "string" && request.sessionKey.trim()
-            ? request.sessionKey.trim()
-            : undefined;
+      const requestedSessionKeyRaw =
+        typeof request.sessionKey === "string" && request.sessionKey.trim()
+          ? request.sessionKey.trim()
+          : undefined;
 
-        let baseProvider: string | undefined;
-        let baseModel: string | undefined;
-        if (requestedSessionKeyRaw) {
-          const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
-          const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
-          baseProvider = modelRef.provider;
-          baseModel = modelRef.model;
-        }
-        const effectiveProvider = providerOverride || baseProvider;
-        const effectiveModel = modelOverride || baseModel;
-        if (effectiveModel) {
-          const catalog = await context.loadGatewayModelCatalog();
-          const catalogModels: unknown[] = Array.isArray(catalog)
-            ? catalog
-            : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
-              ? (catalog as { models: unknown[] }).models
-              : [];
-          const modelEntry = catalogModels.find(
-            (m): m is { id?: unknown; provider?: unknown; input?: unknown[] } =>
-              m !== null &&
-              typeof m === "object" &&
-              (m as Record<string, unknown>).id === effectiveModel &&
-              (!effectiveProvider || (m as Record<string, unknown>).provider === effectiveProvider),
-          );
-          if (modelEntry != null) {
-            supportsImages =
-              Array.isArray(modelEntry.input) && modelEntry.input.includes("image");
-          }
-        }
-      } catch {
-        // Session/catalog unavailable — default to true.
+      let baseProvider: string | undefined;
+      let baseModel: string | undefined;
+      if (requestedSessionKeyRaw) {
+        const { cfg: sessCfg, entry: sessEntry } = loadSessionEntry(requestedSessionKeyRaw);
+        const modelRef = resolveSessionModelRef(sessCfg, sessEntry, undefined);
+        baseProvider = modelRef.provider;
+        baseModel = modelRef.model;
       }
+      const effectiveProvider = providerOverride || baseProvider;
+      const effectiveModel = modelOverride || baseModel;
+      const supportsImages = await resolveGatewayModelSupportsImages({
+        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+        provider: effectiveProvider,
+        model: effectiveModel,
+      });
 
       try {
         const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -23,6 +23,7 @@ import {
 } from "../../infra/outbound/agent-delivery.js";
 import { shouldDowngradeDeliveryToSessionOnly } from "../../infra/outbound/best-effort-delivery.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -348,6 +349,7 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+    let imageOrder: PromptImageOrderEntry[] = [];
     if (normalizedAttachments.length > 0) {
       const requestedSessionKeyRaw =
         typeof request.sessionKey === "string" && request.sessionKey.trim()
@@ -378,6 +380,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         message = parsed.message.trim();
         images = parsed.images;
+        imageOrder = parsed.imageOrder;
         // offloadedRefs are appended as text markers to `message`; the agent
         // runner will resolve them via detectAndLoadPromptImages.
       } catch (err) {
@@ -802,6 +805,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       ingressOpts: {
         message,
         images,
+        imageOrder,
         provider: providerOverride,
         model: modelOverride,
         to: resolvedTo,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -361,7 +361,7 @@ async function persistChatSendImages(params: {
   for (const ref of params.offloadedRefs) {
     saved.push({
       id: ref.id,
-      path: ref.mediaRef,
+      path: ref.path,
       size: 0,
       contentType: ref.mimeType,
     });
@@ -1431,7 +1431,65 @@ export const chatHandlers: GatewayRequestHandlers = {
     let parsedMessage = inboundMessage;
     let parsedImages: ChatImageContent[] = [];
     let parsedOffloadedRefs: OffloadedRef[] = [];
-    if (normalizedAttachments.length > 0) {
+    
+    const timeoutMs = resolveAgentTimeoutMs({
+      cfg,
+      overrideMs: p.timeoutMs,
+    });
+    const now = Date.now();
+    const clientRunId = p.idempotencyKey;
+
+    const sendPolicy = resolveSendPolicy({
+      cfg,
+      entry,
+      sessionKey,
+      channel: entry?.channel,
+      chatType: entry?.chatType,
+    });
+    if (sendPolicy === "deny") {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
+      );
+      return;
+    }
+
+    if (stopCommand) {
+      const res = abortChatRunsForSessionKeyWithPartials({
+        context,
+        ops: createChatAbortOps(context),
+        sessionKey: rawSessionKey,
+        abortOrigin: "stop-command",
+        stopReason: "stop",
+        requester: resolveChatAbortRequester(client),
+      });
+      if (res.unauthorized) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
+        return;
+      }
+      respond(true, { ok: true, aborted: res.aborted, runIds: res.runIds });
+      return;
+    }
+
+    const cached = context.dedupe.get(`chat:${clientRunId}`);
+    if (cached) {
+      respond(cached.ok, cached.payload, cached.error, {
+        cached: true,
+      });
+      return;
+    }
+
+    const activeExisting = context.chatAbortControllers.get(clientRunId);
+    if (activeExisting) {
+      respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
+        cached: true,
+        runId: clientRunId,
+      });
+      return;
+    }
+
+if (normalizedAttachments.length > 0) {
       // Determine whether the selected model supports image input so that large-
       // attachment offload markers are only injected when the model can resolve
       // them. Defaults to true when the catalog is unavailable (backwards-
@@ -1488,63 +1546,6 @@ export const chatHandlers: GatewayRequestHandlers = {
         );
         return;
       }
-    }
-
-    const timeoutMs = resolveAgentTimeoutMs({
-      cfg,
-      overrideMs: p.timeoutMs,
-    });
-    const now = Date.now();
-    const clientRunId = p.idempotencyKey;
-
-    const sendPolicy = resolveSendPolicy({
-      cfg,
-      entry,
-      sessionKey,
-      channel: entry?.channel,
-      chatType: entry?.chatType,
-    });
-    if (sendPolicy === "deny") {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "send blocked by session policy"),
-      );
-      return;
-    }
-
-    if (stopCommand) {
-      const res = abortChatRunsForSessionKeyWithPartials({
-        context,
-        ops: createChatAbortOps(context),
-        sessionKey: rawSessionKey,
-        abortOrigin: "stop-command",
-        stopReason: "stop",
-        requester: resolveChatAbortRequester(client),
-      });
-      if (res.unauthorized) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unauthorized"));
-        return;
-      }
-      respond(true, { ok: true, aborted: res.aborted, runIds: res.runIds });
-      return;
-    }
-
-    const cached = context.dedupe.get(`chat:${clientRunId}`);
-    if (cached) {
-      respond(cached.ok, cached.payload, cached.error, {
-        cached: true,
-      });
-      return;
-    }
-
-    const activeExisting = context.chatAbortControllers.get(clientRunId);
-    if (activeExisting) {
-      respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
-        cached: true,
-        runId: clientRunId,
-      });
-      return;
     }
 
     try {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -64,6 +64,7 @@ import { getMaxChatHistoryMessagesBytes } from "../server-constants.js";
 import {
   capArrayByJsonBytes,
   loadSessionEntry,
+  resolveGatewayModelSupportsImages,
   readSessionMessages,
   resolveSessionModelRef,
 } from "../session-utils.js";
@@ -1431,7 +1432,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     let parsedMessage = inboundMessage;
     let parsedImages: ChatImageContent[] = [];
     let parsedOffloadedRefs: OffloadedRef[] = [];
-    
+
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,
@@ -1489,37 +1490,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
 
-if (normalizedAttachments.length > 0) {
-      // Determine whether the selected model supports image input so that large-
-      // attachment offload markers are only injected when the model can resolve
-      // them. Defaults to true when the catalog is unavailable (backwards-
-      // compatible: unknown models are treated as vision-capable).
-      let supportsImages = true;
-      try {
-        const catalog = await context.loadGatewayModelCatalog();
-        const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
-        const modelRef = resolveSessionModelRef(cfg, entry, sessionAgentId);
-        // The catalog shape is opaque here; probe defensively.
-        // Both flat-array and { models: [...] } shapes are handled.
-        const catalogModels: unknown[] = Array.isArray(catalog)
-          ? catalog
-          : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
-            ? (catalog as { models: unknown[] }).models
-            : [];
-        const modelEntry = catalogModels.find(
-          (m): m is { id?: unknown; provider?: unknown; input?: unknown[] } =>
-            m !== null &&
-            typeof m === "object" &&
-            (m as Record<string, unknown>).id === modelRef.model &&
-            (m as Record<string, unknown>).provider === modelRef.provider,
-        );
-        if (modelEntry != null) {
-          supportsImages =
-            Array.isArray(modelEntry.input) && modelEntry.input.includes("image");
-        }
-      } catch {
-        // Catalog unavailable — default to true (allow image attachment offload).
-      }
+    if (normalizedAttachments.length > 0) {
+      const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+      const modelRef = resolveSessionModelRef(cfg, entry, sessionAgentId);
+      const supportsImages = await resolveGatewayModelSupportsImages({
+        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+        provider: modelRef.provider,
+        model: modelRef.model,
+      });
 
       try {
         const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1449,10 +1449,11 @@ export const chatHandlers: GatewayRequestHandlers = {
             ? (catalog as { models: unknown[] }).models
             : [];
         const modelEntry = catalogModels.find(
-          (m): m is { id?: unknown; input?: unknown[] } =>
+          (m): m is { id?: unknown; provider?: unknown; input?: unknown[] } =>
             m !== null &&
             typeof m === "object" &&
-            (m as Record<string, unknown>).id === modelRef.model,
+            (m as Record<string, unknown>).id === modelRef.model &&
+            (m as Record<string, unknown>).provider === modelRef.provider,
         );
         if (modelEntry != null) {
           supportsImages =

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -12,6 +12,7 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.j
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
 import { createChannelReplyPipeline } from "../../plugin-sdk/channel-reply-pipeline.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -345,6 +346,7 @@ function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"
  */
 async function persistChatSendImages(params: {
   images: ChatImageContent[];
+  imageOrder: PromptImageOrderEntry[];
   offloadedRefs: OffloadedRef[];
   client: GatewayRequestHandlerOptions["client"];
   logGateway: GatewayRequestContext["logGateway"];
@@ -354,22 +356,27 @@ async function persistChatSendImages(params: {
   }
 
   const saved: SavedMedia[] = [];
+  let inlineIndex = 0;
+  let offloadedIndex = 0;
+  for (const entry of params.imageOrder) {
+    if (entry === "offloaded") {
+      const ref = params.offloadedRefs[offloadedIndex++];
+      if (!ref) {
+        continue;
+      }
+      saved.push({
+        id: ref.id,
+        path: ref.path,
+        size: 0,
+        contentType: ref.mimeType,
+      });
+      continue;
+    }
 
-  // Offloaded images are already on disk — convert their metadata directly.
-  // Placed first so MediaPath/MediaPaths in the transcript reflect the original
-  // attachment order (large images precede any trailing inline images in the
-  // message, matching the order in which markers were appended).
-  for (const ref of params.offloadedRefs) {
-    saved.push({
-      id: ref.id,
-      path: ref.path,
-      size: 0,
-      contentType: ref.mimeType,
-    });
-  }
-
-  // Inline images must be saved to disk to obtain a stable transcript path.
-  for (const img of params.images) {
+    const img = params.images[inlineIndex++];
+    if (!img) {
+      continue;
+    }
     try {
       saved.push(await saveMediaBuffer(Buffer.from(img.data, "base64"), img.mimeType, "inbound"));
     } catch (err) {
@@ -1431,6 +1438,7 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     let parsedMessage = inboundMessage;
     let parsedImages: ChatImageContent[] = [];
+    let parsedImageOrder: PromptImageOrderEntry[] = [];
     let parsedOffloadedRefs: OffloadedRef[] = [];
 
     const timeoutMs = resolveAgentTimeoutMs({
@@ -1507,6 +1515,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         });
         parsedMessage = parsed.message;
         parsedImages = parsed.images;
+        parsedImageOrder = parsed.imageOrder;
         parsedOffloadedRefs = parsed.offloadedRefs;
       } catch (err) {
         // MediaOffloadError indicates a server-side storage fault (ENOSPC, EPERM,
@@ -1549,6 +1558,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       // their metadata without re-writing the files.
       const persistedImagesPromise = persistChatSendImages({
         images: parsedImages,
+        imageOrder: parsedImageOrder,
         offloadedRefs: parsedOffloadedRefs,
         client,
         logGateway: context.logGateway,
@@ -1709,6 +1719,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           runId: clientRunId,
           abortSignal: abortController.signal,
           images: parsedImages.length > 0 ? parsedImages : undefined,
+          imageOrder: parsedImageOrder.length > 0 ? parsedImageOrder : undefined,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             void emitUserTranscriptUpdate();

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -35,7 +35,12 @@ import {
   isChatStopCommandText,
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
-import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
+import {
+  type ChatImageContent,
+  MediaOffloadError,
+  type OffloadedRef,
+  parseMessageWithAttachments,
+} from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import { augmentChatHistoryWithCliSessionImports } from "../cli-session-history.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
@@ -326,15 +331,43 @@ function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"
   return scopes.includes(ADMIN_SCOPE);
 }
 
+/**
+ * Persist inline images and offloaded-ref media to the transcript media store.
+ *
+ * Inline images are re-saved from their base64 payload so that a stable
+ * filesystem path can be stored in the transcript.  Offloaded refs are already
+ * on disk (saved by parseMessageWithAttachments); their SavedMedia metadata is
+ * synthesised directly from the OffloadedRef, avoiding a redundant write.
+ *
+ * Both sets are combined so that transcript media fields remain complete
+ * regardless of whether attachments were inlined or offloaded.
+ */
 async function persistChatSendImages(params: {
   images: ChatImageContent[];
+  offloadedRefs: OffloadedRef[];
   client: GatewayRequestHandlerOptions["client"];
   logGateway: GatewayRequestContext["logGateway"];
 }): Promise<SavedMedia[]> {
-  if (params.images.length === 0 || isAcpBridgeClient(params.client)) {
+  if (isAcpBridgeClient(params.client)) {
     return [];
   }
+
   const saved: SavedMedia[] = [];
+
+  // Offloaded images are already on disk — convert their metadata directly.
+  // Placed first so MediaPath/MediaPaths in the transcript reflect the original
+  // attachment order (large images precede any trailing inline images in the
+  // message, matching the order in which markers were appended).
+  for (const ref of params.offloadedRefs) {
+    saved.push({
+      id: ref.id,
+      path: ref.mediaRef,
+      size: 0,
+      contentType: ref.mimeType,
+    });
+  }
+
+  // Inline images must be saved to disk to obtain a stable transcript path.
   for (const img of params.images) {
     try {
       saved.push(await saveMediaBuffer(Buffer.from(img.data, "base64"), img.mimeType, "inbound"));
@@ -344,6 +377,7 @@ async function persistChatSendImages(params: {
       );
     }
   }
+
   return saved;
 }
 
@@ -1387,23 +1421,74 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+
+    // Load session entry before attachment parsing so we can gate media-URI
+    // marker injection on the model's image capability. This prevents opaque
+    // media:// markers from leaking into prompts for text-only model runs.
+    const rawSessionKey = p.sessionKey;
+    const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+
     let parsedMessage = inboundMessage;
     let parsedImages: ChatImageContent[] = [];
+    let parsedOffloadedRefs: OffloadedRef[] = [];
     if (normalizedAttachments.length > 0) {
+      // Determine whether the selected model supports image input so that large-
+      // attachment offload markers are only injected when the model can resolve
+      // them. Defaults to true when the catalog is unavailable (backwards-
+      // compatible: unknown models are treated as vision-capable).
+      let supportsImages = true;
+      try {
+        const catalog = await context.loadGatewayModelCatalog();
+        const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+        const modelRef = resolveSessionModelRef(cfg, entry, sessionAgentId);
+        // The catalog shape is opaque here; probe defensively.
+        // Both flat-array and { models: [...] } shapes are handled.
+        const catalogModels: unknown[] = Array.isArray(catalog)
+          ? catalog
+          : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
+            ? (catalog as { models: unknown[] }).models
+            : [];
+        const modelEntry = catalogModels.find(
+          (m): m is { id?: unknown; input?: unknown[] } =>
+            m !== null &&
+            typeof m === "object" &&
+            (m as Record<string, unknown>).id === modelRef.model,
+        );
+        if (modelEntry != null) {
+          supportsImages =
+            Array.isArray(modelEntry.input) && modelEntry.input.includes("image");
+        }
+      } catch {
+        // Catalog unavailable — default to true (allow image attachment offload).
+      }
+
       try {
         const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
           maxBytes: 5_000_000,
           log: context.logGateway,
+          supportsImages,
         });
         parsedMessage = parsed.message;
         parsedImages = parsed.images;
+        parsedOffloadedRefs = parsed.offloadedRefs;
       } catch (err) {
-        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
+        // MediaOffloadError indicates a server-side storage fault (ENOSPC, EPERM,
+        // etc.). All other errors are client-side input validation failures.
+        // Map them to different HTTP status codes so callers can retry server
+        // faults without treating them as bad requests.
+        const isServerFault = err instanceof MediaOffloadError;
+        respond(
+          false,
+          undefined,
+          errorShape(
+            isServerFault ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+            String(err),
+          ),
+        );
         return;
       }
     }
-    const rawSessionKey = p.sessionKey;
-    const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,
@@ -1477,8 +1562,14 @@ export const chatHandlers: GatewayRequestHandlers = {
         status: "started" as const,
       };
       respond(true, ackPayload, undefined, { runId: clientRunId });
+
+      // Persist both inline images and already-offloaded refs to the media
+      // store so that transcript media fields remain complete for all attachment
+      // sizes. Offloaded refs are already on disk; persistChatSendImages converts
+      // their metadata without re-writing the files.
       const persistedImagesPromise = persistChatSendImages({
         images: parsedImages,
+        offloadedRefs: parsedOffloadedRefs,
         client,
         logGateway: context.logGateway,
       });

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -799,6 +799,7 @@ describe("agent request events", () => {
     parseMessageWithAttachmentsMock.mockResolvedValue({
       message: "parsed message",
       images: [],
+      imageOrder: [],
       offloadedRefs: [],
     });
     agentCommandMock.mockResolvedValue({ status: "ok" } as never);

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -7,6 +7,8 @@ const buildSessionLookup = (
   sessionKey: string,
   entry: {
     sessionId?: string;
+    model?: string;
+    modelProvider?: string;
     lastChannel?: string;
     lastTo?: string;
     lastAccountId?: string;
@@ -23,6 +25,8 @@ const buildSessionLookup = (
   entry: {
     sessionId: entry.sessionId ?? `sid-${sessionKey}`,
     updatedAt: entry.updatedAt ?? Date.now(),
+    model: entry.model,
+    modelProvider: entry.modelProvider,
     lastChannel: entry.lastChannel,
     lastTo: entry.lastTo,
     lastAccountId: entry.lastAccountId,
@@ -44,6 +48,7 @@ const loadOrCreateDeviceIdentityMock = vi.hoisted(() =>
     privateKeyPem: "private",
   })),
 );
+const parseMessageWithAttachmentsMock = vi.hoisted(() => vi.fn());
 const normalizeChannelIdMock = vi.hoisted(() =>
   vi.fn((channel?: string | null) => channel ?? null),
 );
@@ -79,6 +84,13 @@ vi.mock("../infra/push-apns.js", () => ({
 vi.mock("../infra/device-identity.js", () => ({
   loadOrCreateDeviceIdentity: loadOrCreateDeviceIdentityMock,
 }));
+vi.mock("./chat-attachments.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./chat-attachments.js")>();
+  return {
+    ...actual,
+    parseMessageWithAttachments: parseMessageWithAttachmentsMock,
+  };
+});
 vi.mock("./session-utils.js", () => ({
   loadSessionEntry: vi.fn((sessionKey: string) => buildSessionLookup(sessionKey)),
   migrateAndPruneGatewaySessionStoreKey: vi.fn(
@@ -89,10 +101,38 @@ vi.mock("./session-utils.js", () => ({
     }),
   ),
   pruneLegacyStoreKeys: vi.fn(),
+  resolveGatewayModelSupportsImages: vi.fn(
+    async ({
+      loadGatewayModelCatalog,
+      provider,
+      model,
+    }: {
+      loadGatewayModelCatalog: () => Promise<
+        Array<{ id: string; provider: string; input?: string[] }>
+      >;
+      provider?: string;
+      model?: string;
+    }) => {
+      if (!model) {
+        return true;
+      }
+      const catalog = await loadGatewayModelCatalog();
+      const modelEntry = catalog.find(
+        (entry) => entry.id === model && (!provider || entry.provider === provider),
+      );
+      return modelEntry ? (modelEntry.input?.includes("image") ?? false) : true;
+    },
+  ),
   resolveGatewaySessionStoreTarget: vi.fn(({ key }: { key: string }) => ({
     canonicalKey: key,
     storeKeys: [key],
   })),
+  resolveSessionModelRef: vi.fn(
+    (_cfg: OpenClawConfig, entry?: { model?: string; modelProvider?: string }) => ({
+      provider: entry?.modelProvider ?? "test-provider",
+      model: entry?.model ?? "default-model",
+    }),
+  ),
 }));
 
 import { normalizeChannelId } from "../channels/plugins/index.js";
@@ -751,10 +791,16 @@ describe("notifications changed events", () => {
 describe("agent request events", () => {
   beforeEach(() => {
     agentCommandMock.mockClear();
+    parseMessageWithAttachmentsMock.mockReset();
     updateSessionStoreMock.mockClear();
     loadSessionEntryMock.mockClear();
     normalizeChannelIdVi.mockClear();
     normalizeChannelIdVi.mockImplementation((channel?: string | null) => channel ?? null);
+    parseMessageWithAttachmentsMock.mockResolvedValue({
+      message: "parsed message",
+      images: [],
+      offloadedRefs: [],
+    });
     agentCommandMock.mockResolvedValue({ status: "ok" } as never);
     updateSessionStoreMock.mockImplementation(async (_storePath, update) => {
       update({});
@@ -820,5 +866,46 @@ describe("agent request events", () => {
       to: "123",
     });
     expect(opts.runId).toBe(opts.sessionId);
+  });
+
+  it("passes supportsImages false for text-only node-session models", async () => {
+    const ctx = buildCtx();
+    ctx.loadGatewayModelCatalog = async () => [
+      {
+        id: "text-only",
+        name: "Text only",
+        provider: "test-provider",
+        input: ["text"],
+      },
+    ];
+    loadSessionEntryMock.mockReturnValueOnce({
+      ...buildSessionLookup("agent:main:main", {
+        model: "text-only",
+        modelProvider: "test-provider",
+      }),
+      canonicalKey: "agent:main:main",
+    });
+
+    await handleNodeEvent(ctx, "node-text-only", {
+      event: "agent.request",
+      payloadJSON: JSON.stringify({
+        message: "describe",
+        sessionKey: "agent:main:main",
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "dot.png",
+            content: "AAAA",
+          },
+        ],
+      }),
+    });
+
+    expect(parseMessageWithAttachmentsMock).toHaveBeenCalledWith(
+      "describe",
+      expect.any(Array),
+      expect.objectContaining({ supportsImages: false }),
+    );
   });
 });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -13,6 +13,7 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsRegistration } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { deleteMediaBuffer } from "../media/store.js";
 import { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
@@ -372,6 +373,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         link?.attachments ?? undefined,
       );
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+      let imageOrder: PromptImageOrderEntry[] = [];
       if (!message && normalizedAttachments.length === 0) {
         return;
       }
@@ -394,6 +396,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           });
           message = parsed.message.trim();
           images = parsed.images;
+          imageOrder = parsed.imageOrder;
           if (message.length > 20_000) {
             ctx.logGateway.warn(
               `agent.request message exceeds limit after attachment parsing (length=${message.length})`,
@@ -480,6 +483,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           runId: sessionId,
           message,
           images,
+          imageOrder,
           sessionId,
           sessionKey: canonicalKey,
           thinking: link?.thinking ?? undefined,

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -17,8 +17,9 @@ import { defaultRuntime } from "../runtime.js";
 import { parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
-import { loadSessionEntry, migrateAndPruneGatewaySessionStoreKey, resolveSessionModelRef } from "./session-utils.js";
+import { loadSessionEntry, migrateAndPruneGatewaySessionStoreKey} from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
+import { deleteMediaBuffer } from "../media/store.ts";
 
 const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
 const MAX_NOTIFICATION_EVENT_TEXT_CHARS = 120;
@@ -380,16 +381,25 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           message = parsed.message.trim();
           images = parsed.images;
           if (message.length > 20_000) {
-            ctx.logGateway.warn(`agent.request message exceeds limit after attachment parsing (length=${message.length})`);
-            return;
+          ctx.logGateway.warn(`agent.request message exceeds limit after attachment parsing (length=${message.length})`);
+          if (parsed.offloadedRefs && parsed.offloadedRefs.length > 0) {
+            for (const ref of parsed.offloadedRefs) {
+              try {
+                await deleteMediaBuffer(ref.id); 
+              } catch (cleanupErr) {
+                ctx.logGateway.warn(`Failed to cleanup orphaned media ${ref.id}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`);
+              }
+            }
           }
+          return;
+        }
         } catch (err) {
           ctx.logGateway.warn(`agent.request attachment parse failed: ${err instanceof Error ? err.message : String(err)}`);
           return;
         }
       }
 
-      if (!message) {
+      if (!message && images.length === 0) {
         return;
       }
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -379,8 +379,10 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
               ? (catalog as { models: unknown[] }).models
               : [];
           const modelEntry = catalogModels.find(
-            (m): m is { id?: unknown; input?: unknown[] } =>
-              m !== null && typeof m === "object" && (m as Record<string, unknown>).id === modelRef.model,
+            (m): m is { id?: unknown; provider?: unknown; input?: unknown[] } =>
+              m !== null && typeof m === "object" &&
+              (m as Record<string, unknown>).id === modelRef.model &&
+              (m as Record<string, unknown>).provider === modelRef.provider,
           );
           if (modelEntry != null) {
             supportsImages = Array.isArray(modelEntry.input) && modelEntry.input.includes("image");

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -367,33 +367,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
 
       if (normalizedAttachments.length > 0) {
-        let supportsImages = true;
-        try {
-          const catalog = 'loadGatewayModelCatalog' in ctx && typeof ctx.loadGatewayModelCatalog === 'function'
-            ? await (ctx as any).loadGatewayModelCatalog()
-            : [];
-          const modelRef = resolveSessionModelRef(cfg, entry, undefined);
-          const catalogModels: unknown[] = Array.isArray(catalog)
-            ? catalog
-            : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
-              ? (catalog as { models: unknown[] }).models
-              : [];
-          const modelEntry = catalogModels.find(
-            (m): m is { id?: unknown; provider?: unknown; input?: unknown[] } =>
-              m !== null && typeof m === "object" &&
-              (m as Record<string, unknown>).id === modelRef.model &&
-              (m as Record<string, unknown>).provider === modelRef.provider,
-          );
-          if (modelEntry != null) {
-            supportsImages = Array.isArray(modelEntry.input) && modelEntry.input.includes("image");
-          }
-        } catch {}
-
+      // NodeEventContext does not expose loadGatewayModelCatalog.
+      // Node events are fire-and-forget; default to supportsImages:true so
+      // attachments are handled the same as before this change.
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes: 5_000_000,
             log: ctx.logGateway,
-            supportsImages,
           });
           message = parsed.message.trim();
           images = parsed.images;

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import { sanitizeInboundSystemTags } from "../auto-reply/reply/inbound-text.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
@@ -12,14 +13,19 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsRegistration } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { deleteMediaBuffer } from "../media/store.js";
 import { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
-import { loadSessionEntry, migrateAndPruneGatewaySessionStoreKey} from "./session-utils.js";
+import {
+  loadSessionEntry,
+  migrateAndPruneGatewaySessionStoreKey,
+  resolveGatewayModelSupportsImages,
+  resolveSessionModelRef,
+} from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
-import { deleteMediaBuffer } from "../media/store.ts";
 
 const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
 const MAX_NOTIFICATION_EVENT_TEXT_CHARS = 120;
@@ -373,28 +379,42 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         return;
       }
       if (normalizedAttachments.length > 0) {
+        const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+        const modelRef = resolveSessionModelRef(cfg, entry, sessionAgentId);
+        const supportsImages = await resolveGatewayModelSupportsImages({
+          loadGatewayModelCatalog: ctx.loadGatewayModelCatalog,
+          provider: modelRef.provider,
+          model: modelRef.model,
+        });
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes: 5_000_000,
             log: ctx.logGateway,
+            supportsImages,
           });
           message = parsed.message.trim();
           images = parsed.images;
           if (message.length > 20_000) {
-          ctx.logGateway.warn(`agent.request message exceeds limit after attachment parsing (length=${message.length})`);
-          if (parsed.offloadedRefs && parsed.offloadedRefs.length > 0) {
-            for (const ref of parsed.offloadedRefs) {
-              try {
-                await deleteMediaBuffer(ref.id); 
-              } catch (cleanupErr) {
-                ctx.logGateway.warn(`Failed to cleanup orphaned media ${ref.id}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`);
+            ctx.logGateway.warn(
+              `agent.request message exceeds limit after attachment parsing (length=${message.length})`,
+            );
+            if (parsed.offloadedRefs && parsed.offloadedRefs.length > 0) {
+              for (const ref of parsed.offloadedRefs) {
+                try {
+                  await deleteMediaBuffer(ref.id);
+                } catch (cleanupErr) {
+                  ctx.logGateway.warn(
+                    `Failed to cleanup orphaned media ${ref.id}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+                  );
+                }
               }
             }
+            return;
           }
-          return;
-        }
         } catch (err) {
-          ctx.logGateway.warn(`agent.request attachment parse failed: ${err instanceof Error ? err.message : String(err)}`);
+          ctx.logGateway.warn(
+            `agent.request attachment parse failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
           return;
         }
       }

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -379,6 +379,10 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           });
           message = parsed.message.trim();
           images = parsed.images;
+          if (message.length > 20_000) {
+            ctx.logGateway.warn(`agent.request message exceeds limit after attachment parsing (length=${message.length})`);
+            return;
+          }
         } catch (err) {
           ctx.logGateway.warn(`agent.request attachment parse failed: ${err instanceof Error ? err.message : String(err)}`);
           return;

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -357,16 +357,18 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(
         link?.attachments ?? undefined,
       );
-      let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+    let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
       if (normalizedAttachments.length > 0) {
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes: 5_000_000,
             log: ctx.logGateway,
+            supportsImages: true,
           });
           message = parsed.message.trim();
           images = parsed.images;
-        } catch {
+        } catch (err) {
+          ctx.logGateway.warn(`agent.request attachment parse failed: ${err instanceof Error ? err.message : String(err)}`);
           return;
         }
       }

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -17,7 +17,7 @@ import { defaultRuntime } from "../runtime.js";
 import { parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
-import { loadSessionEntry, migrateAndPruneGatewaySessionStoreKey } from "./session-utils.js";
+import { loadSessionEntry, migrateAndPruneGatewaySessionStoreKey, resolveSessionModelRef } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
 const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
@@ -347,23 +347,51 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         timeoutSeconds?: number | null;
         key?: string | null;
       };
+
       let link: AgentDeepLink | null = null;
       try {
         link = JSON.parse(evt.payloadJSON) as AgentDeepLink;
       } catch {
         return;
       }
+
+      const sessionKeyRaw = (link?.sessionKey ?? "").trim();
+      const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : `node-${nodeId}`;
+      const cfg = loadConfig();
+      const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
+
       let message = (link?.message ?? "").trim();
       const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(
         link?.attachments ?? undefined,
       );
-    let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+      let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+
       if (normalizedAttachments.length > 0) {
+        let supportsImages = true;
+        try {
+          const catalog = 'loadGatewayModelCatalog' in ctx && typeof ctx.loadGatewayModelCatalog === 'function'
+            ? await (ctx as any).loadGatewayModelCatalog()
+            : [];
+          const modelRef = resolveSessionModelRef(cfg, entry, undefined);
+          const catalogModels: unknown[] = Array.isArray(catalog)
+            ? catalog
+            : Array.isArray((catalog as { models?: unknown[] } | null)?.models)
+              ? (catalog as { models: unknown[] }).models
+              : [];
+          const modelEntry = catalogModels.find(
+            (m): m is { id?: unknown; input?: unknown[] } =>
+              m !== null && typeof m === "object" && (m as Record<string, unknown>).id === modelRef.model,
+          );
+          if (modelEntry != null) {
+            supportsImages = Array.isArray(modelEntry.input) && modelEntry.input.includes("image");
+          }
+        } catch {}
+
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes: 5_000_000,
             log: ctx.logGateway,
-            supportsImages: true,
+            supportsImages,
           });
           message = parsed.message.trim();
           images = parsed.images;
@@ -372,6 +400,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           return;
         }
       }
+
       if (!message) {
         return;
       }
@@ -388,10 +417,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       const receiptText =
         receiptTextRaw || "Just received your iOS share + request, working on it.";
 
-      const sessionKeyRaw = (link?.sessionKey ?? "").trim();
-      const sessionKey = sessionKeyRaw.length > 0 ? sessionKeyRaw : `node-${nodeId}`;
-      const cfg = loadConfig();
-      const { storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
       const now = Date.now();
       const sessionId = entry?.sessionId ?? randomUUID();
       await touchSessionStore({ cfg, sessionKey, storePath, canonicalKey, entry, sessionId, now });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -365,11 +365,13 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         link?.attachments ?? undefined,
       );
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
-
+      if (!message && normalizedAttachments.length === 0) {
+        return;
+      }
+      if (message.length > 20_000) {
+        return;
+      }
       if (normalizedAttachments.length > 0) {
-      // NodeEventContext does not expose loadGatewayModelCatalog.
-      // Node events are fire-and-forget; default to supportsImages:true so
-      // attachments are handled the same as before this change.
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
             maxBytes: 5_000_000,
@@ -384,9 +386,6 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       if (!message) {
-        return;
-      }
-      if (message.length > 20_000) {
         return;
       }
 

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -22,6 +22,7 @@ import {
   migrateAndPruneGatewaySessionStoreKey,
   parseGroupKey,
   pruneLegacyStoreKeys,
+  resolveGatewayModelSupportsImages,
   resolveGatewaySessionStoreTarget,
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
@@ -2355,6 +2356,30 @@ describe("listSessionsFromStore subagent metadata", () => {
     );
     expect(timeout?.status).toBe("timeout");
     expect(timeout?.runtimeMs).toBe(0);
+  });
+
+  test("fails closed when model lookup misses", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "gpt-5.4",
+        provider: "openai",
+        loadGatewayModelCatalog: async () => [
+          { id: "gpt-5.4", name: "GPT-5.4", provider: "other", input: ["text", "image"] },
+        ],
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test("fails closed when model catalog load throws", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "gpt-5.4",
+        provider: "openai",
+        loadGatewayModelCatalog: async () => {
+          throw new Error("catalog unavailable");
+        },
+      }),
+    ).resolves.toBe(false);
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -8,6 +8,7 @@ import {
 } from "../agents/agent-scope.js";
 import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   parseModelRef,
@@ -1072,6 +1073,27 @@ export function resolveSessionModelRef(
     }
   }
   return { provider, model };
+}
+
+export async function resolveGatewayModelSupportsImages(params: {
+  loadGatewayModelCatalog: () => Promise<ModelCatalogEntry[]>;
+  provider?: string;
+  model?: string;
+}): Promise<boolean> {
+  if (!params.model) {
+    return true;
+  }
+
+  try {
+    const catalog = await params.loadGatewayModelCatalog();
+    const modelEntry = catalog.find(
+      (entry) =>
+        entry.id === params.model && (!params.provider || entry.provider === params.provider),
+    );
+    return modelEntry ? (modelEntry.input?.includes("image") ?? false) : true;
+  } catch {
+    return true;
+  }
 }
 
 export function resolveSessionModelIdentityRef(

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1090,9 +1090,9 @@ export async function resolveGatewayModelSupportsImages(params: {
       (entry) =>
         entry.id === params.model && (!params.provider || entry.provider === params.provider),
     );
-    return modelEntry ? (modelEntry.input?.includes("image") ?? false) : true;
+    return modelEntry ? (modelEntry.input?.includes("image") ?? false) : false;
   } catch {
-    return true;
+    return false;
   }
 }
 

--- a/src/media/prompt-image-order.ts
+++ b/src/media/prompt-image-order.ts
@@ -1,0 +1,1 @@
+export type PromptImageOrderEntry = "inline" | "offloaded";

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -433,10 +433,10 @@ export async function resolveMediaBufferPath(
   id: string,
   subdir: "inbound" = "inbound",
 ): Promise<string> {
-  // Guard against path traversal: reject any ID containing a separator or
-  // "..". IDs produced by buildSavedMediaId only contain alphanumerics,
-  // dots, hyphens, and underscores — no slashes are ever emitted.
-  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
+  // Guard against path traversal: reject any ID containing a separator.
+  // We allow consecutive dots in legitimate filenames (e.g. "report..draft.png"),
+  // but strictly reject the exact string ".." which acts as a traversal operator.
+  if (!id || id.includes("/") || id.includes("\\") || id === "..") {
     throw new Error(`resolveMediaBufferPath: unsafe media ID: ${id}`);
   }
 

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -477,3 +477,29 @@ export async function resolveMediaBufferPath(
 
   return resolved;
 }
+
+/**
+ * Deletes a file previously saved by saveMediaBuffer.
+ *
+ * This is used by parseMessageWithAttachments to clean up files that were
+ * successfully offloaded earlier in the same request when a later attachment
+ * fails validation and the entire parse is aborted, preventing orphaned files
+ * from accumulating on disk ahead of the periodic TTL sweep.
+ *
+ * Uses resolveMediaBufferPath to apply the same path-safety guards as the
+ * read path (separator checks, symlink rejection, etc.) before unlinking.
+ *
+ * Errors are intentionally not suppressed — callers that want best-effort
+ * cleanup should catch and discard exceptions themselves (e.g. via
+ * Promise.allSettled).
+ *
+ * @param id     The media ID as returned by SavedMedia.id.
+ * @param subdir The subdirectory the file was saved into (default "inbound").
+ */
+export async function deleteMediaBuffer(
+  id: string,
+  subdir: "inbound" = "inbound",
+): Promise<void> {
+  const physicalPath = await resolveMediaBufferPath(id, subdir);
+  await fs.unlink(physicalPath);
+}

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -416,14 +416,14 @@ export async function saveMediaBuffer(
  * Gateway's claim-check offload path.
  *
  * Security:
- * - Rejects IDs containing path separators or ".." to prevent directory
- *   traversal outside the resolved subdir.
+ * - Rejects IDs containing path separators, "..", or null bytes to prevent
+ *   directory traversal and path injection outside the resolved subdir.
  * - Verifies the resolved path is a regular file (not a symlink or directory)
  *   before returning it, matching the write-side MEDIA_FILE_MODE policy.
  *
  * @param id      The media ID as returned by SavedMedia.id (may include
  *                extension and original-filename prefix,
- *                e.g. "photo---<uuid>.png").
+ *                e.g. "photo---<uuid>.png" or "图片---<uuid>.png").
  * @param subdir  The subdirectory the file was saved into (default "inbound").
  * @returns       Absolute path to the file on disk.
  * @throws        If the ID is unsafe, the file does not exist, or is not a
@@ -433,11 +433,22 @@ export async function resolveMediaBufferPath(
   id: string,
   subdir: "inbound" = "inbound",
 ): Promise<string> {
-  // Guard against path traversal: reject any ID containing a separator.
+  // Guard against path traversal and null-byte injection.
+  //
+  // - Separator checks: reject any ID containing "/" or "\" (covers all
+  //   relative traversal sequences such as "../foo" or "..\\foo").
+  // - Exact ".." check: reject the bare traversal operator in case a caller
+  //   strips separators but keeps the dots.
+  // - Null-byte check: reject "\0" which can truncate paths on some platforms
+  //   and cause the OS to open a different file than intended.
+  //
   // We allow consecutive dots in legitimate filenames (e.g. "report..draft.png"),
-  // but strictly reject the exact string ".." which acts as a traversal operator.
-  if (!id || id.includes("/") || id.includes("\\") || id === "..") {
-    throw new Error(`resolveMediaBufferPath: unsafe media ID: ${id}`);
+  // so we only reject the exact two-character string "..".
+  //
+  // JSON.stringify is used in the error message so that control characters
+  // (including \0) are rendered visibly in logs rather than silently dropped.
+  if (!id || id.includes("/") || id.includes("\\") || id.includes("\0") || id === "..") {
+    throw new Error(`resolveMediaBufferPath: unsafe media ID: ${JSON.stringify(id)}`);
   }
 
   const dir = path.join(resolveMediaDir(), subdir);
@@ -447,17 +458,21 @@ export async function resolveMediaBufferPath(
   // This should be unreachable after the separator check above, but be
   // explicit about the invariant.
   if (!resolved.startsWith(dir + path.sep) && resolved !== dir) {
-    throw new Error(`resolveMediaBufferPath: path escapes media directory: ${id}`);
+    throw new Error(`resolveMediaBufferPath: path escapes media directory: ${JSON.stringify(id)}`);
   }
 
   // lstat (not stat) so we see symlinks rather than following them.
   const stat = await fs.lstat(resolved);
 
   if (stat.isSymbolicLink()) {
-    throw new Error(`resolveMediaBufferPath: refusing to follow symlink for media ID: ${id}`);
+    throw new Error(
+      `resolveMediaBufferPath: refusing to follow symlink for media ID: ${JSON.stringify(id)}`,
+    );
   }
   if (!stat.isFile()) {
-    throw new Error(`resolveMediaBufferPath: media ID does not resolve to a file: ${id}`);
+    throw new Error(
+      `resolveMediaBufferPath: media ID does not resolve to a file: ${JSON.stringify(id)}`,
+    );
   }
 
   return resolved;

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -407,3 +407,58 @@ export async function saveMediaBuffer(
   await writeSavedMediaBuffer({ dir, id, buffer });
   return buildSavedMediaResult({ dir, id, size: buffer.byteLength, contentType: mime });
 }
+
+/**
+ * Resolves a media ID saved by saveMediaBuffer to its absolute physical path.
+ *
+ * This is the read-side counterpart to saveMediaBuffer and is used by the
+ * agent runner to hydrate opaque `media://inbound/<id>` URIs written by the
+ * Gateway's claim-check offload path.
+ *
+ * Security:
+ * - Rejects IDs containing path separators or ".." to prevent directory
+ *   traversal outside the resolved subdir.
+ * - Verifies the resolved path is a regular file (not a symlink or directory)
+ *   before returning it, matching the write-side MEDIA_FILE_MODE policy.
+ *
+ * @param id      The media ID as returned by SavedMedia.id (may include
+ *                extension and original-filename prefix,
+ *                e.g. "photo---<uuid>.png").
+ * @param subdir  The subdirectory the file was saved into (default "inbound").
+ * @returns       Absolute path to the file on disk.
+ * @throws        If the ID is unsafe, the file does not exist, or is not a
+ *                regular file.
+ */
+export async function resolveMediaBufferPath(
+  id: string,
+  subdir: "inbound" = "inbound",
+): Promise<string> {
+  // Guard against path traversal: reject any ID containing a separator or
+  // "..". IDs produced by buildSavedMediaId only contain alphanumerics,
+  // dots, hyphens, and underscores — no slashes are ever emitted.
+  if (!id || id.includes("/") || id.includes("\\") || id.includes("..")) {
+    throw new Error(`resolveMediaBufferPath: unsafe media ID: ${id}`);
+  }
+
+  const dir = path.join(resolveMediaDir(), subdir);
+  const resolved = path.join(dir, id);
+
+  // Double-check that path.join didn't escape the intended directory.
+  // This should be unreachable after the separator check above, but be
+  // explicit about the invariant.
+  if (!resolved.startsWith(dir + path.sep) && resolved !== dir) {
+    throw new Error(`resolveMediaBufferPath: path escapes media directory: ${id}`);
+  }
+
+  // lstat (not stat) so we see symlinks rather than following them.
+  const stat = await fs.lstat(resolved);
+
+  if (stat.isSymbolicLink()) {
+    throw new Error(`resolveMediaBufferPath: refusing to follow symlink for media ID: ${id}`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`resolveMediaBufferPath: media ID does not resolve to a file: ${id}`);
+  }
+
+  return resolved;
+}

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -233,13 +233,16 @@ function sanitizeLiveConfig(raw: string): string {
         list?: Array<Record<string, unknown>>;
       };
     } = JSON5.parse(raw);
+
     if (!parsed || typeof parsed !== "object") {
       return raw;
     }
+
     if (parsed.agents?.defaults && typeof parsed.agents.defaults === "object") {
       delete parsed.agents.defaults.workspace;
       delete parsed.agents.defaults.agentDir;
     }
+
     if (Array.isArray(parsed.agents?.list)) {
       parsed.agents.list = parsed.agents.list.map((entry) => {
         if (!entry || typeof entry !== "object") {
@@ -251,6 +254,7 @@ function sanitizeLiveConfig(raw: string): string {
         return nextEntry;
       });
     }
+
     return `${JSON.stringify(parsed, null, 2)}\n`;
   } catch {
     return raw;


### PR DESCRIPTION

## ✅ Architecture Decision: `media://inbound/<id>` Opaque URI — Implemented

After reviewing the distributed-deployment constraint and the `workspaceOnly`
sandbox boundary issue raised in reviews, I have chosen and fully implemented
the following contract:

| Attachment Size | Handling |
|---|---|
| < 2 MB | Pass inline as base64 (unchanged) |
| 2–5 MB | Offload to disk → pass `media://inbound/<id>` URI to Agent |
| > 5 MB | Reject with controlled error (unchanged) |
| 2–5 MB, unsupported MIME | Reject with user-friendly error (convert to JPEG/PNG/WEBP/GIF) |

**Rationale for `media://inbound/<id>`:**
- Decouples storage layout from the Agent contract — no filesystem path leaks
- Compatible with `tools.fs.workspaceOnly` sandbox boundaries (media-uri refs
  are intentionally exempt from workspace checks; they live in the Gateway-managed
  media store, not the agent workspace)
- Single resolver on the Agent side (`resolveMediaBufferPath`) to hydrate the
  reference when needed
- Future-proof: switching to S3 or DB only requires changing the resolver, not
  the contract
- HTTP URL was rejected: requires new Gateway routing + auth surface, breaks in
  isolated Docker deployments where the Agent cannot reach the Gateway's HTTP port

**Known limitation (documented in code):**
When a mix of large (offloaded) and small (inline) images is present, offloaded
images appear as text markers appended to the message while inline images are in
the `images` array. This may cause ordering differences vs. the original
attachment list when downstream image detection re-assembles them. A future
refactor should unify all references into a single ordered list.

---

## Summary

**Problem:** Sending large, high-resolution images via the WebUI passes massive
base64 payloads through the WebSocket connection, causing severe memory spikes on
the Gateway, leading to OOM crashes and `socket hang up` errors.

**Why it matters:** It completely breaks the connection for the user and crashes
the core orchestration layer when handling standard modern media files.

**What changed:** Key files touched:

- **`src/gateway/chat-attachments.ts`** — Claim Check pattern implementation.
  The Gateway intercepts large base64 payloads, persists them via `saveMediaBuffer`,
  and emits an opaque `media://inbound/<id>` URI into the message instead of raw
  image data. Includes: size-gated offload with MIME whitelist, `assertSavedMedia`
  type guard (replaces fragile `as SavedMedia` cast), optimized `isValidBase64`
  with sampled spot-check for large payloads, and a hard re-throw on offload
  failure (no silent fallback to inline base64).

- **`src/gateway/server-node-events.ts` & `agent.ts`** — Request validation and IO protection.
  Re-ordered the validation gates to ensure lightweight checks (e.g., `!message` or `message.length > 20_000`) run *before* `parseMessageWithAttachments` is called. This prevents malicious or oversized requests from causing avoidable disk I/O churn. Added a secondary length guard *after* parsing to ensure that the injected `[media attached: ...]` markers do not push the final prompt over the 20,000-character limit.

- **`src/agents/pi-embedded-runner/run/images.ts`** — Agent-side resolver.
  `detectImageReferences` now recognises `media://inbound/<id>` URIs via
  `MEDIA_URI_REGEX`. `loadImageFromRef` handles the new `"media-uri"` ref type by
  calling `resolveMediaBufferPath` to obtain the physical path, then loading via
  the existing `loadWebMedia` pipeline. Media-URI refs are intentionally exempt
  from `workspaceOnly` path checks.

- **`src/media/store.ts`** — Read-side counterpart.
  `resolveMediaBufferPath` maps a media ID to its absolute physical path. Applies
  its own guards against path traversal (`/`, `\`, `..`), null-byte injection, and
  symlinks before returning the path.

**What did NOT change (scope boundary):**
WebUI frontend logic and the downstream Agent's core execution loop.

---

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

---

## Root Cause / Regression History

- **Root cause:** The Gateway holds the entire uncompressed base64 string in
  Node.js memory while routing the message through the WebSocket stream.
- **Missing guardrail:** No payload size limits or streaming/chunking mechanisms
  for media attachments at the Gateway entry point.
- **Prior context:** N/A
- **Why this regressed now:** N/A

---

## Regression Test Plan

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test:** Gateway message routing test.
- **Scenario to lock in:** Sending a >2 MB image via WebSocket should save to
  disk, return a `media://inbound/<id>` reference, and allow the Agent to load
  the image correctly — without the Gateway exceeding a memory threshold.
- **Why E2E is the smallest reliable guardrail:** The issue spans the network
  boundary, WS memory allocation, disk I/O, and the Agent's image resolution
  pipeline.
- **Existing test coverage:** None.
- **Why no new test in this PR:** The E2E harness for Gateway ↔ Agent media flow
  does not yet exist; adding it is a follow-up. Unit tests for
  `parseMessageWithAttachments` and `resolveMediaBufferPath` are a near-term
  priority.

---

## Diagram

```text
Before:
[User sends 5 MB image]
  → [Gateway holds 7 MB Base64 in RAM]
  → [Gateway OOM / Socket Hang Up]

After:
[User sends 5 MB image]
  → [Gateway: sizeBytes > OFFLOAD_THRESHOLD (2 MB)?]
      YES → [saveMediaBuffer → disk: ~/.openclaw/media/inbound/<id>.png]
          → [message += "\n[media attached: media://inbound/<id>]"]
          → [Agent receives message + images=[]]
          → [detectImageReferences finds media://inbound/<id>]
          → [resolveMediaBufferPath(<id>) → physical path]
          → [loadWebMedia(physicalPath) → ImageContent]
          → [Model receives image inline]
      NO  → [images.push(b64 inline)] → [unchanged path]
```

---

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`

**Risk + mitigation for data access change:**

The Gateway now writes user attachments to `~/.openclaw/media/inbound/` on disk.
Mitigations applied at multiple layers:

| Layer | Control |
|---|---|
| Write path | `saveMediaBuffer` enforces size limit, sanitizes filename, writes at `0o644` with parent dirs at `0o700` |
| Media ID | `assertSavedMedia` validates ID is non-empty and contains no path separators or null bytes before embedding in the URI |
| URI parsing | `MEDIA_URI_REGEX` uses an exclusion character class that rejects `]`, whitespace, `/`, `\`, and `\x00` at the parsing layer |
| Read path | `resolveMediaBufferPath` re-checks for path traversal, `..`, null bytes, and symlinks before returning the physical path |
| Sandbox | Media-URI refs bypass `workspaceOnly` only because the files are written by the trusted Gateway process, not user-supplied paths |
| TTL | `cleanOldMedia` expires inbound files after 2 minutes (unchanged) |
| **Resource Exhaustion** | **Pre-validation length guards ensure disk I/O (`saveMediaBuffer`) is strictly bypassed for empty or oversized invalid requests, preventing Disk Churn attacks.** |

---

## Repro + Verification

### Environment

- OS: Windows (WSL2) / Docker Desktop
- Runtime/container: Docker `openclaw:local` (Node 24 bookworm)
- Model/provider: SiliconFlow / router
- Integration/channel: WebUI
- Relevant config (redacted): Standard local `docker-compose` setup

### Steps

1. Start the OpenClaw stack via `docker-compose up -d`.
2. Open the WebUI and drag-and-drop a large image (> 2 MB, < 5 MB).
3. Monitor Gateway logs for `[Gateway] Intercepted large image payload`.
4. Confirm the Agent successfully loads and describes the image.

### Expected

Gateway intercepts the payload, saves it to disk, passes `media://inbound/<id>`
to the Agent. Agent resolves the URI, loads the image, and the model receives it
correctly.

### Actual (with this PR)

File is saved, memory remains stable, Agent resolves the URI via
`resolveMediaBufferPath`, and the model receives the image.

### Evidence
```
[gateway] Intercepted large image payload. Saved: media://inbound/photo---1c77ce17-20b9-4546-be64-6e36a9adcb2c.png
```

---

## Human Verification (required)

- **Verified:** Local Docker deployment sending large images (2–5 MB). Gateway
  survival confirmed. Agent correctly resolves `media://inbound/<id>` and the
  model describes image content.
- **Edge cases checked:** Empty image arrays; images below the 2 MB threshold
  (pass inline unchanged); images above 5 MB (rejected with error); unsupported
  MIME types above threshold (rejected with user-friendly error).
- **Not verified:** Distributed deployments where Gateway and Agent run on
  separate nodes without shared volumes. The `media://` URI contract is designed
  to be storage-backend-agnostic, but the resolver currently reads from the local
  filesystem. A shared storage layer (e.g. S3) would only require changing
  `resolveMediaBufferPath` without altering the URI contract.

---

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] **All Codex bot suggestions have been fully implemented**, including moving disk offload logic behind authentication/validation gates and adding secondary length guards for injected media markers.
- [x] **Merge conflicts with the latest `main` branch** (specifically regarding the new `resolveSkillSource` utility and test environment syntax) have been resolved.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

---

## Compatibility / Migration

- Backward compatible? `Yes` — attachments below 2 MB are unchanged. The new
  `media://inbound/<id>` marker only appears when offloading is triggered.
- Config/env changes? `No`
- Migration needed? `No`

---

## Risks and Mitigations

**Risk 1 — Mixed-batch attachment ordering**

When large and small images are sent together, large images become text markers
appended to the message while small images remain in the `images` array. The
Agent's `detectAndLoadPromptImages` processes `existingImages` first, then
appends URI-detected refs, which may differ from the original attachment order.
This is documented in a JSDoc comment on `parseMessageWithAttachments`.

Mitigation: Prompts that rely on attachment order (e.g. "compare first and second
image") should be retested. A future refactor should unify all references into a
single ordered list before forwarding to the model.

**Risk 2 — Distributed deployments**

The `resolveMediaBufferPath` resolver reads from the local filesystem. If Gateway
and Agent run on separate nodes without a shared volume, the URI cannot be
resolved.

Mitigation: The `media://` contract is intentionally decoupled from the storage
backend. Switching to shared storage (e.g. S3, NFS) only requires updating the
resolver — no changes to the Gateway or the URI format.