### PR TITLE
fix: correct memory flush token projection accounting

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { resolveEffectivePromptTokens } from "./agent-runner-memory.js";
+
+describe("resolveEffectivePromptTokens", () => {
+  it("includes transcript output when the base snapshot is prompt-only", () => {
+    expect(
+      resolveEffectivePromptTokens({
+        basePromptTokens: 41_000,
+        lastOutputTokens: 2_400,
+        promptTokenEstimate: 300,
+        baseIncludesOutput: false,
+      }),
+    ).toBe(43_700);
+  });
+
+  it("does not double count output when the base snapshot already includes it", () => {
+    expect(
+      resolveEffectivePromptTokens({
+        basePromptTokens: 43_400,
+        lastOutputTokens: 2_400,
+        promptTokenEstimate: 300,
+        baseIncludesOutput: true,
+      }),
+    ).toBe(43_700);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -56,17 +56,19 @@ export function estimatePromptTokensForMemoryFlush(prompt?: string): number | un
   return Math.ceil(tokens);
 }
 
-export function resolveEffectivePromptTokens(
-  basePromptTokens?: number,
-  lastOutputTokens?: number,
-  promptTokenEstimate?: number,
-): number {
-  const base = Math.max(0, basePromptTokens ?? 0);
-  const output = Math.max(0, lastOutputTokens ?? 0);
-  const estimate = Math.max(0, promptTokenEstimate ?? 0);
-  // Flush gating projects the next input context by adding the previous
-  // completion and the current user prompt estimate.
-  return base + output + estimate;
+export function resolveEffectivePromptTokens(params: {
+  basePromptTokens?: number;
+  lastOutputTokens?: number;
+  promptTokenEstimate?: number;
+  baseIncludesOutput?: boolean;
+}): number {
+  const base = Math.max(0, params.basePromptTokens ?? 0);
+  const output = Math.max(0, params.lastOutputTokens ?? 0);
+  const estimate = Math.max(0, params.promptTokenEstimate ?? 0);
+  // Flush/compaction gating projects the next input context. Some base snapshots
+  // are prompt-only and still need the prior assistant output added; others are
+  // already full context snapshots and must not double count that output.
+  return base + (params.baseIncludesOutput === true ? 0 : output) + estimate;
 }
 
 export type SessionTranscriptUsageSnapshot = {
@@ -360,7 +362,11 @@ export async function runPreflightCompactionIfNeeded(params: {
         });
   const projectedTokenCount =
     typeof transcriptPromptTokens === "number"
-      ? resolveEffectivePromptTokens(transcriptPromptTokens, undefined, promptTokenEstimate)
+      ? resolveEffectivePromptTokens({
+          basePromptTokens: transcriptPromptTokens,
+          promptTokenEstimate,
+          baseIncludesOutput: false,
+        })
       : undefined;
   const tokenCountForCompaction =
     typeof projectedTokenCount === "number" &&
@@ -598,13 +604,16 @@ export async function runMemoryFlushIfNeeded(params: {
   const hasFreshPromptTokensSnapshot =
     promptTokensSnapshot > 0 &&
     (hasFreshPersistedPromptTokens || hasReliableTranscriptPromptTokens);
+  const promptTokensSnapshotIncludesOutput =
+    hasFreshPersistedPromptTokens && promptTokensSnapshot === (persistedPromptTokens ?? 0);
 
   const projectedTokenCount = hasFreshPromptTokensSnapshot
-    ? resolveEffectivePromptTokens(
-        promptTokensSnapshot,
-        transcriptOutputTokens,
+    ? resolveEffectivePromptTokens({
+        basePromptTokens: promptTokensSnapshot,
+        lastOutputTokens: transcriptOutputTokens,
         promptTokenEstimate,
-      )
+        baseIncludesOutput: promptTokensSnapshotIncludesOutput,
+      })
     : undefined;
   const tokenCountForFlush =
     typeof projectedTokenCount === "number" &&


### PR DESCRIPTION
## Summary
- make memory-flush token projection explicit about whether the base snapshot already includes prior output
- keep transcript-derived prompt snapshots adding transcript output, while avoiding double-counting when the base is already a full context total
- add focused regression tests for both projection paths

## Testing
- pnpm exec vitest run src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/reply-state.test.ts

Closes #55679