### PR TITLE
fix: wire agent.getApiKey after streamFn override in embedded runner

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -871,6 +871,19 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = streamSimple;
       }
 
+      // The streamFn overrides above replace the custom streamFn that
+      // createAgentSession installs – that custom function was the only
+      // path that called modelRegistry.getApiKeyAndHeaders() to inject
+      // the API key into stream-function options.  Without this, the
+      // bare streamSimple receives no apiKey, falls back to env-var
+      // lookup, and throws "No API key for provider: <name>".
+      //
+      // Wire agent.getApiKey so pi-agent-core's agentLoop can resolve
+      // the runtime key (set by initializeAuthProfile / setRuntimeApiKey)
+      // and pass it through to the stream function.
+      activeSession.agent.getApiKey = (provider: string) =>
+        params.authStorage.getApiKey(provider, { includeFallback: false });
+
       const { effectiveExtraParams } = applyExtraParamsToAgent(
         activeSession.agent,
         params.config,


### PR DESCRIPTION
## Problem

After a recent upstream change, the embedded runner throws:

```
No API key for provider: <name>
```

This affects **every provider that goes through `streamSimple` over HTTP**: `github-copilot`, `anthropic`, `google`, `openrouter`, `deepseek`, and any `openai-compatible` provider.

Only four paths are unaffected:
- Direct OpenAI (WebSocket transport fetches the key directly)
- OpenAI Codex (WebSocket)
- Ollama (local, no API key)
- Anthropic Vertex (GCP IAM auth, not API key)

## Root Cause

`createAgentSession` (in `pi-coding-agent`) installs a custom `streamFn` on the agent that internally calls `modelRegistry.getApiKeyAndHeaders(model)` to resolve the API key and passes it to `streamSimple` via `options.apiKey`. This was the **only** code path that injected the API key into the stream function options.

The embedded runner in `attempt.ts` overwrites this custom `streamFn`:

```ts
activeSession.agent.streamFn = streamSimple;
```

The bare `streamSimple` has no knowledge of `modelRegistry` — it relies on `options.apiKey` being passed in by the caller. That value comes from `pi-agent-core`'s `agentLoop`, which resolves it via:

```ts
const resolvedApiKey = (config.getApiKey
  ? await config.getApiKey(config.model.provider)
  : undefined) || config.apiKey;
```

But `agent.getApiKey` is never set (it's not passed in `new Agent({...})` in `createAgentSession`), and `config.apiKey` is also `undefined`. So `resolvedApiKey` becomes `undefined`, `streamSimpleOpenAICompletions` / `streamSimpleAnthropic` receive no API key, try `getEnvApiKey()` which also returns nothing, and throw the error.

Meanwhile, the auth controller works perfectly — `initializeAuthProfile` → `prepareProviderRuntimeAuth` → `setRuntimeApiKey(provider, token)` all succeed. The token is stored in `authStorage.runtimeOverrides` but never read by the stream function.

## Fix

After the `streamFn` override block, wire `agent.getApiKey` to resolve from `authStorage`:

```ts
activeSession.agent.getApiKey = (provider: string) =>
  params.authStorage.getApiKey(provider, { includeFallback: false });
```

This allows `pi-agent-core`'s `agentLoop` to resolve the runtime API key (set by `initializeAuthProfile` / `setRuntimeApiKey`) and pass it through to the stream function via `options.apiKey`.

## Verification

Tested with `github-copilot` provider (`gpt-4o` model) — agent responds successfully where it previously threw the error immediately.