### PR TITLE
test: fix Codex contract refresh fallback

### DIFF
--- a/src/plugins/contracts/runtime.contract.test.ts
+++ b/src/plugins/contracts/runtime.contract.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildOpenAICodexProviderPlugin } from "../../../extensions/openai/openai-codex-provider.js";
 import { createProviderUsageFetch, makeResponse } from "../../test-utils/provider-usage-fetch.js";
 import type { ProviderPlugin, ProviderRuntimeModel } from "../types.js";
 import { requireProviderContractProvider as requireBundledProviderContractProvider } from "./registry.js";
@@ -28,7 +29,7 @@ vi.mock("@mariozechner/pi-ai/oauth", async () => {
   };
 });
 
-vi.mock("../../../extensions/openai/src/openai-codex-provider.runtime.js", () => ({
+vi.mock("../../../extensions/openai/openai-codex-provider.runtime.js", () => ({
   getOAuthApiKey: getOAuthApiKeyMock,
 }));
 
@@ -520,7 +521,11 @@ describe("provider runtime contract", () => {
 
   describe("openai-codex", () => {
     it("owns refresh fallback for accountId extraction failures", async () => {
-      const provider = requireProviderContractProvider("openai-codex");
+      // The bundled plugin contract loader uses Jiti, which bypasses this file's
+      // Vitest mock for the runtime wrapper module. Exercise the provider module
+      // directly here so the fallback behavior stays covered without hitting the
+      // real OAuth refresh path.
+      const provider = buildOpenAICodexProviderPlugin();
       const credential = {
         type: "oauth" as const,
         provider: "openai-codex",


### PR DESCRIPTION
## What
Fixes the OpenAI Codex provider runtime contract so the refresh-fallback assertion uses the current runtime mock path and avoids the bundled loader's Jiti mock bypass for that one case.

## Why
This is a Forge follow-up for an unrelated test failure discovered while preparing PR #54392.

## Changes
- Update the stale Codex runtime mock path
- Instantiate Codex provider directly for fallback contract

## Testing
- `pnpm test -- src/plugins/contracts/runtime.contract.test.ts -t "owns refresh fallback for accountId extraction failures"`
- `pnpm test -- src/plugins/contracts/registry.contract.test.ts`