### PR TITLE
fix(voice-call): wrap guarded JSON API response parse in try-catch

### DIFF
--- a/extensions/voice-call/src/providers/shared/guarded-json-api.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.ts
@@ -35,7 +35,14 @@ export async function guardedJsonApiRequest<T = unknown>(
     }
 
     const text = await response.text();
-    return text ? (JSON.parse(text) as T) : (undefined as T);
+    if (!text) {
+      return undefined as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(`${params.errorPrefix}: invalid JSON response: ${text.slice(0, 200)}`);
+    }
   } finally {
     await release();
   }


### PR DESCRIPTION
## Summary

Wrap bare `JSON.parse` in `guardedJsonApiRequest` with a try-catch to produce a descriptive error when the upstream API returns non-JSON content.

## Problem

Same issue as the Twilio-specific `twilioApiRequest`: `extensions/voice-call/src/providers/shared/guarded-json-api.ts` has a bare `JSON.parse(text)` that throws an opaque `SyntaxError` when the upstream API returns non-JSON content.

## Steps to Reproduce

1. An upstream voice-call provider returns non-JSON content (HTML error, XML, etc.)
2. `JSON.parse(text)` throws `SyntaxError` with no context
3. Error message is not actionable for debugging

## Solution

Wrap `JSON.parse` in a try-catch that includes the first 200 chars of the response and the configured `errorPrefix`:
```ts
try {
  return JSON.parse(text) as T;
} catch {
  throw new Error(`${params.errorPrefix}: invalid JSON response: ${text.slice(0, 200)}`);
}
```

## Impact

- **Scope**: `extensions/voice-call/src/providers/shared/guarded-json-api.ts` (8 lines changed)
- **Risk**: Minimal — only changes error message content
- **Breaking changes**: None

## Type

- [x] Bug fix (non-breaking change that fixes an issue)

## Verification

- `pnpm check` passes
- `pnpm tsgo` passes
- Valid JSON continues to parse normally; invalid JSON produces actionable error

## Analysis

This is the shared counterpart to the Twilio-specific fix. Both functions had identical bare `JSON.parse` patterns and are fixed with the same approach.
