### PR TITLE
fix(agents): preserve original task prompt on model fallback for new sessions

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -787,6 +787,7 @@ async function agentCommandInternal(
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             sessionHasHistory: !isNewSession || (await sessionFileHasContent(sessionFile)),
+            primaryProvider: provider,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -57,6 +57,7 @@ import {
   persistSessionEntry as persistSessionEntryBase,
   prependInternalEventContext,
   runAgentAttempt,
+  sessionFileHasContent,
 } from "./command/attempt-execution.js";
 import { deliverAgentCommandResult } from "./command/delivery.js";
 import { resolveAgentRunContext } from "./command/run-context.js";
@@ -756,7 +757,7 @@ async function agentCommandInternal(
         runId,
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
-        run: (providerOverride, modelOverride, runOptions) => {
+        run: async (providerOverride, modelOverride, runOptions) => {
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;
           return runAgentAttempt({
@@ -785,7 +786,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-            sessionHasHistory: !isNewSession,
+            sessionHasHistory: !isNewSession || (await sessionFileHasContent(sessionFile)),
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -787,7 +787,6 @@ async function agentCommandInternal(
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
             sessionHasHistory: !isNewSession || (await sessionFileHasContent(sessionFile)),
-            primaryProvider: provider,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -785,6 +785,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            sessionHasHistory: !isNewSession,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { resolveFallbackRetryPrompt } from "./attempt-execution.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveFallbackRetryPrompt, sessionFileHasContent } from "./attempt-execution.js";
 
 describe("resolveFallbackRetryPrompt", () => {
   const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
@@ -58,5 +61,61 @@ describe("resolveFallbackRetryPrompt", () => {
         sessionHasHistory: false,
       }),
     ).toBe(originalBody);
+  });
+});
+
+describe("sessionFileHasContent", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oc-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false for undefined sessionFile", async () => {
+    expect(await sessionFileHasContent(undefined)).toBe(false);
+  });
+
+  it("returns false when session file does not exist", async () => {
+    expect(await sessionFileHasContent(path.join(tmpDir, "nonexistent.jsonl"))).toBe(false);
+  });
+
+  it("returns false when session file is empty", async () => {
+    const file = path.join(tmpDir, "empty.jsonl");
+    await fs.writeFile(file, "", "utf-8");
+    expect(await sessionFileHasContent(file)).toBe(false);
+  });
+
+  it("returns false when session file has only user message (no assistant flush)", async () => {
+    const file = path.join(tmpDir, "user-only.jsonl");
+    await fs.writeFile(
+      file,
+      '{"type":"session","id":"s1"}\n{"type":"message","message":{"role":"user","content":"hello"}}\n',
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(false);
+  });
+
+  it("returns true when session file has assistant message (flushed)", async () => {
+    const file = path.join(tmpDir, "with-assistant.jsonl");
+    await fs.writeFile(
+      file,
+      '{"type":"session","id":"s1"}\n{"type":"message","message":{"role":"user","content":"hello"}}\n{"type":"message","message":{"role":"assistant","content":"hi"}}\n',
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(true);
+  });
+
+  it("returns true when session file has spaced JSON (role : assistant)", async () => {
+    const file = path.join(tmpDir, "spaced.jsonl");
+    await fs.writeFile(
+      file,
+      '{"type":"message","message":{"role": "assistant","content":"hi"}}\n',
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(true);
   });
 });

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -63,31 +63,7 @@ describe("resolveFallbackRetryPrompt", () => {
     ).toBe(originalBody);
   });
 
-  it("allows prompt replay when fallback stays within the same provider", () => {
-    expect(
-      resolveFallbackRetryPrompt({
-        body: originalBody,
-        isFallbackRetry: true,
-        sessionHasHistory: false,
-        primaryProvider: "deepseek",
-        fallbackProvider: "deepseek",
-      }),
-    ).toBe(originalBody);
-  });
-
-  it("throws when replaying prompt to a different provider without history", () => {
-    expect(() =>
-      resolveFallbackRetryPrompt({
-        body: originalBody,
-        isFallbackRetry: true,
-        sessionHasHistory: false,
-        primaryProvider: "zai",
-        fallbackProvider: "deepseek",
-      }),
-    ).toThrow("Cannot replay original prompt to a different provider");
-  });
-
-  it("allows prompt replay when provider info is not supplied (defensive default)", () => {
+  it("preserves original body on fallback retry without history", () => {
     expect(
       resolveFallbackRetryPrompt({
         body: originalBody,

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -62,6 +62,40 @@ describe("resolveFallbackRetryPrompt", () => {
       }),
     ).toBe(originalBody);
   });
+
+  it("allows prompt replay when fallback stays within the same provider", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+        sessionHasHistory: false,
+        primaryProvider: "deepseek",
+        fallbackProvider: "deepseek",
+      }),
+    ).toBe(originalBody);
+  });
+
+  it("throws when replaying prompt to a different provider without history", () => {
+    expect(() =>
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+        sessionHasHistory: false,
+        primaryProvider: "zai",
+        fallbackProvider: "deepseek",
+      }),
+    ).toThrow("Cannot replay original prompt to a different provider");
+  });
+
+  it("allows prompt replay when provider info is not supplied (defensive default)", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+        sessionHasHistory: false,
+      }),
+    ).toBe(originalBody);
+  });
 });
 
 describe("sessionFileHasContent", () => {
@@ -117,5 +151,17 @@ describe("sessionFileHasContent", () => {
       "utf-8",
     );
     expect(await sessionFileHasContent(file)).toBe(true);
+  });
+
+  it("returns false when session file is a symbolic link", async () => {
+    const realFile = path.join(tmpDir, "real.jsonl");
+    await fs.writeFile(
+      realFile,
+      '{"type":"message","message":{"role":"assistant","content":"hi"}}\n',
+      "utf-8",
+    );
+    const link = path.join(tmpDir, "link.jsonl");
+    await fs.symlink(realFile, link);
+    expect(await sessionFileHasContent(link)).toBe(false);
   });
 });

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -153,6 +153,22 @@ describe("sessionFileHasContent", () => {
     expect(await sessionFileHasContent(file)).toBe(true);
   });
 
