### PR TITLE
fix(gateway): block internal HTTP session overrides

### DIFF
--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -54,9 +54,18 @@ describe("resolveGatewayRequestContext", () => {
 
   it("rejects explicit session keys that target internal session namespaces", () => {
     const cases = [
-      { sessionKey: "agent:main:subagent:worker", expectedPrefix: "subagent:" },
-      { sessionKey: "agent:main:acp:session", expectedPrefix: "acp:" },
-      { sessionKey: "cron:daily", expectedPrefix: "cron:" },
+      {
+        sessionKey: "agent:main:subagent:worker",
+        expectedPrefix: "subagent:",
+      },
+      {
+        sessionKey: "agent:main:acp:session",
+        expectedPrefix: "acp:",
+      },
+      {
+        sessionKey: "cron:daily",
+        expectedPrefix: "cron:",
+      },
     ];
 
     for (const testCase of cases) {

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -51,6 +51,27 @@ describe("resolveGatewayRequestContext", () => {
 
     expect(result.sessionKey).toContain("openresponses-user:alice");
   });
+
+  it("rejects explicit session keys that target internal session namespaces", () => {
+    const cases = [
+      { sessionKey: "agent:main:subagent:worker", expectedPrefix: "subagent:" },
+      { sessionKey: "agent:main:acp:session", expectedPrefix: "acp:" },
+      { sessionKey: "cron:daily", expectedPrefix: "cron:" },
+    ];
+
+    for (const testCase of cases) {
+      expect(() =>
+        resolveGatewayRequestContext({
+          req: createReq({ "x-openclaw-session-key": testCase.sessionKey }),
+          model: "openclaw",
+          sessionPrefix: "openai",
+          defaultMessageChannel: "webchat",
+        }),
+      ).toThrow(
+        `x-openclaw-session-key may not target internal session namespace ${testCase.expectedPrefix}`,
+      );
+    }
+  });
 });
 
 describe("resolveTrustedHttpOperatorScopes", () => {

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -51,6 +51,48 @@ describe("resolveGatewayRequestContext", () => {
 
     expect(result.sessionKey).toContain("openresponses-user:alice");
   });
+
+  it("rejects explicit session keys that target internal session namespaces", () => {
+    const cases = [
+      {
+        sessionKey: "subagent:worker",
+        expectedPrefix: "subagent:",
+      },
+      {
+        sessionKey: "agent:main:subagent:worker",
+        expectedPrefix: "subagent:",
+      },
+      {
+        sessionKey: "acp:session",
+        expectedPrefix: "acp:",
+      },
+      {
+        sessionKey: "agent:main:acp:session",
+        expectedPrefix: "acp:",
+      },
+      {
+        sessionKey: "cron:daily",
+        expectedPrefix: "cron:",
+      },
+      {
+        sessionKey: "agent:main:cron:daily",
+        expectedPrefix: "cron:",
+      },
+    ];
+
+    for (const testCase of cases) {
+      expect(() =>
+        resolveGatewayRequestContext({
+          req: createReq({ "x-openclaw-session-key": testCase.sessionKey }),
+          model: "openclaw",
+          sessionPrefix: "openai",
+          defaultMessageChannel: "webchat",
+        }),
+      ).toThrow(
+        `x-openclaw-session-key may not target internal session namespace ${testCase.expectedPrefix}`,
+      );
+    }
+  });
 });
 
 describe("resolveTrustedHttpOperatorScopes", () => {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -8,7 +8,11 @@ import {
   resolveDefaultModelForAgent,
 } from "../agents/model-selection.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -35,6 +39,14 @@ export {
 
 export const OPENCLAW_MODEL_ID = "openclaw";
 export const OPENCLAW_DEFAULT_MODEL_ID = "openclaw/default";
+const RESERVED_SESSION_KEY_PREFIXES = ["subagent:", "acp:", "cron:"] as const;
+
+export class GatewaySessionKeyOverrideError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GatewaySessionKeyOverrideError";
+  }
+}
 
 export function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
   const raw =
@@ -134,12 +146,35 @@ export function resolveSessionKey(params: {
 }): string {
   const explicit = getHeader(params.req, "x-openclaw-session-key")?.trim();
   if (explicit) {
+    const reservedPrefix = resolveReservedSessionKeyPrefix(explicit);
+    if (reservedPrefix) {
+      throw new GatewaySessionKeyOverrideError(
+        `x-openclaw-session-key may not target internal session namespace ${reservedPrefix}`,
+      );
+    }
     return explicit;
   }
 
   const user = params.user?.trim();
   const mainKey = user ? `${params.prefix}-user:${user}` : `${params.prefix}:${randomUUID()}`;
   return buildAgentMainSessionKey({ agentId: params.agentId, mainKey });
+}
+
+function resolveReservedSessionKeyPrefix(sessionKey: string): string | undefined {
+  const normalized = normalizeReservedSessionKeyCandidate(sessionKey);
+  if (!normalized) {
+    return undefined;
+  }
+  return RESERVED_SESSION_KEY_PREFIXES.find((prefix) => normalized.startsWith(prefix));
+}
+
+function normalizeReservedSessionKeyCandidate(sessionKey: string): string | undefined {
+  const trimmed = sessionKey.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = parseAgentSessionKey(trimmed)?.rest ?? trimmed;
+  return normalized.trim().toLowerCase() || undefined;
 }
 
 export function resolveGatewayRequestContext(params: {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -9,7 +9,11 @@ import { modelKey, parseModelRef, resolveDefaultModelForAgent } from "../agents/
 import { createModelVisibilityPolicy } from "../agents/model-visibility-policy.js";
 import { getRuntimeConfig } from "../config/io.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
-import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-auth-utils.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
@@ -33,6 +37,14 @@ export {
 
 export const OPENCLAW_MODEL_ID = "openclaw";
 export const OPENCLAW_DEFAULT_MODEL_ID = "openclaw/default";
+const RESERVED_SESSION_KEY_PREFIXES = ["subagent:", "acp:", "cron:"] as const;
+
+export class GatewaySessionKeyOverrideError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GatewaySessionKeyOverrideError";
+  }
+}
 
 function resolveAgentIdFromHeader(req: IncomingMessage): string | undefined {
   const raw =
@@ -146,12 +158,35 @@ function resolveSessionKey(params: {
 }): string {
   const explicit = getHeader(params.req, "x-openclaw-session-key")?.trim();
   if (explicit) {
+    const reservedPrefix = resolveReservedSessionKeyPrefix(explicit);
+    if (reservedPrefix) {
+      throw new GatewaySessionKeyOverrideError(
+        `x-openclaw-session-key may not target internal session namespace ${reservedPrefix}`,
+      );
+    }
     return explicit;
   }
 
   const user = params.user?.trim();
   const mainKey = user ? `${params.prefix}-user:${user}` : `${params.prefix}:${randomUUID()}`;
   return buildAgentMainSessionKey({ agentId: params.agentId, mainKey });
+}
+
+function resolveReservedSessionKeyPrefix(sessionKey: string): string | undefined {
+  const normalized = normalizeReservedSessionKeyCandidate(sessionKey);
+  if (!normalized) {
+    return undefined;
+  }
+  return RESERVED_SESSION_KEY_PREFIXES.find((prefix) => normalized.startsWith(prefix));
+}
+
+function normalizeReservedSessionKeyCandidate(sessionKey: string): string | undefined {
+  const trimmed = sessionKey.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const normalized = parseAgentSessionKey(trimmed)?.rest ?? trimmed;
+  return normalized.trim().toLowerCase() || undefined;
 }
 
 export function resolveGatewayRequestContext(params: {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -231,6 +231,20 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-session-key": "agent:main:subagent:worker" },
+        );
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toContain("internal session namespace subagent:");
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
+
+      {
         mockAgentOnce([{ text: "hello" }]);
         const res = await postChatCompletions(port, {
           user: "alice",

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -248,6 +248,20 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       }
 
       {
+        agentCommand.mockClear();
+        const res = await postChatCompletions(
+          port,
+          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          { "x-openclaw-session-key": "agent:main:subagent:worker" },
+        );
+        expect(res.status).toBe(400);
+        const json = (await res.json()) as { error?: { type?: string; message?: string } };
+        expect(json.error?.type).toBe("invalid_request_error");
+        expect(json.error?.message).toContain("internal session namespace subagent:");
+        expect(agentCommand).toHaveBeenCalledTimes(0);
+      }
+
+      {
         mockAgentOnce([{ text: "hello" }]);
         const res = await postChatCompletions(port, {
           user: "alice",

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -38,6 +38,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
+  GatewaySessionKeyOverrideError,
   resolveGatewayRequestContext,
   resolveOpenAiCompatModelOverride,
   resolveOpenAiCompatibleHttpOperatorScopes,
@@ -546,14 +547,30 @@ export async function handleOpenAiHttpRequest(
   const model = typeof payload.model === "string" ? payload.model : "openclaw";
   const user = typeof payload.user === "string" ? payload.user : undefined;
 
-  const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openai",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let agentId: string;
+  let sessionKey: string;
+  let messageChannel: string;
+  try {
+    ({ agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+    }));
+  } catch (err) {
+    if (!(err instanceof GatewaySessionKeyOverrideError)) {
+      throw err;
+    }
+    sendJson(res, 400, {
+      error: {
+        message: err.message,
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -43,6 +43,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
+  GatewaySessionKeyOverrideError,
   resolveGatewayRequestContext,
   resolveOpenAiCompatModelOverride,
   resolveOpenAiCompatibleHttpOperatorScopes,
@@ -960,14 +961,30 @@ export async function handleOpenAiHttpRequest(
         }
       : undefined;
 
-  const { agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openai",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let agentId: string;
+  let sessionKey: string;
+  let messageChannel: string;
+  try {
+    ({ agentId, sessionKey, messageChannel } = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openai",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+    }));
+  } catch (err) {
+    if (!(err instanceof GatewaySessionKeyOverrideError)) {
+      throw err;
+    }
+    sendJson(res, 400, {
+      error: {
+        message: err.message,
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,
     agentId,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -264,6 +264,20 @@ describe("OpenResponses HTTP API (e2e)", () => {
       );
       await ensureResponseConsumed(resHeader);
 
+      agentCommand.mockClear();
+      const resInternalSession = await postResponses(
+        port,
+        { model: "openclaw", input: "hi" },
+        { "x-openclaw-session-key": "agent:main:subagent:worker" },
+      );
+      expect(resInternalSession.status).toBe(400);
+      const internalSessionJson = (await resInternalSession.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(internalSessionJson.error?.type).toBe("invalid_request_error");
+      expect(internalSessionJson.error?.message).toContain("internal session namespace subagent:");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+
       mockAgentOnce([{ text: "hello" }]);
       const resModel = await postResponses(port, { model: "openclaw/beta", input: "hi" });
       expect(resModel.status).toBe(200);

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -313,6 +313,20 @@ describe("OpenResponses HTTP API (e2e)", () => {
       );
       await ensureResponseConsumed(resHeader);
 
+      agentCommand.mockClear();
+      const resInternalSession = await postResponses(
+        port,
+        { model: "openclaw", input: "hi" },
+        { "x-openclaw-session-key": "agent:main:subagent:worker" },
+      );
+      expect(resInternalSession.status).toBe(400);
+      const internalSessionJson = (await resInternalSession.json()) as {
+        error?: { type?: string; message?: string };
+      };
+      expect(internalSessionJson.error?.type).toBe("invalid_request_error");
+      expect(internalSessionJson.error?.message).toContain("internal session namespace subagent:");
+      expect(agentCommand).toHaveBeenCalledTimes(0);
+
       mockAgentOnce([{ text: "hello" }]);
       const resModel = await postResponses(port, { model: "openclaw/beta", input: "hi" });
       expect(resModel.status).toBe(200);

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -38,6 +38,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
+  GatewaySessionKeyOverrideError,
   getBearerToken,
   getHeader,
   resolveAgentIdForRequest,
@@ -619,14 +620,28 @@ export async function handleOpenResponsesHttpRequest(
     });
     return true;
   }
-  const resolved = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openresponses",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let resolved: ReturnType<typeof resolveGatewayRequestContext>;
+  try {
+    resolved = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openresponses",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+    });
+  } catch (err) {
+    if (!(err instanceof GatewaySessionKeyOverrideError)) {
+      throw err;
+    }
+    sendJson(res, 400, {
+      error: {
+        message: err.message,
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
   const responseSessionScope = createResponseSessionScope({
     req,
     auth: opts.auth,

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -39,6 +39,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
+  GatewaySessionKeyOverrideError,
   getBearerToken,
   getHeader,
   resolveAgentIdForRequest,
@@ -624,14 +625,28 @@ export async function handleOpenResponsesHttpRequest(
     });
     return true;
   }
-  const resolved = resolveGatewayRequestContext({
-    req,
-    model,
-    user,
-    sessionPrefix: "openresponses",
-    defaultMessageChannel: "webchat",
-    useMessageChannelHeader: true,
-  });
+  let resolved: ReturnType<typeof resolveGatewayRequestContext>;
+  try {
+    resolved = resolveGatewayRequestContext({
+      req,
+      model,
+      user,
+      sessionPrefix: "openresponses",
+      defaultMessageChannel: "webchat",
+      useMessageChannelHeader: true,
+    });
+  } catch (err) {
+    if (!(err instanceof GatewaySessionKeyOverrideError)) {
+      throw err;
+    }
+    sendJson(res, 400, {
+      error: {
+        message: err.message,
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
   const responseSessionScope = createResponseSessionScope({
     req,
     auth: opts.auth,


### PR DESCRIPTION
## Summary
- reject explicit `x-openclaw-session-key` overrides that target internal namespaces like `subagent:`, `acp:`, or `cron:`
- return a 400 `invalid_request_error` from the OpenAI and OpenResponses HTTP endpoints instead of passing those keys into owner-trusted ingress
- add request-context and endpoint coverage for the blocked overrides while preserving normal custom session keys

## Testing
- pnpm exec vitest run src/gateway/http-utils.request-context.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts