### PR TITLE
fix(acp): skip text fallback when block was already routed to originating channel

### DIFF
--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -233,7 +233,8 @@ async function finalizeAcpTurnOutput(params: {
     ttsMode !== "all" &&
     hasAccumulatedBlockText &&
     !finalMediaDelivered &&
-    !params.delivery.hasDeliveredFinalReply();
+    !params.delivery.hasDeliveredFinalReply() &&
+    params.delivery.getRoutedCounts().block === 0;
   if (shouldDeliverTextFallback) {
     const delivered = await params.delivery.deliver(
       "final",


### PR DESCRIPTION
lobster-biscuit

Closes #55603

## Problem

Duplicate Telegram messages when using ACP binding with `shouldRouteToOriginating=true`. The agent's response appears twice in the Telegram topic.

## Root cause

`src/auto-reply/reply/dispatch-acp.ts:232-236` — `finalizeAcpTurnOutput` sends a text fallback when `hasDeliveredFinalReply()` is false. But `deliveredFinalReply` is only set for `kind="final"`, never for `kind="block"`. When blocks are already routed to Telegram via `routeReply()`, the accumulated text gets sent again as a duplicate "final" message.

Regression from PR #53692 (v2026.3.24) which added terminal ACP result delivery for direct chats.

## User impact

Every ACP-bound Telegram topic gets duplicate messages. Agent responds once, user sees it twice.

## Fix

Add `params.delivery.getRoutedCounts().block === 0` to the `shouldDeliverTextFallback` guard. When blocks were already delivered via `routeReply()`, the text is already visible — no fallback needed.

1 file, 1 line changed (+1 condition).

## How to verify

1. Set up ACP binding to Telegram topic with `shouldRouteToOriginating=true`
2. Send message → agent responds
3. Before: duplicate message. After: single message.

## Tests

`routedCounts.block` is incremented at `dispatch-acp-delivery.ts:186` on every routed block. The guard leverages existing tracked state — no new tracking needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)