### PR TITLE
feat(feishu): add exec approval support with Interactive Card

### DIFF
--- a/extensions/feishu/api.ts
+++ b/extensions/feishu/api.ts
@@ -1,4 +1,6 @@
 export * from "./src/conversation-id.js";
+export * from "./src/exec-approvals.js";
+export * from "./src/exec-approval-forwarding.js";
 export * from "./src/setup-core.js";
 export * from "./src/setup-surface.js";
 export * from "./src/thread-bindings.js";

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -325,6 +325,17 @@ export async function handleFeishuCardAction(params: {
           accountId,
           chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
         });
+        // Send resolved card to give visual feedback that the action was processed
+        await sendCardFeishu({
+          cfg,
+          to: resolveCallbackTarget(event),
+          card: createExecApprovalResolvedCard({
+            approvalId,
+            decision: execApprovalDecision,
+            resolvedBy: event.operator.open_id,
+          }),
+          accountId,
+        }).catch(() => {});
         completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
         return;
       }

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -316,26 +316,31 @@ export async function handleFeishuCardAction(params: {
         log(
           `feishu[${account.accountId}]: exec approval ${execApprovalDecision} for ${approvalId} by ${event.operator.open_id}`,
         );
-        await dispatchSyntheticCommand({
-          cfg,
-          event,
-          command: `/approve ${approvalId} ${execApprovalDecision}`,
-          botOpenId: params.botOpenId,
-          runtime,
-          accountId,
-          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
-        });
-        // Send resolved card to give visual feedback that the action was processed
-        await sendCardFeishu({
-          cfg,
-          to: resolveCallbackTarget(event),
-          card: createExecApprovalResolvedCard({
-            approvalId,
-            decision: execApprovalDecision,
-            resolvedBy: event.operator.open_id,
-          }),
-          accountId,
-        }).catch(() => {});
+        try {
+          await dispatchSyntheticCommand({
+            cfg,
+            event,
+            command: `/approve ${approvalId} ${execApprovalDecision}`,
+            botOpenId: params.botOpenId,
+            runtime,
+            accountId,
+            chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+          });
+          // Send resolved card only after successful dispatch
+          await sendCardFeishu({
+            cfg,
+            to: resolveCallbackTarget(event),
+            card: createExecApprovalResolvedCard({
+              approvalId,
+              decision: execApprovalDecision,
+              resolvedBy: event.operator.open_id,
+            }),
+            accountId,
+          }).catch(() => {});
+        } catch {
+          // Dispatch failed — don't send resolved card; the error reply
+          // is handled by the command pipeline
+        }
         completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
         return;
       }

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -8,6 +8,12 @@ import {
   FEISHU_APPROVAL_CONFIRM_ACTION,
   FEISHU_APPROVAL_REQUEST_ACTION,
 } from "./card-ux-approval.js";
+import {
+  FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
+  FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+  FEISHU_EXEC_APPROVAL_DENY_ACTION,
+  createExecApprovalResolvedCard,
+} from "./card-ux-exec-approval.js";
 import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 
 export type FeishuCardActionEvent = {
@@ -166,6 +172,21 @@ async function sendInvalidInteractionNotice(params: {
   });
 }
 
+function resolveExecApprovalDecision(
+  action: string,
+): "allow-once" | "allow-always" | "deny" | null {
+  if (action === FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION) {
+    return "allow-once";
+  }
+  if (action === FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION) {
+    return "allow-always";
+  }
+  if (action === FEISHU_EXEC_APPROVAL_DENY_ACTION) {
+    return "deny";
+  }
+  return null;
+}
+
 export async function handleFeishuCardAction(params: {
   cfg: ClawdbotConfig;
   event: FeishuCardActionEvent;
@@ -269,6 +290,36 @@ export async function handleFeishuCardAction(params: {
           cfg,
           event,
           command,
+          botOpenId: params.botOpenId,
+          runtime,
+          accountId,
+          chatType: envelope.c?.t ?? (event.context.chat_id ? "group" : "p2p"),
+        });
+        completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+        return;
+      }
+
+      const execApprovalDecision = resolveExecApprovalDecision(envelope.a);
+      if (execApprovalDecision) {
+        const approvalId =
+          typeof envelope.m?.approvalId === "string" ? envelope.m.approvalId.trim() : "";
+        if (!approvalId) {
+          await sendInvalidInteractionNotice({
+            cfg,
+            event,
+            reason: "malformed",
+            accountId,
+          });
+          completeFeishuCardActionToken({ token: event.token, accountId: account.accountId });
+          return;
+        }
+        log(
+          `feishu[${account.accountId}]: exec approval ${execApprovalDecision} for ${approvalId} by ${event.operator.open_id}`,
+        );
+        await dispatchSyntheticCommand({
+          cfg,
+          event,
+          command: `/approve ${approvalId} ${execApprovalDecision}`,
           botOpenId: params.botOpenId,
           runtime,
           accountId,

--- a/extensions/feishu/src/card-ux-exec-approval.test.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { FEISHU_CARD_INTERACTION_VERSION } from "./card-interaction.js";
+import {
+  createExecApprovalCard,
+  createExecApprovalResolvedCard,
+  FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
+  FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+  FEISHU_EXEC_APPROVAL_DENY_ACTION,
+} from "./card-ux-exec-approval.js";
+
+describe("createExecApprovalCard", () => {
+  it("creates card with three buttons", () => {
+    const card = createExecApprovalCard({
+      approvalId: "abcdef1234567890",
+      command: "rm -rf /tmp/test",
+      cwd: "/home/user",
+      host: "gateway",
+      expiresAtMs: Date.now() + 120_000,
+    });
+
+    expect(card.schema).toBe("2.0");
+    expect((card.header as Record<string, unknown>).template).toBe("orange");
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    expect(body.elements).toHaveLength(2);
+
+    const markdownElement = body.elements[0];
+    expect(markdownElement.tag).toBe("markdown");
+    expect(markdownElement.content).toContain("abcdef12");
+    expect(markdownElement.content).toContain("rm -rf /tmp/test");
+    expect(markdownElement.content).toContain("/home/user");
+
+    const actionElement = body.elements[1] as { actions: Array<Record<string, unknown>> };
+    expect(actionElement.actions).toHaveLength(3);
+
+    const allowOnceButton = actionElement.actions[0];
+    expect((allowOnceButton.text as Record<string, string>).content).toBe("Allow Once");
+    expect(allowOnceButton.type).toBe("primary");
+    const allowOnceValue = allowOnceButton.value as Record<string, unknown>;
+    expect(allowOnceValue.oc).toBe(FEISHU_CARD_INTERACTION_VERSION);
+    expect(allowOnceValue.a).toBe(FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION);
+    expect((allowOnceValue.m as Record<string, string>).approvalId).toBe("abcdef1234567890");
+
+    const allowAlwaysButton = actionElement.actions[1];
+    expect((allowAlwaysButton.text as Record<string, string>).content).toBe("Allow Always");
+    expect(allowAlwaysButton.type).toBe("default");
+    expect((allowAlwaysButton.value as Record<string, unknown>).a).toBe(
+      FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+    );
+
+    const denyButton = actionElement.actions[2];
+    expect((denyButton.text as Record<string, string>).content).toBe("Deny");
+    expect(denyButton.type).toBe("danger");
+    expect((denyButton.value as Record<string, unknown>).a).toBe(FEISHU_EXEC_APPROVAL_DENY_ACTION);
+  });
+
+  it("omits optional fields when not provided", () => {
+    const card = createExecApprovalCard({
+      approvalId: "test123",
+      command: "echo hello",
+      expiresAtMs: Date.now() + 60_000,
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const content = body.elements[0].content as string;
+    expect(content).not.toContain("CWD");
+    expect(content).not.toContain("Host");
+  });
+});
+
+describe("createExecApprovalResolvedCard", () => {
+  it("creates green card for allow-once", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "abcdef1234567890",
+      decision: "allow-once",
+    });
+
+    expect((card.header as Record<string, unknown>).template).toBe("green");
+    const title = (card.header as Record<string, Record<string, string>>).title;
+    expect(title.content).toContain("Allowed (once)");
+  });
+
+  it("creates green card for allow-always", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "allow-always",
+    });
+
+    expect((card.header as Record<string, unknown>).template).toBe("green");
+    const title = (card.header as Record<string, Record<string, string>>).title;
+    expect(title.content).toContain("Allowed (always)");
+  });
+
+  it("creates red card for deny", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "deny",
+    });
+
+    expect((card.header as Record<string, unknown>).template).toBe("red");
+    const title = (card.header as Record<string, Record<string, string>>).title;
+    expect(title.content).toContain("Denied");
+  });
+
+  it("includes resolvedBy when provided", () => {
+    const card = createExecApprovalResolvedCard({
+      approvalId: "test123",
+      decision: "allow-once",
+      resolvedBy: "user@feishu",
+    });
+
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    expect(body.elements[0].content).toContain("user@feishu");
+  });
+});

