### PR TITLE
fix(discord): route REST API calls through configured proxy

### DIFF
--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -13,6 +13,18 @@ import { resolveDiscordRestFetch } from "./monitor/rest-fetch.js";
 import { createDiscordRetryRunner } from "./retry.js";
 import { normalizeDiscordToken } from "./token.js";
 
+/** Cache proxy-aware fetch by proxy URL to avoid creating a ProxyAgent per send. */
+const proxyFetchCache = new Map<string, typeof fetch>();
+
+export function cachedProxyFetch(proxyUrl: string): typeof fetch {
+  let cached = proxyFetchCache.get(proxyUrl);
+  if (!cached) {
+    cached = resolveDiscordRestFetch(proxyUrl, createNonExitingRuntime());
+    proxyFetchCache.set(proxyUrl, cached);
+  }
+  return cached;
+}
+
 export type DiscordClientOpts = {
   cfg?: ReturnType<typeof loadConfig>;
   token?: string;
@@ -70,9 +82,7 @@ export function createDiscordRestClient(
       fallbackToken: account.token,
     });
   const proxyUrl = account.config.proxy?.trim();
-  const proxyFetch = proxyUrl
-    ? resolveDiscordRestFetch(proxyUrl, createNonExitingRuntime())
-    : undefined;
+  const proxyFetch = proxyUrl ? cachedProxyFetch(proxyUrl) : undefined;
   const rest = resolveRest(token, opts.rest, proxyFetch);
   return { token, rest, account, proxyFetch };
 }

