### PR TITLE
fix: restore getApiKey callback after streamFn override (#55816)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -875,6 +875,17 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = defaultSessionStreamFn;
       }
 
+      // Restore getApiKey callback after streamFn override for custom/OAuth providers.
+      // In pi-coding-agent 0.63.0+, createAgentSession() wraps streamFn to inject API keys,
+      // but OpenClaw overwrites streamFn above, losing the auth-injection wrapper.
+      // This fix restores the callback so pi-agent-core can resolve API keys from authStorage.
+      // Guard condition assumes SDK's createAgentSession() does not pre-populate getApiKey.
+      if (!(activeSession.agent as typeof activeSession.agent & { getApiKey?: unknown }).getApiKey) {
+        (activeSession.agent as typeof activeSession.agent & {
+          getApiKey: (provider: string) => Promise<string | undefined>;
+        }).getApiKey = (provider: string) => params.authStorage.getApiKey(provider);
+      }
+
       const { effectiveExtraParams } = applyExtraParamsToAgent(
         activeSession.agent,
         params.config,


### PR DESCRIPTION
Fixes #55816
Fixes #55760

## Problem
After upgrading pi-coding-agent to 0.63.0, custom providers and OAuth-authenticated providers fail with 'No API key for provider' because the SDK's auth-injection wrapper gets stripped when OpenClaw overrides streamFn.

## Root Cause
In pi-coding-agent 0.63.0, createAgentSession() wraps streamFn to inject API keys from modelRegistry.getApiKeyAndHeaders(). OpenClaw's attempt.ts overwrites this wrapper with raw streamSimple, losing the auth injection.

## Fix
Restore the getApiKey callback on the agent after streamFn assignment so pi-agent-core can resolve API keys from authStorage for all provider stream functions.

## Testing
- Type-check passes for modified file (no new errors introduced)
- Fix matches the patch proposed by @alehkot in #55816

## Files Changed
- src/agents/pi-embedded-runner/run/attempt.ts (+11 lines)

## Note
This is a clean resubmission of #55892 (closed due to accidental inclusion of personal files).