### PR TITLE
fix(telegram): cool down transient sendChatAction failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/Telegram: cool down transient `sendChatAction` network, rate-limit, and server failures without reclassifying broad message text, so typing indicators back off during Telegram outages while the shared typing guard still trips. Carries forward #55886; refs #55811, #55838, #56096, and #56153. Thanks @Boulea7, @sumaiazaman, and @Huangting-xy.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -219,6 +219,16 @@ describe("isTelegramServerError", () => {
 });
 
 describe("isTelegramRateLimitError", () => {
+  class MockHttpError extends Error {
+    constructor(
+      message: string,
+      public readonly error: unknown,
+    ) {
+      super(message);
+      this.name = "HttpError";
+    }
+  }
+
   it.each([
     ["Too Many Requests", 429, true],
     ["Forbidden", 403, false],
@@ -230,6 +240,19 @@ describe("isTelegramRateLimitError", () => {
     const inner = Object.assign(new Error("Too Many Requests"), { error_code: 429 });
     const outer = Object.assign(new Error("wrapped"), { cause: inner });
     expect(isTelegramRateLimitError(outer)).toBe(true);
+  });
+
+  it("detects structured grammY HttpError payloads", () => {
+    const wrapped = new MockHttpError("Too Many Requests", {
+      error_code: 429,
+      description: "Too Many Requests: retry after 5",
+      parameters: { retry_after: 5 },
+    });
+    expect(isTelegramRateLimitError(wrapped)).toBe(true);
+  });
+
+  it("does not infer rate limits from plain text", () => {
+    expect(isTelegramRateLimitError(new Error("429 Too Many Requests"))).toBe(false);
   });
 });
 

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   getTelegramNetworkErrorOrigin,
   isRecoverableTelegramNetworkError,
-  isTelegramRateLimitError,
   isSafeToRetrySendError,
   isTelegramClientRejection,
   isTelegramPollingNetworkError,
+  isTelegramRateLimitError,
   isTelegramServerError,
   tagTelegramNetworkError,
 } from "./network-errors.js";
@@ -219,16 +219,11 @@ describe("isTelegramServerError", () => {
 });
 
 describe("isTelegramRateLimitError", () => {
-  it("returns true for Telegram 429 errors", () => {
-    expect(isTelegramRateLimitError(errorWithTelegramCode("Too Many Requests", 429))).toBe(true);
-  });
-
-  it("detects wrapped 429 retry_after errors without error_code", () => {
-    const wrapped = {
-      message: "429 Too Many Requests",
-      response: { parameters: { retry_after: 1 } },
-    };
-    expect(isTelegramRateLimitError(wrapped)).toBe(true);
+  it.each([
+    ["Too Many Requests", 429, true],
+    ["Forbidden", 403, false],
+  ])("returns %s for error_code %s", (message, errorCode, expected) => {
+    expect(isTelegramRateLimitError(errorWithTelegramCode(message, errorCode))).toBe(expected);
   });
 
   it("detects error_code in nested cause", () => {

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -184,47 +184,14 @@ function hasTelegramErrorCode(err: unknown, matches: (code: number) => boolean):
   return false;
 }
 
-function hasTelegramRetryAfter(err: unknown): boolean {
-  for (const candidate of collectTelegramErrorCandidates(err)) {
-    if (!candidate || typeof candidate !== "object") {
-      continue;
-    }
-    const retryAfter =
-      "parameters" in candidate && candidate.parameters && typeof candidate.parameters === "object"
-        ? (candidate.parameters as { retry_after?: unknown }).retry_after
-        : "response" in candidate &&
-            candidate.response &&
-            typeof candidate.response === "object" &&
-            "parameters" in candidate.response
-          ? (
-              candidate.response as {
-                parameters?: { retry_after?: unknown };
-              }
-            ).parameters?.retry_after
-          : "error" in candidate &&
-              candidate.error &&
-              typeof candidate.error === "object" &&
-              "parameters" in candidate.error
-            ? (candidate.error as { parameters?: { retry_after?: unknown } }).parameters
-                ?.retry_after
-            : undefined;
-    if (typeof retryAfter === "number" && Number.isFinite(retryAfter)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /** Returns true for HTTP 5xx server errors (error may have been processed). */
 export function isTelegramServerError(err: unknown): boolean {
   return hasTelegramErrorCode(err, (code) => code >= 500);
 }
 
+/** Returns true for Telegram rate limits (safe to treat as a transient chat-action failure). */
 export function isTelegramRateLimitError(err: unknown): boolean {
-  return (
-    hasTelegramErrorCode(err, (code) => code === 429) ||
-    (hasTelegramRetryAfter(err) && /(?:^|\b)429\b|too many requests/i.test(formatErrorMessage(err)))
-  );
+  return hasTelegramErrorCode(err, (code) => code === 429);
 }
 
 /** Returns true for HTTP 4xx client errors (Telegram explicitly rejected, not applied). */

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -132,8 +132,8 @@ describe("createTelegramSendChatActionHandler", () => {
       maxConsecutive401: 2,
     });
 
-    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
-    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("fetch failed");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("fetch failed");
 
     expect(handler.isSuspended()).toBe(false);
     expect(fn).toHaveBeenCalledTimes(1);
@@ -174,7 +174,7 @@ describe("createTelegramSendChatActionHandler", () => {
         logger,
       });
 
-      await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+      await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("fetch failed");
       now = 10_000;
       await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
 
@@ -193,7 +193,9 @@ describe("createTelegramSendChatActionHandler", () => {
       logger,
     });
 
-    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+    await expect(handler.sendChatAction(123, "typing")).rejects.toMatchObject({
+      error_code: 429,
+    });
     expect(handler.isSuspended()).toBe(false);
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient failure"));
   });
@@ -206,7 +208,9 @@ describe("createTelegramSendChatActionHandler", () => {
       logger,
     });
 
-    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+    await expect(handler.sendChatAction(123, "typing")).rejects.toMatchObject({
+      error_code: 502,
+    });
     expect(handler.isSuspended()).toBe(false);
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient failure"));
   });
@@ -240,7 +244,7 @@ describe("createTelegramSendChatActionHandler", () => {
       });
 
       await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
-      await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+      await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("fetch failed");
       now = 10_000;
       await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
 

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -1,12 +1,13 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  computeBackoff: vi.fn((_policy, attempt: number) => attempt * 1000),
   sleepWithAbort: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock the runtime-exported backoff sleep that the handler actually imports.
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
-  computeBackoff: vi.fn((_policy, attempt: number) => attempt * 1000),
+  computeBackoff: mocks.computeBackoff,
   sleepWithAbort: mocks.sleepWithAbort,
 }));
 
@@ -18,7 +19,19 @@ describe("createTelegramSendChatActionHandler", () => {
   });
 
   const make401Error = () => new Error("401 Unauthorized");
-  const make500Error = () => new Error("500 Internal Server Error");
+  const makeTransientNetworkError = () =>
+    Object.assign(new Error("TypeError: fetch failed"), { code: "ETIMEDOUT" });
+  const makeRateLimitError = () => ({
+    error_code: 429,
+    message: "429 Too Many Requests",
+    description: "Too Many Requests: retry after 5",
+  });
+  const makeServerError = () => ({
+    error_code: 502,
+    message: "502 Bad Gateway",
+    description: "Bad Gateway",
+  });
+  const makeUnexpectedError = () => new Error("400 Bad Request: invalid action");
 
   it("calls sendChatActionFn on success", async () => {
     const fn = vi.fn().mockResolvedValue(true);
@@ -72,7 +85,7 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(fn).toHaveBeenCalledTimes(3); // not called again
   });
 
-  it("resets failure counter on success", async () => {
+  it("resets the 401 failure counter on success", async () => {
     let callCount = 0;
     const fn = vi.fn().mockImplementation(() => {
       callCount++;
@@ -97,8 +110,8 @@ describe("createTelegramSendChatActionHandler", () => {
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("recovered"));
   });
 
-  it("does not count non-401 errors toward suspension", async () => {
-    const fn = vi.fn().mockRejectedValue(make500Error());
+  it("suppresses repeated transient network errors during cooldown", async () => {
+    const fn = vi.fn().mockRejectedValue(makeTransientNetworkError());
     const logger = vi.fn();
     const handler = createTelegramSendChatActionHandler({
       sendChatActionFn: fn,
@@ -106,11 +119,12 @@ describe("createTelegramSendChatActionHandler", () => {
       maxConsecutive401: 2,
     });
 
-    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
-    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
-    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("500");
+    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
 
     expect(handler.isSuspended()).toBe(false);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient failure"));
   });
 
   it("reset() clears suspension", async () => {
@@ -127,6 +141,101 @@ describe("createTelegramSendChatActionHandler", () => {
 
     handler.reset();
     expect(handler.isSuspended()).toBe(false);
+  });
+
+  it("recovers after a transient cooldown expires", async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      let fail = true;
+      const fn = vi.fn().mockImplementation(() => {
+        if (fail) {
+          fail = false;
+          throw makeTransientNetworkError();
+        }
+        return Promise.resolve(true);
+      });
+      const logger = vi.fn();
+      const handler = createTelegramSendChatActionHandler({
+        sendChatActionFn: fn,
+        logger,
+      });
+
+      await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+      now = 10_000;
+      await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+
+      expect(fn).toHaveBeenCalledTimes(2);
+      expect(logger).toHaveBeenCalledWith(expect.stringContaining("recovered"));
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("treats Telegram 429 responses as transient and does not suspend", async () => {
+    const fn = vi.fn().mockRejectedValue(makeRateLimitError());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient failure"));
+  });
+
+  it("treats Telegram 5xx responses as transient and does not suspend", async () => {
+    const fn = vi.fn().mockRejectedValue(makeServerError());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+    expect(handler.isSuspended()).toBe(false);
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient failure"));
+  });
+
+  it("still throws unexpected non-transient errors", async () => {
+    const fn = vi.fn().mockRejectedValue(makeUnexpectedError());
+    const logger = vi.fn();
+    const handler = createTelegramSendChatActionHandler({
+      sendChatActionFn: fn,
+      logger,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("400 Bad Request");
+    expect(handler.isSuspended()).toBe(false);
+  });
+
+  it("preserves the 401 failure counter across an intervening transient cooldown", async () => {
+    let now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(make401Error())
+        .mockRejectedValueOnce(makeTransientNetworkError())
+        .mockRejectedValueOnce(make401Error());
+      const logger = vi.fn();
+      const handler = createTelegramSendChatActionHandler({
+        sendChatActionFn: fn,
+        logger,
+        maxConsecutive401: 3,
+      });
+
+      await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+      await expect(handler.sendChatAction(123, "typing")).resolves.toBeUndefined();
+      now = 10_000;
+      await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("401");
+
+      expect(handler.isSuspended()).toBe(false);
+      expect(logger).toHaveBeenCalledWith(expect.stringContaining("401 error (2/3)"));
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("is shared across multiple chatIds (global handler)", async () => {

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -34,6 +34,8 @@ describe("createTelegramSendChatActionHandler", () => {
   const make401Error = () => new Error("401 Unauthorized");
   const makeTransientNetworkError = () =>
     Object.assign(new Error("TypeError: fetch failed"), { code: "ETIMEDOUT" });
+  const makeBroadNetworkMessageError = () =>
+    new Error("Network request for 'sendChatAction' failed!");
   const makeRateLimitError = () => ({
     error_code: 429,
     message: "429 Too Many Requests",
@@ -198,6 +200,40 @@ describe("createTelegramSendChatActionHandler", () => {
     });
     expect(handler.isSuspended()).toBe(false);
     expect(logger).toHaveBeenCalledWith(expect.stringContaining("transient failure"));
+  });
+
+  it("does not cool down broad network-message errors without structured network details", async () => {
+    const fn = vi.fn().mockRejectedValue(makeBroadNetworkMessageError());
+    const logger = vi.fn();
+    const { handler } = createHandler({
+      sendChatActionFn: fn,
+      logger,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow(
+      "Network request for 'sendChatAction' failed!",
+    );
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow(
+      "Network request for 'sendChatAction' failed!",
+    );
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(logger).not.toHaveBeenCalledWith(expect.stringContaining("transient failure"));
+  });
+
+  it("keeps rejecting during transient cooldown so the typing start guard can trip", async () => {
+    const fn = vi.fn().mockRejectedValue(makeTransientNetworkError());
+    const logger = vi.fn();
+    const { handler } = createHandler({
+      sendChatActionFn: fn,
+      logger,
+    });
+
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("fetch failed");
+    await expect(handler.sendChatAction(123, "typing")).rejects.toThrow("fetch failed");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(logger).toHaveBeenCalledTimes(1);
   });
 
   it("treats Telegram 5xx responses as transient and does not suspend", async () => {

--- a/extensions/telegram/src/sendchataction-401-backoff.test.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.test.ts
@@ -1,23 +1,36 @@
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createTelegramSendChatActionHandler,
+  type CreateTelegramSendChatActionHandlerParams,
+} from "./sendchataction-401-backoff.js";
 
-const mocks = vi.hoisted(() => ({
-  computeBackoff: vi.fn((_policy, attempt: number) => attempt * 1000),
-  sleepWithAbort: vi.fn().mockResolvedValue(undefined),
-}));
+type TelegramSendChatActionTestRuntime = NonNullable<
+  CreateTelegramSendChatActionHandlerParams["runtime"]
+>;
 
-// Mock the runtime-exported backoff sleep that the handler actually imports.
-vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
-  computeBackoff: mocks.computeBackoff,
-  sleepWithAbort: mocks.sleepWithAbort,
-}));
+function createTestRuntime(): TelegramSendChatActionTestRuntime {
+  return {
+    computeBackoff: vi.fn((_policy, attempt: number) => attempt * 1000),
+    sleepWithAbort: vi.fn().mockResolvedValue(undefined),
+  };
+}
 
-let createTelegramSendChatActionHandler: typeof import("./sendchataction-401-backoff.js").createTelegramSendChatActionHandler;
+function createHandler(
+  params: Omit<CreateTelegramSendChatActionHandlerParams, "runtime"> & {
+    runtime?: TelegramSendChatActionTestRuntime;
+  },
+) {
+  const runtime = params.runtime ?? createTestRuntime();
+  return {
+    runtime,
+    handler: createTelegramSendChatActionHandler({
+      ...params,
+      runtime,
+    }),
+  };
+}
 
 describe("createTelegramSendChatActionHandler", () => {
-  beforeAll(async () => {
-    ({ createTelegramSendChatActionHandler } = await import("./sendchataction-401-backoff.js"));
-  });
-
   const make401Error = () => new Error("401 Unauthorized");
   const makeTransientNetworkError = () =>
     Object.assign(new Error("TypeError: fetch failed"), { code: "ETIMEDOUT" });
@@ -36,7 +49,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("calls sendChatActionFn on success", async () => {
     const fn = vi.fn().mockResolvedValue(true);
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
     });
@@ -49,7 +62,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("applies exponential backoff on consecutive 401 errors", async () => {
     const fn = vi.fn().mockRejectedValue(make401Error());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 5,
@@ -67,7 +80,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("suspends after maxConsecutive401 failures", async () => {
     const fn = vi.fn().mockRejectedValue(make401Error());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 3,
@@ -95,7 +108,7 @@ describe("createTelegramSendChatActionHandler", () => {
       return Promise.resolve(true);
     });
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 5,
@@ -113,7 +126,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("suppresses repeated transient network errors during cooldown", async () => {
     const fn = vi.fn().mockRejectedValue(makeTransientNetworkError());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 2,
@@ -130,7 +143,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("reset() clears suspension", async () => {
     const fn = vi.fn().mockRejectedValue(make401Error());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 1,
@@ -156,7 +169,7 @@ describe("createTelegramSendChatActionHandler", () => {
         return Promise.resolve(true);
       });
       const logger = vi.fn();
-      const handler = createTelegramSendChatActionHandler({
+      const { handler } = createHandler({
         sendChatActionFn: fn,
         logger,
       });
@@ -175,7 +188,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("treats Telegram 429 responses as transient and does not suspend", async () => {
     const fn = vi.fn().mockRejectedValue(makeRateLimitError());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
     });
@@ -188,7 +201,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("treats Telegram 5xx responses as transient and does not suspend", async () => {
     const fn = vi.fn().mockRejectedValue(makeServerError());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
     });
@@ -201,7 +214,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("still throws unexpected non-transient errors", async () => {
     const fn = vi.fn().mockRejectedValue(makeUnexpectedError());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
     });
@@ -220,7 +233,7 @@ describe("createTelegramSendChatActionHandler", () => {
         .mockRejectedValueOnce(makeTransientNetworkError())
         .mockRejectedValueOnce(make401Error());
       const logger = vi.fn();
-      const handler = createTelegramSendChatActionHandler({
+      const { handler } = createHandler({
         sendChatActionFn: fn,
         logger,
         maxConsecutive401: 3,
@@ -241,7 +254,7 @@ describe("createTelegramSendChatActionHandler", () => {
   it("is shared across multiple chatIds (global handler)", async () => {
     const fn = vi.fn().mockRejectedValue(make401Error());
     const logger = vi.fn();
-    const handler = createTelegramSendChatActionHandler({
+    const { handler } = createHandler({
       sendChatActionFn: fn,
       logger,
       maxConsecutive401: 3,

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -52,6 +52,10 @@ export type CreateTelegramSendChatActionHandlerParams = {
   sendChatActionFn: SendChatActionFn;
   logger: TelegramSendChatActionLogger;
   maxConsecutive401?: number;
+  runtime?: Partial<{
+    computeBackoff: typeof computeBackoff;
+    sleepWithAbort: typeof sleepWithAbort;
+  }>;
 };
 
 const BACKOFF_POLICY: BackoffPolicy = {
@@ -99,7 +103,10 @@ export function createTelegramSendChatActionHandler({
   sendChatActionFn,
   logger,
   maxConsecutive401 = 10,
+  runtime,
 }: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
+  const computeBackoffFn = runtime?.computeBackoff ?? computeBackoff;
+  const sleepWithAbortFn = runtime?.sleepWithAbort ?? sleepWithAbort;
   let consecutive401Failures = 0;
   let consecutiveTransientFailures = 0;
   let transientCooldownUntil = 0;
@@ -126,12 +133,12 @@ export function createTelegramSendChatActionHandler({
     }
 
     if (consecutive401Failures > 0) {
-      const backoffMs = computeBackoff(BACKOFF_POLICY, consecutive401Failures);
+      const backoffMs = computeBackoffFn(BACKOFF_POLICY, consecutive401Failures);
       logger(
         `sendChatAction backoff: waiting ${backoffMs}ms before retry ` +
           `(failure ${consecutive401Failures}/${maxConsecutive401})`,
       );
-      await sleepWithAbort(backoffMs);
+      await sleepWithAbortFn(backoffMs);
     }
 
     try {
@@ -170,7 +177,7 @@ export function createTelegramSendChatActionHandler({
       } else if (isTransientSendChatActionError(error)) {
         consecutiveTransientFailures++;
         transientCooldownUntil =
-          Date.now() + computeBackoff(TRANSIENT_COOLDOWN_POLICY, consecutiveTransientFailures);
+          Date.now() + computeBackoffFn(TRANSIENT_COOLDOWN_POLICY, consecutiveTransientFailures);
         // Typing indicators are best-effort. Once we enter cooldown, skip repeated
         // sendChatAction calls silently so they do not block message delivery or spam logs.
         logger(

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -5,6 +5,11 @@ import {
   type BackoffPolicy,
 } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+import {
+  isRecoverableTelegramNetworkError,
+  isTelegramRateLimitError,
+  isTelegramServerError,
+} from "./network-errors.js";
 
 export type TelegramSendChatActionLogger = (message: string) => void;
 
@@ -56,6 +61,13 @@ const BACKOFF_POLICY: BackoffPolicy = {
   jitter: 0.1,
 };
 
+const TRANSIENT_COOLDOWN_POLICY: BackoffPolicy = {
+  initialMs: 3000,
+  maxMs: 60_000,
+  factor: 2,
+  jitter: 0.1,
+};
+
 function is401Error(error: unknown): boolean {
   if (!error) {
     return false;
@@ -63,6 +75,14 @@ function is401Error(error: unknown): boolean {
   const message = error instanceof Error ? error.message : JSON.stringify(error);
   return (
     message.includes("401") || normalizeLowercaseStringOrEmpty(message).includes("unauthorized")
+  );
+}
+
+function isTransientSendChatActionError(error: unknown): boolean {
+  return (
+    isTelegramRateLimitError(error) ||
+    isRecoverableTelegramNetworkError(error, { context: "unknown", allowMessageMatch: true }) ||
+    isTelegramServerError(error)
   );
 }
 
@@ -81,10 +101,14 @@ export function createTelegramSendChatActionHandler({
   maxConsecutive401 = 10,
 }: CreateTelegramSendChatActionHandlerParams): TelegramSendChatActionHandler {
   let consecutive401Failures = 0;
+  let consecutiveTransientFailures = 0;
+  let transientCooldownUntil = 0;
   let suspended = false;
 
   const reset = () => {
     consecutive401Failures = 0;
+    consecutiveTransientFailures = 0;
+    transientCooldownUntil = 0;
     suspended = false;
   };
 
@@ -94,6 +118,10 @@ export function createTelegramSendChatActionHandler({
     threadParams?: TelegramSendChatActionParams,
   ): Promise<void> => {
     if (suspended) {
+      return;
+    }
+
+    if (transientCooldownUntil > Date.now()) {
       return;
     }
 
@@ -113,8 +141,17 @@ export function createTelegramSendChatActionHandler({
         logger(`sendChatAction recovered after ${consecutive401Failures} consecutive 401 failures`);
         consecutive401Failures = 0;
       }
+      if (consecutiveTransientFailures > 0) {
+        logger(
+          `sendChatAction recovered after ${consecutiveTransientFailures} consecutive transient failures`,
+        );
+        consecutiveTransientFailures = 0;
+        transientCooldownUntil = 0;
+      }
     } catch (error) {
       if (is401Error(error)) {
+        consecutiveTransientFailures = 0;
+        transientCooldownUntil = 0;
         consecutive401Failures++;
 
         if (consecutive401Failures >= maxConsecutive401) {
@@ -130,6 +167,17 @@ export function createTelegramSendChatActionHandler({
               `Retrying with exponential backoff.`,
           );
         }
+      } else if (isTransientSendChatActionError(error)) {
+        consecutiveTransientFailures++;
+        transientCooldownUntil =
+          Date.now() + computeBackoff(TRANSIENT_COOLDOWN_POLICY, consecutiveTransientFailures);
+        // Typing indicators are best-effort. Once we enter cooldown, skip repeated
+        // sendChatAction calls silently so they do not block message delivery or spam logs.
+        logger(
+          `sendChatAction transient failure (${consecutiveTransientFailures}). ` +
+            `Cooling down before the next retry.`,
+        );
+        return;
       }
       throw error;
     }

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -85,7 +85,7 @@ function is401Error(error: unknown): boolean {
 function isTransientSendChatActionError(error: unknown): boolean {
   return (
     isTelegramRateLimitError(error) ||
-    isRecoverableTelegramNetworkError(error, { context: "unknown", allowMessageMatch: true }) ||
+    isRecoverableTelegramNetworkError(error, { context: "send", allowMessageMatch: false }) ||
     isTelegramServerError(error)
   );
 }

--- a/extensions/telegram/src/sendchataction-401-backoff.ts
+++ b/extensions/telegram/src/sendchataction-401-backoff.ts
@@ -110,12 +110,14 @@ export function createTelegramSendChatActionHandler({
   let consecutive401Failures = 0;
   let consecutiveTransientFailures = 0;
   let transientCooldownUntil = 0;
+  let lastTransientError: unknown;
   let suspended = false;
 
   const reset = () => {
     consecutive401Failures = 0;
     consecutiveTransientFailures = 0;
     transientCooldownUntil = 0;
+    lastTransientError = undefined;
     suspended = false;
   };
 
@@ -129,7 +131,7 @@ export function createTelegramSendChatActionHandler({
     }
 
     if (transientCooldownUntil > Date.now()) {
-      return;
+      throw lastTransientError;
     }
 
     if (consecutive401Failures > 0) {
@@ -154,11 +156,13 @@ export function createTelegramSendChatActionHandler({
         );
         consecutiveTransientFailures = 0;
         transientCooldownUntil = 0;
+        lastTransientError = undefined;
       }
     } catch (error) {
       if (is401Error(error)) {
         consecutiveTransientFailures = 0;
         transientCooldownUntil = 0;
+        lastTransientError = undefined;
         consecutive401Failures++;
 
         if (consecutive401Failures >= maxConsecutive401) {
@@ -178,13 +182,14 @@ export function createTelegramSendChatActionHandler({
         consecutiveTransientFailures++;
         transientCooldownUntil =
           Date.now() + computeBackoffFn(TRANSIENT_COOLDOWN_POLICY, consecutiveTransientFailures);
+        lastTransientError = error;
         // Typing indicators are best-effort. Once we enter cooldown, skip repeated
-        // sendChatAction calls silently so they do not block message delivery or spam logs.
+        // sendChatAction calls, but keep rejecting so the typing start guard can
+        // count failures and trip its circuit breaker during outages or rate limits.
         logger(
           `sendChatAction transient failure (${consecutiveTransientFailures}). ` +
             `Cooling down before the next retry.`,
         );
-        return;
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- Problem: transient Telegram `sendChatAction` failures (network / 429 / temporary 5xx) can keep firing repeatedly, creating noisy retry loops and log spam.
- Why it matters: typing indicators are best-effort, so repeated failures should not keep hammering Telegram or interfere with normal reply delivery.
- What changed: kept the existing 401 suspend behavior, and added a separate transient cooldown path that temporarily suppresses repeated `sendChatAction` calls until a later recovery.
- What did NOT change (scope boundary): this PR does not change `typingMode` config behavior, message delivery flow, or Telegram channel startup/runtime wiring outside the dedicated handler.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55811
- Related #48943
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the dedicated Telegram `sendChatAction` handler only had global backoff / suspension behavior for 401s, but transient failures still retried on every later call path.
- Missing detection / guardrail: the handler had no cooldown state for transient network / rate-limit / temporary server failures, and the dedicated test file did not currently lock in that behavior.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the current per-account guard already existed for 401 token failures in `sendchataction-401-backoff.ts`.
- Why this regressed now: as more users hit Telegram transient failures, the handler protected the invalid-token case but not the best-effort transient case.
- If unknown, what was ruled out: this PR does not treat `typingMode` config propagation as the root cause for this specific issue.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/sendchataction-401-backoff.test.ts`
- Scenario the test should lock in: transient failures enter cooldown, repeated calls are suppressed during cooldown, recovery clears transient state, and 401 suspension semantics still work independently.
- Why this is the smallest reliable guardrail: the bug lives in the dedicated per-account handler state machine, so direct unit coverage is the narrowest reliable test.
- Existing test that already covers this (if any): `extensions/telegram/src/send.test.ts -t "sends typing"` still covers the normal typing send seam.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Repeated transient `sendChatAction` failures no longer keep retrying on every call path.
- 401 invalid-token behavior is unchanged.
- No config or default changes.

## Diagram (if applicable)

```text
Before:
transient sendChatAction failure -> next typing call retries immediately -> repeated failures/log spam

After:
transient sendChatAction failure -> cooldown starts -> repeated typing calls skipped -> later success clears cooldown
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): existing Telegram channel config

### Steps

1. Simulate repeated transient `sendChatAction` failures.
2. Trigger repeated handler calls during the cooldown window.
3. Verify repeated calls are suppressed and later recovery clears the transient state.

### Expected

- transient failures do not suspend the handler permanently
- repeated calls during cooldown do not keep calling Telegram
- later success restores normal behavior
- 401 behavior still suspends as before

### Actual

- matches expected in targeted local verification

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios:
  - transient network failure cooldown
  - transient recovery path
  - 429 transient handling
  - 5xx transient handling
  - unexpected non-transient error still throws
  - 401 semantics remain active
  - mixed `401 -> transient -> 401` sequence preserves 401 counter
- Edge cases checked:
  - cooldown suppression is global per handler
  - `Date.now`-driven cooldown expiry path
- What you did **not** verify:
  - live Telegram outage against the real API
  - broader `typingMode` configuration behavior

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: treating some Telegram-side failures as transient could suppress useful signal for a short period.
  - Mitigation: only network / 429 / temporary 5xx go through cooldown; unexpected non-transient errors still throw, and 401 still suspends.

🤖 AI-assisted (Codex), tested with focused local verification