### PR TITLE
feat(irc): support markdown messages via draft/multiline

### DIFF
--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -45,6 +45,7 @@ import {
   PAIRING_APPROVED_MESSAGE,
   type ChannelPlugin,
 } from "./runtime-api.js";
+import { chunk as ircChunk } from "./chunker.js";
 import { getIrcRuntime } from "./runtime.js";
 import { sendMessageIrc } from "./send.js";
 import { ircSetupAdapter } from "./setup-core.js";
@@ -333,7 +334,7 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChat
   outbound: {
     base: {
       deliveryMode: "direct",
-      chunker: (text, limit) => getIrcRuntime().channel.text.chunkMarkdownText(text, limit),
+      chunker: (text, limit) => ircChunk(text, limit),
       chunkerMode: "markdown",
       textChunkLimit: 16384,
     },

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -335,7 +335,7 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChat
       deliveryMode: "direct",
       chunker: (text, limit) => getIrcRuntime().channel.text.chunkMarkdownText(text, limit),
       chunkerMode: "markdown",
-      textChunkLimit: 350,
+      textChunkLimit: 16384,
     },
     attachedResults: {
       channel: "irc",

--- a/extensions/irc/src/chunker.ts
+++ b/extensions/irc/src/chunker.ts
@@ -1,0 +1,210 @@
+/**
+ * IRC chunker that preserves newlines for draft/multiline support.
+ * Based on OpenClaw's chunkMarkdownText but modified to NOT break on newlines.
+ */
+
+type FenceSpan = {
+  start: number;
+  end: number;
+  openLine: string;
+  marker: string;
+  indent: string;
+};
+
+function parseFenceSpans(buffer: string): FenceSpan[] {
+  const spans: FenceSpan[] = [];
+  let open: { start: number; markerChar: string; markerLen: number; openLine: string; marker: string; indent: string } | undefined;
+  let offset = 0;
+  while (offset <= buffer.length) {
+    const nextNewline = buffer.indexOf("\n", offset);
+    const lineEnd = nextNewline === -1 ? buffer.length : nextNewline;
+    const line = buffer.slice(offset, lineEnd);
+    const match = line.match(/^( {0,3})(`{3,}|~{3,})(.*)$/);
+    if (match) {
+      const indent = match[1];
+      const marker = match[2];
+      const markerChar = marker[0];
+      const markerLen = marker.length;
+      if (!open) {
+        open = { start: offset, markerChar, markerLen, openLine: line, marker, indent };
+      } else if (open.markerChar === markerChar && markerLen >= open.markerLen) {
+        const end = lineEnd;
+        spans.push({ start: open.start, end, openLine: open.openLine, marker: open.marker, indent: open.indent });
+        open = undefined;
+      }
+    }
+    if (nextNewline === -1) break;
+    offset = nextNewline + 1;
+  }
+  if (open) {
+    spans.push({ start: open.start, end: buffer.length, openLine: open.openLine, marker: open.marker, indent: open.indent });
+  }
+  return spans;
+}
+
+function findFenceSpanAt(spans: FenceSpan[], index: number): FenceSpan | undefined {
+  let low = 0;
+  let high = spans.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const span = spans[mid];
+    if (!span) break;
+    if (index <= span.start) {
+      high = mid - 1;
+      continue;
+    }
+    if (index >= span.end) {
+      low = mid + 1;
+      continue;
+    }
+    return span;
+  }
+  return undefined;
+}
+
+function isSafeFenceBreak(spans: FenceSpan[], index: number): boolean {
+  return !findFenceSpanAt(spans, index);
+}
+
+function resolveChunkEarlyReturn(text: string, limit: number): string[] | undefined {
+  if (!text) return [];
+  if (limit <= 0) return [text];
+  if (text.length <= limit) return [text];
+  return undefined;
+}
+
+function skipLeadingNewlines(value: string, start: number = 0): number {
+  let i = start;
+  while (i < value.length && value[i] === "\n") i++;
+  return i;
+}
+
+function scanParenAwareBreakpoints(
+  text: string,
+  start: number,
+  end: number,
+  isAllowed: (index: number) => boolean = () => true
+): { lastNewline: number; lastWhitespace: number } {
+  let lastNewline = -1;
+  let lastWhitespace = -1;
+  let depth = 0;
+  for (let i = start; i < end; i++) {
+    if (!isAllowed(i)) continue;
+    const char = text[i];
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")" && depth > 0) {
+      depth -= 1;
+      continue;
+    }
+    if (depth !== 0) continue;
+    if (char === "\n") lastNewline = i;
+    else if (/\s/.test(char)) lastWhitespace = i;
+  }
+  return { lastNewline, lastWhitespace };
+}
+
+/**
+ * Pick a safe break index - MODIFIED to NOT break on newlines.
+ * Only uses whitespace (spaces, tabs) for breaking, preserving newlines for draft/multiline.
+ */
+function pickSafeBreakIndex(text: string, start: number, end: number, spans: FenceSpan[]): number {
+  const { lastWhitespace } = scanParenAwareBreakpoints(text, start, end, (index) => isSafeFenceBreak(spans, index));
+  // Don't break on newlines - preserve them for draft/multiline
+  if (lastWhitespace > start) return lastWhitespace;
+  return -1;
+}
+
+/**
+ * Chunk text for IRC, preserving newlines for draft/multiline support.
+ * Uses the configured limit from the plugin.
+ */
+export function chunk(text: string, limit: number): string[] {
+  const early = resolveChunkEarlyReturn(text, limit);
+  if (early) return early;
+
+  const chunks: string[] = [];
+  const spans = parseFenceSpans(text);
+  let start = 0;
+  let reopenFence: FenceSpan | undefined;
+
+  while (start < text.length) {
+    const reopenPrefix = reopenFence ? `${reopenFence.openLine}\n` : "";
+    const contentLimit = Math.max(1, limit - reopenPrefix.length);
+
+    if (text.length - start <= contentLimit) {
+      const finalChunk = `${reopenPrefix}${text.slice(start)}`;
+      if (finalChunk.length > 0) chunks.push(finalChunk);
+      break;
+    }
+
+    const windowEnd = Math.min(text.length, start + contentLimit);
+    const softBreak = pickSafeBreakIndex(text, start, windowEnd, spans);
+    let breakIdx = softBreak > start ? softBreak : windowEnd;
+
+    const initialFence = isSafeFenceBreak(spans, breakIdx) ? undefined : findFenceSpanAt(spans, breakIdx);
+    let fenceToSplit = initialFence;
+
+    if (initialFence) {
+      const closeLine = `${initialFence.indent}${initialFence.marker}`;
+      const maxIdxIfNeedNewline = start + (contentLimit - (closeLine.length + 1));
+      if (maxIdxIfNeedNewline <= start) {
+        fenceToSplit = undefined;
+        breakIdx = windowEnd;
+      } else {
+        const minProgressIdx = Math.min(
+          text.length,
+          Math.max(start + 1, initialFence.start + initialFence.openLine.length + 2)
+        );
+        const maxIdxIfAlreadyNewline = start + (contentLimit - closeLine.length);
+        let pickedNewline = false;
+        let lastNewline = text.lastIndexOf("\n", Math.max(start, maxIdxIfAlreadyNewline - 1));
+        while (lastNewline >= start) {
+          const candidateBreak = lastNewline + 1;
+          if (candidateBreak < minProgressIdx) break;
+          const candidateFence = findFenceSpanAt(spans, candidateBreak);
+          if (candidateFence && candidateFence.start === initialFence.start) {
+            breakIdx = candidateBreak;
+            pickedNewline = true;
+            break;
+          }
+          lastNewline = text.lastIndexOf("\n", lastNewline - 1);
+        }
+        if (!pickedNewline) {
+          if (minProgressIdx > maxIdxIfAlreadyNewline) {
+            fenceToSplit = undefined;
+            breakIdx = windowEnd;
+          } else {
+            breakIdx = Math.max(minProgressIdx, maxIdxIfNeedNewline);
+          }
+        }
+        const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
+        fenceToSplit =
+          fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
+      }
+    }
+
+    const rawContent = text.slice(start, breakIdx);
+    if (!rawContent) break;
+
+    let rawChunk = `${reopenPrefix}${rawContent}`;
+    const brokeOnSeparator = breakIdx < text.length && /\s/.test(text[breakIdx]);
+    let nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
+
+    if (fenceToSplit) {
+      const closeLine = `${fenceToSplit.indent}${fenceToSplit.marker}`;
+      rawChunk = rawChunk.endsWith("\n") ? `${rawChunk}${closeLine}` : `${rawChunk}\n${closeLine}`;
+      reopenFence = fenceToSplit;
+    } else {
+      nextStart = skipLeadingNewlines(text, nextStart);
+      reopenFence = undefined;
+    }
+
+    chunks.push(rawChunk);
+    start = nextStart;
+  }
+
+  return chunks;
+}

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -241,7 +241,10 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       const batchId = `m${batchCounter}`;
       sendRaw(`BATCH +${batchId} draft/multiline ${normalizedTarget}`);
       for (const line of lines) {
-        socket.write(`@batch=${batchId} PRIVMSG ${normalizedTarget} :${line}\r\n`);
+        // Send empty lines as a single space to preserve paragraph breaks
+        // without sending invalid empty PRIVMSG (just `:` which some servers reject)
+        const content = line || " ";
+        socket.write(`@batch=${batchId} PRIVMSG ${normalizedTarget} :${content}\r\n`);
       }
       sendRaw(`BATCH -${batchId}`);
     } else {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -461,11 +461,8 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         const text = line.trailing != null ? line.trailing : "";
         const prefix = parseIrcPrefix(line.prefix);
         const senderNick = prefix.nick ? prefix.nick.trim() : "";
-        if (!target || !senderNick || !text.trim()) {
-          continue;
-        }
 
-        // Check if this message is part of a batch
+        // Check if this message is part of a batch *before* filtering empty text
         const batchTag = line.tags?.get("batch");
         if (batchTag) {
           // Buffer the message for later
@@ -476,10 +473,14 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
               senderUser: prefix.user ? prefix.user.trim() : undefined,
               senderHost: prefix.host ? prefix.host.trim() : undefined,
               target,
-              text,
+              text, // preserve blank lines; joining happens at BATCH -<id>
             });
           }
           continue; // Don't emit yet - wait for BATCH -<id>
+        }
+
+        if (!target || !senderNick || !text.trim()) {
+          continue;
         }
 
         if (options.onPrivmsg) {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -1,11 +1,18 @@
 import net from "node:net";
 import tls from "node:tls";
+import fs from "node:fs";
 import {
   parseIrcLine,
   parseIrcPrefix,
   sanitizeIrcOutboundText,
   sanitizeIrcTarget,
 } from "./protocol.js";
+
+const DEBUG_LOG = "/tmp/crayfish-openclaw-irc.debug.log";
+function debugLog(msg: string) {
+  const ts = new Date().toISOString();
+  fs.appendFileSync(DEBUG_LOG, "[" + ts + "] " + msg + "\n");
+}
 
 const IRC_ERROR_CODES = new Set(["432", "464", "465"]);
 const IRC_NICK_COLLISION_CODES = new Set(["433", "436"]);
@@ -116,7 +123,7 @@ export function buildIrcNickServCommands(options?: IrcNickServOptions): string[]
 export async function connectIrcClient(options: IrcClientOptions): Promise<IrcClient> {
   const timeoutMs = options.connectTimeoutMs != null ? options.connectTimeoutMs : 15000;
   const messageChunkMaxChars =
-    options.messageChunkMaxChars != null ? options.messageChunkMaxChars : 16384;
+    options.messageChunkMaxChars != null ? options.messageChunkMaxChars : 350;
 
   if (!options.host.trim()) {
     throw new Error("IRC host is required");
@@ -131,6 +138,22 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   let closed = false;
   let nickServRecoverAttempted = false;
   let fallbackNickAttempted = false;
+
+  // Incoming batch state: batchId -> messages
+  const incomingBatches = new Map<string, Array<{
+    senderNick: string;
+    senderUser?: string;
+    senderHost?: string;
+    target: string;
+    text: string;
+  }>>();
+  let multilineCap = false;
+  let batchCounter = 0;
+  let capNegotiationComplete = false;
+  let resolveCapComplete: (() => void) | null = null;
+  const capCompletePromise = new Promise<void>((resolve) => {
+    resolveCapComplete = resolve;
+  });
 
   const socket = options.tls
     ? tls.connect({
@@ -209,26 +232,30 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   };
 
   const sendPrivmsg = (target: string, text: string) => {
+    debugLog("sendPrivmsg RAW: len=" + text.length + " hasNewlines=" + text.includes("\n"));
     const normalizedTarget = sanitizeIrcTarget(target);
     const cleaned = sanitizeIrcOutboundText(text);
     if (!cleaned) {
       return;
     }
-    let remaining = cleaned;
-    while (remaining.length > 0) {
-      let chunk = remaining;
-      if (chunk.length > messageChunkMaxChars) {
-        let splitAt = chunk.lastIndexOf(" ", messageChunkMaxChars);
-        if (splitAt < Math.floor(messageChunkMaxChars / 2)) {
-          splitAt = messageChunkMaxChars;
-        }
-        chunk = chunk.slice(0, splitAt).trim();
+
+    const hasNewlines = cleaned.includes("\n");
+
+    if (multilineCap && hasNewlines) {
+      // Use BATCH for multiline messages
+      debugLog("Using BATCH for multiline: multilineCap=" + multilineCap + " lines=" + cleaned.split(/\n/).length);
+      const lines = cleaned.split(/\n/);
+      batchCounter++;
+      const batchId = `m${batchCounter}`;
+      sendRaw(`BATCH +${batchId} draft/multiline ${normalizedTarget}`);
+      for (const line of lines) {
+        socket.write(`@batch=${batchId} PRIVMSG ${normalizedTarget} :${line}\r\n`);
       }
-      if (!chunk) {
-        break;
-      }
-      sendRaw(`PRIVMSG ${normalizedTarget} :${chunk}`);
-      remaining = remaining.slice(chunk.length).trimStart();
+      sendRaw(`BATCH -${batchId}`);
+    } else {
+      // Single line or no multiline support - flatten newlines
+      if (hasNewlines) debugLog("FLATTENING newlines (multilineCap=" + multilineCap + ")");
+      socket.write(`PRIVMSG ${normalizedTarget} :${cleaned.replace(/\n/g, " ")}\r\n`);
     }
   };
 
@@ -283,6 +310,45 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         const payload =
           line.trailing != null ? line.trailing : line.params[0] != null ? line.params[0] : "";
         sendRaw(`PONG :${payload}`);
+        continue;
+      }
+
+      // CAP negotiation for draft/multiline
+      if (line.command === "CAP" && line.params[1] === "LS") {
+        const caps = (line.trailing ?? "").toLowerCase();
+        debugLog("CAP LS received: caps=" + caps);
+        if (caps.includes("draft/multiline")) {
+          debugLog("CAP REQ draft/multiline - server supports it");
+          sendRaw(`CAP REQ draft/multiline`);
+        } else {
+          debugLog("CAP END (no multiline support)");
+          capNegotiationComplete = true;
+          resolveCapComplete?.();
+          sendRaw(`CAP END`);
+        }
+        continue;
+      }
+
+      if (line.command === "CAP" && line.params[1] === "ACK") {
+        // Capability can be in trailing OR in params[2] depending on server
+        const acked = ((line.trailing ?? line.params[2] ?? "") as string).toLowerCase();
+        if (acked.includes("draft/multiline")) {
+          multilineCap = true;
+          debugLog("multilineCap set to TRUE");
+        }
+        debugLog("CAP END (after ACK)");
+        capNegotiationComplete = true;
+        resolveCapComplete?.();
+        sendRaw(`CAP END`);
+        continue;
+      }
+
+      if (line.command === "CAP" && line.params[1] === "NAK") {
+        // Server rejected our CAP request, end negotiation
+        debugLog("CAP END (after NAK)");
+        capNegotiationComplete = true;
+        resolveCapComplete?.();
+        sendRaw(`CAP END`);
         continue;
       }
 
@@ -359,6 +425,45 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         continue;
       }
 
+      // Handle BATCH commands for draft/multiline
+      if (line.command === "BATCH") {
+        const batchParam = line.params[0] || line.trailing;
+        debugLog("BATCH CMD: param=" + batchParam);
+        if (!batchParam) continue;
+
+        if (batchParam.startsWith("+")) {
+          // Start of batch - just initialize the buffer
+          const batchId = batchParam.slice(1);
+          incomingBatches.set(batchId, []);
+          debugLog("BATCH START: " + batchId);
+        } else if (batchParam.startsWith("-")) {
+          // End of batch - combine and emit
+          const batchId = batchParam.slice(1);
+          const messages = incomingBatches.get(batchId);
+          incomingBatches.delete(batchId);
+
+          if (messages && messages.length > 0 && options.onPrivmsg) {
+            // Combine all messages in the batch
+            const first = messages[0];
+            const combinedText = messages.map(m => m.text).join("\n");
+            debugLog("BATCH END: " + batchId + " msgs=" + messages.length + " text=" + combinedText);
+            void Promise.resolve(
+              options.onPrivmsg({
+                senderNick: first.senderNick,
+                senderUser: first.senderUser,
+                senderHost: first.senderHost,
+                target: first.target,
+                text: combinedText,
+                rawLine: `[BATCH ${batchId}]`, // Indicate this was a batch
+              }),
+            ).catch((error) => {
+              fail(error);
+            });
+          }
+        }
+        continue;
+      }
+
       if (line.command === "PRIVMSG") {
         const targetParam = line.params[0];
         const target = targetParam ? targetParam.trim() : "";
@@ -368,6 +473,25 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         if (!target || !senderNick || !text.trim()) {
           continue;
         }
+
+        // Check if this message is part of a batch
+        const batchTag = line.tags?.get("batch");
+        if (batchTag) {
+          // Buffer the message for later
+          const batch = incomingBatches.get(batchTag);
+          if (batch) {
+            debugLog("BATCH MSG: batchTag=" + batchTag + " text=" + text);
+            batch.push({
+              senderNick,
+              senderUser: prefix.user ? prefix.user.trim() : undefined,
+              senderHost: prefix.host ? prefix.host.trim() : undefined,
+              target,
+              text,
+            });
+          }
+          continue; // Don't emit yet - wait for BATCH -<id>
+        }
+
         if (options.onPrivmsg) {
           void Promise.resolve(
             options.onPrivmsg({
@@ -388,6 +512,8 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
   socket.once("connect", () => {
     try {
+      // Start CAP negotiation for draft/multiline support
+      sendRaw(`CAP LS 302`);
       if (options.password && options.password.trim()) {
         sendRaw(`PASS ${options.password.trim()}`);
       }
@@ -424,6 +550,10 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   }
 
   await withTimeout(readyPromise, timeoutMs, "IRC connect");
+  // Also wait for CAP negotiation to complete (multiline support)
+  await withTimeout(capCompletePromise, 5000, "IRC CAP negotiation");
+
+  debugLog("Connection ready: multilineCap=" + multilineCap);
 
   return {
     get nick() {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -321,6 +321,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           sendRaw(`CAP REQ :draft/multiline`);
         } else {
           resolveCapComplete?.();
+          resolveCapComplete = null;
           sendRaw(`CAP END`);
         }
         continue;
@@ -333,6 +334,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           multilineCap = true;
         }
         resolveCapComplete?.();
+        resolveCapComplete = null;
         sendRaw(`CAP END`);
         continue;
       }
@@ -340,6 +342,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       if (line.command === "CAP" && line.params[1] === "NAK") {
         // Server rejected our CAP request, end negotiation
         resolveCapComplete?.();
+        resolveCapComplete = null;
         sendRaw(`CAP END`);
         continue;
       }
@@ -382,6 +385,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         // Fallback: if CAP negotiation didn't complete, resolve it now
         // (non-CAP servers won't respond to CAP LS)
         resolveCapComplete?.();
+        resolveCapComplete = null;
         const nickParam = line.params[0];
         if (nickParam && nickParam.trim()) {
           currentNick = nickParam.trim();

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -234,7 +234,8 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
     if (multilineCap && hasNewlines) {
       // Use BATCH for multiline messages
-      const lines = cleaned.split("\n").filter((l) => l.length > 0);
+      // trim() removes trailing newlines but preserves blank lines in the middle (paragraph breaks)
+      const lines = cleaned.trim().split("\n");
       batchCounter++;
       const batchId = `m${batchCounter}`;
       sendRaw(`BATCH +${batchId} draft/multiline ${normalizedTarget}`);

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -116,7 +116,7 @@ export function buildIrcNickServCommands(options?: IrcNickServOptions): string[]
 export async function connectIrcClient(options: IrcClientOptions): Promise<IrcClient> {
   const timeoutMs = options.connectTimeoutMs != null ? options.connectTimeoutMs : 15000;
   const messageChunkMaxChars =
-    options.messageChunkMaxChars != null ? options.messageChunkMaxChars : 350;
+    options.messageChunkMaxChars != null ? options.messageChunkMaxChars : 16384;
 
   if (!options.host.trim()) {
     throw new Error("IRC host is required");

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -142,7 +142,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   }>>();
   let multilineCap = false;
   let batchCounter = 0;
-  let capNegotiationComplete = false;
   let resolveCapComplete: (() => void) | null = null;
   const capCompletePromise = new Promise<void>((resolve) => {
     resolveCapComplete = resolve;
@@ -235,7 +234,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
     if (multilineCap && hasNewlines) {
       // Use BATCH for multiline messages
-      const lines = cleaned.split("\n");
+      const lines = cleaned.split("\n").filter((l) => l.length > 0);
       batchCounter++;
       const batchId = `m${batchCounter}`;
       sendRaw(`BATCH +${batchId} draft/multiline ${normalizedTarget}`);
@@ -371,6 +370,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
       if (line.command === "001") {
         ready = true;
+        // Fallback: if CAP negotiation didn't complete, resolve it now
+        // (non-CAP servers won't respond to CAP LS)
+        resolveCapComplete?.();
         const nickParam = line.params[0];
         if (nickParam && nickParam.trim()) {
           currentNick = nickParam.trim();

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -309,8 +309,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
       // CAP negotiation for draft/multiline
       if (line.command === "CAP" && line.params[1] === "LS") {
-        // Accumulate caps from each chunk
-        accumulatedCaps += " " + (line.trailing ?? "").toLowerCase();
+        // Accumulate caps from each chunk - capability can be in trailing OR params[2]
+        const caps = (line.trailing ?? line.params[2] ?? "") as string;
+        accumulatedCaps += " " + caps.toLowerCase();
         // params[2] === "*" means more chunks coming; wait for final chunk
         if (line.params[2] === "*") {
           continue;

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -1,18 +1,11 @@
 import net from "node:net";
 import tls from "node:tls";
-import fs from "node:fs";
 import {
   parseIrcLine,
   parseIrcPrefix,
   sanitizeIrcOutboundText,
   sanitizeIrcTarget,
 } from "./protocol.js";
-
-const DEBUG_LOG = "/tmp/crayfish-openclaw-irc.debug.log";
-function debugLog(msg: string) {
-  const ts = new Date().toISOString();
-  fs.appendFileSync(DEBUG_LOG, "[" + ts + "] " + msg + "\n");
-}
 
 const IRC_ERROR_CODES = new Set(["432", "464", "465"]);
 const IRC_NICK_COLLISION_CODES = new Set(["433", "436"]);
@@ -232,7 +225,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   };
 
   const sendPrivmsg = (target: string, text: string) => {
-    debugLog("sendPrivmsg RAW: len=" + text.length + " hasNewlines=" + text.includes("\n"));
     const normalizedTarget = sanitizeIrcTarget(target);
     const cleaned = sanitizeIrcOutboundText(text);
     if (!cleaned) {
@@ -243,8 +235,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
     if (multilineCap && hasNewlines) {
       // Use BATCH for multiline messages
-      debugLog("Using BATCH for multiline: multilineCap=" + multilineCap + " lines=" + cleaned.split(/\n/).length);
-      const lines = cleaned.split(/\n/);
+      const lines = cleaned.split("\n");
       batchCounter++;
       const batchId = `m${batchCounter}`;
       sendRaw(`BATCH +${batchId} draft/multiline ${normalizedTarget}`);
@@ -254,7 +245,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       sendRaw(`BATCH -${batchId}`);
     } else {
       // Single line or no multiline support - flatten newlines
-      if (hasNewlines) debugLog("FLATTENING newlines (multilineCap=" + multilineCap + ")");
       socket.write(`PRIVMSG ${normalizedTarget} :${cleaned.replace(/\n/g, " ")}\r\n`);
     }
   };
@@ -316,12 +306,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       // CAP negotiation for draft/multiline
       if (line.command === "CAP" && line.params[1] === "LS") {
         const caps = (line.trailing ?? "").toLowerCase();
-        debugLog("CAP LS received: caps=" + caps);
         if (caps.includes("draft/multiline")) {
-          debugLog("CAP REQ draft/multiline - server supports it");
           sendRaw(`CAP REQ draft/multiline`);
         } else {
-          debugLog("CAP END (no multiline support)");
           capNegotiationComplete = true;
           resolveCapComplete?.();
           sendRaw(`CAP END`);
@@ -334,9 +321,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         const acked = ((line.trailing ?? line.params[2] ?? "") as string).toLowerCase();
         if (acked.includes("draft/multiline")) {
           multilineCap = true;
-          debugLog("multilineCap set to TRUE");
         }
-        debugLog("CAP END (after ACK)");
         capNegotiationComplete = true;
         resolveCapComplete?.();
         sendRaw(`CAP END`);
@@ -345,7 +330,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
       if (line.command === "CAP" && line.params[1] === "NAK") {
         // Server rejected our CAP request, end negotiation
-        debugLog("CAP END (after NAK)");
         capNegotiationComplete = true;
         resolveCapComplete?.();
         sendRaw(`CAP END`);
@@ -428,14 +412,12 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       // Handle BATCH commands for draft/multiline
       if (line.command === "BATCH") {
         const batchParam = line.params[0] || line.trailing;
-        debugLog("BATCH CMD: param=" + batchParam);
         if (!batchParam) continue;
 
         if (batchParam.startsWith("+")) {
           // Start of batch - just initialize the buffer
           const batchId = batchParam.slice(1);
           incomingBatches.set(batchId, []);
-          debugLog("BATCH START: " + batchId);
         } else if (batchParam.startsWith("-")) {
           // End of batch - combine and emit
           const batchId = batchParam.slice(1);
@@ -446,7 +428,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
             // Combine all messages in the batch
             const first = messages[0];
             const combinedText = messages.map(m => m.text).join("\n");
-            debugLog("BATCH END: " + batchId + " msgs=" + messages.length + " text=" + combinedText);
             void Promise.resolve(
               options.onPrivmsg({
                 senderNick: first.senderNick,
@@ -480,7 +461,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
           // Buffer the message for later
           const batch = incomingBatches.get(batchTag);
           if (batch) {
-            debugLog("BATCH MSG: batchTag=" + batchTag + " text=" + text);
             batch.push({
               senderNick,
               senderUser: prefix.user ? prefix.user.trim() : undefined,
@@ -552,8 +532,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   await withTimeout(readyPromise, timeoutMs, "IRC connect");
   // Also wait for CAP negotiation to complete (multiline support)
   await withTimeout(capCompletePromise, 5000, "IRC CAP negotiation");
-
-  debugLog("Connection ready: multilineCap=" + multilineCap);
 
   return {
     get nick() {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -304,11 +304,14 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
       // CAP negotiation for draft/multiline
       if (line.command === "CAP" && line.params[1] === "LS") {
+        // params[2] === "*" means more chunks coming; wait for final chunk
+        if (line.params[2] === "*") {
+          continue;
+        }
         const caps = (line.trailing ?? "").toLowerCase();
         if (caps.includes("draft/multiline")) {
           sendRaw(`CAP REQ draft/multiline`);
         } else {
-          capNegotiationComplete = true;
           resolveCapComplete?.();
           sendRaw(`CAP END`);
         }
@@ -321,7 +324,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         if (acked.includes("draft/multiline")) {
           multilineCap = true;
         }
-        capNegotiationComplete = true;
         resolveCapComplete?.();
         sendRaw(`CAP END`);
         continue;
@@ -329,7 +331,6 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
       if (line.command === "CAP" && line.params[1] === "NAK") {
         // Server rejected our CAP request, end negotiation
-        capNegotiationComplete = true;
         resolveCapComplete?.();
         sendRaw(`CAP END`);
         continue;

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -142,6 +142,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   }>>();
   let multilineCap = false;
   let batchCounter = 0;
+  let accumulatedCaps = ""; // Accumulate caps across multi-chunk CAP LS responses
   let resolveCapComplete: (() => void) | null = null;
   const capCompletePromise = new Promise<void>((resolve) => {
     resolveCapComplete = resolve;
@@ -305,12 +306,14 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
 
       // CAP negotiation for draft/multiline
       if (line.command === "CAP" && line.params[1] === "LS") {
+        // Accumulate caps from each chunk
+        accumulatedCaps += " " + (line.trailing ?? "").toLowerCase();
         // params[2] === "*" means more chunks coming; wait for final chunk
         if (line.params[2] === "*") {
           continue;
         }
-        const caps = (line.trailing ?? "").toLowerCase();
-        if (caps.includes("draft/multiline")) {
+        // Final chunk - process accumulated caps
+        if (accumulatedCaps.includes("draft/multiline")) {
           sendRaw(`CAP REQ draft/multiline`);
         } else {
           resolveCapComplete?.();

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -132,7 +132,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   let nickServRecoverAttempted = false;
   let fallbackNickAttempted = false;
 
-  // Incoming batch state: batchId -> messages
+  // Incoming batch state: batchId -> messages (only for draft/multiline)
   const incomingBatches = new Map<string, Array<{
     senderNick: string;
     senderUser?: string;
@@ -140,6 +140,8 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
     target: string;
     text: string;
   }>>();
+  // Track which batches are draft/multiline
+  const multilineBatchIds = new Set<string>();
   let multilineCap = false;
   let batchCounter = 0;
   let accumulatedCaps = ""; // Accumulate caps across multi-chunk CAP LS responses
@@ -424,20 +426,25 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         continue;
       }
 
-      // Handle BATCH commands for draft/multiline
+      // Handle BATCH commands for draft/multiline only
       if (line.command === "BATCH") {
         const batchParam = line.params[0] || line.trailing;
         if (!batchParam) continue;
 
         if (batchParam.startsWith("+")) {
-          // Start of batch - just initialize the buffer
+          // Start of batch - only track draft/multiline batches
           const batchId = batchParam.slice(1);
-          incomingBatches.set(batchId, []);
+          const batchType = line.params[1]?.toLowerCase();
+          if (batchType === "draft/multiline") {
+            incomingBatches.set(batchId, []);
+            multilineBatchIds.add(batchId);
+          }
         } else if (batchParam.startsWith("-")) {
-          // End of batch - combine and emit
+          // End of batch - combine and emit only for multiline batches
           const batchId = batchParam.slice(1);
           const messages = incomingBatches.get(batchId);
           incomingBatches.delete(batchId);
+          multilineBatchIds.delete(batchId);
 
           if (messages && messages.length > 0 && options.onPrivmsg) {
             // Combine all messages in the batch
@@ -467,9 +474,9 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         const prefix = parseIrcPrefix(line.prefix);
         const senderNick = prefix.nick ? prefix.nick.trim() : "";
 
-        // Check if this message is part of a batch *before* filtering empty text
+        // Check if this message is part of a multiline batch *before* filtering empty text
         const batchTag = line.tags?.get("batch");
-        if (batchTag) {
+        if (batchTag && multilineBatchIds.has(batchTag)) {
           // Buffer the message for later
           const batch = incomingBatches.get(batchTag);
           if (batch) {

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -317,7 +317,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
         }
         // Final chunk - process accumulated caps
         if (accumulatedCaps.includes("draft/multiline")) {
-          sendRaw(`CAP REQ draft/multiline`);
+          sendRaw(`CAP REQ :draft/multiline`);
         } else {
           resolveCapComplete?.();
           sendRaw(`CAP END`);

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -250,8 +250,18 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       }
       sendRaw(`BATCH -${batchId}`);
     } else {
-      // Single line or no multiline support - flatten newlines
-      socket.write(`PRIVMSG ${normalizedTarget} :${cleaned.replace(/\n/g, " ")}\r\n`);
+      // textChunkLimit can be large (default 16384), but without BATCH support we must still
+      // split at messageChunkMaxChars (~350) to stay under IRC's ~512 byte limit.
+      const flat = cleaned.replace(/\n/g, " ");
+      let remaining = flat;
+      while (remaining.length > 0) {
+        let splitAt = remaining.lastIndexOf(" ", messageChunkMaxChars);
+        if (splitAt < Math.floor(messageChunkMaxChars / 2)) splitAt = messageChunkMaxChars;
+        const piece = remaining.slice(0, splitAt).trim();
+        if (!piece) break;
+        socket.write(`PRIVMSG ${normalizedTarget} :${piece}\r\n`);
+        remaining = remaining.slice(piece.length).trimStart();
+      }
     }
   };
 

--- a/extensions/irc/src/control-chars.ts
+++ b/extensions/irc/src/control-chars.ts
@@ -1,5 +1,6 @@
 export function isIrcControlChar(charCode: number): boolean {
-  return charCode <= 0x1f || charCode === 0x7f;
+  // 0x0a is newline - preserve for draft/multiline support
+  return (charCode <= 0x1f || charCode === 0x7f) && charCode !== 0x0a;
 }
 
 export function hasIrcControlChars(value: string): boolean {

--- a/extensions/irc/src/protocol.ts
+++ b/extensions/irc/src/protocol.ts
@@ -140,7 +140,7 @@ export function sanitizeIrcTarget(raw: string): string {
   return decoded;
 }
 
-export function splitIrcText(text: string, maxChars = 350): string[] {
+export function splitIrcText(text: string, maxChars = 16384): string[] {
   const cleaned = sanitizeIrcOutboundText(text);
   if (!cleaned) {
     return [];

--- a/extensions/irc/src/protocol.ts
+++ b/extensions/irc/src/protocol.ts
@@ -5,6 +5,7 @@ const IRC_TARGET_PATTERN = /^[^\s:]+$/u;
 
 export type ParsedIrcLine = {
   raw: string;
+  tags?: Map<string, string>;
   prefix?: string;
   command: string;
   params: string[];
@@ -25,6 +26,27 @@ export function parseIrcLine(line: string): ParsedIrcLine | null {
   }
 
   let cursor = raw;
+  let tags: Map<string, string> | undefined;
+
+  // Parse IRCv3 tags (starts with @)
+  if (cursor.startsWith("@")) {
+    const spaceIdx = cursor.indexOf(" ");
+    if (spaceIdx > 1) {
+      const tagsStr = cursor.slice(1, spaceIdx);
+      tags = new Map();
+      for (const tag of tagsStr.split(";")) {
+        if (!tag) continue;
+        const eqIdx = tag.indexOf("=");
+        if (eqIdx === -1) {
+          tags.set(tag, "");
+        } else {
+          tags.set(tag.slice(0, eqIdx), tag.slice(eqIdx + 1));
+        }
+      }
+      cursor = cursor.slice(spaceIdx + 1).trimStart();
+    }
+  }
+
   let prefix: string | undefined;
   if (cursor.startsWith(":")) {
     const idx = cursor.indexOf(" ");
@@ -69,6 +91,7 @@ export function parseIrcLine(line: string): ParsedIrcLine | null {
 
   return {
     raw,
+    tags,
     prefix,
     command: command.toUpperCase(),
     params,
@@ -119,7 +142,8 @@ function decodeLiteralEscapes(input: string): string {
 
 export function sanitizeIrcOutboundText(text: string): string {
   const decoded = decodeLiteralEscapes(text);
-  return stripIrcControlChars(decoded.replace(/\r?\n/g, " ")).trim();
+  // Preserve newlines for draft/multiline support - flattening happens in client if needed
+  return stripIrcControlChars(decoded).trim();
 }
 
 export function sanitizeIrcTarget(raw: string): string {
@@ -140,7 +164,7 @@ export function sanitizeIrcTarget(raw: string): string {
   return decoded;
 }
 
-export function splitIrcText(text: string, maxChars = 16384): string[] {
+export function splitIrcText(text: string, maxChars = 350): string[] {
   const cleaned = sanitizeIrcOutboundText(text);
   if (!cleaned) {
     return [];

--- a/extensions/irc/src/protocol.ts
+++ b/extensions/irc/src/protocol.ts
@@ -142,8 +142,10 @@ function decodeLiteralEscapes(input: string): string {
 
 export function sanitizeIrcOutboundText(text: string): string {
   const decoded = decodeLiteralEscapes(text);
-  // Preserve newlines for draft/multiline support - flattening happens in client if needed
-  return stripIrcControlChars(decoded).trim();
+  // Normalize \r\n and \r to spaces (sendRaw strips all newlines, so \r\n would collapse tokens)
+  // Preserve standalone \n for draft/multiline support - flattening happens in client if needed
+  const normalized = decoded.replace(/\r\n/g, " ").replace(/\r/g, " ");
+  return stripIrcControlChars(normalized).trim();
 }
 
 export function sanitizeIrcTarget(raw: string): string {


### PR DESCRIPTION
## Summary

Adds support for sending markdown-formatted messages over IRC using the `draft/multiline` CAP extension. This preserves newlines in bot responses, allowing IRC clients to properly render markdown content.

## Motivation

OpenClaw bots typically generate markdown-formatted responses (lists, code blocks, paragraphs). Without multiline support, these get flattened into single lines, making them unreadable on IRC.

The `draft/multiline` spec (https://ircv3.net/specs/extensions/multiline) allows sending multiple lines as a single BATCH, which modern IRC clients can display with proper formatting.

## Changes

- **CAP negotiation**: Requests `draft/multiline` capability on connect, waits for ACK before sending
- **Outgoing BATCH**: Messages with newlines are sent as `BATCH +id draft/multiline #channel` with tagged PRIVMSGs
- **Incoming BATCH**: Multi-line messages received via BATCH are combined into single payload
- **Control chars**: Newlines (`0x0a`) preserved (previously stripped as IRC control chars)
- **Configurable limits**: `textChunkLimit` defaults to 16384 (per spec recommendation)

## Compatibility

- **Servers without draft/multiline**: Falls back to flattening newlines (existing behavior)
- **Clients without draft/multiline**: Will see lines individually (no worse than before)
- **Backwards compatible**: No config changes required

## Testing

Tested on Ergo IRC server with `draft/multiline` support. Bot responses with markdown (lists, code blocks) render correctly in supporting clients.