### PR TITLE
fix(channels): use pinned channel registry in createChannelRegistryLoader

### DIFF
--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { requireActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -13,7 +13,7 @@ export function createChannelRegistryLoader<TValue>(
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
+    const registry = requireActivePluginChannelRegistry();
     if (registry !== lastRegistry) {
       cache.clear();
       lastRegistry = registry;


### PR DESCRIPTION
## Problem

`createChannelRegistryLoader` (used by `loadChannelOutboundAdapter`) calls `getActivePluginRegistry()` which is the **unpinned** active registry. When anything triggers a transient `setActivePluginRegistry()` call — config-schema reads, `maybeBootstrapChannelPlugin`, `loadOpenClawPlugins` for non-primary contexts — the `activeRegistry` pointer changes.

When `registry !== lastRegistry`, the loader cache is cleared. The new (possibly empty or different) registry no longer contains the channel plugin, causing:

```
Outbound not configured for channel: telegram
Outbound not configured for channel: slack
```

Subagent completions silently fail to announce back. Retries all fail because the registry state persists.

## Fix

Use `requireActivePluginChannelRegistry()` — the **pinned** startup registry — matching what `getChannelPlugin()` already does. Two-line change.

## Testing

Verified locally on macOS (arm64), OpenClaw v2026.3.24, Telegram channel. Before fix: subagent announce failed consistently. After fix: announce delivers reliably.

## Related Issues

- Closes #55551
- Related: #55382 (same root cause, Slack — includes deeper analysis)
- Related: #14188 (original Telegram report, v2026.2.9)