### PR TITLE
[CRITICAL BUG]: Embedded agent auth broken after pi-coding-agent 0.63.0 bump - streamFn overrides bypass new auth-injection wrapper

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -81,6 +81,7 @@ import {
   resolveSkillsPromptForRun,
   type SkillSnapshot,
 } from "../skills.js";
+import { wrapStreamFnWithModelRegistryCredentials } from "../stream-fn-credentials.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { classifyCompactionReason, resolveCompactionFailureReason } from "./compact-reasons.js";
 import {
@@ -727,7 +728,10 @@ export async function compactEmbeddedPiSessionDirect(
         workspaceDir: effectiveWorkspace,
       });
       if (providerStreamFn) {
-        session.agent.streamFn = providerStreamFn;
+        session.agent.streamFn = wrapStreamFnWithModelRegistryCredentials(
+          providerStreamFn,
+          modelRegistry,
+        );
       }
 
       try {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -92,6 +92,7 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
+import { wrapStreamFnWithModelRegistryCredentials } from "../../stream-fn-credentials.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
@@ -851,7 +852,10 @@ export async function runEmbeddedAttempt(
         workspaceDir: effectiveWorkspace,
       });
       if (providerStreamFn) {
-        activeSession.agent.streamFn = providerStreamFn;
+        activeSession.agent.streamFn = wrapStreamFnWithModelRegistryCredentials(
+          providerStreamFn,
+          params.modelRegistry,
+        );
       } else if (
         shouldUseOpenAIWebSocketTransport({
           provider: params.provider,
@@ -865,15 +869,22 @@ export async function runEmbeddedAttempt(
           });
         } else {
           log.warn(`[ws-stream] no API key for provider=${params.provider}; using HTTP transport`);
-          activeSession.agent.streamFn = streamSimple;
+          activeSession.agent.streamFn = wrapStreamFnWithModelRegistryCredentials(
+            streamSimple,
+            params.modelRegistry,
+          );
         }
       } else if (params.model.provider === "anthropic-vertex") {
         // Anthropic Vertex AI: inject AnthropicVertex client into pi-ai's
         // streamAnthropic for GCP IAM auth instead of Anthropic API keys.
         activeSession.agent.streamFn = createAnthropicVertexStreamFnForModel(params.model);
       } else {
-        // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
-        activeSession.agent.streamFn = streamSimple;
+        // Keep a stable underlying streamFn reference so vitest can reliably mock
+        // @mariozechner/pi-ai while we preserve per-request credential injection.
+        activeSession.agent.streamFn = wrapStreamFnWithModelRegistryCredentials(
+          streamSimple,
+          params.modelRegistry,
+        );
       }
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(

--- a/src/agents/stream-fn-credentials.test.ts
+++ b/src/agents/stream-fn-credentials.test.ts
@@ -1,0 +1,107 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { wrapStreamFnWithModelRegistryCredentials } from "./stream-fn-credentials.js";
+
+const testModel = {
+  api: "openai-codex-responses",
+  id: "gpt-5.4",
+  provider: "openai-codex",
+} as unknown as Model<Api>;
+
+const testContext = { messages: [] } as Parameters<StreamFn>[1];
+
+function createModelRegistryMock(
+  ...results: Array<Awaited<ReturnType<ModelRegistry["getApiKeyAndHeaders"]>>>
+) {
+  const getApiKeyAndHeaders = vi.fn();
+  for (const result of results) {
+    getApiKeyAndHeaders.mockResolvedValueOnce(result);
+  }
+  if (results.length === 1) {
+    getApiKeyAndHeaders.mockResolvedValue(results[0]);
+  }
+
+  return {
+    getApiKeyAndHeaders,
+  } as unknown as ModelRegistry & {
+    getApiKeyAndHeaders: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("wrapStreamFnWithModelRegistryCredentials", () => {
+  it("injects model-registry credentials and merges headers", async () => {
+    const sentinel = { ok: true } as Awaited<ReturnType<StreamFn>>;
+    const baseStreamFn = vi.fn(async () => sentinel) as unknown as StreamFn;
+    const modelRegistry = createModelRegistryMock({
+      ok: true,
+      apiKey: "resolved-token",
+      headers: {
+        Authorization: "Bearer resolved-token",
+        "X-Registry": "registry",
+        "X-Shared": "registry",
+      },
+    });
+    const wrapped = wrapStreamFnWithModelRegistryCredentials(baseStreamFn, modelRegistry);
+
+    const result = await wrapped(testModel, testContext, {
+      headers: {
+        "X-Client": "client",
+        "X-Shared": "client",
+      },
+    });
+
+    expect(result).toBe(sentinel);
+    expect(modelRegistry.getApiKeyAndHeaders).toHaveBeenCalledWith(testModel);
+    expect(baseStreamFn).toHaveBeenCalledWith(
+      testModel,
+      testContext,
+      expect.objectContaining({
+        apiKey: "resolved-token",
+        headers: {
+          Authorization: "Bearer resolved-token",
+          "X-Client": "client",
+          "X-Registry": "registry",
+          "X-Shared": "client",
+        },
+      }),
+    );
+  });
+
+  it("re-resolves credentials on every call", async () => {
+    const baseStreamFn = vi.fn(async (_model, _context, options) => options) as unknown as StreamFn;
+    const modelRegistry = createModelRegistryMock(
+      { ok: true, apiKey: "first-token", headers: { "X-Seq": "1" } },
+      { ok: true, apiKey: "second-token", headers: { "X-Seq": "2" } },
+    );
+    const wrapped = wrapStreamFnWithModelRegistryCredentials(baseStreamFn, modelRegistry);
+
+    const first = await wrapped(testModel, testContext, {});
+    const second = await wrapped(testModel, testContext, {});
+
+    expect(modelRegistry.getApiKeyAndHeaders).toHaveBeenCalledTimes(2);
+    expect(first).toMatchObject({
+      apiKey: "first-token",
+      headers: { "X-Seq": "1" },
+    });
+    expect(second).toMatchObject({
+      apiKey: "second-token",
+      headers: { "X-Seq": "2" },
+    });
+  });
+
+  it("throws the model-registry error when credentials cannot be resolved", async () => {
+    const baseStreamFn = vi.fn(async () => ({ ok: true })) as unknown as StreamFn;
+    const modelRegistry = createModelRegistryMock({
+      ok: false,
+      error: 'No API key found for "openai-codex"',
+    });
+    const wrapped = wrapStreamFnWithModelRegistryCredentials(baseStreamFn, modelRegistry);
+
+    await expect(wrapped(testModel, testContext, {})).rejects.toThrow(
+      'No API key found for "openai-codex"',
+    );
+    expect(baseStreamFn).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/stream-fn-credentials.ts
+++ b/src/agents/stream-fn-credentials.ts
@@ -1,0 +1,21 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+
+export function wrapStreamFnWithModelRegistryCredentials(
+  streamFn: StreamFn,
+  modelRegistry: ModelRegistry,
+): StreamFn {
+  return async (model, context, options) => {
+    const auth = await modelRegistry.getApiKeyAndHeaders(model);
+    if (!auth.ok) {
+      throw new Error(auth.error);
+    }
+
+    return streamFn(model, context, {
+      ...options,
+      apiKey: auth.apiKey,
+      headers:
+        auth.headers || options?.headers ? { ...auth.headers, ...options?.headers } : undefined,
+    });
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: Embedded agent runs started failing after the `@mariozechner/pi-coding-agent` 0.63.0 bump because OpenClaw replaced the SDK's auth-injecting `streamFn` wrapper with raw provider stream functions.
- Why it matters: Every embedded run could fail with `No API key for provider: <provider>`, which made agent chat unusable even when `auth-profiles.json` credentials were valid.
- What changed: Added a shared wrapper that re-resolves `modelRegistry.getApiKeyAndHeaders()` on every overridden `streamFn` call, then applied it to embedded run and compaction override paths and added focused coverage for credential injection, header merging, and error propagation.
- What did NOT change (scope boundary): WebSocket transport handling and the Anthropic Vertex special transport path were left unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55760
- Related #55672
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The embedded runner and compaction paths overwrote pi-coding-agent's new auth-injecting `streamFn` wrapper with raw stream functions, so provider calls no longer received the resolved `apiKey` and auth headers.
- Missing detection / guardrail: There was no targeted test covering overridden `streamFn` paths after the 0.63.0 auth contract change, so the regression shipped when the dependency bump landed.
- Prior context (`git blame`, prior PR, issue, or refactor if known): The regression was introduced by commit `10527ff8a3` (`build: refresh deps and vitest cache lanes`) after upstream changed from `getApiKey(model)` to `getApiKeyAndHeaders(model)` in pi-mono#1835.
- Why this regressed now: The upstream SDK started injecting credentials in its default wrapper, but OpenClaw's override sites still assumed raw provider stream functions were safe to assign directly.
- If unknown, what was ruled out: Invalid auth profiles and provider configuration were ruled out because `openclaw models status --probe` still succeeded with the same credentials.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/stream-fn-credentials.test.ts`
- Scenario the test should lock in: Wrapped stream functions re-inject `apiKey` and headers from `modelRegistry` on every call, merge caller headers correctly, and fail fast when credential resolution fails.
- Why this is the smallest reliable guardrail: The new helper centralizes the auth restoration logic used by the affected override sites, so exercising the helper directly protects the shared failure mode without requiring a full embedded session harness.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Embedded agent runs and compaction-time provider overrides once again use resolved auth-profile credentials after the 2026.3.26 regression.
- Users with valid provider auth should no longer hit `No API key for provider: <provider>` immediately on embedded runs because of these override paths.
- No config defaults or user-facing commands changed.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: This restores passing model-registry-resolved credentials through overridden stream-function paths. The wrapper uses the existing `modelRegistry` resolution flow, only injects credentials for the requested model at call time, merges headers without widening scope, and throws immediately if credential resolution fails.

## Repro + Verification

### Environment

- OS: Arch Linux (CachyOS) / Linux 6.17.0-19-generic
- Runtime/container: `pnpm dev` in a local clone
- Model/provider: `openai-codex/gpt-5.4`
- Integration/channel (if any): Embedded agent runner, `openclaw -> openai-codex` via ChatGPT OAuth
- Relevant config (redacted): Valid non-expired OAuth credentials in `~/.openclaw/credentials/auth-profiles.json`; `openclaw models status --probe` succeeds

### Steps

1. Update OpenClaw to commit `10527ff8a3`, which bumped `@mariozechner/pi-coding-agent` from 0.61.1 to 0.63.0.
2. Configure any provider with valid auth, for example `openai-codex` via OAuth, and confirm it with `openclaw models status --probe`.
3. Start any embedded agent session and send a prompt.
4. Observe the embedded run end with `No API key for provider: openai-codex`.

### Expected

- The embedded runner resolves credentials from `auth-profiles.json`, injects them into the provider stream function, and the run proceeds normally.

### Actual

- Embedded runs fail immediately because the overridden stream function receives no injected `apiKey` or auth headers.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Manual verification pending
- Edge cases checked: Manual verification pending
- What you did **not** verify: A live embedded agent run against a real provider after the fix

## Review Conversations

- [x] I replied to or resolved every review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: None.

## Risks and Mitigations

- Risk: Any future `streamFn` override path that does not use the shared wrapper could reintroduce the same auth bypass.
  - Mitigation: The shared helper is now applied at the affected embedded-runner and compaction override sites, and targeted tests lock in the credential-injection contract.
- Risk: Header precedence remains caller-over-registry for duplicate keys because the wrapper preserves the SDK's merge order.
  - Mitigation: The helper matches the upstream wrapper behavior exactly, which avoids introducing a second auth-merging contract in OpenClaw.
