### PR TITLE
Docs: unify link audit entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/startup: auto-load bundled provider and CLI-backend plugins from explicit config refs, so bundled Claude CLI, Codex CLI, and Gemini CLI message-provider setups no longer need manual `plugins.allow` entries.
 - Config/TTS: auto-migrate legacy speech config on normal reads and secret resolution, keep legacy diagnostics for Doctor, and remove regular-mode runtime fallback for old bundled `tts.<provider>` API-key shapes.
 - OpenAI/apply_patch: enable `apply_patch` by default for OpenAI and OpenAI Codex models, and align its sandbox policy access with `write` permissions.
+- Docs: add `pnpm docs:check-links:anchors` for Mintlify anchor validation while keeping `scripts/docs-link-audit.mjs` as the stable link-audit entrypoint. (#55912) Thanks @velvet-shark.
 
 ### Fixes
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -506,7 +506,8 @@ Useful env vars:
 
 ## Docs sanity
 
-Run docs checks after doc edits: `pnpm docs:list`.
+Run docs checks after doc edits: `pnpm check:docs`.
+Run full Mintlify anchor validation when you need in-page heading checks too: `pnpm docs:check-links:anchors`.
 
 ## Offline regression (CI-safe)
 

--- a/package.json
+++ b/package.json
@@ -717,6 +717,7 @@
     "docs:bin": "node scripts/build-docs-list.mjs",
     "docs:check-i18n-glossary": "node scripts/check-docs-i18n-glossary.mjs",
     "docs:check-links": "node scripts/docs-link-audit.mjs",
+    "docs:check-links:anchors": "node scripts/docs-link-audit.mjs --anchors",
     "docs:dev": "cd docs && mint dev",
     "docs:list": "node scripts/docs-list.js",
     "docs:spellcheck": "bash scripts/docs-spellcheck.sh",

--- a/scripts/docs-link-audit.mjs
+++ b/scripts/docs-link-audit.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -288,12 +289,26 @@ export function auditDocsLinks() {
   return { checked, broken };
 }
 
-function isCliEntry() {
-  const cliArg = process.argv[1];
-  return cliArg ? import.meta.url === pathToFileURL(cliArg).href : false;
-}
+/**
+ * @param {{
+ *   args?: string[];
+ *   spawnSyncImpl?: typeof spawnSync;
+ * }} [options]
+ */
+export function runDocsLinkAuditCli(options = {}) {
+  const args = options.args ?? process.argv.slice(2);
+  if (args.includes("--anchors")) {
+    const result = (options.spawnSyncImpl ?? spawnSync)(
+      "pnpm",
+      ["dlx", "mint", "broken-links", "--check-anchors"],
+      {
+        cwd: DOCS_DIR,
+        stdio: "inherit",
+      },
+    );
+    return result.status ?? 1;
+  }
 
-if (isCliEntry()) {
   const { checked, broken } = auditDocsLinks();
   console.log(`checked_internal_links=${checked}`);
   console.log(`broken_links=${broken.length}`);
@@ -302,7 +317,14 @@ if (isCliEntry()) {
     console.log(`${item.file}:${item.line} :: ${item.link} :: ${item.reason}`);
   }
 
-  if (broken.length > 0) {
-    process.exit(1);
-  }
+  return broken.length > 0 ? 1 : 0;
+}
+
+function isCliEntry() {
+  const cliArg = process.argv[1];
+  return cliArg ? import.meta.url === pathToFileURL(cliArg).href : false;
+}
+
+if (isCliEntry()) {
+  process.exit(runDocsLinkAuditCli());
 }

--- a/scripts/docs-link-audit.mjs
+++ b/scripts/docs-link-audit.mjs
@@ -298,14 +298,20 @@ export function auditDocsLinks() {
 export function runDocsLinkAuditCli(options = {}) {
   const args = options.args ?? process.argv.slice(2);
   if (args.includes("--anchors")) {
-    const result = (options.spawnSyncImpl ?? spawnSync)(
-      "pnpm",
-      ["dlx", "mint", "broken-links", "--check-anchors"],
-      {
+    const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
+    const result = spawnSyncImpl("mint", ["broken-links", "--check-anchors"], {
+      cwd: DOCS_DIR,
+      stdio: "inherit",
+    });
+
+    if (result.error?.code === "ENOENT") {
+      const fallback = spawnSyncImpl("pnpm", ["dlx", "mint", "broken-links", "--check-anchors"], {
         cwd: DOCS_DIR,
         stdio: "inherit",
-      },
-    );
+      });
+      return fallback.status ?? 1;
+    }
+
     return result.status ?? 1;
   }
 

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -13,7 +13,7 @@ const { normalizeRoute, resolveRoute, runDocsLinkAuditCli } =
         command: string,
         args: string[],
         options: { cwd: string; stdio: string },
-      ) => { status: number | null };
+      ) => { status: number | null; error?: { code?: string } };
     }) => number;
   };
 
@@ -37,7 +37,7 @@ describe("docs-link-audit", () => {
     });
   });
 
