### PR TITLE
fix(feishu): guard parseInt in merge_forward sort against NaN

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -215,7 +215,7 @@ export function parseMergeForwardContent(params: { content: string; log?: Feishu
 
   log?.(`feishu: merge_forward contains ${subMessages.length} sub-messages`);
   subMessages.sort(
-    (a, b) => parseInt(a.create_time || "0", 10) - parseInt(b.create_time || "0", 10),
+    (a, b) => (parseInt(a.create_time || "0", 10) || 0) - (parseInt(b.create_time || "0", 10) || 0),
   );
 
   const lines = ["[Merged and Forwarded Messages]"];


### PR DESCRIPTION
## Summary

Guards against `NaN` propagation in the Feishu `parseMergeForwardContent` sort comparator to ensure consistent message ordering.

## Problem

The existing code had a defensive `|| "0"` fallback on the input:

```typescript
(parseInt(a.create_time || "0") - parseInt(b.create_time || "0"))
```

However, this only guards against `undefined`/`null`/empty-string values. If `create_time` contains a non-numeric but truthy string like `"abc"` or `"invalid"`, `parseInt` returns `NaN`, causing:

- **Undefined sort order**: `NaN` comparisons are implementation-defined
- **Inconsistent behavior**: Message order becomes unpredictable

## Solution

Add `|| 0` after each `parseInt` call to collapse `NaN` to `0`:

```typescript
((parseInt(a.create_time || "0") || 0) - (parseInt(b.create_time || "0") || 0))
```

**Why this works**: In JavaScript, `NaN` is falsy, so `NaN || 0 === 0`.

## Behavior Analysis

| Input | `parseInt(input)` | `\|\| 0` Result |
|-------|-------------------|-----------------|
| `"123"` | `123` | `123` |
| `"0"` | `0` | `0` |
| `""` (guarded) | `0` | `0` |
| `undefined` (guarded) | `0` | `0` |
| `"abc"` | `NaN` | `0` |
| `"N/A"` | `NaN` | `0` |

## Security Properties

- ✅ **No behavioral regression**: Valid numeric strings parse correctly
- ✅ **Consistent sorting**: Malformed timestamps sort as oldest (0)
- ✅ **Minimal scope**: Single-line change with no API surface impact

## Testing

- `pnpm check` ✅
- `pnpm tsgo` ✅

## Files Changed

| File | Change |
|------|--------|
| `extensions/feishu/src/bot-content.ts` | Add `\|\| 0` fallback to sort comparator |
