### PR TITLE
fix(agents): classify nested HTTP 500 for failover

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -82,6 +82,24 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
   });
 
+  it("reads nested HTTP response status for transient server errors", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        response: { status: 500 },
+      }),
+    ).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
+        response: { status: 502 },
+      }),
+    ).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
+        response: { status: 504 },
+      }),
+    ).toBe("timeout");
+  });
+
   it("classifies documented provider error shapes at the error boundary", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -95,9 +95,13 @@ function readDirectStatusCode(err: unknown): number | undefined {
   if (!err || typeof err !== "object") {
     return undefined;
   }
+  const responseCandidate = (err as { response?: { status?: unknown; statusCode?: unknown } })
+    .response;
   const candidate =
     (err as { status?: unknown; statusCode?: unknown }).status ??
-    (err as { statusCode?: unknown }).statusCode;
+    (err as { statusCode?: unknown }).statusCode ??
+    responseCandidate?.status ??
+    responseCandidate?.statusCode;
   if (typeof candidate === "number") {
     return candidate;
   }


### PR DESCRIPTION
## Summary
- classify nested HTTP response statuses from provider/client errors, not just top-level status fields
- ensure HTTP 500 follows the existing transient failover path used for 502/504
- add a focused regression test covering nested response.status values for 500/502/504

## Testing
- pnpm test -- src/agents/failover-error.test.ts *(fails in this environment because node_modules is missing)*
- pnpm install *(fails in this environment due npm DNS/network error: EAI_AGAIN to registry.npmjs.org)*

Closes #55575