### PR TITLE
fix(agents): preserve embedded auth injection for custom streamFns

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -24,6 +24,7 @@ import {
   stripSessionsYieldArtifacts,
   shouldInjectHeartbeatPrompt,
   decodeHtmlEntitiesInObject,
+  wrapStreamFnWithModelRegistryAuth,
   wrapStreamFnRepairMalformedToolCallArguments,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
@@ -302,6 +303,88 @@ describe("composeSystemPromptWithHookContext", () => {
     expect(turns[2]?.prompt.startsWith("hello once more")).toBe(true);
     expect(turns[0]?.prompt).toContain("[Bootstrap truncation warning]");
     expect(turns[2]?.prompt).toContain("[Bootstrap truncation warning]");
+  });
+});
+
+describe("wrapStreamFnWithModelRegistryAuth", () => {
+  it("injects request auth from modelRegistry into custom stream overrides", async () => {
+    const calls: Array<{ apiKey?: string; headers?: Record<string, string> }> = [];
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      calls.push({
+        apiKey: options?.apiKey,
+        headers: options?.headers,
+      });
+      return createFakeStream({ events: [], resultMessage: {} });
+    });
+    const wrapped = wrapStreamFnWithModelRegistryAuth(baseStreamFn as never, "sk-runtime-test");
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-test",
+        headers: { Authorization: null, "X-Model": "1" },
+      } as never,
+      { messages: [] } as never,
+      { headers: { "X-Caller": "2" } } as never,
+    );
+
+    expect(calls).toEqual([
+      {
+        apiKey: "sk-runtime-test",
+        headers: {
+          Authorization: null,
+          "X-Model": "1",
+          "X-Caller": "2",
+        },
+      },
+    ]);
+  });
+
+  it("preserves an explicit caller apiKey", async () => {
+    const calls: Array<{ apiKey?: string }> = [];
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      calls.push({ apiKey: options?.apiKey });
+      return createFakeStream({ events: [], resultMessage: {} });
+    });
+    const wrapped = wrapStreamFnWithModelRegistryAuth(baseStreamFn as never, "sk-runtime-test");
+
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-test",
+      } as never,
+      { messages: [] } as never,
+      { apiKey: "sk-caller" } as never,
+    );
+
+    expect(calls).toEqual([{ apiKey: "sk-caller" }]);
+  });
+
+  it("falls back to the original call when no request auth is available", async () => {
+    const calls: Array<{ apiKey?: string; headers?: Record<string, string> }> = [];
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      calls.push({
+        apiKey: options?.apiKey,
+        headers: options?.headers,
+      });
+      return createFakeStream({ events: [], resultMessage: {} });
+    });
+    const wrapped = wrapStreamFnWithModelRegistryAuth(baseStreamFn as never, undefined);
+
+    const originalOptions = { headers: { "X-Caller": "2" } };
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-test",
+      } as never,
+      { messages: [] } as never,
+      originalOptions as never,
+    );
+
+    expect(calls).toEqual([{ apiKey: undefined, headers: { "X-Caller": "2" } }]);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
@@ -274,6 +274,31 @@ function summarizeSessionContext(messages: AgentMessage[]): {
     totalTextChars,
     totalImageBlocks,
     maxMessageTextChars,
+  };
+}
+
+export function wrapStreamFnWithModelRegistryAuth(
+  streamFn: StreamFn,
+  resolvedApiKey: string | undefined,
+): StreamFn {
+  return (model, context, options) => {
+    const modelHeaders =
+      model.headers && typeof model.headers === "object" && !Array.isArray(model.headers)
+        ? (model.headers as Record<string, string>)
+        : undefined;
+
+    if (!resolvedApiKey && !modelHeaders) {
+      return streamFn(model, context, options);
+    }
+
+    return streamFn(model, context, {
+      ...options,
+      ...(resolvedApiKey && options?.apiKey === undefined ? { apiKey: resolvedApiKey } : {}),
+      headers: {
+        ...(modelHeaders ?? {}),
+        ...(options?.headers ?? {}),
+      },
+    });
   };
 }
 
@@ -850,8 +875,18 @@ export async function runEmbeddedAttempt(
         agentDir,
         workspaceDir: effectiveWorkspace,
       });
+      const resolvedAttemptApiKey = await params.modelRegistry
+        .getApiKey(params.model)
+        .then((apiKey) => (typeof apiKey === "string" && apiKey.length > 0 ? apiKey : undefined))
+        .catch(() => undefined);
+      const setBaseStreamFn = (streamFn: StreamFn) => {
+        activeSession.agent.streamFn = wrapStreamFnWithModelRegistryAuth(
+          streamFn,
+          resolvedAttemptApiKey,
+        );
+      };
       if (providerStreamFn) {
-        activeSession.agent.streamFn = providerStreamFn;
+        setBaseStreamFn(providerStreamFn);
       } else if (
         shouldUseOpenAIWebSocketTransport({
           provider: params.provider,
@@ -860,20 +895,22 @@ export async function runEmbeddedAttempt(
       ) {
         const wsApiKey = await params.authStorage.getApiKey(params.provider);
         if (wsApiKey) {
-          activeSession.agent.streamFn = createOpenAIWebSocketStreamFn(wsApiKey, params.sessionId, {
-            signal: runAbortController.signal,
-          });
+          setBaseStreamFn(
+            createOpenAIWebSocketStreamFn(wsApiKey, params.sessionId, {
+              signal: runAbortController.signal,
+            }),
+          );
         } else {
           log.warn(`[ws-stream] no API key for provider=${params.provider}; using HTTP transport`);
-          activeSession.agent.streamFn = streamSimple;
+          setBaseStreamFn(streamSimple);
         }
       } else if (params.model.provider === "anthropic-vertex") {
         // Anthropic Vertex AI: inject AnthropicVertex client into pi-ai's
         // streamAnthropic for GCP IAM auth instead of Anthropic API keys.
-        activeSession.agent.streamFn = createAnthropicVertexStreamFnForModel(params.model);
+        setBaseStreamFn(createAnthropicVertexStreamFnForModel(params.model));
       } else {
         // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
-        activeSession.agent.streamFn = streamSimple;
+        setBaseStreamFn(streamSimple);
       }
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(


### PR DESCRIPTION
## Summary
- preserve auth injection when the embedded runner swaps in custom streamFns after createAgentSession()
- make custom stream override assignment update the wrapped base stream instead of replacing the upstream-auth-wrapped outer function
- add focused regression coverage for post-session stream overrides so provider auth continues to flow through embedded runs

## Testing
- targeted embedded runner tests updated alongside the fix
- broader runtime validation remains limited in this environment

Closes #55760