### PR TITLE
sandbox: add workspaceMountPropagation config for Docker workspace mount

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -122,6 +122,8 @@ export function resolveSandboxDockerConfig(params: {
     dns: agentDocker?.dns ?? globalDocker?.dns,
     extraHosts: agentDocker?.extraHosts ?? globalDocker?.extraHosts,
     binds: binds.length ? binds : undefined,
+    workspaceMountPropagation:
+      agentDocker?.workspaceMountPropagation ?? globalDocker?.workspaceMountPropagation,
     ...resolveDangerousSandboxDockerBooleans(agentDocker, globalDocker),
   };
 }

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -273,14 +273,14 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(createCall?.args).toContain(`openclaw.configHash=${expectedHash}`);
 
     const bindArgs = collectDockerFlagValues(createCall?.args ?? [], "-v");
-    const workspaceMountIdx = bindArgs.indexOf("/tmp/workspace:/workspace:z");
+    const workspaceMountIdx = bindArgs.indexOf("/tmp/workspace:/workspace:rw,z");
     const customMountIdx = bindArgs.indexOf("/tmp/workspace-shared/USER.md:/workspace/USER.md:ro");
     expect(workspaceMountIdx).toBeGreaterThanOrEqual(0);
     expect(customMountIdx).toBeGreaterThan(workspaceMountIdx);
   });
 
   it.each([
-    { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace:z" },
+    { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace:rw,z" },
     { workspaceAccess: "ro" as const, expectedMainMount: "/tmp/workspace:/workspace:ro,z" },
     { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:ro,z" },
   ])(

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -494,6 +494,7 @@ async function createSandboxContainer(params: {
     agentWorkspaceDir: params.agentWorkspaceDir,
     workdir: cfg.workdir,
     workspaceAccess: params.workspaceAccess,
+    workspaceMountPropagation: cfg.workspaceMountPropagation,
   });
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -3,7 +3,7 @@ import { appendWorkspaceMountArgs } from "./workspace-mounts.js";
 
 describe("appendWorkspaceMountArgs", () => {
   it.each([
-    { access: "rw" as const, expected: "/tmp/workspace:/workspace:z" },
+    { access: "rw" as const, expected: "/tmp/workspace:/workspace:rw,z" },
     { access: "ro" as const, expected: "/tmp/workspace:/workspace:ro,z" },
     { access: "none" as const, expected: "/tmp/workspace:/workspace:ro,z" },
   ])("sets main mount permissions for workspaceAccess=$access", ({ access, expected }) => {
@@ -44,7 +44,43 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace:z"]);
+    expect(mounts).toEqual(["/tmp/workspace:/workspace:rw,z"]);
+  });
+
+  it.each([
+    { propagation: "private" as const, expected: "/tmp/workspace:/workspace:rw,z" },
+    { propagation: "rslave" as const, expected: "/tmp/workspace:/workspace:rw,rslave,z" },
+    { propagation: "rshared" as const, expected: "/tmp/workspace:/workspace:rw,rshared,z" },
+  ])(
+    "appends propagation mode to workspace mount for workspaceMountPropagation=$propagation",
+    ({ propagation, expected }) => {
+      const args: string[] = [];
+      appendWorkspaceMountArgs({
+        args,
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/agent-workspace",
+        workdir: "/workspace",
+        workspaceAccess: "rw",
+        workspaceMountPropagation: propagation,
+      });
+
+      expect(args).toContain(expected);
+    },
+  );
+
+  it("does not append propagation to agent workspace mount", () => {
+    const args: string[] = [];
+    appendWorkspaceMountArgs({
+      args,
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/agent-workspace",
+      workdir: "/workspace",
+      workspaceAccess: "rw",
+      workspaceMountPropagation: "rslave",
+    });
+
+    expect(args).toContain("/tmp/workspace:/workspace:rw,rslave,z");
+    expect(args).toContain("/tmp/agent-workspace:/agent:z");
   });
 
   it("marks split agent workspace mounts shared for SELinux", () => {

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -48,7 +48,7 @@ describe("appendWorkspaceMountArgs", () => {
   });
 
   it.each([
-    { propagation: "private" as const, expected: "/tmp/workspace:/workspace:rw,z" },
+    { propagation: "rprivate" as const, expected: "/tmp/workspace:/workspace:rw,z" },
     { propagation: "rslave" as const, expected: "/tmp/workspace:/workspace:rw,rslave,z" },
     { propagation: "rshared" as const, expected: "/tmp/workspace:/workspace:rw,rshared,z" },
   ])(

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -3,6 +3,20 @@ import type { SandboxWorkspaceAccess } from "./types.js";
 
 export const SANDBOX_MOUNT_FORMAT_VERSION = 2;
 
+type WorkspaceMountPropagation = "private" | "rslave" | "rshared";
+
+function mainWorkspaceMountSpec(
+  access: SandboxWorkspaceAccess,
+  propagation: WorkspaceMountPropagation | undefined,
+): string {
+  const parts: string[] = [access === "rw" ? "rw" : "ro"];
+  if (propagation && propagation !== "private") {
+    parts.push(propagation);
+  }
+  parts.push("z");
+  return parts.join(",");
+}
+
 function formatManagedWorkspaceBind(params: {
   hostPath: string;
   containerPath: string;
@@ -17,17 +31,12 @@ export function appendWorkspaceMountArgs(params: {
   agentWorkspaceDir: string;
   workdir: string;
   workspaceAccess: SandboxWorkspaceAccess;
+  workspaceMountPropagation?: WorkspaceMountPropagation;
 }) {
   const { args, workspaceDir, agentWorkspaceDir, workdir, workspaceAccess } = params;
 
-  args.push(
-    "-v",
-    formatManagedWorkspaceBind({
-      hostPath: workspaceDir,
-      containerPath: workdir,
-      readOnly: workspaceAccess !== "rw",
-    }),
-  );
+  const spec = mainWorkspaceMountSpec(workspaceAccess, params.workspaceMountPropagation);
+  args.push("-v", `${workspaceDir}:${workdir}:${spec}`);
   if (workspaceAccess !== "none" && workspaceDir !== agentWorkspaceDir) {
     args.push(
       "-v",

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -1,16 +1,16 @@
+import type { WorkspaceMountPropagation } from "../../config/types.sandbox.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 export const SANDBOX_MOUNT_FORMAT_VERSION = 2;
 
-type WorkspaceMountPropagation = "private" | "rslave" | "rshared";
 
 function mainWorkspaceMountSpec(
   access: SandboxWorkspaceAccess,
   propagation: WorkspaceMountPropagation | undefined,
 ): string {
   const parts: string[] = [access === "rw" ? "rw" : "ro"];
-  if (propagation && propagation !== "private") {
+  if (propagation && propagation !== "rprivate") {
     parts.push(propagation);
   }
   parts.push("z");

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5196,7 +5196,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                       },
                       workspaceMountPropagation: {
                         type: "string",
-                        enum: ["private", "rslave", "rshared"],
+                        enum: ["rprivate", "rslave", "rshared"],
                       },
                     },
                     additionalProperties: false,
@@ -6476,7 +6476,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                         workspaceMountPropagation: {
                           type: "string",
-                          enum: ["private", "rslave", "rshared"],
+                          enum: ["rprivate", "rslave", "rshared"],
                         },
                       },
                       additionalProperties: false,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5194,6 +5194,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         description:
                           "DANGEROUS break-glass override that allows sandbox Docker network mode container:<id>. This joins another container namespace and weakens sandbox isolation.",
                       },
+                      workspaceMountPropagation: {
+                        type: "string",
+                        enum: ["private", "rslave", "rshared"],
+                      },
                     },
                     additionalProperties: false,
                   },
@@ -6469,6 +6473,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           title: "Agent Sandbox Docker Allow Container Namespace Join",
                           description:
                             "Per-agent DANGEROUS override for container namespace joins in sandbox Docker network mode.",
+                        },
+                        workspaceMountPropagation: {
+                          type: "string",
+                          enum: ["private", "rslave", "rshared"],
                         },
                       },
                       additionalProperties: false,

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -61,7 +61,7 @@ export type SandboxDockerSettings = {
   dangerouslyAllowContainerNamespaceJoin?: boolean;
   /**
    * Mount propagation mode for the workspace bind mount.
-   * - "private" (default): host sub-mounts inside the workspace are not visible in the container.
+   * - "rprivate" (default): host sub-mounts inside the workspace are not visible in the container.
    * - "rslave": host sub-mounts inside the workspace propagate into the container (read-only).
    * - "rshared": host sub-mounts inside the workspace propagate bidirectionally.
    *
@@ -70,8 +70,10 @@ export type SandboxDockerSettings = {
    * the sandbox file tools. Requires the host mount point to have shared propagation
    * (`mount --make-shared`).
    */
-  workspaceMountPropagation?: "private" | "rslave" | "rshared";
+  workspaceMountPropagation?: WorkspaceMountPropagation;
 };
+
+export type WorkspaceMountPropagation = "rprivate" | "rslave" | "rshared";
 
 export type SandboxBrowserSettings = {
   enabled?: boolean;

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -59,6 +59,18 @@ export type SandboxDockerSettings = {
    * Default behavior blocks container namespace joins to preserve sandbox isolation.
    */
   dangerouslyAllowContainerNamespaceJoin?: boolean;
+  /**
+   * Mount propagation mode for the workspace bind mount.
+   * - "private" (default): host sub-mounts inside the workspace are not visible in the container.
+   * - "rslave": host sub-mounts inside the workspace propagate into the container (read-only).
+   * - "rshared": host sub-mounts inside the workspace propagate bidirectionally.
+   *
+   * Set to "rslave" when the workspace directory contains host-level bind mounts
+   * (e.g. symlink targets mounted via `mount --bind`) that you want accessible to
+   * the sandbox file tools. Requires the host mount point to have shared propagation
+   * (`mount --make-shared`).
+   */
+  workspaceMountPropagation?: "private" | "rslave" | "rshared";
 };
 
 export type SandboxBrowserSettings = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -141,7 +141,7 @@ export const SandboxDockerSchema = z
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
-    workspaceMountPropagation: z.enum(["private", "rslave", "rshared"]).optional(),
+    workspaceMountPropagation: z.enum(["rprivate", "rslave", "rshared"]).optional(),
   })
   .strict()
   .superRefine((data, ctx) => {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -141,6 +141,7 @@ export const SandboxDockerSchema = z
     dangerouslyAllowReservedContainerTargets: z.boolean().optional(),
     dangerouslyAllowExternalBindSources: z.boolean().optional(),
     dangerouslyAllowContainerNamespaceJoin: z.boolean().optional(),
+    workspaceMountPropagation: z.enum(["private", "rslave", "rshared"]).optional(),
   })
   .strict()
   .superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary

- Adds `sandbox.docker.workspaceMountPropagation` option (`"private"` | `"rslave"` | `"rshared"`) to control the bind propagation mode of the workspace mount passed to `docker create -v`
- Default is `"private"` — no change to existing behavior
- `"rslave"` causes host-level bind mounts inside the workspace directory to propagate into the container
- Wires the new field through `resolveSandboxDockerConfig` so it reaches container creation

## Motivation

When a workspace subdirectory is itself a bind mount on the host (e.g. `mount --bind /other/path workspace/subdir`), Docker's default `rprivate` propagation makes that subdirectory appear empty inside the container. Setting `workspaceMountPropagation: "rslave"` makes host sub-mounts visible to the sandbox, enabling patterns like mounting a shared directory into multiple agent workspaces without symlinks.

The host mount point must have shared propagation (`mount --make-shared`) for `rslave` to take effect.

## Test plan

- [x] Updated existing workspace mount tests to reflect explicit `rw` in mount spec
- [x] Added propagation test cases for `private`, `rslave`, `rshared`
- [x] Updated `docker.config-hash-recreate` test expectations
- [x] Full `pnpm check` passes (lint, format, type, schema drift)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)