### PR TITLE
fix(discord): cross-channel sends from thread context route to explicit target

### DIFF
--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -56,10 +56,11 @@ describe("discordOutbound", () => {
     resetDiscordOutboundMocks(hoisted);
   });
 
-  it("routes text sends to thread target when threadId is provided", async () => {
+  it("routes text sends to thread target when threadId matches to", async () => {
+    // Normal thread reply: `to` and `threadId` both refer to the thread channel.
     const result = await discordOutbound.sendText?.({
       cfg: {},
-      to: "channel:parent-1",
+      to: "channel:thread-1",
       text: "hello",
       accountId: "default",
       threadId: "thread-1",
@@ -70,6 +71,25 @@ describe("discordOutbound", () => {
       text: "hello",
       result,
     });
+  });
+
+  it("does not override explicit cross-channel target with thread context", async () => {
+    // Cross-channel send from a thread: `to` is a different channel than `threadId`.
+    // The explicit `to` must win — thread context must not hijack cross-channel sends.
+    // See: https://github.com/openclaw/openclaw/issues/55841
+    await discordOutbound.sendText?.({
+      cfg: {},
+      to: "channel:other-channel",
+      text: "cross-channel message",
+      accountId: "default",
+      threadId: "thread-1",
+    });
+
+    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:other-channel",
+      "cross-channel message",
+      expect.objectContaining({ accountId: "default" }),
+    );
   });
 
   it("uses webhook persona delivery for bound thread text replies", async () => {
@@ -84,7 +104,7 @@ describe("discordOutbound", () => {
 
     const result = await discordOutbound.sendText?.({
       cfg,
-      to: "channel:parent-1",
+      to: "channel:thread-1",
       text: "hello from persona",
       accountId: "default",
       threadId: "thread-1",
@@ -124,7 +144,7 @@ describe("discordOutbound", () => {
 
     const result = await discordOutbound.sendText?.({
       cfg: {},
-      to: "channel:parent-1",
+      to: "channel:thread-1",
       text: "silent update",
       accountId: "default",
       threadId: "thread-1",
@@ -146,7 +166,7 @@ describe("discordOutbound", () => {
 
     const result = await discordOutbound.sendText?.({
       cfg: {},
-      to: "channel:parent-1",
+      to: "channel:thread-1",
       text: "fallback",
       accountId: "default",
       threadId: "thread-1",
@@ -160,10 +180,10 @@ describe("discordOutbound", () => {
     });
   });
 
-  it("routes poll sends to thread target when threadId is provided", async () => {
+  it("routes poll sends to thread target when threadId matches to", async () => {
     const result = await discordOutbound.sendPoll?.({
       cfg: {},
-      to: "channel:parent-1",
+      to: "channel:thread-1",
       poll: {
         question: "Best snack?",
         options: ["banana", "apple"],

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -92,6 +92,29 @@ describe("discordOutbound", () => {
     );
   });
 
+  it("does not use webhook delivery for cross-channel sends from webhook-bound threads", async () => {
+    // The webhook binding belongs to thread-1, but the send targets a different channel.
+    // maybeSendDiscordWebhookText must be skipped entirely so the message goes to
+    // the correct destination and not to the bound thread via webhook.
+    // See: https://github.com/openclaw/openclaw/issues/55841
+    mockDiscordBoundThreadManager(hoisted);
+
+    await discordOutbound.sendText?.({
+      cfg: {},
+      to: "channel:other-channel",
+      text: "cross-channel from webhook-bound thread",
+      accountId: "default",
+      threadId: "thread-1",
+    });
+
+    expect(hoisted.sendWebhookMessageDiscordMock).not.toHaveBeenCalled();
+    expect(hoisted.sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:other-channel",
+      "cross-channel from webhook-bound thread",
+      expect.objectContaining({ accountId: "default" }),
+    );
+  });
+
   it("uses webhook persona delivery for bound thread text replies", async () => {
     mockDiscordBoundThreadManager(hoisted);
     const cfg = {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -37,6 +37,15 @@ function resolveDiscordOutboundTarget(params: {
   if (!threadId) {
     return params.to;
   }
+  // Only substitute the thread channel when the explicit `to` target refers to
+  // the same channel. When the agent is sending to a *different* channel (cross-
+  // channel send), the explicit target must win — otherwise thread context from
+  // the inbound session silently overrides it and the message lands in the wrong
+  // place. See: https://github.com/openclaw/openclaw/issues/55841
+  const toNormalized = params.to.replace(/^channel:/i, "").trim();
+  if (toNormalized !== threadId) {
+    return params.to;
+  }
   return `channel:${threadId}`;
 }
 

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -177,16 +177,25 @@ export const discordOutbound: ChannelOutboundAdapter = {
     channel: "discord",
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity, silent }) => {
       if (!silent) {
-        const webhookResult = await maybeSendDiscordWebhookText({
-          cfg,
-          text,
-          threadId,
-          accountId,
-          identity,
-          replyToId,
-        }).catch(() => null);
-        if (webhookResult) {
-          return webhookResult;
+        // Only attempt webhook delivery when the outbound target is the same
+        // channel as the thread. For cross-channel sends the webhook binding
+        // belongs to a different conversation and must not intercept the send.
+        const toNormalized = to.replace(/^channel:/i, "").trim();
+        const resolvedThreadId = threadId != null ? String(threadId).trim() : null;
+        const isSameChannel =
+          resolvedThreadId != null && resolvedThreadId !== "" && toNormalized === resolvedThreadId;
+        if (isSameChannel) {
+          const webhookResult = await maybeSendDiscordWebhookText({
+            cfg,
+            text,
+            threadId,
+            accountId,
+            identity,
+            replyToId,
+          }).catch(() => null);
+          if (webhookResult) {
+            return webhookResult;
+          }
         }
       }
       const send =


### PR DESCRIPTION
## Summary

Fixes #55841

When the `message` tool is used with an explicit target channel from **inside a Discord thread session**, `resolveDiscordOutboundTarget` was unconditionally overriding the `to` parameter with the inbound `threadId`. This caused all cross-channel sends to silently land in the current thread instead of the specified destination.

## Root Cause

In `extensions/discord/src/outbound-adapter.ts`:

```ts
// BEFORE (buggy)
function resolveDiscordOutboundTarget(params: { to: string; threadId?: string | number | null }): string {
  // ...
  return `channel:${threadId}`;  // always overrides to
}
```

When triggered from a thread, the inbound session context sets `threadId` to the current thread's channel ID. `resolveDiscordOutboundTarget` then substituted this for whatever `to` the agent specified — even when it was pointing to a completely different channel.

**Why it worked from top-level channels:** When not in a thread, `threadId` is null → function returned `to` unchanged.

## Fix

Only substitute the thread channel when the explicit `to` target refers to the **same** channel. When `to` is a different channel, the explicit target wins:

```ts
// AFTER
const toNormalized = params.to.replace(/^channel:/i, '').trim();
if (toNormalized !== threadId) {
  return params.to;  // cross-channel target wins
}
return `channel:${threadId}`;
```

**Normal thread replies are unaffected:** For in-thread replies, `to` and `threadId` both refer to the same thread channel (both set from `OriginatingTo`), so the substitution still occurs correctly.

## Tests

- Updated existing tests to use `to=channel:thread-1, threadId=thread-1` (matching IDs = in-thread reply scenario, which is what actually happens in practice for thread replies)
- Added new regression test: `to=channel:other-channel, threadId=thread-1` (cross-channel send from thread → explicit target must win)
- All 14 tests pass ✓

## Affected Files

- `extensions/discord/src/outbound-adapter.ts` — fix
- `extensions/discord/src/outbound-adapter.test.ts` — updated tests + regression test

---

> 🤖 This PR was authored by [Pinche Langosta](https://github.com/plangosta) (an AI assistant running on OpenClaw) while investigating a bug reported by a user. Root cause identified by tracing the code path through `outbound-adapter.ts`, `deliver.ts`, `get-reply-run.ts`, and `message-handler.process.ts`.
> <!-- AI-assisted: generated with Claude (claude-sonnet-4-6) via OpenClaw -->