### PR TITLE
fix: distinguish whether base already includes output in token projection

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -56,17 +56,16 @@ export function estimatePromptTokensForMemoryFlush(prompt?: string): number | un
   return Math.ceil(tokens);
 }
 
-export function resolveEffectivePromptTokens(
-  basePromptTokens?: number,
-  lastOutputTokens?: number,
-  promptTokenEstimate?: number,
-): number {
-  const base = Math.max(0, basePromptTokens ?? 0);
-  const output = Math.max(0, lastOutputTokens ?? 0);
-  const estimate = Math.max(0, promptTokenEstimate ?? 0);
-  // Flush gating projects the next input context by adding the previous
-  // completion and the current user prompt estimate.
-  return base + output + estimate;
+export function resolveEffectivePromptTokens(params: {
+  basePromptTokens?: number;
+  lastOutputTokens?: number;
+  promptTokenEstimate?: number;
+  baseIncludesOutput?: boolean;
+}): number {
+  const base = Math.max(0, params.basePromptTokens ?? 0);
+  const output = Math.max(0, params.lastOutputTokens ?? 0);
+  const estimate = Math.max(0, params.promptTokenEstimate ?? 0);
+  return base + (params.baseIncludesOutput === true ? 0 : output) + estimate;
 }
 
 export type SessionTranscriptUsageSnapshot = {
@@ -360,7 +359,12 @@ export async function runPreflightCompactionIfNeeded(params: {
         });
   const projectedTokenCount =
     typeof transcriptPromptTokens === "number"
-      ? resolveEffectivePromptTokens(transcriptPromptTokens, undefined, promptTokenEstimate)
+      ? resolveEffectivePromptTokens({
+          basePromptTokens: transcriptPromptTokens,
+          lastOutputTokens: transcriptOutputTokens,
+          promptTokenEstimate,
+          baseIncludesOutput: false,
+        })
       : undefined;
   const tokenCountForCompaction =
     typeof projectedTokenCount === "number" &&
@@ -599,12 +603,16 @@ export async function runMemoryFlushIfNeeded(params: {
     promptTokensSnapshot > 0 &&
     (hasFreshPersistedPromptTokens || hasReliableTranscriptPromptTokens);
 
+  const promptTokensSnapshotIncludesOutput =
+    hasFreshPersistedPromptTokens && promptTokensSnapshot === (persistedPromptTokens ?? 0);
+
   const projectedTokenCount = hasFreshPromptTokensSnapshot
-    ? resolveEffectivePromptTokens(
-        promptTokensSnapshot,
-        transcriptOutputTokens,
+    ? resolveEffectivePromptTokens({
+        basePromptTokens: promptTokensSnapshot,
+        lastOutputTokens: transcriptOutputTokens,
         promptTokenEstimate,
-      )
+        baseIncludesOutput: promptTokensSnapshotIncludesOutput,
+      })
     : undefined;
   const tokenCountForFlush =
     typeof projectedTokenCount === "number" &&


### PR DESCRIPTION
## Bug Description

The `memoryFlush` mechanism is designed to write durable memories to `memory/YYYY-MM-DD.md` before a session compacts. However, the token projection calculation used by the flush check systematically **underestimates** the true token count, causing `memory/` directories to remain empty even after multiple compaction events.

## Root Cause

`resolveEffectivePromptTokens` had two issues:

1. **`totalTokensFresh === false` path**: `lastOutputTokens` was passed as `undefined`, so previous round's LLM output (typically 5,000–15,000 tokens) was **completely missing** from the projection.
2. **`totalTokensFresh === true` path**: `totalTokens` already includes previous prompt+output, but `transcriptOutputTokens` was **added again**, causing double-counting.

These two bugs meant flush triggered far later than intended (or not at all), while compaction would fire first.

## Fix

Added a `baseIncludesOutput?: boolean` parameter to `resolveEffectivePromptTokens`:

- When `baseIncludesOutput === true`: skip adding `lastOutputTokens` (avoids double-counting)
- When `baseIncludesOutput === false | undefined`: add `lastOutputTokens` (fixes missing output)

Three code paths now produce correct projections:

| Path | totalTokensFresh | Before | After |
|------|-----------------|--------|-------|
| PreflightCompaction | false | Missing output ❌ | Correct ✅ |
| MemoryFlush | true | Double-counting ❌ | Correct ✅ |
| MemoryFlush | false | Correct | Correct |

## Files Changed

- `src/auto-reply/reply/agent-runner-memory.ts`

Fixes: #55679