+  it("returns true when assistant message appears after large user content", async () => {
+    const file = path.join(tmpDir, "large-user.jsonl");
+    // Create a user message whose JSON line exceeds 256KB to ensure the
+    // JSONL-based parser (CWE-703 fix) finds the assistant record that a
+    // naive byte-prefix approach would miss.
+    const bigContent = "x".repeat(300 * 1024);
+    const lines =
+      [
+        `{"type":"session","id":"s1"}`,
+        `{"type":"message","message":{"role":"user","content":"${bigContent}"}}`,
+        `{"type":"message","message":{"role":"assistant","content":"done"}}`,
+      ].join("\n") + "\n";
+    await fs.writeFile(file, lines, "utf-8");
+    expect(await sessionFileHasContent(file)).toBe(true);
+  });
+
   it("returns false when session file is a symbolic link", async () => {
     const realFile = path.join(tmpDir, "real.jsonl");
     await fs.writeFile(

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { resolveFallbackRetryPrompt } from "./attempt-execution.js";
+
+describe("resolveFallbackRetryPrompt", () => {
+  const originalBody = "Summarize the quarterly earnings report and highlight key trends.";
+
+  it("returns original body on first attempt (isFallbackRetry=false)", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: false,
+      }),
+    ).toBe(originalBody);
+  });
+
+  it("returns recovery prompt for fallback retry with existing session history", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+        sessionHasHistory: true,
+      }),
+    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+  });
+
+  it("preserves original body for fallback retry when session has no history (subagent spawn)", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+        sessionHasHistory: false,
+      }),
+    ).toBe(originalBody);
+  });
+
+  it("preserves original body for fallback retry when sessionHasHistory is undefined", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: true,
+      }),
+    ).toBe(originalBody);
+  });
+
+  it("returns original body on first attempt regardless of sessionHasHistory", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: false,
+        sessionHasHistory: true,
+      }),
+    ).toBe(originalBody);
+
+    expect(
+      resolveFallbackRetryPrompt({
+        body: originalBody,
+        isFallbackRetry: false,
+        sessionHasHistory: false,
+      }),
+    ).toBe(originalBody);
+  });
+});

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import readline from "node:readline";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { normalizeReplyPayload } from "../../auto-reply/reply/normalize-reply.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
@@ -29,15 +30,20 @@ import type { AgentCommandOpts } from "./types.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
-/** Upper bound on bytes read from a session transcript for the history check. */
-const SESSION_FILE_READ_LIMIT = 256 * 1024;
+/** Maximum number of JSONL records to inspect before giving up. */
+const SESSION_FILE_MAX_RECORDS = 500;
 
 /**
  * Check whether a session transcript file exists and contains at least one
  * assistant message, indicating that the SessionManager has flushed the
  * initial user+assistant exchange to disk.  This is used to decide whether
  * a fallback retry can rely on the on-disk history or must re-send the
- * original task prompt.
+ * original prompt.
+ *
+ * The check parses JSONL records line-by-line (CWE-703) instead of relying
+ * on a raw substring match against a bounded byte prefix, which could
+ * produce false negatives when the pre-assistant content exceeds the byte
+ * limit.
  */
 export async function sessionFileHasContent(sessionFile: string | undefined): Promise<boolean> {
   if (!sessionFile) {
@@ -50,15 +56,33 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
       return false;
     }
 
-    // Bounded read: only inspect the first SESSION_FILE_READ_LIMIT bytes to
-    // prevent memory/time DoS on oversized transcripts (CWE-400).
-    const bytesToRead = Math.min(stat.size, SESSION_FILE_READ_LIMIT);
     const fh = await fs.open(sessionFile, "r");
     try {
-      const buf = Buffer.alloc(bytesToRead);
-      const { bytesRead } = await fh.read(buf, 0, bytesToRead, 0);
-      const prefix = buf.subarray(0, bytesRead).toString("utf-8");
-      return prefix.includes('"role":"assistant"') || prefix.includes('"role": "assistant"');
+      const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
+      let recordCount = 0;
+      for await (const line of rl) {
+        if (!line.trim()) {
+          continue;
+        }
+        recordCount++;
+        if (recordCount > SESSION_FILE_MAX_RECORDS) {
+          break;
+        }
+        let obj: unknown;
+        try {
+          obj = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const rec = obj as Record<string, unknown> | null;
+        if (
+          rec?.type === "message" &&
+          (rec.message as Record<string, unknown> | undefined)?.role === "assistant"
+        ) {
+          return true;
+        }
+      }
+      return false;
     } finally {
       await fh.close();
     }

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -54,8 +54,17 @@ export async function persistSessionEntry(params: PersistSessionEntryParams): Pr
 export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
+  sessionHasHistory?: boolean;
 }): string {
   if (!params.isFallbackRetry) {
+    return params.body;
+  }
+  // When the session has no persisted history (e.g. a freshly-spawned subagent
+  // whose first attempt failed before the SessionManager flushed the user
+  // message to disk), the fallback model would receive only the generic
+  // recovery prompt and lose the original task entirely.  Preserve the
+  // original body in that case so the fallback model can execute the task.
+  if (!params.sessionHasHistory) {
     return params.body;
   }
   return "Continue where you left off. The previous model attempt failed or timed out.";
@@ -257,10 +266,12 @@ export function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  sessionHasHistory?: boolean;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
+    sessionHasHistory: params.sessionHasHistory,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -117,8 +117,6 @@ export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
   sessionHasHistory?: boolean;
-  primaryProvider?: string;
-  fallbackProvider?: string;
 }): string {
   if (!params.isFallbackRetry) {
     return params.body;
@@ -129,19 +127,6 @@ export function resolveFallbackRetryPrompt(params: {
   // recovery prompt and lose the original task entirely.  Preserve the
   // original body in that case so the fallback model can execute the task.
   if (!params.sessionHasHistory) {
-    // CWE-201: avoid leaking the original (potentially sensitive) prompt to a
-    // different provider.  Only replay when the fallback stays within the same
-    // provider, or when provider information is unavailable (defensive default).
-    if (
-      params.primaryProvider &&
-      params.fallbackProvider &&
-      params.primaryProvider !== params.fallbackProvider
-    ) {
-      throw new FailoverError(
-        "Cannot replay original prompt to a different provider without persisted session history",
-        { reason: "auth" },
-      );
-    }
     return params.body;
   }
   return "Continue where you left off. The previous model attempt failed or timed out.";
@@ -344,14 +329,11 @@ export function runAgentAttempt(params: {
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
   sessionHasHistory?: boolean;
-  primaryProvider?: string;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
     sessionHasHistory: params.sessionHasHistory,
-    primaryProvider: params.primaryProvider,
-    fallbackProvider: params.providerOverride,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -29,6 +29,9 @@ import type { AgentCommandOpts } from "./types.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
+/** Upper bound on bytes read from a session transcript for the history check. */
+const SESSION_FILE_READ_LIMIT = 256 * 1024;
+
 /**
  * Check whether a session transcript file exists and contains at least one
  * assistant message, indicating that the SessionManager has flushed the
@@ -41,8 +44,24 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
     return false;
   }
   try {
-    const content = await fs.readFile(sessionFile, "utf-8");
-    return content.includes('"role":"assistant"') || content.includes('"role": "assistant"');
+    // Guard against symlink-following (CWE-400 / arbitrary-file-read vector).
+    const stat = await fs.lstat(sessionFile);
+    if (stat.isSymbolicLink()) {
+      return false;
+    }
+
+    // Bounded read: only inspect the first SESSION_FILE_READ_LIMIT bytes to
+    // prevent memory/time DoS on oversized transcripts (CWE-400).
+    const bytesToRead = Math.min(stat.size, SESSION_FILE_READ_LIMIT);
+    const fh = await fs.open(sessionFile, "r");
+    try {
+      const buf = Buffer.alloc(bytesToRead);
+      const { bytesRead } = await fh.read(buf, 0, bytesToRead, 0);
+      const prefix = buf.subarray(0, bytesRead).toString("utf-8");
+      return prefix.includes('"role":"assistant"') || prefix.includes('"role": "assistant"');
+    } finally {
+      await fh.close();
+    }
   } catch {
     return false;
   }
@@ -74,6 +93,8 @@ export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
   sessionHasHistory?: boolean;
+  primaryProvider?: string;
+  fallbackProvider?: string;
 }): string {
   if (!params.isFallbackRetry) {
     return params.body;
@@ -84,6 +105,19 @@ export function resolveFallbackRetryPrompt(params: {
   // recovery prompt and lose the original task entirely.  Preserve the
   // original body in that case so the fallback model can execute the task.
   if (!params.sessionHasHistory) {
+    // CWE-201: avoid leaking the original (potentially sensitive) prompt to a
+    // different provider.  Only replay when the fallback stays within the same
+    // provider, or when provider information is unavailable (defensive default).
+    if (
+      params.primaryProvider &&
+      params.fallbackProvider &&
+      params.primaryProvider !== params.fallbackProvider
+    ) {
+      throw new FailoverError(
+        "Cannot replay original prompt to a different provider without persisted session history",
+        { reason: "auth" },
+      );
+    }
     return params.body;
   }
   return "Continue where you left off. The previous model attempt failed or timed out.";
@@ -286,11 +320,14 @@ export function runAgentAttempt(params: {
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
   sessionHasHistory?: boolean;
+  primaryProvider?: string;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
     sessionHasHistory: params.sessionHasHistory,
+    primaryProvider: params.primaryProvider,
+    fallbackProvider: params.providerOverride,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -29,6 +29,25 @@ import type { AgentCommandOpts } from "./types.js";
 
 const log = createSubsystemLogger("agents/agent-command");
 
+/**
+ * Check whether a session transcript file exists and contains at least one
+ * assistant message, indicating that the SessionManager has flushed the
+ * initial user+assistant exchange to disk.  This is used to decide whether
+ * a fallback retry can rely on the on-disk history or must re-send the
+ * original task prompt.
+ */
+export async function sessionFileHasContent(sessionFile: string | undefined): Promise<boolean> {
+  if (!sessionFile) {
+    return false;
+  }
+  try {
+    const content = await fs.readFile(sessionFile, "utf-8");
+    return content.includes('"role":"assistant"') || content.includes('"role": "assistant"');
+  } catch {
+    return false;
+  }
+}
+
 export type PersistSessionEntryParams = {
   sessionStore: Record<string, SessionEntry>;
   sessionKey: string;


### PR DESCRIPTION
### Summary
Fixes #55581 — Preserves the original task prompt during model fallback for new sessions (like subagent spawns) instead of replacing it with a generic recovery message.

### Root Cause
1. When a model fallback occurs, `resolveFallbackRetryPrompt` replaces the original task prompt with `"Continue where you left off. The previous model attempt failed or timed out."` to prevent duplicate user messages in the session history.
2. However, for new sessions (such as those created by `sessions_spawn` for subagents), the `SessionManager` only flushes the initial user message to the transcript file *after* the first assistant response arrives.
3. If the primary model fails early (e.g., due to an authentication error or prompt rejection), the original user message is never persisted to the session history.
4. Consequently, the fallback model receives only the generic recovery message without any prior context, causing the subagent to lose its original task entirely.

### Changes
#### `src/agents/command/attempt-execution.ts`
- Added a `sessionHasHistory` parameter to `resolveFallbackRetryPrompt` and `runAgentAttempt`.
- Updated `resolveFallbackRetryPrompt` to return the original `body` instead of the recovery message when `sessionHasHistory` is false, ensuring the fallback model receives the actual task.

#### `src/agents/agent-command.ts`
- Passed `!isNewSession` as the `sessionHasHistory` argument when calling `runAgentAttempt` within the fallback loop.

#### `src/agents/command/attempt-execution.test.ts`
- Added unit tests for `resolveFallbackRetryPrompt` to verify prompt preservation logic for both new and existing sessions across initial attempts and fallback retries.

### Test Results
- Unit tests added and passing for `resolveFallbackRetryPrompt`.
- Verified that fallback retries on new sessions correctly preserve the original prompt.