### PR TITLE
fix(cli): fall back to npm after ClawHub resolution failures

### DIFF
--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -117,6 +117,7 @@ vi.mock("../hooks/installs.js", () => ({
 vi.mock("../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
     PACKAGE_NOT_FOUND: "package_not_found",
+    REQUEST_FAILED: "request_failed",
     VERSION_NOT_FOUND: "version_not_found",
   },
   installPluginFromClawHub: (...args: unknown[]) => installPluginFromClawHub(...args),

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -346,6 +346,60 @@ describe("plugins cli install", () => {
     );
   });
 
+  it("falls back to npm when ClawHub resolution fails for a valid npm package spec", async () => {
+    const cfg = {
+      plugins: {
+        entries: {},
+      },
+    } as OpenClawConfig;
+    const enabledCfg = {
+      plugins: {
+        entries: {
+          "@openclaw/voice-call": {
+            enabled: true,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    loadConfig.mockReturnValue(cfg);
+    installPluginFromClawHub.mockResolvedValue({
+      ok: false,
+      error: "fetch failed",
+      code: "request_failed",
+    });
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: true,
+      pluginId: "@openclaw/voice-call",
+      targetDir: "/tmp/openclaw-state/extensions/voice-call",
+      version: "1.2.3",
+      npmResolution: {
+        packageName: "@openclaw/voice-call",
+        resolvedVersion: "1.2.3",
+        tarballUrl: "https://registry.npmjs.org/@openclaw/voice-call/-/voice-call-1.2.3.tgz",
+      },
+    });
+    enablePluginInConfig.mockReturnValue({ config: enabledCfg });
+    recordPluginInstall.mockReturnValue(enabledCfg);
+    applyExclusiveSlotSelection.mockReturnValue({
+      config: enabledCfg,
+      warnings: [],
+    });
+
+    await runPluginsCommand(["plugins", "install", "@openclaw/voice-call@beta"]);
+
+    expect(installPluginFromClawHub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "clawhub:@openclaw/voice-call@beta",
+      }),
+    );
+    expect(installPluginFromNpmSpec).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "@openclaw/voice-call@beta",
+      }),
+    );
+  });
+
   it("does not fall back to npm when ClawHub rejects a real package", async () => {
     installPluginFromClawHub.mockResolvedValue({
       ok: false,

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -166,7 +166,8 @@ export function decidePreferredClawHubFallback(params: {
 }): PreferredClawHubFallbackDecision {
   if (
     params.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    params.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    params.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    params.code === CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED
   ) {
     return PREFERRED_CLAWHUB_FALLBACK_DECISION.FALLBACK_TO_NPM;
   }

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -197,4 +197,14 @@ describe("installPluginFromClawHub", () => {
       error: "Version not found on ClawHub: demo@9.9.9.",
     });
   });
+
+  it("returns typed request failures for non-404 package resolution errors", async () => {
+    fetchClawHubPackageDetailMock.mockRejectedValueOnce(new Error("fetch failed"));
+
+    await expect(installPluginFromClawHub({ spec: "clawhub:demo" })).resolves.toMatchObject({
+      ok: false,
+      code: CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED,
+      error: "fetch failed",
+    });
+  });
 });

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -21,6 +21,7 @@ export const CLAWHUB_INSTALL_ERROR_CODE = {
   INVALID_SPEC: "invalid_spec",
   PACKAGE_NOT_FOUND: "package_not_found",
   VERSION_NOT_FOUND: "version_not_found",
+  REQUEST_FAILED: "request_failed",
   NO_INSTALLABLE_VERSION: "no_installable_version",
   SKILL_PACKAGE: "skill_package",
   UNSUPPORTED_FAMILY: "unsupported_family",
@@ -82,7 +83,10 @@ function mapClawHubRequestError(
       CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND,
     );
   }
-  return buildClawHubInstallFailure(error instanceof Error ? error.message : String(error));
+  return buildClawHubInstallFailure(
+    error instanceof Error ? error.message : String(error),
+    CLAWHUB_INSTALL_ERROR_CODE.REQUEST_FAILED,
+  );
 }
 
 function resolveRequestedVersion(params: {


### PR DESCRIPTION
## Summary
- classify non-404 ClawHub package/version request failures as a typed resolution failure instead of an untyped terminal error
- allow valid npm package specs to fall back to npm when the preferred ClawHub resolution path fails with request/network errors
- add focused ClawHub + plugins CLI regression coverage for the fallback behavior

## Testing
- targeted ClawHub/plugin install tests updated alongside the fix
- runtime test execution remains limited in this environment because checkout dependency install is unavailable

Closes #55805