### PR TITLE
fix(gateway): evict empty node state from pending-work map

### DIFF
--- a/src/gateway/node-pending-work.ts
+++ b/src/gateway/node-pending-work.ts
@@ -181,6 +181,11 @@ export function acknowledgeNodePendingWork(params: { nodeId: string; itemIds: st
   if (removedItemIds.length > 0) {
     state.revision += 1;
   }
+  // Evict empty node state to prevent unbounded Map growth from
+  // disconnected nodes that never enqueue new work.
+  if (state.itemsById.size === 0) {
+    stateByNodeId.delete(nodeId);
+  }
   return { revision: state.revision, removedItemIds };
 }
 


### PR DESCRIPTION
## Summary

Evict empty `NodePendingWorkState` entries from the module-level `stateByNodeId` Map after all pending-work items are acknowledged, preventing unbounded memory growth in long-running gateway processes.

## Problem

The `stateByNodeId` Map in `src/gateway/node-pending-work.ts` grows monotonically: `getOrCreateState()` adds entries when nodes enqueue work, but `acknowledgeNodePendingWork()` only deletes individual items from the inner `itemsById` sub-map — it never removes the outer Map entry when the sub-map becomes empty.

In a long-running gateway process, every node that ever connected leaves a residual `{ revision, itemsById: Map(0) }` object in memory indefinitely.

## Steps to Reproduce

1. Start a gateway process
2. Connect N nodes, each enqueuing and acknowledging pending work
3. Disconnect all N nodes
4. Observe `getNodePendingWorkStateCountForTests()` — it returns N, not 0
5. Over weeks of operation, N grows unboundedly

## Solution

After removing acknowledged items, check if `state.itemsById.size === 0` and delete the nodeId entry from `stateByNodeId`. This keeps memory proportional to **active** nodes rather than **all-time** nodes.

## Impact

- **Scope**: `src/gateway/node-pending-work.ts` (single file, 5 lines added)
- **Risk**: Low — evicted state is reconstructed lazily by `getOrCreateState()` if the same nodeId enqueues new work
- **Breaking changes**: None — revision numbering restarts for evicted nodes, but callers already handle `revision=0`

## Type

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

- Existing `node-pending-work.test.ts` tests pass
- `getNodePendingWorkStateCountForTests()` correctly returns 0 after all items acknowledged
- `pnpm check` and `pnpm tsgo` pass with zero errors

## Analysis

Root cause: accumulator without eviction pattern. The Map acts as both registry and cache, but only the cache-layer (`itemsById`) has cleanup. Fix adds registry-layer cleanup at the natural eviction point (acknowledge).
