### PR TITLE
fix(feishu): replace console.error with logger in docx image processing

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -663,6 +663,7 @@ async function processImages(
   markdown: string,
   insertedBlocks: FeishuDocxBlockChild[],
   maxBytes: number,
+  logger?: Logger,
 ): Promise<number> {
   const imageUrls = extractImageUrls(markdown);
   if (imageUrls.length === 0) {
@@ -694,7 +695,7 @@ async function processImages(
 
       processed++;
     } catch (err) {
-      console.error(`Failed to process image ${url}:`, err);
+      logger?.info?.(`feishu_doc: failed to process image ${url}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -957,7 +958,7 @@ async function writeDoc(
     blocks.length > BATCH_SIZE
       ? await insertBlocksInBatches(client, docToken, orderedBlocks, rootIds, logger)
       : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds);
-  const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes);
+  const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes, logger);
   logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
 
   return {
@@ -987,7 +988,7 @@ async function appendDoc(
     blocks.length > BATCH_SIZE
       ? await insertBlocksInBatches(client, docToken, orderedBlocks, rootIds, logger)
       : await insertBlocksWithDescendant(client, docToken, orderedBlocks, rootIds);
-  const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes);
+  const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes, logger);
   logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
 
   return {
@@ -1061,7 +1062,7 @@ async function insertDoc(
           index: insertIndex,
         });
 
-  const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes);
+  const imagesProcessed = await processImages(client, docToken, markdown, inserted, maxBytes, logger);
   logger?.info?.(`feishu_doc: Done (${blocks.length} blocks, ${imagesProcessed} images)`);
 
   return {


### PR DESCRIPTION
## Summary

Replace `console.error` with the existing `Logger` parameter in the Feishu docx image processing function so errors route through the plugin's structured logging.

## Problem

In `extensions/feishu/src/docx.ts`, `processImages()` uses `console.error` for image download failures:

```ts
} catch (err) {
  console.error(`Failed to process image ${url}:`, err);
}
```

All other logging in the feishu docx module uses the `Logger` interface (`logger?.info?.(...)`), making this `console.error` an inconsistency that bypasses the plugin logging pipeline.

## Steps to Reproduce

1. Write a Feishu doc with a markdown image URL that fails to download
2. `console.error` fires, bypassing plugin logger
3. Error does not appear in structured plugin logs

## Solution

1. Add an optional `logger?: Logger` parameter to `processImages()`
2. Replace `console.error(...)` with `logger?.info?.(...)`
3. Forward the `logger` parameter from all three call sites: `writeDoc()`, `appendDoc()`, `insertDoc()`

## Impact

- **Scope**: `extensions/feishu/src/docx.ts` (5 lines changed across 4 locations)
- **Risk**: Minimal — image processing errors are non-fatal (function continues processing remaining images)
- **Breaking changes**: None — new parameter is optional

## Type

- [x] Code quality improvement

## Verification

- `pnpm check` passes
- `pnpm tsgo` passes
- All three `processImages` call sites now forward the logger parameter
- Image processing errors now route through the plugin logger instead of console

## Analysis

The `processImages` function was likely written before the Logger pattern was established in the feishu docx module. The three calling functions (`writeDoc`, `appendDoc`, `insertDoc`) all already accept and use a `Logger` parameter for their own logging, making the forwarding natural and consistent.
