### PR TITLE
fix(message): cleanup poll params when action != poll

### DIFF
--- a/message-action-runner.ts
+++ b/message-action-runner.ts
@@ -1,0 +1,850 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  readNumberParam,
+  readStringArrayParam,
+  readStringParam,
+} from "../../agents/tools/common.js";
+import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import { getChannelPlugin } from "../../channels/plugins/index.js";
+import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
+import type {
+  ChannelId,
+  ChannelMessageActionName,
+  ChannelThreadingToolContext,
+} from "../../channels/plugins/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { hasInteractiveReplyBlocks, hasReplyPayloadContent } from "../../interactive/payload.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  getAgentScopedMediaLocalRootsForSources,
+} from "../../media/local-roots.js";
+import { hasPollCreationParams, POLL_CREATION_PARAM_NAMES } from "../../poll-params.ts";
+import { toSnakeCaseKey } from "../../param-key.ts";
+import { resolvePollMaxSelections } from "../../polls.js";
+import { buildChannelAccountBindings } from "../../routing/bindings.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
+import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
+import { throwIfAborted } from "./abort.js";
+import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "./channel-selection.js";
+import type { OutboundSendDeps } from "./deliver.js";
+import { normalizeMessageActionInput } from "./message-action-normalization.js";
+import {
+  hydrateAttachmentParamsForAction,
+  normalizeSandboxMediaList,
+  normalizeSandboxMediaParams,
+  parseButtonsParam,
+  parseCardParam,
+  parseComponentsParam,
+  parseInteractiveParam,
+  readBooleanParam,
+  resolveAttachmentMediaPolicy,
+} from "./message-action-params.js";
+import {
+  prepareOutboundMirrorRoute,
+  resolveAndApplyOutboundThreadId,
+} from "./message-action-threading.js";
+import type { MessagePollResult, MessageSendResult } from "./message.js";
+import {
+  applyCrossContextDecoration,
+  buildCrossContextDecoration,
+  type CrossContextDecoration,
+  enforceCrossContextPolicy,
+  shouldApplyCrossContextMarker,
+} from "./outbound-policy.js";
+import { executePollAction, executeSendAction } from "./outbound-send-service.js";
+import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
+import { extractToolPayload } from "./tool-payload.js";
+
+export type MessageActionRunnerGateway = {
+  url?: string;
+  token?: string;
+  timeoutMs?: number;
+  clientName: GatewayClientName;
+  clientDisplayName?: string;
+  mode: GatewayClientMode;
+};
+
+export type RunMessageActionParams = {
+  cfg: OpenClawConfig;
+  action: ChannelMessageActionName;
+  params: Record<string, unknown>;
+  defaultAccountId?: string;
+  requesterSenderId?: string | null;
+  sessionId?: string;
+  toolContext?: ChannelThreadingToolContext;
+  gateway?: MessageActionRunnerGateway;
+  deps?: OutboundSendDeps;
+  sessionKey?: string;
+  agentId?: string;
+  sandboxRoot?: string;
+  dryRun?: boolean;
+  abortSignal?: AbortSignal;
+};
+
+export type MessageActionRunResult =
+  | {
+      kind: "send";
+      channel: ChannelId;
+      action: "send";
+      to: string;
+      handledBy: "plugin" | "core";
+      payload: unknown;
+      toolResult?: AgentToolResult<unknown>;
+      sendResult?: MessageSendResult;
+      dryRun: boolean;
+    }
+  | {
+      kind: "broadcast";
+      channel: ChannelId;
+      action: "broadcast";
+      handledBy: "core" | "dry-run";
+      payload: {
+        results: Array<{
+          channel: ChannelId;
+          to: string;
+          ok: boolean;
+          error?: string;
+          result?: MessageSendResult;
+        }>;
+      };
+      dryRun: boolean;
+    }
+  | {
+      kind: "poll";
+      channel: ChannelId;
+      action: "poll";
+      to: string;
+      handledBy: "plugin" | "core";
+      payload: unknown;
+      toolResult?: AgentToolResult<unknown>;
+      pollResult?: MessagePollResult;
+      dryRun: boolean;
+    }
+  | {
+      kind: "action";
+      channel: ChannelId;
+      action: Exclude<ChannelMessageActionName, "send" | "poll">;
+      handledBy: "plugin" | "dry-run";
+      payload: unknown;
+      toolResult?: AgentToolResult<unknown>;
+      dryRun: boolean;
+    };
+
+export function getToolResult(
+  result: MessageActionRunResult,
+): AgentToolResult<unknown> | undefined {
+  return "toolResult" in result ? result.toolResult : undefined;
+}
+
+function collectActionMediaSourceHints(params: Record<string, unknown>): string[] {
+  const sources: string[] = [];
+  for (const key of ["media", "mediaUrl", "path", "filePath", "fileUrl"] as const) {
+    const value = params[key];
+    if (typeof value === "string" && value.trim()) {
+      sources.push(value);
+    }
+  }
+  return sources;
+}
+
+function applyCrossContextMessageDecoration({
+  params,
+  message,
+  decoration,
+  preferComponents,
+}: {
+  params: Record<string, unknown>;
+  message: string;
+  decoration: CrossContextDecoration;
+  preferComponents: boolean;
+}): string {
+  const applied = applyCrossContextDecoration({
+    message,
+    decoration,
+    preferComponents,
+  });
+  params.message = applied.message;
+  if (applied.componentsBuilder) {
+    params.components = applied.componentsBuilder;
+  }
+  return applied.message;
+}
+
+async function maybeApplyCrossContextMarker(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  action: ChannelMessageActionName;
+  target: string;
+  toolContext?: ChannelThreadingToolContext;
+  accountId?: string | null;
+  args: Record<string, unknown>;
+  message: string;
+  preferComponents: boolean;
+}): Promise<string> {
+  if (!shouldApplyCrossContextMarker(params.action) || !params.toolContext) {
+    return params.message;
+  }
+  const decoration = await buildCrossContextDecoration({
+    cfg: params.cfg,
+    channel: params.channel,
+    target: params.target,
+    toolContext: params.toolContext,
+    accountId: params.accountId ?? undefined,
+  });
+  if (!decoration) {
+    return params.message;
+  }
+  return applyCrossContextMessageDecoration({
+    params: params.args,
+    message: params.message,
+    decoration,
+    preferComponents: params.preferComponents,
+  });
+}
+
+async function resolveChannel(
+  cfg: OpenClawConfig,
+  params: Record<string, unknown>,
+  toolContext?: { currentChannelProvider?: string },
+) {
+  const selection = await resolveMessageChannelSelection({
+    cfg,
+    channel: readStringParam(params, "channel"),
+    fallbackChannel: toolContext?.currentChannelProvider,
+  });
+  if (selection.source === "tool-context-fallback") {
+    params.channel = selection.channel;
+  }
+  return selection.channel;
+}
+
+async function resolveActionTarget(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  action: ChannelMessageActionName;
+  args: Record<string, unknown>;
+  accountId?: string | null;
+}): Promise<ResolvedMessagingTarget | undefined> {
+  let resolvedTarget: ResolvedMessagingTarget | undefined;
+  const toRaw = typeof params.args.to === "string" ? params.args.to.trim() : "";
+  if (toRaw) {
+    const resolved = await resolveChannelTarget({
+      cfg: params.cfg,
+      channel: params.channel,
+      input: toRaw,
+      accountId: params.accountId ?? undefined,
+    });
+    if (resolved.ok) {
+      params.args.to = resolved.target.to;
+      resolvedTarget = resolved.target;
+    } else {
+      throw resolved.error;
+    }
+  }
+  const channelIdRaw =
+    typeof params.args.channelId === "string" ? params.args.channelId.trim() : "";
+  if (channelIdRaw) {
+    const resolved = await resolveChannelTarget({
+      cfg: params.cfg,
+      channel: params.channel,
+      input: channelIdRaw,
+      accountId: params.accountId ?? undefined,
+      preferredKind: "group",
+    });
+    if (resolved.ok) {
+      if (resolved.target.kind === "user") {
+        throw new Error(`Channel id "${channelIdRaw}" resolved to a user target.`);
+      }
+      params.args.channelId = resolved.target.to.replace(/^(channel|group):/i, "");
+    } else {
+      throw resolved.error;
+    }
+  }
+  return resolvedTarget;
+}
+
+type ResolvedActionContext = {
+  cfg: OpenClawConfig;
+  params: Record<string, unknown>;
+  channel: ChannelId;
+  mediaLocalRoots: readonly string[];
+  accountId?: string | null;
+  dryRun: boolean;
+  gateway?: MessageActionRunnerGateway;
+  input: RunMessageActionParams;
+  agentId?: string;
+  resolvedTarget?: ResolvedMessagingTarget;
+  abortSignal?: AbortSignal;
+};
+function resolveGateway(input: RunMessageActionParams): MessageActionRunnerGateway | undefined {
+  if (!input.gateway) {
+    return undefined;
+  }
+  return {
+    url: input.gateway.url,
+    token: input.gateway.token,
+    timeoutMs: input.gateway.timeoutMs,
+    clientName: input.gateway.clientName,
+    clientDisplayName: input.gateway.clientDisplayName,
+    mode: input.gateway.mode,
+  };
+}
+
+async function handleBroadcastAction(
+  input: RunMessageActionParams,
+  params: Record<string, unknown>,
+): Promise<MessageActionRunResult> {
+  throwIfAborted(input.abortSignal);
+  const broadcastEnabled = input.cfg.tools?.message?.broadcast?.enabled !== false;
+  if (!broadcastEnabled) {
+    throw new Error("Broadcast is disabled. Set tools.message.broadcast.enabled to true.");
+  }
+  const rawTargets = readStringArrayParam(params, "targets", { required: true });
+  if (rawTargets.length === 0) {
+    throw new Error("Broadcast requires at least one target in --targets.");
+  }
+  const channelHint = readStringParam(params, "channel");
+  const targetChannels =
+    channelHint && channelHint.trim().toLowerCase() !== "all"
+      ? [await resolveChannel(input.cfg, { channel: channelHint }, input.toolContext)]
+      : await (async () => {
+          const configured = await listConfiguredMessageChannels(input.cfg);
+          if (configured.length === 0) {
+            throw new Error("Broadcast requires at least one configured channel.");
+          }
+          return configured;
+        })();
+  const results: Array<{
+    channel: ChannelId;
+    to: string;
+    ok: boolean;
+    error?: string;
+    result?: MessageSendResult;
+  }> = [];
+  const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === "AbortError";
+  for (const targetChannel of targetChannels) {
+    throwIfAborted(input.abortSignal);
+    for (const target of rawTargets) {
+      throwIfAborted(input.abortSignal);
+      try {
+        const resolved = await resolveChannelTarget({
+          cfg: input.cfg,
+          channel: targetChannel,
+          input: target,
+        });
+        if (!resolved.ok) {
+          throw resolved.error;
+        }
+        const sendResult = await runMessageAction({
+          ...input,
+          action: "send",
+          params: {
+            ...params,
+            channel: targetChannel,
+            target: resolved.target.to,
+          },
+        });
+        results.push({
+          channel: targetChannel,
+          to: resolved.target.to,
+          ok: true,
+          result: sendResult.kind === "send" ? sendResult.sendResult : undefined,
+        });
+      } catch (err) {
+        if (isAbortError(err)) {
+          throw err;
+        }
+        results.push({
+          channel: targetChannel,
+          to: target,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+  return {
+    kind: "broadcast",
+    channel: targetChannels[0] ?? "discord",
+    action: "broadcast",
+    handledBy: input.dryRun ? "dry-run" : "core",
+    payload: { results },
+    dryRun: Boolean(input.dryRun),
+  };
+}
+
+async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+  const {
+    cfg,
+    params,
+    channel,
+    accountId,
+    dryRun,
+    gateway,
+    input,
+    agentId,
+    resolvedTarget,
+    abortSignal,
+  } = ctx;
+  throwIfAborted(abortSignal);
+  const action: ChannelMessageActionName = "send";
+  const to = readStringParam(params, "to", { required: true });
+  // Support media, path, and filePath parameters for attachments
+  const mediaHint =
+    readStringParam(params, "media", { trim: false }) ??
+    readStringParam(params, "mediaUrl", { trim: false }) ??
+    readStringParam(params, "path", { trim: false }) ??
+    readStringParam(params, "filePath", { trim: false }) ??
+    readStringParam(params, "fileUrl", { trim: false });
+  const hasButtons = Array.isArray(params.buttons) && params.buttons.length > 0;
+  const hasCard = params.card != null && typeof params.card === "object";
+  const hasComponents = params.components != null && typeof params.components === "object";
+  const hasInteractive = hasInteractiveReplyBlocks(params.interactive);
+  const hasBlocks =
+    (Array.isArray(params.blocks) && params.blocks.length > 0) ||
+    (typeof params.blocks === "string" && params.blocks.trim().length > 0);
+  const caption = readStringParam(params, "caption", { allowEmpty: true }) ?? "";
+  let message =
+    readStringParam(params, "message", {
+      required:
+        !mediaHint && !hasButtons && !hasCard && !hasComponents && !hasInteractive && !hasBlocks,
+      allowEmpty: true,
+    }) ?? "";
+  if (message.includes("\\n")) {
+    message = message.replaceAll("\\n", "\n");
+  }
+  if (!message.trim() && caption.trim()) {
+    message = caption;
+  }
+
+  const parsed = parseReplyDirectives(message);
+  const mergedMediaUrls: string[] = [];
+  const seenMedia = new Set<string>();
+  const pushMedia = (value?: string | null) => {
+    const trimmed = value?.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (seenMedia.has(trimmed)) {
+      return;
+    }
+    seenMedia.add(trimmed);
+    mergedMediaUrls.push(trimmed);
+  };
+  pushMedia(mediaHint);
+  for (const url of parsed.mediaUrls ?? []) {
+    pushMedia(url);
+  }
+  pushMedia(parsed.mediaUrl);
+
+  const normalizedMediaUrls = await normalizeSandboxMediaList({
+    values: mergedMediaUrls,
+    sandboxRoot: input.sandboxRoot,
+  });
+  mergedMediaUrls.length = 0;
+  mergedMediaUrls.push(...normalizedMediaUrls);
+
+  message = parsed.text;
+  params.message = message;
+  if (!params.replyTo && parsed.replyToId) {
+    params.replyTo = parsed.replyToId;
+  }
+  if (!params.media) {
+    // Use path/filePath if media not set, then fall back to parsed directives
+    params.media = mergedMediaUrls[0] || undefined;
+  }
+
+  message = await maybeApplyCrossContextMarker({
+    cfg,
+    channel,
+    action,
+    target: to,
+    toolContext: input.toolContext,
+    accountId,
+    args: params,
+    message,
+    preferComponents: true,
+  });
+
+  const mediaUrl = readStringParam(params, "media", { trim: false });
+  if (
+    !hasReplyPayloadContent(
+      {
+        text: message,
+        mediaUrl,
+        mediaUrls: mergedMediaUrls,
+        interactive: params.interactive,
+      },
+      {
+        extraContent: hasButtons || hasCard || hasComponents || hasBlocks,
+      },
+    )
+  ) {
+    throw new Error("send requires text or media");
+  }
+  params.message = message;
+  const gifPlayback = readBooleanParam(params, "gifPlayback") ?? false;
+  const forceDocument =
+    readBooleanParam(params, "forceDocument") ?? readBooleanParam(params, "asDocument") ?? false;
+  const bestEffort = readBooleanParam(params, "bestEffort");
+  const silent = readBooleanParam(params, "silent");
+
+  const replyToId = readStringParam(params, "replyTo");
+  const { resolvedThreadId, outboundRoute } = await prepareOutboundMirrorRoute({
+    cfg,
+    channel,
+    to,
+    actionParams: params,
+    accountId,
+    toolContext: input.toolContext,
+    agentId,
+    dryRun,
+    resolvedTarget,
+    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
+    resolveOutboundSessionRoute,
+    ensureOutboundSessionEntry,
+  });
+  const mirrorMediaUrls =
+    mergedMediaUrls.length > 0 ? mergedMediaUrls : mediaUrl ? [mediaUrl] : undefined;
+  throwIfAborted(abortSignal);
+  const send = await executeSendAction({
+    ctx: {
+      cfg,
+      channel,
+      params,
+      agentId,
+      accountId: accountId ?? undefined,
+      gateway,
+      toolContext: input.toolContext,
+      deps: input.deps,
+      dryRun,
+      mirror:
+        outboundRoute && !dryRun
+          ? {
+              sessionKey: outboundRoute.sessionKey,
+              agentId,
+              text: message,
+              mediaUrls: mirrorMediaUrls,
+            }
+          : undefined,
+      abortSignal,
+      silent: silent ?? undefined,
+    },
+    to,
+    message,
+    mediaUrl: mediaUrl || undefined,
+    mediaUrls: mergedMediaUrls.length ? mergedMediaUrls : undefined,
+    gifPlayback,
+    forceDocument,
+    bestEffort: bestEffort ?? undefined,
+    replyToId: replyToId ?? undefined,
+    threadId: resolvedThreadId ?? undefined,
+  });
+
+  return {
+    kind: "send",
+    channel,
+    action,
+    to,
+    handledBy: send.handledBy,
+    payload: send.payload,
+    toolResult: send.toolResult,
+    sendResult: send.sendResult,
+    dryRun,
+  };
+}
+
+async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
+  throwIfAborted(abortSignal);
+  const action: ChannelMessageActionName = "poll";
+  const to = readStringParam(params, "to", { required: true });
+  const silent = readBooleanParam(params, "silent");
+
+  const resolvedThreadId = resolveAndApplyOutboundThreadId(params, {
+    cfg,
+    to,
+    accountId,
+    toolContext: input.toolContext,
+    resolveAutoThreadId: getChannelPlugin(channel)?.threading?.resolveAutoThreadId,
+  });
+
+  const base = typeof params.message === "string" ? params.message : "";
+  await maybeApplyCrossContextMarker({
+    cfg,
+    channel,
+    action,
+    target: to,
+    toolContext: input.toolContext,
+    accountId,
+    args: params,
+    message: base,
+    preferComponents: false,
+  });
+
+  const poll = await executePollAction({
+    ctx: {
+      cfg,
+      channel,
+      params,
+      accountId: accountId ?? undefined,
+      gateway,
+      toolContext: input.toolContext,
+      dryRun,
+      silent: silent ?? undefined,
+    },
+    resolveCorePoll: () => {
+      const question = readStringParam(params, "pollQuestion", {
+        required: true,
+      });
+      const options = readStringArrayParam(params, "pollOption", { required: true });
+      if (options.length < 2) {
+        throw new Error("pollOption requires at least two values");
+      }
+      const allowMultiselect = readBooleanParam(params, "pollMulti") ?? false;
+      const durationHours = readNumberParam(params, "pollDurationHours", {
+        integer: true,
+        strict: true,
+      });
+
+      return {
+        to,
+        question,
+        options,
+        maxSelections: resolvePollMaxSelections(options.length, allowMultiselect),
+        durationHours: durationHours ?? undefined,
+        threadId: resolvedThreadId ?? undefined,
+      };
+    },
+  });
+
+  return {
+    kind: "poll",
+    channel,
+    action,
+    to,
+    handledBy: poll.handledBy,
+    payload: poll.payload,
+    toolResult: poll.toolResult,
+    pollResult: poll.pollResult,
+    dryRun,
+  };
+}
+
+async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
+  const {
+    cfg,
+    params,
+    channel,
+    mediaLocalRoots,
+    accountId,
+    dryRun,
+    gateway,
+    input,
+    abortSignal,
+    agentId,
+  } = ctx;
+  throwIfAborted(abortSignal);
+  const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
+  if (dryRun) {
+    return {
+      kind: "action",
+      channel,
+      action,
+      handledBy: "dry-run",
+      payload: { ok: true, dryRun: true, channel, action },
+      dryRun: true,
+    };
+  }
+
+  const plugin = resolveOutboundChannelPlugin({ channel, cfg });
+  if (!plugin?.actions?.handleAction) {
+    throw new Error(`Channel ${channel} is unavailable for message actions (plugin not loaded).`);
+  }
+
+  const handled = await dispatchChannelMessageAction({
+    channel,
+    action,
+    cfg,
+    params,
+    mediaLocalRoots,
+    accountId: accountId ?? undefined,
+    requesterSenderId: input.requesterSenderId ?? undefined,
+    sessionKey: input.sessionKey,
+    sessionId: input.sessionId,
+    agentId,
+    gateway,
+    toolContext: input.toolContext,
+    dryRun,
+  });
+  if (!handled) {
+    throw new Error(`Message action ${action} not supported for channel ${channel}.`);
+  }
+  return {
+    kind: "action",
+    channel,
+    action,
+    handledBy: "plugin",
+    payload: extractToolPayload(handled),
+    toolResult: handled,
+    dryRun,
+  };
+}
+
+export async function runMessageAction(
+  input: RunMessageActionParams,
+): Promise<MessageActionRunResult> {
+  const cfg = input.cfg;
+  let params = { ...input.params };
+  const resolvedAgentId =
+    input.agentId ??
+    (input.sessionKey
+      ? resolveSessionAgentId({ sessionKey: input.sessionKey, config: cfg })
+      : undefined);
+  parseButtonsParam(params);
+  parseCardParam(params);
+  parseComponentsParam(params);
+  parseInteractiveParam(params);
+
+  const action = input.action;
+  if (action === "broadcast") {
+    return handleBroadcastAction(input, params);
+  }
+  params = normalizeMessageActionInput({
+    action,
+    args: params,
+    toolContext: input.toolContext,
+  });
+
+  // For non-poll actions, check for poll intent early to provide clear errors
+  if (action === "send" && hasPollCreationParams(params)) {
+    throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');
+  }
+
+  // Clean up poll creation params if action is not poll to avoid false positives from wrappers
+  if (action !== "poll") {
+    const keysToRemove = new Set<string>();
+    for (const key of POLL_CREATION_PARAM_NAMES) {
+      keysToRemove.add(key);
+      keysToRemove.add(toSnakeCaseKey(key));
+    }
+    const filtered: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(params)) {
+      if (!keysToRemove.has(key)) {
+        filtered[key] = value;
+      }
+    }
+    params = filtered;
+  }
+
+  const channel = await resolveChannel(cfg, params, input.toolContext);
+  let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+  if (!accountId && resolvedAgentId) {
+    const byAgent = buildChannelAccountBindings(cfg).get(channel);
+    const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));
+    if (boundAccountIds && boundAccountIds.length > 0) {
+      accountId = boundAccountIds[0];
+    }
+  }
+  if (accountId) {
+    params.accountId = accountId;
+  }
+  const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
+  const normalizationPolicy = resolveAttachmentMediaPolicy({
+    sandboxRoot: input.sandboxRoot,
+    mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
+  });
+
+  await normalizeSandboxMediaParams({
+    args: params,
+    mediaPolicy: normalizationPolicy,
+  });
+
+  const mediaLocalRoots = getAgentScopedMediaLocalRootsForSources({
+    cfg,
+    agentId: resolvedAgentId,
+    mediaSources: collectActionMediaSourceHints(params),
+  });
+  const mediaPolicy = resolveAttachmentMediaPolicy({
+    sandboxRoot: input.sandboxRoot,
+    mediaLocalRoots,
+  });
+
+  await hydrateAttachmentParamsForAction({
+    cfg,
+    channel,
+    accountId,
+    args: params,
+    action,
+    dryRun,
+    mediaPolicy,
+  });
+
+  const resolvedTarget = await resolveActionTarget({
+    cfg,
+    channel,
+    action,
+    args: params,
+    accountId,
+  });
+
+  enforceCrossContextPolicy({
+    channel,
+    action,
+    args: params,
+    toolContext: input.toolContext,
+    cfg,
+  });
+
+  const gateway = resolveGateway(input);
+
+  if (action === "send") {
+    return handleSendAction({
+      cfg,
+      params,
+      channel,
+      mediaLocalRoots,
+      accountId,
+      dryRun,
+      gateway,
+      input,
+      agentId: resolvedAgentId,
+      resolvedTarget,
+      abortSignal: input.abortSignal,
+    });
+  }
+
+  if (action === "poll") {
+    return handlePollAction({
+      cfg,
+      params,
+      channel,
+      mediaLocalRoots,
+      accountId,
+      dryRun,
+      gateway,
+      input,
+      abortSignal: input.abortSignal,
+    });
+  }
+
+  return handlePluginAction({
+    cfg,
+    params,
+    channel,
+    mediaLocalRoots,
+    accountId,
+    dryRun,
+    gateway,
+    input,
+    agentId: resolvedAgentId,
+    abortSignal: input.abortSignal,
+  });
+}
+

