### PR TITLE
fix(gateway): prefer transcript model in sessions list

### DIFF
--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -427,7 +427,7 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
-  test("sessions.list surfaces transcript usage fallbacks and parent child relationships", async () => {
+  test("sessions.list surfaces transcript usage and model fallbacks from the transcript", async () => {
     const { dir } = await createSessionStoreDir();
     testState.agentConfig = {
       models: {
@@ -477,7 +477,7 @@ describe("gateway server sessions", () => {
           sessionId: "sess-child",
           updatedAt: Date.now() - 1_000,
           modelProvider: "anthropic",
-          model: "claude-sonnet-4-6",
+          model: "claude-sonnet-4-5",
           parentSessionKey: "agent:main:main",
           totalTokens: 0,
           totalTokensFresh: false,
@@ -499,6 +499,8 @@ describe("gateway server sessions", () => {
         totalTokensFresh?: boolean;
         contextTokens?: number;
         estimatedCostUsd?: number;
+        modelProvider?: string;
+        model?: string;
       }>;
     }>(ws, "sessions.list", {});
 
@@ -513,6 +515,8 @@ describe("gateway server sessions", () => {
     expect(child?.totalTokensFresh).toBe(true);
     expect(child?.contextTokens).toBe(1_048_576);
     expect(child?.estimatedCostUsd).toBe(0.0042);
+    expect(child?.modelProvider).toBe("anthropic");
+    expect(child?.model).toBe("claude-sonnet-4-6");
 
     ws.close();
   });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1444,6 +1444,73 @@ describe("listSessionsFromStore search", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test("keeps the selected override model when runtime identity was intentionally cleared", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-session-utils-cleared-runtime-model-"),
+    );
+    const storePath = path.join(tmpDir, "sessions.json");
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": { params: { context1m: true } },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    fs.writeFileSync(
+      path.join(tmpDir, "sess-override.jsonl"),
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-override" }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: 2_000,
+              output: 500,
+              cacheRead: 1_200,
+              cost: { total: 0.007725 },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      const result = listSessionsFromStore({
+        cfg,
+        storePath,
+        store: {
+          "agent:main:main": {
+            sessionId: "sess-override",
+            updatedAt: now,
+            providerOverride: "openai",
+            modelOverride: "gpt-5.4",
+            totalTokens: 0,
+            totalTokensFresh: false,
+          } as SessionEntry,
+        },
+        opts: {},
+      });
+
+      expect(result.sessions[0]).toMatchObject({
+        key: "agent:main:main",
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        totalTokens: 3_200,
+        totalTokensFresh: true,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("listSessionsFromStore subagent metadata", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1511,6 +1511,71 @@ describe("listSessionsFromStore search", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test("does not replace the current runtime model when transcript fallback is only for missing pricing", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-utils-pricing-"));
+    const storePath = path.join(tmpDir, "sessions.json");
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true }],
+      },
+    } as unknown as OpenClawConfig;
+    fs.writeFileSync(
+      path.join(tmpDir, "sess-pricing.jsonl"),
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-pricing" }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: 2_000,
+              output: 500,
+              cacheRead: 1_200,
+              cost: { total: 0.007725 },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    try {
+      const result = listSessionsFromStore({
+        cfg,
+        storePath,
+        store: {
+          "agent:main:main": {
+            sessionId: "sess-pricing",
+            updatedAt: now,
+            modelProvider: "openai",
+            model: "gpt-5.4",
+            contextTokens: 200_000,
+            totalTokens: 3_200,
+            totalTokensFresh: true,
+            inputTokens: 2_000,
+            outputTokens: 500,
+            cacheRead: 1_200,
+          } as SessionEntry,
+        },
+        opts: {},
+      });
+
+      expect(result.sessions[0]).toMatchObject({
+        key: "agent:main:main",
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        totalTokens: 3_200,
+        totalTokensFresh: true,
+        contextTokens: 200_000,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("listSessionsFromStore subagent metadata", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1364,6 +1364,86 @@ describe("listSessionsFromStore search", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test("keeps a running subagent model when transcript fallback still reflects an older run", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "openclaw-session-utils-subagent-stale-model-"),
+    );
+    const storePath = path.join(tmpDir, "sessions.json");
+    const now = Date.now();
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": { params: { context1m: true } },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    fs.writeFileSync(
+      path.join(tmpDir, "sess-child-stale.jsonl"),
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-child-stale" }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: 2_000,
+              output: 500,
+              cacheRead: 1_200,
+              cost: { total: 0.007725 },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    addSubagentRunForTests({
+      runId: "run-child-live-new-model",
+      childSessionKey: "agent:main:subagent:child-live-stale-transcript",
+      controllerSessionKey: "agent:main:main",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "child task",
+      cleanup: "keep",
+      createdAt: now - 5_000,
+      startedAt: now - 4_000,
+      model: "openai/gpt-5.4",
+    });
+
+    try {
+      const result = listSessionsFromStore({
+        cfg,
+        storePath,
+        store: {
+          "agent:main:subagent:child-live-stale-transcript": {
+            sessionId: "sess-child-stale",
+            updatedAt: now,
+            spawnedBy: "agent:main:main",
+            totalTokens: 0,
+            totalTokensFresh: false,
+          } as SessionEntry,
+        },
+        opts: {},
+      });
+
+      expect(result.sessions[0]).toMatchObject({
+        key: "agent:main:subagent:child-live-stale-transcript",
+        status: "running",
+        modelProvider: "openai",
+        model: "gpt-5.4",
+        totalTokens: 3_200,
+        totalTokensFresh: true,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("listSessionsFromStore subagent metadata", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1196,17 +1196,19 @@ export function buildGatewaySessionRow(params: {
       : null;
   const preferLiveSubagentModelIdentity =
     Boolean(subagentRun?.model?.trim()) && subagentStatus === "running";
-  const preferTranscriptModelIdentity = runtimeModelPresent && !preferLiveSubagentModelIdentity;
-  const modelProvider = preferLiveSubagentModelIdentity
-    ? resolvedModel.provider
-    : (preferTranscriptModelIdentity
-        ? (transcriptUsage?.modelProvider ?? resolvedModel.provider)
-        : resolvedModel.provider);
-  const model = preferLiveSubagentModelIdentity
-    ? (resolvedModel.model ?? DEFAULT_MODEL)
-    : (preferTranscriptModelIdentity
-        ? (transcriptUsage?.model ?? resolvedModel.model ?? DEFAULT_MODEL)
-        : (resolvedModel.model ?? DEFAULT_MODEL));
+  const shouldUseTranscriptModelIdentity =
+    runtimeModelPresent && !preferLiveSubagentModelIdentity;
+  const resolvedModelIdentity = {
+    provider: resolvedModel.provider,
+    model: resolvedModel.model ?? DEFAULT_MODEL,
+  };
+  const modelIdentity = shouldUseTranscriptModelIdentity
+    ? {
+        provider: transcriptUsage?.modelProvider ?? resolvedModelIdentity.provider,
+        model: transcriptUsage?.model ?? resolvedModelIdentity.model,
+      }
+    : resolvedModelIdentity;
+  const { provider: modelProvider, model } = modelIdentity;
   const totalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
     resolvePositiveNumber(transcriptUsage?.totalTokens);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1174,6 +1174,8 @@ export function buildGatewaySessionRow(params: {
     sessionAgentId,
     subagentRun?.model,
   );
+  const runtimeModelPresent =
+    Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
   const transcriptUsage =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined ||
     resolvePositiveNumber(entry?.contextTokens) === undefined ||
@@ -1194,12 +1196,17 @@ export function buildGatewaySessionRow(params: {
       : null;
   const preferLiveSubagentModelIdentity =
     Boolean(subagentRun?.model?.trim()) && subagentStatus === "running";
+  const preferTranscriptModelIdentity = runtimeModelPresent && !preferLiveSubagentModelIdentity;
   const modelProvider = preferLiveSubagentModelIdentity
     ? resolvedModel.provider
-    : (transcriptUsage?.modelProvider ?? resolvedModel.provider);
+    : (preferTranscriptModelIdentity
+        ? (transcriptUsage?.modelProvider ?? resolvedModel.provider)
+        : resolvedModel.provider);
   const model = preferLiveSubagentModelIdentity
     ? (resolvedModel.model ?? DEFAULT_MODEL)
-    : (transcriptUsage?.model ?? resolvedModel.model ?? DEFAULT_MODEL);
+    : (preferTranscriptModelIdentity
+        ? (transcriptUsage?.model ?? resolvedModel.model ?? DEFAULT_MODEL)
+        : (resolvedModel.model ?? DEFAULT_MODEL));
   const totalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
     resolvePositiveNumber(transcriptUsage?.totalTokens);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -312,6 +312,8 @@ function resolveTranscriptUsageFallback(params: {
   totalTokens?: number;
   totalTokensFresh?: boolean;
   contextTokens?: number;
+  modelProvider?: string;
+  model?: string;
 } | null {
   const entry = params.entry;
   if (!entry?.sessionId) {
@@ -352,6 +354,8 @@ function resolveTranscriptUsageFallback(params: {
     },
   });
   return {
+    modelProvider,
+    model,
     totalTokens: resolvePositiveNumber(snapshot.totalTokens),
     totalTokensFresh: snapshot.totalTokensFresh === true,
     contextTokens: resolvePositiveNumber(contextTokens),
@@ -1170,15 +1174,13 @@ export function buildGatewaySessionRow(params: {
     sessionAgentId,
     subagentRun?.model,
   );
-  const modelProvider = resolvedModel.provider;
-  const model = resolvedModel.model ?? DEFAULT_MODEL;
   const transcriptUsage =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined ||
     resolvePositiveNumber(entry?.contextTokens) === undefined ||
     resolveEstimatedSessionCostUsd({
       cfg,
-      provider: modelProvider,
-      model,
+      provider: resolvedModel.provider,
+      model: resolvedModel.model ?? DEFAULT_MODEL,
       entry,
     }) === undefined
       ? resolveTranscriptUsageFallback({
@@ -1186,10 +1188,12 @@ export function buildGatewaySessionRow(params: {
           key,
           entry,
           storePath,
-          fallbackProvider: modelProvider,
-          fallbackModel: model,
+          fallbackProvider: resolvedModel.provider,
+          fallbackModel: resolvedModel.model ?? DEFAULT_MODEL,
         })
       : null;
+  const modelProvider = transcriptUsage?.modelProvider ?? resolvedModel.provider;
+  const model = transcriptUsage?.model ?? resolvedModel.model ?? DEFAULT_MODEL;
   const totalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
     resolvePositiveNumber(transcriptUsage?.totalTokens);

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1176,15 +1176,19 @@ export function buildGatewaySessionRow(params: {
   );
   const runtimeModelPresent =
     Boolean(entry?.model?.trim()) || Boolean(entry?.modelProvider?.trim());
-  const transcriptUsage =
-    resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined ||
-    resolvePositiveNumber(entry?.contextTokens) === undefined ||
+  const needsTranscriptTotalTokens =
+    resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) === undefined;
+  const needsTranscriptContextTokens =
+    resolvePositiveNumber(entry?.contextTokens) === undefined;
+  const needsTranscriptEstimatedCostUsd =
     resolveEstimatedSessionCostUsd({
       cfg,
       provider: resolvedModel.provider,
       model: resolvedModel.model ?? DEFAULT_MODEL,
       entry,
-    }) === undefined
+    }) === undefined;
+  const transcriptUsage =
+    needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd
       ? resolveTranscriptUsageFallback({
           cfg,
           key,
@@ -1197,7 +1201,9 @@ export function buildGatewaySessionRow(params: {
   const preferLiveSubagentModelIdentity =
     Boolean(subagentRun?.model?.trim()) && subagentStatus === "running";
   const shouldUseTranscriptModelIdentity =
-    runtimeModelPresent && !preferLiveSubagentModelIdentity;
+    runtimeModelPresent &&
+    !preferLiveSubagentModelIdentity &&
+    (needsTranscriptTotalTokens || needsTranscriptContextTokens);
   const resolvedModelIdentity = {
     provider: resolvedModel.provider,
     model: resolvedModel.model ?? DEFAULT_MODEL,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1192,8 +1192,14 @@ export function buildGatewaySessionRow(params: {
           fallbackModel: resolvedModel.model ?? DEFAULT_MODEL,
         })
       : null;
-  const modelProvider = transcriptUsage?.modelProvider ?? resolvedModel.provider;
-  const model = transcriptUsage?.model ?? resolvedModel.model ?? DEFAULT_MODEL;
+  const preferLiveSubagentModelIdentity =
+    Boolean(subagentRun?.model?.trim()) && subagentStatus === "running";
+  const modelProvider = preferLiveSubagentModelIdentity
+    ? resolvedModel.provider
+    : (transcriptUsage?.modelProvider ?? resolvedModel.provider);
+  const model = preferLiveSubagentModelIdentity
+    ? (resolvedModel.model ?? DEFAULT_MODEL)
+    : (transcriptUsage?.model ?? resolvedModel.model ?? DEFAULT_MODEL);
   const totalTokens =
     resolvePositiveNumber(resolveFreshSessionTotalTokens(entry)) ??
     resolvePositiveNumber(transcriptUsage?.totalTokens);


### PR DESCRIPTION
## Summary

- Problem: `sessions.list` can fall back to transcript-derived usage/cost/context, but still keeps model identity from the session entry.
- Why it matters: Control UI can show the wrong model in session/header state when the transcript already reflects the real runtime model but the session entry still carries stale model identity.
- What changed: transcript usage fallback now also carries transcript-derived `modelProvider`/`model`, and `buildGatewaySessionRow()` prefers that transcript model identity whenever it is already using transcript fallback data.
- What did NOT change (scope boundary): this PR does not change assistant message transcript contents or the model picker cache; it only fixes the backend session row/snapshot that powers `sessions.list` and related session metadata broadcasts.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #55272
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the gateway session row builder already read transcript usage fallback data, but discarded transcript-derived model identity and kept the session-entry model/provider instead.
- Missing detection / guardrail: the existing regression test covered transcript usage/cost/context fallback, but not model identity fallback.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: UI/session metadata increasingly depends on `sessions.list` rows, so model identity drift in those rows is visible even when transcript-derived runtime info is already available.
- If unknown, what was ruled out: the weaker UI-only model-picker cache path was reviewed and intentionally not used for this PR because it did not match the reported issue as closely.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- Scenario the test should lock in: when transcript fallback supplies the latest runtime model, `sessions.list` should surface that model instead of a stale session-entry model.
- Why this is the smallest reliable guardrail: it exercises the real gateway `sessions.list` path end-to-end against a session store plus transcript fixture.
- Existing test that already covers this (if any): the nearby transcript usage fallback test already covered tokens/cost/context; this change extends it to model identity.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Control UI session metadata backed by `sessions.list` now follows transcript-backed runtime model identity instead of stale session-entry model identity in the affected fallback case.

## Diagram (if applicable)

```text
Before:
[transcript usage fallback found] -> [tokens/context updated] -> [model kept from stale session entry]

After:
[transcript usage fallback found] -> [tokens/context updated] -> [model/provider also taken from transcript snapshot]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local dev macOS
- Runtime/container: pnpm workspace
- Model/provider: transcript fixture using anthropic model metadata
- Integration/channel (if any): gateway `sessions.list`
- Relevant config (redacted): gateway session store + transcript fixture

### Steps

1. Create a session entry with stale model identity.
2. Create a transcript whose latest assistant usage snapshot carries the real runtime model identity.
3. Call `sessions.list`.

### Expected

- Session row exposes the transcript-backed runtime model identity.

### Actual

- Before this change, the row kept the stale session-entry model while only tokens/context/cost came from transcript fallback.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: reviewed the gateway session-row builder and ran the targeted `sessions.list` regression.
- Edge cases checked: delivery-mirror transcript rows remain excluded by the transcript usage reader.
- What you did **not** verify: a live browser reproduction against the exact user config from the issue.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the fix only applies when the row already consults transcript fallback data, so a separate stale-model path outside transcript fallback could still exist.
- Mitigation: the regression test now locks in the known failing path, and the PR scope stays narrow enough to review safely.
