### PR TITLE
Handle transient network uncaught exceptions

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -1,7 +1,6 @@
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { normalizeEnv } from "../infra/env.js";
-import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
@@ -133,16 +132,13 @@ export async function runCli(argv: string[] = process.argv) {
 
     const { buildProgram } = await import("./program.js");
     const program = buildProgram();
-    const { installUnhandledRejectionHandler } = await import("../infra/unhandled-rejections.js");
+    const { installUnhandledRejectionHandler, installUncaughtExceptionHandler } =
+      await import("../infra/unhandled-rejections.js");
 
     // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
     // These log the error and exit gracefully instead of crashing without trace.
     installUnhandledRejectionHandler();
-
-    process.on("uncaughtException", (error) => {
-      console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-      process.exit(1);
-    });
+    installUncaughtExceptionHandler();
 
     const parseArgv = rewriteUpdateFlagArgv(normalizedArgv);
     // Register the primary command (builtin or subcli) so help and command parsing

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { formatUncaughtError } from "./infra/errors.js";
 import { isMainModule } from "./infra/is-main.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
 
 type LegacyCliDeps = {
   installGaxiosFetchCompat: () => Promise<void>;
@@ -89,12 +88,10 @@ if (!isMain) {
 if (isMain) {
   // Global error handlers to prevent silent crashes from unhandled rejections/exceptions.
   // These log the error and exit gracefully instead of crashing without trace.
+  const { installUnhandledRejectionHandler, installUncaughtExceptionHandler } =
+    await import("./infra/unhandled-rejections.js");
   installUnhandledRejectionHandler();
-
-  process.on("uncaughtException", (error) => {
-    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
-    process.exit(1);
-  });
+  installUncaughtExceptionHandler();
 
   void runLegacyCliEntry(process.argv).catch((err) => {
     console.error("[openclaw] CLI failed:", formatUncaughtError(err));

--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -1,6 +1,9 @@
 import process from "node:process";
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
-import { installUnhandledRejectionHandler } from "./unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  installUncaughtExceptionHandler,
+} from "./unhandled-rejections.js";
 
 describe("installUnhandledRejectionHandler - fatal detection", () => {
   let exitCalls: Array<string | number | null> = [];
@@ -11,6 +14,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
   beforeAll(() => {
     originalExit = process.exit.bind(process);
     installUnhandledRejectionHandler();
+    installUncaughtExceptionHandler();
   });
 
   beforeEach(() => {
@@ -41,9 +45,19 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
     process.emit("unhandledRejection", reason, Promise.resolve());
   }
 
+  function emitUncaught(error: unknown): void {
+    process.emit("uncaughtException", error);
+  }
+
   function expectExitCodeFromUnhandled(reason: unknown, expected: number[]): void {
     exitCalls = [];
     emitUnhandled(reason);
+    expect(exitCalls).toEqual(expected);
+  }
+
+  function expectExitCodeFromUncaught(error: unknown, expected: number[]): void {
+    exitCalls = [];
+    emitUncaught(error);
     expect(exitCalls).toEqual(expected);
   }
 
@@ -118,10 +132,15 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
 
       for (const transientErr of transientCases) {
         expectExitCodeFromUnhandled(transientErr, []);
+        expectExitCodeFromUncaught(transientErr, []);
       }
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         "[openclaw] Non-fatal unhandled rejection (continuing):",
+        expect.stringContaining("fetch failed"),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Non-fatal uncaught exception (continuing):",
         expect.stringContaining("fetch failed"),
       );
     });
@@ -133,6 +152,16 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         "[openclaw] Unhandled promise rejection:",
         expect.stringContaining("Something went wrong"),
+      );
+    });
+
+    it("exits on generic uncaught exceptions", () => {
+      const genericErr = new Error("Boom");
+
+      expectExitCodeFromUncaught(genericErr, [1]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[openclaw] Uncaught exception:",
+        expect.stringContaining("Boom"),
       );
     });
 

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -255,3 +255,23 @@ export function installUnhandledRejectionHandler(): void {
     process.exit(1);
   });
 }
+
+export function installUncaughtExceptionHandler(): void {
+  process.on("uncaughtException", (error) => {
+    if (isAbortError(error)) {
+      console.warn("[openclaw] Suppressed AbortError:", formatUncaughtError(error));
+      return;
+    }
+
+    if (isTransientNetworkError(error)) {
+      console.warn(
+        "[openclaw] Non-fatal uncaught exception (continuing):",
+        formatUncaughtError(error),
+      );
+      return;
+    }
+
+    console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- suppress transient network uncaught exceptions the same way we already suppress transient unhandled rejections
- install the shared uncaught-exception handler from both CLI entrypoints instead of hard-exiting inline
- cover the new behavior with fatal-detection tests for both rejection and uncaught-exception paths

## Testing
- pnpm -C /tmp/openclaw-pr-factory test -- src/infra/unhandled-rejections.fatal-detection.test.ts

## Notes
- `pnpm check` in this checkout still fails on unrelated pre-existing TypeScript errors in `extensions/mattermost` and `extensions/nextcloud-talk`.

Closes #55537
