### PR TITLE
fix: update cron sessionFile path on new-session rollover

### DIFF
--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -545,6 +545,61 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("rewrites sessionFile when a cron session rolls to a new session id", async () => {
+    await withTempHome(async (home) => {
+      const previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+      delete process.env.OPENCLAW_TEST_FAST;
+      try {
+        const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+        const raw = await fs.readFile(storePath, "utf-8");
+        const store = JSON.parse(raw) as Record<string, Record<string, unknown>>;
+        const oldSessionFile = path.join(
+          home,
+          ".openclaw",
+          "agents",
+          "main",
+          "sessions",
+          "old-session-id.jsonl",
+        );
+        store["agent:main:cron:job-1"] = {
+          sessionId: "old-session-id",
+          updatedAt: 0,
+          sessionFile: oldSessionFile,
+        };
+        await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+
+        const { res } = await runCronTurn(home, {
+          jobPayload: { kind: "agentTurn", message: "ping", deliver: false },
+          message: "ping",
+          mockTexts: ["ok"],
+          storePath,
+        });
+
+        const updatedRaw = await fs.readFile(storePath, "utf-8");
+        const updatedStore = JSON.parse(updatedRaw) as Record<
+          string,
+          { sessionId?: string; sessionFile?: string }
+        >;
+        const stableEntry = updatedStore["agent:main:cron:job-1"];
+        expect(res.sessionKey).toBeDefined();
+        const runSessionKey = res.sessionKey as string;
+        const runEntry = updatedStore[runSessionKey];
+
+        expect(stableEntry?.sessionId).toBe(res.sessionId);
+        expect(stableEntry?.sessionFile).toContain(`${res.sessionId}.jsonl`);
+        expect(stableEntry?.sessionFile).not.toBe(oldSessionFile);
+        expect(runEntry?.sessionId).toBe(res.sessionId);
+        expect(runEntry?.sessionFile).toBe(stableEntry?.sessionFile);
+      } finally {
+        if (previousFastTestEnv == null) {
+          delete process.env.OPENCLAW_TEST_FAST;
+        } else {
+          process.env.OPENCLAW_TEST_FAST = previousFastTestEnv;
+        }
+      }
+    });
+  });
+
   it("preserves an existing cron session label", async () => {
     await withTempHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -6,6 +6,10 @@ vi.mock("../../config/sessions.js", () => ({
   resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
   evaluateSessionFreshness: vi.fn().mockReturnValue({ fresh: true }),
   resolveSessionResetPolicy: vi.fn().mockReturnValue({ mode: "idle", idleMinutes: 60 }),
+  resolveSessionTranscriptPath: vi.fn(
+    (sessionId: string, agentId?: string) =>
+      `/tmp/agents/${agentId ?? "main"}/sessions/${sessionId}.jsonl`,
+  ),
 }));
 
 vi.mock("../../agents/bootstrap-cache.js", () => ({
@@ -18,7 +22,11 @@ vi.mock("../../agents/bootstrap-cache.js", () => ({
 }));
 
 import { clearBootstrapSnapshot } from "../../agents/bootstrap-cache.js";
-import { loadSessionStore, evaluateSessionFreshness } from "../../config/sessions.js";
+import {
+  loadSessionStore,
+  evaluateSessionFreshness,
+  resolveSessionTranscriptPath,
+} from "../../config/sessions.js";
 import { resolveCronSession } from "./session.js";
 
 const NOW_MS = 1_737_600_000_000;
@@ -52,6 +60,7 @@ function resolveWithStoredEntry(params?: {
 describe("resolveCronSession", () => {
   beforeEach(() => {
     vi.mocked(clearBootstrapSnapshot).mockReset();
+    vi.mocked(resolveSessionTranscriptPath).mockClear();
   });
 
   it("preserves modelOverride and providerOverride from existing session entry", () => {
@@ -97,6 +106,9 @@ describe("resolveCronSession", () => {
     expect(result.sessionEntry.providerOverride).toBeUndefined();
     expect(result.sessionEntry.model).toBeUndefined();
     expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.sessionFile).toBe(
+      `/tmp/agents/main/sessions/${result.sessionEntry.sessionId}.jsonl`,
+    );
   });
 
   // New tests for session reuse behavior (#18027)
@@ -123,6 +135,7 @@ describe("resolveCronSession", () => {
           sessionId: "old-session-id",
           updatedAt: NOW_MS - 86_400_000, // 1 day ago
           systemSent: true,
+          sessionFile: "/tmp/agents/main/sessions/old-session-id.jsonl",
           modelOverride: "gpt-4.1-mini",
           providerOverride: "openai",
           sendPolicy: "allow",
@@ -133,10 +146,17 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.sessionId).not.toBe("old-session-id");
       expect(result.isNewSession).toBe(true);
       expect(result.systemSent).toBe(false);
+      expect(result.sessionEntry.sessionFile).toBe(
+        `/tmp/agents/main/sessions/${result.sessionEntry.sessionId}.jsonl`,
+      );
       expect(result.sessionEntry.modelOverride).toBe("gpt-4.1-mini");
       expect(result.sessionEntry.providerOverride).toBe("openai");
       expect(result.sessionEntry.sendPolicy).toBe("allow");
       expect(clearBootstrapSnapshot).toHaveBeenCalledWith("webhook:stable-key");
+      expect(vi.mocked(resolveSessionTranscriptPath)).toHaveBeenCalledWith(
+        result.sessionEntry.sessionId,
+        "main",
+      );
     });
 
     it("creates new sessionId when forceNew is true", () => {
@@ -155,6 +175,9 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.sessionId).not.toBe("existing-session-id-456");
       expect(result.isNewSession).toBe(true);
       expect(result.systemSent).toBe(false);
+      expect(result.sessionEntry.sessionFile).toBe(
+        `/tmp/agents/main/sessions/${result.sessionEntry.sessionId}.jsonl`,
+      );
       expect(result.sessionEntry.modelOverride).toBe("sonnet-4");
       expect(result.sessionEntry.providerOverride).toBe("anthropic");
       expect(clearBootstrapSnapshot).toHaveBeenCalledWith("webhook:stable-key");
@@ -258,6 +281,9 @@ describe("resolveCronSession", () => {
 
       expect(result.sessionEntry.sessionId).toBeDefined();
       expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.sessionFile).toBe(
+        `/tmp/agents/main/sessions/${result.sessionEntry.sessionId}.jsonl`,
+      );
       // Should still preserve other fields from entry
       expect(result.sessionEntry.modelOverride).toBe("some-model");
     });

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -5,6 +5,7 @@ import {
   evaluateSessionFreshness,
   loadSessionStore,
   resolveSessionResetPolicy,
+  resolveSessionTranscriptPath,
   resolveStorePath,
   type SessionEntry,
 } from "../../config/sessions.js";
@@ -83,6 +84,7 @@ export function resolveCronSession(params: {
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      sessionFile: resolveSessionTranscriptPath(sessionId, params.agentId),
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary
- recompute `sessionFile` for any new cron session in `resolveCronSession(...)`
- preserve current-main delivery-routing cleanup on new cron sessions
- carry forward updated regression coverage on current `main`

## Validation
- `pnpm exec vitest run --config vitest.unit.config.ts src/cron/isolated-agent/session.test.ts src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit`
- repo `pnpm check` via commit hook

Supersedes stale #20188 with the same core fix re-landed on current `main`.
