### PR TITLE
fix: prevent WhatsApp duplicate replies with synchronous dedupe

### DIFF
--- a/extensions/whatsapp/src/inbound/dedupe.ts
+++ b/extensions/whatsapp/src/inbound/dedupe.ts
@@ -5,6 +5,11 @@ const RECENT_WEB_MESSAGE_MAX = 5000;
 const RECENT_OUTBOUND_MESSAGE_TTL_MS = 20 * 60_000;
 const RECENT_OUTBOUND_MESSAGE_MAX = 5000;
 
+// Fast synchronous Set for immediate duplicate detection within the same event loop tick.
+// This prevents race conditions when baileys fires multiple messages.upsert events
+// for the same message in rapid succession (common with media messages).
+const processingMessages = new Set<string>();
+
 const recentInboundMessages = createDedupeCache({
   ttlMs: RECENT_WEB_MESSAGE_TTL_MS,
   maxSize: RECENT_WEB_MESSAGE_MAX,
@@ -31,10 +36,35 @@ function buildMessageKey(params: {
 export function resetWebInboundDedupe(): void {
   recentInboundMessages.clear();
   recentOutboundMessages.clear();
+  processingMessages.clear();
 }
 
+/**
+ * Checks if a message is currently being processed or was recently processed.
+ * This function is synchronous and must be called before any async work starts
+ * to prevent duplicate message processing when baileys fires rapid duplicate events.
+ * 
+ * @param key - Dedupe key (accountId:remoteJid:messageId)
+ * @returns true if message is duplicate (should skip), false if new (should process)
+ */
 export function isRecentInboundMessage(key: string): boolean {
-  return recentInboundMessages.check(key);
+  // Fast path: check if we're currently processing this exact message
+  if (processingMessages.has(key)) {
+    return true;  // Duplicate detected
+  }
+  
+  // Check long-term cache
+  const isDuplicate = recentInboundMessages.check(key);
+  
+  // If this is a new message, mark it as currently processing
+  if (!isDuplicate) {
+    processingMessages.add(key);
+    // Clear from processing set after a short delay (5 seconds)
+    // This handles the case where message processing fails/throws
+    setTimeout(() => processingMessages.delete(key), 5000);
+  }
+  
+  return isDuplicate;
 }
 
 export function rememberRecentOutboundMessage(params: {


### PR DESCRIPTION
## Summary

Fixes #54836 — WhatsApp sends 3 duplicate replies for single inbound messages.

## Root Cause

baileys sometimes fires `messages.upsert` multiple times for the same message within milliseconds (especially for media messages). The existing dedupe cache records messages, but the recording happens **after** async work starts (`await resolveInboundJid()`), allowing duplicates to slip through.

**Race condition timeline:**
1. Event 1 enters loop → calls `isRecentInboundMessage()` (not seen, records) → **awaits** async work
2. Event 2 enters loop (while Event 1 awaits) → calls `isRecentInboundMessage()` (not seen yet, records) → **awaits**
3. Event 3 enters loop → same issue
4. All 3 events complete async work and process the message → 3 duplicate replies

## Solution

Added **immediate synchronous deduplication** using a `Set` to catch rapid duplicate events before any async processing:

```typescript
const processingMessages = new Set<string>();

export function isRecentInboundMessage(key: string): boolean {
  // Fast path: check if we are currently processing this exact message
  if (processingMessages.has(key)) {
    return true;  // Duplicate detected
  }
  
  const isDuplicate = recentInboundMessages.check(key);
  
  if (!isDuplicate) {
    processingMessages.add(key);
    setTimeout(() => processingMessages.delete(key), 5000);
  }
  
  return isDuplicate;
}
```

**Key aspects:**
- Synchronous check happens **before** any `await` statements
- Auto-clears processing messages after 5 seconds (handles failures/crashes)
- Preserves existing long-term dedupe cache (20-minute window)
- No breaking changes to existing behavior

## Changes

- `extensions/whatsapp/src/inbound/dedupe.ts`: Added `processingMessages` Set for immediate duplicate detection

## Testing

- ✅ Tested locally by @vicpon with rapid WhatsApp messages
- ✅ Verified no duplicate replies sent
- ✅ Media messages (historically most prone to duplication) now dedupe correctly
- ✅ No regressions observed in normal message flow

## Impact

- **Fixes:** Users receive only 1 reply instead of 3 identical replies
- **Reduces:** API/LLM costs by 66% (no more 3x processing)
- **Improves:** User experience (no spam)
- **Prevents:** WhatsApp rate limiting/session termination from excessive sends