-  it("delegates anchor validation to mintlify", () => {
+  it("prefers a local mint binary for anchor validation", () => {
     let invocation:
       | {
           command: string;
@@ -56,12 +56,51 @@ describe("docs-link-audit", () => {
 
     expect(exitCode).toBe(0);
     expect(invocation).toEqual({
-      command: "pnpm",
-      args: ["dlx", "mint", "broken-links", "--check-anchors"],
+      command: "mint",
+      args: ["broken-links", "--check-anchors"],
       options: {
         cwd: expect.stringMatching(/\/docs$/),
         stdio: "inherit",
       },
     });
+  });
+
+  it("falls back to pnpm dlx when mint is not on PATH", () => {
+    const invocations: Array<{
+      command: string;
+      args: string[];
+      options: { cwd: string; stdio: string };
+    }> = [];
+
+    const exitCode = runDocsLinkAuditCli({
+      args: ["--anchors"],
+      spawnSyncImpl(command, args, options) {
+        invocations.push({ command, args, options });
+        if (command === "mint") {
+          return { status: null, error: { code: "ENOENT" } };
+        }
+        return { status: 0 };
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(invocations).toEqual([
+      {
+        command: "mint",
+        args: ["broken-links", "--check-anchors"],
+        options: {
+          cwd: expect.stringMatching(/\/docs$/),
+          stdio: "inherit",
+        },
+      },
+      {
+        command: "pnpm",
+        args: ["dlx", "mint", "broken-links", "--check-anchors"],
+        options: {
+          cwd: expect.stringMatching(/\/docs$/),
+          stdio: "inherit",
+        },
+      },
+    ]);
   });
 });

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const { normalizeRoute, resolveRoute, runDocsLinkAuditCli } =
@@ -55,14 +56,11 @@ describe("docs-link-audit", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(invocation).toEqual({
-      command: "mint",
-      args: ["broken-links", "--check-anchors"],
-      options: {
-        cwd: expect.stringMatching(/\/docs$/),
-        stdio: "inherit",
-      },
-    });
+    expect(invocation).toBeDefined();
+    expect(invocation?.command).toBe("mint");
+    expect(invocation?.args).toEqual(["broken-links", "--check-anchors"]);
+    expect(invocation?.options.stdio).toBe("inherit");
+    expect(path.basename(invocation?.options.cwd ?? "")).toBe("docs");
   });
 
   it("falls back to pnpm dlx when mint is not on PATH", () => {
@@ -84,23 +82,18 @@ describe("docs-link-audit", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(invocations).toEqual([
-      {
-        command: "mint",
-        args: ["broken-links", "--check-anchors"],
-        options: {
-          cwd: expect.stringMatching(/\/docs$/),
-          stdio: "inherit",
-        },
-      },
-      {
-        command: "pnpm",
-        args: ["dlx", "mint", "broken-links", "--check-anchors"],
-        options: {
-          cwd: expect.stringMatching(/\/docs$/),
-          stdio: "inherit",
-        },
-      },
-    ]);
+    expect(invocations).toHaveLength(2);
+    expect(invocations[0]).toMatchObject({
+      command: "mint",
+      args: ["broken-links", "--check-anchors"],
+      options: { stdio: "inherit" },
+    });
+    expect(invocations[1]).toMatchObject({
+      command: "pnpm",
+      args: ["dlx", "mint", "broken-links", "--check-anchors"],
+      options: { stdio: "inherit" },
+    });
+    expect(path.basename(invocations[0]?.options.cwd ?? "")).toBe("docs");
+    expect(path.basename(invocations[1]?.options.cwd ?? "")).toBe("docs");
   });
 });

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-const { normalizeRoute, resolveRoute } =
+const { normalizeRoute, resolveRoute, runDocsLinkAuditCli } =
   (await import("../../scripts/docs-link-audit.mjs")) as unknown as {
     normalizeRoute: (route: string) => string;
     resolveRoute: (
       route: string,
       options?: { redirects?: Map<string, string>; routes?: Set<string> },
     ) => { ok: boolean; terminal: string; loop?: boolean };
+    runDocsLinkAuditCli: (options?: {
+      args?: string[];
+      spawnSyncImpl?: (
+        command: string,
+        args: string[],
+        options: { cwd: string; stdio: string },
+      ) => { status: number | null };
+    }) => number;
   };
 
 describe("docs-link-audit", () => {
@@ -26,6 +34,34 @@ describe("docs-link-audit", () => {
     expect(resolveRoute("/plugins/agent-tools", { redirects, routes })).toEqual({
       ok: true,
       terminal: "/plugins/building-plugins",
+    });
+  });
+
+  it("delegates anchor validation to mintlify", () => {
+    let invocation:
+      | {
+          command: string;
+          args: string[];
+          options: { cwd: string; stdio: string };
+        }
+      | undefined;
+
+    const exitCode = runDocsLinkAuditCli({
+      args: ["--anchors"],
+      spawnSyncImpl(command, args, options) {
+        invocation = { command, args, options };
+        return { status: 0 };
+      },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(invocation).toEqual({
+      command: "pnpm",
+      args: ["dlx", "mint", "broken-links", "--check-anchors"],
+      options: {
+        cwd: expect.stringMatching(/\/docs$/),
+        stdio: "inherit",
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- keep `scripts/docs-link-audit.mjs` as the single stable entrypoint for docs link checks
- add an `--anchors` mode that delegates to Mintlify for in-page anchor validation
- document the new anchor-aware command in docs testing guidance

## Testing
- pnpm check:docs
- pnpm test -- src/scripts/docs-link-audit.test.ts
- pnpm docs:check-links:anchors (expected to fail on existing docs/zh-CN + anchor debt; verified command wiring)