### PR TITLE
fix(agents): suppress recovered tool failure warnings

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -236,6 +236,49 @@ describe("handleToolExecutionEnd mutating failure recovery", () => {
 
     expect(ctx.state.lastToolError).toBeUndefined();
   });
+
+  it("clears failure when the same tool call later succeeds", async () => {
+    const { ctx } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "browser",
+        toolCallId: "tool-browser-1",
+        args: {
+          action: "open",
+          url: "https://example.com",
+        },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "browser",
+        toolCallId: "tool-browser-1",
+        isError: true,
+        result: { error: "connection timeout" },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError?.toolCallId).toBe("tool-browser-1");
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "browser",
+        toolCallId: "tool-browser-1",
+        isError: false,
+        result: { ok: true },
+      } as never,
+    );
+
+    expect(ctx.state.lastToolError).toBeUndefined();
+  });
 });
 
 describe("handleToolExecutionEnd exec approval prompts", () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -478,14 +478,18 @@ export async function handleToolExecutionEnd(
     const errorMessage = extractToolErrorMessage(sanitizedResult);
     ctx.state.lastToolError = {
       toolName,
+      toolCallId,
       meta,
       error: errorMessage,
       mutatingAction: callSummary?.mutatingAction,
       actionFingerprint: callSummary?.actionFingerprint,
     };
   } else if (ctx.state.lastToolError) {
+    if (ctx.state.lastToolError.toolCallId === toolCallId) {
+      ctx.state.lastToolError = undefined;
+    }
     // Keep unresolved mutating failures until the same action succeeds.
-    if (ctx.state.lastToolError.mutatingAction) {
+    else if (ctx.state.lastToolError.mutatingAction) {
       if (
         isSameToolMutationAction(ctx.state.lastToolError, {
           toolName,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -19,6 +19,7 @@ export type EmbeddedSubscribeLogger = {
 
 export type ToolErrorSummary = {
   toolName: string;
+  toolCallId?: string;
   meta?: string;
   error?: string;
   mutatingAction?: boolean;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -375,6 +375,36 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.getLastToolError()).toBeUndefined();
   });
 
+  it("clears unresolved failure when the same tool call later succeeds", () => {
+    const { emit, subscription } = createToolErrorHarness("run-tools-2b");
+
+    emit({
+      type: "tool_execution_start",
+      toolName: "browser",
+      toolCallId: "b1",
+      args: { action: "open", url: "https://example.com" },
+    });
+    emit({
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "b1",
+      isError: true,
+      result: { error: "connection timeout" },
+    });
+
+    expect(subscription.getLastToolError()?.toolName).toBe("browser");
+
+    emit({
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "b1",
+      isError: false,
+      result: { ok: true },
+    });
+
+    expect(subscription.getLastToolError()).toBeUndefined();
+  });
+
   it("keeps unresolved mutating failure when same tool succeeds on a different target", () => {
     const { emit, subscription } = createToolErrorHarness("run-tools-3");
 


### PR DESCRIPTION
## Summary
- stop surfacing stale tool failure warnings when the same tool call later succeeds in the same run
- preserve warnings for unresolved failures and unrelated tool successes
- add focused tests covering recovered vs unresolved tool-error state

## Testing
- targeted agent tool failure state tests updated alongside the fix
- local runtime/test execution remains limited in this environment because dependency/runtime setup is incomplete

Closes #55626