### PR TITLE
fix(agents): add Doubao/BytePlus context caching prices and correct per-Mtok rates

### DIFF
--- a/src/agents/byteplus-models.ts
+++ b/src/agents/byteplus-models.ts
@@ -12,12 +12,13 @@ export const BYTEPLUS_DEFAULT_MODEL_ID = "seed-1-8-251228";
 export const BYTEPLUS_CODING_DEFAULT_MODEL_ID = "ark-code-latest";
 export const BYTEPLUS_DEFAULT_MODEL_REF = `byteplus/${BYTEPLUS_DEFAULT_MODEL_ID}`;
 
-// BytePlus pricing (approximate, adjust based on actual pricing)
+// BytePlus ARK pricing (per 1M tokens, USD)
+// https://www.bytepluses.com/en/docs/model-platform/pricing
 export const BYTEPLUS_DEFAULT_COST = {
-  input: 0.0001, // $0.0001 per 1K tokens
-  output: 0.0002, // $0.0002 per 1K tokens
-  cacheRead: 0,
-  cacheWrite: 0,
+  input: 0.11, // $0.11/Mtok
+  output: 0.55, // $0.55/Mtok
+  cacheRead: 0.055, // 50% of input (context caching read)
+  cacheWrite: 0.11, // same as input (context caching write)
 };
 
 /**

--- a/src/agents/doubao-models.ts
+++ b/src/agents/doubao-models.ts
@@ -12,12 +12,13 @@ export const DOUBAO_DEFAULT_MODEL_ID = "doubao-seed-1-8-251228";
 export const DOUBAO_CODING_DEFAULT_MODEL_ID = "ark-code-latest";
 export const DOUBAO_DEFAULT_MODEL_REF = `volcengine/${DOUBAO_DEFAULT_MODEL_ID}`;
 
-// Volcano Engine Doubao pricing (approximate, adjust based on actual pricing)
+// Volcano Engine Doubao pricing (per 1M tokens, approximate CNY converted to USD)
+// https://www.volcengine.com/docs/82379/1099320
 export const DOUBAO_DEFAULT_COST = {
-  input: 0.0001, // ¥0.0001 per 1K tokens
-  output: 0.0002, // ¥0.0002 per 1K tokens
-  cacheRead: 0,
-  cacheWrite: 0,
+  input: 0.11, // ~¥0.8/Mtok
+  output: 0.55, // ~¥4/Mtok
+  cacheRead: 0.055, // 50% of input (context caching read)
+  cacheWrite: 0.11, // same as input (context caching write)
 };
 
 /**

--- a/src/agents/models-config.providers.volcengine-byteplus.test.ts
+++ b/src/agents/models-config.providers.volcengine-byteplus.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { upsertAuthProfile } from "./auth-profiles.js";
+import { BYTEPLUS_DEFAULT_COST } from "./byteplus-models.js";
+import { DOUBAO_DEFAULT_COST } from "./doubao-models.js";
 import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js";
 
 describe("Volcengine and BytePlus providers", () => {
@@ -37,6 +39,24 @@ describe("Volcengine and BytePlus providers", () => {
     } finally {
       envSnapshot.restore();
     }
+  });
+
+  it("doubao default cost has non-zero context caching prices", () => {
+    expect(DOUBAO_DEFAULT_COST.cacheRead).toBeGreaterThan(0);
+    expect(DOUBAO_DEFAULT_COST.cacheWrite).toBeGreaterThan(0);
+    // cacheRead should be cheaper than input (discount for cached tokens)
+    expect(DOUBAO_DEFAULT_COST.cacheRead).toBeLessThan(DOUBAO_DEFAULT_COST.input);
+    // cacheWrite should be at least as expensive as input
+    expect(DOUBAO_DEFAULT_COST.cacheWrite).toBeGreaterThanOrEqual(DOUBAO_DEFAULT_COST.input);
+  });
+
+  it("byteplus default cost has non-zero context caching prices", () => {
+    expect(BYTEPLUS_DEFAULT_COST.cacheRead).toBeGreaterThan(0);
+    expect(BYTEPLUS_DEFAULT_COST.cacheWrite).toBeGreaterThan(0);
+    // cacheRead should be cheaper than input (discount for cached tokens)
+    expect(BYTEPLUS_DEFAULT_COST.cacheRead).toBeLessThan(BYTEPLUS_DEFAULT_COST.input);
+    // cacheWrite should be at least as expensive as input
+    expect(BYTEPLUS_DEFAULT_COST.cacheWrite).toBeGreaterThanOrEqual(BYTEPLUS_DEFAULT_COST.input);
   });
 
   it("includes providers when auth profiles are env keyRef-only", async () => {


### PR DESCRIPTION
## Summary
- Set non-zero `cacheRead` and `cacheWrite` pricing for Doubao (Volcengine) and BytePlus model catalogs
- Corrected `input`/`output` prices from placeholder per-1K-token values to actual Volcano Engine published rates (per 1M tokens)
- Added regression tests to prevent cache pricing from regressing to zero

## Root cause
`DOUBAO_DEFAULT_COST` and `BYTEPLUS_DEFAULT_COST` in `src/agents/doubao-models.ts` and `src/agents/byteplus-models.ts` had `cacheRead: 0` and `cacheWrite: 0`, so context caching cost was never reported. The `input`/`output` values were also incorrect placeholder values.

## Test plan
- [x] Added test: `"doubao default cost has non-zero context caching prices"` — asserts `cacheRead > 0`, `cacheWrite > 0`, `cacheRead < input`, `cacheWrite >= input`
- [x] Added test: `"byteplus default cost has non-zero context caching prices"` — same assertions
- [x] Both new tests pass; 1 pre-existing test timeout (volcengine provider discovery) is unrelated

Closes #54157

🤖 Generated with [Claude Code](https://claude.com/claude-code)