### PR TITLE
fix: format Ollama HTTP errors for failover classification (#55178)

### DIFF
--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -679,6 +679,8 @@ export function createOllamaStreamFn(
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => "unknown error");
+          // Format: "<status> <body>" so extractLeadingHttpStatus can parse
+          // the code and the failover classification system detects retriable errors.
           throw new Error(`${response.status} ${errorText}`);
         }
         if (!response.body) {

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { extractLeadingHttpStatus } from "../shared/assistant-error-format.js";
 import {
   createConfiguredOllamaStreamFn,
   createOllamaStreamFn,
@@ -633,5 +634,70 @@ describe("createConfiguredOllamaStreamFn", () => {
         });
       },
     );
+  });
+});
+
+// Helper: mock fetch to return a non-2xx response with given status/body.
+async function withMockErrorFetch(
+  status: number,
+  body: string,
+  run: () => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = vi.fn(async () => {
+    return new Response(body, { status, statusText: "Error" });
+  }) as unknown as typeof fetch;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+describe("createOllamaStreamFn HTTP error handling", () => {
+  it("formats non-2xx errors with leading status code for failover classification", async () => {
+    await withMockErrorFetch(503, "Service Unavailable", async () => {
+      const stream = await createOllamaTestStream({ baseUrl: "http://localhost:11434" });
+      const events = await collectStreamEvents(stream);
+
+      const errorEvent = events.find((e) => (e as { type: string }).type === "error") as
+        | { type: "error"; error: { errorMessage?: string } }
+        | undefined;
+      expect(errorEvent).toBeDefined();
+
+      const parsed = extractLeadingHttpStatus(errorEvent!.error.errorMessage ?? "");
+      expect(parsed).not.toBeNull();
+      expect(parsed!.code).toBe(503);
+    });
+  });
+
+  it("includes response body in the error message", async () => {
+    await withMockErrorFetch(500, "internal server error", async () => {
+      const stream = await createOllamaTestStream({ baseUrl: "http://localhost:11434" });
+      const events = await collectStreamEvents(stream);
+
+      const errorEvent = events.find((e) => (e as { type: string }).type === "error") as
+        | { type: "error"; error: { errorMessage?: string } }
+        | undefined;
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent!.error.errorMessage).toContain("internal server error");
+      expect(errorEvent!.error.errorMessage).toMatch(/^500\s/);
+    });
+  });
+
+  it("handles 429 rate limit errors with parseable status", async () => {
+    await withMockErrorFetch(429, "Too Many Requests", async () => {
+      const stream = await createOllamaTestStream({ baseUrl: "http://localhost:11434" });
+      const events = await collectStreamEvents(stream);
+
+      const errorEvent = events.find((e) => (e as { type: string }).type === "error") as
+        | { type: "error"; error: { errorMessage?: string } }
+        | undefined;
+      expect(errorEvent).toBeDefined();
+
+      const parsed = extractLeadingHttpStatus(errorEvent!.error.errorMessage ?? "");
+      expect(parsed).not.toBeNull();
+      expect(parsed!.code).toBe(429);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #55178
- Ollama HTTP error messages used the format `"Ollama API error 503: ..."` which `extractLeadingHttpStatus` couldn't parse (expects status code at start)
- Changed to `"503 ..."` format so the failover classification system detects retriable errors
- Added test coverage for non-2xx HTTP error handling

## Test plan
- Configure Ollama with fallback models
- When primary returns 503, verify fallback triggers instead of error propagating