### PR TITLE
infra: unwrap script wrapper approval targets

### DIFF
--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -42,6 +42,37 @@ const TIME_FLAG_OPTIONS = new Set([
   "--version",
 ]);
 const TIME_OPTIONS_WITH_VALUE = new Set(["-f", "--format", "-o", "--output"]);
+const SCRIPT_FLAG_OPTIONS = new Set([
+  "-a",
+  "--append",
+  "-e",
+  "--return",
+  "-f",
+  "--flush",
+  "--force",
+  "-q",
+  "--quiet",
+  "-h",
+  "--help",
+  "-V",
+  "--version",
+]);
+const SCRIPT_OPTIONS_WITH_VALUE = new Set([
+  "-B",
+  "--log-io",
+  "-E",
+  "--echo",
+  "-I",
+  "--log-in",
+  "-m",
+  "--logging-format",
+  "-O",
+  "--log-out",
+  "-o",
+  "--output-limit",
+  "-T",
+  "--log-timing",
+]);
 const TIMEOUT_FLAG_OPTIONS = new Set(["--foreground", "--preserve-status", "-v", "--verbose"]);
 const TIMEOUT_OPTIONS_WITH_VALUE = new Set(["-k", "--kill-after", "-s", "--signal"]);
 
@@ -259,6 +290,43 @@ function unwrapTimeInvocation(argv: string[]): string[] | null {
   });
 }
 
