### PR TITLE
fix(discord): skip channels claimed by other instances

### DIFF
--- a/extensions/discord/src/monitor/instance-claims.test.ts
+++ b/extensions/discord/src/monitor/instance-claims.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const store = new Map<string, string>();
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn(async () => {}),
+  readFile: vi.fn(async (path: string) => {
+    if (!store.has(path)) {
+      throw new Error("ENOENT");
+    }
+    return store.get(path) ?? "";
+  }),
+  writeFile: vi.fn(async (path: string, content: string) => {
+    store.set(path, content);
+  }),
+  rename: vi.fn(async (from: string, to: string) => {
+    const value = store.get(from);
+    if (value == null) throw new Error("ENOENT");
+    store.set(to, value);
+    store.delete(from);
+  }),
+}));
+
+describe("discord instance claims", () => {
+  beforeEach(() => {
+    store.clear();
+    vi.resetModules();
+  });
+
+  it("treats guild-wide claims as owned even when channels are not enumerated", async () => {
+    const claims = await import("./instance-claims.js");
+    const botId = "1483062961550393496";
+    const guildId = "1483039227997585439";
+
+    await claims.refreshDiscordClaims({
+      accountId: "default",
+      configPath: "/Users/test/.openclaw/openclaw.json",
+      botId,
+      guildEntries: {
+        [guildId]: {
+          id: guildId,
+          channels: {},
+        },
+      },
+    });
+
+    await expect(
+      claims.resolveDiscordClaimOwnership({
+        accountId: "default",
+        configPath: "/Users/test/.openclaw/openclaw.json",
+        botId,
+        guildId,
+        channelId: "1483321827781644319",
+      }),
+    ).resolves.toMatchObject({
+      status: "owned",
+      instanceKey: "openclaw-main",
+      matchedChannelId: guildId,
+    });
+
+    await expect(
+      claims.resolveDiscordClaimOwnership({
+        accountId: "default",
+        configPath: "/Users/test/.openclaw-rescue/openclaw.json",
+        botId,
+        guildId,
+        channelId: "1483321827781644319",
+      }),
+    ).resolves.toMatchObject({
+      status: "claimed-by-other",
+      instanceKey: "openclaw-rescue",
+      ownerInstanceKey: "openclaw-main",
+      matchedChannelId: guildId,
+    });
+  });
+
+  it("does not promote channel-scoped guild entries into guild-wide claims", async () => {
+    const claims = await import("./instance-claims.js");
+    const botId = "1483062961550393496";
+    const guildId = "1483039227997585439";
+    const mainChannel = "1483321827781644319";
+    const rescueChannel = "1483059582044606557";
+
+    await claims.refreshDiscordClaims({
+      accountId: "default",
+      configPath: "/Users/test/.openclaw/openclaw.json",
+      botId,
+      guildEntries: {
+        [guildId]: { id: guildId, channels: { [mainChannel]: {} } },
+      },
+    });
+
+    await claims.refreshDiscordClaims({
+      accountId: "default",
+      configPath: "/Users/test/.openclaw-rescue/openclaw.json",
+      botId,
+      guildEntries: {
+        [guildId]: { id: guildId, channels: { [rescueChannel]: {} } },
+      },
+    });
+
+    await expect(
+      claims.resolveDiscordClaimOwnership({
+        accountId: "default",
+        configPath: "/Users/test/.openclaw-rescue/openclaw.json",
+        botId,
+        guildId,
+        channelId: rescueChannel,
+      }),
+    ).resolves.toMatchObject({
+      status: "owned",
+      instanceKey: "openclaw-rescue",
+      matchedChannelId: rescueChannel,
+    });
+
+    await expect(
+      claims.resolveDiscordClaimOwnership({
+        accountId: "default",
+        configPath: "/Users/test/.openclaw-rescue/openclaw.json",
+        botId,
+        guildId,
+        channelId: mainChannel,
+      }),
+    ).resolves.toMatchObject({
+      status: "not-owned",
+      instanceKey: "openclaw-rescue",
+    });
+  });
+});

