### PR TITLE
fix(browser): restore browser tabs action syntax compatibility

### DIFF
--- a/extensions/browser/src/cli/browser-cli-manage.test.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test.ts
@@ -179,4 +179,59 @@ describe("browser manage output", () => {
     expect(output).not.toContain("supersecretpasswordvalue1234");
     expect(output).not.toContain("supersecrettokenvalue1234567890");
   });
+
+  it.each([
+    ["browser tab new", ["browser", "tab", "new"], { action: "new" }],
+    ["browser tabs new", ["browser", "tabs", "new"], { action: "new" }],
+    ["browser tab select", ["browser", "tab", "select", "2"], { action: "select", index: 1 }],
+    [
+      "browser tabs select",
+      ["browser", "tabs", "select", "2"],
+      { action: "select", index: 1 },
+    ],
+    ["browser tab close", ["browser", "tab", "close", "2"], { action: "close", index: 1 }],
+    [
+      "browser tabs close",
+      ["browser", "tabs", "close", "2"],
+      { action: "close", index: 1 },
+    ],
+  ])("%s uses tab action endpoint", async (_label, argv, expectedBody) => {
+    const program = createBrowserManageProgram();
+    await program.parseAsync(argv, { from: "user" });
+
+    expect(getBrowserManageCallBrowserRequestMock()).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/tabs/action",
+        body: expectedBody,
+      }),
+      { timeoutMs: 45_000 },
+    );
+  });
+
+  it("keeps browser tabs as the list command", async () => {
+    getBrowserManageCallBrowserRequestMock().mockImplementation(async (_opts: unknown, req) =>
+      req.path === "/tabs"
+        ? {
+            running: true,
+            tabs: [{ targetId: "tab-1", title: "Example", url: "https://example.com" }],
+          }
+        : {},
+    );
+
+    const program = createBrowserManageProgram();
+    await program.parseAsync(["browser", "tabs"], { from: "user" });
+
+    expect(getBrowserManageCallBrowserRequestMock()).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "GET",
+        path: "/tabs",
+      }),
+      { timeoutMs: 45_000 },
+    );
+    const output = getBrowserCliRuntime().log.mock.calls.at(-1)?.[0] as string;
+    expect(output).toContain("1. Example");
+  });
 });

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -88,6 +88,59 @@ function runBrowserCommand(action: () => Promise<void>) {
   });
 }
 
+async function runBrowserTabNew(parent: BrowserParentOpts, profile?: string) {
+  await runBrowserCommand(async () => {
+    const result = await callTabAction(parent, profile, { action: "new" });
+    if (printJsonResult(parent, result)) {
+      return;
+    }
+    defaultRuntime.log("opened new tab");
+  });
+}
+
+async function runBrowserTabSelect(
+  parent: BrowserParentOpts,
+  profile: string | undefined,
+  index: number,
+) {
+  if (!Number.isFinite(index) || index < 1) {
+    defaultRuntime.error(danger("index must be a positive number"));
+    defaultRuntime.exit(1);
+    return;
+  }
+  await runBrowserCommand(async () => {
+    const result = await callTabAction(parent, profile, {
+      action: "select",
+      index: Math.floor(index) - 1,
+    });
+    if (printJsonResult(parent, result)) {
+      return;
+    }
+    defaultRuntime.log(`selected tab ${Math.floor(index)}`);
+  });
+}
+
+async function runBrowserTabClose(
+  parent: BrowserParentOpts,
+  profile: string | undefined,
+  index?: number,
+) {
+  const idx =
+    typeof index === "number" && Number.isFinite(index) ? Math.floor(index) - 1 : undefined;
+  if (typeof idx === "number" && idx < 0) {
+    defaultRuntime.error(danger("index must be >= 1"));
+    defaultRuntime.exit(1);
+    return;
+  }
+  await runBrowserCommand(async () => {
+    const result = await callTabAction(parent, profile, { action: "close", index: idx });
+    if (printJsonResult(parent, result)) {
+      return;
+    }
+    defaultRuntime.log("closed tab");
+  });
+}
+
 function logBrowserTabs(tabs: BrowserTab[], json?: boolean) {
   if (json) {
     defaultRuntime.writeJson({ tabs });
@@ -244,6 +297,35 @@ export function registerBrowserManageCommands(
       });
     });
 
