### PR TITLE
fix(agents): restore embedded auth injection after pi-coding-agent 0.63.0 bump

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -31,7 +31,7 @@ import {
   resolveAwsSdkEnvVarName,
   type ResolvedProviderAuth,
 } from "./model-auth-runtime-shared.js";
-import { normalizeProviderId } from "./model-selection.js";
+import { normalizeProviderId, normalizeProviderIdForAuth } from "./model-selection.js";
 
 export { ensureAuthProfileStore, resolveAuthProfileOrder } from "./auth-profiles.js";
 export { requireApiKey, resolveAwsSdkEnvVarName } from "./model-auth-runtime-shared.js";
@@ -48,16 +48,32 @@ function resolveProviderConfig(
     return direct;
   }
   const normalized = normalizeProviderId(provider);
-  if (normalized === provider) {
-    const matched = Object.entries(providers).find(
-      ([key]) => normalizeProviderId(key) === normalized,
-    );
-    return matched?.[1];
+  const normalizedForAuth = normalizeProviderIdForAuth(provider);
+
+  // Try exact match with normalized provider id
+  if (providers[normalized]) {
+    return providers[normalized];
   }
-  return (
-    (providers[normalized] as ModelProviderConfig | undefined) ??
-    Object.entries(providers).find(([key]) => normalizeProviderId(key) === normalized)?.[1]
+
+  // Try match with auth-normalized provider id (handles -plan variants etc.)
+  if (normalizedForAuth !== normalized && providers[normalizedForAuth]) {
+    return providers[normalizedForAuth];
+  }
+
+  // Fuzzy match: find any key whose normalized form matches
+  const matched = Object.entries(providers).find(
+    ([key]) =>
+      normalizeProviderId(key) === normalized ||
+      // Only apply auth-normalization when the lookup provider itself is a
+      // plan variant (normalizedForAuth !== normalized) to avoid the reverse
+      // direction (base provider matching a plan-variant config key).
+      (normalizedForAuth !== normalized && normalizeProviderIdForAuth(key) === normalizedForAuth),
   );
+  if (matched) {
+    return matched[1];
+  }
+
+  return undefined;
 }
 
 export function getCustomProviderApiKey(

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -27,6 +27,7 @@ import {
   wrapStreamFnRepairMalformedToolCallArguments,
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
+  wrapStreamFnWithModelRegistryAuth,
 } from "./attempt.js";
 import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
 
@@ -302,6 +303,62 @@ describe("composeSystemPromptWithHookContext", () => {
     expect(turns[2]?.prompt.startsWith("hello once more")).toBe(true);
     expect(turns[0]?.prompt).toContain("[Bootstrap truncation warning]");
     expect(turns[2]?.prompt).toContain("[Bootstrap truncation warning]");
+  });
+});
+
+describe("wrapStreamFnWithModelRegistryAuth", () => {
+  it("injects resolved apiKey and merges model + auth headers into options", () => {
+    const baseStreamFn = vi.fn((_model: never, _context: never, _options?: never) => {
+      return createFakeStream({ events: [], resultMessage: {} });
+    });
+    const wrapped = wrapStreamFnWithModelRegistryAuth(baseStreamFn as never, "sk-test-key", {
+      "x-auth": "bearer-token",
+    });
+    const model = { headers: { "x-model": "custom" } };
+    void wrapped(model as never, {} as never, { headers: { "x-caller": "yes" } } as never);
+    expect(baseStreamFn).toHaveBeenCalledWith(
+      model,
+      {},
+      {
+        apiKey: "sk-test-key",
+        headers: {
+          "x-auth": "bearer-token",
+          "x-model": "custom",
+          "x-caller": "yes",
+        },
+      },
+    );
+  });
+
+  it("preserves caller-supplied apiKey and passes caller headers through", () => {
+    const baseStreamFn = vi.fn((_model: never, _context: never, _options?: never) => {
+      return createFakeStream({ events: [], resultMessage: {} });
+    });
+    const wrapped = wrapStreamFnWithModelRegistryAuth(baseStreamFn as never, "sk-resolved");
+    void wrapped(
+      {} as never,
+      {} as never,
+      { apiKey: "sk-caller", headers: { "x-caller": "yes" } } as never,
+    );
+    expect(baseStreamFn).toHaveBeenCalledWith(
+      {},
+      {},
+      {
+        apiKey: "sk-caller",
+        headers: { "x-caller": "yes" },
+      },
+    );
+  });
+
+  it("takes the fast path when no auth and no headers are present", () => {
+    const baseStreamFn = vi.fn((_model: never, _context: never, _options?: never) => {
+      return createFakeStream({ events: [], resultMessage: {} });
+    });
+    const wrapped = wrapStreamFnWithModelRegistryAuth(baseStreamFn as never, undefined, undefined);
+    const opts = { temperature: 0.5 };
+    void wrapped({} as never, {} as never, opts as never);
+    // Fast path: options object should be passed through as-is
+    expect(baseStreamFn).toHaveBeenCalledWith({}, {}, opts);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -894,7 +894,7 @@ export async function runEmbeddedAttempt(
       const resolvedAuth = await params.modelRegistry
         .getApiKeyAndHeaders(params.model)
         .then((auth) => (auth.ok ? { apiKey: auth.apiKey, headers: auth.headers } : undefined))
-        .catch(() => undefined);
+	.catch((err) => { log.warn(`[auth] getApiKeyAndHeaders failed for model=${params.model}: ${err}`); return undefined; });
 
       const setBaseStreamFn = (fn: StreamFn) => {
         activeSession.agent.streamFn = wrapStreamFnWithModelRegistryAuth(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -210,6 +210,51 @@ export {
   wrapStreamFnSanitizeMalformedToolCalls,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.tool-call-normalization.js";
+
+/**
+ * Wraps a base StreamFn so that every invocation carries the resolved
+ * API key and auth/model headers.  This prevents downstream streamFn
+ * overrides (provider-specific, cache-trace, ollama-compat, etc.) from
+ * silently dropping credentials that were resolved once at attempt start.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/55672
+ * @see https://github.com/openclaw/openclaw/issues/55760
+ */
+export function wrapStreamFnWithModelRegistryAuth(
+  streamFn: StreamFn,
+  resolvedApiKey: string | undefined,
+  resolvedAuthHeaders?: Record<string, string>,
+): StreamFn {
+  return (model, context, options) => {
+    const modelHeaders =
+      model.headers && typeof model.headers === "object" && !Array.isArray(model.headers)
+        ? model.headers
+        : undefined;
+
+    const needsHeaderMerge =
+      modelHeaders != null || resolvedAuthHeaders != null || options?.headers != null;
+
+    // Fast path: nothing to inject
+    if (!resolvedApiKey && !needsHeaderMerge) {
+      return streamFn(model, context, options);
+    }
+
+    return streamFn(model, context, {
+      ...options,
+      // Only inject apiKey when the caller hasn't already provided one
+      ...(resolvedApiKey && options?.apiKey === undefined ? { apiKey: resolvedApiKey } : {}),
+      ...(needsHeaderMerge
+        ? {
+            headers: {
+              ...resolvedAuthHeaders,
+              ...modelHeaders,
+              ...options?.headers,
+            },
+          }
+        : {}),
+    });
+  };
+}
 
 const MAX_BTW_SNAPSHOT_MESSAGES = 100;
 
@@ -844,6 +889,21 @@ export async function runEmbeddedAttempt(
       });
 
       const defaultSessionStreamFn = activeSession.agent.streamFn;
+
+      // Resolve auth once per attempt so every streamFn override carries credentials.
+      const resolvedAuth = await params.modelRegistry
+        .getApiKeyAndHeaders(params.model)
+        .then((auth) => (auth.ok ? { apiKey: auth.apiKey, headers: auth.headers } : undefined))
+        .catch(() => undefined);
+
+      const setBaseStreamFn = (fn: StreamFn) => {
+        activeSession.agent.streamFn = wrapStreamFnWithModelRegistryAuth(
+          fn,
+          resolvedAuth?.apiKey,
+          resolvedAuth?.headers,
+        );
+      };
+
       const providerStreamFn = registerProviderStreamForModel({
         model: params.model,
         cfg: params.config,
@@ -851,7 +911,7 @@ export async function runEmbeddedAttempt(
         workspaceDir: effectiveWorkspace,
       });
       if (providerStreamFn) {
-        activeSession.agent.streamFn = providerStreamFn;
+        setBaseStreamFn(providerStreamFn);
       } else if (
         shouldUseOpenAIWebSocketTransport({
           provider: params.provider,
@@ -860,19 +920,22 @@ export async function runEmbeddedAttempt(
       ) {
         const wsApiKey = await params.authStorage.getApiKey(params.provider);
         if (wsApiKey) {
+          // WebSocket transport already closes over its own apiKey; skip the
+          // auth wrapper to avoid injecting a potentially different key from
+          // the model registry into options.apiKey.
           activeSession.agent.streamFn = createOpenAIWebSocketStreamFn(wsApiKey, params.sessionId, {
             signal: runAbortController.signal,
           });
         } else {
           log.warn(`[ws-stream] no API key for provider=${params.provider}; using HTTP transport`);
-          activeSession.agent.streamFn = defaultSessionStreamFn;
+          setBaseStreamFn(defaultSessionStreamFn);
         }
       } else if (params.model.provider === "anthropic-vertex") {
         // Anthropic Vertex AI: inject AnthropicVertex client into pi-ai's
         // streamAnthropic for GCP IAM auth instead of Anthropic API keys.
-        activeSession.agent.streamFn = createAnthropicVertexStreamFnForModel(params.model);
+        setBaseStreamFn(createAnthropicVertexStreamFnForModel(params.model));
       } else {
-        activeSession.agent.streamFn = defaultSessionStreamFn;
+        setBaseStreamFn(defaultSessionStreamFn);
       }
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -894,7 +894,7 @@ export async function runEmbeddedAttempt(
       const resolvedAuth = await params.modelRegistry
         .getApiKeyAndHeaders(params.model)
         .then((auth) => (auth.ok ? { apiKey: auth.apiKey, headers: auth.headers } : undefined))
-	.catch((err) => { log.warn(`[auth] getApiKeyAndHeaders failed for model=${params.model}: ${err}`); return undefined; });
+        .catch((err) => { log.warn(`[auth] getApiKeyAndHeaders failed for model=${params.model.id}: ${err}`); return undefined; });
 
       const setBaseStreamFn = (fn: StreamFn) => {
         activeSession.agent.streamFn = wrapStreamFnWithModelRegistryAuth(


### PR DESCRIPTION

## Summary

Resolves the **"No API key for provider"** regression that broke all chat functionality on `main` after the `pi-coding-agent` 0.63.0 bump. The upstream dependency replaced `ModelRegistry.getApiKey()` with `getApiKeyAndHeaders()`, but the embedded runner's `streamFn` overrides were not updated, causing credentials to be silently dropped.
- Fixes #55672
- Fixes #55760
- 
## Root Cause

When `pi-coding-agent` 0.63.0 landed, the `ModelRegistry` auth interface changed:

```ts
// Before (pi-coding-agent < 0.63.0)
const apiKey = await modelRegistry.getApiKey(model);

// After (pi-coding-agent >= 0.63.0)
const { ok, apiKey, headers } = await modelRegistry.getApiKeyAndHeaders(model);
```

The embedded runner in OpenClaw assigns `activeSession.agent.streamFn` multiple times (provider-specific, cache-trace, ollama-compat, etc.), and none of these overrides carried the resolved credentials forward. This caused every provider to fail with "No API key for provider".

## Changes

### `src/agents/pi-embedded-runner/run/attempt.ts`
- **New**: `wrapStreamFnWithModelRegistryAuth(streamFn, apiKey, headers)` — wraps any `StreamFn` to inject resolved `apiKey` and merge `auth.headers` + `model.headers` + `caller.headers` into every invocation
- **New**: `setBaseStreamFn(fn)` helper — all non-WebSocket `streamFn` assignments now go through this to ensure auth injection
- **Preserved**: WebSocket transport branch uses direct assignment (it closes over its own `apiKey` via `createOpenAIWebSocketStreamFn`)
- Auth is resolved **once** per attempt via `modelRegistry.getApiKeyAndHeaders(model)`

### `src/agents/model-auth.ts`
- **Fixed**: `resolveProviderConfig()` now uses `normalizeProviderIdForAuth()` to match `-plan` variant providers (e.g., `anthropic-plan` → `anthropic`)
- **Guarded**: Reverse matching is prevented — a base provider key will not accidentally match a `-plan` variant config entry

### `src/agents/pi-embedded-runner/run/attempt.test.ts`
- 3 new unit tests for `wrapStreamFnWithModelRegistryAuth`:
  - Injects `apiKey` and merges auth + model + caller headers
  - Preserves caller-supplied `apiKey` (no override)
  - Fast-path passthrough when no auth and no headers

## Testing

- `wrapStreamFnWithModelRegistryAuth` covered by 3 new unit tests
- `resolveProviderConfig` indirectly covered by existing `resolveApiKeyForProvider` tests


