### PR TITLE
fix(matrix): pass originalFilename to saveMediaBuffer and expose path via MEDIA tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - Memory/search: share memory embedding provider registrations across split plugin runtimes so memory search no longer fails with unknown provider errors after memory-core registers built-in adapters. (#55945) Thanks @glitch418x.
 - Discord/Carbon beta: update `@buape/carbon` to the latest beta and pass the new `RateLimitError` request argument so Discord stays compatible with the upstream beta constructor change. (#55980) Thanks @ngutman.
 - Plugins/inbound claims: pass full inbound attachment arrays through `inbound_claim` hook metadata while keeping the legacy singular media attachment fields for compatibility. (#55452) Thanks @huntharo.
+- Plugins/Matrix: preserve sender filenames for inbound media by forwarding `originalFilename` to `saveMediaBuffer`. (#55692) thanks @esrehmki.
 
 ## 2026.3.24
 

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -74,6 +74,57 @@ describe("createMatrixRoomMessageHandler media failures", () => {
     installMatrixMonitorTestRuntime();
   });
 
+  it("forwards the Matrix event body as originalFilename for media downloads", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/Screenshot-2026-03-27---uuid.png",
+      contentType: "image/png",
+      placeholder: "[matrix media]",
+    });
+    const { handler } = createMediaFailureHarness();
+
+    await handler(
+      "!room:example.org",
+      createImageEvent({
+        msgtype: "m.image",
+        body: " Screenshot 2026-03-27.png ",
+        url: "mxc://example/image",
+      }),
+    );
+
+    expect(downloadMatrixMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mxcUrl: "mxc://example/image",
+        maxBytes: 5 * 1024 * 1024,
+        originalFilename: "Screenshot 2026-03-27.png",
+      }),
+    );
+  });
+
+  it("prefers content.filename over body text when deriving originalFilename", async () => {
+    downloadMatrixMediaMock.mockResolvedValue({
+      path: "/tmp/inbound/Screenshot-2026-03-27---uuid.png",
+      contentType: "image/png",
+      placeholder: "[matrix media]",
+    });
+    const { handler } = createMediaFailureHarness();
+
+    await handler(
+      "!room:example.org",
+      createImageEvent({
+        msgtype: "m.image",
+        body: "can you review this screenshot?",
+        filename: "Screenshot 2026-03-27.png",
+        url: "mxc://example/image",
+      }),
+    );
+
+    expect(downloadMatrixMediaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originalFilename: "Screenshot 2026-03-27.png",
+      }),
+    );
+  });
+
   it("replaces bare image filenames with an unavailable marker when unencrypted download fails", async () => {
     downloadMatrixMediaMock.mockRejectedValue(new Error("download failed"));
     const { handler, recordInboundSession, logger, runtime } = createMediaFailureHarness();

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -658,6 +658,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             sizeBytes: contentSize,
             maxBytes: mediaMaxBytes,
             file: finalContentFile,
+            originalFilename: typeof content.body === "string" ? content.body.trim() : undefined,
           });
         } catch (err) {
           mediaDownloadFailed = true;

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -643,6 +643,9 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ? content.file
           : undefined;
       const finalMediaUrl = finalContentUrl ?? finalContentFile?.url;
+      const contentBody = typeof content.body === "string" ? content.body.trim() : "";
+      const contentFilename = typeof content.filename === "string" ? content.filename.trim() : "";
+      const originalFilename = contentFilename || contentBody || undefined;
       const contentInfo =
         "info" in content && content.info && typeof content.info === "object"
           ? (content.info as { mimetype?: string; size?: number })
@@ -658,7 +661,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             sizeBytes: contentSize,
             maxBytes: mediaMaxBytes,
             file: finalContentFile,
-            originalFilename: typeof content.body === "string" ? content.body.trim() : undefined,
+            originalFilename,
           });
         } catch (err) {
           mediaDownloadFailed = true;
@@ -676,8 +679,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         }
       }
 