+  browser
+    .command("tabs new")
+    .description("Open a new tab (about:blank)")
+    .action(async (_opts, cmd) => {
+      const parent = parentOpts(cmd);
+      const profile = parent?.browserProfile;
+      await runBrowserTabNew(parent, profile);
+    });
+
+  browser
+    .command("tabs select")
+    .description("Focus tab by index (1-based)")
+    .argument("<index>", "Tab index (1-based)", (v: string) => Number(v))
+    .action(async (index: number, _opts, cmd) => {
+      const parent = parentOpts(cmd);
+      const profile = parent?.browserProfile;
+      await runBrowserTabSelect(parent, profile, index);
+    });
+
+  browser
+    .command("tabs close")
+    .description("Close tab by index (1-based); default: first tab")
+    .argument("[index]", "Tab index (1-based)", (v: string) => Number(v))
+    .action(async (index: number | undefined, _opts, cmd) => {
+      const parent = parentOpts(cmd);
+      const profile = parent?.browserProfile;
+      await runBrowserTabClose(parent, profile, index);
+    });
+
   const tab = browser
     .command("tab")
     .description("Tab shortcuts (index-based)")
@@ -274,13 +356,7 @@ export function registerBrowserManageCommands(
     .action(async (_opts, cmd) => {
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
-      await runBrowserCommand(async () => {
-        const result = await callTabAction(parent, profile, { action: "new" });
-        if (printJsonResult(parent, result)) {
-          return;
-        }
-        defaultRuntime.log("opened new tab");
-      });
+      await runBrowserTabNew(parent, profile);
     });
 
   tab
@@ -290,21 +366,7 @@ export function registerBrowserManageCommands(
     .action(async (index: number, _opts, cmd) => {
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
-      if (!Number.isFinite(index) || index < 1) {
-        defaultRuntime.error(danger("index must be a positive number"));
-        defaultRuntime.exit(1);
-        return;
-      }
-      await runBrowserCommand(async () => {
-        const result = await callTabAction(parent, profile, {
-          action: "select",
-          index: Math.floor(index) - 1,
-        });
-        if (printJsonResult(parent, result)) {
-          return;
-        }
-        defaultRuntime.log(`selected tab ${Math.floor(index)}`);
-      });
+      await runBrowserTabSelect(parent, profile, index);
     });
 
   tab
@@ -314,20 +376,7 @@ export function registerBrowserManageCommands(
     .action(async (index: number | undefined, _opts, cmd) => {
       const parent = parentOpts(cmd);
       const profile = parent?.browserProfile;
-      const idx =
-        typeof index === "number" && Number.isFinite(index) ? Math.floor(index) - 1 : undefined;
-      if (typeof idx === "number" && idx < 0) {
-        defaultRuntime.error(danger("index must be >= 1"));
-        defaultRuntime.exit(1);
-        return;
-      }
-      await runBrowserCommand(async () => {
-        const result = await callTabAction(parent, profile, { action: "close", index: idx });
-        if (printJsonResult(parent, result)) {
-          return;
-        }
-        defaultRuntime.log("closed tab");
-      });
+      await runBrowserTabClose(parent, profile, index);
     });
 
   browser


### PR DESCRIPTION
## Summary
- restore support for the legacy  syntax
- keep the current  syntax working unchanged
- add focused CLI tests covering both action syntaxes and verify plain No tabs (browser closed or no targets). still lists tabs

## Testing
- pnpm test -- extensions/browser/src/cli/browser-cli-manage.test.ts extensions/browser/src/cli/browser-cli-manage.timeout-option.test.ts *(fails in this environment because node_modules is missing)*
- pnpm install *(fails in this environment due npm DNS/network error: EAI_AGAIN to registry.npmjs.org)*

Closes #55563