### PR TITLE
fix(tests): repair unrelated mainline prep blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Docs: https://docs.openclaw.ai
 - TUI/activation: validate `/activation` arguments in the TUI and reject invalid values instead of silently coercing them to `mention`. (#55733) Thanks @shakkernerd.
 - Agents/model switching: apply `/model` changes to active embedded runs at the next safe retry boundary, so overloaded or retrying turns switch to the newly selected model instead of staying pinned to the old provider.
 - Agents/Codex fallback: classify Codex `server_error` payloads as failoverable, sanitize `Codex error:` payloads before they reach chat, preserve context-overflow guidance for prefixed `invalid_request_error` payloads, and omit provider `request_id` values from user-facing UI copy. (#42892) Thanks @xaeon2026.
+- Tests/onboarding/channel actions: restore drifted Telegram and Discord test/runtime exports and update the channels mock harness import style so unrelated mainline typecheck blockers stop breaking PR prep branches.
 
 ## 2026.3.24
 

--- a/extensions/telegram/runtime-api.ts
+++ b/extensions/telegram/runtime-api.ts
@@ -79,12 +79,12 @@ export {
   unpinMessageTelegram,
 } from "./src/send.js";
 export {
+  __testing as telegramThreadBindingTesting,
   createTelegramThreadBindingManager,
   getTelegramThreadBindingManager,
   setTelegramThreadBindingIdleTimeoutBySessionKey,
   setTelegramThreadBindingMaxAgeBySessionKey,
 } from "./src/thread-bindings.js";
-export { __testing as telegramThreadBindingTesting } from "./src/thread-bindings.js";
 export { resolveTelegramToken } from "./src/token.js";
 
 export const telegramSessionBindingAdapterChannels = ["telegram"] as const;

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -1,1 +1,1 @@
-export * from "../../../../plugin-sdk/discord.js";
+export { handleDiscordMessageAction } from "../../../../../extensions/discord/src/actions/handle-action.js";

--- a/src/commands/channels.mock-harness.ts
+++ b/src/commands/channels.mock-harness.ts
@@ -15,8 +15,8 @@ export const offsetMocks: {
   deleteTelegramUpdateOffset: vi.fn().mockResolvedValue(undefined) as unknown as MockFn,
 };
 
-vi.mock("../config/config.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../config/config.js")>();
+vi.mock("../config/config.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
   return {
     ...actual,
     readConfigFileSnapshot: configMocks.readConfigFileSnapshot,
@@ -24,17 +24,20 @@ vi.mock("../config/config.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../extensions/telegram/api.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../extensions/telegram/api.js")>();
+vi.mock("../../extensions/telegram/api.js", async () => {
+  const actual = await vi.importActual<typeof import("../../extensions/telegram/api.js")>(
+    "../../extensions/telegram/api.js",
+  );
   return {
     ...actual,
     deleteTelegramUpdateOffset: offsetMocks.deleteTelegramUpdateOffset,
   };
 });
 
-vi.mock("../../extensions/telegram/update-offset-runtime-api.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../extensions/telegram/update-offset-runtime-api.js")>();
+vi.mock("../../extensions/telegram/update-offset-runtime-api.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../extensions/telegram/update-offset-runtime-api.js")
+  >("../../extensions/telegram/update-offset-runtime-api.js");
   return {
     ...actual,
     deleteTelegramUpdateOffset: offsetMocks.deleteTelegramUpdateOffset,


### PR DESCRIPTION
## Summary
- fix the Discord action shim to export `handleDiscordMessageAction` from the runtime implementation again
- re-export Telegram thread binding test helpers from the runtime API surface
- update the channels mock harness to use `vi.importActual(...)` in async mocks so the mock factories match current Vitest expectations
- add a changelog entry for the cleanup

## Why
These were unrelated mainline/typecheck drifts that started blocking maintainer prep/gate flows for other PRs, including #53662.

## Testing
- pnpm check
