### PR TITLE
fix(feishu): fall back from synthetic tool accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - Config/Doctor: rewrite stale bundled plugin load paths from legacy `extensions/*` locations to the packaged bundled path, including directory-name mismatches and slash-suffixed config entries. (#55054) Thanks @SnowSky1.
 - WhatsApp/mentions: stop treating mentions embedded in quoted messages as direct mentions so replying to a message that @mentioned the bot no longer falsely triggers mention gating. (#52711) Thanks @lurebat.
 - Agents/ollama fallback: surface non-2xx Ollama HTTP errors with a leading status code so HTTP 503 responses trigger model fallback again. (#55214) Thanks @bugkill3r.
+- Feishu/tools: stop synthetic agent ids like `agent-spawner` from being treated as Feishu account ids during tool execution, so tools fall back to the configured/default Feishu account unless the contextual id is a real enabled Feishu account. (#55627) Thanks @MonkeyLeeT.
 
 ## 2026.3.24
 

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -126,4 +126,19 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-b");
     expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-a");
   });
+
+  test("falls back to the configured Feishu default selection when agentAccountId is not a real account", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "agent-spawner" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
+  });
 });

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -141,4 +141,33 @@ describe("feishu tool account routing", () => {
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
   });
+
+  test("does not silently fall back when the contextual account is real but uses non-env SecretRefs", async () => {
+    const { api, resolveTool } = createToolFactoryHarness({
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            a: {
+              appId: "app-a",
+              appSecret: "sec-a", // pragma: allowlist secret
+              tools: { wiki: true },
+            },
+            b: {
+              appId: "app-b",
+              appSecret: { source: "file", provider: "default", id: "feishu/b-secret" },
+              tools: { wiki: true },
+            } as never,
+          },
+        },
+      },
+    } as OpenClawPluginApi["config"]);
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "b" });
+    const result = await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(String(result.details.error ?? "")).toContain("unresolved SecretRef");
+  });
 });

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,6 +1,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { resolveFeishuRuntimeAccount } from "./accounts.js";
+import { resolveFeishuAccount, resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
 import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
@@ -21,6 +21,40 @@ function readConfiguredDefaultAccountId(config: OpenClawPluginApi["config"]): st
   return normalizeOptionalAccountId(value);
 }
 
