### PR TITLE
fix(macos): preserve customized AGENTS.md during bootstrap repair

### DIFF
--- a/apps/macos/Sources/OpenClaw/AgentWorkspace.swift
+++ b/apps/macos/Sources/OpenClaw/AgentWorkspace.swift
@@ -67,7 +67,8 @@ enum AgentWorkspace {
     static func isTemplateOnlyWorkspace(workspaceURL: URL) -> Bool {
         guard let entries = try? self.workspaceEntries(workspaceURL: workspaceURL) else { return false }
         guard !entries.isEmpty else { return true }
-        return Set(entries).isSubset(of: self.templateEntries)
+        guard Set(entries).isSubset(of: self.templateEntries) else { return false }
+        return self.presentTemplateEntriesMatchDefaults(entries, workspaceURL: workspaceURL)
     }
 
     static func bootstrapSafety(for workspaceURL: URL) -> BootstrapSafety {
@@ -337,6 +338,38 @@ enum AgentWorkspace {
         let remainder = content[range.upperBound...]
         let trimmed = remainder.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed + "\n"
+    }
+
+    private static func presentTemplateEntriesMatchDefaults(_ entries: [String], workspaceURL: URL) -> Bool {
+        for entry in entries {
+            let expectedContents = self.defaultTemplateContents(for: entry)
+            guard let expectedContents else { return false }
+            let fileURL = workspaceURL.appendingPathComponent(entry)
+            guard let actualContents = try? String(contentsOf: fileURL, encoding: .utf8) else {
+                return false
+            }
+            if actualContents != expectedContents {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func defaultTemplateContents(for entry: String) -> String? {
+        switch entry {
+        case self.agentsFilename:
+            return self.defaultTemplate()
+        case self.soulFilename:
+            return self.defaultSoulTemplate()
+        case self.identityFilename:
+            return self.defaultIdentityTemplate()
+        case self.userFilename:
+            return self.defaultUserTemplate()
+        case self.bootstrapFilename:
+            return self.defaultBootstrapTemplate()
+        default:
+            return nil
+        }
     }
 
     // Identity is written by the agent during the bootstrap ritual.

--- a/apps/macos/Tests/OpenClawIPCTests/AgentWorkspaceTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AgentWorkspaceTests.swift
@@ -109,4 +109,70 @@ struct AgentWorkspaceTests {
 
         #expect(!AgentWorkspace.needsBootstrap(workspaceURL: tmp))
     }
+
+    @Test
+    func `needs bootstrap false when AGENTS is customized`() throws {
+        let tmp = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-ws-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: tmp) }
+        try FileManager().createDirectory(at: tmp, withIntermediateDirectories: true)
+
+        try """
+        # AGENTS.md - OpenClaw Workspace
+
+        Custom instructions for this agent only.
+        """.write(
+            to: tmp.appendingPathComponent(AgentWorkspace.agentsFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultSoulTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.soulFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultIdentityTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.identityFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultUserTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.userFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultBootstrapTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.bootstrapFilename),
+            atomically: true,
+            encoding: .utf8)
+
+        #expect(!AgentWorkspace.needsBootstrap(workspaceURL: tmp))
+    }
+
+    @Test
+    func `needs bootstrap true when workspace still matches defaults`() throws {
+        let tmp = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-ws-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: tmp) }
+        try FileManager().createDirectory(at: tmp, withIntermediateDirectories: true)
+
+        try AgentWorkspace.defaultTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.agentsFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultSoulTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.soulFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultIdentityTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.identityFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultUserTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.userFilename),
+            atomically: true,
+            encoding: .utf8)
+        try AgentWorkspace.defaultBootstrapTemplate().write(
+            to: tmp.appendingPathComponent(AgentWorkspace.bootstrapFilename),
+            atomically: true,
+            encoding: .utf8)
+
+        #expect(AgentWorkspace.needsBootstrap(workspaceURL: tmp))
+    }
 }


### PR DESCRIPTION
## Summary
- stop the macOS workspace/bootstrap repair path from overwriting a non-empty customized AGENTS.md when restoring missing template files
- keep the bootstrap repair behavior for missing companion files like SOUL.md / USER.md / BOOTSTRAP.md
- add focused macOS workspace tests covering both customized and default/template-only workspaces

## Testing
- targeted macOS AgentWorkspace tests updated alongside the fix
- broader runtime validation remains limited in this environment

Closes #55774