### PR TITLE
fix: restore getApiKey callback after streamFn override in embedded runner

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -876,6 +876,15 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = streamSimple;
       }
 
+      // Once we override the SDK-wrapped streamFn, pi-agent-core still needs a per-provider
+      // auth lookup callback so provider stream functions receive runtime credentials.
+      const agentWithDynamicAuth = activeSession.agent as typeof activeSession.agent & {
+        getApiKey?: (provider: string) => Promise<string | undefined>;
+      };
+      if (!agentWithDynamicAuth.getApiKey) {
+        agentWithDynamicAuth.getApiKey = (provider: string) => params.authStorage.getApiKey(provider);
+      }
+
       const { effectiveExtraParams } = applyExtraParamsToAgent(
         activeSession.agent,
         params.config,


### PR DESCRIPTION
## Summary

After upgrading pi-coding-agent to 0.63.0, custom providers and OAuth-authenticated providers fail with 'No API key for provider' because the SDK's auth-injection wrapper gets stripped when OpenClaw overrides streamFn.

## Root Cause

In pi-coding-agent 0.63.0, createAgentSession() wraps streamFn to inject API keys from modelRegistry.getApiKeyAndHeaders(). OpenClaw's attempt.ts (line ~876) overwrites this wrapper with raw streamSimple, losing the auth injection.

## Fix

Restore the getApiKey callback on the agent after streamFn assignment so pi-agent-core can resolve API keys from authStorage for all provider stream functions.

## Testing

- Type-check passes (no new errors introduced)
- Fix matches the patch proposed by @alehkot in #55816

## Related Issues

Fixes #55816
Fixes #55760