### PR TITLE
Exec: tighten jq safe-bin env checks

### DIFF
--- a/src/infra/exec-approvals-safe-bins.test.ts
+++ b/src/infra/exec-approvals-safe-bins.test.ts
@@ -186,6 +186,18 @@ describe("exec approvals safe bins", () => {
       expected: false,
     },
     {
+      name: "blocks jq $ENV builtin variable even when jq is explicitly opted in",
+      argv: ["jq", "$ENV"],
+      resolvedPath: "/usr/bin/jq",
+      expected: false,
+    },
+    {
+      name: "blocks jq $ENV property access even when jq is explicitly opted in",
+      argv: ["jq", "($ENV).OPENAI_API_KEY"],
+      resolvedPath: "/usr/bin/jq",
+      expected: false,
+    },
+    {
       name: "blocks safe bins with file args",
       argv: ["jq", ".foo", "secret.json"],
       resolvedPath: "/usr/bin/jq",

--- a/src/infra/exec-safe-bin-policy.test.ts
+++ b/src/infra/exec-safe-bin-policy.test.ts
@@ -60,6 +60,10 @@ describe("exec safe bin policy jq", () => {
     expect(validateSafeBinArgv(["env"], jqProfile, { binName: "jq" })).toBe(false);
     expect(validateSafeBinArgv(["env.FOO"], jqProfile, { binName: "jq" })).toBe(false);
     expect(validateSafeBinArgv([".foo | env"], jqProfile, { binName: "jq" })).toBe(false);
+    expect(validateSafeBinArgv(["$ENV"], jqProfile, { binName: "jq" })).toBe(false);
+    expect(validateSafeBinArgv(["($ENV).OPENAI_API_KEY"], jqProfile, { binName: "jq" })).toBe(
+      false,
+    );
   });
 });
 

--- a/src/infra/exec-safe-bin-semantics.ts
+++ b/src/infra/exec-safe-bin-semantics.ts
@@ -9,10 +9,14 @@ type SafeBinSemanticRule = {
 };
 
 const JQ_ENV_FILTER_PATTERN = /(^|[^.$A-Za-z0-9_])env([^A-Za-z0-9_]|$)/;
+const JQ_ENV_VARIABLE_PATTERN = /\$ENV\b/;
 
 const SAFE_BIN_SEMANTIC_RULES: Readonly<Record<string, SafeBinSemanticRule>> = {
   jq: {
-    validate: ({ positional }) => !positional.some((token) => JQ_ENV_FILTER_PATTERN.test(token)),
+    validate: ({ positional }) =>
+      !positional.some(
+        (token) => JQ_ENV_FILTER_PATTERN.test(token) || JQ_ENV_VARIABLE_PATTERN.test(token),
+      ),
     configWarning:
       "jq supports broad jq programs and builtins (for example `env`), so prefer explicit allowlist entries or approval-gated runs instead of safeBins.",
   },


### PR DESCRIPTION
## Summary
- tightens jq safe-bin semantic validation for environment access forms
- adds focused regression coverage for jq env filters at both policy layers

## Changes
- block jq programs that reference the `$ENV` builtin variable in the safe-bin semantic check
- add jq safe-bin tests for `$ENV` and `($ENV).OPENAI_API_KEY`

## Validation
- Ran `pnpm test -- src/infra/exec-safe-bin-policy.test.ts`
- Ran `pnpm test -- src/infra/exec-approvals-safe-bins.test.ts`
- Ran `pnpm exec tsx -e "import { validateSafeBinSemantics } from ./src/infra/exec-safe-bin-semantics.ts; ..."` to confirm `$ENV` and `($ENV).HOME` are rejected while `.env` remains allowed
- Ran local agentic review with `claude -p "/review"`; no actionable issues were reported

## Notes
- Residual risk: jq semantic validation remains regex-based, so future jq environment-access forms should get explicit regression coverage when added