--- a/extensions/feishu/src/card-ux-exec-approval.test.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.test.ts
@@ -40,6 +40,9 @@ describe("createExecApprovalCard", () => {
     expect(allowOnceValue.oc).toBe(FEISHU_CARD_INTERACTION_VERSION);
     expect(allowOnceValue.a).toBe(FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION);
     expect((allowOnceValue.m as Record<string, string>).approvalId).toBe("abcdef1234567890");
+    const allowOnceContext = allowOnceValue.c as Record<string, unknown>;
+    expect(allowOnceContext.e).toBeTypeOf("number");
+    expect(allowOnceContext.u).toBeUndefined();
 
     const allowAlwaysButton = actionElement.actions[1];
     expect((allowAlwaysButton.text as Record<string, string>).content).toBe("Allow Always");
@@ -52,6 +55,20 @@ describe("createExecApprovalCard", () => {
     expect((denyButton.text as Record<string, string>).content).toBe("Deny");
     expect(denyButton.type).toBe("danger");
     expect((denyButton.value as Record<string, unknown>).a).toBe(FEISHU_EXEC_APPROVAL_DENY_ACTION);
+  });
+
+  it("includes chatType in button context when provided", () => {
+    const card = createExecApprovalCard({
+      approvalId: "abcdef1234567890",
+      command: "ls",
+      expiresAtMs: Date.now() + 60_000,
+      chatType: "group",
+    });
+    const body = card.body as { elements: Array<Record<string, unknown>> };
+    const actionElement = body.elements[1] as { actions: Array<Record<string, unknown>> };
+    const buttonValue = actionElement.actions[0].value as Record<string, unknown>;
+    const context = buttonValue.c as Record<string, unknown>;
+    expect(context.t).toBe("group");
   });
 
   it("omits optional fields when not provided", () => {

--- a/extensions/feishu/src/card-ux-exec-approval.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.ts
@@ -1,0 +1,123 @@
+import { createFeishuCardInteractionEnvelope } from "./card-interaction.js";
+import { buildFeishuCardButton } from "./card-ux-shared.js";
+
+export const FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION = "feishu.exec_approval.allow_once";
+export const FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION = "feishu.exec_approval.allow_always";
+export const FEISHU_EXEC_APPROVAL_DENY_ACTION = "feishu.exec_approval.deny";
+
+export function createExecApprovalCard(params: {
+  approvalId: string;
+  command: string;
+  cwd?: string;
+  host?: string;
+  nodeId?: string;
+  expiresAtMs: number;
+}): Record<string, unknown> {
+  const approvalSlug = params.approvalId.slice(0, 8);
+  const bodyLines: string[] = [
+    `**Approval ID:** \`${approvalSlug}\``,
+    `**Command:** \`${params.command}\``,
+  ];
+  if (params.cwd) {
+    bodyLines.push(`**CWD:** \`${params.cwd}\``);
+  }
+  if (params.host) {
+    bodyLines.push(`**Host:** ${params.host}`);
+  }
+  if (params.nodeId) {
+    bodyLines.push(`**Node:** \`${params.nodeId}\``);
+  }
+
+  const metadata = { approvalId: params.approvalId };
+
+  return {
+    schema: "2.0",
+    config: {
+      wide_screen_mode: true,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: "Exec Approval Required",
+      },
+      template: "orange",
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: bodyLines.join("\n"),
+        },
+        {
+          tag: "action",
+          actions: [
+            buildFeishuCardButton({
+              label: "Allow Once",
+              type: "primary",
+              value: createFeishuCardInteractionEnvelope({
+                k: "button",
+                a: FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
+                m: metadata,
+              }),
+            }),
+            buildFeishuCardButton({
+              label: "Allow Always",
+              value: createFeishuCardInteractionEnvelope({
+                k: "button",
+                a: FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
+                m: metadata,
+              }),
+            }),
+            buildFeishuCardButton({
+              label: "Deny",
+              type: "danger",
+              value: createFeishuCardInteractionEnvelope({
+                k: "button",
+                a: FEISHU_EXEC_APPROVAL_DENY_ACTION,
+                m: metadata,
+              }),
+            }),
+          ],
+        },
+      ],
+    },
+  };
+}
+
+export function createExecApprovalResolvedCard(params: {
+  approvalId: string;
+  decision: string;
+  resolvedBy?: string;
+}): Record<string, unknown> {
+  const approvalSlug = params.approvalId.slice(0, 8);
+  const decisionLabel =
+    params.decision === "allow-once"
+      ? "Allowed (once)"
+      : params.decision === "allow-always"
+        ? "Allowed (always)"
+        : "Denied";
+  const template = params.decision === "deny" ? "red" : "green";
+  const resolvedByText = params.resolvedBy ? ` by ${params.resolvedBy}` : "";
+
+  return {
+    schema: "2.0",
+    config: {
+      wide_screen_mode: true,
+    },
+    header: {
+      title: {
+        tag: "plain_text",
+        content: `Exec Approval — ${decisionLabel}`,
+      },
+      template,
+    },
+    body: {
+      elements: [
+        {
+          tag: "markdown",
+          content: `**Approval ID:** \`${approvalSlug}\`\n**Decision:** ${decisionLabel}${resolvedByText}`,
+        },
+      ],
+    },
+  };
+}

--- a/extensions/feishu/src/card-ux-exec-approval.ts
+++ b/extensions/feishu/src/card-ux-exec-approval.ts
@@ -12,6 +12,7 @@ export function createExecApprovalCard(params: {
   host?: string;
   nodeId?: string;
   expiresAtMs: number;
+  chatType?: "p2p" | "group";
 }): Record<string, unknown> {
   const approvalSlug = params.approvalId.slice(0, 8);
   const bodyLines: string[] = [
@@ -29,6 +30,13 @@ export function createExecApprovalCard(params: {
   }
 
   const metadata = { approvalId: params.approvalId };
+  // Exec approval context omits u (user) and h (chat) — any configured
+  // approver may click from any surface (DM or channel). Include expiry
+  // and chat type so callbacks enforce TTL and route correctly.
+  const context: { e: number; t?: "p2p" | "group" } = {
+    e: params.expiresAtMs,
+    ...(params.chatType ? { t: params.chatType } : {}),
+  };
 
   return {
     schema: "2.0",
@@ -58,6 +66,7 @@ export function createExecApprovalCard(params: {
                 k: "button",
                 a: FEISHU_EXEC_APPROVAL_ALLOW_ONCE_ACTION,
                 m: metadata,
+                c: context,
               }),
             }),
             buildFeishuCardButton({
@@ -66,6 +75,7 @@ export function createExecApprovalCard(params: {
                 k: "button",
                 a: FEISHU_EXEC_APPROVAL_ALLOW_ALWAYS_ACTION,
                 m: metadata,
+                c: context,
               }),
             }),
             buildFeishuCardButton({
@@ -75,6 +85,7 @@ export function createExecApprovalCard(params: {
                 k: "button",
                 a: FEISHU_EXEC_APPROVAL_DENY_ACTION,
                 m: metadata,
+                c: context,
               }),
             }),
           ],

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -53,6 +53,14 @@ import {
   parseFeishuTargetId,
 } from "./conversation-id.js";
 import { listFeishuDirectoryPeers, listFeishuDirectoryGroups } from "./directory.static.js";
+import {
+  shouldSuppressFeishuExecApprovalForwardingFallback,
+  buildFeishuExecApprovalPendingPayload,
+} from "./exec-approval-forwarding.js";
+import {
+  isFeishuExecApprovalClientEnabled,
+  resolveFeishuExecApprovalTarget,
+} from "./exec-approvals.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
@@ -1079,6 +1087,24 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           looksLikeId: looksLikeFeishuId,
           hint: "<chatId|user:openId|chat:chatId>",
         },
+      },
+      execApprovals: {
+        getInitiatingSurfaceState: ({ cfg, accountId }) =>
+          isFeishuExecApprovalClientEnabled({ cfg, accountId })
+            ? { kind: "enabled" }
+            : { kind: "disabled" },
+        hasConfiguredDmRoute: ({ cfg }) =>
+          listFeishuAccountIds(cfg).some((accountId) => {
+            if (!isFeishuExecApprovalClientEnabled({ cfg, accountId })) {
+              return false;
+            }
+            const target = resolveFeishuExecApprovalTarget({ cfg, accountId });
+            return target === "dm" || target === "both";
+          }),
+        shouldSuppressForwardingFallback: (params) =>
+          shouldSuppressFeishuExecApprovalForwardingFallback(params),
+        buildPendingPayload: ({ request, nowMs }) =>
+          buildFeishuExecApprovalPendingPayload({ request, nowMs }),
       },
       directory: createChannelDirectoryAdapter({
         listPeers: async ({ cfg, query, limit, accountId }) =>

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -60,6 +60,7 @@ import {
 import {
   isFeishuExecApprovalClientEnabled,
   resolveFeishuExecApprovalTarget,
+  shouldSuppressLocalFeishuExecApprovalPrompt,
 } from "./exec-approvals.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -1093,6 +1094,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           isFeishuExecApprovalClientEnabled({ cfg, accountId })
             ? { kind: "enabled" }
             : { kind: "disabled" },
+        shouldSuppressLocalPrompt: ({ cfg, accountId, payload }) =>
+          shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, accountId, payload }),
         hasConfiguredDmRoute: ({ cfg }) =>
           listFeishuAccountIds(cfg).some((accountId) => {
             if (!isFeishuExecApprovalClientEnabled({ cfg, accountId })) {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -59,7 +59,6 @@ import {
 } from "./exec-approval-forwarding.js";
 import {
   isFeishuExecApprovalClientEnabled,
-  resolveFeishuExecApprovalTarget,
   shouldSuppressLocalFeishuExecApprovalPrompt,
 } from "./exec-approvals.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
@@ -1096,14 +1095,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             : { kind: "disabled" },
         shouldSuppressLocalPrompt: ({ cfg, accountId, payload }) =>
           shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, accountId, payload }),
-        hasConfiguredDmRoute: ({ cfg }) =>
-          listFeishuAccountIds(cfg).some((accountId) => {
-            if (!isFeishuExecApprovalClientEnabled({ cfg, accountId })) {
-              return false;
-            }
-            const target = resolveFeishuExecApprovalTarget({ cfg, accountId });
-            return target === "dm" || target === "both";
-          }),
+        // Feishu does not have a dedicated exec approval DM client — delivery
+        // relies entirely on the forwarding fallback pipeline. Reporting a DM
+        // route here would cause the framework to tell users "I sent DMs to
+        // approvers" when no dedicated DM was actually sent. Return false until
+        // a Feishu exec approval handler client is implemented.
+        hasConfiguredDmRoute: () => false,
         shouldSuppressForwardingFallback: (params) =>
           shouldSuppressFeishuExecApprovalForwardingFallback(params),
         buildPendingPayload: ({ cfg, request, target, nowMs }) =>

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1106,8 +1106,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           }),
         shouldSuppressForwardingFallback: (params) =>
           shouldSuppressFeishuExecApprovalForwardingFallback(params),
