### PR TITLE
Fix Feishu group session orchestration fallbacks

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -323,6 +323,32 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain('Use `runtime: "subagent"` instead.');
   });
 
+  it("guides Feishu group sessions toward subagent run mode and agentId sends", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["sessions_list", "sessions_send", "sessions_spawn"],
+      runtimeInfo: {
+        channel: "feishu",
+      },
+    });
+
+    expect(prompt).toContain(
+      "Use it when you know the target sessionKey/label, or when you want the most recent visible session for a specific `agentId`.",
+    );
+    expect(prompt).toContain(
+      "omit `activeMinutes` unless you explicitly want only very recent sessions",
+    );
+    expect(prompt).toContain(
+      "Only call `sessions_yield` after at least one delegated/background task was accepted.",
+    );
+    expect(prompt).toContain(
+      "In ordinary Feishu group chats, do not rely on thread-bound current-conversation child sessions.",
+    );
+    expect(prompt).toContain(
+      'prefer `sessions_spawn({ runtime: "subagent", mode: "run", agentId: ... })`',
+    );
+  });
+
   it("preserves tool casing in the prompt", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -245,12 +245,14 @@ export function buildAgentSystemPrompt(params: {
     agents_list: acpSpawnRuntimeEnabled
       ? 'List OpenClaw agent ids allowed for sessions_spawn when runtime="subagent" (not ACP harness ids)'
       : "List OpenClaw agent ids allowed for sessions_spawn",
-    sessions_list: "List other sessions (incl. sub-agents) with filters/last",
+    sessions_list:
+      "List other sessions (incl. sub-agents) with filters/last; omit activeMinutes unless you truly need recent-only results",
     sessions_history: "Fetch history for another session/sub-agent",
-    sessions_send: "Send a message to another session/sub-agent",
+    sessions_send:
+      "Send a message to another session/sub-agent (target by sessionKey, label, or agentId)",
     sessions_spawn: acpSpawnRuntimeEnabled
       ? 'Spawn an isolated sub-agent or ACP coding session (runtime="acp" requires `agentId` unless `acp.defaultAgent` is configured; ACP harness ids follow acp.allowedAgents, not agents_list)'
-      : "Spawn an isolated sub-agent session",
+      : 'Spawn an isolated sub-agent session; in ordinary Feishu groups prefer runtime="subagent" + mode="run" for delegated work',
     subagents: "List, steer, or kill sub-agent runs for this requester session",
     session_status:
       "Show a /status-equivalent status card (usage + time + Reasoning/Verbose/Elevated); use for model-use questions (📊 session_status); optional per-session model override",
@@ -433,12 +435,21 @@ export function buildAgentSystemPrompt(params: {
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
     "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
+    "`sessions_send` is for contacting an already-existing session. Use it when you know the target sessionKey/label, or when you want the most recent visible session for a specific `agentId`.",
+    "When using `sessions_list` to discover sessions, omit `activeMinutes` unless you explicitly want only very recent sessions; narrow filters can hide valid targets.",
+    "Only call `sessions_yield` after at least one delegated/background task was accepted. If every `sessions_send` / `sessions_spawn` call failed synchronously, stay in the current turn and report the failure.",
     ...(acpHarnessSpawnAllowed
       ? [
           'For requests like "do this in codex/claude code/gemini", treat it as ACP harness intent and call `sessions_spawn` with `runtime: "acp"`.',
           'On Discord, default ACP harness requests to thread-bound persistent sessions (`thread: true`, `mode: "session"`) unless the user asks otherwise.',
           "Set `agentId` explicitly unless `acp.defaultAgent` is configured, and do not route ACP harness requests through `subagents`/`agents_list` or local PTY exec flows.",
           'For ACP harness thread spawns, do not call `message` with `action=thread-create`; use `sessions_spawn` (`runtime: "acp"`, `thread: true`) as the single thread creation path.',
+          'Do not mix ACP-only params like `streamTo` or `resumeSessionId` with `runtime: "subagent"`.',
+        ]
+      : []),
+    ...(runtimeChannel === "feishu"
+      ? [
+          'In ordinary Feishu group chats, do not rely on thread-bound current-conversation child sessions. Keep the parent session in the group, and for long-running delegated work prefer `sessions_spawn({ runtime: "subagent", mode: "run", agentId: ... })` so child results auto-announce back to you before you reply to the group.',
         ]
       : []),
     "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -2,7 +2,11 @@ import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
-import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  isValidAgentId,
+  normalizeAgentId,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import {
   type GatewayMessageChannel,
@@ -27,7 +31,14 @@ import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
-  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  agentId: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 64,
+      description:
+        "Agent id to target. When used without sessionKey/label, OpenClaw sends to the most recent visible session for that agent.",
+    }),
+  ),
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
 });
@@ -76,7 +87,7 @@ export function createSessionsSendTool(opts?: {
     label: "Session Send",
     name: "sessions_send",
     description:
-      "Send a message into another session. Use sessionKey or label to identify the target.",
+      "Send a message into another session. Use sessionKey, label, or agentId to identify the target.",
     parameters: SessionsSendToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -94,30 +105,23 @@ export function createSessionsSendTool(opts?: {
       const sessionKeyParam = readStringParam(params, "sessionKey");
       const labelParam = readStringParam(params, "label")?.trim() || undefined;
       const labelAgentIdParam = readStringParam(params, "agentId")?.trim() || undefined;
-      if (sessionKeyParam && labelParam) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error: "Provide either sessionKey or label (not both).",
-        });
-      }
+      const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+      const requestedAgentIdFromParam = labelAgentIdParam
+        ? normalizeAgentId(labelAgentIdParam)
+        : undefined;
 
-      let sessionKey = sessionKeyParam;
-      if (!sessionKey && labelParam) {
-        const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
-        const requestedAgentId = labelAgentIdParam
-          ? normalizeAgentId(labelAgentIdParam)
-          : undefined;
-
-        if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
+      const buildRequestedAgentDeniedResult = (requestedAgentId?: string) => {
+        if (!requestedAgentId) {
+          return null;
+        }
+        if (restrictToSpawned && requestedAgentId !== requesterAgentId) {
           return jsonResult({
             runId: crypto.randomUUID(),
             status: "forbidden",
-            error: "Sandboxed sessions_send label lookup is limited to this agent",
+            error: "Sandboxed sessions_send agent lookup is limited to this agent",
           });
         }
-
-        if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
+        if (requestedAgentId !== requesterAgentId) {
           if (!a2aPolicy.enabled) {
             return jsonResult({
               runId: crypto.randomUUID(),
@@ -134,6 +138,88 @@ export function createSessionsSendTool(opts?: {
             });
           }
         }
+        return null;
+      };
+
+      const resolveLatestSessionKeyForAgent = async (
+        requestedAgentId: string | undefined,
+        missingError: string,
+      ): Promise<{ key: string } | { result: ReturnType<typeof jsonResult> }> => {
+        if (!requestedAgentId) {
+          return { key: "" };
+        }
+        const deniedResult = buildRequestedAgentDeniedResult(requestedAgentId);
+        if (deniedResult) {
+          return { result: deniedResult };
+        }
+        try {
+          const listed = await gatewayCall<{
+            sessions?: Array<{
+              key?: string;
+            }>;
+          }>({
+            method: "sessions.list",
+            params: {
+              limit: 50,
+              includeGlobal: false,
+              includeUnknown: false,
+              agentId: requestedAgentId,
+              ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
+            },
+            timeoutMs: 10_000,
+          });
+          const sessions = Array.isArray(listed?.sessions) ? listed.sessions : [];
+          for (const entry of sessions) {
+            const key = typeof entry?.key === "string" ? entry.key.trim() : "";
+            if (key) {
+              return { key };
+            }
+          }
+        } catch (err) {
+          const messageText = err instanceof Error ? err.message : String(err);
+          if (restrictToSpawned) {
+            return {
+              result: jsonResult({
+                runId: crypto.randomUUID(),
+                status: "forbidden",
+                error: "Session not visible from this sandboxed agent session.",
+              }),
+            };
+          }
+          return {
+            result: jsonResult({
+              runId: crypto.randomUUID(),
+              status: "error",
+              error: messageText || missingError,
+            }),
+          };
+        }
+        return {
+          result: jsonResult({
+            runId: crypto.randomUUID(),
+            status: restrictToSpawned ? "forbidden" : "error",
+            error: restrictToSpawned
+              ? "Session not visible from this sandboxed agent session."
+              : missingError,
+          }),
+        };
+      };
+
+      if (sessionKeyParam && labelParam) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "Provide either sessionKey or label (not both).",
+        });
+      }
+
+      let sessionKey = sessionKeyParam;
+      if (!sessionKey && labelParam) {
+        const requestedAgentId = requestedAgentIdFromParam;
+        const deniedResult = buildRequestedAgentDeniedResult(requestedAgentId);
+        if (deniedResult) {
+          return deniedResult;
+        }
 
         const resolveParams: Record<string, unknown> = {
           label: labelParam,
@@ -141,6 +227,7 @@ export function createSessionsSendTool(opts?: {
           ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
         };
         let resolvedKey = "";
+        let resolveErrorMessage = "";
         try {
           const resolved = await gatewayCall<{ key: string }>({
             method: "sessions.resolve",
@@ -149,19 +236,21 @@ export function createSessionsSendTool(opts?: {
           });
           resolvedKey = typeof resolved?.key === "string" ? resolved.key.trim() : "";
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          if (restrictToSpawned) {
-            return jsonResult({
-              runId: crypto.randomUUID(),
-              status: "forbidden",
-              error: "Session not visible from this sandboxed agent session.",
-            });
+          resolveErrorMessage = err instanceof Error ? err.message : String(err);
+        }
+
+        if (!resolvedKey) {
+          const fallbackAgentId =
+            requestedAgentId ??
+            (isValidAgentId(labelParam) ? normalizeAgentId(labelParam) : undefined);
+          const fallback = await resolveLatestSessionKeyForAgent(
+            fallbackAgentId,
+            `No session found with label: ${labelParam}`,
+          );
+          if ("result" in fallback) {
+            return fallback.result;
           }
-          return jsonResult({
-            runId: crypto.randomUUID(),
-            status: "error",
-            error: msg || `No session found with label: ${labelParam}`,
-          });
+          resolvedKey = fallback.key;
         }
 
         if (!resolvedKey) {
@@ -175,17 +264,28 @@ export function createSessionsSendTool(opts?: {
           return jsonResult({
             runId: crypto.randomUUID(),
             status: "error",
-            error: `No session found with label: ${labelParam}`,
+            error: resolveErrorMessage || `No session found with label: ${labelParam}`,
           });
         }
         sessionKey = resolvedKey;
+      }
+
+      if (!sessionKey && requestedAgentIdFromParam) {
+        const fallback = await resolveLatestSessionKeyForAgent(
+          requestedAgentIdFromParam,
+          `No session found for agentId: ${requestedAgentIdFromParam}`,
+        );
+        if ("result" in fallback) {
+          return fallback.result;
+        }
+        sessionKey = fallback.key;
       }
 
       if (!sessionKey) {
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "error",
-          error: "Either sessionKey or label is required",
+          error: "Either sessionKey, label, or agentId is required",
         });
       }
       const resolvedSession = await resolveSessionReference({

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -239,7 +239,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('ignores ACP-only streamTo when runtime is not "acp"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -251,12 +251,16 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(result.details).toMatchObject({
-      status: "error",
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
     });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        streamTo: "parent",
+      }),
+      expect.any(Object),
+    );
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -81,7 +81,7 @@ export function createSessionsSpawnTool(
     label: "Sessions",
     name: "sessions_spawn",
     description:
-      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically.',
+      'Spawn an isolated session (runtime="subagent" or runtime="acp"). mode="run" is one-shot and mode="session" is persistent/thread-bound. Subagents inherit the parent workspace directory automatically. In ordinary Feishu groups, prefer runtime="subagent" with mode="run" for delegated work.',
     parameters: SessionsSpawnToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -105,7 +105,8 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const requestedStreamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo = runtime === "acp" ? requestedStreamTo : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"
@@ -126,13 +127,6 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
 
       if (resumeSessionId && runtime !== "acp") {
         return jsonResult({

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -434,7 +434,7 @@ describe("sessions_send gating", () => {
     callGatewayMock.mockClear();
   });
 
-  it("returns an error when neither sessionKey nor label is provided", async () => {
+  it("returns an error when neither sessionKey, label, nor agentId is provided", async () => {
     const tool = createMainSessionsSendTool();
 
     const result = await tool.execute("call-missing-target", {
@@ -444,17 +444,74 @@ describe("sessions_send gating", () => {
 
     expect(result.details).toMatchObject({
       status: "error",
-      error: "Either sessionKey or label is required",
+      error: "Either sessionKey, label, or agentId is required",
     });
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("resolves bare agentId to the most recent visible session", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: true },
+        sessions: { visibility: "all" },
+      },
+    });
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [{ key: "agent:worker:discord:group:dev" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-agentid", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "run-agentid", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return {
+          messages: [{ role: "assistant", content: [{ type: "text", text: "done" }] }],
+        };
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    const result = await tool.execute("call-agent-id", {
+      agentId: "worker",
+      message: "hello",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      reply: "done",
+      sessionKey: "agent:worker:discord:group:dev",
+    });
+    expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({
+      method: "sessions.list",
+      params: expect.objectContaining({ agentId: "worker" }),
+    });
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) =>
+          (call[0] as { method?: string; params?: Record<string, unknown> }).method === "agent" &&
+          (call[0] as { params?: Record<string, unknown> }).params?.sessionKey ===
+            "agent:worker:discord:group:dev",
+      ),
+    ).toBe(true);
+  });
+
   it("returns an error when label resolution fails", async () => {
-    callGatewayMock.mockRejectedValueOnce(new Error("No session found with label: nope"));
+    callGatewayMock.mockRejectedValueOnce(
+      new Error("No session found with label: Agent not found: nope"),
+    );
     const tool = createMainSessionsSendTool();
 
     const result = await tool.execute("call-missing-label", {
-      label: "nope",
+      label: "Agent not found: nope",
       message: "hello",
       timeoutSeconds: 5,
     });


### PR DESCRIPTION
## Summary
- allow `sessions_send` to target an `agentId` by resolving the most recent visible session
- ignore ACP-only `streamTo` when `sessions_spawn` is running with `runtime: "subagent"`
- tighten the agent system prompt guidance for long-running work in ordinary Feishu groups

## Testing
- corepack pnpm exec vitest run src/agents/tools/sessions.test.ts
- corepack pnpm exec vitest run src/agents/tools/sessions-spawn-tool.test.ts
- corepack pnpm exec vitest run src/agents/system-prompt.test.ts
- PATH="/tmp/codex-bin:$PATH" pnpm check