### PR TITLE
fix: inject anthropic service_tier for OAuth auth

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2058,7 +2058,7 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.service_tier).toBe("standard_only");
   });
 
-  it("does not inject Anthropic fast mode service_tier for OAuth auth", () => {
+  it("injects Anthropic fast mode service_tier for OAuth auth", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "anthropic",
       applyModelId: "claude-sonnet-4-5",
@@ -2074,7 +2074,26 @@ describe("applyExtraParamsToAgent", () => {
       },
       payload: {},
     });
-    expect(payload).not.toHaveProperty("service_tier");
+    expect(payload.service_tier).toBe("auto");
+  });
+
+  it("injects Anthropic standard_only service_tier for OAuth auth when fast mode is off", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-sonnet-4-5",
+      extraParamsOverride: { fastMode: false },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        baseUrl: "https://api.anthropic.com",
+      } as unknown as Model<"anthropic-messages">,
+      options: {
+        apiKey: "sk-ant-oat-test-token",
+      },
+      payload: {},
+    });
+    expect(payload.service_tier).toBe("standard_only");
   });
 
   it("does not inject Anthropic fast mode service_tier for proxied base URLs", () => {

--- a/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/anthropic-stream-wrappers.ts
@@ -361,8 +361,7 @@ export function createAnthropicFastModeWrapper(
     if (
       model.api !== "anthropic-messages" ||
       model.provider !== "anthropic" ||
-      !isAnthropicPublicApiBaseUrl(model.baseUrl) ||
-      isAnthropicOAuthApiKey(options?.apiKey)
+      !isAnthropicPublicApiBaseUrl(model.baseUrl)
     ) {
       return underlying(model, context, options);
     }


### PR DESCRIPTION
## Summary

Allow Anthropic OAuth-backed requests (`sk-ant-oat-*`) to receive the same `service_tier` injection as direct Anthropic API-key requests. This removes the broad OAuth exclusion in `createAnthropicFastModeWrapper`, so OpenClaw no longer silently drops `service_tier` for OAuth auth and is less likely to hit avoidable 529 overload cascades.

## Changes

- remove the OAuth-only early return from `createAnthropicFastModeWrapper`
- update the existing OAuth expectation to assert `service_tier=auto` in fast mode
- add a regression test covering OAuth + `fastMode: false` => `service_tier=standard_only`

## Testing

- `pnpm exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts` ✅ (94 tests passed)
- repo pre-commit hook runs `pnpm check`, but that currently fails on unrelated existing format-check drift in many UI/test files; this PR does not touch those files

Fixes openclaw/openclaw#55758