+function resolveImplicitToolAccountId(params: {
+  api: Pick<OpenClawPluginApi, "config">;
+  executeParams?: AccountAwareParams;
+  defaultAccountId?: string;
+}): string | undefined {
+  const explicitAccountId = normalizeOptionalAccountId(params.executeParams?.accountId);
+  if (explicitAccountId) {
+    return explicitAccountId;
+  }
+
+  const configuredDefaultAccountId = readConfiguredDefaultAccountId(params.api.config);
+  if (configuredDefaultAccountId) {
+    return configuredDefaultAccountId;
+  }
+
+  const contextualAccountId = normalizeOptionalAccountId(params.defaultAccountId);
+  if (!contextualAccountId) {
+    return undefined;
+  }
+
+  const contextualAccount = resolveFeishuAccount({
+    cfg: params.api.config,
+    accountId: contextualAccountId,
+  });
+  if (contextualAccount.enabled && contextualAccount.configured) {
+    return contextualAccountId;
+  }
+
+  // Tool contexts often pass agent ids here. If that id does not resolve to a
+  // configured Feishu account, fall back to the normal default-account
+  // selection instead of erroring on a synthetic account name.
+  return undefined;
+}
+
 export function resolveFeishuToolAccount(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
@@ -31,10 +65,7 @@ export function resolveFeishuToolAccount(params: {
   }
   return resolveFeishuRuntimeAccount({
     cfg: params.api.config,
-    accountId:
-      normalizeOptionalAccountId(params.executeParams?.accountId) ??
-      readConfiguredDefaultAccountId(params.api.config) ??
-      normalizeOptionalAccountId(params.defaultAccountId),
+    accountId: resolveImplicitToolAccountId(params),
   });
 }
 

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -1,6 +1,10 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { resolveFeishuAccount, resolveFeishuRuntimeAccount } from "./accounts.js";
+import {
+  listFeishuAccountIds,
+  resolveFeishuAccount,
+  resolveFeishuRuntimeAccount,
+} from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { resolveToolsConfig } from "./tools-config.js";
 import type { FeishuToolsConfig, ResolvedFeishuAccount } from "./types.js";
@@ -41,18 +45,15 @@ function resolveImplicitToolAccountId(params: {
     return undefined;
   }
 
+  if (!listFeishuAccountIds(params.api.config).includes(contextualAccountId)) {
+    return undefined;
+  }
+
   const contextualAccount = resolveFeishuAccount({
     cfg: params.api.config,
     accountId: contextualAccountId,
   });
-  if (contextualAccount.enabled && contextualAccount.configured) {
-    return contextualAccountId;
-  }
-
-  // Tool contexts often pass agent ids here. If that id does not resolve to a
-  // configured Feishu account, fall back to the normal default-account
-  // selection instead of erroring on a synthetic account name.
-  return undefined;
+  return contextualAccount.enabled ? contextualAccountId : undefined;
 }
 
 export function resolveFeishuToolAccount(params: {


### PR DESCRIPTION
## Summary

- Problem: Feishu tools can inherit `ctx.agentAccountId` values like `agent-spawner` that are not real Feishu accounts.
- Why it matters: tool execution fails with `Feishu credentials not configured for account "agent-spawner"` even when valid Feishu account credentials are configured.
- What changed: implicit Feishu tool account resolution now only uses contextual `agentAccountId` when it resolves to an enabled/configured Feishu account; otherwise it falls back to normal Feishu default-account selection.
- What did NOT change (scope boundary): explicit `accountId` params still win, and real configured default Feishu accounts still take precedence over contextual routing.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #55345
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Feishu tool account resolution trusted `ctx.agentAccountId` as an implicit account fallback even when that value was a synthetic agent id rather than a configured Feishu account id.
- Missing detection / guardrail: tests covered real account routing and explicit overrides, but not invalid contextual account ids.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: multi-agent/tool contexts can now supply non-Feishu agent ids through the default-account path.
- If unknown, what was ruled out: explicit `accountId` override behavior and configured `channels.feishu.defaultAccount` behavior were unchanged.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/feishu/src/tool-account-routing.test.ts`
- Scenario the test should lock in: when `agentAccountId` is not a configured Feishu account, tool routing falls back to the configured/default Feishu account instead of erroring.
- Why this is the smallest reliable guardrail: it exercises the exact implicit account resolution path used by Feishu tools without requiring live Feishu network calls.
- Existing test that already covers this (if any): existing routing tests still cover real account routing and explicit overrides.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Feishu tools no longer fail on synthetic agent ids like `agent-spawner` when valid Feishu account credentials are configured.

## Diagram (if applicable)

```text
Before:
[tool ctx agentAccountId=agent-spawner] -> [treat as Feishu account] -> [missing creds error]

After:
[tool ctx agentAccountId=agent-spawner] -> [reject as implicit Feishu account] -> [fall back to configured/default Feishu account]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local dev macOS
- Runtime/container: pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu tools
- Relevant config (redacted): multi-account Feishu config with tool-enabled accounts

### Steps

1. Resolve a Feishu tool in a context whose `agentAccountId` is a synthetic agent id like `agent-spawner`.
2. Execute the tool without an explicit `accountId`.
3. Observe the chosen Feishu client account.

### Expected

- Tool falls back to the configured/default Feishu account.

### Actual

- Before this change, the tool treated the synthetic id as a Feishu account and failed with missing credentials.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: reviewed the implicit account selection path and ran the targeted Feishu routing tests.
- Edge cases checked: explicit `accountId` override still wins; configured `defaultAccount` still wins over contextual account ids.
- What you did **not** verify: live Feishu API calls.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a caller that intentionally relied on a non-Feishu contextual `agentAccountId` being treated as an account id will now fall back instead.
- Mitigation: explicit `accountId` still provides deterministic routing, and real configured Feishu accounts still route as before.
