### PR TITLE
fix(agents): keep Telegram message buttons optional

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -546,6 +546,58 @@ describe("message tool schema scoping", () => {
     expect(schema.required ?? []).not.toContain("buttons");
   });
 
+  it("keeps contributed optional buttons out of required even when the optional marker comes from another typebox copy", () => {
+    const foreignOptionalMarker = Symbol("TypeBox.Optional");
+    const telegramPluginWithForeignOptionalButtons = createChannelPlugin({
+      id: "telegram",
+      label: "Telegram",
+      docsPath: "/channels/telegram",
+      blurb: "Telegram test plugin.",
+      actions: ["send"],
+      capabilities: ["interactive", "buttons"],
+      toolSchema: () => ({
+        properties: {
+          buttons: {
+            type: "array",
+            items: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  text: { type: "string" },
+                  callback_data: { type: "string" },
+                },
+              },
+            },
+            [foreignOptionalMarker]: "Optional",
+          } as unknown as ReturnType<typeof createMessageToolButtonsSchema>,
+        },
+      }),
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: telegramPluginWithForeignOptionalButtons,
+        },
+      ]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "telegram",
+    });
+    const schema = tool.parameters as {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    };
+
+    expect(schema.properties?.buttons).toBeDefined();
+    expect(schema.required ?? []).not.toContain("buttons");
+  });
+
   it("hides telegram poll extras when telegram polls are disabled in scoped mode", () => {
     const telegramPluginWithConfig = createChannelPlugin({
       id: "telegram",

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -370,6 +370,13 @@ function buildMessageToolSchemaProps(options: {
   };
 }
 
+function isOptionalSchemaMarker(schema: TSchema): boolean {
+  return Object.getOwnPropertySymbols(schema).some((symbol) => {
+    const description = symbol.description ?? String(symbol);
+    return description.includes("Optional");
+  });
+}
+
 function buildMessageToolSchemaFromActions(
   actions: readonly string[],
   options: {
@@ -378,10 +385,21 @@ function buildMessageToolSchemaFromActions(
   },
 ) {
   const props = buildMessageToolSchemaProps(options);
-  return Type.Object({
+  const optionalPropertyNames = Object.entries(props)
+    .filter(([, schema]) => isOptionalSchemaMarker(schema))
+    .map(([name]) => name);
+  const schema = Type.Object({
     action: stringEnum(actions),
     ...props,
   });
+  if (optionalPropertyNames.length === 0 || !Array.isArray(schema.required)) {
+    return schema;
+  }
+  const required = schema.required.filter((name) => !optionalPropertyNames.includes(name));
+  return {
+    ...schema,
+    ...(required.length > 0 ? { required } : {}),
+  };
 }
 
 const MessageToolSchema = buildMessageToolSchemaFromActions(AllMessageActions, {


### PR DESCRIPTION
## Summary
- stop schema normalization from re-marking optional Telegram message buttons as required
- preserve validation for real required parameters while honoring TypeBox optional properties in final tool schemas
- add focused regression coverage for the message tool optional-buttons path

## Testing
- targeted message tool schema tests updated alongside the fix
- runtime test execution remains limited in this environment because dependency install is unavailable in the checkout

Closes #55795