### PR TITLE
feat(acp): forward image blocks in tool call results

### DIFF
--- a/src/acp/event-mapper.test.ts
+++ b/src/acp/event-mapper.test.ts
@@ -61,6 +61,17 @@ describe("extractToolCallContent", () => {
     expect(result).toEqual([{ type: "content", content: { type: "text", text: "fallback" } }]);
   });
 
+  it("skips image blocks with whitespace-only data or mimeType strings", () => {
+    const result = extractToolCallContent({
+      content: [
+        { type: "image", data: "   ", mimeType: "image/png" },
+        { type: "image", data: "iVBORw0KGgo=", mimeType: "  \t  " },
+        { type: "text", text: "fallback" },
+      ],
+    });
+    expect(result).toEqual([{ type: "content", content: { type: "text", text: "fallback" } }]);
+  });
+
   it("returns undefined for empty content", () => {
     expect(extractToolCallContent({})).toBeUndefined();
     expect(extractToolCallContent({ content: [] })).toBeUndefined();

--- a/src/acp/event-mapper.test.ts
+++ b/src/acp/event-mapper.test.ts
@@ -1,5 +1,65 @@
 import { describe, expect, it } from "vitest";
-import { extractToolCallLocations } from "./event-mapper.js";
+import { extractToolCallContent, extractToolCallLocations } from "./event-mapper.js";
+
+describe("extractToolCallContent", () => {
+  it("extracts text blocks from tool results", () => {
+    const result = extractToolCallContent({
+      content: [{ type: "text", text: "hello" }],
+    });
+    expect(result).toEqual([{ type: "content", content: { type: "text", text: "hello" } }]);
+  });
+
+  it("extracts image blocks from tool results", () => {
+    const result = extractToolCallContent({
+      content: [{ type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" }],
+    });
+    expect(result).toEqual([
+      {
+        type: "content",
+        content: { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+      },
+    ]);
+  });
+
+  it("extracts mixed text and image blocks", () => {
+    const result = extractToolCallContent({
+      content: [
+        { type: "text", text: "Chart output:" },
+        { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    expect(result![0]).toEqual({
+      type: "content",
+      content: { type: "text", text: "Chart output:" },
+    });
+    expect(result![1]).toEqual({
+      type: "content",
+      content: { type: "image", data: "iVBORw0KGgo=", mimeType: "image/png" },
+    });
+  });
+
+  it("skips image blocks with missing data or mimeType", () => {
+    const result = extractToolCallContent({
+      content: [
+        { type: "image", mimeType: "image/png" },
+        { type: "image", data: "iVBORw0KGgo=" },
+        { type: "text", text: "fallback" },
+      ],
+    });
+    expect(result).toEqual([{ type: "content", content: { type: "text", text: "fallback" } }]);
+  });
+
+  it("returns undefined for empty content", () => {
+    expect(extractToolCallContent({})).toBeUndefined();
+    expect(extractToolCallContent({ content: [] })).toBeUndefined();
+  });
+
+  it("returns text from string input", () => {
+    const result = extractToolCallContent("plain text");
+    expect(result).toEqual([{ type: "content", content: { type: "text", text: "plain text" } }]);
+  });
+});
 
 describe("extractToolCallLocations", () => {
   it("enforces the global node visit cap across nested structures", () => {

--- a/src/acp/event-mapper.test.ts
+++ b/src/acp/event-mapper.test.ts
@@ -50,6 +50,17 @@ describe("extractToolCallContent", () => {
     expect(result).toEqual([{ type: "content", content: { type: "text", text: "fallback" } }]);
   });
 
+  it("skips image blocks with empty data or mimeType strings", () => {
+    const result = extractToolCallContent({
+      content: [
+        { type: "image", data: "", mimeType: "image/png" },
+        { type: "image", data: "iVBORw0KGgo=", mimeType: "" },
+        { type: "text", text: "fallback" },
+      ],
+    });
+    expect(result).toEqual([{ type: "content", content: { type: "text", text: "fallback" } }]);
+  });
+
   it("returns undefined for empty content", () => {
     expect(extractToolCallContent({})).toBeUndefined();
     expect(extractToolCallContent({ content: [] })).toBeUndefined();

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -373,6 +373,19 @@ export function extractToolCallContent(value: unknown): ToolCallContent[] | unde
           text: entry.text,
         },
       });
+    } else if (
+      entry?.type === "image" &&
+      typeof entry.data === "string" &&
+      typeof entry.mimeType === "string"
+    ) {
+      contents.push({
+        type: "content",
+        content: {
+          type: "image",
+          data: entry.data,
+          mimeType: entry.mimeType,
+        } as ImageContent & { type: "image" },
+      });
     }
   }
 

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -376,9 +376,9 @@ export function extractToolCallContent(value: unknown): ToolCallContent[] | unde
     } else if (
       entry?.type === "image" &&
       typeof entry.data === "string" &&
-      entry.data.length > 0 &&
+      entry.data.trim() &&
       typeof entry.mimeType === "string" &&
-      entry.mimeType.length > 0
+      entry.mimeType.trim()
     ) {
       contents.push({
         type: "content",

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -376,7 +376,9 @@ export function extractToolCallContent(value: unknown): ToolCallContent[] | unde
     } else if (
       entry?.type === "image" &&
       typeof entry.data === "string" &&
-      typeof entry.mimeType === "string"
+      entry.data.length > 0 &&
+      typeof entry.mimeType === "string" &&
+      entry.mimeType.length > 0
     ) {
       contents.push({
         type: "content",


### PR DESCRIPTION
## Summary

- `extractToolCallContent()` in the ACP event mapper previously only extracted `type: "text"` blocks from tool results, silently dropping image content blocks
- ACP clients (Feishu, Discord, etc.) could not display images produced by tools (e.g. the Read tool reading PNG/JPG files) because image blocks were never forwarded
- Added image block extraction with validation (`data` and `mimeType` must both be present), using the existing `ImageContent` type from `@agentclientprotocol/sdk`
- No protocol changes needed — the ACP SDK already supports `ImageContent` in `ToolCallContent`

## Test plan

- [x] Added unit tests for `extractToolCallContent()` covering:
  - Text-only extraction (existing behavior)
  - Image-only extraction
  - Mixed text + image blocks
  - Malformed image blocks (missing data/mimeType) are skipped
  - Empty content returns undefined
  - String input fallback
- [ ] Manual verification: use ACP bridge with a Feishu/Discord client, have the agent read a PNG file, confirm the image is displayed in the client

🤖 Generated with [Claude Code](https://claude.com/claude-code)