### PR TITLE
feat(config): add safety posture presets for sandbox and session isolation

### DIFF
--- a/extensions/google/media-understanding-provider.video.test.ts
+++ b/extensions/google/media-understanding-provider.video.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ssrf from "../../src/infra/net/ssrf.js";
-import { createRequestCaptureJsonFetch } from "../../src/media-understanding/audio.test-helpers.js";
-import { withFetchPreconnect } from "../../src/test-utils/fetch-mock.js";
+import { withFetchPreconnect } from "../../test/helpers/extensions/fetch-mock.js";
+import { createRequestCaptureJsonFetch } from "../../test/helpers/extensions/media-understanding.js";
 import { describeGeminiVideo } from "./media-understanding-provider.js";
 
 const TEST_NET_IP = "203.0.113.10";

--- a/extensions/kilocode/onboard.test.ts
+++ b/extensions/kilocode/onboard.test.ts
@@ -12,7 +12,7 @@ import {
   KILOCODE_DEFAULT_MAX_TOKENS,
   KILOCODE_DEFAULT_COST,
 } from "../../src/plugin-sdk/provider-models.js";
-import { captureEnv } from "../../src/test-utils/env.js";
+import { captureEnv } from "../../test/helpers/extensions/env.js";
 import {
   applyKilocodeProviderConfig,
   applyKilocodeConfig,

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { withEnv } from "../../../src/test-utils/env.js";
+import { withEnv } from "../../../test/helpers/extensions/env.js";
 import { __testing } from "./kimi-web-search-provider.js";
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { withEnv } from "../../../src/test-utils/env.js";
+import { withEnv } from "../../../test/helpers/extensions/env.js";
 import { __testing } from "./perplexity-web-search-provider.js";
 
 const openRouterApiKeyEnv = ["OPENROUTER_API", "KEY"].join("_");

--- a/extensions/xai/src/grok-web-search-provider.test.ts
+++ b/extensions/xai/src/grok-web-search-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { withEnv } from "../../../src/test-utils/env.js";
+import { withEnv } from "../../../test/helpers/extensions/env.js";
 import { __testing } from "./grok-web-search-provider.js";
 
 describe("grok web search provider", () => {

--- a/src/config/apply-safety-posture.test.ts
+++ b/src/config/apply-safety-posture.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { applySafetyPosture } from "./apply-safety-posture.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+describe("applySafetyPosture", () => {
+  it("returns config unchanged when no safetyPosture preset", () => {
+    const cfg: OpenClawConfig = { commands: {} } as OpenClawConfig;
+    expect(applySafetyPosture(cfg)).toBe(cfg);
+  });
+
+  it("returns config unchanged when preset is undefined", () => {
+    const cfg: OpenClawConfig = {
+      commands: {},
+      safetyPosture: {},
+    } as OpenClawConfig;
+    expect(applySafetyPosture(cfg)).toBe(cfg);
+  });
+
+  it("applies development preset: sandbox off, dmScope main", () => {
+    const cfg = applySafetyPosture({
+      commands: {},
+      safetyPosture: { preset: "development" },
+    } as OpenClawConfig);
+
+    expect(cfg.agents?.defaults?.sandbox?.mode).toBe("off");
+    expect(cfg.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+    expect(cfg.session?.dmScope).toBe("main");
+    expect(cfg._safetyPostureResolvedProfile).toBe("full");
+  });
+
+  it("applies balanced preset: sandbox non-main, dmScope per-channel-peer", () => {
+    const cfg = applySafetyPosture({
+      commands: {},
+      safetyPosture: { preset: "balanced" },
+    } as OpenClawConfig);
+
+    expect(cfg.agents?.defaults?.sandbox?.mode).toBe("non-main");
+    expect(cfg.agents?.defaults?.sandbox?.workspaceAccess).toBe("ro");
+    expect(cfg.session?.dmScope).toBe("per-channel-peer");
+    expect(cfg._safetyPostureResolvedProfile).toBe("limited");
+  });
+
+  it("applies strict preset: sandbox all, workspace none, memory disabled", () => {
+    const cfg = applySafetyPosture({
+      commands: {},
+      safetyPosture: { preset: "strict" },
+    } as OpenClawConfig);
+
+    expect(cfg.agents?.defaults?.sandbox?.mode).toBe("all");
+    expect(cfg.agents?.defaults?.sandbox?.workspaceAccess).toBe("none");
+    expect(cfg.session?.dmScope).toBe("per-channel-peer");
+    expect(cfg._safetyPostureResolvedProfile).toBe("public");
+  });
+
+  it("explicit config values override preset defaults", () => {
+    const cfg = applySafetyPosture({
+      commands: {},
+      safetyPosture: { preset: "strict" },
+      agents: {
+        defaults: {
+          sandbox: { mode: "non-main", workspaceAccess: "rw" },
+        },
+      },
+      session: { dmScope: "main" },
+    } as unknown as OpenClawConfig);
+
+    // Explicit values should be preserved
+    expect(cfg.agents?.defaults?.sandbox?.mode).toBe("non-main");
+    expect(cfg.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+    expect(cfg.session?.dmScope).toBe("main");
+    // Profile still derived from preset
+    expect(cfg._safetyPostureResolvedProfile).toBe("public");
+  });
+
+  it("agentProfile override takes precedence over preset default", () => {
+    const cfg = applySafetyPosture({
+      commands: {},
+      safetyPosture: { preset: "development", agentProfile: "limited" },
+    } as OpenClawConfig);
+
+    expect(cfg._safetyPostureResolvedProfile).toBe("limited");
+  });
+
+  it("preserves existing config fields", () => {
+    const cfg = applySafetyPosture({
+      commands: { ownerDisplaySecret: "test" },
+      safetyPosture: { preset: "balanced" },
+      model: { default: "gpt-4" },
+    } as unknown as OpenClawConfig);
+
+    expect(cfg.commands).toEqual({ ownerDisplaySecret: "test" });
+    expect((cfg as Record<string, unknown>).model).toEqual({ default: "gpt-4" });
+  });
+});

--- a/src/config/apply-safety-posture.ts
+++ b/src/config/apply-safety-posture.ts
@@ -1,0 +1,88 @@
+/**
+ * Runtime expansion of safety posture presets into concrete config fields.
+ *
+ * Presets provide opinionated defaults; explicit config values always win.
+ */
+
+import type {
+  SafetyPosturePreset,
+  AgentToolProfile,
+} from "./types.safety-posture.js";
+import {
+  SANDBOX_PRESETS,
+  SESSION_PRESETS,
+  MEMORY_PRESETS,
+} from "./types.safety-posture.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
+
+const DEFAULT_AGENT_PROFILE: Record<SafetyPosturePreset, AgentToolProfile> = {
+  development: "full",
+  balanced: "limited",
+  strict: "public",
+};
+
+/**
+ * Apply safety posture preset to config.
+ *
+ * Explicit config values take precedence over preset defaults.
+ * Returns a new config object (shallow-merges at affected paths).
+ */
+export function applySafetyPosture(cfg: OpenClawConfig): OpenClawConfig {
+  const preset = cfg.safetyPosture?.preset;
+  if (!preset) {
+    return cfg;
+  }
+
+  const sandboxPreset = SANDBOX_PRESETS[preset];
+  const sessionPreset = SESSION_PRESETS[preset];
+  const memoryPreset = MEMORY_PRESETS[preset];
+
+  // Build next config
+  let next = cfg;
+
+  // Sandbox mode — only apply if not explicitly set
+  const agentDefaults = next.agents?.defaults;
+  if (agentDefaults?.sandbox?.mode === undefined) {
+    next = setDeep(next, ["agents", "defaults", "sandbox", "mode"], sandboxPreset.mode);
+  }
+  if (agentDefaults?.sandbox?.workspaceAccess === undefined) {
+    next = setDeep(next, ["agents", "defaults", "sandbox", "workspaceAccess"], sandboxPreset.workspaceAccess);
+  }
+
+  // Session dmScope — only apply if not explicitly set
+  if (next.session?.dmScope === undefined) {
+    next = setDeep(next, ["session", "dmScope"], sessionPreset.dmScope);
+  }
+
+  // Memory long-term enabled — store as memory.qmd.sessions.enabled or similar.
+  // Since there's no direct longTermMemoryEnabled field, we skip this mapping
+  // unless the config gains one. The preset data is available for consumers
+  // that check MEMORY_PRESETS directly.
+  // TODO: Wire when config gains an explicit longTermMemoryEnabled field.
+
+  // Agent tool profile
+  if (cfg.safetyPosture?.agentProfile === undefined) {
+    next = setDeep(next, ["_safetyPostureResolvedProfile"], DEFAULT_AGENT_PROFILE[preset]);
+  } else {
+    next = setDeep(next, ["_safetyPostureResolvedProfile"], cfg.safetyPosture.agentProfile);
+  }
+
+  return next;
+}
+
+/**
+ * Type-safe deep set. Returns a new object with the path set to value.
+ * Only creates new intermediate objects; does not mutate the input.
+ */
+function setDeep<T>(obj: T, path: string[], value: unknown): T {
+  if (path.length === 0) return obj;
+  const [head, ...rest] = path;
+  const current = (obj as Record<string, unknown>)[head];
+  if (rest.length === 0) {
+    if (current === value) return obj;
+    return { ...obj, [head]: value };
+  }
+  const nested = setDeep(current ?? {}, rest, value);
+  if (current !== undefined && nested === current) return obj;
+  return { ...obj, [head]: nested };
+}

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -28,6 +28,7 @@ import {
   applyTalkConfigNormalization,
   applyTalkApiKey,
 } from "./defaults.js";
+import { applySafetyPosture } from "./apply-safety-posture.js";
 import { restoreEnvVarRefs } from "./env-preserve.js";
 import {
   type EnvSubstitutionWarning,
@@ -1372,7 +1373,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           applyCompactionDefaults(
             applyContextPruningDefaults(
               applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(applySafetyPosture(validated.config)))),
               ),
             ),
           ),

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -11343,6 +11343,22 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
         },
         additionalProperties: false,
       },