-        buildPendingPayload: ({ request, nowMs }) =>
-          buildFeishuExecApprovalPendingPayload({ request, nowMs }),
+        buildPendingPayload: ({ cfg, request, target, nowMs }) =>
+          buildFeishuExecApprovalPendingPayload({ cfg, request, target, nowMs }),
       },
       directory: createChannelDirectoryAdapter({
         listPeers: async ({ cfg, query, limit, accountId }) =>

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -138,6 +138,19 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+const FeishuExecApprovalTargetSchema = z.enum(["dm", "channel", "both"]);
+
+const FeishuExecApprovalConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    approvers: z.array(z.union([z.string(), z.number()])).optional(),
+    agentFilter: z.array(z.string()).optional(),
+    sessionFilter: z.array(z.string()).optional(),
+    target: FeishuExecApprovalTargetSchema.optional(),
+  })
+  .strict()
+  .optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -182,6 +195,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  execApprovals: FeishuExecApprovalConfigSchema,
 };
 
 /**

--- a/extensions/feishu/src/exec-approval-forwarding.test.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { buildFeishuExecApprovalPendingPayload } from "./exec-approval-forwarding.js";
+
+function buildConfig(execApprovals?: Record<string, unknown>) {
+  return {
+    channels: {
+      feishu: {
+        appId: "cli_test",
+        appSecret: "secret",
+        ...(execApprovals ? { execApprovals } : {}),
+      },
+    },
+  } as never;
+}
+
+function buildRequest(id = "approval-123") {
+  return {
+    id,
+    expiresAtMs: Date.now() + 60_000,
+    request: {
+      command: "rm -rf /tmp/test",
+      cwd: "/home/user",
+      host: "gateway" as const,
+      agentId: "agent-1",
+      sessionKey: "session-1",
+    },
+  } as never;
+}
+
+describe("buildFeishuExecApprovalPendingPayload target routing", () => {
+  it("returns card for DM target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).not.toBeNull();
+    expect(result?.channelData?.feishu?.card).toBeDefined();
+  });
+
+  it("returns null for group target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns card for group target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(result).not.toBeNull();
+    expect(result?.channelData?.feishu?.card).toBeDefined();
+  });
+
+  it("returns null for DM target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns card for both DM and group when configured as both", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
+    const dmResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    const groupResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(dmResult).not.toBeNull();
+    expect(groupResult).not.toBeNull();
+  });
+
+  it("defaults to dm when no target configured", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    const dmResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    const groupResult = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "chat:oc_group123" },
+      nowMs: Date.now(),
+    });
+    expect(dmResult).not.toBeNull();
+    expect(groupResult).toBeNull();
+  });
+});

--- a/extensions/feishu/src/exec-approval-forwarding.test.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildFeishuExecApprovalPendingPayload } from "./exec-approval-forwarding.js";
+import {
+  buildFeishuExecApprovalPendingPayload,
+  shouldSuppressFeishuExecApprovalForwardingFallback,
+} from "./exec-approval-forwarding.js";
 
 function buildConfig(execApprovals?: Record<string, unknown>) {
   return {
@@ -108,5 +111,80 @@ describe("buildFeishuExecApprovalPendingPayload target routing", () => {
     });
     expect(dmResult).not.toBeNull();
     expect(groupResult).toBeNull();
+  });
+});
+
+describe("shouldSuppressFeishuExecApprovalForwardingFallback", () => {
+  it("returns false when client is not enabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses group target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress DM target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "user:ou_123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses DM target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "user:ou_123" },
+        request: buildRequest(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress group target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("does not suppress any target when configured as both", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "user:ou_123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/feishu/src/exec-approval-forwarding.test.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.test.ts
@@ -112,6 +112,52 @@ describe("buildFeishuExecApprovalPendingPayload target routing", () => {
     expect(dmResult).not.toBeNull();
     expect(groupResult).toBeNull();
   });
+
+  it("detects bare ou_ IDs as DM targets", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "ou_abc123" },
+      nowMs: Date.now(),
+    });
+    expect(result).not.toBeNull();
+    expect(result?.channelData?.feishu?.card).toBeDefined();
+  });
+
+  it("detects bare on_ IDs as DM targets", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "on_abc123" },
+      nowMs: Date.now(),
+    });
+    // on_ is a DM target, but config is channel-only → null
+    expect(result).toBeNull();
+  });
+
+  it("returns null when exec approvals are disabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"], target: "both" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no approvers are configured", () => {
+    const cfg = buildConfig({ enabled: true, approvers: [], target: "both" });
+    const result = buildFeishuExecApprovalPendingPayload({
+      cfg,
+      request: buildRequest(),
+      target: { channel: "feishu", to: "user:ou_123" },
+      nowMs: Date.now(),
+    });
+    expect(result).toBeNull();
+  });
 });
 
 describe("shouldSuppressFeishuExecApprovalForwardingFallback", () => {
@@ -183,6 +229,28 @@ describe("shouldSuppressFeishuExecApprovalForwardingFallback", () => {
       shouldSuppressFeishuExecApprovalForwardingFallback({
         cfg,
         target: { channel: "feishu", to: "chat:oc_group123" },
+        request: buildRequest(),
+      }),
+    ).toBe(false);
+  });
+
+  it("suppresses bare ou_ DM target when configured as channel", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "channel" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "ou_abc123" },
+        request: buildRequest(),
+      }),
+    ).toBe(true);
+  });
+
+  it("does not suppress bare ou_ DM target when configured as dm", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "dm" });
+    expect(
+      shouldSuppressFeishuExecApprovalForwardingFallback({
+        cfg,
+        target: { channel: "feishu", to: "ou_abc123" },
         request: buildRequest(),
       }),
     ).toBe(false);

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -5,19 +5,39 @@ import {
   resolveExecApprovalCommandDisplay,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { createExecApprovalCard } from "./card-ux-exec-approval.js";
-import { resolveFeishuExecApprovalTarget } from "./exec-approvals.js";
+import {
+  isFeishuExecApprovalClientEnabled,
+  resolveFeishuExecApprovalTarget,
+} from "./exec-approvals.js";
 
-// Unlike Telegram (which has an independent TelegramExecApprovalHandler gateway
-// client to take over delivery), Feishu currently delivers exec approval cards
-// only via the forwarding fallback pipeline. Suppressing the fallback would
-// remove the only delivery route, causing approval requests to expire silently
-// with "no-approval-route". Always return false until a dedicated Feishu exec
-// approval handler client is implemented.
-export function shouldSuppressFeishuExecApprovalForwardingFallback(_params: {
+// Suppress forwarding to a specific target when the configured exec approval
+// target routing (dm/channel/both) doesn't match the actual target chat type.
+// This prevents both Interactive Cards AND plain-text fallback from leaking
+// into excluded chats. Without a dedicated Feishu exec approval handler client,
+// forwarding fallback is the only delivery path, so we only suppress targets
+// that violate the routing config — never suppress all targets unconditionally.
+export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
   cfg: OpenClawConfig;
-  target: { channel: string; accountId?: string | null };
+  target: { channel: string; to: string; accountId?: string | null };
   request: ExecApprovalRequest;
 }): boolean {
+  if (!isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.target.accountId })) {
+    return false;
+  }
+  const configuredTarget = resolveFeishuExecApprovalTarget({
+    cfg: params.cfg,
+    accountId: params.target.accountId,
+  });
+  if (configuredTarget === "both") {
+    return false;
+  }
+  const isDm = isFeishuDmTarget(params.target.to);
+  if (configuredTarget === "dm" && !isDm) {
+    return true;
+  }
+  if (configuredTarget === "channel" && isDm) {
+    return true;
+  }
   return false;
 }
 

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -1,0 +1,62 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { ExecApprovalRequest } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  buildExecApprovalPendingReplyPayload,
+  resolveExecApprovalCommandDisplay,
+} from "openclaw/plugin-sdk/infra-runtime";
+import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
+import { createExecApprovalCard } from "./card-ux-exec-approval.js";
+import { isFeishuExecApprovalClientEnabled } from "./exec-approvals.js";
+
+export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
+  cfg: OpenClawConfig;
+  target: { channel: string; accountId?: string | null };
+  request: ExecApprovalRequest;
+}): boolean {
+  const channel = normalizeMessageChannel(params.target.channel) ?? params.target.channel;
+  if (channel !== "feishu") {
+    return false;
+  }
+  const requestChannel = normalizeMessageChannel(params.request.request.turnSourceChannel ?? "");
+  if (requestChannel !== "feishu") {
+    return false;
+  }
+  const accountId =
+    params.target.accountId?.trim() || params.request.request.turnSourceAccountId?.trim();
+  return isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId });
+}
+
+export function buildFeishuExecApprovalPendingPayload(params: {
+  request: ExecApprovalRequest;
+  nowMs: number;
+}) {
+  const commandDisplay = resolveExecApprovalCommandDisplay(params.request.request);
+  const payload = buildExecApprovalPendingReplyPayload({
+    approvalId: params.request.id,
+    approvalSlug: params.request.id.slice(0, 8),
+    approvalCommandId: params.request.id,
+    command: commandDisplay.commandText,
+    cwd: params.request.request.cwd ?? undefined,
+    host: params.request.request.host === "node" ? "node" : "gateway",
+    nodeId: params.request.request.nodeId ?? undefined,
+    expiresAtMs: params.request.expiresAtMs,
+    nowMs: params.nowMs,
+  });
+
+  const card = createExecApprovalCard({
+    approvalId: params.request.id,
+    command: commandDisplay.commandText,
+    cwd: params.request.request.cwd ?? undefined,
+    host: params.request.request.host === "node" ? "node" : "gateway",
+    nodeId: params.request.request.nodeId ?? undefined,
+    expiresAtMs: params.request.expiresAtMs,
+  });
+
+  return {
+    ...payload,
+    channelData: {
+      ...payload.channelData,
+      feishu: { card },
+    },
+  };
+}

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -41,9 +41,14 @@ export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
   return false;
 }
 
-// Determine whether a Feishu target address is a DM (user:*) or group (chat:*).
+// Determine whether a Feishu target address is a DM. Handles both prefixed
+// forms (user:ou_xxx) and bare normalized IDs (ou_xxx, on_xxx) since
+// normalizeFeishuTarget strips type prefixes and session routes store bare IDs.
 function isFeishuDmTarget(to: string): boolean {
-  return to.startsWith("user:");
+  if (to.startsWith("user:") || to.startsWith("dm:")) return true;
+  const lower = to.toLowerCase();
+  if (lower.startsWith("ou_") || lower.startsWith("on_")) return true;
+  return false;
 }
 
 export function buildFeishuExecApprovalPendingPayload(params: {
@@ -52,6 +57,13 @@ export function buildFeishuExecApprovalPendingPayload(params: {
   target: { channel: string; to: string; accountId?: string | null };
   nowMs: number;
 }) {
+  // Don't attach an Interactive Card when exec approvals are disabled or no
+  // approvers are configured — button clicks would be rejected by the Feishu
+  // gate in handleApproveCommand, producing dead buttons.
+  if (!isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.target.accountId })) {
+    return null;
+  }
+
   // Defense-in-depth: if the configured target routing doesn't match this
   // specific forward target, return null so the framework falls back to
   // plain text instead of leaking an Interactive Card into an excluded chat.

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -4,9 +4,55 @@ import {
   buildExecApprovalPendingReplyPayload,
   resolveExecApprovalCommandDisplay,
 } from "openclaw/plugin-sdk/infra-runtime";
-import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
+import { normalizeMessageChannel, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { compileSafeRegex, testRegexWithBoundedInput } from "openclaw/plugin-sdk/security-runtime";
 import { createExecApprovalCard } from "./card-ux-exec-approval.js";
-import { isFeishuExecApprovalClientEnabled } from "./exec-approvals.js";
+import {
+  getFeishuExecApprovalApprovers,
+  isFeishuExecApprovalClientEnabled,
+  resolveFeishuExecApprovalConfig,
+} from "./exec-approvals.js";
+
+function matchesFeishuFilters(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  request: ExecApprovalRequest;
+}): boolean {
+  const config = resolveFeishuExecApprovalConfig({ cfg: params.cfg, accountId: params.accountId });
+  if (!config?.enabled) {
+    return false;
+  }
+  if (
+    getFeishuExecApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }).length === 0
+  ) {
+    return false;
+  }
+  if (config.agentFilter?.length) {
+    const agentId =
+      params.request.request.agentId ??
+      parseAgentSessionKey(params.request.request.sessionKey)?.agentId;
+    if (!agentId || !config.agentFilter.includes(agentId)) {
+      return false;
+    }
+  }
+  if (config.sessionFilter?.length) {
+    const sessionKey = params.request.request.sessionKey;
+    if (!sessionKey) {
+      return false;
+    }
+    const matches = config.sessionFilter.some((pattern) => {
+      if (sessionKey.includes(pattern)) {
+        return true;
+      }
+      const regex = compileSafeRegex(pattern);
+      return regex ? testRegexWithBoundedInput(regex, sessionKey) : false;
+    });
+    if (!matches) {
+      return false;
+    }
+  }
+  return true;
+}
 
 export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
   cfg: OpenClawConfig;
@@ -23,7 +69,7 @@ export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
   }
   const accountId =
     params.target.accountId?.trim() || params.request.request.turnSourceAccountId?.trim();
-  return isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId });
+  return matchesFeishuFilters({ cfg: params.cfg, accountId, request: params.request });
 }
 
 export function buildFeishuExecApprovalPendingPayload(params: {

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -4,72 +4,20 @@ import {
   buildExecApprovalPendingReplyPayload,
   resolveExecApprovalCommandDisplay,
 } from "openclaw/plugin-sdk/infra-runtime";
-import { normalizeMessageChannel, parseAgentSessionKey } from "openclaw/plugin-sdk/routing";
-import { compileSafeRegex, testRegexWithBoundedInput } from "openclaw/plugin-sdk/security-runtime";
 import { createExecApprovalCard } from "./card-ux-exec-approval.js";
-import {
-  getFeishuExecApprovalApprovers,
-  isFeishuExecApprovalClientEnabled,
-  resolveFeishuExecApprovalConfig,
-} from "./exec-approvals.js";
 
-function matchesFeishuFilters(params: {
-  cfg: OpenClawConfig;
-  accountId?: string | null;
-  request: ExecApprovalRequest;
-}): boolean {
-  const config = resolveFeishuExecApprovalConfig({ cfg: params.cfg, accountId: params.accountId });
-  if (!config?.enabled) {
-    return false;
-  }
-  if (
-    getFeishuExecApprovalApprovers({ cfg: params.cfg, accountId: params.accountId }).length === 0
-  ) {
-    return false;
-  }
-  if (config.agentFilter?.length) {
-    const agentId =
-      params.request.request.agentId ??
-      parseAgentSessionKey(params.request.request.sessionKey)?.agentId;
-    if (!agentId || !config.agentFilter.includes(agentId)) {
-      return false;
-    }
-  }
-  if (config.sessionFilter?.length) {
-    const sessionKey = params.request.request.sessionKey;
-    if (!sessionKey) {
-      return false;
-    }
-    const matches = config.sessionFilter.some((pattern) => {
-      if (sessionKey.includes(pattern)) {
-        return true;
-      }
-      const regex = compileSafeRegex(pattern);
-      return regex ? testRegexWithBoundedInput(regex, sessionKey) : false;
-    });
-    if (!matches) {
-      return false;
-    }
-  }
-  return true;
-}
-
-export function shouldSuppressFeishuExecApprovalForwardingFallback(params: {
+// Unlike Telegram (which has an independent TelegramExecApprovalHandler gateway
+// client to take over delivery), Feishu currently delivers exec approval cards
+// only via the forwarding fallback pipeline. Suppressing the fallback would
+// remove the only delivery route, causing approval requests to expire silently
+// with "no-approval-route". Always return false until a dedicated Feishu exec
+// approval handler client is implemented.
+export function shouldSuppressFeishuExecApprovalForwardingFallback(_params: {
   cfg: OpenClawConfig;
   target: { channel: string; accountId?: string | null };
   request: ExecApprovalRequest;
 }): boolean {
-  const channel = normalizeMessageChannel(params.target.channel) ?? params.target.channel;
-  if (channel !== "feishu") {
-    return false;
-  }
-  const requestChannel = normalizeMessageChannel(params.request.request.turnSourceChannel ?? "");
-  if (requestChannel !== "feishu") {
-    return false;
-  }
-  const accountId =
-    params.target.accountId?.trim() || params.request.request.turnSourceAccountId?.trim();
-  return matchesFeishuFilters({ cfg: params.cfg, accountId, request: params.request });
+  return false;
 }
 
 export function buildFeishuExecApprovalPendingPayload(params: {

--- a/extensions/feishu/src/exec-approval-forwarding.ts
+++ b/extensions/feishu/src/exec-approval-forwarding.ts
@@ -5,6 +5,7 @@ import {
   resolveExecApprovalCommandDisplay,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { createExecApprovalCard } from "./card-ux-exec-approval.js";
+import { resolveFeishuExecApprovalTarget } from "./exec-approvals.js";
 
 // Unlike Telegram (which has an independent TelegramExecApprovalHandler gateway
 // client to take over delivery), Feishu currently delivers exec approval cards
@@ -20,10 +21,32 @@ export function shouldSuppressFeishuExecApprovalForwardingFallback(_params: {
   return false;
 }
 
+// Determine whether a Feishu target address is a DM (user:*) or group (chat:*).
+function isFeishuDmTarget(to: string): boolean {
+  return to.startsWith("user:");
+}
+
 export function buildFeishuExecApprovalPendingPayload(params: {
+  cfg: OpenClawConfig;
   request: ExecApprovalRequest;
+  target: { channel: string; to: string; accountId?: string | null };
   nowMs: number;
 }) {
+  // Defense-in-depth: if the configured target routing doesn't match this
+  // specific forward target, return null so the framework falls back to
+  // plain text instead of leaking an Interactive Card into an excluded chat.
+  const configuredTarget = resolveFeishuExecApprovalTarget({
+    cfg: params.cfg,
+    accountId: params.target.accountId,
+  });
+  const isDm = isFeishuDmTarget(params.target.to);
+  if (configuredTarget === "dm" && !isDm) {
+    return null;
+  }
+  if (configuredTarget === "channel" && isDm) {
+    return null;
+  }
+
   const commandDisplay = resolveExecApprovalCommandDisplay(params.request.request);
   const payload = buildExecApprovalPendingReplyPayload({
     approvalId: params.request.id,

--- a/extensions/feishu/src/exec-approvals.test.ts
+++ b/extensions/feishu/src/exec-approvals.test.ts
@@ -5,6 +5,7 @@ import {
   isFeishuExecApprovalClientEnabled,
   isFeishuExecApprovalApprover,
   resolveFeishuExecApprovalTarget,
+  shouldSuppressLocalFeishuExecApprovalPrompt,
 } from "./exec-approvals.js";
 
 function buildConfig(execApprovals?: Record<string, unknown>) {
@@ -96,5 +97,31 @@ describe("resolveFeishuExecApprovalTarget", () => {
   it("returns configured target", () => {
     const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
     expect(resolveFeishuExecApprovalTarget({ cfg })).toBe("both");
+  });
+});
+
+describe("shouldSuppressLocalFeishuExecApprovalPrompt", () => {
+  const execApprovalPayload = {
+    channelData: { execApproval: { approvalId: "test1234", approvalSlug: "test1234" } },
+  } as never;
+  const plainPayload = { text: "hello" } as never;
+
+  it("returns false when client is not enabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"] });
+    expect(shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, payload: execApprovalPayload })).toBe(
+      false,
+    );
+  });
+
+  it("returns false when no exec approval data in payload", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    expect(shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, payload: plainPayload })).toBe(false);
+  });
+
+  it("returns true when client enabled and payload has exec approval data", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    expect(shouldSuppressLocalFeishuExecApprovalPrompt({ cfg, payload: execApprovalPayload })).toBe(
+      true,
+    );
   });
 });

--- a/extensions/feishu/src/exec-approvals.test.ts
+++ b/extensions/feishu/src/exec-approvals.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveFeishuExecApprovalConfig,
+  getFeishuExecApprovalApprovers,
+  isFeishuExecApprovalClientEnabled,
+  isFeishuExecApprovalApprover,
+  resolveFeishuExecApprovalTarget,
+} from "./exec-approvals.js";
+
+function buildConfig(execApprovals?: Record<string, unknown>) {
+  return {
+    channels: {
+      feishu: {
+        appId: "cli_test",
+        appSecret: "secret",
+        ...(execApprovals ? { execApprovals } : {}),
+      },
+    },
+  } as never;
+}
+
+describe("resolveFeishuExecApprovalConfig", () => {
+  it("returns undefined when no execApprovals config", () => {
+    expect(resolveFeishuExecApprovalConfig({ cfg: buildConfig() })).toBeUndefined();
+  });
+
+  it("returns config when execApprovals is present", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    const result = resolveFeishuExecApprovalConfig({ cfg });
+    expect(result).toEqual({ enabled: true, approvers: ["ou_123"] });
+  });
+});
+
+describe("getFeishuExecApprovalApprovers", () => {
+  it("returns empty array when no config", () => {
+    expect(getFeishuExecApprovalApprovers({ cfg: buildConfig() })).toEqual([]);
+  });
+
+  it("normalizes approver IDs to strings", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123", 456] });
+    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123", "456"]);
+  });
+
+  it("filters empty approver IDs", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123", "", "  "] });
+    expect(getFeishuExecApprovalApprovers({ cfg })).toEqual(["ou_123"]);
+  });
+});
+
+describe("isFeishuExecApprovalClientEnabled", () => {
+  it("returns false when no config", () => {
+    expect(isFeishuExecApprovalClientEnabled({ cfg: buildConfig() })).toBe(false);
+  });
+
+  it("returns false when enabled but no approvers", () => {
+    const cfg = buildConfig({ enabled: true, approvers: [] });
+    expect(isFeishuExecApprovalClientEnabled({ cfg })).toBe(false);
+  });
+
+  it("returns false when not enabled", () => {
+    const cfg = buildConfig({ enabled: false, approvers: ["ou_123"] });
+    expect(isFeishuExecApprovalClientEnabled({ cfg })).toBe(false);
+  });
+
+  it("returns true when enabled with approvers", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"] });
+    expect(isFeishuExecApprovalClientEnabled({ cfg })).toBe(true);
+  });
+});
+
+describe("isFeishuExecApprovalApprover", () => {
+  const cfg = buildConfig({ enabled: true, approvers: ["ou_123", "ou_456"] });
+
+  it("returns false for null senderId", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: null })).toBe(false);
+  });
+
+  it("returns false for empty senderId", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: "" })).toBe(false);
+  });
+
+  it("returns true for valid approver", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: "ou_123" })).toBe(true);
+  });
+
+  it("returns false for non-approver", () => {
+    expect(isFeishuExecApprovalApprover({ cfg, senderId: "ou_999" })).toBe(false);
+  });
+});
+
+describe("resolveFeishuExecApprovalTarget", () => {
+  it("defaults to dm", () => {
+    expect(resolveFeishuExecApprovalTarget({ cfg: buildConfig() })).toBe("dm");
+  });
+
+  it("returns configured target", () => {
+    const cfg = buildConfig({ enabled: true, approvers: ["ou_123"], target: "both" });
+    expect(resolveFeishuExecApprovalTarget({ cfg })).toBe("both");
+  });
+});

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -1,0 +1,71 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { getExecApprovalReplyMetadata } from "openclaw/plugin-sdk/infra-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveFeishuAccount } from "./accounts.js";
+
+type FeishuExecApprovalConfig = {
+  enabled?: boolean;
+  approvers?: Array<string | number>;
+  agentFilter?: string[];
+  sessionFilter?: string[];
+  target?: "dm" | "channel" | "both";
+};
+
+function normalizeApproverId(value: string | number): string {
+  return String(value).trim();
+}
+
+export function resolveFeishuExecApprovalConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): FeishuExecApprovalConfig | undefined {
+  const config = resolveFeishuAccount(params).config;
+  return (config as Record<string, unknown>).execApprovals as FeishuExecApprovalConfig | undefined;
+}
+
+export function getFeishuExecApprovalApprovers(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] {
+  return (resolveFeishuExecApprovalConfig(params)?.approvers ?? [])
+    .map(normalizeApproverId)
+    .filter(Boolean);
+}
+
+export function isFeishuExecApprovalClientEnabled(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): boolean {
+  const config = resolveFeishuExecApprovalConfig(params);
+  return Boolean(config?.enabled && getFeishuExecApprovalApprovers(params).length > 0);
+}
+
+export function isFeishuExecApprovalApprover(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  senderId?: string | null;
+}): boolean {
+  const senderId = params.senderId?.trim();
+  if (!senderId) {
+    return false;
+  }
+  const approvers = getFeishuExecApprovalApprovers(params);
+  return approvers.includes(senderId);
+}
+
+export function resolveFeishuExecApprovalTarget(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): "dm" | "channel" | "both" {
+  return resolveFeishuExecApprovalConfig(params)?.target ?? "dm";
+}
+
+export function shouldSuppressLocalFeishuExecApprovalPrompt(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  payload: ReplyPayload;
+}): boolean {
+  void params.cfg;
+  void params.accountId;
+  return getExecApprovalReplyMetadata(params.payload) !== null;
+}

--- a/extensions/feishu/src/exec-approvals.ts
+++ b/extensions/feishu/src/exec-approvals.ts
@@ -65,7 +65,8 @@ export function shouldSuppressLocalFeishuExecApprovalPrompt(params: {
   accountId?: string | null;
   payload: ReplyPayload;
 }): boolean {
-  void params.cfg;
-  void params.accountId;
-  return getExecApprovalReplyMetadata(params.payload) !== null;
+  return (
+    isFeishuExecApprovalClientEnabled(params) &&
+    getExecApprovalReplyMetadata(params.payload) !== null
+  );
 }

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,11 +1,19 @@
 import fs from "fs";
 import path from "path";
-import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import {
+  attachChannelToResult,
+  createAttachedChannelResultAdapter,
+} from "openclaw/plugin-sdk/channel-send-result";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMarkdownCardFeishu, sendMessageFeishu, sendStructuredCardFeishu } from "./send.js";
+import {
+  sendCardFeishu,
+  sendMarkdownCardFeishu,
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+} from "./send.js";
 
 function normalizePossibleLocalImagePath(text: string | undefined): string | null {
   const raw = text?.trim();
@@ -202,4 +210,31 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       });
     },
   }),
+  sendPayload: async ({ cfg, to, payload, accountId, replyToId, threadId }) => {
+    const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+    // Extract Feishu Interactive Card from channelData if present
+    const feishuData = payload.channelData?.feishu as
+      | { card?: Record<string, unknown> }
+      | undefined;
+    if (feishuData?.card) {
+      const result = await sendCardFeishu({
+        cfg,
+        to,
+        card: feishuData.card,
+        accountId: accountId ?? undefined,
+        replyToMessageId,
+      });
+      return attachChannelToResult("feishu", result);
+    }
+    // Fallback: send as text
+    const text = payload.text ?? "";
+    const result = await sendOutboundText({
+      cfg,
+      to,
+      text,
+      accountId: accountId ?? undefined,
+      replyToMessageId,
+    });
+    return attachChannelToResult("feishu", result);
+  },
 };

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -1,4 +1,8 @@
 import {
+  isFeishuExecApprovalApprover,
+  isFeishuExecApprovalClientEnabled,
+} from "../../../extensions/feishu/api.js";
+import {
   isTelegramExecApprovalAuthorizedSender,
   isTelegramExecApprovalClientEnabled,
 } from "../../../extensions/telegram/api.js";
@@ -178,6 +182,27 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
           "❌ You are not authorized to approve this request.",
       },
     };
+  }
+
+  if (params.command.channel === "feishu") {
+    if (!isFeishuExecApprovalClientEnabled({ cfg: params.cfg, accountId: params.ctx.AccountId })) {
+      return {
+        shouldContinue: false,
+        reply: { text: "❌ Feishu exec approvals are not enabled for this bot account." },
+      };
+    }
+    if (
+      !isFeishuExecApprovalApprover({
+        cfg: params.cfg,
+        accountId: params.ctx.AccountId,
+        senderId: params.command.senderId,
+      })
+    ) {
+      return {
+        shouldContinue: false,
+        reply: { text: "❌ You are not authorized to approve exec requests on Feishu." },
+      };
+    }
   }
 
   const missingScope = requireGatewayClientScopeForInternalChannel(params, {

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -3665,6 +3665,44 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           default: true,
           type: "boolean",
         },
+        execApprovals: {
+          type: "object",
+          properties: {
+            enabled: {
+              type: "boolean",
+            },
+            approvers: {
+              type: "array",
+              items: {
+                anyOf: [
+                  {
+                    type: "string",
+                  },
+                  {
+                    type: "number",
+                  },
+                ],
+              },
+            },
+            agentFilter: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            sessionFilter: {
+              type: "array",
+              items: {
+                type: "string",
+              },
+            },
+            target: {
+              type: "string",
+              enum: ["dm", "channel", "both"],
+            },
+          },
+          additionalProperties: false,
+        },
         groupSessionScope: {
           type: "string",
           enum: ["group", "group_sender", "group_topic", "group_topic_sender"],
@@ -4217,6 +4255,44 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               resolveSenderNames: {
                 type: "boolean",
+              },
+              execApprovals: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                  approvers: {
+                    type: "array",
+                    items: {
+                      anyOf: [
+                        {
+                          type: "string",
+                        },
+                        {
+                          type: "number",
+                        },
+                      ],
+                    },
+                  },
+                  agentFilter: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                  sessionFilter: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
+                  target: {
+                    type: "string",
+                    enum: ["dm", "channel", "both"],
+                  },
+                },
+                additionalProperties: false,
               },
               groupSessionScope: {
                 type: "string",


### PR DESCRIPTION
## Summary

- Add Feishu exec approval support via Interactive Card (schema 2.0) with three action buttons: **Allow Once**, **Allow Always**, **Deny**
- Register `execApprovals` adapter in Feishu channel plugin following the existing Telegram pattern
- Add Feishu approver authorization gate in `/approve` command handler
- New config schema fields for `feishu.execApprovals` (enabled, approvers, agentFilter, sessionFilter, target)

## Files Changed

**New files:**
- `extensions/feishu/src/exec-approvals.ts` — Config resolution, approver validation, local prompt suppression
- `extensions/feishu/src/card-ux-exec-approval.ts` — Interactive Card builders (pending + resolved states)
- `extensions/feishu/src/exec-approval-forwarding.ts` — Pending payload builder and suppress-forwarding-fallback logic
- `extensions/feishu/src/exec-approvals.test.ts` — 15 tests for config/approver logic
- `extensions/feishu/src/card-ux-exec-approval.test.ts` — 6 tests for card construction

**Modified files:**
- `extensions/feishu/src/card-action.ts` — Exec approval button callback → synthetic `/approve` dispatch
- `extensions/feishu/src/channel.ts` — Register `execApprovals` adapter
- `extensions/feishu/src/config-schema.ts` — Add `execApprovals` config shape
- `extensions/feishu/api.ts` — Export new modules
- `src/auto-reply/reply/commands-approve.ts` — Feishu channel approver auth gate

## Test plan

- [x] 21 new tests pass (`pnpm test -- extensions/feishu/src/exec-approvals.test.ts extensions/feishu/src/card-ux-exec-approval.test.ts`)
- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] Format/lint passes (`pnpm check`)
- [x] Pre-commit hooks pass
- [ ] Integration test with real Feishu bot account

🤖 Generated with [Claude Code](https://claude.com/claude-code)