--- a/extensions/discord/src/client.ts
+++ b/extensions/discord/src/client.ts
@@ -3,11 +3,13 @@ import { loadConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { RetryConfig } from "openclaw/plugin-sdk/infra-runtime";
 import type { RetryRunner } from "openclaw/plugin-sdk/infra-runtime";
 import { normalizeAccountId } from "openclaw/plugin-sdk/routing";
+import { createNonExitingRuntime } from "openclaw/plugin-sdk/runtime-env";
 import {
   mergeDiscordAccountConfig,
   resolveDiscordAccount,
   type ResolvedDiscordAccount,
 } from "./accounts.js";
+import { resolveDiscordRestFetch } from "./monitor/rest-fetch.js";
 import { createDiscordRetryRunner } from "./retry.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -30,8 +32,8 @@ function resolveToken(params: { accountId: string; fallbackToken?: string }) {
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+function resolveRest(token: string, rest?: RequestClient, customFetch?: typeof fetch) {
+  return rest ?? new RequestClient(token, customFetch ? { fetch: customFetch } : undefined);
 }
 
 function resolveAccountWithoutToken(params: {
@@ -67,21 +69,25 @@ export function createDiscordRestClient(
       accountId: account.accountId,
       fallbackToken: account.token,
     });
-  const rest = resolveRest(token, opts.rest);
-  return { token, rest, account };
+  const proxyUrl = account.config.proxy?.trim();
+  const proxyFetch = proxyUrl
+    ? resolveDiscordRestFetch(proxyUrl, createNonExitingRuntime())
+    : undefined;
+  const rest = resolveRest(token, opts.rest, proxyFetch);
+  return { token, rest, account, proxyFetch };
 }
 
 export function createDiscordClient(
   opts: DiscordClientOpts,
   cfg?: ReturnType<typeof loadConfig>,
-): { token: string; rest: RequestClient; request: RetryRunner } {
-  const { token, rest, account } = createDiscordRestClient(opts, opts.cfg ?? cfg);
+): { token: string; rest: RequestClient; request: RetryRunner; proxyFetch?: typeof fetch } {
+  const { token, rest, account, proxyFetch } = createDiscordRestClient(opts, opts.cfg ?? cfg);
   const request = createDiscordRetryRunner({
     retry: opts.retry,
     configRetry: account.config.retry,
     verbose: opts.verbose,
   });
-  return { token, rest, request };
+  return { token, rest, request, proxyFetch };
 }
 
 export function resolveDiscordRest(opts: DiscordClientOpts) {

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -13,11 +13,10 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-runtime";
 import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import type { PollInput } from "openclaw/plugin-sdk/media-runtime";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
-import { createNonExitingRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
-import { resolveDiscordRestFetch } from "./monitor/rest-fetch.js";
+import { cachedProxyFetch } from "./client.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import {
   buildDiscordMessagePayload,
@@ -373,7 +372,7 @@ export async function sendWebhookMessageDiscord(
       const account = resolveDiscordAccount({ cfg, accountId: opts.accountId });
       const proxyUrl = account.config.proxy?.trim();
       if (proxyUrl) {
-        resolvedProxyFetch = resolveDiscordRestFetch(proxyUrl, createNonExitingRuntime());
+        resolvedProxyFetch = cachedProxyFetch(proxyUrl);
       }
     } catch {
       // Best-effort proxy resolution; fall back to bare fetch.

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -329,6 +329,7 @@ type DiscordWebhookSendOpts = {
   username?: string;
   avatarUrl?: string;
   wait?: boolean;
+  proxyFetch?: typeof fetch;
 };
 
 function resolveWebhookExecutionUrl(params: {
@@ -363,7 +364,8 @@ export async function sendWebhookMessageDiscord(
   const replyTo = typeof opts.replyTo === "string" ? opts.replyTo.trim() : "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
 
-  const response = await fetch(
+  const fetchImpl = opts.proxyFetch ?? fetch;
+  const response = await fetchImpl(
     resolveWebhookExecutionUrl({
       webhookId,
       webhookToken,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -13,9 +13,11 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-runtime";
 import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
 import type { PollInput } from "openclaw/plugin-sdk/media-runtime";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import { createNonExitingRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
+import { resolveDiscordRestFetch } from "./monitor/rest-fetch.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import {
   buildDiscordMessagePayload,
@@ -364,7 +366,20 @@ export async function sendWebhookMessageDiscord(
   const replyTo = typeof opts.replyTo === "string" ? opts.replyTo.trim() : "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
 
-  const fetchImpl = opts.proxyFetch ?? fetch;
+  let resolvedProxyFetch = opts.proxyFetch;
+  if (!resolvedProxyFetch) {
+    try {
+      const cfg = opts.cfg ?? loadConfig();
+      const account = resolveDiscordAccount({ cfg, accountId: opts.accountId });
+      const proxyUrl = account.config.proxy?.trim();
+      if (proxyUrl) {
+        resolvedProxyFetch = resolveDiscordRestFetch(proxyUrl, createNonExitingRuntime());
+      }
+    } catch {
+      // Best-effort proxy resolution; fall back to bare fetch.
+    }
+  }
+  const fetchImpl = resolvedProxyFetch ?? fetch;
   const response = await fetchImpl(
     resolveWebhookExecutionUrl({
       webhookId,


### PR DESCRIPTION
## Summary

- Route Discord REST API calls (message sends, webhook sends) through the configured `channels.discord.proxy`
- Reuse existing `resolveDiscordRestFetch()` from the monitor path to create proxy-aware fetch
- Pass custom fetch to `@buape/carbon` `RequestClient` via its `{ fetch }` constructor option
- Webhook sends use proxy-aware fetch when available

Fixes #28788

## Context

Discord WebSocket connections already respect the `channels.discord.proxy` config (handled by `gateway-plugin.ts`), but REST API calls for sending messages used bare `fetch()` without proxy support. This caused `TypeError: fetch failed` for users behind corporate proxies, VPNs, or in regions requiring proxy access to Discord.

The `@buape/carbon` `RequestClient` constructor accepts an `options.fetch` parameter but it was never being passed. The existing `resolveDiscordRestFetch()` in `extensions/discord/src/monitor/rest-fetch.ts` already creates the correct proxy-aware fetch using undici `ProxyAgent` — this PR reuses that proven pattern in the send path.

## Files changed

- `extensions/discord/src/client.ts` — resolve proxy from account config, pass proxy-aware fetch to `RequestClient`
- `extensions/discord/src/send.outbound.ts` — use proxy-aware fetch for webhook sends

## Test plan

- [x] `pnpm test -- extensions/discord/src/client.test.ts` (3/3 pass)
- [x] `pnpm test -- extensions/discord/src/send` (42/42 pass)
- [x] `pnpm test -- extensions/discord/src/monitor/provider.rest-proxy.test.ts` (2/2 pass)
- [x] `pnpm tsgo` — 0 new type errors (13 pre-existing on main)
- [x] `pnpm format` — clean
- [ ] Manual test: configure `channels.discord.proxy` and verify message sends succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)