### PR TITLE
fix(discord): suppress expected reconnect-exhausted on stale-socket restart

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -813,7 +813,7 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("does not suppress reconnect-exhausted already queued before shutdown", async () => {
+  it("suppresses reconnect-exhausted already queued after intentional shutdown/restart", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const pendingGatewayEvents: DiscordGatewayEvent[] = [];
     const abortController = new AbortController();
@@ -836,8 +836,8 @@ describe("runDiscordGatewayLifecycle", () => {
 
     // Start lifecycle; it yields at execApprovalsHandler.start(). We then
     // queue a reconnect-exhausted event and abort. The lifecycle resumes and
-    // drains the queued fatal event before shutdown teardown flips
-    // lifecycleStopping, so the event still rejects the run.
+    // drains the queued event before final teardown, but the abort path has
+    // already forced maxAttempts=0 so this should be treated as expected.
     const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
 
     pendingGatewayEvents.push(
@@ -848,13 +848,13 @@ describe("runDiscordGatewayLifecycle", () => {
     );
     abortController.abort();
 
-    await expect(lifecyclePromise).rejects.toThrow(
-      "Max reconnect attempts (0) reached after code 1005",
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown/restart"),
     );
-    expect(runtimeLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
     );
-    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
   });
 
   it("does not push connected: true when abortSignal is already aborted", async () => {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -37,6 +37,8 @@ export async function runDiscordGatewayLifecycle(params: {
     runtime: params.runtime,
   });
   let lifecycleStopping = false;
+  const isExpectedReconnectExhausted = (event: DiscordGatewayEvent): boolean =>
+    event.type === "reconnect-exhausted" && gateway?.options.reconnect?.maxAttempts === 0;
 
   const pushStatus = (patch: Parameters<DiscordMonitorStatusSink>[0]) => {
     params.statusSink?.(patch);
@@ -67,9 +69,9 @@ export async function runDiscordGatewayLifecycle(params: {
     // When we deliberately set maxAttempts=0 and disconnected (health-monitor
     // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
     // is expected — log at info instead of error to avoid false alarms.
-    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+    if (isExpectedReconnectExhausted(event)) {
       params.runtime.log?.(
-        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+        `discord: ignoring expected reconnect-exhausted during shutdown/restart: ${event.message}`,
       );
       return "stop";
     }
@@ -85,10 +87,7 @@ export async function runDiscordGatewayLifecycle(params: {
       // Don't throw for expected shutdown events — intentional disconnect
       // (reconnect-exhausted with maxAttempts=0) and disallowed-intents are
       // both handled without crashing the provider.
-      if (
-        event.type === "disallowed-intents" ||
-        (lifecycleStopping && event.type === "reconnect-exhausted")
-      ) {
+      if (event.type === "disallowed-intents" || isExpectedReconnectExhausted(event)) {
         return "stop";
       }
       throw event.err;


### PR DESCRIPTION
## Summary
- treat reconnect-exhausted as expected whenever Discord gateway reconnect has already been forced into maxAttempts=0 intentional shutdown/restart mode
- keep the lifecycle from surfacing the expected code 1005 reconnect exhaustion as an uncaught fatal error during stale-socket restarts
- update the lifecycle regression test to cover the queued-event ordering that previously crashed the gateway

## Testing
- pnpm test -- extensions/discord/src/monitor/provider.lifecycle.test.ts *(fails in this environment because node_modules is missing)*
- pnpm install *(fails in this environment due npm DNS/network error: EAI_AGAIN to registry.npmjs.org)*

Closes #55554