### PR TITLE
docs: fix Browserless and broken doc links

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -402,7 +402,7 @@ Docker installs and the containerized gateway live here:
 For Docker gateway deployments, `scripts/docker/setup.sh` can bootstrap sandbox config.
 Set `OPENCLAW_SANDBOX=1` (or `true`/`yes`/`on`) to enable that path. You can
 override socket location with `OPENCLAW_DOCKER_SOCKET`. Full setup and env
-reference: [Docker](/install/docker#enable-agent-sandbox-for-docker-gateway).
+reference: [Docker](/install/docker#agent-sandbox).
 
 ## setupCommand (one-time container setup)
 

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -91,7 +91,7 @@ Custom profiles use `~/.openclaw-<profile>/` or a path set via `OPENCLAW_STATE_D
 
   <Accordion title="Remote mode">
     If your UI points at a **remote** gateway, the remote host owns sessions and workspace.
-    Migrate the gateway host itself, not your local laptop. See [FAQ](/help/faq#where-does-openclaw-store-its-data).
+    Migrate the gateway host itself, not your local laptop. See [FAQ](/help/faq#where-things-live-on-disk).
   </Accordion>
 
   <Accordion title="Secrets in backups">

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -231,8 +231,9 @@ Notes:
 ## Browserless (hosted remote CDP)
 
 [Browserless](https://browserless.io) is a hosted Chromium service that exposes
-CDP endpoints over HTTPS. You can point an OpenClaw browser profile at a
-Browserless region endpoint and authenticate with your API key.
+CDP connection URLs over HTTPS and WebSocket. OpenClaw can use either form, but
+for a remote browser profile the simplest option is the direct WebSocket URL
+from Browserless' connection docs.
 
 Example:
 
@@ -245,7 +246,7 @@ Example:
     remoteCdpHandshakeTimeoutMs: 4000,
     profiles: {
       browserless: {
-        cdpUrl: "https://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
+        cdpUrl: "wss://production-sfo.browserless.io?token=<BROWSERLESS_API_KEY>",
         color: "#00AA00",
       },
     },
@@ -257,17 +258,21 @@ Notes:
 
 - Replace `<BROWSERLESS_API_KEY>` with your real Browserless token.
 - Choose the region endpoint that matches your Browserless account (see their docs).
+- If Browserless gives you an HTTPS base URL, you can either convert it to
+  `wss://` for a direct CDP connection or keep the HTTPS URL and let OpenClaw
+  discover `/json/version`.
 
 ## Direct WebSocket CDP providers
 
 Some hosted browser services expose a **direct WebSocket** endpoint rather than
 the standard HTTP-based CDP discovery (`/json/version`). OpenClaw supports both:
 
-- **HTTP(S) endpoints** (e.g. Browserless) — OpenClaw calls `/json/version` to
-  discover the WebSocket debugger URL, then connects.
+- **HTTP(S) endpoints** — OpenClaw calls `/json/version` to discover the
+  WebSocket debugger URL, then connects.
 - **WebSocket endpoints** (`ws://` / `wss://`) — OpenClaw connects directly,
   skipping `/json/version`. Use this for services like
-  [Browserbase](https://www.browserbase.com) or any provider that hands you a
+  [Browserless](https://browserless.io),
+  [Browserbase](https://www.browserbase.com), or any provider that hands you a
   WebSocket URL.
 
 ### Browserbase

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -413,8 +413,8 @@ topics, OpenClaw preserves the topic for the approval prompt and the post-approv
 
 See:
 
-- [Discord](/channels/discord#exec-approvals-in-discord)
-- [Telegram](/channels/telegram#exec-approvals-in-telegram)
+- [Discord](/channels/discord)
+- [Telegram](/channels/telegram)
 
 ### macOS IPC flow
 


### PR DESCRIPTION
## Summary
- fix three broken internal docs links in sandboxing, migration, and exec approvals pages
- update the Browserless example to use the current `wss://` connection format
- keep the Browserless explanation internally consistent by documenting both HTTPS discovery and direct WebSocket CDP usage

## Testing
- `pnpm format`
- manual anchor validation for the touched docs targets
- manual source review of Browserless CDP support in `extensions/browser/src/browser/chrome.ts` and `extensions/browser/src/browser/cdp.ts`

## Notes
- `pnpm check` currently fails on unrelated pre-existing `origin/main` TypeScript/module issues outside this patch (Matrix, OpenAI, Tlon, Anthropic Vertex, skills, TUI)
- supersedes #55711, #55717, and #55720 with only the valid docs changes kept
