### PR TITLE
fix(browser): skip internal Chrome UI targets in CDP selection

### DIFF
--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.suite.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.suite.ts
@@ -158,6 +158,57 @@ describe("browser server-context remote profile tab operations", () => {
     expect(second.targetId).toBe("A");
   });
 
+  it("skips Chrome internal UI targets for remote default selection", async () => {
+    const listPagesViaPlaywright = vi.fn(
+      createSequentialPageLister([
+        [
+          {
+            targetId: "OMNI",
+            title: "Omnibox",
+            url: "chrome://omnibox-popup.top-chrome/",
+            type: "page",
+          },
+        ],
+        [
+          {
+            targetId: "OMNI",
+            title: "Omnibox",
+            url: "chrome://omnibox-popup.top-chrome/",
+            type: "page",
+          },
+          {
+            targetId: "REAL",
+            title: "New Tab",
+            url: "about:blank",
+            type: "page",
+          },
+        ],
+      ]),
+    );
+    const createPageViaPlaywright = vi.fn(async () => ({
+      targetId: "REAL",
+      title: "New Tab",
+      url: "about:blank",
+      type: "page",
+    }));
+
+    vi.spyOn(pwAiModule, "getPwAiModule").mockResolvedValue({
+      listPagesViaPlaywright,
+      createPageViaPlaywright,
+    } as unknown as Awaited<ReturnType<typeof pwAiModule.getPwAiModule>>);
+
+    const { state, remote } = createRemoteRouteHarness();
+
+    const selected = await remote.ensureTabAvailable();
+    expect(selected.targetId).toBe("REAL");
+    expect(state.profiles.get("remote")?.lastTargetId).toBe("REAL");
+    expect(createPageViaPlaywright).toHaveBeenCalledWith({
+      cdpUrl: "https://browserless.example/chrome?token=abc",
+      url: "about:blank",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+  });
+
   it("rejects stale targetId for remote profiles even when only one tab remains", async () => {
     const responses = [
       [{ targetId: "T1", title: "Tab 1", url: "https://example.com", type: "page" }],

--- a/extensions/browser/src/browser/server-context.selection.ts
+++ b/extensions/browser/src/browser/server-context.selection.ts
@@ -23,6 +23,29 @@ type SelectionOps = {
   closeTab: (targetId: string) => Promise<void>;
 };
 
+function isBrowserInternalSurfaceUrl(url: string | undefined): boolean {
+  const normalized = url?.trim().toLowerCase() ?? "";
+  if (!normalized) {
+    return false;
+  }
+
+  return (
+    normalized.startsWith("chrome://") ||
+    normalized.startsWith("devtools://") ||
+    normalized.startsWith("edge://") ||
+    normalized.startsWith("brave://") ||
+    normalized.startsWith("vivaldi://") ||
+    normalized.startsWith("opera://")
+  );
+}
+
+function isDefaultNavigableTab(tab: BrowserTab): boolean {
+  if ((tab.type ?? "page") !== "page") {
+    return false;
+  }
+  return !isBrowserInternalSurfaceUrl(tab.url);
+}
+
 export function createProfileSelectionOps({
   profile,
   getProfileState,
@@ -41,8 +64,15 @@ export function createProfileSelectionOps({
       await openTab("about:blank");
     }
 
-    const tabs = await listTabs();
-    const candidates = capabilities.supportsPerTabWs ? tabs.filter((t) => Boolean(t.wsUrl)) : tabs;
+    const listCandidateTabs = async () => {
+      const tabs = await listTabs();
+      return capabilities.supportsPerTabWs ? tabs.filter((t) => Boolean(t.wsUrl)) : tabs;
+    };
+    let candidates = await listCandidateTabs();
+    if (!targetId && candidates.length > 0 && !candidates.some(isDefaultNavigableTab)) {
+      await openTab("about:blank");
+      candidates = await listCandidateTabs();
+    }
 
     const resolveById = (raw: string) => {
       const resolved = resolveTargetIdFromTabs(raw, candidates);
@@ -58,11 +88,11 @@ export function createProfileSelectionOps({
     const pickDefault = () => {
       const last = profileState.lastTargetId?.trim() || "";
       const lastResolved = last ? resolveById(last) : null;
-      if (lastResolved && lastResolved !== "AMBIGUOUS") {
+      if (lastResolved && lastResolved !== "AMBIGUOUS" && isDefaultNavigableTab(lastResolved)) {
         return lastResolved;
       }
       // Prefer a real page tab first (avoid service workers/background targets).
-      const page = candidates.find((t) => (t.type ?? "page") === "page");
+      const page = candidates.find(isDefaultNavigableTab);
       return page ?? candidates.at(0) ?? null;
     };
 

--- a/extensions/browser/src/browser/server-context.tab-selection-state.suite.ts
+++ b/extensions/browser/src/browser/server-context.tab-selection-state.suite.ts
@@ -129,6 +129,67 @@ describe("browser server-context tab selection state", () => {
     });
   });
 
+  it("opens a real tab when only Chrome internal UI targets are listed", async () => {
+    const openTabSpy = vi
+      .spyOn(cdpModule, "createTargetViaCdp")
+      .mockResolvedValue({ targetId: "REAL" });
+    let listCount = 0;
+    const fetchMock = vi.fn(async (url: unknown) => {
+      const value = String(url);
+      if (!value.includes("/json/list")) {
+        throw new Error(`unexpected fetch: ${value}`);
+      }
+      listCount += 1;
+      if (listCount === 1) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              id: "OMNI",
+              title: "Search tabs",
+              url: "chrome://tab-search.top-chrome/",
+              webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/OMNI",
+              type: "page",
+            },
+          ],
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        json: async () => [
+          {
+            id: "OMNI",
+            title: "Search tabs",
+            url: "chrome://tab-search.top-chrome/",
+            webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/OMNI",
+            type: "page",
+          },
+          {
+            id: "REAL",
+            title: "New Tab",
+            url: "about:blank",
+            webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/REAL",
+            type: "page",
+          },
+        ],
+      } as unknown as Response;
+    });
+
+    global.fetch = withFetchPreconnect(fetchMock);
+    const state = makeState("openclaw");
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const openclaw = ctx.forProfile("openclaw");
+
+    const selected = await openclaw.ensureTabAvailable();
+    expect(selected.targetId).toBe("REAL");
+    expect(state.profiles.get("openclaw")?.lastTargetId).toBe("REAL");
+    expect(openTabSpy).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18800",
+      url: "about:blank",
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+  });
+
   it("closes excess managed tabs after opening a new tab", async () => {
     vi.spyOn(cdpModule, "createTargetViaCdp").mockResolvedValue({ targetId: "NEW" });
     const existingTabs = makeManagedTabsWithNew();


### PR DESCRIPTION
## Summary
- exclude Chrome internal top-chrome surfaces from implicit/default CDP page selection
- fall back to opening a real about:blank tab when only browser-internal UI targets are present
- add focused browser tab-selection regression coverage for raw CDP and remote Playwright-backed selection

## Testing
- targeted browser selection tests updated alongside the fix
- local runtime validation remains limited in this environment outside the focused suite

Closes #55734