### PR TITLE
Ensure transcripts exist immediately after session rollover

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
@@ -1544,7 +1545,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       existingSessionFile,
       `${JSON.stringify({
         type: "session",
-        version: 3,
+        version: CURRENT_SESSION_VERSION,
         id: existingSessionId,
         timestamp: new Date().toISOString(),
         cwd: process.cwd(),

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1522,10 +1522,67 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
           reason: "reset",
         }),
       );
+      const newSessionFile = result.sessionEntry.sessionFile;
+      expect(newSessionFile).toBeTruthy();
+      const content = await fs.readFile(newSessionFile ?? "", "utf-8");
+      const header = JSON.parse(content.trim());
+      expect(header.type).toBe("session");
+      expect(header.id).toBe(result.sessionId);
       archiveSpy.mockRestore();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("creates a fresh transcript header immediately for explicit resets", async () => {
+    const storePath = await createStorePath("openclaw-reset-creates-transcript-");
+    const sessionKey = "agent:main:telegram:dm:reset-user";
+    const existingSessionId = "reset-old-session-id";
+    const existingSessionFile = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+    await fs.mkdir(path.dirname(existingSessionFile), { recursive: true });
+    await fs.writeFile(
+      existingSessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: existingSessionId,
+        timestamp: new Date().toISOString(),
+        cwd: process.cwd(),
+      })}\n`,
+      "utf-8",
+    );
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        sessionFile: existingSessionFile,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/reset",
+        RawBody: "/reset",
+        CommandBody: "/reset",
+        From: "reset-user",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    const newSessionFile = result.sessionEntry.sessionFile;
+    expect(newSessionFile).toBeTruthy();
+    const content = await fs.readFile(newSessionFile ?? "", "utf-8");
+    const header = JSON.parse(content.trim());
+    expect(header.type).toBe("session");
+    expect(header.id).toBe(result.sessionId);
   });
 
   it("idle-based new session does NOT preserve overrides (no entry to read)", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -506,6 +506,7 @@ export async function initSessionState(params: {
     sessionsDir: path.dirname(storePath),
     fallbackSessionFile,
     activeSessionKey: sessionKey,
+    ensureTranscriptHeader: true,
   });
   sessionEntry = resolvedSessionFile.sessionEntry;
   if (isNewSession) {

--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -1,6 +1,34 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { resolveSessionFilePath } from "./paths.js";
 import { updateSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
+
+async function ensureSessionTranscriptHeader(params: {
+  sessionFile: string;
+  sessionId: string;
+}): Promise<void> {
+  try {
+    await fs.stat(params.sessionFile);
+    return;
+  } catch {
+    // Create a fresh header below.
+  }
+
+  await fs.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  const header = {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: params.sessionId,
+    timestamp: new Date().toISOString(),
+    cwd: process.cwd(),
+  };
+  await fs.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+}
 
 export async function resolveAndPersistSessionFile(params: {
   sessionId: string;
@@ -12,6 +40,7 @@ export async function resolveAndPersistSessionFile(params: {
   sessionsDir?: string;
   fallbackSessionFile?: string;
   activeSessionKey?: string;
+  ensureTranscriptHeader?: boolean;
 }): Promise<{ sessionFile: string; sessionEntry: SessionEntry }> {
   const { sessionId, sessionKey, sessionStore, storePath } = params;
   const baseEntry = params.sessionEntry ??
@@ -31,6 +60,12 @@ export async function resolveAndPersistSessionFile(params: {
     updatedAt: Date.now(),
     sessionFile,
   };
+  if (params.ensureTranscriptHeader) {
+    await ensureSessionTranscriptHeader({
+      sessionFile,
+      sessionId,
+    });
+  }
   if (baseEntry.sessionId !== sessionId || baseEntry.sessionFile !== sessionFile) {
     sessionStore[sessionKey] = persistedEntry;
     await updateSessionStore(

--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -12,8 +12,11 @@ async function ensureSessionTranscriptHeader(params: {
   try {
     await fs.stat(params.sessionFile);
     return;
-  } catch {
-    // Create a fresh header below.
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+    // File does not exist. Create a fresh header below.
   }
 
   await fs.mkdir(path.dirname(params.sessionFile), { recursive: true });


### PR DESCRIPTION
## Summary

Fix a session persistence consistency gap where `sessions.json` can be rotated to a fresh `sessionId` before the new transcript file exists on disk.

With the current behavior, monitors and history UIs can see:

- a live session key bound to a new `sessionId`
- the previous transcript already archived as `.reset.*`
- no current `*.jsonl` for the new shell yet

That can surface as `transcript missing`, empty history panes, and broken transcript-derived introspection even though the route itself already moved to the new session shell.

## Root Cause

`initSessionState()` resolves and persists the new `sessionId`/`sessionFile` into `sessions.json`, but the new transcript file is only created later by transcript append paths.

That leaves a window where the store points to a non-existent primary transcript.

## Fix

Add an optional `ensureTranscriptHeader` path to `resolveAndPersistSessionFile()` and enable it from `initSessionState()`.

This ensures active session rollovers create a header-only transcript immediately, so the store does not settle on a missing primary transcript.

A header-only transcript is preferable to a missing file because:

- history tooling can still resolve the current shell safely
- UIs no longer see false-empty active sessions caused only by missing file creation
- archive fallback logic becomes a recovery path, not the primary path

## Tests

Added regression coverage for:

- daily/stale-session rollover creating a new transcript header immediately
- explicit `/reset` creating a fresh transcript header immediately

Local verification:

- `pnpm exec vitest run src/auto-reply/reply/session.test.ts src/config/sessions/sessions.test.ts`

Passed: `68` tests.

## Context

This was found while improving ClawMonitor transcript/history handling for sessions whose current shell points to a missing transcript while older `.reset.*` archives still contain the real history.
