### PR TITLE
feat(slack): add thread-aware requireMentionInThreads config (#30270)

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -404,7 +404,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
     Per-channel controls (`channels.slack.channels.<id>`; names only via startup resolution or `dangerouslyAllowNameMatching`):
 
     - `requireMention`
-    - `requireMentionInThreads` — override mention gating for thread replies (`true` = always require explicit @mention; `false` = threads never require a mention; unset = inherit `requireMention`)
+    - `requireMentionInThreads` — override mention gating for thread replies (`true` = always require a mention; `false` = threads never require a mention; unset = inherit `requireMention`)
     - `users` (allowlist)
     - `allowBots`
     - `skills`

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -404,6 +404,7 @@ Current Slack message actions include `send`, `upload-file`, `download-file`, `r
     Per-channel controls (`channels.slack.channels.<id>`; names only via startup resolution or `dangerouslyAllowNameMatching`):
 
     - `requireMention`
+    - `requireMentionInThreads` — override mention gating for thread replies (`true` = always require explicit @mention; `false` = threads never require a mention; unset = inherit `requireMention`)
     - `users` (allowlist)
     - `allowBots`
     - `skills`

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -405,7 +405,12 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       allowFrom: ["U123", "U456", "*"],
       dm: { enabled: true, groupEnabled: false, groupChannels: ["G123"] },
       channels: {
-        C123: { allow: true, requireMention: true, allowBots: false },
+        C123: {
+          allow: true,
+          requireMention: true,
+          requireMentionInThreads: false,
+          allowBots: false,
+        },
         "#general": {
           allow: true,
           requireMention: true,

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -12,6 +12,7 @@ import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from ".
 export type SlackChannelConfigResolved = {
   allowed: boolean;
   requireMention: boolean;
+  requireMentionInThreads?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -23,6 +24,7 @@ export type SlackChannelConfigResolved = {
 export type SlackChannelConfigEntry = {
   enabled?: boolean;
   requireMention?: boolean;
+  requireMentionInThreads?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -91,6 +93,7 @@ export function resolveSlackChannelConfig(params: {
   channels?: SlackChannelConfigEntries;
   channelKeys?: string[];
   defaultRequireMention?: boolean;
+  defaultRequireMentionInThreads?: boolean;
   allowNameMatching?: boolean;
 }): SlackChannelConfigResolved | null {
   const {
@@ -127,11 +130,20 @@ export function resolveSlackChannelConfig(params: {
   const { entry: matched, wildcardEntry: fallback } = match;
 
   const requireMentionDefault = defaultRequireMention ?? true;
+  const requireMentionInThreadsDefault = params.defaultRequireMentionInThreads;
   if (keys.length === 0) {
-    return { allowed: true, requireMention: requireMentionDefault };
+    return {
+      allowed: true,
+      requireMention: requireMentionDefault,
+      requireMentionInThreads: requireMentionInThreadsDefault,
+    };
   }
   if (!matched && !fallback) {
-    return { allowed: false, requireMention: requireMentionDefault };
+    return {
+      allowed: false,
+      requireMention: requireMentionDefault,
+      requireMentionInThreads: requireMentionInThreadsDefault,
+    };
   }
 
   const resolved = matched ?? fallback ?? {};
@@ -139,6 +151,11 @@ export function resolveSlackChannelConfig(params: {
   const requireMention =
     firstDefined(resolved.requireMention, fallback?.requireMention, requireMentionDefault) ??
     requireMentionDefault;
+  const requireMentionInThreads = firstDefined(
+    resolved.requireMentionInThreads,
+    fallback?.requireMentionInThreads,
+    params.defaultRequireMentionInThreads,
+  );
   const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
@@ -146,6 +163,7 @@ export function resolveSlackChannelConfig(params: {
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
+    requireMentionInThreads,
     allowBots,
     users,
     skills,

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -49,6 +49,7 @@ export type SlackMonitorContext = {
   groupDmEnabled: boolean;
   groupDmChannels: string[];
   defaultRequireMention: boolean;
+  defaultRequireMentionInThreads?: boolean;
   channelsConfig?: SlackChannelConfigEntries;
   channelsConfigKeys: string[];
   groupPolicy: GroupPolicy;
@@ -115,6 +116,7 @@ export function createSlackMonitorContext(params: {
   groupDmEnabled: boolean;
   groupDmChannels: Array<string | number> | undefined;
   defaultRequireMention?: boolean;
+  defaultRequireMentionInThreads?: boolean;
   channelsConfig?: SlackMonitorContext["channelsConfig"];
   groupPolicy: SlackMonitorContext["groupPolicy"];
   useAccessGroups: boolean;
@@ -150,6 +152,7 @@ export function createSlackMonitorContext(params: {
   const groupDmChannels = normalizeAllowList(params.groupDmChannels);
   const groupDmChannelsLower = normalizeAllowListLower(groupDmChannels);
   const defaultRequireMention = params.defaultRequireMention ?? true;
+  const defaultRequireMentionInThreads = params.defaultRequireMentionInThreads;
   const hasChannelAllowlistConfig = Object.keys(params.channelsConfig ?? {}).length > 0;
   const channelsConfigKeys = Object.keys(params.channelsConfig ?? {});
 
@@ -334,6 +337,7 @@ export function createSlackMonitorContext(params: {
         channels: params.channelsConfig,
         channelKeys: channelsConfigKeys,
         defaultRequireMention,
+        defaultRequireMentionInThreads,
         allowNameMatching: params.allowNameMatching,
       });
       const channelMatchMeta = formatAllowlistMatchMeta(channelConfig);
@@ -415,6 +419,7 @@ export function createSlackMonitorContext(params: {
     groupDmEnabled: params.groupDmEnabled,
     groupDmChannels,
     defaultRequireMention,
+    defaultRequireMentionInThreads,
     channelsConfig: params.channelsConfig,
     channelsConfigKeys,
     groupPolicy: params.groupPolicy,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -916,7 +916,7 @@ describe("requireMentionInThreads", () => {
       message: makeMessage({ thread_ts: "100.000" }),
       opts: { source: "message" },
     });
-    // requireMentionInThreads: true overrides implicit mention — explicit @mention needed.
+    // requireMentionInThreads: true overrides implicit mention — mention needed.
     expect(result).toBeNull();
   });
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -5,10 +5,15 @@ import type { App } from "@slack/bolt";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { expectChannelInboundContextContract as expectInboundContextContract } from "../../../../../src/channels/plugins/contracts/test-helpers.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
+import {
+  clearSlackThreadParticipationCache,
+  recordSlackThreadParticipation,
+} from "../../sent-thread-cache.js";
 import type { SlackMessageEvent } from "../../types.js";
+import type { SlackChannelConfigEntries } from "../channel-config.js";
 import type { SlackMonitorContext } from "../context.js";
 import { prepareSlackMessage } from "./prepare.js";
 import { createInboundSlackTestContext, createSlackTestAccount } from "./prepare.test-helpers.js";
@@ -824,6 +829,144 @@ describe("slack thread.requireExplicitMention", () => {
       ctx,
       account,
       message,
+      opts: { source: "message" },
+    });
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("requireMentionInThreads", () => {
+  afterEach(() => {
+    clearSlackThreadParticipationCache();
+  });
+
+  function createMentionGateCtx(channelsConfig: SlackChannelConfigEntries) {
+    const ctx = createInboundSlackTestContext({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    ctx.channelsConfig = channelsConfig;
+    ctx.channelsConfigKeys = Object.keys(channelsConfig);
+    // oxlint-disable-next-line typescript/no-explicit-any
+    ctx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    ctx.resolveChannelName = async () => ({ name: "test", type: "channel" as const });
+    return ctx;
+  }
+
+  function makeMessage(overrides: Partial<SlackMessageEvent>): SlackMessageEvent {
+    return {
+      channel: "C1",
+      channel_type: "channel",
+      user: "U1",
+      text: "hello",
+      ts: "101.000",
+      ...overrides,
+    } as SlackMessageEvent;
+  }
+
+  const account = createSlackTestAccount();
+
+  it("drops thread reply when requireMentionInThreads is not set and no mention", async () => {
+    const ctx = createMentionGateCtx({ C1: { enabled: true, requireMention: true } });
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000" }),
+      opts: { source: "message" },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("allows thread reply when requireMentionInThreads is false", async () => {
+    const ctx = createMentionGateCtx({
+      C1: { enabled: true, requireMention: true, requireMentionInThreads: false },
+    });
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000" }),
+      opts: { source: "message" },
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("still requires mention in main channel even when requireMentionInThreads is false", async () => {
+    const ctx = createMentionGateCtx({
+      C1: { enabled: true, requireMention: true, requireMentionInThreads: false },
+    });
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({}),
+      opts: { source: "message" },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("drops thread reply with implicit mention when requireMentionInThreads is true", async () => {
+    recordSlackThreadParticipation("default", "C1", "100.000");
+    const ctx = createMentionGateCtx({
+      C1: { enabled: true, requireMention: true, requireMentionInThreads: true },
+    });
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000" }),
+      opts: { source: "message" },
+    });
+    // requireMentionInThreads: true overrides implicit mention — explicit @mention needed.
+    expect(result).toBeNull();
+  });
+
+  it("allows thread reply with explicit mention when requireMentionInThreads is true", async () => {
+    const ctx = createMentionGateCtx({
+      C1: { enabled: true, requireMention: true, requireMentionInThreads: true },
+    });
+    ctx.botUserId = "BBOT";
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000", text: "<@BBOT> hello" }),
+      opts: { source: "message" },
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("allows thread reply with implicit mention when requireMentionInThreads is not set", async () => {
+    recordSlackThreadParticipation("default", "C1", "100.000");
+    const ctx = createMentionGateCtx({ C1: { enabled: true, requireMention: true } });
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000" }),
+      opts: { source: "message" },
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("sets WasMentioned true when requireMentionInThreads false allows unmentioned thread reply", async () => {
+    const ctx = createMentionGateCtx({
+      C1: { enabled: true, requireMention: true, requireMentionInThreads: false },
+    });
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000" }),
+      opts: { source: "message" },
+    });
+    expect(result).not.toBeNull();
+    expect(result!.ctxPayload.WasMentioned).toBe(true);
+  });
+
+  it("allows thread reply when account-level defaultRequireMentionInThreads is false with no per-channel override", async () => {
+    const ctx = createMentionGateCtx({ C1: { enabled: true, requireMention: true } });
+    ctx.defaultRequireMentionInThreads = false;
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: makeMessage({ thread_ts: "100.000" }),
       opts: { source: "message" },
     });
     expect(result).not.toBeNull();

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -151,6 +151,7 @@ async function resolveSlackConversationContext(params: {
         channels: ctx.channelsConfig,
         channelKeys: ctx.channelsConfigKeys,
         defaultRequireMention: ctx.defaultRequireMention,
+        defaultRequireMentionInThreads: ctx.defaultRequireMentionInThreads,
         allowNameMatching: ctx.allowNameMatching,
       })
     : null;
@@ -493,12 +494,21 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const shouldRequireMention = isRoom
+  const baseMentionRequired = isRoom
     ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
     : false;
+  const threadMentionOverride =
+    isRoom && isThreadReply ? channelConfig?.requireMentionInThreads : undefined;
+  const shouldRequireMention =
+    threadMentionOverride !== undefined ? threadMentionOverride : baseMentionRequired;
 
   // Allow "control commands" to bypass mention gating if sender is authorized.
   const canDetectMention = Boolean(ctx.botUserId) || mentionRegexes.length > 0;
+  // When requireMentionInThreads is true, block all implicit mention kinds so only
+  // explicit @mentions satisfy the gate. When threadRequireExplicitMention is set,
+  // that also blocks implicit kinds. Otherwise allow all implicit kinds.
+  const suppressImplicit =
+    threadMentionOverride === true || ctx.threadRequireExplicitMention;
   const mentionDecision = resolveInboundMentionDecision({
     facts: {
       canDetectMention,
@@ -509,13 +519,18 @@ export async function prepareSlackMessage(params: {
     policy: {
       isGroup: isRoom,
       requireMention: Boolean(shouldRequireMention),
-      allowedImplicitMentionKinds: ctx.threadRequireExplicitMention ? [] : undefined,
+      allowedImplicitMentionKinds: suppressImplicit ? [] : undefined,
       allowTextCommands,
       hasControlCommand: hasControlCommandInMessage,
       commandAuthorized,
     },
   });
-  const effectiveWasMentioned = mentionDecision.effectiveWasMentioned;
+  // When requireMentionInThreads explicitly relaxes the requirement (false) for a thread
+  // that would otherwise need a mention, treat the turn as mentioned so downstream directive
+  // gating (elevated/exec) is not inadvertently stripped.
+  const effectiveWasMentioned =
+    mentionDecision.effectiveWasMentioned ||
+    (threadMentionOverride === false && baseMentionRequired);
   if (isRoom && shouldRequireMention && mentionDecision.shouldSkip) {
     ctx.logger.info({ channel: message.channel, reason: "no-mention" }, "skipping channel message");
     const pendingText = (message.text ?? "").trim();

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -104,6 +104,73 @@ describe("resolveSlackChannelConfig", () => {
       matchSource: "direct",
     });
   });
+
+  it("resolves requireMentionInThreads from direct channel entry", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { C1: { enabled: true, requireMention: true, requireMentionInThreads: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({ requireMention: true, requireMentionInThreads: false });
+  });
+
+  it("resolves requireMentionInThreads from wildcard fallback", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { "*": { requireMentionInThreads: false } },
+      defaultRequireMention: true,
+    });
+    expect(res).toMatchObject({ requireMention: true, requireMentionInThreads: false });
+  });
+
+  it("resolves requireMentionInThreads from account-level default", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { C1: { enabled: true } },
+      defaultRequireMention: true,
+      defaultRequireMentionInThreads: false,
+    });
+    expect(res).toMatchObject({ requireMention: true, requireMentionInThreads: false });
+  });
+
+  it("prefers channel-level requireMentionInThreads over account default", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { C1: { enabled: true, requireMentionInThreads: true } },
+      defaultRequireMention: true,
+      defaultRequireMentionInThreads: false,
+    });
+    expect(res).toMatchObject({ requireMentionInThreads: true });
+  });
+
+  it("leaves requireMentionInThreads undefined when not configured anywhere", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: { C1: { enabled: true } },
+      defaultRequireMention: true,
+    });
+    expect(res?.requireMentionInThreads).toBeUndefined();
+  });
+
+  it("honors account-level requireMentionInThreads when channels config is empty", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C1",
+      channels: {},
+      defaultRequireMention: true,
+      defaultRequireMentionInThreads: false,
+    });
+    expect(res).toMatchObject({ requireMentionInThreads: false });
+  });
+
+  it("honors account-level requireMentionInThreads when channel is unmatched", () => {
+    const res = resolveSlackChannelConfig({
+      channelId: "C_OTHER",
+      channels: { C1: { enabled: true } },
+      defaultRequireMention: true,
+      defaultRequireMentionInThreads: false,
+    });
+    expect(res).toMatchObject({ requireMentionInThreads: false });
+  });
 });
 
 const baseParams = () => ({

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -417,6 +417,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     groupDmEnabled,
     groupDmChannels,
     defaultRequireMention: slackCfg.requireMention,
+    defaultRequireMentionInThreads: slackCfg.requireMentionInThreads,
     channelsConfig,
     groupPolicy,
     useAccessGroups,

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -33,6 +33,13 @@ export type SlackChannelConfig = {
   enabled?: boolean;
   /** Require mentioning the bot to trigger replies. */
   requireMention?: boolean;
+  /**
+   * Override mention gating for thread replies.
+   * - true: requires explicit @mention even with prior bot participation.
+   * - false: threads never require a mention.
+   * - unset: inherits requireMention behavior.
+   */
+  requireMentionInThreads?: boolean;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -141,6 +148,13 @@ export type SlackAccountConfig = {
   dangerouslyAllowNameMatching?: boolean;
   /** Default mention requirement for channel messages (default: true). */
   requireMention?: boolean;
+  /**
+   * Default override for mention gating in thread replies.
+   * - true: requires explicit @mention even with prior bot participation.
+   * - false: threads never require a mention.
+   * - unset: inherits requireMention behavior.
+   */
+  requireMentionInThreads?: boolean;
   /**
    * Controls how channel messages are handled:
    * - "open": channels bypass allowlists; mention-gating applies

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -852,6 +852,7 @@ export const SlackChannelSchema = z
   .object({
     enabled: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    requireMentionInThreads: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     allowBots: z.boolean().optional(),
@@ -906,6 +907,7 @@ export const SlackAccountSchema = z
     allowBots: z.boolean().optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     requireMention: z.boolean().optional(),
+    requireMentionInThreads: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional(),
     contextVisibility: ContextVisibilityModeSchema.optional(),
     historyLimit: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary

- Problem: `requireMention` in Slack channel config is binary — either all messages require a mention or none do, with no way to distinguish between main channel and thread behavior.
- Why it matters: In project channels, the bot should stay quiet unless mentioned in the main channel, but actively participate in threads once engaged — the current config can't express this.
- What changed: Added `requireMentionInThreads` config option (per-channel + account-level default) that overrides mention gating for thread replies. When explicitly set to true, it also suppresses the implicit mention bypass from thread participation.
- What did NOT change (scope boundary): The shared `mention-gating.ts` logic is untouched — thread awareness stays in the Slack prepare layer. No changes to other channels (Discord/Telegram). No changes to DM or group DM handling.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30270
- Supersedes #48978 (closed as dirty after rebase)

## User-visible / Behavior Changes
- New optional config field `requireMentionInThreads` (boolean) on `channels.slack.channels.<id>` and `channels.slack` (account-level default).
- `false`: bot responds in threads without requiring `@mention`.
- `true`: bot requires explicit `@mention` in threads, even if it has previously participated in the thread.
- Not set: inherits from `requireMention` (current behavior, fully backward compatible).


## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No


## Human Verification (required)

What you personally verified (not just CI), and how:

Verified scenarios tested in live slack e2e testing with: 
- `requireMentionInThreads: false`
    - channel, no mention → bot ignores
    - channel, with @mention → bot responds
    - thread, no mention → bot responds
    - thread, with @mention → bot responds
 - `requireMentionInThreads: true`
    - thread, no mention, bot already participated → bot ignores (overrides implicit mention)
    - thread, with @mention → bot responds
 - `requireMentionInThreads not set`
    - thread, no mention, bot NOT yet in thread → bot ignores
    - thread, no mention, bot already participated → bot responds


## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes — new optional field, `undefined = current` behavior.
- Config/env changes? Yes — new optional `requireMentionInThreads` config key.
- Migration needed? No


## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `requireMentionInThreads` from config — behavior falls back to `requireMention` as before.
- Files/config to restore: N/A — no migration, no schema version change.
- Known bad symptoms reviewers should watch for: Bot unexpectedly responding (or not) in threads after config change.

## Risks and Mitigations

- Risk: Operators set `requireMentionInThreads`: false on a noisy channel and the bot responds to every thread message.
  - Mitigation: This is opt-in and per-channel. Default (unset) preserves existing behavior.