### PR TITLE
fix(whatsapp): fix DM self-chat echo loop on personal-number setup

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -143,11 +143,18 @@ export async function monitorWebInbox(options: {
     resolveJidToE164(jid, { authDir: options.authDir, lidLookup });
 
   const rememberOutboundMessage = (remoteJid: string, result: unknown) => {
-    const messageId =
-      typeof result === "object" && result && "key" in result
-        ? String((result as { key?: { id?: string } }).key?.id ?? "")
-        : "";
-    if (!messageId) {
+    let messageId = "";
+
+    // Support send.ts return format: { messageId, toJid }
+    if (typeof result === "object" && result && "messageId" in result) {
+      messageId = String((result as { messageId?: string }).messageId ?? "");
+    }
+    // Fallback to Baileys format: { key: { id } }
+    else if (typeof result === "object" && result && "key" in result) {
+      messageId = String((result as { key?: { id?: string } }).key?.id ?? "");
+    }
+
+    if (!messageId || messageId === "unknown") {
       return;
     }
     rememberRecentOutboundMessage({


### PR DESCRIPTION
## 🐛 Problem

WhatsApp DM self-chat echo loop when using a personal number (same number for bot and owner). The bot's own outbound replies are received back as inbound messages via Baileys's messages.upsert event, causing the bot to process and reply to its own messages.

**Fixes #55426**

## ✅ Root Cause

**Code mismatch between send.ts and monitor.ts**:

- send.ts returns: `{ messageId, toJid }`
- monitor.ts expected: `result.key?.id` ← result has no 'key' property!
- Result: messageId = "" → outbound not recorded → fromMe not filtered → echo loop

## 🔧 Solution

Update `rememberOutboundMessage()` in `extensions/whatsapp/src/inbound/monitor.ts`:
- Prioritize send.ts format (messageId field)
- Fallback to Baileys format (key.id field)
- Filter out empty and 'unknown' messageId values

## 📝 Changes

- `extensions/whatsapp/src/inbound/monitor.ts`: `rememberOutboundMessage()` (+12/-5)

## 🔗 Related

- Similar to iMessage #38440 and BlueBubbles #38442
- Group echo suppression already exists (#53624)
- This fix extends dedup to DMs