--- a/extensions/discord/src/monitor/instance-claims.test.ts
+++ b/extensions/discord/src/monitor/instance-claims.test.ts
@@ -15,7 +15,9 @@ vi.mock("node:fs/promises", () => ({
   }),
   rename: vi.fn(async (from: string, to: string) => {
     const value = store.get(from);
-    if (value == null) throw new Error("ENOENT");
+    if (value == null) {
+      throw new Error("ENOENT");
+    }
     store.set(to, value);
     store.delete(from);
   }),

--- a/extensions/discord/src/monitor/instance-claims.ts
+++ b/extensions/discord/src/monitor/instance-claims.ts
@@ -1,0 +1,322 @@
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+
+const DISCORD_CLAIMS_SCHEMA_VERSION = 2;
+const DISCORD_CLAIMS_TTL_MS = 90_000;
+
+export const DISCORD_CLAIMS_PATH = join(homedir(), ".discord-claims.json");
+
+export type DiscordClaimOwnership = {
+  status: "owned" | "not-owned" | "claimed-by-other" | "no-entry";
+  instanceKey: string;
+  botId?: string;
+  matchedChannelId?: string;
+  ownerInstanceKey?: string;
+};
+
+type DiscordClaimChannelEntry = {
+  updatedAt: number;
+  source: string;
+};
+
+type DiscordClaimBotEntry = {
+  updatedAt: number;
+  channels: Record<string, DiscordClaimChannelEntry>;
+  guilds: Record<string, DiscordClaimChannelEntry>;
+};
+
+type DiscordClaimInstanceEntry = {
+  updatedAt: number;
+  bots: Record<string, DiscordClaimBotEntry>;
+};
+
+type DiscordClaimsFile = {
+  version: number;
+  instances: Record<string, DiscordClaimInstanceEntry>;
+};
+
+type MinimalGuildEntry = {
+  id?: string;
+  guildId?: string;
+  channels?: Record<string, unknown>;
+};
+
+function sanitizeInstanceKey(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function resolveConfiguredInstanceId(cfg?: OpenClawConfig): string {
+  const value = (cfg as OpenClawConfig & { gateway?: { instanceId?: string } })?.gateway?.instanceId;
+  return sanitizeInstanceKey(value);
+}
+
+function deriveInstanceKeyFromConfigPath(configPath?: string): string {
+  const normalized = String(configPath ?? "").trim().replace(/\\/g, "/");
+  if (!normalized) return "";
+  const parts = normalized.split("/").filter(Boolean);
+  const parent = parts.at(-2) ?? "";
+  if (!parent) return "";
+  if (parent === ".openclaw") return "openclaw-main";
+  if (parent.startsWith(".openclaw-")) return sanitizeInstanceKey(`openclaw-${parent.slice(10)}`);
+  return sanitizeInstanceKey(parent.startsWith(".") ? parent.slice(1) : parent);
+}
+
+export function resolveDiscordInstanceKey(params: {
+  cfg?: OpenClawConfig;
+  instanceId?: string;
+  accountId?: string;
+  configPath?: string;
+}): string {
+  const explicit =
+    sanitizeInstanceKey(params.instanceId) ||
+    resolveConfiguredInstanceId(params.cfg) ||
+    sanitizeInstanceKey(process.env.OPENCLAW_INSTANCE_ID);
+  if (explicit) return explicit;
+  const fromPath =
+    deriveInstanceKeyFromConfigPath(params.configPath) ||
+    deriveInstanceKeyFromConfigPath(process.env.OPENCLAW_CONFIG_PATH);
+  if (fromPath) return fromPath;
+  return `openclaw-${sanitizeInstanceKey(params.accountId ?? "default") || "default"}`;
+}
+
+function normalizeGuildEntries(
+  guildEntries?: Record<string, MinimalGuildEntry> | MinimalGuildEntry[],
+): Record<string, MinimalGuildEntry> {
+  if (!guildEntries) return {};
+  if (!Array.isArray(guildEntries)) return guildEntries;
+  return Object.fromEntries(
+    guildEntries
+      .map((guild) => [String(guild?.id ?? guild?.guildId ?? "").trim(), guild] as const)
+      .filter(([guildId]) => Boolean(guildId)),
+  );
+}
+
+function pruneClaimChannels(
+  channels: Record<string, DiscordClaimChannelEntry> | undefined,
+  now: number,
+): Record<string, DiscordClaimChannelEntry> {
+  const next: Record<string, DiscordClaimChannelEntry> = {};
+  for (const [channelId, claim] of Object.entries(channels ?? {})) {
+    const key = String(channelId).trim();
+    if (!/^\d+$/.test(key)) continue;
+    if (!claim || now - Number(claim.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) continue;
+    next[key] = claim;
+  }
+  return next;
+}
+
+function pruneClaimsFile(data: DiscordClaimsFile, now: number): DiscordClaimsFile {
+  const next: DiscordClaimsFile = {
+    version: DISCORD_CLAIMS_SCHEMA_VERSION,
+    instances: {},
+  };
+  for (const [instanceKey, instanceEntry] of Object.entries(data.instances ?? {})) {
+    const bots: Record<string, DiscordClaimBotEntry> = {};
+    for (const [botId, botEntry] of Object.entries(instanceEntry?.bots ?? {})) {
+      const channels = pruneClaimChannels(botEntry?.channels, now);
+      const guilds = pruneClaimChannels(botEntry?.guilds, now);
+      if (
+        Object.keys(channels).length === 0 &&
+        Object.keys(guilds).length === 0 &&
+        now - Number(botEntry?.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS
+      ) {
+        continue;
+      }
+      bots[botId] = {
+        updatedAt: Number(botEntry?.updatedAt ?? now),
+        channels,
+        guilds,
+      };
+    }
+    if (Object.keys(bots).length === 0 && now - Number(instanceEntry?.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) {
+      continue;
+    }
+    next.instances[instanceKey] = {
+      updatedAt: Number(instanceEntry?.updatedAt ?? now),
+      bots,
+    };
+  }
+  return next;
+}
+
+export async function loadDiscordClaimsFile(): Promise<DiscordClaimsFile> {
+  try {
+    const raw = await readFile(DISCORD_CLAIMS_PATH, "utf8");
+    const parsed = JSON.parse(raw) as Partial<DiscordClaimsFile>;
+    if (parsed && typeof parsed === "object" && parsed.instances && typeof parsed.instances === "object") {
+      return {
+        version: typeof parsed.version === "number" ? parsed.version : DISCORD_CLAIMS_SCHEMA_VERSION,
+        instances: parsed.instances as Record<string, DiscordClaimInstanceEntry>,
+      };
+    }
+  } catch {}
+  return { version: DISCORD_CLAIMS_SCHEMA_VERSION, instances: {} };
+}
+
+async function saveDiscordClaimsFileAtomic(data: DiscordClaimsFile): Promise<void> {
+  await mkdir(dirname(DISCORD_CLAIMS_PATH), { recursive: true });
+  const tmpPath = `${DISCORD_CLAIMS_PATH}.tmp-${process.pid}`;
+  await writeFile(tmpPath, JSON.stringify(data, null, 2));
+  await rename(tmpPath, DISCORD_CLAIMS_PATH);
+}
+
+function buildClaimEntries(
+  guildEntries?: Record<string, MinimalGuildEntry> | MinimalGuildEntry[],
+  now = Date.now(),
+): {
+  channels: Record<string, DiscordClaimChannelEntry>;
+  guilds: Record<string, DiscordClaimChannelEntry>;
+} {
+  const channels: Record<string, DiscordClaimChannelEntry> = {};
+  const guilds: Record<string, DiscordClaimChannelEntry> = {};
+  for (const [guildKey, guild] of Object.entries(normalizeGuildEntries(guildEntries))) {
+    const guildId = String(guild?.id ?? guild?.guildId ?? guildKey ?? "").trim();
+    const channelEntries = guild?.channels ?? {};
+    const channelKeys = Object.keys(channelEntries);
+    const wildcardEntry = channelEntries["*"] as { allow?: boolean } | undefined;
+    const claimsEntireGuild =
+      channelKeys.length === 0 ||
+      (channelKeys.length === 1 && channelKeys[0] === "*" && wildcardEntry?.allow !== false);
+    if (/^\d+$/.test(guildId) && claimsEntireGuild) {
+      guilds[guildId] = {
+        updatedAt: now,
+        source: `guild:${guildId}`,
+      };
+    }
+    for (const channelId of channelKeys) {
+      const key = String(channelId).trim();
+      if (!/^\d+$/.test(key)) continue;
+      channels[key] = {
+        updatedAt: now,
+        source: `guild:${guildId}`,
+      };
+    }
+  }
+  return { channels, guilds };
+}
+
+export async function refreshDiscordClaims(params: {
+  cfg?: OpenClawConfig;
+  instanceId?: string;
+  accountId?: string;
+  configPath?: string;
+  botId: string;
+  guildEntries?: Record<string, MinimalGuildEntry> | MinimalGuildEntry[];
+}): Promise<{ instanceKey: string; botId: string; channelCount: number }> {
+  const instanceKey = resolveDiscordInstanceKey(params);
+  const botId = String(params.botId).trim();
+  const now = Date.now();
+  const data = pruneClaimsFile(await loadDiscordClaimsFile(), now);
+  const { channels, guilds } = buildClaimEntries(params.guildEntries, now);
+  data.instances[instanceKey] = data.instances[instanceKey] ?? { updatedAt: now, bots: {} };
+  data.instances[instanceKey].updatedAt = now;
+  data.instances[instanceKey].bots[botId] = {
+    updatedAt: now,
+    channels,
+    guilds,
+  };
+  await saveDiscordClaimsFileAtomic(data);
+  return { instanceKey, botId, channelCount: Object.keys(channels).length };
+}
+
+export async function resolveDiscordClaimOwnership(params: {
+  cfg?: OpenClawConfig;
+  instanceId?: string;
+  accountId?: string;
+  configPath?: string;
+  botId?: string;
+  guildId?: string;
+  channelId?: string;
+  parentId?: string;
+}): Promise<DiscordClaimOwnership> {
+  const instanceKey = resolveDiscordInstanceKey(params);
+  const lookupIds = [params.channelId, params.parentId]
+    .map((value) => String(value ?? "").trim())
+    .filter(Boolean);
+  if (lookupIds.length === 0 && !String(params.guildId ?? "").trim()) {
+    return { status: "no-entry", instanceKey, botId: params.botId };
+  }
+  const data = pruneClaimsFile(await loadDiscordClaimsFile(), Date.now());
+  const requestedBotId = String(params.botId ?? "").trim();
+  const requestedGuildId = String(params.guildId ?? "").trim();
+  const collectBotKeys = (bots: Record<string, DiscordClaimBotEntry>) =>
+    requestedBotId ? [requestedBotId] : Object.keys(bots);
+  const instanceEntry = data.instances[instanceKey];
+  if (instanceEntry) {
+    let sawClaims = false;
+    for (const botKey of collectBotKeys(instanceEntry.bots)) {
+      const botEntry = instanceEntry.bots[botKey];
+      if (!botEntry) continue;
+      const channels = pruneClaimChannels(botEntry.channels, Date.now());
+      const guilds = pruneClaimChannels(botEntry.guilds, Date.now());
+      if (Object.keys(channels).length === 0 && Object.keys(guilds).length === 0) continue;
+      sawClaims = true;
+      for (const lookupId of lookupIds) {
+        if (channels[lookupId]) {
+          return {
+            status: "owned",
+            instanceKey,
+            botId: botKey,
+            matchedChannelId: lookupId,
+          };
+        }
+      }
+      if (requestedGuildId && guilds[requestedGuildId]) {
+        return {
+          status: "owned",
+          instanceKey,
+          botId: botKey,
+          matchedChannelId: requestedGuildId,
+        };
+      }
+    }
+    if (sawClaims) {
+      return {
+        status: "not-owned",
+        instanceKey,
+        botId: requestedBotId || undefined,
+      };
+    }
+  }
+  for (const [otherInstanceKey, otherInstanceEntry] of Object.entries(data.instances)) {
+    if (otherInstanceKey === instanceKey) continue;
+    for (const botKey of collectBotKeys(otherInstanceEntry.bots)) {
+      const botEntry = otherInstanceEntry.bots[botKey];
+      if (!botEntry) continue;
+      const channels = pruneClaimChannels(botEntry.channels, Date.now());
+      const guilds = pruneClaimChannels(botEntry.guilds, Date.now());
+      for (const lookupId of lookupIds) {
+        if (channels[lookupId]) {
+          return {
+            status: "claimed-by-other",
+            instanceKey,
+            ownerInstanceKey: otherInstanceKey,
+            botId: botKey,
+            matchedChannelId: lookupId,
+          };
+        }
+      }
+      if (requestedGuildId && guilds[requestedGuildId]) {
+        return {
+          status: "claimed-by-other",
+          instanceKey,
+          ownerInstanceKey: otherInstanceKey,
+          botId: botKey,
+          matchedChannelId: requestedGuildId,
+        };
+      }
+    }
+  }
+  return {
+    status: "no-entry",
+    instanceKey,
+    botId: requestedBotId || undefined,
+  };
+}

--- a/extensions/discord/src/monitor/instance-claims.ts
+++ b/extensions/discord/src/monitor/instance-claims.ts
@@ -43,7 +43,7 @@ type MinimalGuildEntry = {
   channels?: Record<string, unknown>;
 };
 
-function sanitizeInstanceKey(value: unknown): string {
+function sanitizeInstanceKey(value: string | null | undefined): string {
   return String(value ?? "")
     .trim()
     .toLowerCase()
@@ -59,12 +59,20 @@ function resolveConfiguredInstanceId(cfg?: OpenClawConfig): string {
 
 function deriveInstanceKeyFromConfigPath(configPath?: string): string {
   const normalized = String(configPath ?? "").trim().replace(/\\/g, "/");
-  if (!normalized) return "";
+  if (!normalized) {
+    return "";
+  }
   const parts = normalized.split("/").filter(Boolean);
   const parent = parts.at(-2) ?? "";
-  if (!parent) return "";
-  if (parent === ".openclaw") return "openclaw-main";
-  if (parent.startsWith(".openclaw-")) return sanitizeInstanceKey(`openclaw-${parent.slice(10)}`);
+  if (!parent) {
+    return "";
+  }
+  if (parent === ".openclaw") {
+    return "openclaw-main";
+  }
+  if (parent.startsWith(".openclaw-")) {
+    return sanitizeInstanceKey(`openclaw-${parent.slice(10)}`);
+  }
   return sanitizeInstanceKey(parent.startsWith(".") ? parent.slice(1) : parent);
 }
 
@@ -78,19 +86,27 @@ export function resolveDiscordInstanceKey(params: {
     sanitizeInstanceKey(params.instanceId) ||
     resolveConfiguredInstanceId(params.cfg) ||
     sanitizeInstanceKey(process.env.OPENCLAW_INSTANCE_ID);
-  if (explicit) return explicit;
+  if (explicit) {
+    return explicit;
+  }
   const fromPath =
     deriveInstanceKeyFromConfigPath(params.configPath) ||
     deriveInstanceKeyFromConfigPath(process.env.OPENCLAW_CONFIG_PATH);
-  if (fromPath) return fromPath;
+  if (fromPath) {
+    return fromPath;
+  }
   return `openclaw-${sanitizeInstanceKey(params.accountId ?? "default") || "default"}`;
 }
 
 function normalizeGuildEntries(
   guildEntries?: Record<string, MinimalGuildEntry> | MinimalGuildEntry[],
 ): Record<string, MinimalGuildEntry> {
-  if (!guildEntries) return {};
-  if (!Array.isArray(guildEntries)) return guildEntries;
+  if (!guildEntries) {
+    return {};
+  }
+  if (!Array.isArray(guildEntries)) {
+    return guildEntries;
+  }
   return Object.fromEntries(
     guildEntries
       .map((guild) => [String(guild?.id ?? guild?.guildId ?? "").trim(), guild] as const)
@@ -105,8 +121,12 @@ function pruneClaimChannels(
   const next: Record<string, DiscordClaimChannelEntry> = {};
   for (const [channelId, claim] of Object.entries(channels ?? {})) {
     const key = String(channelId).trim();
-    if (!/^\d+$/.test(key)) continue;
-    if (!claim || now - Number(claim.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) continue;
+    if (!/^\d+$/.test(key)) {
+      continue;
+    }
+    if (!claim || now - Number(claim.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) {
+      continue;
+    }
     next[key] = claim;
   }
   return next;
@@ -153,7 +173,7 @@ export async function loadDiscordClaimsFile(): Promise<DiscordClaimsFile> {
     if (parsed && typeof parsed === "object" && parsed.instances && typeof parsed.instances === "object") {
       return {
         version: typeof parsed.version === "number" ? parsed.version : DISCORD_CLAIMS_SCHEMA_VERSION,
-        instances: parsed.instances as Record<string, DiscordClaimInstanceEntry>,
+        instances: parsed.instances,
       };
     }
   } catch {}
@@ -192,7 +212,9 @@ function buildClaimEntries(
     }
     for (const channelId of channelKeys) {
       const key = String(channelId).trim();
-      if (!/^\d+$/.test(key)) continue;
+      if (!/^\d+$/.test(key)) {
+        continue;
+      }
       channels[key] = {
         updatedAt: now,
         source: `guild:${guildId}`,
@@ -253,10 +275,14 @@ export async function resolveDiscordClaimOwnership(params: {
     let sawClaims = false;
     for (const botKey of collectBotKeys(instanceEntry.bots)) {
       const botEntry = instanceEntry.bots[botKey];
-      if (!botEntry) continue;
+      if (!botEntry) {
+        continue;
+      }
       const channels = pruneClaimChannels(botEntry.channels, Date.now());
       const guilds = pruneClaimChannels(botEntry.guilds, Date.now());
-      if (Object.keys(channels).length === 0 && Object.keys(guilds).length === 0) continue;
+      if (Object.keys(channels).length === 0 && Object.keys(guilds).length === 0) {
+        continue;
+      }
       sawClaims = true;
       for (const lookupId of lookupIds) {
         if (channels[lookupId]) {
@@ -286,10 +312,14 @@ export async function resolveDiscordClaimOwnership(params: {
     }
   }
   for (const [otherInstanceKey, otherInstanceEntry] of Object.entries(data.instances)) {
-    if (otherInstanceKey === instanceKey) continue;
+    if (otherInstanceKey === instanceKey) {
+      continue;
+    }
     for (const botKey of collectBotKeys(otherInstanceEntry.bots)) {
       const botEntry = otherInstanceEntry.bots[botKey];
-      if (!botEntry) continue;
+      if (!botEntry) {
+        continue;
+      }
       const channels = pruneClaimChannels(botEntry.channels, Date.now());
       const guilds = pruneClaimChannels(botEntry.guilds, Date.now());
       for (const lookupId of lookupIds) {

--- a/extensions/discord/src/monitor/instance-claims.ts
+++ b/extensions/discord/src/monitor/instance-claims.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 
 const DISCORD_CLAIMS_SCHEMA_VERSION = 2;
 const DISCORD_CLAIMS_TTL_MS = 90_000;

--- a/extensions/discord/src/monitor/instance-claims.ts
+++ b/extensions/discord/src/monitor/instance-claims.ts
@@ -44,7 +44,7 @@ type MinimalGuildEntry = {
 };
 
 function sanitizeInstanceKey(value: string | null | undefined): string {
-  return String(value ?? "")
+  return (value ?? "")
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9._-]+/g, "-")
@@ -58,7 +58,7 @@ function resolveConfiguredInstanceId(cfg?: OpenClawConfig): string {
 }
 
 function deriveInstanceKeyFromConfigPath(configPath?: string): string {
-  const normalized = String(configPath ?? "").trim().replace(/\\/g, "/");
+  const normalized = (configPath ?? "").trim().replace(/\\/g, "/");
   if (!normalized) {
     return "";
   }
@@ -109,7 +109,7 @@ function normalizeGuildEntries(
   }
   return Object.fromEntries(
     guildEntries
-      .map((guild) => [String(guild?.id ?? guild?.guildId ?? "").trim(), guild] as const)
+      .map((guild) => [(guild?.id ?? guild?.guildId ?? "").trim(), guild] as const)
       .filter(([guildId]) => Boolean(guildId)),
   );
 }
@@ -120,11 +120,11 @@ function pruneClaimChannels(
 ): Record<string, DiscordClaimChannelEntry> {
   const next: Record<string, DiscordClaimChannelEntry> = {};
   for (const [channelId, claim] of Object.entries(channels ?? {})) {
-    const key = String(channelId).trim();
+    const key = channelId.trim();
     if (!/^\d+$/.test(key)) {
       continue;
     }
-    if (!claim || now - Number(claim.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) {
+    if (!claim || now - claim.updatedAt > DISCORD_CLAIMS_TTL_MS) {
       continue;
     }
     next[key] = claim;
@@ -145,21 +145,21 @@ function pruneClaimsFile(data: DiscordClaimsFile, now: number): DiscordClaimsFil
       if (
         Object.keys(channels).length === 0 &&
         Object.keys(guilds).length === 0 &&
-        now - Number(botEntry?.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS
+        now - (botEntry?.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS
       ) {
         continue;
       }
       bots[botId] = {
-        updatedAt: Number(botEntry?.updatedAt ?? now),
+        updatedAt: botEntry?.updatedAt ?? now,
         channels,
         guilds,
       };
     }
-    if (Object.keys(bots).length === 0 && now - Number(instanceEntry?.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) {
+    if (Object.keys(bots).length === 0 && now - (instanceEntry?.updatedAt ?? 0) > DISCORD_CLAIMS_TTL_MS) {
       continue;
     }
     next.instances[instanceKey] = {
-      updatedAt: Number(instanceEntry?.updatedAt ?? now),
+      updatedAt: instanceEntry?.updatedAt ?? now,
       bots,
     };
   }
@@ -197,7 +197,7 @@ function buildClaimEntries(
   const channels: Record<string, DiscordClaimChannelEntry> = {};
   const guilds: Record<string, DiscordClaimChannelEntry> = {};
   for (const [guildKey, guild] of Object.entries(normalizeGuildEntries(guildEntries))) {
-    const guildId = String(guild?.id ?? guild?.guildId ?? guildKey ?? "").trim();
+    const guildId = (guild?.id ?? guild?.guildId ?? guildKey ?? "").trim();
     const channelEntries = guild?.channels ?? {};
     const channelKeys = Object.keys(channelEntries);
     const wildcardEntry = channelEntries["*"] as { allow?: boolean } | undefined;
@@ -211,7 +211,7 @@ function buildClaimEntries(
       };
     }
     for (const channelId of channelKeys) {
-      const key = String(channelId).trim();
+      const key = channelId.trim();
       if (!/^\d+$/.test(key)) {
         continue;
       }
@@ -233,7 +233,7 @@ export async function refreshDiscordClaims(params: {
   guildEntries?: Record<string, MinimalGuildEntry> | MinimalGuildEntry[];
 }): Promise<{ instanceKey: string; botId: string; channelCount: number }> {
   const instanceKey = resolveDiscordInstanceKey(params);
-  const botId = String(params.botId).trim();
+  const botId = params.botId.trim();
   const now = Date.now();
   const data = pruneClaimsFile(await loadDiscordClaimsFile(), now);
   const { channels, guilds } = buildClaimEntries(params.guildEntries, now);
@@ -260,14 +260,14 @@ export async function resolveDiscordClaimOwnership(params: {
 }): Promise<DiscordClaimOwnership> {
   const instanceKey = resolveDiscordInstanceKey(params);
   const lookupIds = [params.channelId, params.parentId]
-    .map((value) => String(value ?? "").trim())
+    .map((value) => (value ?? "").trim())
     .filter(Boolean);
-  if (lookupIds.length === 0 && !String(params.guildId ?? "").trim()) {
+  if (lookupIds.length === 0 && !(params.guildId ?? "").trim()) {
     return { status: "no-entry", instanceKey, botId: params.botId };
   }
   const data = pruneClaimsFile(await loadDiscordClaimsFile(), Date.now());
-  const requestedBotId = String(params.botId ?? "").trim();
-  const requestedGuildId = String(params.guildId ?? "").trim();
+  const requestedBotId = (params.botId ?? "").trim();
+  const requestedGuildId = (params.guildId ?? "").trim();
   const collectBotKeys = (bots: Record<string, DiscordClaimBotEntry>) =>
     requestedBotId ? [requestedBotId] : Object.keys(bots);
   const instanceEntry = data.instances[instanceKey];

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -1014,6 +1014,13 @@ export async function preflightDiscordMessage(
   logDebug(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionDecision.shouldSkip=${mentionDecision.shouldSkip} wasMentioned=${wasMentioned}`,
   );
+
+  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
+    logDebug(`[discord-preflight] drop: member not allowed`);
+    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
+    return null;
+  }
+
   if (isGuildMessage && shouldRequireMention) {
     if (botId && mentionDecision.shouldSkip) {
       logDebug(`[discord-preflight] drop: no-mention`);
@@ -1063,12 +1070,6 @@ export async function preflightDiscordMessage(
       limit: params.historyLimit,
       entry: historyEntry ?? null,
     });
-    return null;
-  }
-
-  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
-    logDebug(`[discord-preflight] drop: member not allowed`);
-    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
     return null;
   }
 

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -50,6 +50,7 @@ import {
   resolveDiscordMessageChannelId,
   resolveDiscordMessageText,
 } from "./message-utils.js";
+import { resolveDiscordClaimOwnership } from "./instance-claims.js";
 import {
   buildDiscordRoutePeer,
   resolveDiscordConversationRoute,
@@ -771,6 +772,26 @@ export async function preflightDiscordMessage(
   const threadChannelSlug = channelName ? normalizeDiscordSlug(channelName) : "";
   const threadParentSlug = threadParentName ? normalizeDiscordSlug(threadParentName) : "";
 
+  const claimOwnership = isGuildMessage
+    ? await resolveDiscordClaimOwnership({
+        cfg: params.cfg,
+        accountId: params.accountId,
+        botId: params.botUserId,
+        guildId: params.data.guild_id ?? undefined,
+        channelId: message.channelId,
+        parentId: threadParentId ?? undefined,
+      })
+    : { status: "owned" as const, instanceKey: "" };
+  if (
+    isGuildMessage &&
+    (claimOwnership.status === "not-owned" || claimOwnership.status === "claimed-by-other")
+  ) {
+    logVerbose(
+      `discord: skip channel ${message.channelId} (instance=${claimOwnership.instanceKey} owner=${claimOwnership.ownerInstanceKey ?? ""} bot=${claimOwnership.botId ?? params.botUserId ?? ""})`,
+    );
+    return null;
+  }
+
   const baseSessionKey = effectiveRoute.sessionKey;
   const channelConfig = isGuildMessage
     ? resolveDiscordChannelConfigWithFallback({
@@ -884,13 +905,6 @@ export async function preflightDiscordMessage(
     shouldRequireMention: shouldRequireMentionByConfig,
     bypassMentionRequirement,
   });
-  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
-    channelConfig,
-    guildInfo,
-    memberRoleIds,
-    sender,
-    allowNameMatching,
-  });
 
   if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
     logDebug(`[discord-preflight] drop: member not allowed`);
@@ -939,6 +953,13 @@ export async function preflightDiscordMessage(
     surface: "discord",
   });
   const hasControlCommandInMessage = hasControlCommand(baseText, params.cfg);
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig,
+    guildInfo,
+    memberRoleIds,
+    sender,
+    allowNameMatching,
+  });
 
   if (!isDirectMessage) {
     const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
@@ -1042,6 +1063,12 @@ export async function preflightDiscordMessage(
       limit: params.historyLimit,
       entry: historyEntry ?? null,
     });
+    return null;
+  }
+
+  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
+    logDebug(`[discord-preflight] drop: member not allowed`);
+    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
     return null;
   }
 

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -906,6 +906,13 @@ export async function preflightDiscordMessage(
     bypassMentionRequirement,
   });
 
+  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
+    channelConfig,
+    guildInfo,
+    memberRoleIds,
+    sender,
+    allowNameMatching,
+  });
   if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
     logDebug(`[discord-preflight] drop: member not allowed`);
     // Keep stable Discord user IDs out of routine deny-path logs.
@@ -953,13 +960,6 @@ export async function preflightDiscordMessage(
     surface: "discord",
   });
   const hasControlCommandInMessage = hasControlCommand(baseText, params.cfg);
-  const { hasAccessRestrictions, memberAllowed } = resolveDiscordMemberAccessState({
-    channelConfig,
-    guildInfo,
-    memberRoleIds,
-    sender,
-    allowNameMatching,
-  });
 
   if (!isDirectMessage) {
     const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
@@ -1015,11 +1015,6 @@ export async function preflightDiscordMessage(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionDecision.shouldSkip=${mentionDecision.shouldSkip} wasMentioned=${wasMentioned}`,
   );
 
-  if (isGuildMessage && hasAccessRestrictions && !memberAllowed) {
-    logDebug(`[discord-preflight] drop: member not allowed`);
-    logVerbose(`Blocked discord guild sender ${sender.id} (not in users/roles allowlist)`);
-    return null;
-  }
 
   if (isGuildMessage && shouldRequireMention) {
     if (botId && mentionDecision.shouldSkip) {

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -41,6 +41,7 @@ import {
   resolveDiscordSystemLocation,
   resolveTimestampMs,
 } from "./format.js";
+import { resolveDiscordClaimOwnership } from "./instance-claims.js";
 import type {
   DiscordMessagePreflightContext,
   DiscordMessagePreflightParams,
@@ -50,7 +51,6 @@ import {
   resolveDiscordMessageChannelId,
   resolveDiscordMessageText,
 } from "./message-utils.js";
-import { resolveDiscordClaimOwnership } from "./instance-claims.js";
 import {
   buildDiscordRoutePeer,
   resolveDiscordConversationRoute,
@@ -1014,7 +1014,6 @@ export async function preflightDiscordMessage(
   logDebug(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionDecision.shouldSkip=${mentionDecision.shouldSkip} wasMentioned=${wasMentioned}`,
   );
-
 
   if (isGuildMessage && shouldRequireMention) {
     if (botId && mentionDecision.shouldSkip) {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -69,6 +69,7 @@ import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
 import { buildDiscordNativeCommandContext } from "./native-command-context.js";
 import type { DispatchDiscordCommandInteractionResult } from "./native-command-dispatch.js";
 import { resolveDiscordNativeInteractionRouteState } from "./native-command-route.js";
+import { resolveDiscordClaimOwnership } from "./instance-claims.js";
 import {
   buildDiscordCommandArgMenu,
   createDiscordCommandArgFallbackButton as createDiscordCommandArgFallbackButtonUi,
@@ -369,33 +370,6 @@ function shouldBypassConfiguredAcpGuildGuards(commandName: string): boolean {
   return normalized === "new" || normalized === "reset";
 }
 
-function resolveDiscordNativeGroupDmAccess(params: {
-  isGroupDm: boolean;
-  groupEnabled?: boolean;
-  groupChannels?: string[];
-  channelId: string;
-  channelName?: string;
-  channelSlug: string;
-}): { allowed: true } | { allowed: false; reason: "disabled" | "not-allowlisted" } {
-  if (!params.isGroupDm) {
-    return { allowed: true };
-  }
-  if (params.groupEnabled === false) {
-    return { allowed: false, reason: "disabled" };
-  }
-  if (
-    !resolveGroupDmAllow({
-      channels: params.groupChannels,
-      channelId: params.channelId,
-      channelName: params.channelName,
-      channelSlug: params.channelSlug,
-    })
-  ) {
-    return { allowed: false, reason: "not-allowlisted" };
-  }
-  return { allowed: true };
-}
-
 async function resolveDiscordNativeAutocompleteAuthorized(params: {
   interaction: AutocompleteInteraction;
   cfg: OpenClawConfig;
@@ -461,6 +435,18 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
     guildId: interaction.guild?.id ?? undefined,
     guildEntries: discordConfig?.guilds,
   });
+  const claimOwnership = interaction.guild
+    ? await resolveDiscordClaimOwnership({
+        cfg,
+        accountId,
+        guildId: interaction.guild?.id,
+        channelId: rawChannelId,
+        parentId: threadParentId,
+      })
+    : { status: "owned" as const, instanceKey: "" };
+  if (claimOwnership.status === "not-owned" || claimOwnership.status === "claimed-by-other") {
+    return false;
+  }
   const channelConfig = interaction.guild
     ? resolveDiscordChannelConfigWithFallback({
         guildInfo,
@@ -516,15 +502,7 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
       return false;
     }
   }
-  const groupDmAccess = resolveDiscordNativeGroupDmAccess({
-    isGroupDm,
-    groupEnabled: discordConfig?.dm?.groupEnabled,
-    groupChannels: discordConfig?.dm?.groupChannels,
-    channelId: rawChannelId,
-    channelName,
-    channelSlug,
-  });
-  if (!groupDmAccess.allowed) {
+  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
     return false;
   }
   if (!isDirectMessage) {
@@ -840,6 +818,18 @@ async function dispatchDiscordCommandInteraction(params: {
     guildId: interaction.guild?.id ?? undefined,
     guildEntries: discordConfig?.guilds,
   });
+  const claimOwnership = interaction.guild
+    ? await resolveDiscordClaimOwnership({
+        cfg,
+        accountId,
+        guildId: interaction.guild?.id,
+        channelId: rawChannelId,
+        parentId: threadParentId,
+      })
+    : { status: "owned" as const, instanceKey: "" };
+  if (claimOwnership.status === "not-owned" || claimOwnership.status === "claimed-by-other") {
+    return;
+  }
   const channelConfig = interaction.guild
     ? resolveDiscordChannelConfigWithFallback({
         guildInfo,
@@ -990,6 +980,10 @@ async function dispatchDiscordCommandInteraction(params: {
       await respond("You are not authorized to use this command.", { ephemeral: true });
       return { accepted: false };
     }
+  }
+  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
+    await respond("Discord group DMs are disabled.");
+    return;
   }
 
   const menuNeedsModelContext =

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -1004,7 +1004,7 @@ async function dispatchDiscordCommandInteraction(params: {
       channelSlug,
     });
     if (!groupDmAllowed) {
-      await respond("This channel is not allowed.");
+      await respond("This group DM is not allowed.");
       return;
     }
   }

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -502,8 +502,19 @@ async function resolveDiscordNativeAutocompleteAuthorized(params: {
       return false;
     }
   }
-  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
-    return false;
+  if (isGroupDm) {
+    if (discordConfig?.dm?.groupEnabled === false) {
+      return false;
+    }
+    const groupDmAllowed = resolveGroupDmAllow({
+      channels: discordConfig?.dm?.groupChannels,
+      channelId: rawChannelId,
+      channelName,
+      channelSlug,
+    });
+    if (!groupDmAllowed) {
+      return false;
+    }
   }
   if (!isDirectMessage) {
     return resolveDiscordGuildNativeCommandAuthorized({
@@ -981,9 +992,21 @@ async function dispatchDiscordCommandInteraction(params: {
       return { accepted: false };
     }
   }
-  if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
-    await respond("Discord group DMs are disabled.");
-    return;
+  if (isGroupDm) {
+    if (discordConfig?.dm?.groupEnabled === false) {
+      await respond("Discord group DMs are disabled.");
+      return;
+    }
+    const groupDmAllowed = resolveGroupDmAllow({
+      channels: discordConfig?.dm?.groupChannels,
+      channelId: rawChannelId,
+      channelName,
+      channelSlug,
+    });
+    if (!groupDmAllowed) {
+      await respond("This channel is not allowed.");
+      return;
+    }
   }
 
   const menuNeedsModelContext =

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -370,6 +370,33 @@ function shouldBypassConfiguredAcpGuildGuards(commandName: string): boolean {
   return normalized === "new" || normalized === "reset";
 }
 
+function resolveDiscordNativeGroupDmAccess(params: {
+  isGroupDm: boolean;
+  groupEnabled?: boolean;
+  groupChannels?: string[];
+  channelId: string;
+  channelName?: string;
+  channelSlug: string;
+}): { allowed: true } | { allowed: false; reason: "disabled" | "not-allowlisted" } {
+  if (!params.isGroupDm) {
+    return { allowed: true };
+  }
+  if (params.groupEnabled === false) {
+    return { allowed: false, reason: "disabled" };
+  }
+  if (
+    !resolveGroupDmAllow({
+      channels: params.groupChannels,
+      channelId: params.channelId,
+      channelName: params.channelName,
+      channelSlug: params.channelSlug,
+    })
+  ) {
+    return { allowed: false, reason: "not-allowlisted" };
+  }
+  return { allowed: true };
+}
+
 async function resolveDiscordNativeAutocompleteAuthorized(params: {
   interaction: AutocompleteInteraction;
   cfg: OpenClawConfig;
@@ -839,7 +866,7 @@ async function dispatchDiscordCommandInteraction(params: {
       })
     : { status: "owned" as const, instanceKey: "" };
   if (claimOwnership.status === "not-owned" || claimOwnership.status === "claimed-by-other") {
-    return;
+    return { accepted: false };
   }
   const channelConfig = interaction.guild
     ? resolveDiscordChannelConfigWithFallback({
@@ -995,7 +1022,7 @@ async function dispatchDiscordCommandInteraction(params: {
   if (isGroupDm) {
     if (discordConfig?.dm?.groupEnabled === false) {
       await respond("Discord group DMs are disabled.");
-      return;
+      return { accepted: false };
     }
     const groupDmAllowed = resolveGroupDmAllow({
       channels: discordConfig?.dm?.groupChannels,
@@ -1005,7 +1032,7 @@ async function dispatchDiscordCommandInteraction(params: {
     });
     if (!groupDmAllowed) {
       await respond("This group DM is not allowed.");
-      return;
+      return { accepted: false };
     }
   }
 

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -87,6 +87,7 @@ import {
 } from "./provider.startup.js";
 import { resolveDiscordRestFetch } from "./rest-fetch.js";
 import { formatDiscordStartupStatusMessage } from "./startup-status.js";
+import { DISCORD_CLAIMS_PATH, refreshDiscordClaims } from "./instance-claims.js";
 import type { DiscordMonitorStatusSink } from "./status.js";
 import { formatThreadBindingDurationLabel } from "./thread-bindings.messages.js";
 
@@ -838,6 +839,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   let lifecycleStarted = false;
   let gatewaySupervisor: ReturnType<typeof createDiscordGatewaySupervisor> | undefined;
   let deactivateMessageHandler: (() => void) | undefined;
+  let claimsRefreshTimer: ReturnType<typeof setInterval> | undefined;
   let autoPresenceController: Awaited<
     ReturnType<typeof createDiscordMonitorClient>
   >["autoPresenceController"] = null;
@@ -1033,6 +1035,30 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
           details,
         }),
     });
+    try {
+      const claimsInfo = await refreshDiscordClaims({
+        cfg,
+        accountId: account.accountId,
+        botId: applicationId ?? botUserId ?? account.accountId,
+        guildEntries,
+      });
+      runtime.log?.(
+        `discord claims registered path=${DISCORD_CLAIMS_PATH} instance=${claimsInfo.instanceKey} bot=${claimsInfo.botId} channels=${claimsInfo.channelCount}`,
+      );
+    } catch (error) {
+      runtime.error?.(
+        danger(`discord claims registration failed; continuing without shared ownership claims: ${String(error)}`),
+      );
+    }
+    claimsRefreshTimer = setInterval(() => {
+      refreshDiscordClaims({
+        cfg,
+        accountId: account.accountId,
+        botId: applicationId ?? botUserId ?? account.accountId,
+        guildEntries,
+      }).catch((error) => runtime.error?.(danger(`discord claims refresh failed: ${String(error)}`)));
+    }, 30_000);
+    claimsRefreshTimer.unref?.();
     let voiceManager: DiscordVoiceManager | null = null;
 
     if (nativeDisabledExplicit) {
@@ -1159,6 +1185,10 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       gatewaySupervisor,
     });
   } finally {
+    if (claimsRefreshTimer) {
+      clearInterval(claimsRefreshTimer);
+      claimsRefreshTimer = undefined;
+    }
     deactivateMessageHandler?.();
     autoPresenceController?.stop();
     opts.setStatus?.({ connected: false });


### PR DESCRIPTION
## Summary

Add a lightweight shared Discord channel-claim registry so multi-instance deployments sharing the same bot token can silently skip channels owned by another instance instead of replying `This channel is not allowed.`.

## What changed

- add `src/discord/monitor/instance-claims.ts`
- register Discord claims on provider startup and refresh them periodically
- gate Discord slash command dispatch with per-instance channel ownership
- gate Discord message preflight with per-instance channel ownership
- add a focused test for instance-key derivation and claim ownership

## Why

Without shared ownership, a rescue/secondary instance can receive a slash interaction for a channel owned by the primary instance and reject it using its local allowlist. That causes:
- user-facing `This channel is not allowed.` on valid channels
- `already acknowledged` / `unknown interaction` on the intended owner instance

This PR makes the non-owner instance silently return instead.

## Scope

This PR intentionally does **not** change Discord interaction defer/reply timing. It only addresses cross-instance channel ownership.

## Testing

- added `src/discord/monitor.instance-claims.test.ts`
- local repo in this environment does not currently have dependencies installed, so full vitest/tsc was not runnable here
- live validation was done against two local OpenClaw instances (`~/.openclaw` + `~/.openclaw-rescue`) sharing one bot token; the incorrect deny path stopped reproducing after the claim gating patch

Closes #55651