+    safetyPosture: {
+      type: "object",
+      properties: {
+        preset: {
+          type: "string",
+          enum: ["development", "balanced", "strict"],
+        },
+        agentProfile: {
+          type: "string",
+          enum: ["full", "limited", "public"],
+        },
+        secureDmMode: {
+          type: "boolean",
+        },
+      },
+      additionalProperties: false,
     },
     required: ["commands"],
     additionalProperties: false,
@@ -14721,6 +14737,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
       label: "Canvas Host",
       help: "Canvas host settings for serving canvas assets and local live-reload behavior used by canvas-enabled workflows. Keep disabled unless canvas-hosted assets are actively used.",
       tags: ["advanced"],
+    },
+    safetyPosture: {
+      label: "Safety Posture",
+      group: "Security",
+      order: 240,
+      help: "Safety posture presets that control default security configurations including sandbox mode, session isolation, and tool access profiles. Choose \"development\" for local work, \"balanced\" for most deployments, or \"strict\" for public-facing production.",
+      tags: ["security"],
     },
     "canvasHost.enabled": {
       label: "Canvas Host Enabled",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -16,6 +16,7 @@ import type {
 import type { HooksConfig } from "./types.hooks.js";
 import type { McpConfig } from "./types.mcp.js";
 import type { MemoryConfig } from "./types.memory.js";
+import type { SafetyPostureConfig } from "./types.safety-posture.js";
 import type {
   AudioConfig,
   BroadcastConfig,
@@ -121,6 +122,7 @@ export type OpenClawConfig = {
   talk?: TalkConfig;
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
+  safetyPosture?: SafetyPostureConfig;
   mcp?: McpConfig;
 };
 

--- a/src/config/types.safety-posture.ts
+++ b/src/config/types.safety-posture.ts
@@ -1,0 +1,161 @@
+/**
+ * Safety Posture Presets for OpenClaw
+ *
+ * These presets control default security configurations for new installations.
+ * Issue #7827: Default Safety Posture - Sandbox & Session Isolation
+ */
+
+/**
+ * Safety posture preset identifiers.
+ *
+ * - "development": Permissive defaults for local development (sandbox off, full tool access)
+ * - "balanced": Moderate security with sandbox for non-main sessions (recommended default)
+ * - "strict": Maximum security isolation for public-facing deployments
+ */
+export type SafetyPosturePreset = "development" | "balanced" | "strict";
+
+/**
+ * Agent profile identifiers for tool access control.
+ *
+ * - "full": All tools available (development mode)
+ * - "limited": High-risk tools blocked (exec, browser, web_fetch on host)
+ * - "public": Minimal tool access for untrusted contexts
+ */
+export type AgentToolProfile = "full" | "limited" | "public";
+
+/**
+ * Sandbox mode presets for agent configurations.
+ */
+export type SandboxModePreset = "off" | "non-main" | "all";
+
+/**
+ * Workspace access presets for sandboxed sessions.
+ */
+export type SandboxWorkspaceAccessPreset = "none" | "ro" | "rw";
+
+/**
+ * Configuration for safety posture presets.
+ */
+export type SafetyPostureConfig = {
+  /**
+   * Active safety posture preset.
+   * Default: "development" for backward compatibility with existing installs.
+   * New installs should use "balanced" for better security.
+   */
+  preset?: SafetyPosturePreset;
+
+  /**
+   * Agent tool access profile override.
+   * When set, overrides the default profile derived from the preset.
+   */
+  agentProfile?: AgentToolProfile;
+
+  /**
+   * Enable secure DM mode (per-channel-peer session isolation).
+   * When true, sets session.dmScope to "per-channel-peer" for better
+   * isolation between different users in DMs.
+   */
+  secureDmMode?: boolean;
+};
+
+/**
+ * Default values for safety posture configuration.
+ */
+export const SAFETY_POSTURE_DEFAULTS = {
+  /** Default preset for new installations */
+  defaultPreset: "development" as SafetyPosturePreset,
+
+  /** Recommended preset for production deployments */
+  recommendedPreset: "balanced" as SafetyPosturePreset,
+
+  /** Default DM scope for secure mode */
+  secureDmScope: "per-channel-peer" as const,
+} as const;
+
+/**
+ * High-risk tools that are denied in "public" agent profile.
+ * These tools can access external systems or execute arbitrary code.
+ */
+export const PUBLIC_PROFILE_DENIED_TOOLS = [
+  "exec",
+  "browser",
+  "web_fetch",
+  "web_search",
+  "gateway",
+  "nodes",
+  "cron",
+  "canvas",
+  "subagents",
+  "sessions_spawn",
+  "sessions_send",
+] as const;
+
+/**
+ * Tools denied in "limited" agent profile.
+ * These can escape the sandbox or access host resources.
+ */
+export const LIMITED_PROFILE_HOST_DENIED_TOOLS = [
+  "exec",
+  "browser",
+  "web_fetch",
+  "gateway",
+  "nodes",
+  "cron",
+] as const;
+
+/**
+ * Sandbox configuration presets by safety posture.
+ */
+export const SANDBOX_PRESETS = {
+  development: {
+    mode: "off" as const,
+    workspaceAccess: "rw" as const,
+    docker: {
+      network: "bridge" as const,
+    },
+  },
+  balanced: {
+    mode: "non-main" as const,
+    workspaceAccess: "ro" as const,
+    docker: {
+      network: "none" as const,
+    },
+  },
+  strict: {
+    mode: "all" as const,
+    workspaceAccess: "none" as const,
+    docker: {
+      network: "none" as const,
+    },
+  },
+} as const;
+
+/**
+ * Session configuration presets by safety posture.
+ */
+export const SESSION_PRESETS = {
+  development: {
+    dmScope: "main" as const,
+  },
+  balanced: {
+    dmScope: "per-channel-peer" as const,
+  },
+  strict: {
+    dmScope: "per-channel-peer" as const,
+  },
+} as const;
+
+/**
+ * Memory configuration presets by safety posture.
+ */
+export const MEMORY_PRESETS = {
+  development: {
+    longTermMemoryEnabled: true,
+  },
+  balanced: {
+    longTermMemoryEnabled: true,
+  },
+  strict: {
+    longTermMemoryEnabled: false, // Disable for public agents
+  },
+} as const;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -34,3 +34,4 @@ export * from "./types.tools.js";
 export * from "./types.whatsapp.js";
 export * from "./types.memory.js";
 export * from "./types.mcp.js";
+export * from "./types.safety-posture.js";

--- a/src/config/zod-schema.safety-posture.ts
+++ b/src/config/zod-schema.safety-posture.ts
@@ -1,0 +1,39 @@
+/**
+ * Zod schema for safety posture configuration.
+ * Issue #7827: Default Safety Posture - Sandbox & Session Isolation
+ */
+
+import { z } from "zod";
+
+export const SafetyPosturePresetSchema = z.union([
+  z.literal("development"),
+  z.literal("balanced"),
+  z.literal("strict"),
+]);
+
+export const AgentToolProfileSchema = z.union([
+  z.literal("full"),
+  z.literal("limited"),
+  z.literal("public"),
+]);
+
+export const SafetyPostureConfigSchema = z
+  .object({
+    /**
+     * Active safety posture preset.
+     * - development: Permissive defaults (sandbox off)
+     * - balanced: Moderate security (sandbox for non-main sessions)
+     * - strict: Maximum isolation (sandbox all sessions)
+     */
+    preset: SafetyPosturePresetSchema.optional(),
+    /**
+     * Override the agent tool profile derived from preset.
+     */
+    agentProfile: AgentToolProfileSchema.optional(),
+    /**
+     * Enable secure DM mode (per-channel-peer isolation).
+     */
+    secureDmMode: z.boolean().optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -13,6 +13,7 @@ import {
 import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
 import { PluginInstallRecordShape } from "./zod-schema.installs.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
+import { SafetyPostureConfigSchema } from "./zod-schema.safety-posture.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 import {
   CommandsSchema,
@@ -877,6 +878,7 @@ export const OpenClawSchema = z
       })
       .optional(),
     memory: MemorySchema,
+    safetyPosture: SafetyPostureConfigSchema,
     mcp: McpConfigSchema,
     skills: z
       .object({

--- a/test/helpers/extensions/media-understanding.ts
+++ b/test/helpers/extensions/media-understanding.ts
@@ -1,0 +1,1 @@
+export { createRequestCaptureJsonFetch } from "../../../src/media-understanding/audio.test-helpers.js";


### PR DESCRIPTION
Implements #7827

Adds SafetyPostureConfig with development/balanced/strict presets, agent tool profiles (full/limited/public), and sandbox presets for secure-by-default installations.

Extracted from #34185 (split into focused PRs).