### PR TITLE
fix(gateway): require read scope for models http

### DIFF
--- a/src/gateway/models-http.test.ts
+++ b/src/gateway/models-http.test.ts
@@ -3,6 +3,8 @@ import { getFreePort, installGatewayTestHooks } from "./test-helpers.js";
 
 installGatewayTestHooks({ scope: "suite" });
 
+const READ_SCOPE_HEADER = { "x-openclaw-scopes": "operator.read" };
+
 let startGatewayServer: typeof import("./server.js").startGatewayServer;
 let enabledServer: Awaited<ReturnType<typeof startServer>>;
 let enabledPort: number;
@@ -30,6 +32,7 @@ async function getModels(pathname: string, headers?: Record<string, string>) {
   return await fetch(`http://127.0.0.1:${enabledPort}${pathname}`, {
     headers: {
       authorization: "Bearer secret",
+      ...READ_SCOPE_HEADER,
       ...headers,
     },
   });
@@ -61,6 +64,49 @@ describe("OpenAI-compatible models HTTP API (e2e)", () => {
     const json = (await res.json()) as { id?: string; object?: string };
     expect(json.object).toBe("model");
     expect(json.id).toBe(firstId);
+  });
+
+  it("rejects operator scopes that lack read access", async () => {
+    const res = await getModels("/v1/models", { "x-openclaw-scopes": "operator.approvals" });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.read",
+      },
+    });
+  });
+
+  it("rejects requests with no declared operator scopes", async () => {
+    const res = await getModels("/v1/models", { "x-openclaw-scopes": "" });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.read",
+      },
+    });
+  });
+
+  it("rejects /v1/models/{id} without read access", async () => {
+    const list = (await (await getModels("/v1/models")).json()) as {
+      data?: Array<{ id?: string }>;
+    };
+    const firstId = list.data?.[0]?.id;
+    expect(typeof firstId).toBe("string");
+    const res = await getModels(`/v1/models/${encodeURIComponent(firstId!)}`, {
+      "x-openclaw-scopes": "operator.approvals",
+    });
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: "missing scope: operator.read",
+      },
+    });
   });
 
   it("rejects when disabled", async () => {

--- a/src/gateway/models-http.ts
+++ b/src/gateway/models-http.ts
@@ -3,13 +3,17 @@ import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig } from "../config/config.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
+import {
+  authorizeGatewayBearerRequestOrReply,
+  resolveGatewayRequestedOperatorScopes,
+} from "./http-auth-helpers.js";
 import { sendInvalidRequest, sendJson, sendMethodNotAllowed } from "./http-common.js";
 import {
   OPENCLAW_DEFAULT_MODEL_ID,
   OPENCLAW_MODEL_ID,
   resolveAgentIdFromModel,
 } from "./http-utils.js";
+import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 
 type OpenAiModelsHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -82,6 +86,19 @@ export async function handleOpenAiModelsHttpRequest(
   }
 
   if (!(await authorizeRequest(req, res, opts))) {
+    return true;
+  }
+
+  const requestedScopes = resolveGatewayRequestedOperatorScopes(req);
+  const scopeAuth = authorizeOperatorScopesForMethod("models.list", requestedScopes);
+  if (!scopeAuth.allowed) {
+    sendJson(res, 403, {
+      ok: false,
+      error: {
+        type: "forbidden",
+        message: `missing scope: ${scopeAuth.missingScope}`,
+      },
+    });
     return true;
   }
 


### PR DESCRIPTION
## Summary
- requires declared read scopes for the OpenAI-compatible models HTTP endpoints
- aligns HTTP models authorization with the existing gateway method-scope policy

## Changes
- enforce `models.list` operator scope checks for `/v1/models` and `/v1/models/{id}` after bearer auth succeeds
- add regression coverage for missing scopes and non-read scopes on both list and item lookups

## Validation
- Ran `pnpm test -- src/gateway/models-http.test.ts`
- Ran `claude -p "/review"` and addressed the follow-up test coverage suggestions
- Commit hook passed `pnpm check`

## Notes
- Residual risk or follow-up: other HTTP compatibility routes should continue to be audited for transport-policy parity