### PR TITLE
fix(acp): avoid duplicate final reply after routed block

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createAcpDispatchDeliveryCoordinator } from "./dispatch-acp-delivery.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -13,6 +13,14 @@ const ttsMocks = vi.hoisted(() => ({
 
 vi.mock("../../tts/tts.js", () => ({
   maybeApplyTtsToPayload: (params: unknown) => ttsMocks.maybeApplyTtsToPayload(params),
+}));
+
+const routeReplyMocks = vi.hoisted(() => ({
+  routeReply: vi.fn(async (_params: unknown) => ({ ok: true as const, messageId: "mock" })),
+}));
+
+vi.mock("./route-reply.js", () => ({
+  routeReply: (params: unknown) => routeReplyMocks.routeReply(params),
 }));
 
 function createDispatcher(): ReplyDispatcher {
@@ -43,6 +51,36 @@ function createCoordinator(onReplyStart?: (...args: unknown[]) => Promise<void>)
 }
 
 describe("createAcpDispatchDeliveryCoordinator", () => {
+  beforeEach(() => {
+    routeReplyMocks.routeReply.mockClear();
+    ttsMocks.maybeApplyTtsToPayload.mockClear();
+  });
+
+  it("tracks routed telegram block text separately from final replies", async () => {
+    const dispatcher = createDispatcher();
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "discord",
+        Surface: "discord",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: true,
+      originatingChannel: "telegram",
+      originatingTo: "telegram:thread-1",
+    });
+
+    await coordinator.deliver("block", { text: "hello" }, { skipTts: true });
+
+    expect(coordinator.hasDeliveredFinalReply()).toBe(false);
+    expect(coordinator.hasDeliveredVisibleText()).toBe(true);
+    expect(coordinator.hasDeliveredRoutedVisibleBlockText()).toBe(true);
+    expect(routeReplyMocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendBlockReply).not.toHaveBeenCalled();
+  });
+
   it("bypasses TTS when skipTts is requested", async () => {
     const dispatcher = createDispatcher();
     const coordinator = createAcpDispatchDeliveryCoordinator({
@@ -62,6 +100,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
 
     expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "hello" });
+    expect(coordinator.hasDeliveredRoutedVisibleBlockText()).toBe(false);
   });
 
   it("tracks successful final delivery separately from routed counters", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -48,6 +48,7 @@ type AcpDispatchDeliveryState = {
   blockCount: number;
   deliveredFinalReply: boolean;
   deliveredVisibleText: boolean;
+  deliveredRoutedVisibleBlockText: boolean;
   failedVisibleTextDelivery: boolean;
   queuedDirectVisibleTextDeliveries: number;
   settledDirectVisibleText: boolean;
@@ -67,6 +68,7 @@ export type AcpDispatchDeliveryCoordinator = {
   settleVisibleText: () => Promise<void>;
   hasDeliveredFinalReply: () => boolean;
   hasDeliveredVisibleText: () => boolean;
+  hasDeliveredRoutedVisibleBlockText: () => boolean;
   hasFailedVisibleTextDelivery: () => boolean;
   getRoutedCounts: () => Record<ReplyDispatchKind, number>;
   applyRoutedCounts: (counts: Record<ReplyDispatchKind, number>) => void;
@@ -90,6 +92,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     blockCount: 0,
     deliveredFinalReply: false,
     deliveredVisibleText: false,
+    deliveredRoutedVisibleBlockText: false,
     failedVisibleTextDelivery: false,
     queuedDirectVisibleTextDeliveries: 0,
     settledDirectVisibleText: false,
@@ -241,6 +244,9 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       }
       if (tracksVisibleText) {
         state.deliveredVisibleText = true;
+        if (kind === "block") {
+          state.deliveredRoutedVisibleBlockText = true;
+        }
       }
       state.routedCounts[kind] += 1;
       return true;
@@ -277,6 +283,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
     settleVisibleText: settleDirectVisibleText,
     hasDeliveredFinalReply: () => state.deliveredFinalReply,
     hasDeliveredVisibleText: () => state.deliveredVisibleText,
+    hasDeliveredRoutedVisibleBlockText: () => state.deliveredRoutedVisibleBlockText,
     hasFailedVisibleTextDelivery: () => state.failedVisibleTextDelivery,
     getRoutedCounts: () => ({ ...state.routedCounts }),
     applyRoutedCounts: (counts) => {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -476,6 +476,37 @@ describe("tryDispatchAcpReply", () => {
     expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
   });
 
+  it("does not duplicate routed telegram block text as a synthetic final reply", async () => {
+    setReadyAcpResolution();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    queueTtsReplies({ text: "CODEX_OK" }, {} as ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>);
+    routeMocks.routeReply
+      .mockResolvedValueOnce({ ok: true, messageId: "block-1" })
+      .mockResolvedValueOnce({ ok: true, messageId: "final-1" });
+    managerMocks.runTurn.mockImplementation(
+      async ({ onEvent }: { onEvent: (event: unknown) => Promise<void> }) => {
+        await onEvent({ type: "text_delta", text: "CODEX_OK", tag: "agent_message_chunk" });
+        await onEvent({ type: "done" });
+      },
+    );
+
+    const { dispatcher } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "reply",
+      dispatcher,
+      shouldRouteToOriginating: true,
+    });
+
+    expect(result?.counts.block).toBe(1);
+    expect(result?.counts.final).toBe(0);
+    expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(routeMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ text: "CODEX_OK" }),
+      }),
+    );
+  });
+
   it("does not deliver final fallback text when direct block text was already visible", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -234,6 +234,7 @@ async function finalizeAcpTurnOutput(params: {
   const shouldDeliverTextFallback =
     ttsMode !== "all" &&
     hasAccumulatedBlockText &&
+    !params.delivery.hasDeliveredRoutedVisibleBlockText() &&
     !finalMediaDelivered &&
     !params.delivery.hasDeliveredFinalReply() &&
     (!params.delivery.hasDeliveredVisibleText() || params.delivery.hasFailedVisibleTextDelivery());


### PR DESCRIPTION
## Summary
- remember when ACP block text was already routed visibly to the originating chat
- suppress the synthetic accumulated-text final fallback in that routed-block case
- add focused coordinator and ACP dispatch regression tests for the Telegram duplicate-message path

## Testing
- pnpm test -- src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/dispatch-acp.test.ts *(fails in this environment because node_modules is missing)*
- pnpm install *(fails in this environment due npm DNS/network error: EAI_AGAIN to registry.npmjs.org)*

Closes #55603