### PR TITLE
fix(gateway): require admin for persisted verbose defaults

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -25,6 +25,7 @@ import {
   formatElevatedRuntimeHint,
   formatElevatedUnavailableText,
   formatInternalExecPersistenceDeniedText,
+  formatInternalVerboseCurrentReplyOnlyText,
   formatInternalVerbosePersistenceDeniedText,
   enqueueModeSwitchEvents,
   withOptions,
@@ -469,11 +470,13 @@ export async function handleDirectiveOnly(
   }
   if (directives.hasVerboseDirective && directives.verboseLevel) {
     parts.push(
-      directives.verboseLevel === "off"
-        ? formatDirectiveAck("Verbose logging disabled.")
-        : directives.verboseLevel === "full"
-          ? formatDirectiveAck("Verbose logging set to full.")
-          : formatDirectiveAck("Verbose logging enabled."),
+      !allowInternalVerbosePersistence
+        ? formatDirectiveAck(formatInternalVerboseCurrentReplyOnlyText())
+        : directives.verboseLevel === "off"
+          ? formatDirectiveAck("Verbose logging disabled.")
+          : directives.verboseLevel === "full"
+            ? formatDirectiveAck("Verbose logging set to full.")
+            : formatDirectiveAck("Verbose logging enabled."),
     );
   }
   if (

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -20,10 +20,12 @@ import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
 import { maybeHandleQueueDirective } from "./directive-handling.queue-validation.js";
 import {
   canPersistInternalExecDirective,
+  canPersistInternalVerboseDirective,
   formatDirectiveAck,
   formatElevatedRuntimeHint,
   formatElevatedUnavailableText,
   formatInternalExecPersistenceDeniedText,
+  formatInternalVerbosePersistenceDeniedText,
   enqueueModeSwitchEvents,
   withOptions,
 } from "./directive-handling.shared.js";
@@ -96,6 +98,10 @@ export async function handleDirectiveOnly(
   }).sandboxed;
   const shouldHintDirectRuntime = directives.hasElevatedDirective && !runtimeIsSandboxed;
   const allowInternalExecPersistence = canPersistInternalExecDirective({
+    surface: params.surface,
+    gatewayClientScopes: params.gatewayClientScopes,
+  });
+  const allowInternalVerbosePersistence = canPersistInternalVerboseDirective({
     surface: params.surface,
     gatewayClientScopes: params.gatewayClientScopes,
   });
@@ -319,7 +325,9 @@ export async function handleDirectiveOnly(
   const shouldPersistSessionEntry =
     (directives.hasThinkDirective && Boolean(directives.thinkLevel)) ||
     (directives.hasFastDirective && directives.fastMode !== undefined) ||
-    (directives.hasVerboseDirective && Boolean(directives.verboseLevel)) ||
+    (directives.hasVerboseDirective &&
+      Boolean(directives.verboseLevel) &&
+      allowInternalVerbosePersistence) ||
     (directives.hasReasoningDirective && Boolean(directives.reasoningLevel)) ||
     (directives.hasElevatedDirective && Boolean(directives.elevatedLevel)) ||
     (directives.hasExecDirective && directives.hasExecOptions && allowInternalExecPersistence) ||
@@ -342,7 +350,11 @@ export async function handleDirectiveOnly(
     if (shouldDowngradeXHigh) {
       sessionEntry.thinkingLevel = "high";
     }
-    if (directives.hasVerboseDirective && directives.verboseLevel) {
+    if (
+      directives.hasVerboseDirective &&
+      directives.verboseLevel &&
+      allowInternalVerbosePersistence
+    ) {
       applyVerboseOverride(sessionEntry, directives.verboseLevel);
     }
     if (directives.hasReasoningDirective && directives.reasoningLevel) {
@@ -463,6 +475,13 @@ export async function handleDirectiveOnly(
           ? formatDirectiveAck("Verbose logging set to full.")
           : formatDirectiveAck("Verbose logging enabled."),
     );
+  }
+  if (
+    directives.hasVerboseDirective &&
+    directives.verboseLevel &&
+    !allowInternalVerbosePersistence
+  ) {
+    parts.push(formatDirectiveAck(formatInternalVerbosePersistenceDeniedText()));
   }
   if (directives.hasReasoningDirective && directives.reasoningLevel) {
     parts.push(

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -597,7 +597,7 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       }),
     );
 
-    expect(result?.text).toContain("Verbose logging set to full.");
+    expect(result?.text).toContain("Verbose logging set for the current reply only.");
     expect(result?.text).toContain("operator.admin");
     expect(sessionEntry.verboseLevel).toBeUndefined();
   });

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -583,6 +583,43 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(sessionEntry.execNode).toBeUndefined();
   });
 
