### PR TITLE
fix(agents): preserve subagent task across model fallback retry

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -785,6 +785,7 @@ async function agentCommandInternal(
             sessionStore,
             storePath,
             allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            runStartedAt: startedAt,
             onAgentEvent: (evt) => {
               // Track lifecycle end for fallback emission below.
               if (

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveFallbackRetryPrompt } from "./attempt-execution.js";
+
+const tempDirs: string[] = [];
+
+async function createSessionFile(
+  messages: Array<{ role: string; content: string; timestamp: number }>,
+) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-execution-"));
+  tempDirs.push(dir);
+  const sessionFile = path.join(dir, "session.jsonl");
+  const lines = [
+    JSON.stringify({
+      type: "session",
+      version: 7,
+      id: "session-1",
+      timestamp: new Date().toISOString(),
+      cwd: dir,
+    }),
+  ];
+  let parentId: string | null = null;
+  for (const [index, message] of messages.entries()) {
+    const id = `msg-${index + 1}`;
+    lines.push(
+      JSON.stringify({
+        type: "message",
+        id,
+        parentId,
+        timestamp: new Date(message.timestamp).toISOString(),
+        message: {
+          role: message.role,
+          content: message.content,
+        },
+      }),
+    );
+    parentId = id;
+  }
+  await fs.writeFile(sessionFile, `${lines.join("\n")}\n`, "utf-8");
+  return sessionFile;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("resolveFallbackRetryPrompt", () => {
+  it("keeps the original prompt when this run has not persisted it yet", async () => {
+    const sessionFile = await createSessionFile([
+      { role: "user", content: "older prompt", timestamp: 1_000 },
+      { role: "assistant", content: "done", timestamp: 1_100 },
+    ]);
+
+    expect(
+      resolveFallbackRetryPrompt({
+        body: "new task",
+        isFallbackRetry: true,
+        runStartedAt: 2_000,
+        sessionFile,
+      }),
+    ).toBe("new task");
+  });
+
+  it("uses the resume prompt when the current run already wrote the same user turn", async () => {
+    const sessionFile = await createSessionFile([
+      { role: "user", content: "new task", timestamp: 2_100 },
+    ]);
+
+    expect(
+      resolveFallbackRetryPrompt({
+        body: "new task",
+        isFallbackRetry: true,
+        runStartedAt: 2_000,
+        sessionFile,
+      }),
+    ).toBe("Continue where you left off. The previous model attempt failed or timed out.");
+  });
+
+  it("keeps the original prompt when the transcript file does not exist", () => {
+    expect(
+      resolveFallbackRetryPrompt({
+        body: "new task",
+        isFallbackRetry: true,
+        runStartedAt: 2_000,
+        sessionFile: path.join(os.tmpdir(), "openclaw-missing-session.jsonl"),
+      }),
+    ).toBe("new task");
+  });
+});

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1,3 +1,4 @@
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { normalizeReplyPayload } from "../../auto-reply/reply/normalize-reply.js";
@@ -54,11 +55,45 @@ export async function persistSessionEntry(params: PersistSessionEntryParams): Pr
 export function resolveFallbackRetryPrompt(params: {
   body: string;
   isFallbackRetry: boolean;
+  runStartedAt: number;
+  sessionFile: string;
 }): string {
   if (!params.isFallbackRetry) {
     return params.body;
   }
-  return "Continue where you left off. The previous model attempt failed or timed out.";
+  try {
+    const raw = nodeFs.readFileSync(params.sessionFile, "utf-8");
+    const lines = raw.split(/\r?\n/);
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      const line = lines[index]?.trim();
+      if (!line) {
+        continue;
+      }
+      const parsed = JSON.parse(line) as {
+        type?: unknown;
+        timestamp?: unknown;
+        message?: { role?: unknown; content?: unknown };
+      };
+      if (parsed.type !== "message" || parsed.message?.role !== "user") {
+        continue;
+      }
+      const timestamp =
+        typeof parsed.timestamp === "number"
+          ? parsed.timestamp
+          : typeof parsed.timestamp === "string"
+            ? Date.parse(parsed.timestamp)
+            : Number.NaN;
+      if (!Number.isFinite(timestamp) || timestamp < params.runStartedAt) {
+        break;
+      }
+      if (parsed.message.content === params.body) {
+        return "Continue where you left off. The previous model attempt failed or timed out.";
+      }
+    }
+  } catch {
+    return params.body;
+  }
+  return params.body;
 }
 
 export function prependInternalEventContext(
@@ -257,10 +292,13 @@ export function runAgentAttempt(params: {
   sessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   allowTransientCooldownProbe?: boolean;
+  runStartedAt: number;
 }) {
   const effectivePrompt = resolveFallbackRetryPrompt({
     body: params.body,
     isFallbackRetry: params.isFallbackRetry,
+    runStartedAt: params.runStartedAt,
+    sessionFile: params.sessionFile,
   });
   const bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.sessionEntry?.systemPromptReport,


### PR DESCRIPTION
## Summary

- Problem: subagent runs could lose the original task when the first model attempt failed and fallback retried with the generic prompt `Continue where you left off...`.
- Why it matters: first-turn subagent fallbacks could waste tokens on a meaningless recovery prompt instead of executing the requested task.
- What changed: fallback retry prompt selection now checks whether the current run already persisted the same user turn; if not, it reuses the original task body. Added a focused regression test for both branches.
- What did NOT change (scope boundary): no fallback candidate selection, auth failover policy, or broader subagent orchestration behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55581
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: fallback retry prompt resolution unconditionally replaced the original body with a generic resume prompt on every retry, even when the failed attempt had not yet persisted the user turn.
- Missing detection / guardrail: there was no check for whether the current run had already written the in-flight user message into the session transcript.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue report in #55581; local fix was derived from the current fallback retry path rather than a specific prior refactor.
- Why this regressed now: the retry path assumed an existing persisted turn and treated all retries like “resume from interrupted conversation”, which is wrong for first-turn subagent failures.
- If unknown, what was ruled out: ruled out model fallback candidate selection itself; the failure was in prompt replacement before the retried run.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/command/attempt-execution.test.ts`
- Scenario the test should lock in: fallback retry keeps the original task when the current run has not yet persisted it, and uses the resume prompt only when the same user turn is already present in the transcript.
- Why this is the smallest reliable guardrail: the bug is isolated to prompt selection at the retry boundary and does not require a full model-fallback integration harness to reproduce.
- Existing test that already covers this (if any): none found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Subagents now keep the original task on fallback retry when the first failed attempt did not persist the user turn yet.
- Resume-style retry text is still used for retries that genuinely continue an already-persisted turn.

## Diagram (if applicable)

```text
Before:
[user spawns subagent] -> [first model attempt fails before turn is persisted] -> [retry uses generic resume prompt] -> [original task lost]

After:
[user spawns subagent] -> [first model attempt fails before turn is persisted] -> [retry reuses original task] -> [subagent executes intended request]
