### PR TITLE
fix(auto-reply): replace console.warn with subsystem logger in command-auth

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -2,7 +2,10 @@ import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
+
+const log = createSubsystemLogger("command-auth");
 import {
   INTERNAL_MESSAGE_CHANNEL,
   isInternalMessageChannel,
@@ -172,8 +175,8 @@ function resolveProviderAllowFrom(params: {
       };
     }
     if (!Array.isArray(allowFrom)) {
-      console.warn(
-        `[command-auth] resolveAllowFrom returned an invalid allowFrom for provider "${providerId}", falling back to config allowFrom: invalid_result`,
+      log.warn(
+        `resolveAllowFrom returned an invalid allowFrom for provider "${providerId}", falling back to config allowFrom: invalid_result`,
       );
       return {
         allowFrom: resolveFallbackAllowFrom({ cfg, providerId, accountId }),
@@ -185,8 +188,8 @@ function resolveProviderAllowFrom(params: {
       hadResolutionError: false,
     };
   } catch (err) {
-    console.warn(
-      `[command-auth] resolveAllowFrom threw for provider "${providerId}", falling back to config allowFrom: ${describeAllowFromResolutionError(err)}`,
+    log.warn(
+      `resolveAllowFrom threw for provider "${providerId}", falling back to config allowFrom: ${describeAllowFromResolutionError(err)}`,
     );
     return {
       allowFrom: resolveFallbackAllowFrom({ cfg, providerId, accountId }),


### PR DESCRIPTION
## Summary

Replace `console.warn` calls with `createSubsystemLogger` in `command-auth.ts` so authorization warnings route through the structured logging pipeline.

## Problem

In `src/auto-reply/command-auth.ts`, `resolveProviderAllowFrom()` uses `console.warn` in two places:

1. When `resolveAllowFrom` returns an invalid (non-array) result
2. When `resolveAllowFrom` throws an exception

These bypass the structured logging system and cannot be filtered, routed to file logs, or formatted consistently.

## Steps to Reproduce

1. Configure a channel plugin with a buggy `resolveAllowFrom` implementation
2. Send a command message
3. `console.warn` fires directly, ignoring log-level settings
4. Warning is not captured in file logs for post-incident analysis

## Solution

Import `createSubsystemLogger` and replace both `console.warn` calls:

```ts
const log = createSubsystemLogger("command-auth");
// ...
log.warn(`resolveAllowFrom returned an invalid allowFrom for provider "${providerId}"...`);
log.warn(`resolveAllowFrom threw for provider "${providerId}"...`);
```

The `[command-auth]` prefix is removed from the message string since the subsystem logger adds it automatically.

## Impact

- **Scope**: `src/auto-reply/command-auth.ts` (7 lines changed)
- **Risk**: Minimal — same warnings, proper logging channel
- **Breaking changes**: None

## Type

- [x] Code quality improvement

## Verification

- `pnpm check` passes
- `pnpm tsgo` passes
- Warnings now route through structured logging with proper formatting

## Analysis

Authorization-related warnings are operationally important for diagnosing why commands are accepted/rejected. Routing them through the structured logger ensures they appear in file logs and respect the configured log level.
