### PR TITLE
feat(plugins): inject execute context (agentId) into plugin tool calls

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -131,13 +131,13 @@ const createCompactionEvent = (params: { messageText: string; tokensBefore: numb
 
 const createCompactionContext = (params: {
   sessionManager: ExtensionContext["sessionManager"];
-  getApiKeyMock: ReturnType<typeof vi.fn>;
+  getApiKeyAndHeadersMock: ReturnType<typeof vi.fn>;
 }) =>
   ({
     model: undefined,
     sessionManager: params.sessionManager,
     modelRegistry: {
-      getApiKey: params.getApiKeyMock,
+      getApiKeyAndHeaders: params.getApiKeyAndHeadersMock,
     },
   }) as unknown as Partial<ExtensionContext>;
 
@@ -147,10 +147,14 @@ async function runCompactionScenario(params: {
   apiKey: string | null;
 }) {
   const compactionHandler = createCompactionHandler();
-  const getApiKeyMock = vi.fn().mockResolvedValue(params.apiKey ?? undefined);
+  const getApiKeyAndHeadersMock = vi
+    .fn()
+    .mockResolvedValue(
+      params.apiKey ? { ok: true, apiKey: params.apiKey } : { ok: false, error: "no key" },
+    );
   const mockContext = createCompactionContext({
     sessionManager: params.sessionManager,
-    getApiKeyMock,
+    getApiKeyAndHeadersMock,
   });
   const result = (await compactionHandler(params.event, mockContext)) as {
     cancel?: boolean;
@@ -160,7 +164,7 @@ async function runCompactionScenario(params: {
       tokensBefore: number;
     };
   };
-  return { result, getApiKeyMock };
+  return { result, getApiKeyAndHeadersMock };
 }
 
 function expectCompactionResult(result: {
@@ -1222,10 +1226,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
+      getApiKeyAndHeadersMock,
     });
     const messagesToSummarize: AgentMessage[] = Array.from({ length: 4 }, (_unused, index) => ({
       role: "user",
@@ -1278,10 +1282,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
+      getApiKeyAndHeadersMock,
     });
     const event = {
       preparation: {
@@ -1343,10 +1347,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
+      getApiKeyAndHeadersMock,
     });
     const event = {
       preparation: {
@@ -1446,10 +1450,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
+      getApiKeyAndHeadersMock,
     });
     const event = {
       preparation: {
@@ -1509,10 +1513,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
+      getApiKeyAndHeadersMock,
     });
     const event = {
       preparation: {
@@ -1572,10 +1576,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
     });
 
     const compactionHandler = createCompactionHandler();
-    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyMock,
+      getApiKeyAndHeadersMock,
     });
     const event = {
       preparation: {
@@ -1634,7 +1638,7 @@ describe("compaction-safeguard extension model fallback", () => {
       messageText: "test message",
       tokensBefore: 1000,
     });
-    const { result, getApiKeyMock } = await runCompactionScenario({
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
       apiKey: null,
@@ -1645,7 +1649,7 @@ describe("compaction-safeguard extension model fallback", () => {
     // KEY ASSERTION: Prove the fallback path was exercised
     // The handler should have resolved request auth with runtime.model
     // (via ctx.model ?? runtime?.model).
-    expect(getApiKeyMock).toHaveBeenCalledWith(model);
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalledWith(model);
 
     // Verify runtime.model is still available (for completeness)
     const retrieved = getCompactionSafeguardRuntime(sessionManager);
@@ -1661,7 +1665,7 @@ describe("compaction-safeguard extension model fallback", () => {
       messageText: "test",
       tokensBefore: 500,
     });
-    const { result, getApiKeyMock } = await runCompactionScenario({
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
       apiKey: null,
@@ -1670,7 +1674,7 @@ describe("compaction-safeguard extension model fallback", () => {
     expect(result).toEqual({ cancel: true });
 
     // Verify early return: request auth should NOT have been resolved when both models are missing.
-    expect(getApiKeyMock).not.toHaveBeenCalled();
+    expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 });
 
@@ -1691,7 +1695,7 @@ describe("compaction-safeguard double-compaction guard", () => {
       customInstructions: "",
       signal: new AbortController().signal,
     };
-    const { result, getApiKeyMock } = await runCompactionScenario({
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
       apiKey: "sk-test", // pragma: allowlist secret
@@ -1705,7 +1709,7 @@ describe("compaction-safeguard double-compaction guard", () => {
     expect(compaction.summary).toContain("## Open TODOs");
     expect(compaction.firstKeptEntryId).toBe("entry-1");
     expect(compaction.tokensBefore).toBe(1500);
-    expect(getApiKeyMock).not.toHaveBeenCalled();
+    expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
 
   it("returns compaction result with structured fallback summary sections", async () => {
@@ -1816,13 +1820,13 @@ describe("compaction-safeguard double-compaction guard", () => {
       messageText: "real message",
       tokensBefore: 1500,
     });
-    const { result, getApiKeyMock } = await runCompactionScenario({
+    const { result, getApiKeyAndHeadersMock } = await runCompactionScenario({
       sessionManager,
       event: mockEvent,
       apiKey: null,
     });
     expect(result).toEqual({ cancel: true });
-    expect(getApiKeyMock).toHaveBeenCalled();
+    expect(getApiKeyAndHeadersMock).toHaveBeenCalled();
   });
 
   it("treats tool results as real conversation only when linked to a meaningful user ask", async () => {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -616,7 +616,18 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
     let apiKey: string | undefined;
     try {
-      apiKey = await ctx.modelRegistry.getApiKey(model);
+      const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+      if (!auth.ok) {
+        log.warn(
+          `Compaction safeguard: request credentials unavailable; cancelling compaction. ${auth.error}`,
+        );
+        setCompactionSafeguardCancelReason(
+          ctx.sessionManager,
+          `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${auth.error}`,
+        );
+        return { cancel: true };
+      }
+      apiKey = auth.apiKey;
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       log.warn(

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -201,9 +201,6 @@ describe("execute context injection", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.mock("./loader.js", () => ({
-      loadOpenClawPlugins: (params: unknown) => loadOpenClawPluginsMock(params),
-    }));
     const mod = await import("./tools.js");
     resolvePluginTools = mod.resolvePluginTools;
     const runtimeMod = await import("./runtime.js");

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -208,13 +208,23 @@ describe("execute context injection", () => {
     resetPluginRuntimeStateForTest();
   });
 
-  it("injects agentId into execute context as third argument", async () => {
+  it("injects agentId into execute context as fifth argument", async () => {
     let receivedContext: unknown = undefined;
+    let receivedSignal: unknown = undefined;
+    let receivedOnUpdate: unknown = undefined;
     const tool = {
       name: "ctx_test",
       description: "test tool",
       parameters: { type: "object" as const, properties: {} },
-      async execute(_callId: string, _params: unknown, context?: unknown) {
+      async execute(
+        _callId: string,
+        _params: unknown,
+        signal?: AbortSignal,
+        onUpdate?: unknown,
+        context?: unknown,
+      ) {
+        receivedSignal = signal;
+        receivedOnUpdate = onUpdate;
         receivedContext = context;
         return { content: [{ type: "text" as const, text: "ok" }] };
       },
@@ -241,7 +251,10 @@ describe("execute context injection", () => {
     });
 
     expect(tools).toHaveLength(1);
-    await tools[0].execute("call-1", {});
+
+    const ac = new AbortController();
+    const onUpdate = vi.fn();
+    await tools[0].execute("call-1", {}, ac.signal, onUpdate);
 
     expect(receivedContext).toEqual(
       expect.objectContaining({
@@ -249,6 +262,45 @@ describe("execute context injection", () => {
         sessionKey: "agent:test_agent_42:main",
       }),
     );
+    // signal and onUpdate must be forwarded, not dropped
+    expect(receivedSignal).toBe(ac.signal);
+    expect(receivedOnUpdate).toBe(onUpdate);
+  });
+
+  it("forwards signal and onUpdate to plugin tool", async () => {
+    let receivedSignal: unknown = undefined;
+    let receivedOnUpdate: unknown = undefined;
+    const tool = {
+      name: "signal_test",
+      description: "test tool",
+      parameters: { type: "object" as const, properties: {} },
+      async execute(_callId: string, _params: unknown, signal?: AbortSignal, onUpdate?: unknown) {
+        receivedSignal = signal;
+        receivedOnUpdate = onUpdate;
+        return { content: [{ type: "text" as const, text: "ok" }] };
+      },
+    };
+
+    setRegistry([
+      {
+        pluginId: "signal-test-plugin",
+        optional: false,
+        source: "test",
+        factory: () => tool,
+        names: ["signal_test"],
+      },
+    ]);
+
+    const tools = resolvePluginTools({
+      context: createContext() as never,
+    });
+
+    const ac = new AbortController();
+    const onUpdate = vi.fn();
+    await tools[0].execute("call-1", {}, ac.signal, onUpdate);
+
+    expect(receivedSignal).toBe(ac.signal);
+    expect(receivedOnUpdate).toBe(onUpdate);
   });
 
   it("does not leak config into execute context", async () => {
@@ -257,7 +309,13 @@ describe("execute context injection", () => {
       name: "leak_test",
       description: "test tool",
       parameters: { type: "object" as const, properties: {} },
-      async execute(_callId: string, _params: unknown, context?: unknown) {
+      async execute(
+        _callId: string,
+        _params: unknown,
+        _signal?: AbortSignal,
+        _onUpdate?: unknown,
+        context?: unknown,
+      ) {
         receivedContext = (context ?? {}) as Record<string, unknown>;
         return { content: [{ type: "text" as const, text: "ok" }] };
       },

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -4,6 +4,7 @@ type MockRegistryToolEntry = {
   pluginId: string;
   optional: boolean;
   source: string;
+  names?: string[];
   factory: (ctx: unknown) => unknown;
 };
 
@@ -193,5 +194,104 @@ describe("resolvePluginTools optional tools", () => {
         },
       }),
     );
+  });
+});
+
+describe("execute context injection", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.mock("./loader.js", () => ({
+      loadOpenClawPlugins: (params: unknown) => loadOpenClawPluginsMock(params),
+    }));
+    const mod = await import("./tools.js");
+    resolvePluginTools = mod.resolvePluginTools;
+    const runtimeMod = await import("./runtime.js");
+    resetPluginRuntimeStateForTest = runtimeMod.resetPluginRuntimeStateForTest;
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("injects agentId into execute context as third argument", async () => {
+    let receivedContext: unknown = undefined;
+    const tool = {
+      name: "ctx_test",
+      description: "test tool",
+      parameters: { type: "object" as const, properties: {} },
+      async execute(_callId: string, _params: unknown, context?: unknown) {
+        receivedContext = context;
+        return { content: [{ type: "text" as const, text: "ok" }] };
+      },
+    };
+
+    setRegistry([
+      {
+        pluginId: "ctx-test-plugin",
+        optional: false,
+        source: "test",
+        factory: () => tool,
+        names: ["ctx_test"],
+      },
+    ]);
+
+    const ctx = {
+      ...createContext(),
+      agentId: "test_agent_42",
+      sessionKey: "agent:test_agent_42:main",
+    };
+
+    const tools = resolvePluginTools({
+      context: ctx as never,
+    });
+
+    expect(tools).toHaveLength(1);
+    await tools[0].execute("call-1", {});
+
+    expect(receivedContext).toEqual(
+      expect.objectContaining({
+        agentId: "test_agent_42",
+        sessionKey: "agent:test_agent_42:main",
+      }),
+    );
+  });
+
+  it("does not leak config into execute context", async () => {
+    let receivedContext: Record<string, unknown> = {};
+    const tool = {
+      name: "leak_test",
+      description: "test tool",
+      parameters: { type: "object" as const, properties: {} },
+      async execute(_callId: string, _params: unknown, context?: unknown) {
+        receivedContext = (context ?? {}) as Record<string, unknown>;
+        return { content: [{ type: "text" as const, text: "ok" }] };
+      },
+    };
+
+    setRegistry([
+      {
+        pluginId: "leak-test-plugin",
+        optional: false,
+        source: "test",
+        factory: () => tool,
+        names: ["leak_test"],
+      },
+    ]);
+
+    const ctx = {
+      ...createContext(),
+      agentId: "agent_1",
+    };
+
+    const tools = resolvePluginTools({
+      context: ctx as never,
+    });
+
+    await tools[0].execute("call-1", {});
+
+    // config must NOT be present in execute context
+    expect(receivedContext).not.toHaveProperty("config");
+    expect(receivedContext).not.toHaveProperty("workspaceDir");
+    expect(receivedContext).not.toHaveProperty("agentDir");
+    // but agentId must be present
+    expect(receivedContext).toHaveProperty("agentId", "agent_1");
   });
 });

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -57,7 +57,9 @@ function wrapToolWithExecuteContext(
   execCtx: OpenClawPluginToolExecuteContext,
 ): AnyAgentTool {
   const original = tool.execute;
-  if (!original) return tool;
+  if (!original) {
+    return tool;
+  }
   // We intentionally pass `execCtx` as the third argument instead of an AbortSignal.
   // Plugin tools that declare a third parameter receive identity context; plugins
   // that don't declare it simply ignore the extra argument. The cast is necessary

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -44,13 +44,21 @@ function buildExecuteContext(ctx: OpenClawPluginToolContext): OpenClawPluginTool
 }
 
 /**
- * Wrap a plugin tool's `execute` method so the tool-context is forwarded as
- * the third argument: `execute(callId, params, context)`.
+ * Wrap a plugin tool's `execute` method so the tool-context is appended as
+ * the fifth argument: `execute(callId, params, signal, onUpdate, context)`.
  *
- * This is the "Level 1" injection path — plugins that declare a third parameter
+ * This is the "Level 1" injection path — plugins that declare a fifth parameter
  * on their execute function receive identity context (agentId, sessionKey, etc.)
  * automatically, without needing to close over the factory context or rely on
  * environment variables.
+ *
+ * The wrapper preserves the dispatcher-provided `signal` and `onUpdate` arguments
+ * so that plugin tools can still honor abort requests and emit progress updates.
+ *
+ * We use object spread (not Object.create) so that name, description, parameters,
+ * etc. remain own enumerable properties. Downstream code (pi-tools.schema.ts,
+ * pi-tools.before-tool-call.ts, pi-tools.abort.ts) clones tools via { ...tool },
+ * which only copies own properties — inherited prototype fields would be lost.
  */
 function wrapToolWithExecuteContext(
   tool: AnyAgentTool,
@@ -60,21 +68,12 @@ function wrapToolWithExecuteContext(
   if (!original) {
     return tool;
   }
-  // We intentionally pass `execCtx` as the third argument instead of an AbortSignal.
-  // Plugin tools that declare a third parameter receive identity context; plugins
-  // that don't declare it simply ignore the extra argument. The cast is necessary
-  // because the core AgentTool type declares execute's third arg as AbortSignal,
-  // but the plugin dispatch convention extends that slot for context injection.
-  //
-  // We use object spread (not Object.create) so that name, description, parameters,
-  // etc. remain own enumerable properties. Downstream code (pi-tools.schema.ts,
-  // pi-tools.before-tool-call.ts, pi-tools.abort.ts) clones tools via { ...tool },
-  // which only copies own properties — inherited prototype fields would be lost.
   // oxlint-disable-next-line typescript/no-explicit-any
   const originalAsAny = original as (...args: any[]) => unknown;
   return {
     ...tool,
-    execute: (callId: string, params: unknown) => originalAsAny.call(tool, callId, params, execCtx),
+    execute: (callId: string, params: unknown, signal?: AbortSignal, onUpdate?: unknown) =>
+      originalAsAny.call(tool, callId, params, signal, onUpdate, execCtx),
   } as AnyAgentTool;
 }
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -5,7 +5,7 @@ import { applyTestPluginDefaults, normalizePluginsConfig } from "./config-state.
 import { loadOpenClawPlugins } from "./loader.js";
 import { createPluginLoaderLogger } from "./logger.js";
 import { getActivePluginRegistry, getActivePluginRegistryKey } from "./runtime.js";
-import type { OpenClawPluginToolContext } from "./types.js";
+import type { OpenClawPluginToolContext, OpenClawPluginToolExecuteContext } from "./types.js";
 
 const log = createSubsystemLogger("plugins");
 
@@ -25,6 +25,46 @@ export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): 
   if (meta) {
     pluginToolMeta.set(target, meta);
   }
+}
+
+/**
+ * Build the lightweight execution context forwarded to plugin tool `execute`
+ * calls as the third argument.  This contains only identity/session fields —
+ * never config or secrets.
+ */
+function buildExecuteContext(ctx: OpenClawPluginToolContext): OpenClawPluginToolExecuteContext {
+  return {
+    agentId: ctx.agentId,
+    sessionKey: ctx.sessionKey,
+    sessionId: ctx.sessionId,
+    messageChannel: ctx.messageChannel,
+    agentAccountId: ctx.agentAccountId,
+    sandboxed: ctx.sandboxed,
+  };
+}
+
+/**
+ * Wrap a plugin tool's `execute` method so the tool-context is forwarded as
+ * the third argument: `execute(callId, params, context)`.
+ *
+ * This is the "Level 1" injection path — plugins that declare a third parameter
+ * on their execute function receive identity context (agentId, sessionKey, etc.)
+ * automatically, without needing to close over the factory context or rely on
+ * environment variables.
+ */
+function wrapToolWithExecuteContext(
+  tool: AnyAgentTool,
+  execCtx: OpenClawPluginToolExecuteContext,
+): AnyAgentTool {
+  const original = tool.execute;
+  if (!original) return tool;
+  return Object.create(tool, {
+    execute: {
+      value: (callId: string, params: unknown) => original.call(tool, callId, params, execCtx),
+      writable: true,
+      configurable: true,
+    },
+  });
 }
 
 function normalizeAllowlist(list?: string[]) {
@@ -88,6 +128,7 @@ export function resolvePluginTools(params: {
   const existingNormalized = new Set(Array.from(existing, (tool) => normalizeToolName(tool)));
   const allowlist = normalizeAllowlist(params.toolAllowlist);
   const blockedPlugins = new Set<string>();
+  const execCtx = buildExecuteContext(params.context);
 
   for (const entry of registry.tools) {
     if (blockedPlugins.has(entry.pluginId)) {
@@ -153,11 +194,12 @@ export function resolvePluginTools(params: {
       }
       nameSet.add(tool.name);
       existing.add(tool.name);
-      pluginToolMeta.set(tool, {
+      const wrapped = wrapToolWithExecuteContext(tool, execCtx);
+      pluginToolMeta.set(wrapped, {
         pluginId: entry.pluginId,
         optional: entry.optional,
       });
-      tools.push(tool);
+      tools.push(wrapped);
     }
   }
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -58,9 +58,16 @@ function wrapToolWithExecuteContext(
 ): AnyAgentTool {
   const original = tool.execute;
   if (!original) return tool;
+  // We intentionally pass `execCtx` as the third argument instead of an AbortSignal.
+  // Plugin tools that declare a third parameter receive identity context; plugins
+  // that don't declare it simply ignore the extra argument. The cast is necessary
+  // because the core AgentTool type declares execute's third arg as AbortSignal,
+  // but the plugin dispatch convention extends that slot for context injection.
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const originalAsAny = original as (...args: any[]) => unknown;
   return Object.create(tool, {
     execute: {
-      value: (callId: string, params: unknown) => original.call(tool, callId, params, execCtx),
+      value: (callId: string, params: unknown) => originalAsAny.call(tool, callId, params, execCtx),
       writable: true,
       configurable: true,
     },

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -65,15 +65,17 @@ function wrapToolWithExecuteContext(
   // that don't declare it simply ignore the extra argument. The cast is necessary
   // because the core AgentTool type declares execute's third arg as AbortSignal,
   // but the plugin dispatch convention extends that slot for context injection.
+  //
+  // We use object spread (not Object.create) so that name, description, parameters,
+  // etc. remain own enumerable properties. Downstream code (pi-tools.schema.ts,
+  // pi-tools.before-tool-call.ts, pi-tools.abort.ts) clones tools via { ...tool },
+  // which only copies own properties — inherited prototype fields would be lost.
   // oxlint-disable-next-line typescript/no-explicit-any
   const originalAsAny = original as (...args: any[]) => unknown;
-  return Object.create(tool, {
-    execute: {
-      value: (callId: string, params: unknown) => originalAsAny.call(tool, callId, params, execCtx),
-      writable: true,
-      configurable: true,
-    },
-  });
+  return {
+    ...tool,
+    execute: (callId: string, params: unknown) => originalAsAny.call(tool, callId, params, execCtx),
+  } as AnyAgentTool;
 }
 
 function normalizeAllowlist(list?: string[]) {
@@ -137,7 +139,7 @@ export function resolvePluginTools(params: {
   const existingNormalized = new Set(Array.from(existing, (tool) => normalizeToolName(tool)));
   const allowlist = normalizeAllowlist(params.toolAllowlist);
   const blockedPlugins = new Set<string>();
-  const execCtx = buildExecuteContext(params.context);
+  const execCtx = Object.freeze(buildExecuteContext(params.context));
 
   for (const entry of registry.tools) {
     if (blockedPlugins.has(entry.pluginId)) {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -29,7 +29,7 @@ export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): 
 
 /**
  * Build the lightweight execution context forwarded to plugin tool `execute`
- * calls as the third argument.  This contains only identity/session fields —
+ * calls as the fifth argument.  This contains only identity/session fields —
  * never config or secrets.
  */
 function buildExecuteContext(ctx: OpenClawPluginToolContext): OpenClawPluginToolExecuteContext {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -132,6 +132,22 @@ export type OpenClawPluginToolContext = {
   sandboxed?: boolean;
 };
 
+/**
+ * Execution-time context injected as the third argument to plugin tool
+ * `execute(callId, params, context)` calls. Contains identity and session
+ * fields that may change between tool invocations (e.g. when tools are shared
+ * across sessions). Plugin authors should prefer this over factory-time closure
+ * captures for identity-sensitive operations.
+ */
+export type OpenClawPluginToolExecuteContext = {
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  messageChannel?: string;
+  agentAccountId?: string;
+  sandboxed?: boolean;
+};
+
 export type OpenClawPluginToolFactory = (
   ctx: OpenClawPluginToolContext,
 ) => AnyAgentTool | AnyAgentTool[] | null | undefined;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -133,11 +133,11 @@ export type OpenClawPluginToolContext = {
 };
 
 /**
- * Execution-time context injected as the third argument to plugin tool
- * `execute(callId, params, context)` calls. Contains identity and session
- * fields that may change between tool invocations (e.g. when tools are shared
- * across sessions). Plugin authors should prefer this over factory-time closure
- * captures for identity-sensitive operations.
+ * Execution-time context injected as the fifth argument to plugin tool
+ * `execute(callId, params, signal, onUpdate, context)` calls. Contains identity
+ * and session fields that may change between tool invocations (e.g. when tools
+ * are shared across sessions). Plugin authors should prefer this over
+ * factory-time closure captures for identity-sensitive operations.
  */
 export type OpenClawPluginToolExecuteContext = {
   agentId?: string;


### PR DESCRIPTION
**Author: 📐 Drew Prints** (`mcfiddles_architect_51132`)

## Problem

Plugin tools that need the calling agent's identity (e.g. `platform_tasks_complete`, `platform_comms_inbox`) have no reliable way to resolve `agentId` at execute time. The plugin tool factory receives the full `OpenClawPluginToolContext` (including `agentId`), but the `execute(callId, params)` contract only passes two arguments — the context is never forwarded.

This forces plugins to fall back to:
1. `process.env.OPENCLAW_AGENT_ID` — not set in multi-agent deployments
2. Workspace directory name parsing (`/workspace-<agentId>/`) — brittle and fails when the workspace dir doesn't follow the naming convention

The plugin architecture already has a "Level 1 path" designed for this (`ctx.agentId` in `OpenClawPluginToolContext`), but it's only available at factory time, not execute time.

## Solution

Wrap each plugin tool's `execute` method in `resolvePluginTools` to forward a lightweight `OpenClawPluginToolExecuteContext` as the third argument:

```typescript
// Before: execute(callId, params)
// After:  execute(callId, params, { agentId, sessionKey, sessionId, ... })
```

The execute context includes only identity/session fields — never config, filesystem paths, or secrets. This is **backward-compatible**: plugins that don't declare a third parameter simply ignore it.

### Changes

- **`src/plugins/types.ts`**: New `OpenClawPluginToolExecuteContext` type with identity fields
- **`src/plugins/tools.ts`**: `buildExecuteContext()` + `wrapToolWithExecuteContext()` + integration in `resolvePluginTools`
- **`src/plugins/tools.optional.test.ts`**: Two tests verifying context injection and config non-leakage

### Affected plugins

Any plugin whose `execute` function accepts a third `context` parameter now receives the resolved agent identity. Known beneficiaries:
- `platform-tasks` (task create/complete/cancel)
- `platform-comms` (inbox, send-message)
- `platform-vault` (credential operations)
- `platform-awareness` (self-awareness summary)
- `platform-chronos` (work requests)
- `platform-ops` (agent/user management)