### PR TITLE
fix(web-fetch): use fromCodePoint with range validation in HTML entity decoding

### DIFF
--- a/src/agents/tools/web-fetch-utils.decode-entities.test.ts
+++ b/src/agents/tools/web-fetch-utils.decode-entities.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { htmlToMarkdown } from "./web-fetch-utils.js";
+
+describe("decodeEntities", () => {
+  it("decodes basic named entities", () => {
+    const { text } = htmlToMarkdown("&amp; &lt; &gt; &quot; &#39;");
+    expect(text).toBe("& < > \" '");
+  });
+
+  it("decodes BMP hex entities", () => {
+    const { text } = htmlToMarkdown("&#x41;&#x42;&#x43;");
+    expect(text).toBe("ABC");
+  });
+
+  it("decodes BMP decimal entities", () => {
+    const { text } = htmlToMarkdown("&#65;&#66;&#67;");
+    expect(text).toBe("ABC");
+  });
+
+  it("handles astral plane code points via hex entity", () => {
+    // U+1F600 = 😀 — requires fromCodePoint, not fromCharCode
+    const { text } = htmlToMarkdown("&#x1F600;");
+    expect(text).toBe("\u{1F600}");
+  });
+
+  it("handles astral plane code points via decimal entity", () => {
+    // U+1F4A9 = 💩 (decimal 128169)
+    const { text } = htmlToMarkdown("&#128169;");
+    expect(text).toBe("\u{1F4A9}");
+  });
+
+  it("drops code points above U+10FFFF", () => {
+    const { text } = htmlToMarkdown("&#x110000;");
+    expect(text).toBe("");
+  });
+
+  it("drops negative numeric references", () => {
+    // &#-1; should not match the decimal pattern (no sign in regex)
+    // but &#xFFFFFFFF; could produce a huge number
+    const { text } = htmlToMarkdown("&#xFFFFFFFF;");
+    expect(text).toBe("");
+  });
+});

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -32,6 +32,13 @@ async function loadReadabilityDeps(): Promise<{
   }
 }
 
+function safeFromCodePoint(code: number): string {
+  if (!Number.isFinite(code) || code < 0 || code > 0x10ffff) {
+    return "";
+  }
+  return String.fromCodePoint(code);
+}
+
 function decodeEntities(value: string): string {
   return value
     .replace(/&nbsp;/gi, " ")
@@ -40,8 +47,8 @@ function decodeEntities(value: string): string {
     .replace(/&#39;/gi, "'")
     .replace(/&lt;/gi, "<")
     .replace(/&gt;/gi, ">")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
-    .replace(/&#(\d+);/gi, (_, dec) => String.fromCharCode(Number.parseInt(dec, 10)));
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => safeFromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/gi, (_, dec) => safeFromCodePoint(Number.parseInt(dec, 10)));
 }
 
 function stripTags(value: string): string {


### PR DESCRIPTION
## Problem

`decodeEntities()` in `web-fetch-utils.ts` uses `String.fromCharCode()` for numeric HTML entity references (`&#xNNNN;` and `&#NNNN;`). `fromCharCode` only handles code points in the Basic Multilingual Plane (U+0000..U+FFFF) and silently produces garbled output for astral plane characters (U+10000 and above).

This means any fetched web content containing emoji or supplementary Unicode characters encoded as numeric HTML entities would be decoded incorrectly, producing surrogate-half garbage instead of the intended character. Beyond correctness, the garbled output could potentially bypass downstream content sanitization or filtering that expects well-formed Unicode.

Notably, the same pattern was already fixed in `pi-embedded-runner/run/attempt.ts`, which correctly uses `String.fromCodePoint()`.

## Fix

- Replace `String.fromCharCode()` with `String.fromCodePoint()` wrapped in a `safeFromCodePoint()` helper
- The helper validates the code point is within the valid Unicode range (0..0x10FFFF) and returns an empty string for out-of-range values, preventing `RangeError` exceptions from malformed entities like `&#xFFFFFFFF;`

## Testing

Added `web-fetch-utils.decode-entities.test.ts` with coverage for:
- Named entity decoding (baseline)
- BMP hex and decimal entities
- Astral plane code points (emoji via hex and decimal)
- Out-of-range rejection (above U+10FFFF)