### PR TITLE
fix(agents): guard parseFloat in OpenRouter pricing against NaN

### DIFF
--- a/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
+++ b/src/agents/pi-embedded-runner/openrouter-model-capabilities.ts
@@ -170,10 +170,10 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
       model.max_output_tokens ??
       8192,
     cost: {
-      input: parseFloat(model.pricing?.prompt || "0") * 1_000_000,
-      output: parseFloat(model.pricing?.completion || "0") * 1_000_000,
-      cacheRead: parseFloat(model.pricing?.input_cache_read || "0") * 1_000_000,
-      cacheWrite: parseFloat(model.pricing?.input_cache_write || "0") * 1_000_000,
+      input: (parseFloat(model.pricing?.prompt || "0") || 0) * 1_000_000,
+      output: (parseFloat(model.pricing?.completion || "0") || 0) * 1_000_000,
+      cacheRead: (parseFloat(model.pricing?.input_cache_read || "0") || 0) * 1_000_000,
+      cacheWrite: (parseFloat(model.pricing?.input_cache_write || "0") || 0) * 1_000_000,
     },
   };
 }


### PR DESCRIPTION
## Summary

Guards against `NaN` propagation in the OpenRouter pricing parser to ensure correct model cost calculations.

## Problem

The existing code had a defensive `|| "0"` fallback on the input:

```typescript
input: parseFloat(pricing.prompt || "0"),
output: parseFloat(pricing.completion || "0"),
```

However, this only guards against `undefined`/`null`/empty-string values. If pricing strings contain non-numeric but truthy values like `"free"`, `"N/A"`, or `"coming soon"`, `parseFloat` returns `NaN`, causing:

- **Poisoned cost comparisons**: `NaN < 0.001` is `false`, `NaN > 0.001` is also `false`
- **Broken model selection**: Cost-based model ranking becomes unreliable
- **Silent failures**: No error thrown, just wrong behavior

## Solution

Add `|| 0` after each `parseFloat` call to collapse `NaN` to `0`:

```typescript
input: parseFloat(pricing.prompt || "0") || 0,
output: parseFloat(pricing.completion || "0") || 0,
cacheRead: parseFloat(pricing.request || "0") || 0,
cacheWrite: parseFloat(pricing.response || "0") || 0,
```

**Why this works**: In JavaScript, `NaN` is falsy, so `NaN || 0 === 0`.

## Behavior Analysis

| Input | `parseFloat(input)` | `\|\| 0` Result |
|-------|---------------------|-----------------|
| `"0.00001"` | `0.00001` | `0.00001` |
| `"0"` | `0` | `0` |
| `""` (guarded) | `0` | `0` |
| `"free"` | `NaN` | `0` |
| `"N/A"` | `NaN` | `0` |
| `"coming soon"` | `NaN` | `0` |

## Security Properties

- ✅ **No behavioral regression**: Valid numeric pricing parses correctly
- ✅ **Safe default**: Unparseable pricing defaults to `0` (free), not expensive
- ✅ **Consistent across fields**: All four pricing fields guarded identically
- ✅ **Minimal scope**: Single function, no side effects

## Testing

- `pnpm check` ✅
- `pnpm tsgo` ✅

## Files Changed

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/openrouter-model-capabilities.ts` | Add `\|\| 0` fallback to all four `parseFloat` calls |