+  it("blocks internal operator.write verbose persistence in directive-only handling", async () => {
+    const directives = parseInlineDirectives("/verbose full");
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives,
+        sessionEntry,
+        sessionStore,
+        surface: "webchat",
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(result?.text).toContain("Verbose logging set to full.");
+    expect(result?.text).toContain("operator.admin");
+    expect(sessionEntry.verboseLevel).toBeUndefined();
+  });
+
+  it("allows internal operator.admin verbose persistence in directive-only handling", async () => {
+    const directives = parseInlineDirectives("/verbose full");
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives,
+        sessionEntry,
+        sessionStore,
+        surface: "webchat",
+        gatewayClientScopes: ["operator.admin"],
+      }),
+    );
+
+    expect(result?.text).toContain("Verbose logging set to full.");
+    expect(sessionEntry.verboseLevel).toBe("full");
+  });
+
   it("allows internal operator.admin exec persistence in directive-only handling", async () => {
     const directives = parseInlineDirectives(
       "/exec host=node security=allowlist ask=always node=worker-1",
@@ -645,5 +682,39 @@ describe("persistInlineDirectives internal exec scope gate", () => {
     expect(sessionEntry.execSecurity).toBeUndefined();
     expect(sessionEntry.execAsk).toBeUndefined();
     expect(sessionEntry.execNode).toBeUndefined();
+  });
+
+  it("skips verbose persistence for internal operator.write callers", async () => {
+    const allowedModelKeys = new Set(["anthropic/claude-opus-4-5", "openai/gpt-4o"]);
+    const directives = parseInlineDirectives("/verbose full");
+    const sessionEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+    } as SessionEntry;
+    const sessionStore = { "agent:main:main": sessionEntry };
+
+    await persistInlineDirectives({
+      directives,
+      cfg: baseConfig(),
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:main",
+      storePath: "/tmp/sessions.json",
+      elevatedEnabled: true,
+      elevatedAllowed: true,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-5",
+      aliasIndex: baseAliasIndex(),
+      allowedModelKeys,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      initialModelLabel: "anthropic/claude-opus-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: undefined,
+      surface: "webchat",
+      gatewayClientScopes: ["operator.write"],
+    });
+
+    expect(sessionEntry.verboseLevel).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -16,6 +16,7 @@ import { resolveModelSelectionFromDirective } from "./directive-handling.model-s
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import {
   canPersistInternalExecDirective,
+  canPersistInternalVerboseDirective,
   enqueueModeSwitchEvents,
 } from "./directive-handling.shared.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
@@ -65,6 +66,10 @@ export async function persistInlineDirectives(params: {
     surface: params.surface,
     gatewayClientScopes: params.gatewayClientScopes,
   });
+  const allowInternalVerbosePersistence = canPersistInternalVerboseDirective({
+    surface: params.surface,
+    gatewayClientScopes: params.gatewayClientScopes,
+  });
   const activeAgentId = sessionKey
     ? resolveSessionAgentId({ sessionKey, config: cfg })
     : resolveDefaultAgentId(cfg);
@@ -89,7 +94,11 @@ export async function persistInlineDirectives(params: {
       sessionEntry.thinkingLevel = directives.thinkLevel;
       updated = true;
     }
-    if (directives.hasVerboseDirective && directives.verboseLevel) {
+    if (
+      directives.hasVerboseDirective &&
+      directives.verboseLevel &&
+      allowInternalVerbosePersistence
+    ) {
       applyVerboseOverride(sessionEntry, directives.verboseLevel);
       updated = true;
     }

--- a/src/auto-reply/reply/directive-handling.shared.ts
+++ b/src/auto-reply/reply/directive-handling.shared.ts
@@ -20,7 +20,10 @@ export const formatInternalExecPersistenceDeniedText = () =>
 export const formatInternalVerbosePersistenceDeniedText = () =>
   "Verbose defaults require operator.admin for internal gateway callers; skipped persistence.";
 
-export function canPersistInternalExecDirective(params: {
+export const formatInternalVerboseCurrentReplyOnlyText = () =>
+  "Verbose logging set for the current reply only.";
+
+function canPersistInternalDirective(params: {
   surface?: string;
   gatewayClientScopes?: string[];
 }): boolean {
@@ -31,16 +34,8 @@ export function canPersistInternalExecDirective(params: {
   return scopes.includes("operator.admin");
 }
 
-export function canPersistInternalVerboseDirective(params: {
-  surface?: string;
-  gatewayClientScopes?: string[];
-}): boolean {
-  if (!isInternalMessageChannel(params.surface)) {
-    return true;
-  }
-  const scopes = params.gatewayClientScopes ?? [];
-  return scopes.includes("operator.admin");
-}
+export const canPersistInternalExecDirective = canPersistInternalDirective;
+export const canPersistInternalVerboseDirective = canPersistInternalDirective;
 
 export const formatElevatedEvent = (level: ElevatedLevel) => {
   if (level === "full") {

--- a/src/auto-reply/reply/directive-handling.shared.ts
+++ b/src/auto-reply/reply/directive-handling.shared.ts
@@ -17,7 +17,21 @@ export const formatElevatedRuntimeHint = () =>
 export const formatInternalExecPersistenceDeniedText = () =>
   "Exec defaults require operator.admin for internal gateway callers; skipped persistence.";
 
+export const formatInternalVerbosePersistenceDeniedText = () =>
+  "Verbose defaults require operator.admin for internal gateway callers; skipped persistence.";
+
 export function canPersistInternalExecDirective(params: {
+  surface?: string;
+  gatewayClientScopes?: string[];
+}): boolean {
+  if (!isInternalMessageChannel(params.surface)) {
+    return true;
+  }
+  const scopes = params.gatewayClientScopes ?? [];
+  return scopes.includes("operator.admin");
+}
+
+export function canPersistInternalVerboseDirective(params: {
   surface?: string;
   gatewayClientScopes?: string[];
 }): boolean {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -14,6 +14,7 @@ import {
   rpcReq,
   testState,
   trackConnectChallengeNonce,
+  withGatewayServer,
   writeSessionStore,
 } from "./test-helpers.js";
 import { agentCommand } from "./test-helpers.mocks.js";
@@ -685,39 +686,43 @@ describe("gateway server chat", () => {
   });
 
   test("chat.send does not persist verboseLevel for operator.write callers", async () => {
-    await withMainSessionStore(async () => {
-      let scopedWs: WebSocket | undefined;
+    await withGatewayServer(async ({ port }) => {
+      await withMainSessionStore(async () => {
+        let scopedWs: WebSocket | undefined;
 
-      try {
-        scopedWs = new WebSocket(`ws://127.0.0.1:${port}`, {
-          headers: { origin: `http://127.0.0.1:${port}` },
-        });
-        trackConnectChallengeNonce(scopedWs);
-        await new Promise<void>((resolve) => scopedWs?.once("open", resolve));
-        await connectOk(scopedWs, {
-          scopes: ["operator.write"],
-        });
+        try {
+          scopedWs = new WebSocket(`ws://127.0.0.1:${port}`);
+          trackConnectChallengeNonce(scopedWs);
+          await new Promise<void>((resolve) => scopedWs?.once("open", resolve));
+          await connectOk(scopedWs, {
+            scopes: ["operator.write"],
+          });
 
-        const sendRes = await rpcReq(scopedWs, "chat.send", {
-          sessionKey: "main",
-          message: "/verbose full",
-          idempotencyKey: "idem-write-scope-verbose-no-persist",
-        });
-        expect(sendRes.ok).toBe(true);
+          const sendRes = await rpcReq(scopedWs, "chat.send", {
+            sessionKey: "main",
+            message: "/verbose full",
+            idempotencyKey: "idem-write-scope-verbose-no-persist",
+          });
+          expect(sendRes.ok).toBe(true);
 
-        await vi.waitFor(async () => {
+          const waitRes = await rpcReq(scopedWs, "agent.wait", {
+            runId: "idem-write-scope-verbose-no-persist",
+            timeoutMs: 1_000,
+          });
+          expect(waitRes.ok).toBe(true);
+          expect(waitRes.payload?.status).toBe("ok");
+
           const raw = await fs.readFile(testState.sessionStorePath!, "utf-8");
           const stored = JSON.parse(raw) as {
             "agent:main:main"?: {
               verboseLevel?: string;
             };
           };
-
           expect(stored["agent:main:main"]?.verboseLevel).toBeUndefined();
-        });
-      } finally {
-        scopedWs?.close();
-      }
+        } finally {
+          scopedWs?.close();
+        }
+      });
     });
   });
 

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -684,6 +684,43 @@ describe("gateway server chat", () => {
     ]);
   });
 
+  test("chat.send does not persist verboseLevel for operator.write callers", async () => {
+    await withMainSessionStore(async () => {
+      let scopedWs: WebSocket | undefined;
+
+      try {
+        scopedWs = new WebSocket(`ws://127.0.0.1:${port}`, {
+          headers: { origin: `http://127.0.0.1:${port}` },
+        });
+        trackConnectChallengeNonce(scopedWs);
+        await new Promise<void>((resolve) => scopedWs?.once("open", resolve));
+        await connectOk(scopedWs, {
+          scopes: ["operator.write"],
+        });
+
+        const sendRes = await rpcReq(scopedWs, "chat.send", {
+          sessionKey: "main",
+          message: "/verbose full",
+          idempotencyKey: "idem-write-scope-verbose-no-persist",
+        });
+        expect(sendRes.ok).toBe(true);
+
+        await vi.waitFor(async () => {
+          const raw = await fs.readFile(testState.sessionStorePath!, "utf-8");
+          const stored = JSON.parse(raw) as {
+            "agent:main:main"?: {
+              verboseLevel?: string;
+            };
+          };
+
+          expect(stored["agent:main:main"]?.verboseLevel).toBeUndefined();
+        });
+      } finally {
+        scopedWs?.close();
+      }
+    });
+  });
+
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     await withMainSessionStore(async () => {
       const runId = "idem-wait-chat-1";


### PR DESCRIPTION
## Summary
- keeps inline `/verbose` changes ephemeral for internal gateway callers without `operator.admin`
- preserves persisted session verbose updates for admin-scoped callers
- adds directive and gateway regressions for the stored `verboseLevel` path

## Changes
- gated internal `/verbose` session persistence behind the same admin-only check used for durable internal exec defaults
- left inline verbose handling active for the current reply while skipping session-store writes for write-scoped internal callers
- added unit coverage for directive-only and persisted-inline behavior plus a gateway regression for `chat.send`

## Validation
- Ran `pnpm exec oxlint src/auto-reply/reply/directive-handling.shared.ts src/auto-reply/reply/directive-handling.impl.ts src/auto-reply/reply/directive-handling.persist.ts src/auto-reply/reply/directive-handling.model.test.ts src/gateway/server.chat.gateway-server-chat.test.ts`
- Ran `git diff --check`
- Ran local agentic review with `claude -p "/review"` and addressed the cleanup feedback it raised
- Attempted `pnpm test -- src/auto-reply/reply/directive-handling.model.test.ts` and `pnpm test -- src/gateway/server.chat.gateway-server-chat.test.ts -t "chat.send does not persist verboseLevel for operator.write callers"`, but both focused Vitest runs hung after startup in this worktree

## Notes
- Residual risk or follow-up: the local Vitest hang prevented a green targeted test run here, so CI should confirm the new regressions and runtime behavior on a clean runner
