### PR TITLE
[codex] Runner: resume retries without reinjecting prompts

### DIFF
--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -58,22 +58,26 @@ const installRunEmbeddedMocks = () => {
   vi.doMock("./pi-embedded-runner/run/attempt.js", () => ({
     runEmbeddedAttempt: (params: unknown) => runEmbeddedAttemptMock(params),
   }));
-  vi.doMock("../plugins/provider-runtime.js", () => ({
-    prepareProviderRuntimeAuth: async (params: {
-      provider: string;
-      context: { apiKey: string };
-    }) => {
-      if (params.provider !== "github-copilot") {
-        return undefined;
-      }
-      const token = await resolveCopilotApiTokenMock(params.context.apiKey);
-      return {
-        apiKey: token.token,
-        baseUrl: token.baseUrl,
-        expiresAt: token.expiresAt,
-      };
-    },
-  }));
+  vi.doMock("../plugins/provider-runtime.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../plugins/provider-runtime.js")>();
+    return {
+      ...actual,
+      prepareProviderRuntimeAuth: async (params: {
+        provider: string;
+        context: { apiKey: string };
+      }) => {
+        if (params.provider !== "github-copilot") {
+          return undefined;
+        }
+        const token = await resolveCopilotApiTokenMock(params.context.apiKey);
+        return {
+          apiKey: token.token,
+          baseUrl: token.baseUrl,
+          expiresAt: token.expiresAt,
+        };
+      },
+    };
+  });
   vi.doMock("../infra/backoff.js", () => ({
     computeBackoff: (
       policy: { initialMs: number; maxMs: number; factor: number; jitter: number },
@@ -436,6 +440,8 @@ async function runAutoPinnedRotationCase(params: {
     });
 
     expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAttemptMock.mock.calls[0]?.[0]).toMatchObject({ isRetry: false });
+    expect(runEmbeddedAttemptMock.mock.calls[1]?.[0]).toMatchObject({ isRetry: true });
     const usageStats = await readUsageStats(agentDir);
     return { usageStats };
   });
@@ -458,6 +464,8 @@ async function runAutoPinnedPromptErrorRotationCase(params: {
     });
 
     expect(runEmbeddedAttemptMock).toHaveBeenCalledTimes(2);
+    expect(runEmbeddedAttemptMock.mock.calls[0]?.[0]).toMatchObject({ isRetry: false });
+    expect(runEmbeddedAttemptMock.mock.calls[1]?.[0]).toMatchObject({ isRetry: true });
     const usageStats = await readUsageStats(agentDir);
     return { usageStats };
   });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -437,6 +437,7 @@ export async function runEmbeddedPiAgent(
             provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
 
           const attempt = await runEmbeddedAttempt({
+            isRetry: runLoopIterations > 1,
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
             trigger: params.trigger,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -21,6 +21,7 @@ import {
   shouldInjectHeartbeatPrompt,
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
+  prepareRetryResumeAttempt,
   wrapOllamaCompatNumCtx,
   wrapStreamFnRepairMalformedToolCallArguments,
   wrapStreamFnSanitizeMalformedToolCalls,
@@ -300,6 +301,88 @@ describe("composeSystemPromptWithHookContext", () => {
     expect(turns[2]?.prompt.startsWith("hello once more")).toBe(true);
     expect(turns[0]?.prompt).toContain("[Bootstrap truncation warning]");
     expect(turns[2]?.prompt).toContain("[Bootstrap truncation warning]");
+  });
+});
+
+describe("prepareRetryResumeAttempt", () => {
+  it("branches away from a terminal assistant failure before retry continue()", () => {
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 1,
+    } as AgentMessage;
+    const failedAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      stopReason: "error",
+      errorMessage: "401 unauthorized",
+      timestamp: 2,
+    } as AgentMessage;
+    const replaceMessages = vi.fn();
+    const branch = vi.fn();
+    const getLeafEntry = vi
+      .fn()
+      .mockReturnValueOnce({
+        type: "message",
+        id: "assistant-2",
+        parentId: "user-1",
+        message: failedAssistant,
+      })
+      .mockReturnValueOnce({
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        message: userMessage,
+      });
+    const buildSessionContext = vi
+      .fn()
+      .mockReturnValueOnce({ messages: [userMessage, failedAssistant] })
+      .mockReturnValueOnce({ messages: [userMessage] });
+
+    const shouldResume = prepareRetryResumeAttempt({
+      isRetry: true,
+      activeSession: {
+        agent: { replaceMessages },
+      } as unknown as Parameters<typeof prepareRetryResumeAttempt>[0]["activeSession"],
+      sessionManager: {
+        branch,
+        buildSessionContext,
+        getLeafEntry,
+      } as unknown as Parameters<typeof prepareRetryResumeAttempt>[0]["sessionManager"],
+      runId: "run-retry-resume",
+      sessionId: "embedded-session",
+    });
+
+    expect(shouldResume).toBe(true);
+    expect(branch).toHaveBeenCalledWith("user-1");
+    expect(replaceMessages).toHaveBeenCalledWith([userMessage]);
+  });
+
+  it("does not resume from successful assistant turns", () => {
+    const replaceMessages = vi.fn();
+    const successAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "done" }],
+      stopReason: "end_turn",
+      timestamp: 2,
+    } as AgentMessage;
+
+    const shouldResume = prepareRetryResumeAttempt({
+      isRetry: true,
+      activeSession: {
+        agent: { replaceMessages },
+      } as unknown as Parameters<typeof prepareRetryResumeAttempt>[0]["activeSession"],
+      sessionManager: {
+        buildSessionContext: () => ({ messages: [successAssistant] }),
+        getLeafEntry: () => undefined,
+        branch: vi.fn(),
+      } as unknown as Parameters<typeof prepareRetryResumeAttempt>[0]["sessionManager"],
+      runId: "run-retry-skip",
+      sessionId: "embedded-session",
+    });
+
+    expect(shouldResume).toBe(false);
+    expect(replaceMessages).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -210,6 +210,59 @@ export {
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 
+type RetryResumeLeafEntry = {
+  type?: string;
+  parentId?: string | null;
+  message?: AgentMessage;
+};
+
+export function prepareRetryResumeAttempt(params: {
+  isRetry?: boolean;
+  activeSession: Awaited<ReturnType<typeof createAgentSession>>["session"];
+  sessionManager: ReturnType<typeof guardSessionManager>;
+  runId: string;
+  sessionId: string;
+}): boolean {
+  if (params.isRetry !== true) {
+    return false;
+  }
+
+  let sessionContext = params.sessionManager.buildSessionContext();
+  let lastMessage = sessionContext.messages.at(-1);
+
+  if (!lastMessage) {
+    return false;
+  }
+
+  if (lastMessage.role === "assistant") {
+    const stopReason = (lastMessage as { stopReason?: unknown }).stopReason;
+    if (stopReason !== "error" && stopReason !== "aborted") {
+      return false;
+    }
+
+    let leafEntry = params.sessionManager.getLeafEntry() as RetryResumeLeafEntry | undefined;
+    while (
+      leafEntry?.parentId &&
+      (leafEntry.type !== "message" || leafEntry.message?.role === "assistant")
+    ) {
+      params.sessionManager.branch(leafEntry.parentId);
+      leafEntry = params.sessionManager.getLeafEntry() as RetryResumeLeafEntry | undefined;
+    }
+
+    sessionContext = params.sessionManager.buildSessionContext();
+    lastMessage = sessionContext.messages.at(-1);
+    if (!lastMessage || lastMessage.role === "assistant") {
+      log.warn(
+        `retry resume could not restore non-assistant leaf: runId=${params.runId} sessionId=${params.sessionId}`,
+      );
+      return false;
+    }
+  }
+
+  params.activeSession.agent.replaceMessages(sessionContext.messages);
+  return true;
+}
+
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
   const content = (msg as { content?: unknown }).content;
   if (typeof content === "string") {
@@ -1505,12 +1558,26 @@ export async function runEmbeddedAttempt(
             inFlightPrompt: effectivePrompt,
           });
 
-          // Only pass images option if there are actually images to pass
-          // This avoids potential issues with models that don't expect the images parameter
-          if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
+          const shouldResumeRetry = prepareRetryResumeAttempt({
+            isRetry: params.isRetry,
+            activeSession,
+            sessionManager,
+            runId: params.runId,
+            sessionId: params.sessionId,
+          });
+
+          if (shouldResumeRetry) {
+            await abortable(activeSession.agent.continue());
           } else {
-            await abortable(activeSession.prompt(effectivePrompt));
+            // Only pass images option if there are actually images to pass.
+            // Retries resume the already-persisted user turn via continue().
+            if (imageResult.images.length > 0) {
+              await abortable(
+                activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+              );
+            } else {
+              await abortable(activeSession.prompt(effectivePrompt));
+            }
           }
         } catch (err) {
           // Yield-triggered abort is intentional — treat as clean stop, not error.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -15,6 +15,8 @@ type EmbeddedRunAttemptBase = Omit<
 >;
 
 export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
+  /** True when this attempt is retrying the same user turn. */
+  isRetry?: boolean;
   /** Pluggable context engine for ingest/assemble/compact lifecycle. */
   contextEngine?: ContextEngine;
   /** Resolved model context window in tokens for assemble/compact budgeting. */


### PR DESCRIPTION
## Summary
- mark rerun attempts with `isRetry` in the embedded runner loop
- resume retry attempts from the existing persisted turn instead of sending the same user prompt again
- cover the retry-resume branch behavior and auth-profile rotation flag plumbing with focused tests

## Root Cause
`runEmbeddedPiAgent()` retried failed attempts by calling `runEmbeddedAttempt()` again with the same prompt, and `runEmbeddedAttempt()` always called `activeSession.prompt(...)`. For auth-profile rotation and similar internal reruns, the prior user turn was already persisted in session state, so the retry injected the same user message again.

## Fix
On retry attempts, `runEmbeddedAttempt()` now rebuilds session state from the current leaf, branches away from trailing assistant `error`/`aborted` messages when needed, and resumes the existing turn with `activeSession.agent.continue()`.

## Validation
- `pnpm test -- src/agents/pi-embedded-runner/run/attempt.test.ts`
- `pnpm test -- src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts`
- `pnpm build` *(fails on current `origin/main` with unrelated errors in `src/agents/compaction.ts`, `src/agents/pi-extensions/compaction-safeguard.ts`, and `src/agents/skills/config.ts`)*
