### PR TITLE
fix: preserve Matrix inbound media filenames and paths

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -7,8 +7,17 @@ import {
 } from "./handler.test-helpers.js";
 import type { MatrixRawEvent } from "./types.js";
 
+const { downloadMatrixMediaMock } = vi.hoisted(() => ({
+  downloadMatrixMediaMock: vi.fn(),
+}));
+
+vi.mock("./media.js", () => ({
+  downloadMatrixMedia: (...args: unknown[]) => downloadMatrixMediaMock(...args),
+}));
+
 describe("createMatrixRoomMessageHandler inbound body formatting", () => {
   beforeEach(() => {
+    downloadMatrixMediaMock.mockReset();
     installMatrixMonitorTestRuntime({
       matchesMentionPatterns: () => false,
       saveMediaBuffer: vi.fn(),
@@ -120,6 +129,45 @@ describe("createMatrixRoomMessageHandler inbound body formatting", () => {
     expect(recordInboundSession).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: "agent:ops:main",
+      }),
+    );
+  });
+
+  it("appends a MEDIA tag with the saved inbound path for downloaded media", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "./media/inbound/screenshot---uuid.png",
+      contentType: "image/png",
+      placeholder: "[matrix media]",
+    });
+
+    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
+      isDirectMessage: true,
+    });
+
+    await handler("!room:example.org", {
+      type: "m.room.message",
+      sender: "@user:example.org",
+      event_id: "$image1",
+      origin_server_ts: 2,
+      content: {
+        msgtype: "m.image",
+        body: "Screenshot 2026-03-26 at 12.00.09.png",
+        url: "mxc://example/image",
+      },
+    } as MatrixRawEvent);
+
+    expect(downloadMatrixMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originalFilename: "Screenshot 2026-03-26 at 12.00.09.png",
+      }),
+    );
+    expect(recordInboundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          RawBody: expect.stringContaining("MEDIA:./media/inbound/screenshot---uuid.png"),
+          CommandBody: expect.stringContaining("MEDIA:./media/inbound/screenshot---uuid.png"),
+          MediaPath: "./media/inbound/screenshot---uuid.png",
+        }),
       }),
     );
   });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -114,21 +114,27 @@ function resolveMatrixInboundBodyText(params: {
   rawBody: string;
   filename?: string;
   mediaPlaceholder?: string;
+  mediaPath?: string;
   msgtype?: string;
   hadMediaUrl: boolean;
   mediaDownloadFailed: boolean;
 }): string {
+  let body = "";
   if (params.mediaPlaceholder) {
-    return params.rawBody || params.mediaPlaceholder;
+    body = params.rawBody || params.mediaPlaceholder;
+  } else if (!params.mediaDownloadFailed || !params.hadMediaUrl) {
+    body = params.rawBody;
+  } else {
+    body = formatMatrixMediaUnavailableText({
+      body: params.rawBody,
+      filename: params.filename,
+      msgtype: params.msgtype,
+    });
   }
-  if (!params.mediaDownloadFailed || !params.hadMediaUrl) {
-    return params.rawBody;
+  if (!params.mediaPath) {
+    return body;
   }
-  return formatMatrixMediaUnavailableText({
-    body: params.rawBody,
-    filename: params.filename,
-    msgtype: params.msgtype,
-  });
+  return body ? `${body}\nMEDIA:${params.mediaPath}` : `MEDIA:${params.mediaPath}`;
 }
 
 function resolveMatrixAllowBotsMode(value?: boolean | "mentions"): MatrixAllowBotsMode {
@@ -658,6 +664,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             sizeBytes: contentSize,
             maxBytes: mediaMaxBytes,
             file: finalContentFile,
+            originalFilename: typeof content.body === "string" ? content.body : undefined,
           });
         } catch (err) {
           mediaDownloadFailed = true;
@@ -681,6 +688,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         rawBody,
         filename: typeof content.filename === "string" ? content.filename : undefined,
         mediaPlaceholder: media?.placeholder,
+        mediaPath: media?.path,
         msgtype: content.msgtype,
         hadMediaUrl: Boolean(finalMediaUrl),
         mediaDownloadFailed,

--- a/extensions/matrix/src/matrix/monitor/media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/media.test.ts
@@ -71,6 +71,7 @@ describe("downloadMatrixMedia", () => {
       "image/png",
       "inbound",
       1024,
+      undefined,
     );
     expect(result?.path).toBe("/tmp/media");
   });
@@ -112,5 +113,29 @@ describe("downloadMatrixMedia", () => {
       maxBytes: 4096,
       readIdleTimeoutMs: 30_000,
     });
+  });
+
+  it("passes the original filename through to saveMediaBuffer", async () => {
+    const downloadContent = vi.fn().mockResolvedValue(Buffer.from("plain"));
+
+    const client = {
+      downloadContent,
+    } as unknown as import("../sdk.js").MatrixClient;
+
+    await downloadMatrixMedia({
+      client,
+      mxcUrl: "mxc://example/file",
+      contentType: "image/png",
+      maxBytes: 4096,
+      originalFilename: "Screenshot 2026-03-26 at 12.00.09.png",
+    });
+
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      Buffer.from("plain"),
+      "image/png",
+      "inbound",
+      4096,
+      "Screenshot 2026-03-26 at 12.00.09.png",
+    );
   });
 });

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -69,6 +69,7 @@ export async function downloadMatrixMedia(params: {
   sizeBytes?: number;
   maxBytes: number;
   file?: EncryptedFile;
+  originalFilename?: string;
 }): Promise<{
   path: string;
   contentType?: string;
@@ -104,6 +105,7 @@ export async function downloadMatrixMedia(params: {
     headerType,
     "inbound",
     params.maxBytes,
+    params.originalFilename,
   );
   return {
     path: saved.path,


### PR DESCRIPTION
## Summary

Preserve Matrix inbound media filenames when saving downloaded attachments, and append a `MEDIA:` tag with the saved local path to the body delivered to the agent. This lets Matrix image/file turns reuse the real inbound file on the first turn and on follow-up turns instead of guessing a nonexistent workspace path.

## Changes

- pass `originalFilename` through `downloadMatrixMedia()` into `saveMediaBuffer()`
- forward Matrix `content.body` as the original filename from the inbound handler
- append `MEDIA:{saved_path}` to inbound Matrix body text when media download succeeds
- add regression tests for filename forwarding and body `MEDIA:` path injection

## Testing

- `pnpm vitest run extensions/matrix/src/matrix/monitor/media.test.ts extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts`
- commit hook checks passed during `git commit`

Fixes openclaw/openclaw#55609