### PR TITLE
sandbox: add workspaceMountPropagation config for Docker workspace mount

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -121,6 +121,8 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    workspaceMountPropagation:
+      agentDocker?.workspaceMountPropagation ?? globalDocker?.workspaceMountPropagation,
     ...resolveDangerousSandboxDockerBooleans(agentDocker, globalDocker),
   };
 }

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -275,14 +275,14 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(createCall?.args).toContain(`openclaw.configHash=${expectedHash}`);
 
     const bindArgs = collectDockerFlagValues(createCall?.args ?? [], "-v");
-    const workspaceMountIdx = bindArgs.indexOf("/tmp/workspace:/workspace");
+    const workspaceMountIdx = bindArgs.indexOf("/tmp/workspace:/workspace:rw");
     const customMountIdx = bindArgs.indexOf("/tmp/workspace-shared/USER.md:/workspace/USER.md:ro");
     expect(workspaceMountIdx).toBeGreaterThanOrEqual(0);
     expect(customMountIdx).toBeGreaterThan(workspaceMountIdx);
   });
 
   it.each([
-    { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace" },
+    { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace:rw" },
     { workspaceAccess: "ro" as const, expectedMainMount: "/tmp/workspace:/workspace:ro" },
     { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:ro" },
   ])(

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -462,6 +462,7 @@ async function createSandboxContainer(params: {
     agentWorkspaceDir: params.agentWorkspaceDir,
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
+    workspaceMountPropagation: cfg.workspaceMountPropagation,
   });
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -3,7 +3,7 @@ import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
 
 describe("appendWorkspaceMountArgs", () => {
   it.each([
-    { access: "rw" as const, expected: "/tmp/workspace:/workspace" },
+    { access: "rw" as const, expected: "/tmp/workspace:/workspace:rw" },
     { access: "ro" as const, expected: "/tmp/workspace:/workspace:ro" },
     { access: "none" as const, expected: "/tmp/workspace:/workspace:ro" },
   ])("sets main mount permissions for workspaceAccess=$access", ({ access, expected }) => {
@@ -44,6 +44,42 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace"]);
+    expect(mounts).toEqual(["/tmp/workspace:/workspace:rw"]);
+  });
+
+  it.each([
+    { propagation: "private" as const, expected: "/tmp/workspace:/workspace:rw" },
+    { propagation: "rslave" as const, expected: "/tmp/workspace:/workspace:rw,rslave" },
+    { propagation: "rshared" as const, expected: "/tmp/workspace:/workspace:rw,rshared" },
+  ])(
+    "appends propagation mode to workspace mount for workspaceMountPropagation=$propagation",
+    ({ propagation, expected }) => {
+      const args: string[] = [];
+      appendWorkspaceMountArgs({
+        args,
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/agent-workspace",
+        workdir: "/workspace",
+        workspaceAccess: "rw",
+        workspaceMountPropagation: propagation,
+      });
+
+      expect(args).toContain(expected);
+    },
+  );
+
+  it("does not append propagation to agent workspace mount", () => {
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/agent-workspace",
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+      workspaceMountPropagation: "rslave",
+    });
+
+    expect(args).toContain("/tmp/workspace:/workspace:rw,rslave");
+    expect(args).toContain("/tmp/agent-workspace:/agent");
   });
 });

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -1,8 +1,17 @@
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
-function mainWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {
-  return access === "rw" ? "" : ":ro";
+type WorkspaceMountPropagation = "private" | "rslave" | "rshared";
+
+function mainWorkspaceMountSpec(
+  access: SandboxWorkspaceAccess,
+  propagation: WorkspaceMountPropagation | undefined,
+): string {
+  const parts: string[] = [access === "rw" ? "rw" : "ro"];
+  if (propagation && propagation !== "private") {
+    parts.push(propagation);
+  }
+  return parts.join(",");
 }
 
 function agentWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {
@@ -15,10 +24,12 @@ export function appendWorkspaceMountArgs(params: {
   agentWorkspaceDir: string;
   workdir: string;
   workspaceAccess: SandboxWorkspaceAccess;
+  workspaceMountPropagation?: WorkspaceMountPropagation;
 }) {
   const { args, workspaceDir, agentWorkspaceDir, workdir, workspaceAccess } = params;
 
-  args.push("-v", `${workspaceDir}:${workdir}${mainWorkspaceMountSuffix(workspaceAccess)}`);
+  const spec = mainWorkspaceMountSpec(workspaceAccess, params.workspaceMountPropagation);
+  args.push("-v", `${workspaceDir}:${workdir}:${spec}`);
   if (workspaceAccess !== "none" && workspaceDir !== agentWorkspaceDir) {
     args.push(
       "-v",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2998,6 +2998,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                       dangerouslyAllowContainerNamespaceJoin: {
                         type: "boolean",
                       },
+                      workspaceMountPropagation: {
+                        type: "string",
+                        enum: ["private", "rslave", "rshared"],
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -4135,6 +4139,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                         },
                         dangerouslyAllowContainerNamespaceJoin: {
                           type: "boolean",
+                        },
+                        workspaceMountPropagation: {
+                          type: "string",
+                          enum: ["private", "rslave", "rshared"],
                         },
                       },
                       additionalProperties: false,

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -59,6 +59,18 @@ export type SandboxDockerSettings = {
    * Default behavior blocks container namespace joins to preserve sandbox isolation.
    */
   dangerouslyAllowContainerNamespaceJoin?: boolean;
+  /**
+   * Mount propagation mode for the workspace bind mount.
+   * - "private" (default): host sub-mounts inside the workspace are not visible in the container.
+   * - "rslave": host sub-mounts inside the workspace propagate into the container (read-only).
+   * - "rshared": host sub-mounts inside the workspace propagate bidirectionally.
+   *
+   * Set to "rslave" when the workspace directory contains host-level bind mounts
+   * (e.g. symlink targets mounted via `mount --bind`) that you want accessible to
+   * the sandbox file tools. Requires the host mount point to have shared propagation
+   * (`mount --make-shared`).
+   */
+  workspaceMountPropagation?: "private" | "rslave" | "rshared";
 };
 
 export type SandboxBrowserSettings = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -135,6 +135,7 @@ export const SandboxDockerSchema = z
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
+    workspaceMountPropagation: z.enum(["private", "rslave", "rshared"]).optional(),
   })
   .strict()
   .superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary

- Adds `sandbox.docker.workspaceMountPropagation` option (`"private"` | `"rslave"` | `"rshared"`) to control the bind propagation mode of the workspace mount passed to `docker create -v`
- Default is `"private"` — no change to existing behavior
- `"rslave"` causes host-level bind mounts inside the workspace directory to propagate into the container

## Motivation

When a workspace subdirectory is itself a bind mount on the host (e.g. `mount --bind /other/path workspace/subdir`), Docker's default `rprivate` propagation makes that subdirectory appear empty inside the container. Setting `workspaceMountPropagation: "rslave"` makes host sub-mounts visible to the sandbox, enabling patterns like mounting a shared skills directory into multiple agent workspaces without symlinks.

The host mount point must have shared propagation (`mount --make-shared`) for `rslave` to take effect.

## Test plan

- [x] Updated existing workspace mount tests to reflect explicit `rw` in mount spec
- [x] Added propagation test cases for `private`, `rslave`, `rshared`
- [x] Updated `docker.config-hash-recreate` test expectations
- [x] Full `pnpm check` passes (lint, format, type, schema drift)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)