--- a/message-tool.ts
+++ b/message-tool.ts
@@ -1,0 +1,806 @@
+import { Type, type TSchema } from "@sinclair/typebox";
+import { listChannelPlugins } from "../../channels/plugins/index.js";
+import {
+  channelSupportsMessageCapability,
+  channelSupportsMessageCapabilityForChannel,
+  listChannelMessageActions,
+  resolveChannelMessageToolSchemaProperties,
+} from "../../channels/plugins/message-action-discovery.js";
+import type { ChannelMessageCapability } from "../../channels/plugins/message-capabilities.js";
+import {
+  CHANNEL_MESSAGE_ACTION_NAMES,
+  type ChannelMessageActionName,
+} from "../../channels/plugins/types.js";
+import { resolveCommandSecretRefsViaGateway } from "../../cli/command-secret-gateway.js";
+import { getScopedChannelsCommandSecretTargets } from "../../cli/command-secret-targets.js";
+import { resolveMessageSecretScope } from "../../cli/message-secret-scope.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
+import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
+import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.ts";
+import { normalizeAccountId } from "../../routing/session-key.js";
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { resolveSessionAgentId } from "../agent-scope.js";
+import { listChannelSupportedActions } from "../channel-tools.js";
+import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+import { resolveGatewayOptions } from "./gateway.js";
+
+const AllMessageActions = CHANNEL_MESSAGE_ACTION_NAMES;
+const EXPLICIT_TARGET_ACTIONS = new Set<ChannelMessageActionName>([
+  "send",
+  "sendWithEffect",
+  "sendAttachment",
+  "upload-file",
+  "reply",
+  "thread-reply",
+  "broadcast",
+]);
+
+function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
+  return EXPLICIT_TARGET_ACTIONS.has(action);
+}
+function buildRoutingSchema() {
+  return {
+    channel: Type.Optional(Type.String()),
+    target: Type.Optional(channelTargetSchema({ description: "Target channel/user id or name." })),
+    targets: Type.Optional(channelTargetsSchema()),
+    accountId: Type.Optional(Type.String()),
+    dryRun: Type.Optional(Type.Boolean()),
+  };
+}
+
+const interactiveOptionSchema = Type.Object({
+  label: Type.String(),
+  value: Type.String(),
+});
+
+const interactiveButtonSchema = Type.Object({
+  label: Type.String(),
+  value: Type.String(),
+  style: Type.Optional(stringEnum(["primary", "secondary", "success", "danger"])),
+});
+
+const interactiveBlockSchema = Type.Object({
+  type: stringEnum(["text", "buttons", "select"]),
+  text: Type.Optional(Type.String()),
+  buttons: Type.Optional(Type.Array(interactiveButtonSchema)),
+  placeholder: Type.Optional(Type.String()),
+  options: Type.Optional(Type.Array(interactiveOptionSchema)),
+});
+
+const interactiveMessageSchema = Type.Object(
+  {
+    blocks: Type.Array(interactiveBlockSchema),
+  },
+  {
+    description:
+      "Shared interactive message payload for buttons and selects. Channels render this into their native components when supported.",
+  },
+);
+
+function buildSendSchema(options: { includeInteractive: boolean }) {
+  const props: Record<string, TSchema> = {
+    message: Type.Optional(Type.String()),
+    effectId: Type.Optional(
+      Type.String({
+        description: "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+      }),
+    ),
+    effect: Type.Optional(
+      Type.String({ description: "Alias for effectId (e.g., invisible-ink, balloons)." }),
+    ),
+    media: Type.Optional(
+      Type.String({
+        description: "Media URL or local path. data: URLs are not supported here, use buffer.",
+      }),
+    ),
+    filename: Type.Optional(Type.String()),
+    buffer: Type.Optional(
+      Type.String({
+        description: "Base64 payload for attachments (optionally a data: URL).",
+      }),
+    ),
+    contentType: Type.Optional(Type.String()),
+    mimeType: Type.Optional(Type.String()),
+    caption: Type.Optional(Type.String()),
+    path: Type.Optional(Type.String()),
+    filePath: Type.Optional(Type.String()),
+    replyTo: Type.Optional(Type.String()),
+    threadId: Type.Optional(Type.String()),
+    asVoice: Type.Optional(Type.Boolean()),
+    silent: Type.Optional(Type.Boolean()),
+    quoteText: Type.Optional(
+      Type.String({ description: "Quote text for Telegram reply_parameters" }),
+    ),
+    bestEffort: Type.Optional(Type.Boolean()),
+    gifPlayback: Type.Optional(Type.Boolean()),
+    forceDocument: Type.Optional(
+      Type.Boolean({
+        description: "Send image/GIF as document to avoid Telegram compression (Telegram only).",
+      }),
+    ),
+    asDocument: Type.Optional(
+      Type.Boolean({
+        description:
+          "Send image/GIF as document to avoid Telegram compression. Alias for forceDocument (Telegram only).",
+      }),
+    ),
+    interactive: Type.Optional(interactiveMessageSchema),
+  };
+  if (!options.includeInteractive) {
+    delete props.interactive;
+  }
+  return props;
+}
+
+function buildReactionSchema() {
+  return {
+    messageId: Type.Optional(
+      Type.String({
+        description:
+          "Target message id for reaction. If omitted, defaults to the current inbound message id when available.",
+      }),
+    ),
+    message_id: Type.Optional(
+      Type.String({
+        // Intentional duplicate alias for tool-schema discoverability in LLMs.
+        description:
+          "snake_case alias of messageId. If omitted, defaults to the current inbound message id when available.",
+      }),
+    ),
+    emoji: Type.Optional(Type.String()),
+    remove: Type.Optional(Type.Boolean()),
+    targetAuthor: Type.Optional(Type.String()),
+    targetAuthorUuid: Type.Optional(Type.String()),
+    groupId: Type.Optional(Type.String()),
+  };
+}
+
+function buildFetchSchema() {
+  return {
+    limit: Type.Optional(Type.Number()),
+    pageSize: Type.Optional(Type.Number()),
+    pageToken: Type.Optional(Type.String()),
+    before: Type.Optional(Type.String()),
+    after: Type.Optional(Type.String()),
+    around: Type.Optional(Type.String()),
+    fromMe: Type.Optional(Type.Boolean()),
+    includeArchived: Type.Optional(Type.Boolean()),
+  };
+}
+
+function buildPollSchema() {
+  const props: Record<string, TSchema> = {
+    pollId: Type.Optional(Type.String()),
+    pollOptionId: Type.Optional(
+      Type.String({
+        description: "Poll answer id to vote for. Use when the channel exposes stable answer ids.",
+      }),
+    ),
+    pollOptionIds: Type.Optional(
+      Type.Array(
+        Type.String({
+          description:
+            "Poll answer ids to vote for in a multiselect poll. Use when the channel exposes stable answer ids.",
+        }),
+      ),
+    ),
+    pollOptionIndex: Type.Optional(
+      Type.Number({
+        description:
+          "1-based poll option number to vote for, matching the rendered numbered poll choices.",
+      }),
+    ),
+    pollOptionIndexes: Type.Optional(
+      Type.Array(
+        Type.Number({
+          description:
+            "1-based poll option numbers to vote for in a multiselect poll, matching the rendered numbered poll choices.",
+        }),
+      ),
+    ),
+  };
+  for (const name of SHARED_POLL_CREATION_PARAM_NAMES) {
+    const def = POLL_CREATION_PARAM_DEFS[name];
+    switch (def.kind) {
+      case "string":
+        props[name] = Type.Optional(Type.String());
+        break;
+      case "stringArray":
+        props[name] = Type.Optional(Type.Array(Type.String()));
+        break;
+      case "number":
+        props[name] = Type.Optional(Type.Number());
+        break;
+      case "boolean":
+        props[name] = Type.Optional(Type.Boolean());
+        break;
+    }
+  }
+  return props;
+}
+
+function buildChannelTargetSchema() {
+  return {
+    channelId: Type.Optional(
+      Type.String({ description: "Channel id filter (search/thread list/event create)." }),
+    ),
+    chatId: Type.Optional(
+      Type.String({ description: "Chat id for chat-scoped metadata actions." }),
+    ),
+    channelIds: Type.Optional(
+      Type.Array(Type.String({ description: "Channel id filter (repeatable)." })),
+    ),
+    memberId: Type.Optional(Type.String()),
+    memberIdType: Type.Optional(Type.String()),
+    guildId: Type.Optional(Type.String()),
+    userId: Type.Optional(Type.String()),
+    openId: Type.Optional(Type.String()),
+    unionId: Type.Optional(Type.String()),
+    authorId: Type.Optional(Type.String()),
+    authorIds: Type.Optional(Type.Array(Type.String())),
+    roleId: Type.Optional(Type.String()),
+    roleIds: Type.Optional(Type.Array(Type.String())),
+    participant: Type.Optional(Type.String()),
+    includeMembers: Type.Optional(Type.Boolean()),
+    members: Type.Optional(Type.Boolean()),
+    scope: Type.Optional(Type.String()),
+    kind: Type.Optional(Type.String()),
+  };
+}
+
+function buildStickerSchema() {
+  return {
+    emojiName: Type.Optional(Type.String()),
+    stickerId: Type.Optional(Type.Array(Type.String())),
+    stickerName: Type.Optional(Type.String()),
+    stickerDesc: Type.Optional(Type.String()),
+    stickerTags: Type.Optional(Type.String()),
+  };
+}
+
+function buildThreadSchema() {
+  return {
+    threadName: Type.Optional(Type.String()),
+    autoArchiveMin: Type.Optional(Type.Number()),
+    appliedTags: Type.Optional(Type.Array(Type.String())),
+  };
+}
+
+function buildEventSchema() {
+  return {
+    query: Type.Optional(Type.String()),
+    eventName: Type.Optional(Type.String()),
+    eventType: Type.Optional(Type.String()),
+    startTime: Type.Optional(Type.String()),
+    endTime: Type.Optional(Type.String()),
+    desc: Type.Optional(Type.String()),
+    location: Type.Optional(Type.String()),
+    durationMin: Type.Optional(Type.Number()),
+    until: Type.Optional(Type.String()),
+  };
+}
+
+function buildModerationSchema() {
+  return {
+    reason: Type.Optional(Type.String()),
+    deleteDays: Type.Optional(Type.Number()),
+  };
+}
+
+function buildGatewaySchema() {
+  return {
+    gatewayUrl: Type.Optional(Type.String()),
+    gatewayToken: Type.Optional(Type.String()),
+    timeoutMs: Type.Optional(Type.Number()),
+  };
+}
+
+function buildPresenceSchema() {
+  return {
+    activityType: Type.Optional(
+      Type.String({
+        description: "Activity type: playing, streaming, listening, watching, competing, custom.",
+      }),
+    ),
+    activityName: Type.Optional(
+      Type.String({
+        description: "Activity name shown in sidebar (e.g. 'with fire'). Ignored for custom type.",
+      }),
+    ),
+    activityUrl: Type.Optional(
+      Type.String({
+        description:
+          "Streaming URL (Twitch or YouTube). Only used with streaming type; may not render for bots.",
+      }),
+    ),
+    activityState: Type.Optional(
+      Type.String({
+        description:
+          "State text. For custom type this is the status text; for others it shows in the flyout.",
+      }),
+    ),
+    status: Type.Optional(
+      Type.String({ description: "Bot status: online, dnd, idle, invisible." }),
+    ),
+  };
+}
+
+function buildChannelManagementSchema() {
+  return {
+    name: Type.Optional(Type.String()),
+    type: Type.Optional(Type.Number()),
+    parentId: Type.Optional(Type.String()),
+    topic: Type.Optional(Type.String()),
+    position: Type.Optional(Type.Number()),
+    nsfw: Type.Optional(Type.Boolean()),
+    rateLimitPerUser: Type.Optional(Type.Number()),
+    categoryId: Type.Optional(Type.String()),
+    clearParent: Type.Optional(
+      Type.Boolean({
+        description: "Clear the parent/category when supported by the provider.",
+      }),
+    ),
+  };
+}
+
+function buildMessageToolSchemaProps(options: {
+  includeInteractive: boolean;
+  extraProperties?: Record<string, TSchema>;
+}) {
+  return {
+    ...buildRoutingSchema(),
+    ...buildSendSchema(options),
+    ...buildReactionSchema(),
+    ...buildFetchSchema(),
+    ...buildPollSchema(),
+    ...buildChannelTargetSchema(),
+    ...buildStickerSchema(),
+    ...buildThreadSchema(),
+    ...buildEventSchema(),
+    ...buildModerationSchema(),
+    ...buildGatewaySchema(),
+    ...buildChannelManagementSchema(),
+    ...buildPresenceSchema(),
+    ...options.extraProperties,
+  };
+}
+
+function buildMessageToolSchemaFromActions(
+  actions: readonly string[],
+  options: {
+    includeInteractive: boolean;
+    extraProperties?: Record<string, TSchema>;
+  },
+) {
+  const props = buildMessageToolSchemaProps(options);
+  return Type.Object({
+    action: stringEnum(actions),
+    ...props,
+  });
+}
+
+const MessageToolSchema = buildMessageToolSchemaFromActions(AllMessageActions, {
+  includeInteractive: true,
+});
+
+type MessageToolOptions = {
+  agentAccountId?: string;
+  agentSessionKey?: string;
+  sessionId?: string;
+  config?: OpenClawConfig;
+  loadConfig?: () => OpenClawConfig;
+  resolveCommandSecretRefsViaGateway?: typeof resolveCommandSecretRefsViaGateway;
+  runMessageAction?: typeof runMessageAction;
+  currentChannelId?: string;
+  currentChannelProvider?: string;
+  currentThreadTs?: string;
+  currentMessageId?: string | number;
+  replyToMode?: "off" | "first" | "all";
+  hasRepliedRef?: { value: boolean };
+  sandboxRoot?: string;
+  requireExplicitTarget?: boolean;
+  requesterSenderId?: string;
+};
+
+function resolveMessageToolSchemaActions(params: {
+  cfg: OpenClawConfig;
+  currentChannelProvider?: string;
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  currentMessageId?: string | number;
+  currentAccountId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  requesterSenderId?: string;
+}): string[] {
+  const currentChannel = normalizeMessageChannel(params.currentChannelProvider);
+  if (currentChannel) {
+    const scopedActions = listChannelSupportedActions({
+      cfg: params.cfg,
+      channel: currentChannel,
+      currentChannelId: params.currentChannelId,
+      currentThreadTs: params.currentThreadTs,
+      currentMessageId: params.currentMessageId,
+      accountId: params.currentAccountId,
+      sessionKey: params.sessionKey,
+      sessionId: params.sessionId,
+      agentId: params.agentId,
+      requesterSenderId: params.requesterSenderId,
+    });
+    const allActions = new Set<string>(["send", ...scopedActions]);
+    // Include actions from other configured channels so isolated/cron agents
+    // can invoke cross-channel actions without validation errors.
+    for (const plugin of listChannelPlugins()) {
+      if (plugin.id === currentChannel) {
+        continue;
+      }
+      for (const action of listChannelSupportedActions({
+        cfg: params.cfg,
+        channel: plugin.id,
+        currentChannelId: params.currentChannelId,
+        currentThreadTs: params.currentThreadTs,
+        currentMessageId: params.currentMessageId,
+        accountId: params.currentAccountId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        agentId: params.agentId,
+        requesterSenderId: params.requesterSenderId,
+      })) {
+        allActions.add(action);
+      }
+    }
+    return Array.from(allActions);
+  }
+  const actions = listChannelMessageActions(params.cfg);
+  return actions.length > 0 ? actions : ["send"];
+}
+
+function resolveIncludeCapability(
+  params: {
+    cfg: OpenClawConfig;
+    currentChannelProvider?: string;
+    currentChannelId?: string;
+    currentThreadTs?: string;
+    currentMessageId?: string | number;
+    currentAccountId?: string;
+    sessionKey?: string;
+    sessionId?: string;
+    agentId?: string;
+    requesterSenderId?: string;
+  },
+  capability: ChannelMessageCapability,
+): boolean {
+  const currentChannel = normalizeMessageChannel(params.currentChannelProvider);
+  if (currentChannel) {
+    return channelSupportsMessageCapabilityForChannel(
+      {
+        cfg: params.cfg,
+        channel: currentChannel,
+        currentChannelId: params.currentChannelId,
+        currentThreadTs: params.currentThreadTs,
+        currentMessageId: params.currentMessageId,
+        accountId: params.currentAccountId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        agentId: params.agentId,
+        requesterSenderId: params.requesterSenderId,
+      },
+      capability,
+    );
+  }
+  return channelSupportsMessageCapability(params.cfg, capability);
+}
+
+function resolveIncludeInteractive(params: {
+  cfg: OpenClawConfig;
+  currentChannelProvider?: string;
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  currentMessageId?: string | number;
+  currentAccountId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  requesterSenderId?: string;
+}): boolean {
+  return resolveIncludeCapability(params, "interactive");
+}
+
+function buildMessageToolSchema(params: {
+  cfg: OpenClawConfig;
+  currentChannelProvider?: string;
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  currentMessageId?: string | number;
+  currentAccountId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  requesterSenderId?: string;
+}) {
+  const actions = resolveMessageToolSchemaActions(params);
+  const includeInteractive = resolveIncludeInteractive(params);
+  const extraProperties = resolveChannelMessageToolSchemaProperties({
+    cfg: params.cfg,
+    channel: normalizeMessageChannel(params.currentChannelProvider),
+    currentChannelId: params.currentChannelId,
+    currentThreadTs: params.currentThreadTs,
+    currentMessageId: params.currentMessageId,
+    accountId: params.currentAccountId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    agentId: params.agentId,
+    requesterSenderId: params.requesterSenderId,
+  });
+  return buildMessageToolSchemaFromActions(actions.length > 0 ? actions : ["send"], {
+    includeInteractive,
+    extraProperties,
+  });
+}
+
+function resolveAgentAccountId(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return normalizeAccountId(trimmed);
+}
+
+function buildMessageToolDescription(options?: {
+  config?: OpenClawConfig;
+  currentChannel?: string;
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  currentMessageId?: string | number;
+  currentAccountId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  requesterSenderId?: string;
+}): string {
+  const baseDescription = "Send, delete, and manage messages via channel plugins.";
+  const resolvedOptions = options ?? {};
+  const currentChannel = normalizeMessageChannel(resolvedOptions.currentChannel);
+
+  // If we have a current channel, show its actions and list other configured channels
+  if (currentChannel) {
+    const channelActions = listChannelSupportedActions({
+      cfg: resolvedOptions.config,
+      channel: currentChannel,
+      currentChannelId: resolvedOptions.currentChannelId,
+      currentThreadTs: resolvedOptions.currentThreadTs,
+      currentMessageId: resolvedOptions.currentMessageId,
+      accountId: resolvedOptions.currentAccountId,
+      sessionKey: resolvedOptions.sessionKey,
+      sessionId: resolvedOptions.sessionId,
+      agentId: resolvedOptions.agentId,
+      requesterSenderId: resolvedOptions.requesterSenderId,
+    });
+    if (channelActions.length > 0) {
+      // Always include "send" as a base action
+      const allActions = new Set(["send", ...channelActions]);
+      const actionList = Array.from(allActions).toSorted().join(", ");
+      let desc = `${baseDescription} Current channel (${currentChannel}) supports: ${actionList}.`;
+
+      // Include other configured channels so cron/isolated agents can discover them
+      const otherChannels: string[] = [];
+      for (const plugin of listChannelPlugins()) {
+        if (plugin.id === currentChannel) {
+          continue;
+        }
+        const actions = listChannelSupportedActions({
+          cfg: resolvedOptions.config,
+          channel: plugin.id,
+          currentChannelId: resolvedOptions.currentChannelId,
+          currentThreadTs: resolvedOptions.currentThreadTs,
+          currentMessageId: resolvedOptions.currentMessageId,
+          accountId: resolvedOptions.currentAccountId,
+          sessionKey: resolvedOptions.sessionKey,
+          sessionId: resolvedOptions.sessionId,
+          agentId: resolvedOptions.agentId,
+          requesterSenderId: resolvedOptions.requesterSenderId,
+        });
+        if (actions.length > 0) {
+          const all = new Set(["send", ...actions]);
+          otherChannels.push(`${plugin.id} (${Array.from(all).toSorted().join(", ")})`);
+        }
+      }
+      if (otherChannels.length > 0) {
+        desc += ` Other configured channels: ${otherChannels.join(", ")}.`;
+      }
+
+      return desc;
+    }
+  }
+
+  // Fallback to generic description with all configured actions
+  if (resolvedOptions.config) {
+    const actions = listChannelMessageActions(resolvedOptions.config);
+    if (actions.length > 0) {
+      return `${baseDescription} Supports actions: ${actions.join(", ")}.`;
+    }
+  }
+
+  return `${baseDescription} Supports actions: send, delete, react, poll, pin, threads, and more.`;
+}
+
+export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
+  const loadConfigForTool = options?.loadConfig ?? loadConfig;
+  const resolveSecretRefsForTool =
+    options?.resolveCommandSecretRefsViaGateway ?? resolveCommandSecretRefsViaGateway;
+  const runMessageActionForTool = options?.runMessageAction ?? runMessageAction;
+  const agentAccountId = resolveAgentAccountId(options?.agentAccountId);
+  const resolvedAgentId = options?.agentSessionKey
+    ? resolveSessionAgentId({
+        sessionKey: options.agentSessionKey,
+        config: options?.config,
+      })
+    : undefined;
+  const schema = options?.config
+    ? buildMessageToolSchema({
+        cfg: options.config,
+        currentChannelProvider: options.currentChannelProvider,
+        currentChannelId: options.currentChannelId,
+        currentThreadTs: options.currentThreadTs,
+        currentMessageId: options.currentMessageId,
+        currentAccountId: agentAccountId,
+        sessionKey: options.agentSessionKey,
+        sessionId: options.sessionId,
+        agentId: resolvedAgentId,
+        requesterSenderId: options.requesterSenderId,
+      })
+    : MessageToolSchema;
+  const description = buildMessageToolDescription({
+    config: options?.config,
+    currentChannel: options?.currentChannelProvider,
+    currentChannelId: options?.currentChannelId,
+    currentThreadTs: options?.currentThreadTs,
+    currentMessageId: options?.currentMessageId,
+    currentAccountId: agentAccountId,
+    sessionKey: options?.agentSessionKey,
+    sessionId: options?.sessionId,
+    agentId: resolvedAgentId,
+    requesterSenderId: options?.requesterSenderId,
+  });
+
+  return {
+    label: "Message",
+    name: "message",
+    displaySummary: "Send and manage messages across configured channels.",
+    description,
+    parameters: schema,
+    execute: async (_toolCallId, args, signal) => {
+      // Check if already aborted before doing any work
+      if (signal?.aborted) {
+        const err = new Error("Message send aborted");
+        err.name = "AbortError";
+        throw err;
+      }
+      // Shallow-copy so we don't mutate the original event args (used for logging/dedup).
+      const params = { ...(args as Record<string, unknown>) };
+
+      // Strip reasoning tags from text fields — models may include <think>…</think>
+      // in tool arguments, and the messaging tool send path has no other tag filtering.
+      for (const field of ["text", "content", "message", "caption"]) {
+        if (typeof params[field] === "string") {
+          params[field] = stripReasoningTagsFromText(params[field]);
+        }
+      }
+
+      const action = readStringParam(params, "action", {
+        required: true,
+      }) as ChannelMessageActionName;
+      let cfg = options?.config;
+      if (!cfg) {
+        const loadedRaw = loadConfigForTool();
+        const scope = resolveMessageSecretScope({
+          channel: params.channel,
+          target: params.target,
+          targets: params.targets,
+          fallbackChannel: options?.currentChannelProvider,
+          accountId: params.accountId,
+          fallbackAccountId: agentAccountId,
+        });
+        const scopedTargets = getScopedChannelsCommandSecretTargets({
+          config: loadedRaw,
+          channel: scope.channel,
+          accountId: scope.accountId,
+        });
+        cfg = (
+          await resolveSecretRefsForTool({
+            config: loadedRaw,
+            commandName: "tools.message",
+            targetIds: scopedTargets.targetIds,
+            ...(scopedTargets.allowedPaths ? { allowedPaths: scopedTargets.allowedPaths } : {}),
+            mode: "enforce_resolved",
+          })
+        ).resolvedConfig;
+      }
+      const requireExplicitTarget = options?.requireExplicitTarget === true;
+      if (requireExplicitTarget && actionNeedsExplicitTarget(action)) {
+        const explicitTarget =
+          (typeof params.target === "string" && params.target.trim().length > 0) ||
+          (typeof params.to === "string" && params.to.trim().length > 0) ||
+          (typeof params.channelId === "string" && params.channelId.trim().length > 0) ||
+          (Array.isArray(params.targets) &&
+            params.targets.some((value) => typeof value === "string" && value.trim().length > 0));
+        if (!explicitTarget) {
+          throw new Error(
+            "Explicit message target required for this run. Provide target/targets (and channel when needed).",
+          );
+        }
+      }
+
+      const accountId = readStringParam(params, "accountId") ?? agentAccountId;
+      if (accountId) {
+        params.accountId = accountId;
+      }
+
+      const gatewayResolved = resolveGatewayOptions({
+        gatewayUrl: readStringParam(params, "gatewayUrl", { trim: false }),
+        gatewayToken: readStringParam(params, "gatewayToken", { trim: false }),
+        timeoutMs: readNumberParam(params, "timeoutMs"),
+      });
+      const gateway = {
+        url: gatewayResolved.url,
+        token: gatewayResolved.token,
+        timeoutMs: gatewayResolved.timeoutMs,
+        clientName: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
+        clientDisplayName: "agent",
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      };
+      const hasCurrentMessageId =
+        typeof options?.currentMessageId === "number" ||
+        (typeof options?.currentMessageId === "string" &&
+          options.currentMessageId.trim().length > 0);
+
+      const toolContext =
+        options?.currentChannelId ||
+        options?.currentChannelProvider ||
+        options?.currentThreadTs ||
+        hasCurrentMessageId ||
+        options?.replyToMode ||
+        options?.hasRepliedRef
+          ? {
+              currentChannelId: options?.currentChannelId,
+              currentChannelProvider: options?.currentChannelProvider,
+              currentThreadTs: options?.currentThreadTs,
+              currentMessageId: options?.currentMessageId,
+              replyToMode: options?.replyToMode,
+              hasRepliedRef: options?.hasRepliedRef,
+              // Direct tool invocations should not add cross-context decoration.
+              // The agent is composing a message, not forwarding from another chat.
+              skipCrossContextDecoration: true,
+            }
+          : undefined;
+
+      const result = await runMessageActionForTool({
+        cfg,
+        action,
+        params,
+        defaultAccountId: accountId ?? undefined,
+        requesterSenderId: options?.requesterSenderId,
+        gateway,
+        toolContext,
+        sessionKey: options?.agentSessionKey,
+        sessionId: options?.sessionId,
+        agentId: resolvedAgentId,
+        sandboxRoot: options?.sandboxRoot,
+        abortSignal: signal,
+      });
+
+      const toolResult = getToolResult(result);
+      if (toolResult) {
+        return toolResult;
+      }
+      return jsonResult(result.payload);
+    },
+  };
+}
+

--- a/param-key.ts
+++ b/param-key.ts
@@ -1,0 +1,17 @@
+export function toSnakeCaseKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+export function readSnakeCaseParamRaw(params: Record<string, unknown>, key: string): unknown {
+  if (Object.hasOwn(params, key)) {
+    return params[key];
+  }
+  const snakeKey = toSnakeCaseKey(key);
+  if (snakeKey !== key && Object.hasOwn(params, snakeKey)) {
+    return params[snakeKey];
+  }
+  return undefined;
+}

--- a/poll-params.ts
+++ b/poll-params.ts
@@ -1,0 +1,92 @@
+import { readSnakeCaseParamRaw } from "./param-key.js";
+
+export type PollCreationParamKind = "string" | "stringArray" | "number" | "boolean";
+
+export type PollCreationParamDef = {
+  kind: PollCreationParamKind;
+};
+
+const SHARED_POLL_CREATION_PARAM_DEFS = {
+  pollQuestion: { kind: "string" },
+  pollOption: { kind: "stringArray" },
+  pollDurationHours: { kind: "number" },
+  pollMulti: { kind: "boolean" },
+} satisfies Record<string, PollCreationParamDef>;
+
+const TELEGRAM_POLL_CREATION_PARAM_DEFS = {
+  pollDurationSeconds: { kind: "number" },
+  pollAnonymous: { kind: "boolean" },
+  pollPublic: { kind: "boolean" },
+} satisfies Record<string, PollCreationParamDef>;
+
+export const POLL_CREATION_PARAM_DEFS: Record<string, PollCreationParamDef> = {
+  ...SHARED_POLL_CREATION_PARAM_DEFS,
+  ...TELEGRAM_POLL_CREATION_PARAM_DEFS,
+};
+
+export type SharedPollCreationParamName = keyof typeof SHARED_POLL_CREATION_PARAM_DEFS;
+export type TelegramPollCreationParamName = keyof typeof TELEGRAM_POLL_CREATION_PARAM_DEFS;
+export type PollCreationParamName = keyof typeof POLL_CREATION_PARAM_DEFS;
+
+export const POLL_CREATION_PARAM_NAMES = Object.keys(POLL_CREATION_PARAM_DEFS);
+export const SHARED_POLL_CREATION_PARAM_NAMES = Object.keys(
+  SHARED_POLL_CREATION_PARAM_DEFS,
+) as SharedPollCreationParamName[];
+export const TELEGRAM_POLL_CREATION_PARAM_NAMES = Object.keys(
+  TELEGRAM_POLL_CREATION_PARAM_DEFS,
+) as TelegramPollCreationParamName[];
+
+function readPollParamRaw(params: Record<string, unknown>, key: string): unknown {
+  return readSnakeCaseParamRaw(params, key);
+}
+
+export function resolveTelegramPollVisibility(params: {
+  pollAnonymous?: boolean;
+  pollPublic?: boolean;
+}): boolean | undefined {
+  if (params.pollAnonymous && params.pollPublic) {
+    throw new Error("pollAnonymous and pollPublic are mutually exclusive");
+  }
+  return params.pollAnonymous ? true : params.pollPublic ? false : undefined;
+}
+
+export function hasPollCreationParams(params: Record<string, unknown>): boolean {
+  for (const key of POLL_CREATION_PARAM_NAMES) {
+    const def = POLL_CREATION_PARAM_DEFS[key];
+    const value = readPollParamRaw(params, key);
+    if (def.kind === "string" && typeof value === "string" && value.trim().length > 0) {
+      return true;
+    }
+    if (def.kind === "stringArray") {
+      if (
+        Array.isArray(value) &&
+        value.some((entry) => typeof entry === "string" && entry.trim())
+      ) {
+        return true;
+      }
+      if (typeof value === "string" && value.trim().length > 0) {
+        return true;
+      }
+    }
+    if (def.kind === "number") {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return true;
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
+          return true;
+        }
+      }
+    }
+    if (def.kind === "boolean") {
+      if (value === true) {
+        return true;
+      }
+      if (typeof value === "string" && value.trim().toLowerCase() === "true") {
+        return true;
+      }
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
fix(message): cleanup poll params when action != poll

When action is 'send' or other non-poll actions, explicitly remove all
poll creation parameters (pollQuestion, pollOption, pollDurationHours, etc.)
to avoid false positive detection in hasPollCreationParams().

This fixes the issue where empty/default poll fields auto-populated by
wrappers would cause 'Poll fields require action poll' errors.

Fixes #51830
