### PR TITLE
macOS: add Universal Binary verification, CI validation, and architecture docs

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -69,6 +69,33 @@ jobs:
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           pnpm release:openclaw:npm:check
 
+      - name: Validate Universal Binary packaging defaults
+        run: |
+          set -euo pipefail
+          # Verify dist script defaults to universal (BUILD_ARCHS=all)
+          if ! grep -q 'BUILD_ARCHS:-all' scripts/package-mac-dist.sh; then
+            echo "::error::package-mac-dist.sh does not default BUILD_ARCHS to 'all' (Universal Binary)"
+            exit 1
+          fi
+          # Verify app script expands 'all' to 'arm64 x86_64'
+          if ! grep -q '"arm64 x86_64"' scripts/package-mac-app.sh; then
+            echo "::error::package-mac-app.sh does not expand 'all' to 'arm64 x86_64'"
+            exit 1
+          fi
+          # Verify Info.plist declares both architectures in LSArchitecturePriority
+          PLIST="apps/macos/Sources/OpenClaw/Resources/Info.plist"
+          if ! grep -q 'LSArchitecturePriority' "$PLIST"; then
+            echo "::error::Info.plist missing LSArchitecturePriority key"
+            exit 1
+          fi
+          for arch in arm64 x86_64; do
+            if ! grep -q "<string>${arch}</string>" "$PLIST"; then
+              echo "::error::Info.plist LSArchitecturePriority missing ${arch}"
+              exit 1
+            fi
+          done
+          echo "✅ Universal Binary packaging defaults validated (arm64 + x86_64)"
+
       - name: Summarize next step
         env:
           RELEASE_TAG: ${{ inputs.tag }}
@@ -77,6 +104,9 @@ jobs:
             echo "## Public macOS validation only"
             echo
             echo "This workflow no longer builds, signs, notarizes, or uploads macOS assets."
+            echo
+            echo "**Architecture:** Release builds produce Universal Binaries (arm64 + x86_64) by default."
+            echo "Set \`PER_ARCH_DIST=1\` in the private workflow to also produce per-architecture zips."
             echo
             echo "Next step:"
             echo "- Run \`openclaw/releases-private/.github/workflows/openclaw-macos-publish.yml\` with tag \`${RELEASE_TAG}\`."

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -31,6 +31,11 @@
             </array>
         </dict>
     </array>
+    <key>LSArchitecturePriority</key>
+    <array>
+        <string>arm64</string>
+        <string>x86_64</string>
+    </array>
     <key>LSMinimumSystemVersion</key>
     <string>15.0</string>
     <key>LSUIElement</key>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -513,6 +513,10 @@
       "destination": "/platforms/mac/child-process"
     },
     {
+      "source": "/mac/building",
+      "destination": "/platforms/mac/building"
+    },
+    {
       "source": "/mac/dev-setup",
       "destination": "/platforms/mac/dev-setup"
     },
