### PR TITLE
fix(discord): suppress expected reconnect-exhausted on stale-socket restart

### DIFF
--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -813,7 +813,7 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("does not suppress reconnect-exhausted already queued before shutdown", async () => {
+  it("suppresses reconnect-exhausted already queued after intentional shutdown/restart", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
     const pendingGatewayEvents: DiscordGatewayEvent[] = [];
     const abortController = new AbortController();
@@ -835,9 +835,9 @@ describe("runDiscordGatewayLifecycle", () => {
     lifecycleParams.abortSignal = abortController.signal;
 
     // Start lifecycle; it yields at execApprovalsHandler.start(). We then
-    // queue a reconnect-exhausted event and abort. The lifecycle resumes and
-    // drains the queued fatal event before shutdown teardown flips
-    // lifecycleStopping, so the event still rejects the run.
+    // queue a reconnect-exhausted event and abort. The abort path sets
+    // maxAttempts=0 (intentional stale-socket restart), so the queued event
+    // is treated as expected and the lifecycle resolves cleanly.
     const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
 
     pendingGatewayEvents.push(
@@ -848,13 +848,28 @@ describe("runDiscordGatewayLifecycle", () => {
     );
     abortController.abort();
 
-    await expect(lifecyclePromise).rejects.toThrow(
-      "Max reconnect attempts (0) reached after code 1005",
+    await expect(lifecyclePromise).resolves.toBeUndefined();
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown/restart"),
     );
-    expect(runtimeLog).not.toHaveBeenCalledWith(
-      expect.stringContaining("ignoring expected reconnect-exhausted during shutdown"),
+    expect(runtimeError).not.toHaveBeenCalledWith(
+      expect.stringContaining("Max reconnect attempts"),
     );
-    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("Max reconnect attempts"));
+  });
+
+  it("does not suppress reconnect-exhausted when maxAttempts is not 0", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { lifecycleParams } = createLifecycleHarness({
+      pendingGatewayEvents: [
+        createGatewayEvent(
+          "reconnect-exhausted",
+          "Max reconnect attempts (3) reached after code 1006",
+        ),
+      ],
+    });
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
+      "Max reconnect attempts (3) reached after code 1006",
+    );
   });
 
   it("does not push connected: true when abortSignal is already aborted", async () => {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -37,6 +37,8 @@ export async function runDiscordGatewayLifecycle(params: {
     runtime: params.runtime,
   });
   let lifecycleStopping = false;
+  const isExpectedReconnectExhausted = (event: DiscordGatewayEvent): boolean =>
+    event.type === "reconnect-exhausted" && gateway?.options.reconnect?.maxAttempts === 0;
 
   const pushStatus = (patch: Parameters<DiscordMonitorStatusSink>[0]) => {
     params.statusSink?.(patch);
@@ -67,9 +69,9 @@ export async function runDiscordGatewayLifecycle(params: {
     // When we deliberately set maxAttempts=0 and disconnected (health-monitor
     // stale-socket restart), Carbon fires "Max reconnect attempts (0)". This
     // is expected — log at info instead of error to avoid false alarms.
-    if (lifecycleStopping && event.type === "reconnect-exhausted") {
+    if (isExpectedReconnectExhausted(event)) {
       params.runtime.log?.(
-        `discord: ignoring expected reconnect-exhausted during shutdown: ${event.message}`,
+        `discord: ignoring expected reconnect-exhausted during shutdown/restart: ${event.message}`,
       );
       return "stop";
     }
@@ -85,10 +87,7 @@ export async function runDiscordGatewayLifecycle(params: {
       // Don't throw for expected shutdown events — intentional disconnect
       // (reconnect-exhausted with maxAttempts=0) and disallowed-intents are
       // both handled without crashing the provider.
-      if (
-        event.type === "disallowed-intents" ||
-        (lifecycleStopping && event.type === "reconnect-exhausted")
-      ) {
+      if (event.type === "disallowed-intents" || isExpectedReconnectExhausted(event)) {
         return "stop";
       }
       throw event.err;


### PR DESCRIPTION
## Summary

- **Problem:** When the health-monitor triggers a stale-socket restart, it sets `gateway.options.reconnect.maxAttempts = 0` then calls `disconnect()`. Carbon immediately emits `"Max reconnect attempts (0) reached after code 1005"`, which lands in the supervisor's pending queue while the lifecycle is still awaiting an early step (e.g. `execApprovalsHandler.start()`).
- **Why it matters:** The previous guard checked `lifecycleStopping`, which is only set in the `finally` block — after `drainPendingGatewayErrors()` has already run. The queued event fell through to `throw event.err`, crashing the entire gateway process (~54s downtime per occurrence, recurring every ~35 minutes).
- **What changed:** Replaced the timing-sensitive `lifecycleStopping` check with `isExpectedReconnectExhausted`, which checks `gateway.options.reconnect.maxAttempts === 0`. This value is set synchronously before `disconnect()`, so it is reliably true at drain time regardless of async ordering. Added a regression test confirming that reconnect-exhausted with `maxAttempts !== 0` (genuine Carbon retry exhaustion) still propagates as a fatal error.
- **What did NOT change:** No change to reconnect logic, health-monitor behavior, or any other lifecycle path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #55554
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- **Root cause:** `lifecycleStopping` is set in the `finally` block of `runDiscordGatewayLifecycle`, but `drainPendingGatewayErrors()` is called inside the `try` block — before `finally` ever runs. On a stale-socket restart, the reconnect-exhausted event is queued synchronously (Carbon emits in the same tick as `disconnect()`), so it is always drained before `lifecycleStopping` becomes `true`.
- **Missing detection / guardrail:** No test covered the queued-before-drain timing window.
- **Prior context:** The `lifecycleStopping` guard was added to handle intentional shutdowns, but did not account for the async ordering between `drainPendingGatewayErrors` and the `finally` block.
- **Why this regressed now:** The health-monitor stale-socket path sets `maxAttempts=0` and disconnects — Carbon's error fires faster than the lifecycle flag advances.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test: `extensions/discord/src/monitor/provider.lifecycle.test.ts`
- Scenario: queue a reconnect-exhausted event before abort fires; verify lifecycle resolves cleanly (not rejects) when `maxAttempts=0`; verify it still rejects when `maxAttempts` is not 0.
- Why this is the smallest reliable guardrail: directly exercises the drain-before-finally timing window without requiring real WebSocket infrastructure.

## User-visible / Behavior Changes

Gateway no longer crashes on health-monitor stale-socket restarts. The restart proceeds silently (log at info level instead of an uncaught exception).

## Diagram (if applicable)

```text
Before:
[health-monitor abort] -> [maxAttempts=0, disconnect()] -> [Carbon emits error]
  -> [pending queue] -> [drainPendingGatewayErrors]
  -> lifecycleStopping=false -> throw event.err -> CRASH

After:
[health-monitor abort] -> [maxAttempts=0, disconnect()] -> [Carbon emits error]
  -> [pending queue] -> [drainPendingGatewayErrors]
  -> maxAttempts===0 -> log + return "stop" -> lifecycle resolves cleanly
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (darwin arm64) / Windows 10 x64 (as reported in issue)
- Runtime: Node 24.14.1
- Integration/channel: Discord

### Steps

1. Gateway running with Discord channel enabled
2. Health-monitor detects stale socket and triggers restart
3. WebSocket closes with code 1005

### Expected

Gateway handles reconnect-exhausted gracefully, logs at info level, continues running.

### Actual (before fix)

Uncaught exception: `Error: Max reconnect attempts (0) reached after code 1005` — gateway process crashes.

## Evidence

- [x] Failing test before + passing after: repurposed existing test `"does not suppress reconnect-exhausted already queued before shutdown"` → now asserts `resolves.toBeUndefined()` and confirms the info log. Added `"does not suppress reconnect-exhausted when maxAttempts is not 0"` as the negative regression guard. All 22 tests pass.

## Human Verification (required)

- Verified scenarios: lifecycle test suite (22/22), full discord extension test suite — all pass.
- Edge cases checked: `maxAttempts` undefined (default gateway options) still propagates as fatal; `maxAttempts=0` with code 1005 resolves cleanly.
- What I did **not** verify: live Discord environment with actual stale-socket trigger (no Discord bot token available).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `isExpectedReconnectExhausted` might suppress a genuine exhaustion if something else sets `maxAttempts=0`.
  - Mitigation: `maxAttempts=0` is only set in one place (`provider.lifecycle.reconnect.ts:404`, the `onAbort` handler). The negative regression test guards against over-suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)