### PR TITLE
fix(ui): hide internal context-only chat messages

### DIFF
--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -7,7 +7,7 @@ const thinkingCache = new WeakMap<object, string | null>();
 
 function processMessageText(text: string, role: string): string {
   const shouldStripInboundMetadata = role.toLowerCase() === "user";
-  if (role === "assistant") {
+  if (!shouldStripInboundMetadata) {
     return stripThinkingTags(text);
   }
   return shouldStripInboundMetadata

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -123,6 +123,39 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages[0]).toEqual(payload.message);
   });
 
+  it("drops internal-only final payload from another run without clearing active stream", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-user",
+      chatStream: "Working...",
+      chatStreamStartedAt: 123,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: [
+              "<relevant-memories>",
+              "Internal memory context",
+              "</relevant-memories>",
+            ].join("\n"),
+          },
+        ],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+    expect(state.chatStreamStartedAt).toBe(123);
+    expect(state.chatMessages).toEqual([]);
+  });
+
   it("drops NO_REPLY final payload from another run without clearing active stream", () => {
     const state = createActiveStreamingState();
     const payload = createOtherRunNoReplyFinalPayload();
@@ -531,6 +564,50 @@ describe("loadChatHistory", () => {
 
     // text takes precedence — "real reply" is NOT silent, so message is kept.
     expect(state.chatMessages).toHaveLength(1);
+  });
+
+  it("filters internal-only context messages from history while keeping visible system messages", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: [
+              "<relevant-memories>",
+              "Internal memory context",
+              "</relevant-memories>",
+            ].join("\n"),
+          },
+        ],
+      },
+      {
+        role: "system",
+        content: [
+          {
+            type: "text",
+            text: [
+              "<thinking>",
+              "internal",
+              "</thinking>",
+              "Visible system notice",
+            ].join("\n"),
+          },
+        ],
+      },
+      { role: "assistant", content: [{ type: "text", text: "Real answer" }] },
+    ];
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([messages[1], messages[2]]);
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -32,6 +32,45 @@ function isAssistantSilentReply(message: unknown): boolean {
   return typeof text === "string" && isSilentReplyStream(text);
 }
 
+function hasVisibleChatText(message: unknown): boolean {
+  const text = extractText(message);
+  return typeof text === "string" ? text.trim().length > 0 : false;
+}
+
+function hasRenderableNonTextContent(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  if (!Array.isArray(entry.content)) {
+    return false;
+  }
+  return entry.content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = typeof (block as { type?: unknown }).type === "string"
+      ? ((block as { type: string }).type ?? "").toLowerCase()
+      : "";
+    return type !== "" && type !== "text";
+  });
+}
+
+function shouldRenderChatMessage(message: unknown): boolean {
+  if (isAssistantSilentReply(message)) {
+    return false;
+  }
+  if (!message || typeof message !== "object") {
+    return true;
+  }
+  const entry = message as Record<string, unknown>;
+  const role = typeof entry.role === "string" ? entry.role.toLowerCase() : "";
+  if (!role || role === "user") {
+    return true;
+  }
+  return hasVisibleChatText(message) || hasRenderableNonTextContent(message);
+}
+
 export type ChatState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -83,7 +122,7 @@ export async function loadChatHistory(state: ChatState) {
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+    state.chatMessages = messages.filter(shouldRenderChatMessage);
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
@@ -283,7 +322,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
-      if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+      if (finalMessage && shouldRenderChatMessage(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];
         return null;
       }
@@ -302,7 +341,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
-    if (finalMessage && !isAssistantSilentReply(finalMessage)) {
+    if (finalMessage && shouldRenderChatMessage(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
     } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
       state.chatMessages = [
@@ -319,7 +358,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStreamStartedAt = null;
   } else if (payload.state === "aborted") {
     const normalizedMessage = normalizeAbortedAssistantMessage(payload.message);
-    if (normalizedMessage && !isAssistantSilentReply(normalizedMessage)) {
+    if (normalizedMessage && shouldRenderChatMessage(normalizedMessage)) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";


### PR DESCRIPTION
## Summary
- stop webchat/control-ui from rendering internal context-only transcript messages that are meant only for model context
- apply the visibility filter consistently to loaded history and live chat events instead of only stripping assistant NO_REPLY cases
- add focused UI controller regression coverage for hidden internal context entries

## Testing
- targeted chat controller tests updated alongside the fix
- broader runtime validation remains limited in this environment

Closes #55825