### PR TITLE
fix(brave): normalize unsupported country filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Matrix: prefer explicit DM signals when choosing outbound direct rooms and routing unmapped verification summaries, so strict 2-person fallback rooms do not outrank the real DM. (#56076) thanks @gumadeiras
 - Microsoft Teams/proactive DMs: prefer the freshest personal conversation reference for `user:<aadObjectId>` sends when multiple stored references exist, so replies stop targeting stale DM threads. (#54702) Thanks @gumclaw.
 - Gateway/plugins: reuse the session workspace when building HTTP `/tools/invoke` tool lists and harden tool construction to infer the session agent workspace by default, so workspace plugins do not re-register on repeated HTTP tool calls. (#56101) thanks @neeravmakwana
+- Brave/web search: normalize unsupported Brave `country` filters to `ALL` before request and cache-key generation so locale-derived values like `VN` stop failing with upstream 422 validation errors. (#55695) Thanks @chen-zhang-cs-code.
 
 ## 2026.3.24
 

--- a/extensions/brave/src/brave-web-search-provider.test.ts
+++ b/extensions/brave/src/brave-web-search-provider.test.ts
@@ -2,8 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { __testing, createBraveWebSearchProvider } from "./brave-web-search-provider.js";
 
 describe("brave web search provider", () => {
+  const priorFetch = global.fetch;
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    global.fetch = priorFetch;
   });
 
   it("normalizes brave language parameters and swaps reversed ui/search inputs", () => {
@@ -42,6 +45,12 @@ describe("brave web search provider", () => {
     expect(__testing.normalizeBraveLanguageParams({ ui_lang: "en" })).toEqual({
       invalidField: "ui_lang",
     });
+  });
+
+  it("normalizes Brave country codes and falls back unsupported values to ALL", () => {
+    expect(__testing.normalizeBraveCountry("de")).toBe("DE");
+    expect(__testing.normalizeBraveCountry(" VN ")).toBe("ALL");
+    expect(__testing.normalizeBraveCountry("")).toBeUndefined();
   });
 
   it("defaults brave mode to web unless llm-context is explicitly selected", () => {
@@ -95,5 +104,36 @@ describe("brave web search provider", () => {
     expect(result).toMatchObject({
       error: "invalid_date_range",
     });
+  });
+
+  it("falls back unsupported country values before calling Brave", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = vi.fn(async (_input?: unknown, _init?: unknown) => {
+      return {
+        ok: true,
+        json: async () => ({ web: { results: [] } }),
+      } as Response;
+    });
+    global.fetch = mockFetch as typeof global.fetch;
+
+    const provider = createBraveWebSearchProvider();
+    const tool = provider.createTool({
+      config: {},
+      searchConfig: {
+        apiKey: "BSA...",
+        brave: { apiKey: "BSA..." },
+      },
+    });
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({
+      query: "latest Vietnam news",
+      country: "VN",
+    });
+
+    const requestUrl = new URL(String(mockFetch.mock.calls[0]?.[0]));
+    expect(requestUrl.searchParams.get("country")).toBe("ALL");
   });
 });

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -29,6 +29,46 @@ import {
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
+const BRAVE_COUNTRY_CODES = new Set([
+  "AR",
+  "AU",
+  "AT",
+  "BE",
+  "BR",
+  "CA",
+  "CL",
+  "DK",
+  "FI",
+  "FR",
+  "DE",
+  "GR",
+  "HK",
+  "IN",
+  "ID",
+  "IT",
+  "JP",
+  "KR",
+  "MY",
+  "MX",
+  "NL",
+  "NZ",
+  "NO",
+  "CN",
+  "PL",
+  "PT",
+  "PH",
+  "RU",
+  "SA",
+  "ZA",
+  "ES",
+  "SE",
+  "CH",
+  "TW",
+  "TR",
+  "GB",
+  "US",
+  "ALL",
+]);
 const BRAVE_SEARCH_LANG_CODES = new Set([
   "ar",
   "eu",
@@ -144,6 +184,18 @@ function normalizeBraveSearchLang(value: string | undefined): string | undefined
     return undefined;
   }
   return canonical;
+}
+
+function normalizeBraveCountry(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const canonical = trimmed.toUpperCase();
+  return BRAVE_COUNTRY_CODES.has(canonical) ? canonical : "ALL";
 }
 
 function normalizeBraveUiLang(value: string | undefined): string | undefined {
@@ -410,7 +462,7 @@ function createBraveToolDefinition(
         readNumberParam(params, "count", { integer: true }) ??
         searchConfig?.maxResults ??
         undefined;
-      const country = readStringParam(params, "country");
+      const country = normalizeBraveCountry(readStringParam(params, "country"));
       const language = readStringParam(params, "language");
       const search_lang = readStringParam(params, "search_lang");
       const ui_lang = readStringParam(params, "ui_lang");
@@ -610,6 +662,7 @@ export function createBraveWebSearchProvider(): WebSearchProviderPlugin {
 
 export const __testing = {
   normalizeFreshness,
+  normalizeBraveCountry,
   normalizeBraveLanguageParams,
   resolveBraveMode,
   mapBraveLlmContextResults,

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -29,6 +29,7 @@ import {
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
+// Mirror Brave's documented country enum so unsupported locale guesses can collapse to ALL.
 const BRAVE_COUNTRY_CODES = new Set([
   "AR",
   "AU",


### PR DESCRIPTION
## Summary

- Problem: Brave `web_search` forwards raw `country` values, so unsupported codes like `VN` hit Brave's enum validation and fail with a 422.
- Why it matters: locale-aware searches can fail before any results are returned, even though the request could safely fall back to a non-country-specific search.
- What changed: normalized Brave `country` values before cache-key generation and upstream requests, uppercasing supported codes and falling unsupported ones back to `ALL`; added focused regression tests.
- What did NOT change (scope boundary): no changes to non-Brave providers, no schema tightening, and no changes to Brave language/freshness/date behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55636
- Related #55636
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Brave provider normalized `search_lang` and `ui_lang`, but passed `country` through unchanged.
- Missing detection / guardrail: there was no provider-level normalization test for unsupported Brave country enums.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this looks like a longstanding gap in the Brave compatibility layer rather than a fresh refactor regression.
- Why this regressed now: likely not a new regression; it became user-visible once the model/runtime started emitting unsupported locale-derived values like `VN`.
- If unknown, what was ruled out: ruled out shared `web_search` wiring because the Brave provider is the layer that directly forwards `country`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/brave/src/brave-web-search-provider.test.ts`
- Scenario the test should lock in: unsupported Brave `country` values (for example `VN`) fall back to `ALL` before the upstream request is sent.
- Why this is the smallest reliable guardrail: the bug lives entirely in the Brave provider normalization layer, so a provider-focused test catches it without needing networked end-to-end setup.
- Existing test that already covers this (if any): reran `src/agents/tools/web-tools.enabled-defaults.test.ts` with the `web_search country and language parameters` filter as a seam-level verification pass.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Unsupported Brave `country` values now fall back to `ALL` instead of hard-failing with a 422. Supported country codes are normalized to Brave's uppercase enum format before the request is sent.

## Diagram (if applicable)

```text
Before:
[user/tool sends country=VN] -> [Brave provider forwards VN] -> [Brave 422 validation error]

After:
[user/tool sends country=VN] -> [Brave provider normalizes to ALL] -> [request succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local repo test runner
- Model/provider: Brave web search provider
- Integration/channel (if any): `web_search`
- Relevant config (redacted): `tools.web.search.provider=brave`

### Steps

1. Call `web_search` with Brave selected and `country="VN"`.
2. Observe the outbound request Brave receives.
3. Compare behavior before and after this patch.

### Expected

- Unsupported Brave country values are normalized before the request is sent.
- The request falls back to a valid Brave country enum instead of failing validation.

### Actual

- Before: Brave received `country=VN` and returned a 422 validation error.
- After: Brave receives `country=ALL` for the same unsupported input.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added a Brave provider regression test for unsupported country fallback; reran the existing `web_search country and language parameters` seam test filter.
- Edge cases checked: valid lowercase country codes normalize to uppercase; blank country values stay unset.
- What you did **not** verify: no live Brave API request was run against a real key.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a caller expecting invalid country inputs to hard-fail will now get `ALL` instead.
  - Mitigation: this matches Brave's documented enum contract more closely and keeps the search request usable instead of failing.