### PR TITLE
fix(tui): prune chat log system messages atomically

### DIFF
--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -1,6 +1,7 @@
 export const GATEWAY_CLIENT_IDS = {
   WEBCHAT_UI: "webchat-ui",
   CONTROL_UI: "openclaw-control-ui",
+  TUI: "openclaw-tui",
   WEBCHAT: "webchat",
   CLI: "cli",
   GATEWAY_CLIENT: "gateway-client",

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -224,6 +224,32 @@ describe("gateway auth browser hardening", () => {
     });
   });
 
+  test("rejects browser-origin connects that claim to be tui clients", async () => {
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    await withGatewayServer(async ({ port }) => {
+      const ws = await openWs(port, { origin: "https://attacker.example" });
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          client: {
+            id: GATEWAY_CLIENT_NAMES.TUI,
+            version: "1.0.0",
+            platform: "darwin",
+            mode: GATEWAY_CLIENT_MODES.UI,
+          },
+          device: null,
+        });
+        expect(res.ok).toBe(false);
+        expect(res.error?.message ?? "").toContain("origin not allowed");
+        expect((res.error?.details as { code?: string } | undefined)?.code).toBe(
+          ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED,
+        );
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
   test("rate-limits browser-origin auth failures on loopback even when loopback exemption is enabled", async () => {
     testState.gatewayAuth = {
       mode: "token",

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -299,9 +299,7 @@ export function registerControlUiAndPairingSuite(): void {
 
   test("allows localhost tui without device identity when insecure auth is enabled", async () => {
     testState.gatewayControlUi = { allowInsecureAuth: true };
-    const { server, ws, prevToken } = await startServerWithClient("secret", {
-      wsHeaders: { origin: "http://127.0.0.1" },
-    });
+    const { server, ws, prevToken } = await startServerWithClient("secret");
     await connectControlUiWithoutDeviceAndExpectOk({
       ws,
       token: "secret",

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -122,12 +122,13 @@ export function registerControlUiAndPairingSuite(): void {
     ws: WebSocket;
     token?: string;
     password?: string;
+    client?: { id: string; version: string; platform: string; mode: string };
   }) => {
     const res = await connectReq(params.ws, {
       ...(params.token ? { token: params.token } : {}),
       ...(params.password ? { password: params.password } : {}),
       device: null,
-      client: { ...CONTROL_UI_CLIENT },
+      client: { ...(params.client ?? CONTROL_UI_CLIENT) },
     });
     expect(res.ok).toBe(true);
     await expectStatusAndHealthOk(params.ws);
@@ -291,6 +292,26 @@ export function registerControlUiAndPairingSuite(): void {
       wsHeaders: { origin: "http://127.0.0.1" },
     });
     await connectControlUiWithoutDeviceAndExpectOk({ ws, token: "secret" });
+    ws.close();
+    await server.close();
+    restoreGatewayToken(prevToken);
+  });
+
+  test("allows localhost tui without device identity when insecure auth is enabled", async () => {
+    testState.gatewayControlUi = { allowInsecureAuth: true };
+    const { server, ws, prevToken } = await startServerWithClient("secret", {
+      wsHeaders: { origin: "http://127.0.0.1" },
+    });
+    await connectControlUiWithoutDeviceAndExpectOk({
+      ws,
+      token: "secret",
+      client: {
+        id: GATEWAY_CLIENT_NAMES.TUI,
+        version: "1.0.0",
+        platform: "darwin",
+        mode: GATEWAY_CLIENT_MODES.UI,
+      },
+    });
     ws.close();
     await server.close();
     restoreGatewayToken(prevToken);

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -1,6 +1,9 @@
-import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
+import {
+  isGatewayCliClient,
+  isOperatorUiClient,
+  isWebchatClient,
+} from "../../../utils/message-channel.js";
 import type { ResolvedGatewayAuth } from "../../auth.js";
-import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 
 export type AuthProvidedKind = "token" | "bootstrap-token" | "device-token" | "password" | "none";
 
@@ -12,7 +15,7 @@ export function formatGatewayAuthFailureMessage(params: {
 }): string {
   const { authMode, authProvided, reason, client } = params;
   const isCli = isGatewayCliClient(client);
-  const isControlUi = client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+  const isControlUi = isOperatorUiClient(client);
   const isWebchat = isWebchatClient(client);
   const uiHint = "open the dashboard URL and paste the token in Control UI settings";
   const tokenHint = isCli

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -24,6 +24,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
+  isBrowserOperatorUiClient,
   isGatewayCliClient,
   isOperatorUiClient,
   isWebchatClient,
@@ -406,8 +407,9 @@ export function attachGatewayWsMessageHandler(params: {
         connectParams.scopes = scopes;
 
         const isControlUi = isOperatorUiClient(connectParams.client);
+        const isBrowserOperatorUi = isBrowserOperatorUiClient(connectParams.client);
         const isWebchat = isWebchatConnect(connectParams);
-        if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) {
+        if (enforceOriginCheckForAnyClient || isBrowserOperatorUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =
             configSnapshot.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true;
           const originCheck = checkBrowserOrigin({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,11 @@ import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
-import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
+import {
+  isGatewayCliClient,
+  isOperatorUiClient,
+  isWebchatClient,
+} from "../../../utils/message-channel.js";
 import { resolveRuntimeServiceVersion } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
@@ -42,7 +46,6 @@ import {
 } from "../../net.js";
 import { resolveNodeCommandAllowlist } from "../../node-command-policy.js";
 import { checkBrowserOrigin } from "../../origin-check.js";
-import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 import {
   ConnectErrorDetailCodes,
   resolveDeviceAuthConnectErrorDetailCode,
@@ -402,7 +405,7 @@ export function attachGatewayWsMessageHandler(params: {
         connectParams.role = role;
         connectParams.scopes = scopes;
 
-        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+        const isControlUi = isOperatorUiClient(connectParams.client);
         const isWebchat = isWebchatConnect(connectParams);
         if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =

--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -53,6 +53,22 @@ describe("ChatLog", () => {
     expect(chatLog.children.length).toBe(20);
   });
 
+  it("prunes system messages atomically when a non-system entry overflows the log", () => {
+    const chatLog = new ChatLog(20);
+    for (let i = 1; i <= 20; i++) {
+      chatLog.addSystem(`system-${i}`);
+    }
+
+    chatLog.addUser("hello");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).not.toMatch(/\bsystem-1\b/);
+    expect(rendered).toMatch(/\bsystem-2\b/);
+    expect(rendered).toMatch(/\bsystem-20\b/);
+    expect(rendered).toContain("hello");
+    expect(chatLog.children.length).toBe(20);
+  });
+
   it("renders BTW inline and removes it when dismissed", () => {
     const chatLog = new ChatLog(40);
 

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -57,9 +57,15 @@ export class ChatLog extends Container {
     this.btwMessage = null;
   }
 
+  private createSystemMessage(text: string): Container {
+    const entry = new Container();
+    entry.addChild(new Spacer(1));
+    entry.addChild(new Text(theme.system(text), 1, 0));
+    return entry;
+  }
+
   addSystem(text: string) {
-    this.append(new Spacer(1));
-    this.append(new Text(theme.system(text), 1, 0));
+    this.append(this.createSystemMessage(text));
   }
 
   addUser(text: string) {

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../gateway/gateway-connection.test-mocks.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 
-const { resolveGatewayConnection } = await import("./gateway-chat.js");
+const { GatewayChatClient, resolveGatewayConnection } = await import("./gateway-chat.js");
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -131,6 +131,7 @@ describe("resolveGatewayConnection", () => {
     expect(result).toEqual({
       url: "wss://override.example/ws",
       ...expected,
+      allowInsecureLocalOperatorUi: false,
     });
   });
   it("uses config auth token for local mode when both config and env tokens are set", async () => {
@@ -348,5 +349,46 @@ describe("resolveGatewayConnection", () => {
         expect(await fileExists(passwordMarker)).toBe(true);
       },
     );
+  });
+
+  it("marks loopback local connections for insecure operator ui auth when enabled", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        controlUi: {
+          allowInsecureAuth: true,
+        },
+        auth: {
+          mode: "token",
+          token: "config-token",
+        },
+      },
+    });
+
+    const result = await resolveGatewayConnection({});
+    expect(result.allowInsecureLocalOperatorUi).toBe(true);
+  });
+});
+
+describe("GatewayChatClient", () => {
+  it("identifies the TUI as a tui client and skips device identity on insecure local ui paths", () => {
+    const client = new GatewayChatClient({
+      url: "ws://127.0.0.1:18789",
+      token: "test-token",
+      allowInsecureLocalOperatorUi: true,
+    });
+
+    expect(
+      (client as unknown as { client: { opts: { clientName?: string; mode?: string } } }).client
+        .opts.clientName,
+    ).toBe("openclaw-tui");
+    expect(
+      (client as unknown as { client: { opts: { clientName?: string; mode?: string } } }).client
+        .opts.mode,
+    ).toBe("ui");
+    expect(
+      (client as unknown as { client: { opts: { deviceIdentity?: unknown } } }).client.opts
+        .deviceIdentity,
+    ).toBeUndefined();
   });
 });

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -368,6 +368,28 @@ describe("resolveGatewayConnection", () => {
     const result = await resolveGatewayConnection({});
     expect(result.allowInsecureLocalOperatorUi).toBe(true);
   });
+
+  it("preserves insecure local operator ui auth when a loopback url override is provided", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "local",
+        controlUi: {
+          allowInsecureAuth: true,
+        },
+        auth: {
+          mode: "token",
+          token: "config-token",
+        },
+      },
+    });
+
+    const result = await resolveGatewayConnection({
+      url: "ws://127.0.0.1:18791",
+      token: "override-token",
+    });
+    expect(result.allowInsecureLocalOperatorUi).toBe(true);
+    expect(result.token).toBe("override-token");
+  });
 });
 
 describe("GatewayChatClient", () => {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -8,6 +8,7 @@ import {
   resolveExplicitGatewayAuth,
 } from "../gateway/call.js";
 import { GatewayClient } from "../gateway/client.js";
+import { isLoopbackHost } from "../gateway/net.js";
 import { GATEWAY_CLIENT_CAPS } from "../gateway/protocol/client-info.js";
 import {
   type HelloOk,
@@ -46,6 +47,7 @@ type ResolvedGatewayConnection = {
   url: string;
   token?: string;
   password?: string;
+  allowInsecureLocalOperatorUi?: boolean;
 };
 
 function trimToUndefined(value: unknown): string | undefined {
@@ -152,11 +154,12 @@ export class GatewayChatClient {
       url: connection.url,
       token: connection.token,
       password: connection.password,
-      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientName: GATEWAY_CLIENT_NAMES.TUI,
       clientDisplayName: "openclaw-tui",
       clientVersion: VERSION,
       platform: process.platform,
       mode: GATEWAY_CLIENT_MODES.UI,
+      deviceIdentity: connection.allowInsecureLocalOperatorUi ? null : undefined,
       caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
       instanceId: randomUUID(),
       minProtocol: PROTOCOL_VERSION,
@@ -291,12 +294,23 @@ export async function resolveGatewayConnection(
     config,
     ...(urlOverride ? { url: urlOverride } : {}),
   }).url;
+  const allowInsecureLocalOperatorUi = (() => {
+    if (config.gateway?.controlUi?.allowInsecureAuth !== true) {
+      return false;
+    }
+    try {
+      return isLoopbackHost(new URL(url).hostname);
+    } catch {
+      return false;
+    }
+  })();
 
   if (urlOverride) {
     return {
       url,
       token: explicitAuth.token,
       password: explicitAuth.password,
+      allowInsecureLocalOperatorUi: false,
     };
   }
 
@@ -328,7 +342,7 @@ export async function resolveGatewayConnection(
           "Missing gateway auth credentials.",
       );
     }
-    return { url, token, password };
+    return { url, token, password, allowInsecureLocalOperatorUi: false };
   }
 
   if (gatewayAuthMode === "none" || gatewayAuthMode === "trusted-proxy") {
@@ -336,6 +350,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token ?? envToken,
       password: explicitAuth.password ?? envPassword,
+      allowInsecureLocalOperatorUi,
     };
   }
 
@@ -368,6 +383,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token ?? envToken,
       password,
+      allowInsecureLocalOperatorUi,
     };
   }
 
@@ -395,6 +411,7 @@ export async function resolveGatewayConnection(
       url,
       token,
       password: explicitAuth.password ?? envPassword,
+      allowInsecureLocalOperatorUi,
     };
   }
 
@@ -421,6 +438,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token ?? envToken,
       password,
+      allowInsecureLocalOperatorUi,
     };
   }
 
@@ -429,5 +447,6 @@ export async function resolveGatewayConnection(
     url,
     token,
     password: explicitAuth.password ?? envPassword,
+    allowInsecureLocalOperatorUi,
   };
 }

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -310,7 +310,7 @@ export async function resolveGatewayConnection(
       url,
       token: explicitAuth.token,
       password: explicitAuth.password,
-      allowInsecureLocalOperatorUi: false,
+      allowInsecureLocalOperatorUi,
     };
   }
 

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -47,6 +47,11 @@ export function isOperatorUiClient(client?: GatewayClientInfoLike | null): boole
   return clientId === GATEWAY_CLIENT_NAMES.CONTROL_UI || clientId === GATEWAY_CLIENT_NAMES.TUI;
 }
 
+export function isBrowserOperatorUiClient(client?: GatewayClientInfoLike | null): boolean {
+  const clientId = normalizeGatewayClientName(client?.id);
+  return clientId === GATEWAY_CLIENT_NAMES.CONTROL_UI;
+}
+
 export function isInternalMessageChannel(raw?: string | null): raw is InternalMessageChannel {
   return normalizeMessageChannel(raw) === INTERNAL_MESSAGE_CHANNEL;
 }

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -42,6 +42,11 @@ export function isGatewayCliClient(client?: GatewayClientInfoLike | null): boole
   return normalizeGatewayClientMode(client?.mode) === GATEWAY_CLIENT_MODES.CLI;
 }
 