-      const rawBody =
-        locationPayload?.text ?? (typeof content.body === "string" ? content.body.trim() : "");
+      const rawBody = locationPayload?.text ?? contentBody;
       const bodyText = resolveMatrixInboundBodyText({
         rawBody,
         filename: typeof content.filename === "string" ? content.filename : undefined,

--- a/extensions/matrix/src/matrix/monitor/media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/media.test.ts
@@ -75,6 +75,28 @@ describe("downloadMatrixMedia", () => {
     expect(result?.path).toBe("/tmp/media");
   });
 
+  it("forwards originalFilename to saveMediaBuffer when provided", async () => {
+    const { client } = createEncryptedClient();
+    const file = createEncryptedFile();
+
+    await downloadMatrixMedia({
+      client,
+      mxcUrl: "mxc://example/file",
+      contentType: "image/png",
+      maxBytes: 1024,
+      file,
+      originalFilename: "Screenshot 2026-03-27.png",
+    });
+
+    expect(saveMediaBuffer).toHaveBeenCalledWith(
+      Buffer.from("decrypted"),
+      "image/png",
+      "inbound",
+      1024,
+      "Screenshot 2026-03-27.png",
+    );
+  });
+
   it("rejects encrypted media that exceeds maxBytes before decrypting", async () => {
     const { client, decryptMedia } = createEncryptedClient();
     const file = createEncryptedFile();

--- a/extensions/matrix/src/matrix/monitor/media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/media.test.ts
@@ -71,6 +71,7 @@ describe("downloadMatrixMedia", () => {
       "image/png",
       "inbound",
       1024,
+      undefined,
     );
     expect(result?.path).toBe("/tmp/media");
   });

--- a/extensions/matrix/src/matrix/monitor/media.ts
+++ b/extensions/matrix/src/matrix/monitor/media.ts
@@ -69,6 +69,7 @@ export async function downloadMatrixMedia(params: {
   sizeBytes?: number;
   maxBytes: number;
   file?: EncryptedFile;
+  originalFilename?: string;
 }): Promise<{
   path: string;
   contentType?: string;
@@ -104,6 +105,7 @@ export async function downloadMatrixMedia(params: {
     headerType,
     "inbound",
     params.maxBytes,
+    params.originalFilename,
   );
   return {
     path: saved.path,


### PR DESCRIPTION
## Summary

- **Problem:** The Matrix plugin's `downloadMatrixMedia()` calls `saveMediaBuffer()` with only 4 arguments, omitting the supported 5th `originalFilename` parameter. Inbound images are saved as `{uuid}.{ext}` and the actual file path is never exposed to the agent in the message body.
- **Why it matters:** The agent's `image` tool can never resolve inbound Matrix images. It fabricates a path from the sender filename (`content.body`) against the workspace directory, which doesn't exist. The media understanding pipeline provides a one-shot text description, but the agent cannot re-analyze the image on any subsequent turn.
- **What changed:** (1) `media.ts` now accepts `originalFilename` and passes it as the 5th argument to `saveMediaBuffer`. (2) `handler.ts` passes `content.body` as `originalFilename` and appends a `MEDIA:` tag with the actual file path to the body text.
- **What did NOT change:** No changes to the core, plugin SDK, `saveMediaBuffer` implementation, `parseMediaPathFromText`, or any other extension. The fix uses only existing, documented API surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55609
- Related #12691 (identical fix applied to WhatsApp)
- Related #31768 (same root cause reported for Telegram)
- Related #44792 (same root cause reported for Feishu, still open)
- Related #22487 (same root cause reported for Signal, still open)

## User-visible / Behavior Changes

1. Inbound Matrix images are now saved with human-readable filenames:
   - Before: `d424ee8d-2071-4114-853c-7ce578fdf70c.png`
   - After: `Screenshot-2026-03-26-at-12.00.09---d424ee8d-2071-4114-853c-7ce578fdf70c.png`
2. The agent's message body now includes the actual file path via a `MEDIA:` tag:
   ```
   Screenshot 2026-03-26 at 12.00.09.png
   MEDIA: `/root/.openclaw/media/inbound/Screenshot-2026-03-26-at-12.00.09---d424ee8d-...png`
   ```
3. The `image` tool and `read` tool can now resolve inbound Matrix images on any turn, not just the first.

No config changes. No new defaults. Fully backward compatible — images saved before this fix remain accessible by their UUID paths.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Debian 13.4 Trixie (VM)
- Runtime/container: Node.js 24.14.0, npm global install
- Model/provider: Any vision-capable model via LiteLLM (reproduced with Qwen3-VL-32B)
- Integration/channel: Matrix (Synapse homeserver, E2E encryption enabled)
- Relevant config: Default Matrix plugin config, no special media settings

### Steps

1. Configure OpenClaw with the Matrix plugin and a vision-capable model.
2. Send an image via Matrix DM to the bot.
3. The media understanding pipeline produces a text description — the agent sees `[Image] ... Description: ...` but no file path.
4. The agent calls the `image` tool using the filename from `content.body` resolved against the workspace directory.
5. `LocalMediaAccessError("not-found")` — the file is actually at `~/.openclaw/media/inbound/{uuid}.png`.

### Expected

- Image saved with human-readable filename including the original sender filename.
- `MEDIA:` tag in the body text exposing the actual file path to the agent.
- The `image` tool resolves the file on any turn.

### Actual (before fix)

- Image saved as `{uuid}.png` — no original filename preserved.
- No `MEDIA:` tag in body text — agent has no way to discover the file path.
- The `image` tool fails with `Local media file not found` on every turn (including the first).

## Evidence

**Filename on disk — before vs after:**

```
# Before (UUID-only):
d424ee8d-2071-4114-853c-7ce578fdf70c.png

# After (human-readable + UUID):
Screenshot_2026-03-27_at_08.34.49---21df3efc-7cdd-4dc4-8f2e-ce0067333b99.png
```

**Diff (2 files, 7 insertions, 1 deletion):**

`media.ts`:
- Added `originalFilename?: string` to `downloadMatrixMedia` params type.
- Passed `params.originalFilename` as 5th argument to `saveMediaBuffer`.

`handler.ts`:
- Passed `content.body` as `originalFilename` to `downloadMatrixMedia`.
- Changed `const bodyText` to `let bodyText`.
- Added `MEDIA:` tag injection: `bodyText = bodyText ? \`${bodyText}\nMEDIA: \`${media.path}\`\` : \`MEDIA: \`${media.path}\`\``.

**Cross-channel precedent:** The identical pattern (passing `originalFilename` to `saveMediaBuffer`) was merged for WhatsApp in PR #12691. This PR applies the same fix to the Matrix plugin.

## Human Verification (required)

- Verified scenarios:
  - Sent an image via Matrix DM with E2E encryption enabled. File saved with human-readable name on disk. Old UUID-only images from before the fix remain untouched.
  - Gateway restart with the fix applied — service starts cleanly, Matrix E2E encryption re-initializes, no errors in logs.
- Edge cases checked:
  - `content.body` is the filename string for `m.image` events per the Matrix spec. For text messages, `rawBody` takes precedence (no behavioral change).
  - `originalFilename` is optional — if `content.body` is not a string, `undefined` is passed and `saveMediaBuffer` falls back to UUID-only naming (existing behavior preserved).
- What I did **not** verify:
  - Unencrypted media (tested only with E2E enabled).
  - Non-image media types (`m.file`, `m.video`, `m.audio`) — the fix applies to all media since the download path is shared, but only image was tested.
  - The `MEDIA:` tag being picked up by `parseMediaPathFromText` in the resize/inference pipeline — verified tag injection in the body text, but did not test a full multi-turn re-analysis scenario end to end.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — existing UUID-only files remain valid. No config changes.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `556498c` — the two files return to their previous state (4-argument `saveMediaBuffer` call, `const bodyText` without `MEDIA:` tag).
- Files/config to restore: `extensions/matrix/src/matrix/monitor/media.ts`, `extensions/matrix/src/matrix/monitor/handler.ts`
- Known bad symptoms reviewers should watch for: If `saveMediaBuffer` changes its 5th parameter semantics in a future release, filenames could become malformed. The `MEDIA:` tag could theoretically confuse agents that parse backtick-delimited paths from message text for other purposes.

## Risks and Mitigations

- Risk: `content.body` for media events may contain unexpected characters or very long filenames.
  - Mitigation: `saveMediaBuffer` → `buildSavedMediaId` already sanitizes the filename via `sanitizeFilename()` (replaces spaces, strips path separators, truncates). This PR does not bypass that sanitization.
- Risk: The `MEDIA:` tag adds ~80 characters per image to the body text, consuming context window.
  - Mitigation: Negligible cost (~0.1% of a 65K context window). The alternative (agent fabricating paths and hallucinating) is far more expensive in wasted tokens.