### PR TITLE
fix(config): apply TTL expiry to serialized session store cache

### DIFF
--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -13,7 +13,9 @@ const DEFAULT_SESSION_STORE_TTL_MS = 45_000; // 45 seconds (between 30-60s)
 const SESSION_STORE_CACHE = createExpiringMapCache<string, SessionStoreCacheEntry>({
   ttlMs: getSessionStoreTtl,
 });
-const SESSION_STORE_SERIALIZED_CACHE = new Map<string, string>();
+const SESSION_STORE_SERIALIZED_CACHE = createExpiringMapCache<string, string>({
+  ttlMs: getSessionStoreTtl,
+});
 
 export function getSessionStoreTtl(): number {
   return resolveCacheTtlMs({


### PR DESCRIPTION
## Summary

Replace the plain `Map` used for `SESSION_STORE_SERIALIZED_CACHE` with `createExpiringMapCache` so it shares the same TTL-based expiry as its companion `SESSION_STORE_CACHE`.

## Problem

In `src/config/sessions/store-cache.ts`, two caches work in tandem:
- `SESSION_STORE_CACHE` — uses `createExpiringMapCache` with a configurable TTL (default 45s)
- `SESSION_STORE_SERIALIZED_CACHE` — uses a **plain `Map`** with no expiry

While both caches are cleared together via `clearSessionStoreCaches()` and `invalidateSessionStoreCache()`, the serialized cache has no TTL-based automatic eviction. If a store path is written once but never explicitly invalidated, the serialized string remains in memory indefinitely.

## Steps to Reproduce

1. Write a session store entry via `writeSessionStoreCache()` with `serialized` data
2. Wait longer than `SESSION_STORE_TTL_MS` (default 45s)
3. `SESSION_STORE_CACHE.get(path)` returns `undefined` (expired)
4. `SESSION_STORE_SERIALIZED_CACHE.get(path)` still returns the stale string — inconsistency

## Solution

Replace `new Map<string, string>()` with `createExpiringMapCache<string, string>({ ttlMs: getSessionStoreTtl })`. The `ExpiringMapCache` API is a superset of the `Map` methods used (`.get()`, `.set()`, `.delete()`, `.clear()`), so no call-site changes are needed.

## Impact

- **Scope**: `src/config/sessions/store-cache.ts` (single file, 3 lines changed)
- **Risk**: Minimal — entries that were previously retained indefinitely now expire, which is the correct behavior
- **Breaking changes**: None

## Type

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

- `pnpm check` passes (format, lint, type-check, all boundary checks)
- `pnpm tsgo` passes
- Manual review confirms `ExpiringMapCache` API compatibility with all call sites

## Analysis

The inconsistency appears to be an oversight from when `SESSION_STORE_CACHE` was migrated to the expiring cache utility but `SESSION_STORE_SERIALIZED_CACHE` was left as a plain Map. Both caches should have identical lifetime semantics.
