### PR TITLE
fix(agents): preserve ACP requester agent overrides

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -940,6 +940,55 @@ describe("spawnAcpDirect", () => {
     expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
   });
 
+  it("uses requesterAgentIdOverride for implicit ACP parent-stream eligibility", async () => {
+    replaceSpawnConfig({
+      ...hoisted.state.cfg,
+      agents: {
+        list: [{ id: "main", heartbeat: { every: "30m", target: "last" } }, { id: "research" }],
+      },
+    });
+    hoisted.loadSessionStoreMock.mockReset().mockImplementation(() => {
+      const store: Record<
+        string,
+        { sessionId: string; updatedAt: number; deliveryContext?: unknown }
+      > = {
+        "agent:main:subagent:parent": {
+          sessionId: "parent-sess-1",
+          updatedAt: Date.now(),
+          deliveryContext: {
+            channel: "discord",
+            to: "channel:parent-channel",
+            accountId: "default",
+          },
+        },
+      };
+      return new Proxy(store, {
+        get(target, prop) {
+          if (typeof prop === "string" && prop.startsWith("agent:codex:acp:")) {
+            return { sessionId: "sess-123", updatedAt: Date.now() };
+          }
+          return target[prop as keyof typeof target];
+        },
+      });
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+      },
+      {
+        agentSessionKey: "agent:main:subagent:parent",
+        requesterAgentIdOverride: "research",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.mode).toBe("run");
+    expect(result.streamLogPath).toBeUndefined();
+    expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
   it("does not implicitly stream for subagent requester sessions when heartbeat cadence is invalid", async () => {
     replaceSpawnConfig({
       ...hoisted.state.cfg,

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -83,6 +83,7 @@ export type SpawnAcpContext = {
   agentAccountId?: string;
   agentTo?: string;
   agentThreadId?: string | number;
+  requesterAgentIdOverride?: string;
   sandboxed?: boolean;
 };
 
@@ -182,11 +183,14 @@ function resolveAcpSessionMode(mode: SpawnAcpMode): AcpRuntimeSessionMode {
 function isHeartbeatEnabledForSessionAgent(params: {
   cfg: OpenClawConfig;
   sessionKey?: string;
+  requesterAgentIdOverride?: string;
 }): boolean {
   if (!areHeartbeatsEnabled()) {
     return false;
   }
-  const requesterAgentId = parseAgentSessionKey(params.sessionKey)?.agentId;
+  const requesterAgentId =
+    normalizeOptionalAgentId(params.requesterAgentIdOverride) ??
+    parseAgentSessionKey(params.sessionKey)?.agentId;
   if (!requesterAgentId) {
     return true;
   }
@@ -460,7 +464,9 @@ function resolveAcpSpawnRequesterState(params: {
     typeof params.ctx.agentThreadId === "string"
       ? params.ctx.agentThreadId.trim().length > 0
       : params.ctx.agentThreadId != null;
-  const requesterAgentId = requesterParsedSession?.agentId;
+  const requesterAgentId =
+    normalizeOptionalAgentId(params.ctx.requesterAgentIdOverride) ??
+    requesterParsedSession?.agentId;
 
   return {
     parentSessionKey: params.parentSessionKey,
@@ -470,6 +476,7 @@ function resolveAcpSpawnRequesterState(params: {
     heartbeatEnabled: isHeartbeatEnabledForSessionAgent({
       cfg: params.cfg,
       sessionKey: params.parentSessionKey,
+      requesterAgentIdOverride: params.ctx.requesterAgentIdOverride,
     }),
     heartbeatRelayRouteUsable:
       params.parentSessionKey && requesterAgentId

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -120,6 +120,7 @@ describe("sessions_spawn tool", () => {
       agentAccountId: "default",
       agentTo: "channel:123",
       agentThreadId: "456",
+      requesterAgentIdOverride: "ops",
     });
 
     const result = await tool.execute("call-2", {
@@ -148,6 +149,7 @@ describe("sessions_spawn tool", () => {
       }),
       expect.objectContaining({
         agentSessionKey: "agent:main:main",
+        requesterAgentIdOverride: "ops",
       }),
     );
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -167,6 +167,7 @@ export function createSessionsSpawnTool(
             agentAccountId: opts?.agentAccountId,
             agentTo: opts?.agentTo,
             agentThreadId: opts?.agentThreadId,
+            requesterAgentIdOverride: opts?.requesterAgentIdOverride,
             sandboxed: opts?.sandboxed,
           },
         );


### PR DESCRIPTION
## Summary
- pass `requesterAgentIdOverride` through the ACP `sessions_spawn` path
- resolve ACP requester heartbeat/relay eligibility from the explicit override before falling back to the parent session key
- add regression coverage for the tool passthrough and for implicit parent-stream gating using the overridden requester agent

## Testing
- pnpm exec vitest run src/agents/tools/sessions-spawn-tool.test.ts src/agents/acp-spawn.test.ts