### PR TITLE
fix(bluebubbles): eliminate timing side-channel in secret comparison

### DIFF
--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -124,10 +124,18 @@ function safeEqualSecret(aRaw: string, bRaw: string): boolean {
   }
   const bufA = Buffer.from(a, "utf8");
   const bufB = Buffer.from(b, "utf8");
-  if (bufA.length !== bufB.length) {
-    return false;
-  }
-  return timingSafeEqual(bufA, bufB);
+  // Pad to equal length before constant-time comparison to prevent
+  // leaking length information via early-return timing.
+  const maxLen = Math.max(bufA.length, bufB.length);
+  const paddedA = Buffer.alloc(maxLen);
+  const paddedB = Buffer.alloc(maxLen);
+  bufA.copy(paddedA);
+  bufB.copy(paddedB);
+
+  // Call timingSafeEqual unconditionally to ensure constant-time execution
+  // regardless of length mismatch (avoids && short-circuit timing leak).
+  const equalContent = timingSafeEqual(paddedA, paddedB);
+  return bufA.length === bufB.length && equalContent;
 }
 
 function collectTrustedProxies(targets: readonly WebhookTarget[]): string[] {


### PR DESCRIPTION
## Summary

Eliminates a timing side-channel vulnerability in the `safeEqualSecret` function used for BlueBubbles webhook authentication.

## Problem

The original implementation had an early return when buffer lengths differed, creating a timing side-channel:

```typescript
// VULNERABLE: Early return leaks length information
if (bufA.length !== bufB.length) {
  return false;  // Returns immediately - attackers can measure this
}
return timingSafeEqual(bufA, bufB);
```

An attacker could measure response times to determine if their guess had the correct length, then use that information to narrow down the secret.

## Solution

The fix pads both buffers to equal length and calls `timingSafeEqual` **unconditionally**:

```typescript
// Pad to equal length
const maxLen = Math.max(bufA.length, bufB.length);
const paddedA = Buffer.alloc(maxLen);
const paddedB = Buffer.alloc(maxLen);
bufA.copy(paddedA);
bufB.copy(paddedB);

// CRITICAL: Store result BEFORE the && to avoid short-circuit evaluation
const equalContent = timingSafeEqual(paddedA, paddedB);
return bufA.length === bufB.length && equalContent;
```

**Key insight**: JavaScript's `&&` operator uses short-circuit evaluation. If we wrote:
```typescript
return bufA.length === bufB.length && timingSafeEqual(paddedA, paddedB);
```
Then when lengths differ, `timingSafeEqual` would **never execute**, preserving the timing leak!

By storing the result in `equalContent` first, we ensure `timingSafeEqual` always runs regardless of the length check outcome.

## Security Properties

- ✅ **Constant-time comparison**: `timingSafeEqual` always executes
- ✅ **No length leakage**: Padded buffers have identical lengths
- ✅ **Correct rejection**: Length mismatch still returns `false`
- ✅ **No short-circuit bypass**: Result stored before `&&` evaluation

## Testing

- `pnpm check` ✅
- `pnpm tsgo` ✅

## Files Changed

| File | Change |
|------|--------|
| `extensions/bluebubbles/src/monitor.ts` | Fix timing side-channel in `safeEqualSecret` |
