### PR TITLE
fix(agents): suppress invalid Telegram reaction alerts

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -283,6 +283,18 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("suppresses invalid Telegram reaction warnings when messages.suppressToolErrors is enabled", () => {
+    expectNoPayloads({
+      lastToolError: {
+        toolName: "telegram",
+        meta: "react",
+        error: "REACTION_INVALID",
+        mutatingAction: true,
+      },
+      config: { messages: { suppressToolErrors: true } },
+    });
+  });
+
   it.each([
     {
       name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -34,6 +34,18 @@ type ToolErrorWarningPolicy = {
   includeDetails: boolean;
 };
 
+function isSuppressibleInvalidReactionWarning(lastToolError: LastToolError): boolean {
+  const normalizedToolName = lastToolError.toolName.trim().toLowerCase();
+  if (normalizedToolName !== "telegram") {
+    return false;
+  }
+  const errorLower = (lastToolError.error ?? "").trim().toLowerCase();
+  return (
+    errorLower === "reaction_invalid" ||
+    errorLower.includes("reaction unavailable:")
+  );
+}
+
 const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
   "required",
   "missing",
@@ -76,6 +88,9 @@ function resolveToolErrorWarningPolicy(params: {
   }
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
+  if (params.suppressToolErrors && isSuppressibleInvalidReactionWarning(params.lastToolError)) {
+    return { showWarning: false, includeDetails };
+  }
   if (isMutatingToolError) {
     return { showWarning: true, includeDetails };
   }


### PR DESCRIPTION
## Summary
- suppress benign Telegram REACTION_INVALID / reaction-unavailable tool warnings when messages.suppressToolErrors is enabled
- keep the suppression narrowly scoped so other mutating tool failures still surface as alerts
- add focused payload regression coverage for the invalid-reaction case

## Testing
- targeted embedded runner payload tests updated alongside the fix
- runtime test execution remains limited in this environment because dependency install hit npm DNS/network issues

Closes #55786