### PR TITLE
fix(whatsapp): flush creds save queue on shutdown

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -9,7 +9,12 @@ import { getChildLogger } from "openclaw/plugin-sdk/text-runtime";
 import { resolveJidToE164 } from "openclaw/plugin-sdk/text-runtime";
 import { readWebSelfIdentity } from "../auth-store.js";
 import { getPrimaryIdentityId, resolveComparableIdentity } from "../identity.js";
-import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
+import {
+  createWaSocket,
+  getStatusCode,
+  waitForCredsSaveQueueWithTimeout,
+  waitForWaConnection,
+} from "../session.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import {
   isRecentInboundMessage,
@@ -545,6 +550,7 @@ export async function monitorWebInbox(options: {
         detachMessagesUpsert();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);
+        await waitForCredsSaveQueueWithTimeout(options.authDir);
       } catch (err) {
         logVerbose(`Socket close failed: ${String(err)}`);
       }

--- a/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.captures-media-path-image-messages.test.ts
@@ -5,6 +5,7 @@ import {
   getAuthDir,
   getMonitorWebInbox,
   getSock,
+  getWaitForCredsSaveQueueWithTimeoutMock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
 } from "./monitor-inbox.test-harness.js";
@@ -133,6 +134,30 @@ describe("web monitor inbox", () => {
     expect(sock.ev.listenerCount("messages.upsert")).toBe(0);
     expect(sock.ev.listenerCount("connection.update")).toBe(0);
     expect(sock.ws.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for pending creds flush before close() resolves", async () => {
+    let releaseFlush: (() => void) | null = null;
+    const flushGate = new Promise<void>((resolve) => {
+      releaseFlush = resolve;
+    });
+    const waitForCredsSaveQueueWithTimeoutMock = getWaitForCredsSaveQueueWithTimeoutMock();
+    waitForCredsSaveQueueWithTimeoutMock.mockReturnValueOnce(flushGate);
+
+    const listener = await openMonitor(vi.fn());
+    const closePromise = listener.close();
+    let closed = false;
+    void closePromise.then(() => {
+      closed = true;
+    });
+
+    await Promise.resolve();
+    expect(waitForCredsSaveQueueWithTimeoutMock).toHaveBeenCalledWith(getAuthDir());
+    expect(closed).toBe(false);
+
+    releaseFlush?.();
+    await closePromise;
+    expect(closed).toBe(true);
   });
 
   it("logs inbound bodies through the inbound child logger", async () => {

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -51,6 +51,7 @@ export type MockSock = {
 
 const sessionState = vi.hoisted(() => ({
   sock: undefined as MockSock | undefined,
+  waitForCredsSaveQueueWithTimeout: vi.fn().mockResolvedValue(undefined),
 }));
 
 function createResolvedMock() {
@@ -100,6 +101,7 @@ vi.mock("./session.js", async () => {
       return sessionState.sock;
     }),
     waitForWaConnection: vi.fn().mockResolvedValue(undefined),
+    waitForCredsSaveQueueWithTimeout: sessionState.waitForCredsSaveQueueWithTimeout,
     getStatusCode: vi.fn(() => 500),
   };
 });
@@ -109,6 +111,10 @@ export function getSock(): MockSock {
     throw new Error("mock WhatsApp socket not initialized");
   }
   return sessionState.sock;
+}
+
+export function getWaitForCredsSaveQueueWithTimeoutMock() {
+  return sessionState.waitForCredsSaveQueueWithTimeout;
 }
 
 type MonitorWebInbox = typeof import("./inbound.js").monitorWebInbox;
@@ -225,6 +231,7 @@ export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }
     vi.resetModules();
     vi.clearAllMocks();
     sessionState.sock = createMockSock();
+    sessionState.waitForCredsSaveQueueWithTimeout.mockReset().mockResolvedValue(undefined);
     resetPairingSecurityMocks(DEFAULT_WEB_INBOX_CONFIG);
     const inboundModule = await import("./inbound.js");
     monitorWebInbox = inboundModule.monitorWebInbox;


### PR DESCRIPTION
## Summary
- wait for the WhatsApp creds save queue during inbox listener shutdown so clean restarts do not exit with pending auth-state writes
- keep the fix narrowly scoped to the clean shutdown path that was leaving creds.json partial/corrupted on next boot
- add focused inbox-monitor harness coverage for the shutdown flush behavior

## Testing
- targeted WhatsApp inbox monitor tests updated alongside the fix
- broader runtime validation remains limited in this environment

Closes #55752