### PR TITLE
fix(voice-call): wrap JSON.parse in try-catch for API responses

### DIFF
--- a/extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
@@ -103,4 +103,31 @@ describe("guardedJsonApiRequest", () => {
 
     expect(release).toHaveBeenCalledTimes(1);
   });
+
+  it("throws descriptive error when response is 200 OK but body is not valid JSON", async () => {
+    const release = vi.fn(async () => {});
+    const htmlBody = "<html><body>Service Unavailable</body></html>";
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(htmlBody, {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      }),
+      release,
+    });
+
+    await expect(
+      guardedJsonApiRequest({
+        url: "https://api.example.com/v1/calls/4",
+        method: "GET",
+        headers: {},
+        allowedHostnames: ["api.example.com"],
+        auditContext: "voice-call:test",
+        errorPrefix: "Acme API error",
+      }),
+    ).rejects.toThrow(
+      "Acme API error: invalid JSON response: <html><body>Service Unavailable</body></html>",
+    );
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/voice-call/src/providers/shared/guarded-json-api.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.ts
@@ -35,7 +35,14 @@ export async function guardedJsonApiRequest<T = unknown>(
     }
 
     const text = await response.text();
-    return text ? (JSON.parse(text) as T) : (undefined as T);
+    if (!text) {
+      return undefined as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(`${params.errorPrefix}: invalid JSON response: ${text.slice(0, 200)}`);
+    }
   } finally {
     await release();
   }

--- a/extensions/voice-call/src/providers/twilio/api.ts
+++ b/extensions/voice-call/src/providers/twilio/api.ts
@@ -38,5 +38,12 @@ export async function twilioApiRequest<T = unknown>(params: {
   }
 
   const text = await response.text();
-  return text ? (JSON.parse(text) as T) : (undefined as T);
+  if (!text) {
+    return undefined as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new Error(`Twilio API returned invalid JSON: ${text.slice(0, 200)}`);
+  }
 }


### PR DESCRIPTION
## Summary

Wrap bare `JSON.parse()` calls in the voice-call extension's API helpers with try-catch blocks to produce descriptive errors when upstream APIs return non-JSON content.

## Problem

In `extensions/voice-call/src/providers/`, both `twilioApiRequest` and `guardedJsonApiRequest` parse response bodies with bare `JSON.parse(text)`. When the upstream API returns non-JSON content (e.g. an HTML error page during maintenance, an XML fault, or a truncated response), this throws a generic `SyntaxError: Unexpected token '<'` with no context about what the server actually returned.

**Affected files:**
- `extensions/voice-call/src/providers/twilio/api.ts`
- `extensions/voice-call/src/providers/shared/guarded-json-api.ts`

## Steps to Reproduce

1. Upstream API (Twilio or any provider using guardedJsonApiRequest) returns an HTML error page
2. `response.ok` is true (200) but body is `<html>Service Unavailable</html>`
3. `JSON.parse(text)` throws `SyntaxError: Unexpected token '<'`
4. Error propagates with no indication of what the server returned
5. Debugging requires adding ad-hoc logging to reproduce

## Solution

Wrap each `JSON.parse()` call in a try-catch that includes the first 200 characters of the response body:

```ts
// twilioApiRequest
try {
  return JSON.parse(text) as T;
} catch {
  throw new Error(`Twilio API returned invalid JSON: ${text.slice(0, 200)}`);
}

// guardedJsonApiRequest
try {
  return JSON.parse(text) as T;
} catch {
  throw new Error(`${params.errorPrefix}: invalid JSON response: ${text.slice(0, 200)}`);
}
```

## Impact

- **Scope**: 2 files in `extensions/voice-call/src/providers/` (43 lines added, 2 removed)
- **Risk**: Minimal — only changes error message content, not control flow
- **Breaking changes**: None — callers already catch errors from these functions

## Type

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

```bash
# All tests pass
pnpm test -- extensions/voice-call/src/providers/shared/guarded-json-api.test.ts
# ✓ 4 tests passed

# Type checking passes
pnpm tsgo
# No errors

# Full check suite passes
pnpm check
# All checks pass
```

**Test coverage:** Added a new test case `throws descriptive error when response is 200 OK but body is not valid JSON` that verifies the new error handling path.

## Analysis

This is a defensive coding improvement addressing a common debugging pain point. The 200-character limit in the error message prevents accidentally logging enormous response bodies while providing enough context for diagnosis.

**Root cause:** Both functions assumed upstream APIs always return valid JSON on success (HTTP 2xx), but this assumption fails during:
- API maintenance windows returning HTML pages
- Load balancer errors returning default pages
- Network issues causing truncated responses
- Misconfigured reverse proxies

**Why this approach:**
1. Preserves existing behavior for valid JSON responses
2. Fails fast with actionable error messages for invalid JSON
3. Truncation prevents log pollution from large HTML error pages
4. Uses existing `errorPrefix` parameter in guardedJsonApiRequest for consistency
