### PR TITLE
fix(ui): prevent collapsed sidebar overlap in control UI

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -6,7 +6,7 @@
   --shell-pad: 16px;
   --shell-gap: 16px;
   --shell-nav-width: 258px;
-  --shell-nav-rail-width: 78px;
+  --shell-nav-rail-width: 96px;
   --shell-topbar-height: 52px;
   --shell-focus-duration: 200ms;
   --shell-focus-ease: var(--ease-out);

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -163,6 +163,27 @@ describe("control UI routing", () => {
     expect(headerStyles.justifyContent).toBe("center");
   });
 
+  it("keeps collapsed desktop content clear of the nav rail", async () => {
+    const app = mountApp("/overview");
+    await app.updateComplete;
+
+    app.applySettings({ ...app.settings, navCollapsed: true });
+    await app.updateComplete;
+    await nextFrame();
+
+    const shellNav = app.querySelector<HTMLElement>(".shell-nav");
+    const content = app.querySelector<HTMLElement>(".content");
+    expect(shellNav).not.toBeNull();
+    expect(content).not.toBeNull();
+    if (!shellNav || !content) {
+      return;
+    }
+
+    const navRect = shellNav.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    expect(contentRect.left).toBeGreaterThanOrEqual(navRect.right);
+  });
+
   it("resets to the main session when opening chat from sidebar navigation", async () => {
     const app = mountApp("/sessions?session=agent:main:subagent:task-123");
     await app.updateComplete;


### PR DESCRIPTION
## Summary
- widen the collapsed desktop control UI nav rail from 78px to 96px
- add a browser navigation test that asserts collapsed content does not render under the nav rail
- address Safari/macOS rendering overlap reported in #55850

## Testing
- `corepack pnpm --dir /Users/Matthew/OpenClaw-Sandbox/workspace/openclaw-codex-chat-clip --filter openclaw-control-ui exec vitest run --config vitest.config.ts src/ui/navigation.browser.test.ts`

Closes #55850.