+export function isOperatorUiClient(client?: GatewayClientInfoLike | null): boolean {
+  const clientId = normalizeGatewayClientName(client?.id);
+  return clientId === GATEWAY_CLIENT_NAMES.CONTROL_UI || clientId === GATEWAY_CLIENT_NAMES.TUI;
+}
+
 export function isInternalMessageChannel(raw?: string | null): raw is InternalMessageChannel {
   return normalizeMessageChannel(raw) === INTERNAL_MESSAGE_CHANNEL;
 }

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -5,7 +5,12 @@ import type { PluginWebSearchProviderEntry } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const runTui = vi.hoisted(() => vi.fn(async () => {}));
-const probeGatewayReachable = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
+const probeGatewayReachable = vi.hoisted(() =>
+  vi.fn<() => Promise<{ ok: boolean; detail?: string }>>(async () => ({ ok: true })),
+);
+const waitForGatewayReachable = vi.hoisted(() =>
+  vi.fn<() => Promise<{ ok: boolean; detail?: string }>>(async () => ({ ok: true })),
+);
 const setupWizardShellCompletion = vi.hoisted(() => vi.fn(async () => {}));
 const buildGatewayInstallPlan = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -58,7 +63,7 @@ vi.mock("../commands/onboard-helpers.js", () => ({
     httpUrl: "http://127.0.0.1:18789",
     wsUrl: "ws://127.0.0.1:18789",
   })),
