### PR TITLE
feat(feishu): add immediate Typing reaction on message receipt

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -324,6 +324,17 @@ export async function handleFeishuMessage(params: {
     `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${ctx.chatId} (${ctx.chatType})`,
   );
 
+  // Immediately acknowledge receipt by adding a Typing reaction to the user's message
+  try {
+    await createFeishuClient(account).im.messageReaction.create({
+      path: { message_id: messageId },
+      data: { reaction_type: { emoji_type: "Typing" } },
+    });
+    log(`feishu[${account.accountId}]: ack reaction (Typing) added to ${messageId}`);
+  } catch (ackErr) {
+    log(`feishu[${account.accountId}]: ack reaction failed: ${String(ackErr)}`);
+  }
+
   // Log mention targets if detected
   if (ctx.mentionTargets && ctx.mentionTargets.length > 0) {
     const names = ctx.mentionTargets.map((t) => t.name).join(", ");


### PR DESCRIPTION
## Summary

- When a message is received from Feishu, immediately adds a **Typing** emoji reaction to the user's message before any processing begins.
- This provides instant visual feedback that the bot has seen and is processing the message, addressing the gap where users had no way to know if the bot received their message.

## Motivation

Feishu bot API does not support marking messages as read. The existing typing indicator only fires during reply delivery (on the reply target message), which can be too late or invisible for quick responses. This change adds acknowledgment at the earliest possible point in the message handling pipeline.

## Changes

- **extensions/feishu/src/bot.ts**: Added `createFeishuClient().im.messageReaction.create()` call with `Typing` emoji right after the 'received message' log in `handleFeishuMessage()`, before any routing or mention checks.