### PR TITLE
fix(model-selector): preserve provider prefix when model already includes one

### DIFF
--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -126,12 +126,16 @@ export async function resolveCronModelSelection(
   if (!modelOverride && !hooksGmailModelApplied) {
     const sessionModelOverride = params.sessionEntry.modelOverride?.trim();
     if (sessionModelOverride) {
-      const sessionProviderOverride =
-        params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;
+      // If the model already includes a provider prefix (e.g. "anthropic/claude-sonnet-4-6"),
+      // use it directly without prepending the session provider. Otherwise prepend the
+      // session provider (or default) so it resolves correctly.
+      const rawModelRef = sessionModelOverride.includes("/")
+        ? sessionModelOverride
+        : `${params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider}/${sessionModelOverride}`;
       const resolvedSessionOverride = resolveAllowedModelRef({
         cfg: params.cfgWithAgentDefaults,
         catalog: await loadCatalogOnce(),
-        raw: `${sessionProviderOverride}/${sessionModelOverride}`,
+        raw: rawModelRef,
         defaultProvider: resolvedDefault.provider,
         defaultModel: resolvedDefault.model,
       });


### PR DESCRIPTION
## Summary

When the model selector dropdown in the webchat UI includes a full provider/model ref (like 'anthropic/claude-sonnet-4-6'), the session model override was incorrectly prepending the current session provider prefix, producing 'zai-glm5/anthropic/claude-sonnet-4-6' and triggering 'model not allowed'.

## Root Cause

In `src/cron/isolated-agent/model-selection.ts`, the `resolveCronModelSelection` function always constructed the model reference as:

```
raw: `${sessionProviderOverride}/${sessionModelOverride}`
```

This is wrong when `sessionModelOverride` already contains a provider prefix (e.g. "anthropic/claude-sonnet-4-6"), resulting in a malformed key like "zai-glm5/anthropic/claude-sonnet-4-6".

## Fix

Detect if the model already includes a '/' and use it directly; only inject the session provider when the model is bare (no slash).

```ts
const rawModelRef = sessionModelOverride.includes("/")
  ? sessionModelOverride
  : `${params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider}/${sessionModelOverride}`;
```

## Testing

- [x] Select anthropic/claude-sonnet-4-6 from dropdown while on zai-glm5 session → no longer errors
- [x] Select bare model name (e.g. "glm-4.7") without provider → still prepends session provider correctly

## Related Issue

Fixes openclaw/openclaw#48224