### PR TITLE
fix(hooks): reject internal session namespaces

### DIFF
--- a/src/gateway/hook-session-key.ts
+++ b/src/gateway/hook-session-key.ts
@@ -1,0 +1,26 @@
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+const HOOK_RESERVED_SESSION_KEY_PREFIXES = ["subagent:", "acp:", "cron:"] as const;
+
+function resolveSessionKey(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  return value ? value : undefined;
+}
+
+function normalizeHookValidatedSessionKey(raw: string | undefined): string | undefined {
+  const value = resolveSessionKey(raw);
+  if (!value) {
+    return undefined;
+  }
+  return parseAgentSessionKey(value)?.rest ?? value;
+}
+
+export function resolveReservedHookSessionKeyPrefix(
+  sessionKey: string | undefined,
+): string | undefined {
+  const normalized = normalizeHookValidatedSessionKey(sessionKey)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return HOOK_RESERVED_SESSION_KEY_PREFIXES.find((prefix) => normalized.startsWith(prefix));
+}

--- a/src/gateway/hook-session-key.ts
+++ b/src/gateway/hook-session-key.ts
@@ -10,9 +10,13 @@ function resolveSessionKey(raw: string | undefined): string | undefined {
 function normalizeHookValidatedSessionKey(raw: string | undefined): string | undefined {
   let value = resolveSessionKey(raw);
   while (value) {
-    const parsed = parseAgentSessionKey(value);
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = parseAgentSessionKey(trimmed);
     if (!parsed) {
-      return value;
+      return trimmed;
     }
     value = parsed.rest;
   }

--- a/src/gateway/hook-session-key.ts
+++ b/src/gateway/hook-session-key.ts
@@ -8,11 +8,15 @@ function resolveSessionKey(raw: string | undefined): string | undefined {
 }
 
 function normalizeHookValidatedSessionKey(raw: string | undefined): string | undefined {
-  const value = resolveSessionKey(raw);
-  if (!value) {
-    return undefined;
+  let value = resolveSessionKey(raw);
+  while (value) {
+    const parsed = parseAgentSessionKey(value);
+    if (!parsed) {
+      return value;
+    }
+    value = parsed.rest;
   }
-  return parseAgentSessionKey(value)?.rest ?? value;
+  return undefined;
 }
 
 export function resolveReservedHookSessionKeyPrefix(

--- a/src/gateway/hook-session-key.ts
+++ b/src/gateway/hook-session-key.ts
@@ -1,0 +1,34 @@
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+const HOOK_RESERVED_SESSION_KEY_PREFIXES = ["subagent:", "acp:", "cron:"] as const;
+
+function resolveSessionKey(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  return value ? value : undefined;
+}
+
+function normalizeHookValidatedSessionKey(raw: string | undefined): string | undefined {
+  let value = resolveSessionKey(raw);
+  while (value) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = parseAgentSessionKey(trimmed);
+    if (!parsed) {
+      return trimmed;
+    }
+    value = parsed.rest;
+  }
+  return undefined;
+}
+
+export function resolveReservedHookSessionKeyPrefix(
+  sessionKey: string | undefined,
+): string | undefined {
+  const normalized = normalizeHookValidatedSessionKey(sessionKey)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return HOOK_RESERVED_SESSION_KEY_PREFIXES.find((prefix) => normalized.startsWith(prefix));
+}

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -161,6 +161,39 @@ describe("hooks mapping", () => {
     expect(mappings[0]?.matchPath).toBe("gmail");
   });
 
+  it("rejects static mapping sessionKey targeting reserved internal namespaces", () => {
+    expect(() =>
+      resolveHookMappings({
+        mappings: [
+          {
+            id: "reserved-session",
+            match: { path: "gmail" },
+            action: "agent",
+            messageTemplate: "Subject: {{messages[0].subject}}",
+            sessionKey: "agent:main:subagent:worker",
+          },
+        ],
+      }),
+    ).toThrow(
+      "hook mapping 'reserved-session' sessionKey may not target internal session namespace subagent:",
+    );
+  });
+
+  it("allows templated mapping sessionKey to defer validation until runtime", () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "templated-session",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          sessionKey: "hook:{{messages[0].subject}}",
+        },
+      ],
+    });
+    expect(mappings[0]?.sessionKey).toBe("hook:{{messages[0].subject}}");
+  });
+
   it("renders template from payload", async () => {
     const result = await applyGmailMappings({
       mappings: [

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -161,7 +161,10 @@ describe("hooks mapping", () => {
     expect(mappings[0]?.matchPath).toBe("gmail");
   });
 
-  it("rejects static mapping sessionKey targeting reserved internal namespaces", () => {
+  it.each([
+    "agent:main:subagent:worker",
+    "agent:main:subagent:{{worker",
+  ])("rejects static mapping sessionKey targeting reserved internal namespace %s", (sessionKey) => {
     expect(() =>
       resolveHookMappings({
         mappings: [
@@ -170,7 +173,7 @@ describe("hooks mapping", () => {
             match: { path: "gmail" },
             action: "agent",
             messageTemplate: "Subject: {{messages[0].subject}}",
-            sessionKey: "agent:main:subagent:worker",
+            sessionKey,
           },
         ],
       }),

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -208,6 +208,42 @@ describe("hooks mapping", () => {
     }
   });
 
+  it.each(["agent:main:subagent:worker", "agent:main:subagent:{{worker"])(
+    "rejects static mapping sessionKey targeting reserved internal namespace %s",
+    (sessionKey) => {
+      expect(() =>
+        resolveHookMappings({
+          mappings: [
+            {
+              id: "reserved-session",
+              match: { path: "gmail" },
+              action: "agent",
+              messageTemplate: "Subject: {{messages[0].subject}}",
+              sessionKey,
+            },
+          ],
+        }),
+      ).toThrow(
+        "hook mapping 'reserved-session' sessionKey may not target internal session namespace subagent:",
+      );
+    },
+  );
+
+  it("allows templated mapping sessionKey to defer validation until runtime", () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "templated-session",
+          match: { path: "gmail" },
+          action: "agent",
+          messageTemplate: "Subject: {{messages[0].subject}}",
+          sessionKey: "hook:{{messages[0].subject}}",
+        },
+      ],
+    });
+    expect(mappings[0]?.sessionKey).toBe("hook:{{messages[0].subject}}");
+  });
+
   it("marks literal session keys as static", async () => {
     const result = await applyGmailMappings({
       mappings: [

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -4,6 +4,7 @@ import { resolveConfigPathCandidate } from "../config/paths.js";
 import type { HookMappingConfig, HooksConfig } from "../config/types.hooks.js";
 import { importFileModule, resolveFunctionModuleExport } from "../hooks/module-loader.js";
 import { normalizeOptionalString, readStringValue } from "../shared/string-coerce.js";
+import { resolveReservedHookSessionKeyPrefix } from "./hook-session-key.js";
 import type { HookMessageChannel } from "./hooks.types.js";
 
 export type HookMappingResolved = {
@@ -198,6 +199,15 @@ function normalizeHookMapping(
   const matchSource = mapping.match?.source?.trim();
   const action = mapping.action ?? "agent";
   const wakeMode = mapping.wakeMode ?? "now";
+  const sessionKey = mapping.sessionKey?.trim() || undefined;
+  if (sessionKey && !sessionKey.includes("{{")) {
+    const reservedSessionPrefix = resolveReservedHookSessionKeyPrefix(sessionKey);
+    if (reservedSessionPrefix) {
+      throw new Error(
+        `hook mapping '${id}' sessionKey may not target internal session namespace ${reservedSessionPrefix}`,
+      );
+    }
+  }
   const transform = mapping.transform
     ? {
         modulePath: resolveContainedPath(transformsDir, mapping.transform.module, "Hook transform"),
@@ -213,7 +223,7 @@ function normalizeHookMapping(
     wakeMode,
     name: mapping.name,
     agentId: normalizeOptionalString(mapping.agentId),
-    sessionKey: mapping.sessionKey,
+    sessionKey,
     messageTemplate: mapping.messageTemplate,
     textTemplate: mapping.textTemplate,
     deliver: mapping.deliver,

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -200,7 +200,7 @@ function normalizeHookMapping(
   const action = mapping.action ?? "agent";
   const wakeMode = mapping.wakeMode ?? "now";
   const sessionKey = mapping.sessionKey?.trim() || undefined;
-  if (sessionKey && !sessionKey.includes("{{")) {
+  if (sessionKey && !hasHookTemplateExpressions(sessionKey)) {
     const reservedSessionPrefix = resolveReservedHookSessionKeyPrefix(sessionKey);
     if (reservedSessionPrefix) {
       throw new Error(

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -200,7 +200,7 @@ function normalizeHookMapping(
   const action = mapping.action ?? "agent";
   const wakeMode = mapping.wakeMode ?? "now";
   const sessionKey = mapping.sessionKey?.trim() || undefined;
-  if (sessionKey && !hasHookTemplateExpressions(sessionKey)) {
+  if (action === "agent" && sessionKey && !hasHookTemplateExpressions(sessionKey)) {
     const reservedSessionPrefix = resolveReservedHookSessionKeyPrefix(sessionKey);
     if (reservedSessionPrefix) {
       throw new Error(

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -7,6 +7,7 @@ import {
 import { resolveConfigPathCandidate } from "../config/paths.js";
 import type { HookMappingConfig, HooksConfig } from "../config/types.hooks.js";
 import { importFileModule, resolveFunctionModuleExport } from "../hooks/module-loader.js";
+import { resolveReservedHookSessionKeyPrefix } from "./hook-session-key.js";
 import type { HookMessageChannel } from "./hooks.types.js";
 
 export type HookMappingResolved = {
@@ -201,6 +202,15 @@ function normalizeHookMapping(
   const matchSource = mapping.match?.source?.trim();
   const action = mapping.action ?? "agent";
   const wakeMode = mapping.wakeMode ?? "now";
+  const sessionKey = normalizeOptionalString(mapping.sessionKey);
+  if (action === "agent" && sessionKey && !hasHookTemplateExpressions(sessionKey)) {
+    const reservedSessionPrefix = resolveReservedHookSessionKeyPrefix(sessionKey);
+    if (reservedSessionPrefix) {
+      throw new Error(
+        `hook mapping '${id}' sessionKey may not target internal session namespace ${reservedSessionPrefix}`,
+      );
+    }
+  }
   const transform = mapping.transform
     ? {
         modulePath: resolveContainedPath(transformsDir, mapping.transform.module, "Hook transform"),
@@ -216,7 +226,7 @@ function normalizeHookMapping(
     wakeMode,
     name: mapping.name,
     agentId: normalizeOptionalString(mapping.agentId),
-    sessionKey: mapping.sessionKey,
+    sessionKey,
     messageTemplate: mapping.messageTemplate,
     textTemplate: mapping.textTemplate,
     deliver: mapping.deliver,

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -278,14 +278,14 @@ describe("gateway hooks helpers", () => {
     expect(
       resolveHookSessionKey({
         hooksConfig: resolved,
-        source: "mapping",
+        source: "mapping-static",
         sessionKey: "agent:main:acp:svc",
       }),
     ).toMatchObject({ ok: false });
     expect(
       resolveHookSessionKey({
         hooksConfig: resolved,
-        source: "mapping",
+        source: "mapping-static",
         sessionKey: "cron:daily",
       }),
     ).toMatchObject({ ok: false });

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -289,6 +289,13 @@ describe("gateway hooks helpers", () => {
         sessionKey: "cron:daily",
       }),
     ).toMatchObject({ ok: false });
+    expect(
+      resolveHookSessionKey({
+        hooksConfig: resolved,
+        source: "request",
+        sessionKey: "agent:main:agent:hooks:subagent:worker",
+      }),
+    ).toMatchObject({ ok: false });
   });
 
   test("resolveHookSessionKey enforces allowed prefixes", () => {
@@ -572,6 +579,16 @@ describe("gateway hooks helpers", () => {
           enabled: true,
           token: "secret",
           defaultSessionKey: "agent:main:subagent:worker",
+          allowedSessionKeyPrefixes: ["hook:", "agent:"],
+        },
+      } as OpenClawConfig),
+    ).toThrow("hooks.defaultSessionKey may not target internal session namespace subagent:");
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          defaultSessionKey: "agent:main:agent:hooks:subagent:worker",
           allowedSessionKeyPrefixes: ["hook:", "agent:"],
         },
       } as OpenClawConfig),

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -529,6 +529,25 @@ describe("gateway hooks helpers", () => {
     ).not.toThrow();
   });
 
+  test("resolveHooksConfig ignores static session keys on wake mappings", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              match: { path: "wake" },
+              action: "wake",
+              textTemplate: "ping",
+              sessionKey: "agent:main:subagent:worker",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
+
   test("resolveHooksConfig treats '/' match.path as a catch-all for shadowing", () => {
     expect(() =>
       resolveHooksConfig({

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -253,6 +253,44 @@ describe("gateway hooks helpers", () => {
     expect(allowed).toEqual({ ok: true, value: "hook:manual" });
   });
 
+  test("resolveHookSessionKey rejects internal control session namespaces", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowRequestSessionKey: true,
+        allowedSessionKeyPrefixes: ["hook:", "agent:"],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfig(cfg);
+    expect(resolved).not.toBeNull();
+    if (!resolved) {
+      return;
+    }
+
+    expect(
+      resolveHookSessionKey({
+        hooksConfig: resolved,
+        source: "request",
+        sessionKey: "agent:main:subagent:worker",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      resolveHookSessionKey({
+        hooksConfig: resolved,
+        source: "mapping",
+        sessionKey: "agent:main:acp:svc",
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      resolveHookSessionKey({
+        hooksConfig: resolved,
+        source: "mapping",
+        sessionKey: "cron:daily",
+      }),
+    ).toMatchObject({ ok: false });
+  });
+
   test("resolveHookSessionKey enforces allowed prefixes", () => {
     const cfg = {
       hooks: {
@@ -525,6 +563,19 @@ describe("gateway hooks helpers", () => {
         },
       } as OpenClawConfig),
     ).not.toThrow();
+  });
+
+  test("resolveHooksConfig rejects internal defaultSessionKey namespaces", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          defaultSessionKey: "agent:main:subagent:worker",
+          allowedSessionKeyPrefixes: ["hook:", "agent:"],
+        },
+      } as OpenClawConfig),
+    ).toThrow("hooks.defaultSessionKey may not target internal session namespace subagent:");
   });
 });
 

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -296,6 +296,13 @@ describe("gateway hooks helpers", () => {
         sessionKey: "agent:main:agent:hooks:subagent:worker",
       }),
     ).toMatchObject({ ok: false });
+    expect(
+      resolveHookSessionKey({
+        hooksConfig: resolved,
+        source: "request",
+        sessionKey: "agent:main: subagent:worker",
+      }),
+    ).toMatchObject({ ok: false });
   });
 
   test("resolveHookSessionKey enforces allowed prefixes", () => {

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -284,6 +284,34 @@ describe("gateway hooks helpers", () => {
     expect(allowed).toEqual({ ok: true, value: "hook:gmail:1" });
   });
 
+  test("resolveHookSessionKey rejects internal control session namespaces", () => {
+    const cfg = {
+      hooks: {
+        enabled: true,
+        token: "secret",
+        allowRequestSessionKey: true,
+        allowedSessionKeyPrefixes: ["hook:", "agent:"],
+      },
+    } as OpenClawConfig;
+    const resolved = resolveHooksConfigOrThrow(cfg);
+
+    for (const sessionKey of [
+      "agent:main:subagent:worker",
+      "agent:main:acp:svc",
+      "cron:daily",
+      "agent:main:agent:hooks:subagent:worker",
+      "agent:main: subagent:worker",
+    ]) {
+      expect(
+        resolveHookSessionKey({
+          hooksConfig: resolved,
+          source: "request",
+          sessionKey,
+        }),
+      ).toMatchObject({ ok: false });
+    }
+  });
+
   test("resolveHookSessionKey blocks templated mapping sessionKey when request overrides are disabled", () => {
     const cfg = {
       hooks: {
@@ -378,6 +406,49 @@ describe("gateway hooks helpers", () => {
     ).toThrow(
       "hooks.allowedSessionKeyPrefixes must include 'hook:' when hooks.defaultSessionKey is unset",
     );
+  });
+
+  test("resolveHooksConfig rejects internal defaultSessionKey namespaces", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          defaultSessionKey: "agent:main:subagent:worker",
+          allowedSessionKeyPrefixes: ["hook:", "agent:"],
+        },
+      } as OpenClawConfig),
+    ).toThrow("hooks.defaultSessionKey may not target internal session namespace subagent:");
+
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          defaultSessionKey: "agent:main:agent:hooks:subagent:worker",
+          allowedSessionKeyPrefixes: ["hook:", "agent:"],
+        },
+      } as OpenClawConfig),
+    ).toThrow("hooks.defaultSessionKey may not target internal session namespace subagent:");
+  });
+
+  test("resolveHooksConfig ignores static session keys on wake mappings", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          mappings: [
+            {
+              match: { path: "wake" },
+              action: "wake",
+              textTemplate: "ping",
+              sessionKey: "agent:main:subagent:worker",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
   });
 
   test("resolveHooksConfig requires prefixes for templated mapping session keys", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -11,6 +11,7 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
+import { resolveReservedHookSessionKeyPrefix } from "./hook-session-key.js";
 import {
   hasHookTemplateExpressions,
   type HookMappingResolved,
@@ -22,7 +23,6 @@ import type { HookMessageChannel } from "./hooks.types.js";
 const DEFAULT_HOOKS_PATH = "/hooks";
 const DEFAULT_HOOKS_MAX_BODY_BYTES = 256 * 1024;
 const MAX_HOOK_IDEMPOTENCY_KEY_LENGTH = 256;
-const HOOK_RESERVED_SESSION_KEY_PREFIXES = ["subagent:", "acp:", "cron:"] as const;
 
 export type HooksConfigResolved = {
   basePath: string;
@@ -154,22 +154,6 @@ export function isSessionKeyAllowedByPrefix(sessionKey: string, prefixes: string
     return false;
   }
   return prefixes.some((prefix) => normalized.startsWith(prefix));
-}
-
-function normalizeHookValidatedSessionKey(raw: string | undefined): string | undefined {
-  const value = resolveSessionKey(raw);
-  if (!value) {
-    return undefined;
-  }
-  return parseAgentSessionKey(value)?.rest ?? value;
-}
-
-function resolveReservedHookSessionKeyPrefix(sessionKey: string | undefined): string | undefined {
-  const normalized = normalizeHookValidatedSessionKey(sessionKey)?.toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  return HOOK_RESERVED_SESSION_KEY_PREFIXES.find((prefix) => normalized.startsWith(prefix));
 }
 
 export function extractHookToken(req: IncomingMessage): string | undefined {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -22,6 +22,7 @@ import type { HookMessageChannel } from "./hooks.types.js";
 const DEFAULT_HOOKS_PATH = "/hooks";
 const DEFAULT_HOOKS_MAX_BODY_BYTES = 256 * 1024;
 const MAX_HOOK_IDEMPOTENCY_KEY_LENGTH = 256;
+const HOOK_RESERVED_SESSION_KEY_PREFIXES = ["subagent:", "acp:", "cron:"] as const;
 
 export type HooksConfigResolved = {
   basePath: string;
@@ -78,6 +79,12 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     !isSessionKeyAllowedByPrefix(defaultSessionKey, allowedSessionKeyPrefixes)
   ) {
     throw new Error("hooks.defaultSessionKey must match hooks.allowedSessionKeyPrefixes");
+  }
+  const reservedDefaultSessionPrefix = resolveReservedHookSessionKeyPrefix(defaultSessionKey);
+  if (reservedDefaultSessionPrefix) {
+    throw new Error(
+      `hooks.defaultSessionKey may not target internal session namespace ${reservedDefaultSessionPrefix}`,
+    );
   }
   if (
     !defaultSessionKey &&
@@ -147,6 +154,22 @@ export function isSessionKeyAllowedByPrefix(sessionKey: string, prefixes: string
     return false;
   }
   return prefixes.some((prefix) => normalized.startsWith(prefix));
+}
+
+function normalizeHookValidatedSessionKey(raw: string | undefined): string | undefined {
+  const value = resolveSessionKey(raw);
+  if (!value) {
+    return undefined;
+  }
+  return parseAgentSessionKey(value)?.rest ?? value;
+}
+
+function resolveReservedHookSessionKeyPrefix(sessionKey: string | undefined): string | undefined {
+  const normalized = normalizeHookValidatedSessionKey(sessionKey)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  return HOOK_RESERVED_SESSION_KEY_PREFIXES.find((prefix) => normalized.startsWith(prefix));
 }
 
 export function extractHookToken(req: IncomingMessage): string | undefined {
@@ -315,6 +338,8 @@ export const getHookSessionKeyRequestPolicyError = () =>
   "sessionKey is disabled for externally supplied hook payload values; set hooks.allowRequestSessionKey=true to enable";
 export const getHookSessionKeyPrefixError = (prefixes: string[]) =>
   `sessionKey must start with one of: ${prefixes.join(", ")}`;
+export const getHookSessionKeyReservedPrefixError = (prefix: string) =>
+  `sessionKey may not target internal session namespace ${prefix}`;
 
 export function resolveHookSessionKey(params: {
   hooksConfig: HooksConfigResolved;
@@ -333,6 +358,10 @@ export function resolveHookSessionKey(params: {
     const allowedPrefixes = params.hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
     if (allowedPrefixes && !isSessionKeyAllowedByPrefix(requested, allowedPrefixes)) {
       return { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) };
+    }
+    const reservedPrefix = resolveReservedHookSessionKeyPrefix(requested);
+    if (reservedPrefix) {
+      return { ok: false, error: getHookSessionKeyReservedPrefixError(reservedPrefix) };
     }
     return { ok: true, value: requested };
   }

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -11,6 +11,7 @@ import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-bod
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
+import { resolveReservedHookSessionKeyPrefix } from "./hook-session-key.js";
 import {
   hasHookTemplateExpressions,
   type HookMappingResolved,
@@ -78,6 +79,12 @@ export function resolveHooksConfig(cfg: OpenClawConfig): HooksConfigResolved | n
     !isSessionKeyAllowedByPrefix(defaultSessionKey, allowedSessionKeyPrefixes)
   ) {
     throw new Error("hooks.defaultSessionKey must match hooks.allowedSessionKeyPrefixes");
+  }
+  const reservedDefaultSessionPrefix = resolveReservedHookSessionKeyPrefix(defaultSessionKey);
+  if (reservedDefaultSessionPrefix) {
+    throw new Error(
+      `hooks.defaultSessionKey may not target internal session namespace ${reservedDefaultSessionPrefix}`,
+    );
   }
   if (
     !defaultSessionKey &&
@@ -319,6 +326,8 @@ const getHookSessionKeyRequestPolicyError = () =>
   "sessionKey is disabled for externally supplied hook payload values; set hooks.allowRequestSessionKey=true to enable";
 export const getHookSessionKeyPrefixError = (prefixes: string[]) =>
   `sessionKey must start with one of: ${prefixes.join(", ")}`;
+export const getHookSessionKeyReservedPrefixError = (prefix: string) =>
+  `sessionKey may not target internal session namespace ${prefix}`;
 
 export function resolveHookSessionKey(params: {
   hooksConfig: HooksConfigResolved;
@@ -337,6 +346,10 @@ export function resolveHookSessionKey(params: {
     const allowedPrefixes = params.hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
     if (allowedPrefixes && !isSessionKeyAllowedByPrefix(requested, allowedPrefixes)) {
       return { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) };
+    }
+    const reservedPrefix = resolveReservedHookSessionKeyPrefix(requested);
+    if (reservedPrefix) {
+      return { ok: false, error: getHookSessionKeyReservedPrefixError(reservedPrefix) };
     }
     return { ok: true, value: requested };
   }

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -363,7 +363,26 @@ describe("gateway server hooks", () => {
     });
   });
 
-  test("rejects hook session keys that target internal control namespaces", async () => {
+  test("rejects request hook session keys that target internal control namespaces", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const requestDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main:subagent:worker",
+      });
+      expect(requestDenied.status).toBe(400);
+      const requestDeniedBody = (await requestDenied.json()) as { error?: string };
+      expect(requestDeniedBody.error).toContain("internal session namespace subagent:");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
+    });
+  });
+
+  test("rejects mapped hook session keys that target internal control namespaces at startup", async () => {
     testState.hooksConfig = {
       enabled: true,
       token: HOOK_TOKEN,
@@ -378,21 +397,10 @@ describe("gateway server hooks", () => {
         },
       ],
     };
-    await withGatewayServer(async ({ port }) => {
-      const requestDenied = await postHook(port, "/hooks/agent", {
-        message: "Do it",
-        sessionKey: "agent:main:subagent:worker",
-      });
-      expect(requestDenied.status).toBe(400);
-      const requestDeniedBody = (await requestDenied.json()) as { error?: string };
-      expect(requestDeniedBody.error).toContain("internal session namespace subagent:");
 
-      const mappedDenied = await postHook(port, "/hooks/mapped-subagent", { subject: "hello" });
-      expect(mappedDenied.status).toBe(400);
-      const mappedDeniedBody = (await mappedDenied.json()) as { error?: string };
-      expect(mappedDeniedBody.error).toContain("internal session namespace subagent:");
-      expect(cronIsolatedRun).not.toHaveBeenCalled();
-    });
+    await expect(withGatewayServer(async () => undefined)).rejects.toThrow(
+      "hook mapping 'mapping-1' sessionKey may not target internal session namespace subagent:",
+    );
   });
 
   test("respects hooks session policy for request + mapping session keys", async () => {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -363,6 +363,38 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("rejects hook session keys that target internal control namespaces", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+      mappings: [
+        {
+          match: { path: "mapped-subagent" },
+          action: "agent",
+          messageTemplate: "Mapped: {{payload.subject}}",
+          sessionKey: "agent:main:subagent:worker",
+        },
+      ],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const requestDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main:subagent:worker",
+      });
+      expect(requestDenied.status).toBe(400);
+      const requestDeniedBody = (await requestDenied.json()) as { error?: string };
+      expect(requestDeniedBody.error).toContain("internal session namespace subagent:");
+
+      const mappedDenied = await postHook(port, "/hooks/mapped-subagent", { subject: "hello" });
+      expect(mappedDenied.status).toBe(400);
+      const mappedDeniedBody = (await mappedDenied.json()) as { error?: string };
+      expect(mappedDeniedBody.error).toContain("internal session namespace subagent:");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
+    });
+  });
+
   test("respects hooks session policy for request + mapping session keys", async () => {
     testState.hooksConfig = {
       enabled: true,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -379,6 +379,15 @@ describe("gateway server hooks", () => {
       const requestDeniedBody = (await requestDenied.json()) as { error?: string };
       expect(requestDeniedBody.error).toContain("internal session namespace subagent:");
       expect(cronIsolatedRun).not.toHaveBeenCalled();
+
+      const nestedDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main:agent:hooks:subagent:worker",
+      });
+      expect(nestedDenied.status).toBe(400);
+      const nestedDeniedBody = (await nestedDenied.json()) as { error?: string };
+      expect(nestedDeniedBody.error).toContain("internal session namespace subagent:");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
     });
   });
 

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -388,6 +388,15 @@ describe("gateway server hooks", () => {
       const nestedDeniedBody = (await nestedDenied.json()) as { error?: string };
       expect(nestedDeniedBody.error).toContain("internal session namespace subagent:");
       expect(cronIsolatedRun).not.toHaveBeenCalled();
+
+      const spacedDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main: subagent:worker",
+      });
+      expect(spacedDenied.status).toBe(400);
+      const spacedDeniedBody = (await spacedDenied.json()) as { error?: string };
+      expect(spacedDeniedBody.error).toContain("internal session namespace subagent:");
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
     });
   });
 

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -290,6 +290,63 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("rejects request hook session keys that target internal control namespaces", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const requestDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main:subagent:worker",
+      });
+      expect(requestDenied.status).toBe(400);
+      const requestDeniedBody = (await requestDenied.json()) as { error?: string };
+      expect(requestDeniedBody.error).toContain("internal session namespace subagent:");
+
+      const nestedDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main:agent:hooks:subagent:worker",
+      });
+      expect(nestedDenied.status).toBe(400);
+      const nestedDeniedBody = (await nestedDenied.json()) as { error?: string };
+      expect(nestedDeniedBody.error).toContain("internal session namespace subagent:");
+
+      const spacedDenied = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        sessionKey: "agent:main: subagent:worker",
+      });
+      expect(spacedDenied.status).toBe(400);
+      const spacedDeniedBody = (await spacedDenied.json()) as { error?: string };
+      expect(spacedDeniedBody.error).toContain("internal session namespace subagent:");
+
+      expect(cronIsolatedRun).not.toHaveBeenCalled();
+    });
+  });
+
+  test("rejects mapped hook session keys that target internal control namespaces at startup", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+      mappings: [
+        {
+          match: { path: "mapped-subagent" },
+          action: "agent",
+          messageTemplate: "Mapped: {{payload.subject}}",
+          sessionKey: "agent:main:subagent:worker",
+        },
+      ],
+    };
+
+    await expect(withGatewayServer(async () => undefined)).rejects.toThrow(
+      "hook mapping 'mapping-1' sessionKey may not target internal session namespace subagent:",
+    );
+  });
+
   test("preserves mapped hook provenance across async dispatch", async () => {
     testState.hooksConfig = {
       enabled: true,


### PR DESCRIPTION
## Summary
- reject hook-provided session keys that target internal `subagent:`, `acp:`, or `cron:` namespaces
- validate `hooks.defaultSessionKey` against the same reserved namespaces at config load time
- add unit + server hook regressions covering request, mapping, and config paths

## Why
Hook agent runs execute through the isolated cron path. If external hooks can choose an existing internal session namespace, the resulting run inherits session-key scoped control state intended only for internal subagent / ACP / cron flows.

## Testing
- pnpm exec vitest run src/gateway/hooks.test.ts src/gateway/server.hooks.test.ts src/cron/isolated-agent/run.session-key.test.ts