### PR TITLE
fix: keep openai-codex on HTTP responses transport

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.websocket.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.websocket.test.ts
@@ -11,15 +11,6 @@ describe("openai websocket transport selection", () => {
     ).toBe(true);
   });
 
-  it("accepts the Codex responses transport pair", () => {
-    expect(
-      shouldUseOpenAIWebSocketTransport({
-        provider: "openai-codex",
-        modelApi: "openai-codex-responses",
-      }),
-    ).toBe(true);
-  });
-
   it("rejects mismatched OpenAI websocket transport pairs", () => {
     expect(
       shouldUseOpenAIWebSocketTransport({
@@ -31,6 +22,12 @@ describe("openai websocket transport selection", () => {
       shouldUseOpenAIWebSocketTransport({
         provider: "openai-codex",
         modelApi: "openai-responses",
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseOpenAIWebSocketTransport({
+        provider: "openai-codex",
+        modelApi: "openai-codex-responses",
       }),
     ).toBe(false);
     expect(

--- a/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.thread-helpers.ts
@@ -35,10 +35,10 @@ export function shouldUseOpenAIWebSocketTransport(params: {
   provider: string;
   modelApi?: string | null;
 }): boolean {
-  return (
-    (params.modelApi === "openai-responses" && params.provider === "openai") ||
-    (params.modelApi === "openai-codex-responses" && params.provider === "openai-codex")
-  );
+  // openai-codex normalizes to the ChatGPT backend HTTP path, not the public
+  // OpenAI Responses websocket endpoint. Keep it on HTTP until a provider-
+  // specific websocket target exists and is verified end-to-end.
+  return params.modelApi === "openai-responses" && params.provider === "openai";
 }
 
 export function shouldAppendAttemptCacheTtl(params: {


### PR DESCRIPTION
## Summary

- keep `openai-codex` on its existing HTTP responses path instead of routing it into the generic OpenAI websocket transport selector
- update the websocket transport selector test to explicitly reject the `openai-codex` / `openai-codex-responses` pair

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [ ] Test-only

## Scope

This PR is intentionally narrow.

It only changes websocket transport eligibility for `openai-codex` on the embedded runner path.

It does not change:
- the `openai-codex` provider normalization logic
- HTTP request payload behavior for Codex
- any image/media-understanding routing
- any memory provider routing

## Linked Issue/PR

- Related #55523
- Related #56826
- Related #56881
- Follow-up to merged PR #53702
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

`openai-codex` models normalize to the ChatGPT backend HTTP path (`https://chatgpt.com/backend-api`) and use `openai-codex-responses`.

After #53702, the embedded runner's websocket eligibility selector also treated the `openai-codex` / `openai-codex-responses` pair as websocket-eligible. However, the websocket connection manager still targets the generic OpenAI Responses websocket endpoint rather than a Codex-specific transport target.

In isolated upstream-main smoke testing, that caused `openai-codex` requests to attempt websocket first, fail with HTTP 500, and then fall back to HTTP.

This patch keeps `openai-codex` on the existing HTTP path until there is a verified provider-specific websocket target and end-to-end support for it.

## Behavior Changes

Before:
- `openai-codex` / `openai-codex-responses` entered the generic OpenAI websocket selector
- websocket could fail and fall back to HTTP in isolated smoke tests

After:
- only native `openai` / `openai-responses` is websocket-eligible
- `openai-codex` stays on HTTP responses transport

## Regression Test Plan

Updated:
- `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.websocket.test.ts`

Coverage:
- accepts the native `openai` / `openai-responses` websocket pair
- rejects `openai-codex` / `openai-codex-responses`
- rejects mismatched provider/API websocket pairs

## Repro + Verification

Observed on merged `upstream/main` during isolated smoke validation of #53702:
- `openai-codex/gpt-5.4` requests succeeded, but only after websocket failed and the runner fell back to HTTP
- gateway log showed websocket connect failure with HTTP 500 before fallback

With this patch:
- the websocket selector no longer routes `openai-codex` into the generic OpenAI websocket path
- focused websocket selector test passes locally

## Tests

Passed locally:
- `corepack pnpm test -- src/agents/pi-embedded-runner/run/attempt.spawn-workspace.websocket.test.ts --reporter=verbose`
- pre-commit `pnpm check` passed during commit

## Risks and Mitigations

Risk:
- if `openai-codex` later gets a valid provider-specific websocket endpoint, this patch will keep it on HTTP until that support is added explicitly

Mitigation:
- this preserves the existing working HTTP transport and avoids the currently observed websocket->HTTP fallback path
- the selector remains a small, centralized surface to expand later once Codex websocket support is verified end-to-end

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and tested by me.
