### PR TITLE
Z.AI: support glm-5.1 forward-compat

### DIFF
--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -28,12 +28,20 @@ const GLM5_MODEL_ID = "glm-5";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
 
+function isGlm5ForwardCompatModelId(modelId: string): boolean {
+  const lower = modelId.trim().toLowerCase();
+  return (
+    lower === GLM5_MODEL_ID ||
+    lower.startsWith(`${GLM5_MODEL_ID}.`) ||
+    lower.startsWith(`${GLM5_MODEL_ID}-`)
+  );
+}
+
 function resolveGlm5ForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
   const trimmedModelId = ctx.modelId.trim();
-  const lower = trimmedModelId.toLowerCase();
-  if (lower !== GLM5_MODEL_ID && !lower.startsWith(`${GLM5_MODEL_ID}-`)) {
+  if (!isGlm5ForwardCompatModelId(trimmedModelId)) {
     return undefined;
   }
 
@@ -287,7 +295,7 @@ export default definePluginEntry({
       isModernModelRef: ({ modelId }) => {
         const lower = modelId.trim().toLowerCase();
         return (
-          lower.startsWith("glm-5") ||
+          isGlm5ForwardCompatModelId(lower) ||
           lower.startsWith("glm-4.7") ||
           lower.startsWith("glm-4.7-flash") ||
           lower.startsWith("glm-4.7-flashx")

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -38,33 +38,22 @@ const ANTHROPIC_SONNET_EXPECTED = {
   reasoning: true,
 };
 
-const ZAI_GLM5_CASE = {
-  provider: "zai",
-  id: "glm-5",
-  expectedModel: {
+const ZAI_REGISTRY_ENTRIES = [
+  {
     provider: "zai",
-    id: "glm-5",
-    api: "openai-completions",
-    baseUrl: "https://api.z.ai/api/paas/v4",
-    reasoning: true,
-  },
-  registryEntries: [
-    {
+    modelId: "glm-4.7",
+    model: buildForwardCompatTemplate({
+      id: "glm-4.7",
+      name: "GLM-4.7",
       provider: "zai",
-      modelId: "glm-4.7",
-      model: buildForwardCompatTemplate({
-        id: "glm-4.7",
-        name: "GLM-4.7",
-        provider: "zai",
-        api: "openai-completions",
-        baseUrl: "https://api.z.ai/api/paas/v4",
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        maxTokens: 131072,
-      }),
-    },
-  ],
-} as const;
+      api: "openai-completions",
+      baseUrl: "https://api.z.ai/api/paas/v4",
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      maxTokens: 131072,
+    }),
+  },
+] as const;
 
 function createRuntimeHooks() {
   return createProviderRuntimeTestMock({
@@ -123,13 +112,13 @@ function runAnthropicSonnetForwardCompatFallback() {
   });
 }
 
-function runZaiForwardCompatFallback() {
+function runZaiForwardCompatFallback(modelId: string) {
   const result = resolveModelWithRegistry({
-    provider: ZAI_GLM5_CASE.provider,
-    modelId: ZAI_GLM5_CASE.id,
+    provider: "zai",
+    modelId,
     agentDir: "/tmp/agent",
     modelRegistry: createRegistry(
-      ZAI_GLM5_CASE.registryEntries.map((entry) => ({
+      ZAI_REGISTRY_ENTRIES.map((entry) => ({
         provider: entry.provider,
         modelId: entry.modelId,
         model: entry.model,
@@ -139,7 +128,13 @@ function runZaiForwardCompatFallback() {
   });
   expectResolvedForwardCompatFallbackWithRegistryResult({
     result,
-    expectedModel: ZAI_GLM5_CASE.expectedModel,
+    expectedModel: {
+      provider: "zai",
+      id: modelId,
+      api: "openai-completions",
+      baseUrl: "https://api.z.ai/api/paas/v4",
+      reasoning: true,
+    },
   });
 }
 
@@ -154,5 +149,11 @@ describe("resolveModel forward-compat tail", () => {
     runAnthropicSonnetForwardCompatFallback,
   );
 
-  it("builds a zai forward-compat fallback for glm-5", runZaiForwardCompatFallback);
+  it("builds a zai forward-compat fallback for glm-5", () => {
+    runZaiForwardCompatFallback("glm-5");
+  });
+
+  it("builds a zai forward-compat fallback for glm-5.1", () => {
+    runZaiForwardCompatFallback("glm-5.1");
+  });
 });

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -82,6 +82,11 @@ function normalizeDynamicModel(params: { provider: string; model: ResolvedModelL
   return undefined;
 }
 
+function isGlm5ForwardCompatModelId(modelId: string): boolean {
+  const lower = modelId.trim().toLowerCase();
+  return lower === "glm-5" || lower.startsWith("glm-5.") || lower.startsWith("glm-5-");
+}
+
 function buildDynamicModel(
   params: DynamicModelContext,
   options: Required<
@@ -268,7 +273,7 @@ function buildDynamicModel(
       );
     }
     case "zai": {
-      if (lower !== "glm-5") {
+      if (!isGlm5ForwardCompatModelId(modelId)) {
         return undefined;
       }
       const template = findTemplate(params, "zai", ["glm-4.7"]);

--- a/src/plugins/contracts/runtime.contract.test.ts
+++ b/src/plugins/contracts/runtime.contract.test.ts
@@ -743,6 +743,35 @@ describe("provider runtime contract", { timeout: CONTRACT_SETUP_TIMEOUT_MS }, ()
       });
     });
 
+    it("owns glm-5.1 forward-compat resolution", () => {
+      const provider = requireProviderContractProvider("zai");
+      const model = provider.resolveDynamicModel?.({
+        provider: "zai",
+        modelId: "glm-5.1",
+        modelRegistry: {
+          find: (_provider: string, id: string) =>
+            id === "glm-4.7"
+              ? createModel({
+                  id,
+                  api: "openai-completions",
+                  provider: "zai",
+                  baseUrl: "https://api.z.ai/api/paas/v4",
+                  reasoning: false,
+                  contextWindow: 202_752,
+                  maxTokens: 16_384,
+                })
+              : null,
+        } as never,
+      });
+
+      expect(model).toMatchObject({
+        id: "glm-5.1",
+        provider: "zai",
+        api: "openai-completions",
+        reasoning: true,
+      });
+    });
+
     it("owns usage auth resolution", async () => {
       const provider = requireProviderContractProvider("zai");
       await expect(


### PR DESCRIPTION
## Summary

- Problem: explicit `zai/glm-5.1` agent defaults resolved in config/status, but the Z.AI dynamic-model runtime path only recognized `glm-5` or `glm-5-*`, so fresh runs still started on `glm-5`.
- Why it matters: agents configured to prefer `glm-5.1` silently ran on the older model, which broke the intended `glm-5.1` primary + `glm-5` fallback setup.
- What changed: taught the Z.AI provider forward-compat resolver and the runner's provider-runtime test mock to accept dotted `glm-5.*` ids, and added regression coverage for `glm-5.1`.
- What did NOT change (scope boundary): this does not change repo-tracked default agent configs or provider onboarding defaults; it only fixes explicit runtime resolution for already-configured `glm-5.1` selections.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/zai/index.ts` only treated `glm-5` and `glm-5-*` as forward-compatible dynamic model ids, so dotted ids like `glm-5.1` were rejected and later code paths fell back to `glm-5`.
- Missing detection / guardrail: contract and runner forward-compat tests only covered bare `glm-5`, not explicit dotted variants.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: local agent config switched explicit primaries from `zai/glm-5` to `zai/glm-5.1`, which exposed the narrower matcher.
- If unknown, what was ruled out: ruled out stale session reuse by rerunning on fresh local source-driven agent runs after the code change.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/model.forward-compat.test.ts`, `src/plugins/contracts/runtime.contract.test.ts`
- Scenario the test should lock in: explicit `zai/glm-5.1` resolves through the Z.AI forward-compat runtime path instead of downgrading to `glm-5`.
- Why this is the smallest reliable guardrail: it covers both the plugin-owned dynamic-model contract and the runner path that consumes it.
- Existing test that already covers this (if any): existing `glm-5` forward-compat coverage covered the same path, but not dotted ids.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Agents already configured with explicit `zai/glm-5.1` primaries now run on `glm-5.1` as expected. Existing `glm-5` selections are unchanged.

## Diagram (if applicable)

```text
Before:
[agent configured with zai/glm-5.1] -> [dynamic resolver rejects glm-5.1] -> [run starts on glm-5]

After:
[agent configured with zai/glm-5.1] -> [dynamic resolver accepts glm-5.1] -> [run starts on glm-5.1]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source tree via `pnpm openclaw agent --local`
- Model/provider: `zai/glm-5.1`, fallback `zai/glm-5`
- Integration/channel (if any): local agent runtime
- Relevant config (redacted): only agents already using `zai/glm-5` were changed locally to `primary=zai/glm-5.1`, `fallbacks=[zai/glm-5]`

### Steps

1. Configure an agent with explicit primary `zai/glm-5.1`.
2. Run the agent through the local source runtime on a fresh session.
3. Inspect the returned `meta.agentMeta.model` and system prompt report.

### Expected

- The run uses `glm-5.1`.

### Actual

- Before this patch, fresh runs still used `glm-5`.
- After this patch, fresh local runs use `glm-5.1`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test -- src/agents/pi-embedded-runner/model.forward-compat.test.ts`; `pnpm test -- src/plugins/contracts/runtime.contract.test.ts`; `pnpm openclaw agent --local --agent developer --session-id codex-glm51-local-developer-20260327 --message 'Reply with exactly OK.' --json`; `pnpm openclaw agent --local --agent opencode-agent --session-id codex-glm51-local-opencode-20260327 --message 'Reply with exactly OK.' --json`.
- Edge cases checked: bare `glm-5` coverage remains; explicit dotted `glm-5.1` now resolves and runs.
- What you did **not** verify: full `pnpm check` / `pnpm build` are currently failing on unrelated existing `main` TypeScript errors in compaction and skills files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the broader matcher could accidentally classify an unintended future `glm-5` variant.
  - Mitigation: matching remains constrained to `glm-5`, `glm-5.*`, and `glm-5-*`, and regression tests cover the intended dotted variant.
