### PR TITLE
fix(channels): replace console.warn with subsystem logger in typing

### DIFF
--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -1,5 +1,8 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
 import { createTypingStartGuard } from "./typing-start-guard.js";
+
+const log = createSubsystemLogger("channels/typing");
 
 export type TypingCallbacks = {
   onReplyStart: () => Promise<void>;
@@ -55,7 +58,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     clearTtlTimer();
     ttlTimer = setTimeout(() => {
       if (!closed) {
-        console.warn(`[typing] TTL exceeded (${maxDurationMs}ms), auto-stopping typing indicator`);
+        log.warn(`TTL exceeded (${maxDurationMs}ms), auto-stopping typing indicator`);
         fireStop();
       }
     }, maxDurationMs);


### PR DESCRIPTION
## Summary

Replace `console.warn` with `createSubsystemLogger` in the typing indicator TTL handler so the warning routes through the structured logging pipeline.

## Problem

In `src/channels/typing.ts`, the TTL safety timer uses `console.warn` directly:

```ts
console.warn(`[typing] TTL exceeded (${maxDurationMs}ms), auto-stopping typing indicator`);
```

This bypasses the project's structured logging system (`createSubsystemLogger`), meaning the message:
- Does not respect log-level configuration
- Does not route to file logs
- Does not get formatted with timestamps, colors, or subsystem tags
- Cannot be filtered or suppressed in production

## Steps to Reproduce

1. Configure log level to suppress warnings
2. Trigger a typing TTL expiry
3. The warning still appears on console despite log level configuration

## Solution

Import `createSubsystemLogger` and use `log.warn()`:

```ts
const log = createSubsystemLogger("channels/typing");
// ...
log.warn(`TTL exceeded (${maxDurationMs}ms), auto-stopping typing indicator`);
```

## Impact

- **Scope**: `src/channels/typing.ts` (4 lines changed)
- **Risk**: Minimal — same message content, different output mechanism
- **Breaking changes**: None

## Type

- [x] Code quality improvement

## Verification

- `pnpm check` passes
- `pnpm tsgo` passes
- Warning now appears with proper subsystem tag formatting: `[channels/typing] TTL exceeded...`

## Analysis

This is one of several `console.warn` instances in production code that should use the structured logger. The typing module is particularly important because TTL warnings can occur during normal operation under high load.
