### PR TITLE
fix(line): eliminate timing side-channel in HMAC signature validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - macOS/local gateway: stop OpenClaw.app from killing healthy local gateway listeners after startup by recognizing the current `openclaw-gateway` process title and using the current `openclaw gateway` launch shape.
 - Memory/QMD: resolve slugified `memory_search` file hints back to the indexed filesystem path before returning search hits, so `memory_get` works again for mixed-case and spaced paths. (#50313) Thanks @erra9x.
+- Security/LINE: make webhook signature validation run the timing-safe compare even when the supplied signature length is wrong, closing a small timing side-channel. (#55663) Thanks @gavyngong.
 
 ## 2026.3.28-beta.1
 

--- a/extensions/line/src/signature.test.ts
+++ b/extensions/line/src/signature.test.ts
@@ -1,0 +1,34 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { validateLineSignature } from "./signature.js";
+
+function sign(body: string, secret: string): string {
+  return crypto.createHmac("SHA256", secret).update(body).digest("base64");
+}
+
+describe("validateLineSignature", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts a valid signature", () => {
+    const body = JSON.stringify({ events: [{ type: "message" }] });
+    const secret = "top-secret";
+
+    expect(validateLineSignature(body, sign(body, secret), secret)).toBe(true);
+  });
+
+  it("still performs timing-safe comparison when signature length mismatches", () => {
+    const body = JSON.stringify({ events: [{ type: "message" }] });
+    const secret = "top-secret";
+    const spy = vi.spyOn(crypto, "timingSafeEqual");
+
+    expect(validateLineSignature(body, "short", secret)).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    const [left, right] = spy.mock.calls[0] ?? [];
+    expect(left).toBeInstanceOf(Buffer);
+    expect(right).toBeInstanceOf(Buffer);
+    expect(left?.byteLength).toBe(right?.byteLength);
+  });
+});

--- a/extensions/line/src/signature.ts
+++ b/extensions/line/src/signature.ts
@@ -9,10 +9,16 @@ export function validateLineSignature(
   const hashBuffer = Buffer.from(hash);
   const signatureBuffer = Buffer.from(signature);
 
-  // Use constant-time comparison to prevent timing attacks.
-  if (hashBuffer.length !== signatureBuffer.length) {
-    return false;
-  }
+  // Pad to equal length before constant-time comparison to prevent
+  // leaking length information via early-return timing.
+  const maxLen = Math.max(hashBuffer.length, signatureBuffer.length);
+  const paddedHash = Buffer.alloc(maxLen);
+  const paddedSig = Buffer.alloc(maxLen);
+  hashBuffer.copy(paddedHash);
+  signatureBuffer.copy(paddedSig);
 
-  return crypto.timingSafeEqual(hashBuffer, signatureBuffer);
+  // Call timingSafeEqual unconditionally to ensure constant-time execution
+  // regardless of length mismatch (avoids && short-circuit timing leak).
+  const timingResult = crypto.timingSafeEqual(paddedHash, paddedSig);
+  return hashBuffer.length === signatureBuffer.length && timingResult;
 }


### PR DESCRIPTION
## Summary

Eliminate a timing side-channel in LINE webhook HMAC signature validation that leaks expected signature length.

## Problem

In `extensions/line/src/signature.ts`, `validateLineSignature()` returned early when buffer lengths differ:

```ts
if (hashBuffer.length !== signatureBuffer.length) {
  return false;  // ← timing leak
}
return crypto.timingSafeEqual(hashBuffer, signatureBuffer);
```

The early return reveals whether the provided signature has the correct length, which leaks information about the expected HMAC output format.

## Steps to Reproduce

1. Send LINE webhook requests with signatures of varying lengths
2. Measure response latency
3. Correct-length signatures take longer (enter `timingSafeEqual`)
4. Attacker learns expected signature encoding/length

## Solution

Pad both buffers to equal length and call `timingSafeEqual` **unconditionally**:

```ts
const maxLen = Math.max(hashBuffer.length, signatureBuffer.length);
const paddedHash = Buffer.alloc(maxLen);
const paddedSig = Buffer.alloc(maxLen);
hashBuffer.copy(paddedHash);
signatureBuffer.copy(paddedSig);

// Call timingSafeEqual unconditionally to ensure constant-time execution
// regardless of length mismatch (avoids && short-circuit timing leak).
const timingResult = crypto.timingSafeEqual(paddedHash, paddedSig);
return hashBuffer.length === signatureBuffer.length && timingResult;
```

### Key Implementation Detail

The `timingSafeEqual` result is **stored before** the `&&` length check. This is critical because:

- JavaScript's `&&` uses short-circuit evaluation
- If we wrote `return lengthCheck && crypto.timingSafeEqual(...)`, the `timingSafeEqual` would be skipped when lengths differ
- By calling `timingSafeEqual` first and storing the result, we ensure constant-time execution regardless of length match

## Impact

- **Scope**: `extensions/line/src/signature.ts` (net +6 lines)
- **Risk**: Low — correct signatures continue to validate, incorrect ones continue to reject
- **Breaking changes**: None
- **Security**: Closes timing side-channel in webhook signature validation

## Type

- [x] Security fix

## Verification

- `pnpm check` passes
- `pnpm tsgo` passes
- Valid LINE signatures validate correctly
- Invalid signatures of all lengths are correctly rejected in constant time
- `timingSafeEqual` executes on every call path (verified via code inspection)

## Analysis

For HMAC-SHA256 with base64 encoding, the hash length is always 44 characters, so a length mismatch indicates a malformed signature. However, even leaking this information aids attackers in crafting correctly-formatted forgery attempts. Defense-in-depth dictates constant-time comparison for all crypto operations.
