### PR TITLE
fix: include message_id in Telegram callback_query data (#55462)

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1573,6 +1573,7 @@ export const registerTelegramHandlers = ({
       await processMessage(buildSyntheticContext(ctx, syntheticMessage), [], storeAllowFrom, {
         forceWasMentioned: true,
         messageIdOverride: callback.id,
+        callbackMessageId: callbackMessage.message_id,
       });
     } catch (err) {
       runtime.error?.(danger(`callback handler failed: ${String(err)}`));

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -208,6 +208,7 @@ export async function buildTelegramInboundContextPayload(params: {
     Surface: "telegram",
     BotUsername: primaryCtx.me?.username ?? undefined,
     MessageSid: options?.messageIdOverride ?? String(msg.message_id),
+    CallbackMessageId: options?.callbackMessageId,
     ReplyToId: replyTarget?.id,
     ReplyToBody: replyTarget?.body,
     ReplyToSender: replyTarget?.sender,

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -18,6 +18,8 @@ export type TelegramMediaRef = {
 export type TelegramMessageContextOptions = {
   forceWasMentioned?: boolean;
   messageIdOverride?: string;
+  /** message_id of the source message for callback_query (inline button click) */
+  callbackMessageId?: number;
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
 };

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -24,7 +24,12 @@ export function buildThreadingToolContext(params: {
   hasRepliedRef: { value: boolean } | undefined;
 }): ChannelThreadingToolContext {
   const { sessionCtx, config, hasRepliedRef } = params;
-  const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  // For callback queries (e.g. Telegram inline keyboard), prefer the source message id
+  // over the callback query id stored in MessageSid.
+  const currentMessageId =
+    sessionCtx.CallbackMessageId != null
+      ? String(sessionCtx.CallbackMessageId)
+      : (sessionCtx.MessageSidFull ?? sessionCtx.MessageSid);
   const originProvider = resolveOriginMessageProvider({
     originatingChannel: sessionCtx.OriginatingChannel,
     provider: sessionCtx.Provider,

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -92,6 +92,10 @@ export function buildInboundUserContextPrefix(
 
   const conversationInfo = {
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
+    callback_message_id:
+      shouldIncludeConversationInfo && ctx.CallbackMessageId != null
+        ? ctx.CallbackMessageId
+        : undefined,
     reply_to_id: shouldIncludeConversationInfo ? safeTrim(ctx.ReplyToId) : undefined,
     sender_id: shouldIncludeConversationInfo ? safeTrim(ctx.SenderId) : undefined,
     conversation_label: isDirect ? undefined : safeTrim(ctx.ConversationLabel),

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -81,6 +81,8 @@ export type MsgContext = {
   ForwardedFromChatType?: string;
   ForwardedFromMessageId?: number;
   ForwardedDate?: number;
+  /** Source message id for callback queries (e.g. Telegram inline keyboard callbacks). */
+  CallbackMessageId?: number;
   ThreadStarterBody?: string;
   /** Full thread history when starting a new thread session. */
   ThreadHistoryBody?: string;


### PR DESCRIPTION
## Summary
- Fixes #55462
- Telegram callback_query handler now includes `callback_message_id` from the source message
- Enables agents to use editMessage in response to inline button clicks

## Test plan
- Send a message with inline buttons via Telegram bot
- Click a button and verify the agent receives callback_message_id alongside callback_data