### PR TITLE
fix(memory): resolve provider auth targets for CLI search

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -6,6 +6,7 @@ import {
   colorize,
   defaultRuntime,
   formatErrorMessage,
+  getModelsCommandSecretTargetIds,
   isRich,
   resolveCommandSecretRefsViaGateway,
   setVerbose,
@@ -53,10 +54,14 @@ type LoadedMemoryCommandConfig = {
 };
 
 function getMemoryCommandSecretTargetIds(): Set<string> {
-  return new Set([
+  const targetIds = new Set([
     "agents.defaults.memorySearch.remote.apiKey",
     "agents.list[].memorySearch.remote.apiKey",
   ]);
+  for (const id of getModelsCommandSecretTargetIds()) {
+    targetIds.add(id);
+  }
+  return targetIds;
 }
 
 async function loadMemoryCommandConfig(commandName: string): Promise<LoadedMemoryCommandConfig> {

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -240,12 +240,15 @@ describe("memory cli", () => {
     expect(resolveCommandSecretRefsViaGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         commandName: "memory status",
-        targetIds: new Set([
-          "agents.defaults.memorySearch.remote.apiKey",
-          "agents.list[].memorySearch.remote.apiKey",
-        ]),
+        targetIds: expect.any(Set),
       }),
     );
+    const call = resolveCommandSecretRefsViaGateway.mock.calls.at(-1)?.[0] as
+      | { targetIds?: Set<string> }
+      | undefined;
+    expect(call?.targetIds?.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
+    expect(call?.targetIds?.has("agents.list[].memorySearch.remote.apiKey")).toBe(true);
+    expect(call?.targetIds?.has("models.providers.*.apiKey")).toBe(true);
   });
 
   it("logs gateway secret diagnostics for non-json status output", async () => {

--- a/packages/memory-host-sdk/src/runtime-cli.ts
+++ b/packages/memory-host-sdk/src/runtime-cli.ts
@@ -2,6 +2,7 @@
 
 export { formatErrorMessage, withManager } from "../../../src/cli/cli-utils.js";
 export { formatHelpExamples } from "../../../src/cli/help-format.js";
+export { getModelsCommandSecretTargetIds } from "../../../src/cli/command-secret-targets.js";
 export { resolveCommandSecretRefsViaGateway } from "../../../src/cli/command-secret-gateway.js";
 export { withProgress, withProgressTotals } from "../../../src/cli/progress.js";
 export { defaultRuntime } from "../../../src/runtime.js";


### PR DESCRIPTION
## Summary
- include model/provider auth secret targets when resolving memory CLI config via the gateway secret resolver
- keep the existing memorySearch secret targets while also covering provider-backed embedding auth
- update the memory CLI test to assert the expanded target set without over-coupling to exact Set identity

## Testing
- targeted memory CLI test coverage updated in extensions/memory-core/src/cli.test.ts
- runtime validation remains limited in this environment because local dependency/runtime setup is incomplete

Closes #55608