### PR TITLE
Gateway: require verified scope for chat provenance

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1115,6 +1115,49 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(mockState.lastDispatchCtx).toBeUndefined();
   });
 
+  it("rejects forged ACP metadata when the caller lacks admin scope", async () => {
+    createTranscriptFixture("openclaw-chat-send-system-provenance-spoof-reject-");
+    mockState.finalText = "ok";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-system-provenance-spoof-reject",
+      client: {
+        connect: {
+          scopes: ["operator.write"],
+          client: {
+            id: "cli",
+            mode: "cli",
+            displayName: "ACP",
+            version: "acp",
+          },
+        },
+      },
+      requestParams: {
+        systemInputProvenance: {
+          kind: "external_user",
+          originSessionId: "acp-session-spoof",
+          sourceChannel: "acp",
+          sourceTool: "openclaw_acp",
+        },
+        systemProvenanceReceipt:
+          "[Source Receipt]\nbridge=openclaw-acp\noriginSessionId=acp-session-spoof\n[/Source Receipt]",
+      },
+      expectBroadcast: false,
+      waitForCompletion: false,
+    });
+
+    const [ok, _payload, error] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(false);
+    expect(error).toMatchObject({
+      message: "system provenance fields are reserved for the ACP bridge",
+    });
+    expect(mockState.lastDispatchCtx).toBeUndefined();
+  });
+
   it("injects ACP system provenance into the agent-visible body", async () => {
     createTranscriptFixture("openclaw-chat-send-system-provenance-acp-");
     mockState.finalText = "ok";
@@ -1128,6 +1171,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       message: "bench update",
       client: {
         connect: {
+          scopes: ["operator.admin"],
           client: {
             id: "cli",
             mode: "cli",

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1110,7 +1110,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const [ok, _payload, error] = respond.mock.calls.at(-1) ?? [];
     expect(ok).toBe(false);
     expect(error).toMatchObject({
-      message: "system provenance fields are reserved for the ACP bridge",
+      message: "system provenance fields require admin scope",
     });
     expect(mockState.lastDispatchCtx).toBeUndefined();
   });
@@ -1153,9 +1153,57 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     const [ok, _payload, error] = respond.mock.calls.at(-1) ?? [];
     expect(ok).toBe(false);
     expect(error).toMatchObject({
-      message: "system provenance fields are reserved for the ACP bridge",
+      message: "system provenance fields require admin scope",
     });
     expect(mockState.lastDispatchCtx).toBeUndefined();
+  });
+
+  it("allows admin-scoped clients to inject system provenance without ACP metadata", async () => {
+    createTranscriptFixture("openclaw-chat-send-system-provenance-admin-");
+    mockState.finalText = "ok";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-system-provenance-admin",
+      message: "ops update",
+      client: {
+        connect: {
+          scopes: ["operator.admin"],
+          client: {
+            id: "custom-operator",
+            mode: "cli",
+            displayName: "custom-operator",
+            version: "1.0.0",
+          },
+        },
+      },
+      requestParams: {
+        systemInputProvenance: {
+          kind: "external_user",
+          originSessionId: "admin-session-1",
+          sourceChannel: "acp",
+          sourceTool: "openclaw_acp",
+        },
+        systemProvenanceReceipt:
+          "[Source Receipt]\nbridge=openclaw-acp\noriginSessionId=admin-session-1\n[/Source Receipt]",
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx?.InputProvenance).toEqual({
+      kind: "external_user",
+      originSessionId: "admin-session-1",
+      sourceChannel: "acp",
+      sourceTool: "openclaw_acp",
+    });
+    expect(mockState.lastDispatchCtx?.Body).toBe(
+      "[Source Receipt]\nbridge=openclaw-acp\noriginSessionId=admin-session-1\n[/Source Receipt]\n\nops update",
+    );
+    expect(mockState.lastDispatchCtx?.RawBody).toBe("ops update");
+    expect(mockState.lastDispatchCtx?.CommandBody).toBe("ops update");
   });
 
   it("injects ACP system provenance into the agent-visible body", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1277,10 +1277,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "system provenance fields are reserved for the ACP bridge",
-        ),
+        errorShape(ErrorCodes.INVALID_REQUEST, "system provenance fields require admin scope"),
       );
       return;
     }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -299,6 +299,11 @@ function isAcpBridgeClient(client: GatewayRequestHandlerOptions["client"]): bool
   );
 }
 
+function canInjectSystemProvenance(client: GatewayRequestHandlerOptions["client"]): boolean {
+  const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+  return scopes.includes(ADMIN_SCOPE);
+}
+
 async function persistChatSendImages(params: {
   images: ChatImageContent[];
   client: GatewayRequestHandlerOptions["client"];
@@ -1265,7 +1270,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       systemProvenanceReceipt?: string;
       idempotencyKey: string;
     };
-    if ((p.systemInputProvenance || p.systemProvenanceReceipt) && !isAcpBridgeClient(client)) {
+    if (
+      (p.systemInputProvenance || p.systemProvenanceReceipt) &&
+      !canInjectSystemProvenance(client)
+    ) {
       respond(
         false,
         undefined,


### PR DESCRIPTION
## Summary
- Require verified gateway scope state before `chat.send` accepts reserved system provenance fields
- Keep the existing admin-scoped ACP path working while blocking spoofed client metadata alone

## Changes
- Replaced the reserved provenance gate in `chat.send` so it checks authenticated operator scopes instead of client-declared ACP labels
- Added a regression test that proves forged ACP metadata with only `operator.write` is rejected
- Kept the existing admin-scoped provenance injection path covered

## Validation
- Ran `pnpm test -- src/gateway/server-methods/chat.directive-tags.test.ts`
- Verified spoofed ACP client metadata no longer unlocks reserved provenance fields without verified admin scope
- Ran local agentic review with `claude -p "/review"`; it timed out without findings in this environment

## Notes
- Residual follow-up: admin-scoped clients can still set reserved provenance fields; this change narrows the gate to verified authz state without changing the broader admin trust model