@@ -1240,6 +1244,7 @@
               {
                 "group": "macOS companion app",
                 "pages": [
+                  "platforms/mac/building",
                   "platforms/mac/dev-setup",
                   "platforms/mac/menu-bar",
                   "platforms/mac/voicewake",

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -125,4 +125,6 @@ Stable macOS releases ship as **Universal Binaries** containing both arm64 (Appl
 
 For users who want smaller downloads, per-architecture zips (`OpenClaw-<version>-arm64.zip`, `OpenClaw-<version>-x86_64.zip`) can be produced by setting `PER_ARCH_DIST=1` during release packaging.
 
+Full detail (verify with `lipo`, maintainer scripts, FAQ for Intel vs Universal): [macOS release artifacts & CPU architectures](/platforms/mac/release-artifacts-and-architectures).
+
 For building from source with a specific architecture, see [Cross-architecture builds](/platforms/mac/building).

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -118,3 +118,11 @@ Beta and dev builds may **not** include a macOS app release. That is OK:
 
 - The git tag and npm dist-tag can still be published.
 - Call out "no macOS build for this beta" in release notes or changelog.
+
+## macOS app architecture
+
+Stable macOS releases ship as **Universal Binaries** containing both arm64 (Apple Silicon) and x86_64 (Intel) code. The app runs natively on all supported Macs without Rosetta.
+
+For users who want smaller downloads, per-architecture zips (`OpenClaw-<version>-arm64.zip`, `OpenClaw-<version>-x86_64.zip`) can be produced by setting `PER_ARCH_DIST=1` during release packaging.
+
+For building from source with a specific architecture, see [Cross-architecture builds](/platforms/mac/building).

--- a/docs/platforms/mac/building.md
+++ b/docs/platforms/mac/building.md
@@ -136,5 +136,6 @@ lipo -archs dist/OpenClaw.app/Contents/MacOS/OpenClaw
 
 ## Related Documentation
 
+- [Release artifacts & CPU architectures](/platforms/mac/release-artifacts-and-architectures) - What stable releases ship (Universal vs per-arch zips), `lipo` verification
 - [macOS Dev Setup](/platforms/mac/dev-setup) - General macOS development setup
 - [macOS Signing](/platforms/mac/signing) - Code signing for macOS builds

--- a/docs/platforms/mac/building.md
+++ b/docs/platforms/mac/building.md
@@ -1,0 +1,140 @@
+---
+summary: "Build OpenClaw macOS app for specific architectures or as Universal binaries"
+read_when:
+  - Building OpenClaw macOS app for a specific architecture
+  - Creating Universal binaries for distribution
+title: "macOS Cross-Architecture Builds"
+---
+
+# macOS Cross-Architecture Builds
+
+OpenClaw supports building the macOS app for different architectures. This guide explains how to build for Apple Silicon (arm64), Intel (x86_64), or as Universal binaries (both architectures in one package).
+
+## Architecture Overview
+
+- **Apple Silicon (arm64)**: Native on M1/M2/M3/M4 Macs
+- **Intel (x86_64)**: Native on Intel-based Macs
+- **Universal Binary**: Single app bundle containing both arm64 and x86_64 code, runs natively on all Macs
+
+## Default Build Behavior
+
+The packaging script (`scripts/package-mac-app.sh`) has sensible defaults:
+
+| Build Mode                       | Default Architecture         | When To Use                       |
+| -------------------------------- | ---------------------------- | --------------------------------- |
+| Release (`BUILD_CONFIG=release`) | Universal                    | Production releases, distribution |
+| Debug (`BUILD_CONFIG=debug`)     | Current machine (`uname -m`) | Development, testing              |
+
+## Quick Start
+
+### Default Build
+
+```bash
+# Build release (Universal binary)
+./scripts/package-mac-app.sh
+
+# Build debug (current architecture only)
+BUILD_CONFIG=debug ./scripts/package-mac-app.sh
+```
+
+### Build for Specific Architectures
+
+Use the `BUILD_ARCHS` environment variable to control which architectures to build:
+
+```bash
+# Intel-only build (useful from Apple Silicon to test Intel compatibility)
+BUILD_ARCHS="x86_64" ./scripts/package-mac-app.sh
+
+# Apple Silicon-only build (useful from Intel Mac to test ARM compatibility)
+BUILD_ARCHS="arm64" ./scripts/package-mac-app.sh
+
+# Universal debug build (both architectures, dev mode)
+BUILD_ARCHS="arm64 x86_64" BUILD_CONFIG=debug ./scripts/package-mac-app.sh
+```
+
+## Common Scenarios
+
+### Building Intel-Only from Apple Silicon
+
+If you need an Intel-only version (e.g., for a specific Intel Mac without Rosetta 2):
+
+```bash
+BUILD_ARCHS="x86_64" ./scripts/package-mac-app.sh
+```
+
+**Note**: This requires an appropriate Xcode cross-compilation setup. The Swift compiler will target x86_64 from your arm64 host.
+
+### Building Universal from Apple Silicon
+
+The standard release build is already Universal. For a Universal debug build:
+
+```bash
+BUILD_ARCHS="arm64 x86_64" BUILD_CONFIG=debug ./scripts/package-mac-app.sh
+```
+
+### Testing Both Architectures
+
+To verify your app works on both architectures:
+
+1. Build Universal binary: `./scripts/package-mac-app.sh`
+2. Verify architecture with: `file dist/OpenClaw.app/Contents/MacOS/OpenClaw`
+3. Expected output shows both architectures:
+   ```
+   dist/OpenClaw.app/Contents/MacOS/OpenClaw: Mach-O universal binary with 2 architectures
+   ```
+
+### Building Without Rosetta 2
+
+Even without Rosetta installed on Apple Silicon, you can build Intel versions:
+
+```bash
+BUILD_ARCHS="x86_64" ./scripts/package-mac-app.sh
+```
+
+The resulting app will run on Intel Macs natively, and on Apple Silicon Macs via Rosetta 2 (if installed).
+
+## Technical Details
+
+### Build Process
+
+The packaging script:
+
+1. Builds separate Swift binaries for each architecture using `swift build --arch <arch>`
+2. Merges binaries using `/usr/bin/lipo -create` if multiple architectures
+3. Handles framework merging (e.g., Sparkle.framework) across architectures
+4. Creates a single `.app` bundle
+
+### Framework Merging
+
+For Universal builds containing frameworks (like Sparkle), the script:
+
+1. Compiles frameworks for each architecture
+2. Merges Mach-O files within the framework using `lipo`
+3. Ensures the final framework contains both arm64 and x86_64 code
+
+### Binary Verification
+
+Verify the architecture of your build:
+
+```bash
+# Check the main binary
+file dist/OpenClaw.app/Contents/MacOS/OpenClaw
+
+# Check for specific architectures
+lipo -info dist/OpenClaw.app/Contents/MacOS/OpenClaw
+
+# List all architectures in the binary
+lipo -archs dist/OpenClaw.app/Contents/MacOS/OpenClaw
+```
+
+## Performance Considerations
+
+- **Universal binaries** are larger (~2x size) but provide best compatibility
+- **Single-architecture builds** are smaller and faster to compile
+- For development: use current architecture (`BUILD_CONFIG=debug`)
+- For distribution: use Universal (`BUILD_CONFIG=release`)
+
+## Related Documentation
+
+- [macOS Dev Setup](/platforms/mac/dev-setup) - General macOS development setup
+- [macOS Signing](/platforms/mac/signing) - Code signing for macOS builds

--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -32,6 +32,8 @@ To build the macOS app and package it into `dist/OpenClaw.app`, run:
 ./scripts/package-mac-app.sh
 ```
 
+This creates a Universal binary (arm64 + x86_64) by default for release builds. For debugging and testing, see the [cross-architecture builds guide](/platforms/mac/building) for options to build for specific architectures (Intel-only, Apple Silicon-only, or Universal debug builds).
+
 If you don't have an Apple Developer ID certificate, the script will automatically use **ad-hoc signing** (`-`).
 
 For dev run modes, signing flags, and Team ID troubleshooting, see the macOS app README:

--- a/docs/platforms/mac/release-artifacts-and-architectures.md
+++ b/docs/platforms/mac/release-artifacts-and-architectures.md
@@ -1,0 +1,63 @@
+---
+summary: "What architectures ship in official macOS builds, how to verify, and how maintainers produce thin (per-CPU) zips"
+read_when:
+  - Users ask for Intel (x86_64) or Universal Binary downloads
+  - Triaging GitHub issues about macOS CPU architecture
+  - Release engineering for macOS .zip / .dmg assets
+title: "macOS release artifacts & CPU architectures"
+---
+
+# macOS release artifacts & CPU architectures
+
+## For users (Intel / Apple Silicon)
+
+**Stable macOS app releases are intended to ship as a single Universal Binary**: one `OpenClaw.app` whose main executable contains **both** `arm64` (Apple Silicon) and `x86_64` (Intel). You do **not** need a separate “Intel build” for normal installs—download the standard release from [GitHub Releases](https://github.com/openclaw/openclaw/releases).
+
+### Verify locally
+
+After installing or unpacking the app:
+
+```bash
+file dist/OpenClaw.app/Contents/MacOS/OpenClaw
+# Expect: Mach-O universal binary with 2 architectures: [x86_64:arm64] (order may vary)
+
+lipo -archs dist/OpenClaw.app/Contents/MacOS/OpenClaw
+# Expect: arm64 x86_64 (order may vary)
+```
+
+If you only see one architecture, that build may be a **single-arch** artifact (debug build, custom packaging, or an intermediate)—compare with the [development channels](/install/development-channels) notes for that release.
+
+### Smaller downloads (optional)
+
+Release packaging can also emit **per-architecture zips** (`OpenClaw-<version>-arm64.zip`, `OpenClaw-<version>-x86_64.zip`) when `PER_ARCH_DIST=1` is set during `scripts/package-mac-dist.sh`. That is optional and usually for bandwidth-sensitive users; the default Universal `.zip` / `.dmg` remains the primary artifact.
+
+---
+
+## For maintainers & contributors
+
+| Piece                                                                                                                       | Role                                                                                                                                                                             |
+| --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`scripts/package-mac-app.sh`](https://github.com/openclaw/openclaw/blob/main/scripts/package-mac-app.sh)                   | Builds `OpenClaw.app`; **release** defaults to `BUILD_ARCHS=all` → `arm64 x86_64`.                                                                                               |
+| [`scripts/package-mac-dist.sh`](https://github.com/openclaw/openclaw/blob/main/scripts/package-mac-dist.sh)                 | Wraps the app script, then zips/DMG; defaults `BUILD_ARCHS=all`; enforces Universal on **release** when `BUILD_ARCHS=all`.                                                       |
+| `PER_ARCH_DIST=1`                                                                                                           | When `BUILD_ARCHS=all`, also produces thin zips via `lipo -thin`.                                                                                                                |
+| [`.github/workflows/macos-release.yml`](https://github.com/openclaw/openclaw/blob/main/.github/workflows/macos-release.yml) | **Validation-only** on the public repo: checks scripts still default to Universal; **signing/notarization/upload** runs in the private release workflow referenced in that file. |
+
+### Build Intel-only or Universal from source
+
+See [Cross-architecture builds](/platforms/mac/building). Quick examples:
+
+```bash
+# Intel-only (e.g. test on Intel without caring about arm64 slice)
+BUILD_ARCHS="x86_64" ./scripts/package-mac-app.sh
+
+# Universal release (default when BUILD_CONFIG=release)
+./scripts/package-mac-dist.sh
+```
+
+---
+
+## Related
+
+- [macOS App overview](/platforms/macos) — requirements and feature list
+- [Development channels](/install/development-channels) — stable channel + macOS app notes
+- [Cross-architecture builds](/platforms/mac/building) — `BUILD_ARCHS` reference

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -15,7 +15,7 @@ capabilities to the agent as a node.
 ## System requirements
 
 - **macOS 15 (Sequoia)** or later
-- **Architecture**: the macOS app ships as a **Universal Binary** (arm64 + x86_64) — it runs natively on both Apple Silicon and Intel Macs
+- **Architecture**: the macOS app ships as a **Universal Binary** (arm64 + x86_64) — it runs natively on both Apple Silicon and Intel Macs. Details, verification commands, and optional thin zips: [Release artifacts & CPU architectures](/platforms/mac/release-artifacts-and-architectures).
 - For building from source, see [Cross-architecture builds](/platforms/mac/building)
 
 ## What it does

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -12,6 +12,12 @@ The macOS app is the **menu‑bar companion** for OpenClaw. It owns permissions,
 manages/attaches to the Gateway locally (launchd or manual), and exposes macOS
 capabilities to the agent as a node.
 
+## System requirements
+
+- **macOS 15 (Sequoia)** or later
+- **Architecture**: the macOS app ships as a **Universal Binary** (arm64 + x86_64) — it runs natively on both Apple Silicon and Intel Macs
+- For building from source, see [Cross-architecture builds](/platforms/mac/building)
+
 ## What it does
 
 - Shows native notifications and status in the menu bar.

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 # Build and bundle OpenClaw into a minimal .app we can open.
 # Outputs to dist/OpenClaw.app
+#
+# ARCHITECTURE OPTIONS:
+# - Release builds (BUILD_CONFIG=release) create Universal binaries (arm64 + x86_64) by default
+# - Debug builds default to the current machine architecture (uname -m)
+# - Build for specific architectures with BUILD_ARCHS:
+#   BUILD_ARCHS="x86_64" - Intel-only build
+#   BUILD_ARCHS="arm64" - Apple Silicon-only build
+#   BUILD_ARCHS="arm64 x86_64" - Universal binary
+# Examples:
+#   BUILD_ARCHS="x86_64" scripts/package-mac-app.sh  # Intel-only debug build
+#   BUILD_ARCHS="arm64 x86_64" BUILD_CONFIG=debug scripts/package-mac-app.sh  # Universal debug build
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 APP_ROOT="$ROOT_DIR/dist/OpenClaw.app"
@@ -203,6 +214,17 @@ fi
 chmod +x "$APP_ROOT/Contents/MacOS/OpenClaw"
 # SwiftPM outputs ad-hoc signed binaries; strip the signature before install_name_tool to avoid warnings.
 /usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/OpenClaw" 2>/dev/null || true
+
+# Verify the final binary contains exactly the expected architectures.
+ACTUAL_ARCHS=$(/usr/bin/lipo -archs "$APP_ROOT/Contents/MacOS/OpenClaw" 2>/dev/null | tr ' ' '\n' | sort | tr '\n' ' ' | xargs)
+EXPECTED_ARCHS=$(printf '%s\n' "${BUILD_ARCHS[@]}" | sort | tr '\n' ' ' | xargs)
+if [[ "$ACTUAL_ARCHS" != "$EXPECTED_ARCHS" ]]; then
+  echo "ERROR: Architecture mismatch in final binary." >&2
+  echo "  Expected: $EXPECTED_ARCHS" >&2
+  echo "  Actual:   $ACTUAL_ARCHS" >&2
+  exit 1
+fi
+echo "✅ Binary architecture verified: $ACTUAL_ARCHS"
 
 SPARKLE_FRAMEWORK_PRIMARY="$(sparkle_framework_for_arch "$PRIMARY_ARCH")"
 if [ -d "$SPARKLE_FRAMEWORK_PRIMARY" ]; then

--- a/scripts/package-mac-dist.sh
+++ b/scripts/package-mac-dist.sh
@@ -43,6 +43,22 @@ if [[ ! -d "$APP" ]]; then
   exit 1
 fi
 
+# Verify architecture of the built binary.
+# Release builds MUST be Universal (arm64 + x86_64) unless explicitly overridden.
+APP_BINARY="$APP/Contents/MacOS/OpenClaw"
+if [[ -f "$APP_BINARY" ]]; then
+  ACTUAL_ARCHS="$(/usr/bin/lipo -archs "$APP_BINARY" 2>/dev/null || true)"
+  echo "🔍 Binary architectures: $ACTUAL_ARCHS"
+  if [[ "$BUILD_CONFIG" == "release" && "${BUILD_ARCHS}" == "all" ]]; then
+    if [[ ! "$ACTUAL_ARCHS" == *"arm64"* ]] || [[ ! "$ACTUAL_ARCHS" == *"x86_64"* ]]; then
+      echo "Error: release build is not Universal Binary (expected arm64 + x86_64, got: $ACTUAL_ARCHS)" >&2
+      echo "Set BUILD_ARCHS explicitly to override this check." >&2
+      exit 1
+    fi
+    echo "✅ Verified: Universal Binary (arm64 + x86_64)"
+  fi
+fi
+
 VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$APP/Contents/Info.plist" 2>/dev/null || echo "0.0.0")
 BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "$APP/Contents/Info.plist" 2>/dev/null || echo "")
 ACTUAL_BUNDLE_ID=$(/usr/libexec/PlistBuddy -c "Print CFBundleIdentifier" "$APP/Contents/Info.plist" 2>/dev/null || echo "")
@@ -110,6 +126,34 @@ if [[ "$SKIP_DMG" != "1" ]]; then
   fi
 else
   echo "💿 Skipping DMG (SKIP_DMG=1)"
+fi
+
+# Produce per-architecture dist artifacts alongside the Universal zip/dmg.
+# Useful for users who want smaller, single-architecture downloads.
+# Enable with PER_ARCH_DIST=1 (only meaningful for multi-arch builds).
+PER_ARCH_DIST="${PER_ARCH_DIST:-0}"
+if [[ "$PER_ARCH_DIST" == "1" && "${BUILD_ARCHS}" == "all" ]]; then
+  for THIN_ARCH in arm64 x86_64; do
+    THIN_BIN="$BUILD_ROOT/$THIN_ARCH/$BUILD_CONFIG/$PRODUCT"
+    if [[ -f "$THIN_BIN" ]]; then
+      THIN_ZIP="$ROOT_DIR/dist/OpenClaw-${VERSION}-${THIN_ARCH}.zip"
+      THIN_TMP="$(mktemp -d)"
+      mkdir -p "$THIN_TMP/OpenClaw.app/Contents/MacOS"
+      cp -R "$APP/Contents/Info.plist" "$THIN_TMP/OpenClaw.app/Contents/"
+      cp -R "$APP/Contents/Resources" "$THIN_TMP/OpenClaw.app/Contents/"
+      cp -R "$APP/Contents/Frameworks" "$THIN_TMP/OpenClaw.app/Contents/" 2>/dev/null || true
+      # Extract the single-arch slice from the Universal binary
+      /usr/bin/lipo -thin "$THIN_ARCH" "$APP_BINARY" -output "$THIN_TMP/OpenClaw.app/Contents/MacOS/OpenClaw" 2>/dev/null \
+        || cp "$THIN_BIN" "$THIN_TMP/OpenClaw.app/Contents/MacOS/OpenClaw"
+      chmod +x "$THIN_TMP/OpenClaw.app/Contents/MacOS/OpenClaw"
+      echo "📦 Per-arch zip ($THIN_ARCH): $THIN_ZIP"
+      rm -f "$THIN_ZIP"
+      ditto -c -k --sequesterRsrc --keepParent "$THIN_TMP/OpenClaw.app" "$THIN_ZIP"
+      rm -rf "$THIN_TMP"
+    else
+      echo "WARN: $THIN_ARCH binary not found at $THIN_BIN; skipping per-arch zip" >&2
+    fi
+  done
 fi
 
 if [[ "$SKIP_DSYM" != "1" ]]; then


### PR DESCRIPTION
Closes: #32451

## Summary

This PR adds explicit build-time verification and documentation for macOS Universal Binary support (arm64 + x86_64), ensuring release builds natively support both Apple Silicon and Intel Macs.

## Background

OpenClaw's macOS packaging scripts already supported Universal Binaries via `BUILD_ARCHS=all`, but there were no automated checks to:
- Verify the final binary actually contains both architectures after lipo merging
- Validate CI defaults before release packaging
- Explicitly document supported architectures in Info.plist

This addresses user requests for guaranteed x86_64/Universal Binary support by adding hard gates and comprehensive documentation.

## Changes

**Build verification:**
- `scripts/package-mac-app.sh`: Add post-lipo `lipo -archs` check; fail if `ACTUAL_ARCHS ≠ EXPECTED_ARCHS`
- `scripts/package-mac-dist.sh`: Add release-time Universal Binary gate (must include arm64 + x86_64 unless `BUILD_ARCHS` is explicitly overridden)
- `scripts/package-mac-dist.sh`: Add optional `PER_ARCH_DIST=1` mode to produce per-architecture zip artifacts alongside the Universal binary

**Bundle metadata:**
- `apps/macos/Sources/OpenClaw/Resources/Info.plist`: Add `LSArchitecturePriority` with arm64 (preferred) and x86_64 (fallback)

**CI validation:**
- `.github/workflows/macos-release.yml`: Add "Validate Universal Binary packaging defaults" step that verifies:
  - `package-mac-dist.sh` defaults `BUILD_ARCHS` to `all`
  - `package-mac-app.sh` expands `all` to `arm64 x86_64`
  - `Info.plist` declares both architectures in `LSArchitecturePriority`

**Documentation:**
- `docs/platforms/macos.md`: Add System requirements section noting Universal Binary (arm64 + x86_64) and macOS 15+ minimum
- `docs/platforms/mac/building.md`: New comprehensive guide covering `BUILD_ARCHS` usage, per-arch builds, binary verification with `lipo`, and performance considerations
- `docs/platforms/mac/dev-setup.md`: Cross-ref to building.md for architecture options
- `docs/install/development-channels.md`: Add macOS architecture section explaining Universal vs per-arch artifacts
- `docs/platforms/mac/release-artifacts-and-architectures.md`: New doc explaining release artifacts by architecture
- `docs/docs.json`: Navigation updates and redirects

## Testing

Shell syntax validated for both packaging scripts (`bash -n`). Formatting (`pnpm format`) and lint (`pnpm check`) passed. The CI validation step runs on every release preflight to catch regressions.

To test locally on macOS:

\`\`\`bash
# Verify Universal binary build (default)
./scripts/package-mac-dist.sh

# Check the binary architecture
lipo -archs dist/OpenClaw.app/Contents/MacOS/OpenClaw

# Build per-arch zips
PER_ARCH_DIST=1 ./scripts/package-mac-dist.sh
\`\`\`

## Impact

- Release builds now fail fast if they do not produce a proper Universal Binary
- CI preflight catches packaging regressions before publishing
- Users on Intel Macs get guaranteed native support without Rosetta 2
- Optional per-architecture zips allow users preferring smaller downloads to choose a single architecture

Co-Authored-By: Oz <oz-agent@warp.dev>