+function unwrapScriptInvocation(argv: string[]): string[] | null {
+  return scanWrapperInvocation(argv, {
+    separators: new Set(["--"]),
+    onToken: (_token, lower) => {
+      if (!lower.startsWith("-") || lower === "-") {
+        return "stop";
+      }
+      if (lower === "-c" || lower === "--command" || lower === "-t" || lower.startsWith("-t")) {
+        return "invalid";
+      }
+      if (SCRIPT_FLAG_OPTIONS.has(lower)) {
+        return "continue";
+      }
+      const [flag] = lower.split("=", 2);
+      if (SCRIPT_OPTIONS_WITH_VALUE.has(flag)) {
+        return lower.includes("=") ? "continue" : "consume-next";
+      }
+      return "invalid";
+    },
+    adjustCommandIndex: (commandIndex, currentArgv) => {
+      let sawTranscript = false;
+      for (let idx = commandIndex; idx < currentArgv.length; idx += 1) {
+        const token = currentArgv[idx]?.trim() ?? "";
+        if (!token) {
+          continue;
+        }
+        if (!sawTranscript) {
+          sawTranscript = true;
+          continue;
+        }
+        return idx;
+      }
+      return null;
+    },
+  });
+}
+
 function unwrapTimeoutInvocation(argv: string[]): string[] | null {
   return unwrapDashOptionInvocation(argv, {
     onFlag: (flag, lower) => {
@@ -294,6 +362,7 @@ const DISPATCH_WRAPPER_SPECS: readonly DispatchWrapperSpec[] = [
   { name: "ionice" },
   { name: "nice", unwrap: unwrapNiceInvocation, transparentUsage: true },
   { name: "nohup", unwrap: unwrapNohupInvocation, transparentUsage: true },
+  { name: "script", unwrap: unwrapScriptInvocation, transparentUsage: true },
   { name: "setsid" },
   { name: "stdbuf", unwrap: unwrapStdbufInvocation, transparentUsage: true },
   { name: "sudo" },

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -42,37 +42,8 @@ const TIME_FLAG_OPTIONS = new Set([
   "--version",
 ]);
 const TIME_OPTIONS_WITH_VALUE = new Set(["-f", "--format", "-o", "--output"]);
-const SCRIPT_FLAG_OPTIONS = new Set([
-  "-a",
-  "--append",
-  "-e",
-  "--return",
-  "-f",
-  "--flush",
-  "--force",
-  "-q",
-  "--quiet",
-  "-h",
-  "--help",
-  "-V",
-  "--version",
-]);
-const SCRIPT_OPTIONS_WITH_VALUE = new Set([
-  "-B",
-  "--log-io",
-  "-E",
-  "--echo",
-  "-I",
-  "--log-in",
-  "-m",
-  "--logging-format",
-  "-O",
-  "--log-out",
-  "-o",
-  "--output-limit",
-  "-T",
-  "--log-timing",
-]);
+const BSD_SCRIPT_FLAG_OPTIONS = new Set(["-a", "-d", "-k", "-p", "-q", "-r"]);
+const BSD_SCRIPT_OPTIONS_WITH_VALUE = new Set(["-F", "-t"]);
 const TIMEOUT_FLAG_OPTIONS = new Set(["--foreground", "--preserve-status", "-v", "--verbose"]);
 const TIMEOUT_OPTIONS_WITH_VALUE = new Set(["-k", "--kill-after", "-s", "--signal"]);
 
@@ -304,15 +275,11 @@ function unwrapScriptInvocation(argv: string[]): string[] | null {
       if (!lower.startsWith("-") || lower === "-") {
         return "stop";
       }
-      if (lower === "-c" || lower === "--command" || lower === "-t" || lower.startsWith("-t")) {
-        return "invalid";
-      }
       const [flag] = token.split("=", 2);
-      const [lowerFlag] = lower.split("=", 2);
-      if (SCRIPT_OPTIONS_WITH_VALUE.has(flag) || SCRIPT_OPTIONS_WITH_VALUE.has(lowerFlag)) {
-        return lower.includes("=") ? "continue" : "consume-next";
+      if (BSD_SCRIPT_OPTIONS_WITH_VALUE.has(flag)) {
+        return token.includes("=") ? "continue" : "consume-next";
       }
-      if (SCRIPT_FLAG_OPTIONS.has(flag) || SCRIPT_FLAG_OPTIONS.has(lowerFlag)) {
+      if (BSD_SCRIPT_FLAG_OPTIONS.has(flag)) {
         return "continue";
       }
       return "invalid";

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -293,19 +293,20 @@ function unwrapTimeInvocation(argv: string[]): string[] | null {
 function unwrapScriptInvocation(argv: string[]): string[] | null {
   return scanWrapperInvocation(argv, {
     separators: new Set(["--"]),
-    onToken: (_token, lower) => {
+    onToken: (token, lower) => {
       if (!lower.startsWith("-") || lower === "-") {
         return "stop";
       }
       if (lower === "-c" || lower === "--command" || lower === "-t" || lower.startsWith("-t")) {
         return "invalid";
       }
-      if (SCRIPT_FLAG_OPTIONS.has(lower)) {
-        return "continue";
-      }
-      const [flag] = lower.split("=", 2);
-      if (SCRIPT_OPTIONS_WITH_VALUE.has(flag)) {
+      const [flag] = token.split("=", 2);
+      const [lowerFlag] = lower.split("=", 2);
+      if (SCRIPT_OPTIONS_WITH_VALUE.has(flag) || SCRIPT_OPTIONS_WITH_VALUE.has(lowerFlag)) {
         return lower.includes("=") ? "continue" : "consume-next";
+      }
+      if (SCRIPT_FLAG_OPTIONS.has(flag) || SCRIPT_FLAG_OPTIONS.has(lowerFlag)) {
+        return "continue";
       }
       return "invalid";
     },

--- a/src/infra/dispatch-wrapper-resolution.ts
+++ b/src/infra/dispatch-wrapper-resolution.ts
@@ -290,7 +290,14 @@ function unwrapTimeInvocation(argv: string[]): string[] | null {
   });
 }
 
+function supportsScriptPositionalCommand(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin" || platform === "freebsd";
+}
+
 function unwrapScriptInvocation(argv: string[]): string[] | null {
+  if (!supportsScriptPositionalCommand()) {
+    return null;
+  }
   return scanWrapperInvocation(argv, {
     separators: new Set(["--"]),
     onToken: (token, lower) => {

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -619,6 +619,23 @@ $0 \\"$1\\"" touch {marker}`,
     });
   });
 
+  it("prevents allow-always bypass for script wrapper chains", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const echo = makeExecutable(dir, "echo");
+    makeExecutable(dir, "id");
+    const env = makePathEnv(dir);
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "/usr/bin/script -q /dev/null /bin/sh -lc 'echo warmup-ok'",
+      secondCommand: "/usr/bin/script -q /dev/null /bin/sh -lc 'id > marker'",
+      env,
+      persistedPattern: echo,
+    });
+  });
+
   it("does not persist comment-tailed payload paths that never execute", () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -620,7 +620,7 @@ $0 \\"$1\\"" touch {marker}`,
   });
 
   it("prevents allow-always bypass for script wrapper chains", () => {
-    if (process.platform === "win32") {
+    if (process.platform !== "darwin" && process.platform !== "freebsd") {
       return;
     }
     const dir = makeTempDir();

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -40,6 +40,7 @@ describe("normalizeExecutableToken", () => {
 describe("wrapper classification", () => {
   test.each([
     { token: "sudo", dispatch: true, shell: false },
+    { token: "script", dispatch: true, shell: false },
     { token: "time", dispatch: true, shell: false },
     { token: "timeout.exe", dispatch: true, shell: false },
     { token: "bash", dispatch: false, shell: true },
@@ -120,6 +121,10 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "unwrapped", wrapper: "nohup", argv: ["bash", "-lc", "echo hi"] },
     },
     {
+      argv: ["script", "-q", "/dev/null", "bash", "-lc", "echo hi"],
+      expected: { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
       argv: ["stdbuf", "-o", "L", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "stdbuf", argv: ["bash", "-lc", "echo hi"] },
     },
@@ -130,6 +135,10 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     {
       argv: ["timeout", "--signal=TERM", "5s", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "timeout", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
+      argv: ["script", "-q", "/dev/null"],
+      expected: { kind: "blocked", wrapper: "script" },
     },
     {
       argv: ["sudo", "bash", "-lc", "echo hi"],

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -132,9 +132,7 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     },
     {
       argv: ["script", "-E", "always", "/dev/null", "bash", "-lc", "echo hi"],
-      expected: supportsScriptPositionalCommandForTests()
-        ? { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] }
-        : { kind: "blocked", wrapper: "script" },
+      expected: { kind: "blocked", wrapper: "script" },
     },
     {
       argv: ["stdbuf", "-o", "L", "bash", "-lc", "echo hi"],

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -13,6 +13,10 @@ import {
   unwrapKnownShellMultiplexerInvocation,
 } from "./exec-wrapper-resolution.js";
 
+function supportsScriptPositionalCommandForTests(): boolean {
+  return process.platform === "darwin" || process.platform === "freebsd";
+}
+
 describe("basenameLower", () => {
   test.each([
     { token: " Bun.CMD ", expected: "bun.cmd" },
@@ -122,11 +126,15 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
     },
     {
       argv: ["script", "-q", "/dev/null", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] },
+      expected: supportsScriptPositionalCommandForTests()
+        ? { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] }
+        : { kind: "blocked", wrapper: "script" },
     },
     {
       argv: ["script", "-E", "always", "/dev/null", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] },
+      expected: supportsScriptPositionalCommandForTests()
+        ? { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] }
+        : { kind: "blocked", wrapper: "script" },
     },
     {
       argv: ["stdbuf", "-o", "L", "bash", "-lc", "echo hi"],

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -125,6 +125,10 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] },
     },
     {
+      argv: ["script", "-E", "always", "/dev/null", "bash", "-lc", "echo hi"],
+      expected: { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] },
+    },
+    {
       argv: ["stdbuf", "-o", "L", "bash", "-lc", "echo hi"],
       expected: { kind: "unwrapped", wrapper: "stdbuf", argv: ["bash", "-lc", "echo hi"] },
     },

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -18,6 +18,22 @@ describe("resolveExecWrapperTrustPlan", () => {
     });
   });
 
+  test("unwraps script wrappers before evaluating nested shell payloads", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    expect(
+      resolveExecWrapperTrustPlan(["/usr/bin/script", "-q", "/dev/null", "sh", "-lc", "echo hi"]),
+    ).toEqual({
+      argv: ["sh", "-lc", "echo hi"],
+      policyArgv: ["sh", "-lc", "echo hi"],
+      wrapperChain: ["script"],
+      policyBlocked: false,
+      shellWrapperExecutable: true,
+      shellInlineCommand: "echo hi",
+    });
+  });
+
   test("fails closed for unsupported shell multiplexer applets", () => {
     expect(resolveExecWrapperTrustPlan(["busybox", "sed", "-n", "1p"])).toEqual({
       argv: ["busybox", "sed", "-n", "1p"],

--- a/src/infra/exec-wrapper-trust-plan.test.ts
+++ b/src/infra/exec-wrapper-trust-plan.test.ts
@@ -19,7 +19,7 @@ describe("resolveExecWrapperTrustPlan", () => {
   });
 
   test("unwraps script wrappers before evaluating nested shell payloads", () => {
-    if (process.platform === "win32") {
+    if (process.platform !== "darwin" && process.platform !== "freebsd") {
       return;
     }
     expect(


### PR DESCRIPTION
## Summary
- unwrap `script` wrapper invocations that carry an explicit downstream command
- keep allow-always persistence anchored to the wrapped command instead of the outer wrapper path

## Changes
- added `script` parsing to dispatch-wrapper resolution for supported `file command...` forms
- added regression coverage for wrapper resolution, trust-plan handling, and allow-always bypass prevention

## Validation
- Ran `pnpm test -- src/infra/exec-wrapper-resolution.test.ts src/infra/exec-wrapper-trust-plan.test.ts src/infra/exec-approvals-allow-always.test.ts`
- Ran `pnpm build`
- Ran `pnpm check` via the commit hook
- Attempted local agentic review with `claude -p "/review"`; it timed out without producing actionable output in this environment

## Notes
- `script -c` and ambiguous `script -t` forms still fail closed rather than being treated as transparent wrappers