### PR TITLE
fix(skills): honor OPENAI_BASE_URL in whisper api skill

### DIFF
--- a/skills/openai-whisper-api/SKILL.md
+++ b/skills/openai-whisper-api/SKILL.md
@@ -49,9 +49,7 @@ Defaults:
 
 ## API key
 
-Set `OPENAI_API_KEY`. Optionally set `OPENAI_BASE_URL` (for example `http://127.0.0.1:51805/v1`) to use an OpenAI-compatible proxy or local gateway.
-
-Set `OPENAI_API_KEY`, or configure it in `~/.openclaw/openclaw.json`:
+Set `OPENAI_API_KEY`, or configure it in `~/.openclaw/openclaw.json`. Optionally set `OPENAI_BASE_URL` (for example `http://127.0.0.1:51805/v1`) to use an OpenAI-compatible proxy or local gateway:
 
 ```json5
 {

--- a/skills/openai-whisper-api/SKILL.md
+++ b/skills/openai-whisper-api/SKILL.md
@@ -25,7 +25,7 @@ metadata:
 
 # OpenAI Whisper API (curl)
 
-Transcribe an audio file via OpenAI’s `/v1/audio/transcriptions` endpoint.
+Transcribe an audio file via OpenAI’s `/v1/audio/transcriptions` endpoint. Set `OPENAI_BASE_URL` to use an OpenAI-compatible proxy or local gateway.
 
 ## Quick start
 
@@ -48,6 +48,8 @@ Defaults:
 ```
 
 ## API key
+
+Set `OPENAI_API_KEY`. Optionally set `OPENAI_BASE_URL` (for example `http://127.0.0.1:51805/v1`) to use an OpenAI-compatible proxy or local gateway.
 
 Set `OPENAI_API_KEY`, or configure it in `~/.openclaw/openclaw.json`:
 

--- a/skills/openai-whisper-api/scripts/transcribe.sh
+++ b/skills/openai-whisper-api/scripts/transcribe.sh
@@ -72,7 +72,10 @@ fi
 
 mkdir -p "$(dirname "$out")"
 
-curl -sS https://api.openai.com/v1/audio/transcriptions \
+api_base="${OPENAI_BASE_URL:-https://api.openai.com/v1}"
+api_base="${api_base%/}"
+
+curl -sS "${api_base}/audio/transcriptions" \
   -H "Authorization: Bearer $OPENAI_API_KEY" \
   -H "Accept: application/json" \
   -F "file=@${in}" \


### PR DESCRIPTION
## Summary
- make `skills/openai-whisper-api/scripts/transcribe.sh` honor `OPENAI_BASE_URL`
- keep the default OpenAI endpoint unchanged when the env var is unset
- document the `OPENAI_BASE_URL` override in the skill docs

## Why
The current `openai-whisper-api` skill hardcodes `https://api.openai.com/v1/audio/transcriptions`, which makes it fail for users routing OpenAI-compatible traffic through a local gateway or proxy (for example LiteLLM).

This keeps the existing default behavior, but allows:
- `OPENAI_BASE_URL=http://127.0.0.1:51805/v1`
- `OPENAI_BASE_URL=https://proxy.example.com/v1`

## Testing
- [x] tested locally with `bash -n skills/openai-whisper-api/scripts/transcribe.sh`
- [x] verified the script now builds `${OPENAI_BASE_URL}/audio/transcriptions`
- [ ] full `pnpm build && pnpm check && pnpm test` not run
  - attempted broader repo checks, but they fail locally due to an unrelated existing config validation issue in `/home/asaf/.openclaw/openclaw.json`

## AI assistance
AI-assisted. I verified the change and the resulting diff.