-  waitForGatewayReachable: vi.fn(async () => {}),
+  waitForGatewayReachable,
 }));
 
 vi.mock("../commands/daemon-install-helpers.js", () => ({
@@ -233,6 +238,8 @@ describe("finalizeSetupWizard", () => {
   beforeEach(() => {
     runTui.mockClear();
     probeGatewayReachable.mockClear();
+    waitForGatewayReachable.mockReset();
+    waitForGatewayReachable.mockResolvedValue({ ok: true });
     setupWizardShellCompletion.mockClear();
     buildGatewayInstallPlan.mockClear();
     gatewayServiceInstall.mockClear();
@@ -504,5 +511,49 @@ describe("finalizeSetupWizard", () => {
       ),
       "Web search",
     );
+  });
+
+  it("shows actionable gateway guidance instead of a hard error in no-daemon onboarding", async () => {
+    waitForGatewayReachable.mockResolvedValue({
+      ok: false,
+      detail: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+    });
+    probeGatewayReachable.mockResolvedValue({
+      ok: false,
+      detail: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+    });
+    const prompter = createLaterPrompter();
+    const runtime = createRuntime();
+
+    await finalizeSetupWizard({
+      flow: "quickstart",
+      opts: {
+        acceptRisk: true,
+        authChoice: "skip",
+        installDaemon: false,
+        skipHealth: false,
+        skipUi: false,
+      },
+      baseConfig: {},
+      nextConfig: {},
+      workspaceDir: "/tmp",
+      settings: {
+        port: 18789,
+        bind: "loopback",
+        authMode: "token",
+        gatewayToken: "test-token",
+        tailscaleMode: "off",
+        tailscaleResetOnExit: false,
+      },
+      prompter,
+      runtime,
+    });
+
+    expect(runtime.error).not.toHaveBeenCalledWith("health failed");
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("Setup was run without Gateway service install"),
+      "Gateway",
+    );
+    expect(prompter.note).not.toHaveBeenCalledWith(expect.any(String), "Dashboard ready");
   });
 });

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -51,6 +51,7 @@ export async function finalizeSetupWizard(
   options: FinalizeOnboardingOptions,
 ): Promise<{ launchedTui: boolean }> {
   const { flow, opts, baseConfig, nextConfig, settings, prompter, runtime } = options;
+  let gatewayProbe: { ok: boolean; detail?: string } = { ok: true };
 
   const withWizardProgress = async <T>(
     label: string,
@@ -232,15 +233,33 @@ export async function finalizeSetupWizard(
       basePath: undefined,
     });
     // Daemon install/restart can briefly flap the WS; wait a bit so health check doesn't false-fail.
-    await waitForGatewayReachable({
+    gatewayProbe = await waitForGatewayReachable({
       url: probeLinks.wsUrl,
       token: settings.gatewayToken,
       deadlineMs: 15_000,
     });
-    try {
-      await healthCommand({ json: false, timeoutMs: 10_000 }, runtime);
-    } catch (err) {
-      runtime.error(formatHealthCheckFailure(err));
+    if (gatewayProbe.ok) {
+      try {
+        await healthCommand({ json: false, timeoutMs: 10_000 }, runtime);
+      } catch (err) {
+        runtime.error(formatHealthCheckFailure(err));
+        await prompter.note(
+          [
+            "Docs:",
+            "https://docs.openclaw.ai/gateway/health",
+            "https://docs.openclaw.ai/gateway/troubleshooting",
+          ].join("\n"),
+          "Health check help",
+        );
+      }
+    } else if (installDaemon) {
+      runtime.error(
+        formatHealthCheckFailure(
+          new Error(
+            gatewayProbe.detail ?? `gateway did not become reachable at ${probeLinks.wsUrl}`,
+          ),
+        ),
+      );
       await prompter.note(
         [
           "Docs:",
@@ -248,6 +267,17 @@ export async function finalizeSetupWizard(
           "https://docs.openclaw.ai/gateway/troubleshooting",
         ].join("\n"),
         "Health check help",
+      );
+    } else {
+      await prompter.note(
+        [
+          "Gateway not detected yet.",
+          "Setup was run without Gateway service install, so no background gateway is expected.",
+          `Start now: ${formatCliCommand("openclaw gateway run")}`,
+          `Or rerun with: ${formatCliCommand("openclaw onboard --install-daemon")}`,
+          `Or skip this probe next time: ${formatCliCommand("openclaw onboard --skip-health")}`,
+        ].join("\n"),
+        "Gateway",
       );
     }
   }
@@ -304,11 +334,13 @@ export async function finalizeSetupWizard(
     }
   }
 
-  const gatewayProbe = await probeGatewayReachable({
-    url: links.wsUrl,
-    token: settings.authMode === "token" ? settings.gatewayToken : undefined,
-    password: settings.authMode === "password" ? resolvedGatewayPassword : "",
-  });
+  if (opts.skipHealth || !gatewayProbe.ok) {
+    gatewayProbe = await probeGatewayReachable({
+      url: links.wsUrl,
+      token: settings.authMode === "token" ? settings.gatewayToken : undefined,
+      password: settings.authMode === "password" ? resolvedGatewayPassword : "",
+    });
+  }
   const gatewayStatusLine = gatewayProbe.ok
     ? "Gateway: reachable"
     : `Gateway: not detected${gatewayProbe.detail ? ` (${gatewayProbe.detail})` : ""}`;
@@ -446,6 +478,7 @@ export async function finalizeSetupWizard(
 
   const shouldOpenControlUi =
     !opts.skipUi &&
+    gatewayProbe.ok &&
     settings.authMode === "token" &&
     Boolean(settings.gatewayToken) &&
     hatchChoice === null;

--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -119,6 +119,35 @@ describe("configureGatewayForSetup", () => {
     }
   });
 
+  it("enables insecure local control ui auth for fresh quickstart loopback setups", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const result = await runGatewayConfig({
+      flow: "quickstart",
+      textQueue: [],
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(true);
+  });
+
+  it("preserves explicit control ui auth policy in quickstart", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+
+    const result = await runGatewayConfig({
+      flow: "quickstart",
+      textQueue: [],
+      nextConfig: {
+        gateway: {
+          controlUi: {
+            allowInsecureAuth: false,
+          },
+        },
+      },
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(false);
+  });
+
   it("does not set password to literal 'undefined' when prompt returns undefined", async () => {
     mocks.randomToken.mockReturnValue("unused");
     const result = await runGatewayConfig({

--- a/src/wizard/setup.gateway-config.test.ts
+++ b/src/wizard/setup.gateway-config.test.ts
@@ -148,6 +148,35 @@ describe("configureGatewayForSetup", () => {
     expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(false);
   });
 
+  it("enables insecure local control ui auth when quickstart reuses an existing loopback config", async () => {
+    mocks.randomToken.mockReturnValue("generated-token");
+    const prompter = createPrompter({
+      selectQueue: [],
+      textQueue: [],
+    });
+    const runtime = createRuntime();
+
+    const result = await configureGatewayForSetup({
+      flow: "quickstart",
+      baseConfig: {},
+      nextConfig: {
+        gateway: {
+          port: 18789,
+          bind: "loopback",
+        },
+      },
+      localPort: 18789,
+      quickstartGateway: {
+        ...createQuickstartGateway("token"),
+        hasExisting: true,
+      },
+      prompter,
+      runtime,
+    });
+
+    expect(result.nextConfig.gateway?.controlUi?.allowInsecureAuth).toBe(true);
+  });
+
   it("does not set password to literal 'undefined' when prompt returns undefined", async () => {
     mocks.randomToken.mockReturnValue("unused");
     const result = await runGatewayConfig({

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -294,6 +294,24 @@ export async function configureGatewayForSetup(
     },
   };
 
+  if (
+    flow === "quickstart" &&
+    bind === "loopback" &&
+    !quickstartGateway.hasExisting &&
+    nextConfig.gateway?.controlUi?.allowInsecureAuth === undefined
+  ) {
+    nextConfig = {
+      ...nextConfig,
+      gateway: {
+        ...nextConfig.gateway,
+        controlUi: {
+          ...nextConfig.gateway?.controlUi,
+          allowInsecureAuth: true,
+        },
+      },
+    };
+  }
+
   nextConfig = ensureControlUiAllowedOriginsForNonLoopbackBind(nextConfig, {
     requireControlUiEnabled: true,
   }).config;

--- a/src/wizard/setup.gateway-config.ts
+++ b/src/wizard/setup.gateway-config.ts
@@ -297,7 +297,6 @@ export async function configureGatewayForSetup(
   if (
     flow === "quickstart" &&
     bind === "loopback" &&
-    !quickstartGateway.hasExisting &&
     nextConfig.gateway?.controlUi?.allowInsecureAuth === undefined
   ) {
     nextConfig = {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -69,6 +69,13 @@ const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const healthCommand = vi.hoisted(() => vi.fn(async () => {}));
 const ensureWorkspaceAndSessions = vi.hoisted(() => vi.fn(async () => {}));
 const writeConfigFile = vi.hoisted(() => vi.fn(async () => {}));
+const resolveGatewayPort = vi.hoisted(() =>
+  vi.fn((_cfg?: unknown, env?: NodeJS.ProcessEnv) => {
+    const raw = env?.OPENCLAW_GATEWAY_PORT ?? process.env.OPENCLAW_GATEWAY_PORT;
+    const port = raw ? Number.parseInt(String(raw), 10) : Number.NaN;
+    return Number.isFinite(port) && port > 0 ? port : 18789;
+  }),
+);
 const readConfigFileSnapshot = vi.hoisted(() =>
   vi.fn(async () => ({
     path: "/tmp/.openclaw/openclaw.json",
@@ -137,7 +144,7 @@ vi.mock("../commands/onboard-hooks.js", () => ({
 
 vi.mock("../config/config.js", () => ({
   DEFAULT_GATEWAY_PORT: 18789,
-  resolveGatewayPort: () => 18789,
+  resolveGatewayPort,
   readConfigFileSnapshot,
   writeConfigFile,
 }));
@@ -595,5 +602,47 @@ describe("runSetupWizard", () => {
         secretInputMode: "ref", // pragma: allowlist secret
       }),
     );
+  });
+
+  it("shows the resolved gateway port in quickstart for fresh envs", async () => {
+    const previousPort = process.env.OPENCLAW_GATEWAY_PORT;
+    process.env.OPENCLAW_GATEWAY_PORT = "18791";
+    const note: WizardPrompter["note"] = vi.fn(async () => {});
+    const prompter = buildWizardPrompter({ note });
+    const runtime = createRuntime();
+
+    try {
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipSearch: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      );
+    } finally {
+      if (previousPort === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_PORT;
+      } else {
+        process.env.OPENCLAW_GATEWAY_PORT = previousPort;
+      }
+    }
+
+    const calls = (note as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(
+      calls.some(
+        (call) =>
+          call?.[1] === "QuickStart" &&
+          typeof call?.[0] === "string" &&
+          call[0].includes("Gateway port: 18791"),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -6,12 +6,7 @@ import type {
   ResetScope,
 } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  DEFAULT_GATEWAY_PORT,
-  readConfigFileSnapshot,
-  resolveGatewayPort,
-  writeConfigFile,
-} from "../config/config.js";
+import { readConfigFileSnapshot, resolveGatewayPort, writeConfigFile } from "../config/config.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
 import {
   buildPluginCompatibilityNotices,
@@ -295,7 +290,7 @@ export async function runSetupWizard(
           "Direct to chat channels.",
         ]
       : [
-          `Gateway port: ${DEFAULT_GATEWAY_PORT}`,
+          `Gateway port: ${quickstartGateway.port}`,
           "Gateway bind: Loopback (127.0.0.1)",
           "Gateway auth: Token (default)",
           "Tailscale exposure: Off",


### PR DESCRIPTION
## Summary
- keep chat-log system messages as single logical entries instead of separate spacer/text nodes
- prune overflow at whole-message boundaries so later entries do not leave broken system-message spacing
- add a regression test covering overflow from system entries into a non-system entry

## Testing
- pnpm test -- src/tui/components/chat-log.test.ts