### PR TITLE
fix: surface fake tool runs, placeholder replies, and legacy WS auth failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/WebChat/Gateway: surface downgraded text-form tool calls, placeholder-only replies, inline chat run errors, and legacy `?agent=...&token=` WebSocket auth attempts as explicit failures instead of silent stalls or timeout noise. Carries forward #55923 and #40150; refs #40082, #40008, and #50930. Thanks @cgdusek and @hhy5562877.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/Anthropic: cancel stalled Anthropic Messages SSE body reads when abort signals fire, so active-memory timeouts release transport resources instead of leaving hidden recall runs parked on `reader.read()`. Refs #72965 and #73120. Thanks @wdeveloper16.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -416,4 +416,15 @@ describe("buildEmbeddedRunPayloads placeholder reply detection", () => {
       "I checked the file and the config key is missing from the JSON payload.",
     );
   });
+
+  it("keeps normal replies that mention placeholder phrases inline", () => {
+    const reply =
+      "The benchmark completes in one sec on my machine, but it still needs CI confirmation.";
+    const payloads = buildPayloads({
+      assistantTexts: [reply],
+      lastAssistant: makeAssistantMessage(reply),
+    });
+
+    expectSinglePayloadText(payloads, reply);
+  });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -6,6 +6,26 @@ import {
   expectSingleToolErrorPayload,
 } from "./payloads.test-helpers.js";
 
+function makeAssistantMessage(text: string): AssistantMessage {
+  return {
+    role: "assistant",
+    api: "responses",
+    provider: "openai",
+    model: "gpt-5",
+    timestamp: Date.now(),
+    stopReason: "stop",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    content: [{ type: "text", text }],
+  } as AssistantMessage;
+}
+
 describe("buildEmbeddedRunPayloads tool-error warnings", () => {
   function expectNoPayloads(params: Parameters<typeof buildPayloads>[0]) {
     const payloads = buildPayloads(params);
@@ -311,5 +331,89 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
 
     expectSinglePayloadText(payloads, "THINKING-OFF-OK");
+  });
+});
+
+describe("buildEmbeddedRunPayloads downgraded tool call detection", () => {
+  it("surfaces downgraded text-form tool calls as an explicit error", () => {
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistantMessage(
+        `[Tool Call: read (ID: toolu_1)]\nArguments: {"path":"notes.md"}`,
+      ),
+    });
+
+    expectSinglePayloadText(
+      payloads,
+      "⚠️ The model emitted a text-form tool call instead of executing a real tool. No tool action was actually run. Please retry, or switch to a provider/model with reliable tool calling.",
+      true,
+    );
+  });
+
+  it("does not add a second tool warning after a synthetic downgraded-tool error", () => {
+    const payloads = buildPayloads({
+      lastAssistant: makeAssistantMessage(
+        `[Tool Call: read (ID: toolu_1)]\nArguments: {"path":"notes.md"}`,
+      ),
+      lastToolError: { toolName: "read", error: "permission denied" },
+      verboseLevel: "on",
+    });
+
+    expectSinglePayloadText(
+      payloads,
+      "⚠️ The model emitted a text-form tool call instead of executing a real tool. No tool action was actually run. Please retry, or switch to a provider/model with reliable tool calling.",
+      true,
+    );
+  });
+
+  it("keeps normal replies that only quote downgraded tool markers", () => {
+    const quotedToolMarkerReply =
+      "For debugging, the transcript may include literal text like [Tool Call: read (ID: toolu_1)] before the real answer.";
+    const payloads = buildPayloads({
+      assistantTexts: [quotedToolMarkerReply],
+      lastAssistant: makeAssistantMessage(quotedToolMarkerReply),
+    });
+
+    expectSinglePayloadText(payloads, quotedToolMarkerReply);
+  });
+});
+
+describe("buildEmbeddedRunPayloads placeholder reply detection", () => {
+  it("surfaces short non-executing placeholder replies as an explicit error", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Let me actually check that now instead of just saying I will. One sec."],
+      lastAssistant: makeAssistantMessage(
+        "Let me actually check that now instead of just saying I will. One sec.",
+      ),
+    });
+
+    expectSinglePayloadText(
+      payloads,
+      "⚠️ The agent returned a placeholder reply without starting any real tool work. Please retry, or switch to a provider/model with reliable tool execution.",
+      true,
+    );
+  });
+
+  it("does not flag placeholder replies when structured tool activity occurred", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Let me check that now. One sec."],
+      lastAssistant: makeAssistantMessage("Let me check that now. One sec."),
+      toolMetas: [{ toolName: "exec" }],
+    });
+
+    expectSinglePayloadText(payloads, "Let me check that now. One sec.");
+  });
+
+  it("keeps substantive plain-text answers that do not match placeholder heuristics", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["I checked the file and the config key is missing from the JSON payload."],
+      lastAssistant: makeAssistantMessage(
+        "I checked the file and the config key is missing from the JSON payload.",
+      ),
+    });
+
+    expectSinglePayloadText(
+      payloads,
+      "I checked the file and the config key is missing from the JSON payload.",
+    );
   });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -21,6 +21,8 @@ import {
 } from "../../pi-embedded-helpers.js";
 import type { ToolResultFormat } from "../../pi-embedded-subscribe.shared-types.js";
 import {
+  containsDowngradedToolCallText,
+  extractAssistantRawText,
   extractAssistantThinking,
   extractAssistantVisibleText,
   formatReasoningMessage,
@@ -66,6 +68,20 @@ const MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN = new RegExp(
 const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
 
+// Short, future-action-phrased replies with no tool execution indicate the model
+// is stalling rather than performing real work. Only short replies (<=220 chars,
+// <=4 lines) matching explicit "let me check" / "one sec" patterns are flagged.
+const NON_EXECUTING_REPLY_PATTERNS = [
+  /\bone sec\b/i,
+  /\bhold on\b/i,
+  /\bstill planning to\b/i,
+  /\bworking on it\b/i,
+  /\blet me (?:actually )?(?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b/i,
+  /\bi(?:'|')ll (?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b.*\bnow\b/i,
+] as const;
+
+const NON_EXECUTING_REPLY_MAX_CHARS = 220;
+
 function isRecoverableToolError(error: string | undefined): boolean {
   const errorLower = normalizeOptionalLowercaseString(error) ?? "";
   return RECOVERABLE_TOOL_ERROR_KEYWORDS.some((keyword) => errorLower.includes(keyword));
@@ -90,6 +106,18 @@ function hasExplicitMutatingToolFailureAcknowledgement(text: string): boolean {
     MUTATING_FAILURE_FAILURE_THEN_ACTION_PATTERN.test(normalizedText) ||
     MUTATING_FAILURE_ERROR_WHILE_ACTION_PATTERN.test(normalizedText)
   );
+}
+
+function isLikelyNonExecutingPlaceholderReply(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized || normalized.length > NON_EXECUTING_REPLY_MAX_CHARS) {
+    return false;
+  }
+  const lineCount = normalized.split(/\r?\n/).filter(Boolean).length;
+  if (lineCount > 4) {
+    return false;
+  }
+  return NON_EXECUTING_REPLY_PATTERNS.some((pattern) => pattern.test(normalized));
 }
 
 function isVerboseToolDetailEnabled(level?: VerboseLevel): boolean {
@@ -282,6 +310,15 @@ export function buildEmbeddedRunPayloads(params: {
     ? extractAssistantVisibleText(params.lastAssistant)
     : "";
   const fallbackRawAnswerText = resolveRawAssistantAnswerText(params.lastAssistant);
+  const rawAssistantText = params.lastAssistant
+    ? extractAssistantRawText(params.lastAssistant)
+    : "";
+  const hadStructuredToolActivity =
+    params.toolMetas.length > 0 || params.didSendViaMessagingTool === true;
+  const downgradedToolCallDetected =
+    !lastAssistantErrored &&
+    !hadStructuredToolActivity &&
+    containsDowngradedToolCallText(rawAssistantText);
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantErrored) {
       return false;
@@ -362,32 +399,54 @@ export function buildEmbeddedRunPayloads(params: {
             : []
       ).filter((text) => !shouldSuppressRawErrorText(text));
 
+  const placeholderReplyDetected =
+    !lastAssistantErrored &&
+    !hadStructuredToolActivity &&
+    answerTexts.length > 0 &&
+    answerTexts.every((text) => isLikelyNonExecutingPlaceholderReply(text));
+
   let hasUserFacingAssistantReply = false;
   let hasUserFacingFailureAcknowledgement = false;
-  for (const text of answerTexts) {
-    const {
-      text: cleanedText,
-      mediaUrls,
-      audioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
-    } = parseReplyDirectives(text);
-    if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
-      continue;
+  if (!downgradedToolCallDetected && !placeholderReplyDetected) {
+    for (const text of answerTexts) {
+      const {
+        text: cleanedText,
+        mediaUrls,
+        audioAsVoice,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      } = parseReplyDirectives(text);
+      if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
+        continue;
+      }
+      replyItems.push({
+        text: cleanedText,
+        media: mediaUrls,
+        audioAsVoice,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      });
+      hasUserFacingAssistantReply = true;
+      if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
+        hasUserFacingFailureAcknowledgement = true;
+      }
     }
+  }
+
+  if (downgradedToolCallDetected) {
     replyItems.push({
-      text: cleanedText,
-      media: mediaUrls,
-      audioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
+      text: "⚠️ The model emitted a text-form tool call instead of executing a real tool. No tool action was actually run. Please retry, or switch to a provider/model with reliable tool calling.",
+      isError: true,
     });
     hasUserFacingAssistantReply = true;
-    if (cleanedText && hasExplicitMutatingToolFailureAcknowledgement(cleanedText)) {
-      hasUserFacingFailureAcknowledgement = true;
-    }
+  } else if (placeholderReplyDetected) {
+    replyItems.push({
+      text: "⚠️ The agent returned a placeholder reply without starting any real tool work. Please retry, or switch to a provider/model with reliable tool execution.",
+      isError: true,
+    });
+    hasUserFacingAssistantReply = true;
   }
 
   if (params.lastToolError) {

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -77,7 +77,7 @@ const NON_EXECUTING_REPLY_PATTERNS = [
   /\bstill planning to\b/i,
   /\bworking on it\b/i,
   /\blet me (?:actually )?(?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b/i,
-  /\bi(?:'|')ll (?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b.*\bnow\b/i,
+  /\bi(?:'|')ll (?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b[^.!?\n]{0,60}\bnow\b/i,
 ] as const;
 
 const NON_EXECUTING_REPLY_MAX_CHARS = 220;

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -69,15 +69,12 @@ const DID_NOT_FAIL_PATTERN = /\b(?:did not|didn't)\s+fail\b/u;
 const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/u;
 
 // Short, future-action-phrased replies with no tool execution indicate the model
-// is stalling rather than performing real work. Only short replies (<=220 chars,
-// <=4 lines) matching explicit "let me check" / "one sec" patterns are flagged.
+// is stalling rather than performing real work. Keep these anchored so normal
+// prose that only mentions a placeholder phrase is not replaced by an error.
 const NON_EXECUTING_REPLY_PATTERNS = [
-  /\bone sec\b/i,
-  /(?:^|[.!?]\s+)hold on\b/i,
-  /\bstill planning to\b/i,
-  /\bworking on it\b/i,
-  /\blet me (?:actually )?(?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b/i,
-  /\bi(?:'|')ll (?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b[^.!?\n]{0,60}\bnow\b/i,
+  /^(?:ok(?:ay)?[,.! ]*)?(?:one sec(?:ond)?|give me (?:a )?(?:sec(?:ond)?|moment)|hold on)\b[^\n]{0,120}$/i,
+  /^(?:still planning to|working on it)\b[^\n]{0,120}$/i,
+  /^(?:let me (?:actually )?(?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b|i(?:'|\u2019)ll (?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b[^.!?\n]{0,60}\bnow\b)[^\n]{0,120}$/i,
 ] as const;
 
 const NON_EXECUTING_REPLY_MAX_CHARS = 220;

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -73,7 +73,7 @@ const NEGATED_FAILURE_PATTERN = /\b(?:no|not|without)\s+(?:failures?|errors?)\b/
 // <=4 lines) matching explicit "let me check" / "one sec" patterns are flagged.
 const NON_EXECUTING_REPLY_PATTERNS = [
   /\bone sec\b/i,
-  /\bhold on\b/i,
+  /(?:^|[.!?]\s+)hold on\b/i,
   /\bstill planning to\b/i,
   /\bworking on it\b/i,
   /\blet me (?:actually )?(?:check|do|look|read|run|test|open|inspect|verify|fetch|pull)\b/i,

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -1,6 +1,8 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  containsDowngradedToolCallText,
+  extractAssistantRawText,
   extractAssistantText,
   extractAssistantThinking,
   extractAssistantVisibleText,
@@ -33,6 +35,35 @@ function makeAssistantMessage(
 }
 
 describe("extractAssistantText", () => {
+  it("extracts raw assistant text without stripping downgraded tool markers", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `[Tool Call: read (ID: toolu_1)]\nArguments: {"path":"notes.md"}`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantRawText(msg)).toContain("[Tool Call: read");
+  });
+
+  it("detects downgraded tool call markers", () => {
+    expect(containsDowngradedToolCallText(`[Tool Call: read (ID: toolu_1)]`)).toBe(true);
+    expect(containsDowngradedToolCallText(`[Tool Result for ID toolu_1] ok`)).toBe(true);
+    expect(containsDowngradedToolCallText("normal assistant reply")).toBe(false);
+  });
+
+  it("ignores normal replies that only quote tool markers inline", () => {
+    expect(
+      containsDowngradedToolCallText(
+        "For debugging, the transcript may include literal text like [Tool Call: read (ID: toolu_1)] before the real answer.",
+      ),
+    ).toBe(false);
+  });
+
   it("strips tool-only Minimax invocation XML from text", () => {
     const cases = [
       `<invoke name="Bash">

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -6,7 +6,10 @@ import {
   parseAssistantTextSignature,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
-import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
+import {
+  sanitizeAssistantVisibleText,
+  stripDowngradedToolCallText,
+} from "../shared/text/assistant-visible-text.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./pi-embedded-helpers/sanitize-user-facing-text.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
@@ -19,6 +22,42 @@ export { stripModelSpecialTokens } from "../shared/text/model-special-tokens.js"
 
 export function isAssistantMessage(msg: AgentMessage | undefined): msg is AssistantMessage {
   return msg?.role === "assistant";
+}
+
+/**
+ * Detect whether assistant text contains downgraded tool-call markers
+ * (e.g. `[Tool Call: read (ID: toolu_1)]`) as the primary content,
+ * indicating the model emitted a text-form tool invocation instead of
+ * a structured `tool_use` block. Normal prose that quotes these markers
+ * inline is excluded - only standalone tool-artifact payloads qualify.
+ */
+export function containsDowngradedToolCallText(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+  const hasDowngradedToolMarkers =
+    /\[Tool Call:/i.test(text) ||
+    /\[Tool Result for ID/i.test(text) ||
+    /\[Historical context:/i.test(text);
+  if (!hasDowngradedToolMarkers) {
+    return false;
+  }
+
+  // Only treat standalone tool-artifact payloads as downgraded tool output.
+  // Normal assistant prose may legitimately quote these markers while explaining behavior.
+  return stripDowngradedToolCallText(text).length === 0;
+}
+
+/**
+ * Extract raw assistant text without any normalization or stripping.
+ */
+export function extractAssistantRawText(msg: AssistantMessage): string {
+  return (
+    extractTextFromChatContent(msg.content, {
+      joinWith: "\n",
+      normalizeText: (text) => text,
+    }) ?? ""
+  );
 }
 
 /**

--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -31,9 +31,95 @@ function createResolvedAuth(token: string): ResolvedGatewayAuth {
   };
 }
 
+function createConnectionHarness(url?: string) {
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  const wss = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      listeners.set(event, handler);
+    }),
+  } as unknown as WebSocketServer;
+  const socket = Object.assign(new EventEmitter(), {
+    _socket: {
+      remoteAddress: "127.0.0.1",
+      remotePort: 1234,
+      localAddress: "127.0.0.1",
+      localPort: 5678,
+    },
+    send: vi.fn(),
+    close: vi.fn(),
+  });
+  const release = vi.fn();
+
+  attachGatewayWsConnectionHandler({
+    wss,
+    clients: new Set(),
+    preauthConnectionBudget: { release } as never,
+    port: 19001,
+    canvasHostEnabled: false,
+    resolvedAuth: createResolvedAuth("token"),
+    gatewayMethods: [],
+    events: [],
+    refreshHealthSnapshot: vi.fn(),
+    logGateway: createLogger() as never,
+    logHealth: createLogger() as never,
+    logWsControl: createLogger() as never,
+    extraHandlers: {},
+    broadcast: vi.fn(),
+    buildRequestContext: () =>
+      ({
+        unsubscribeAllSessionEvents: vi.fn(),
+        nodeRegistry: { unregister: vi.fn() },
+        nodeUnsubscribeAll: vi.fn(),
+      }) as never,
+  });
+
+  const onConnection = listeners.get("connection");
+  expect(onConnection).toBeTypeOf("function");
+  onConnection?.(socket, {
+    url,
+    headers: { host: "127.0.0.1:19001" },
+    socket: { localAddress: "127.0.0.1" },
+  });
+
+  return { socket, release };
+}
+
 describe("attachGatewayWsConnectionHandler", () => {
   beforeEach(() => {
     attachGatewayWsMessageHandlerMock.mockReset();
+  });
+
+  it("rejects legacy websocket query auth on the ws path before the handshake", () => {
+    const { socket, release } = createConnectionHarness("/ws?agent=main&token=legacy-token");
+
+    expect(socket.close).toHaveBeenCalledWith(
+      1008,
+      "legacy websocket query auth is unsupported; use connect handshake",
+    );
+    expect(socket.send).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(attachGatewayWsMessageHandlerMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects legacy websocket query auth on the root gateway path", () => {
+    const { socket } = createConnectionHarness("/?agent=main&password=legacy-password");
+
+    expect(socket.close).toHaveBeenCalledWith(
+      1008,
+      "legacy websocket query auth is unsupported; use connect handshake",
+    );
+    expect(socket.send).not.toHaveBeenCalled();
+  });
+
+  it("does not treat token-only websocket query strings as legacy agent query auth", () => {
+    const { socket } = createConnectionHarness("/ws?token=kept-for-compat");
+
+    expect(socket.close).not.toHaveBeenCalled();
+    expect(JSON.parse(String(socket.send.mock.calls[0]?.[0]))).toMatchObject({
+      type: "event",
+      event: "connect.challenge",
+    });
+    expect(attachGatewayWsMessageHandlerMock).toHaveBeenCalledTimes(1);
   });
 
   it("threads current auth getters into the handshake handler instead of a stale snapshot", () => {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -123,7 +123,7 @@ type LegacyGatewayQueryAuthAttempt = {
 };
 
 /**
- * Detect legacy websocket clients that pass auth via query parameters
+ * Detect legacy websocket clients that pass agent auth via query parameters
  * (`/ws?agent=...&token=...`) instead of the current connect-challenge
  * handshake. These clients cause repeated handshake-timeout noise and
  * should be rejected immediately with a clear error.
@@ -141,14 +141,14 @@ function detectLegacyGatewayQueryAuth(
     return null;
   }
   const pathname = parsed.pathname || "/";
-  if (pathname !== "/ws") {
+  if (pathname !== "/" && pathname !== "/ws") {
     return null;
   }
   const params = parsed.searchParams;
   const agent = params.get("agent")?.trim();
   const token = params.get("token")?.trim();
   const password = params.get("password")?.trim();
-  if (!token && !password) {
+  if (!agent || (!token && !password)) {
     return null;
   }
   return {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -320,6 +320,20 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
     };
 
+    // Absorb socket errors that fire before or after close() so Node does not
+    // treat them as unhandled emitter errors and crash the process.
+    socket.once("error", (err) => {
+      if (isWsPayloadLimitError(err)) {
+        logRejectedLargePayload({
+          surface: client ? "gateway.ws.frame" : "gateway.ws.preauth",
+          limitBytes: client ? MAX_PAYLOAD_BYTES : MAX_PREAUTH_PAYLOAD_BYTES,
+          reason: client ? "ws_frame_limit" : "preauth_frame_limit",
+        });
+      }
+      logWsControl.warn(`error conn=${connId} remote=${remoteAddr ?? "?"}: ${formatError(err)}`);
+      close();
+    });
+
     // Reject legacy websocket clients using query-auth immediately instead of
     // waiting for the handshake timeout. This eliminates the repeated timeout
     // noise reported in #40082.
@@ -343,18 +357,6 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       type: "event",
       event: "connect.challenge",
       payload: { nonce: connectNonce, ts: Date.now() },
-    });
-
-    socket.once("error", (err) => {
-      if (isWsPayloadLimitError(err)) {
-        logRejectedLargePayload({
-          surface: client ? "gateway.ws.frame" : "gateway.ws.preauth",
-          limitBytes: client ? MAX_PAYLOAD_BYTES : MAX_PREAUTH_PAYLOAD_BYTES,
-          reason: client ? "ws_frame_limit" : "preauth_frame_limit",
-        });
-      }
-      logWsControl.warn(`error conn=${connId} remote=${remoteAddr ?? "?"}: ${formatError(err)}`);
-      close();
     });
 
     const isNoisySwiftPmHelperClose = (userAgent: string | undefined, remote: string | undefined) =>

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -265,6 +265,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     let lastFrameType: string | undefined;
     let lastFrameMethod: string | undefined;
     let lastFrameId: string | undefined;
+    let handshakeTimer: ReturnType<typeof setTimeout> | null = null;
 
     const setCloseCause = (cause: string, meta?: Record<string, unknown>) => {
       if (!closeCause) {
@@ -304,7 +305,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         return;
       }
       closed = true;
-      clearTimeout(handshakeTimer);
+      if (handshakeTimer) {
+        clearTimeout(handshakeTimer);
+        handshakeTimer = null;
+      }
       releasePreauthBudget();
       if (client) {
         clients.delete(client);
@@ -426,7 +430,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     });
 
     const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv();
-    const handshakeTimer = setTimeout(() => {
+    handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";
         setCloseCause("handshake-timeout", {
@@ -468,7 +472,12 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       send,
       close,
       isClosed: () => closed,
-      clearHandshakeTimer: () => clearTimeout(handshakeTimer),
+      clearHandshakeTimer: () => {
+        if (handshakeTimer) {
+          clearTimeout(handshakeTimer);
+          handshakeTimer = null;
+        }
+      },
       getClient: () => client,
       setClient: (next) => {
         if (closed) {

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -116,6 +116,48 @@ function isWsPayloadLimitError(err: unknown): boolean {
   return typeof message === "string" && /max payload size exceeded/i.test(message);
 }
 
+type LegacyGatewayQueryAuthAttempt = {
+  pathname: string;
+  agent?: string;
+  authMethod: "token" | "password";
+};
+
+/**
+ * Detect legacy websocket clients that pass auth via query parameters
+ * (`/ws?agent=...&token=...`) instead of the current connect-challenge
+ * handshake. These clients cause repeated handshake-timeout noise and
+ * should be rejected immediately with a clear error.
+ */
+function detectLegacyGatewayQueryAuth(
+  urlValue: string | undefined,
+): LegacyGatewayQueryAuthAttempt | null {
+  if (!urlValue || !urlValue.includes("?")) {
+    return null;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(urlValue, "ws://localhost");
+  } catch {
+    return null;
+  }
+  const pathname = parsed.pathname || "/";
+  if (pathname !== "/ws") {
+    return null;
+  }
+  const params = parsed.searchParams;
+  const agent = params.get("agent")?.trim();
+  const token = params.get("token")?.trim();
+  const password = params.get("password")?.trim();
+  if (!token && !password) {
+    return null;
+  }
+  return {
+    pathname: sanitizeLogValue(pathname) ?? "/ws",
+    agent: sanitizeLogValue(agent || undefined),
+    authMethod: token ? "token" : "password",
+  };
+}
+
 export type GatewayWsSharedHandlerParams = {
   wss: WebSocketServer;
   clients: Set<GatewayWsClient>;
@@ -257,13 +299,6 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
     };
 
-    const connectNonce = randomUUID();
-    send({
-      type: "event",
-      event: "connect.challenge",
-      payload: { nonce: connectNonce, ts: Date.now() },
-    });
-
     const close = (code = 1000, reason?: string) => {
       if (closed) {
         return;
@@ -280,6 +315,31 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         /* ignore */
       }
     };
+
+    // Reject legacy websocket clients using query-auth immediately instead of
+    // waiting for the handshake timeout. This eliminates the repeated timeout
+    // noise reported in #40082.
+    const legacyQueryAuth = detectLegacyGatewayQueryAuth(upgradeReq.url);
+    if (legacyQueryAuth) {
+      handshakeState = "failed";
+      setCloseCause("legacy-query-auth", {
+        legacyAgent: legacyQueryAuth.agent,
+        legacyAuthMethod: legacyQueryAuth.authMethod,
+        requestPath: legacyQueryAuth.pathname,
+      });
+      logWsControl.warn(
+        `legacy websocket query-auth rejected conn=${connId} remote=${remoteAddr ?? "?"} path=${legacyQueryAuth.pathname} agent=${legacyQueryAuth.agent || "n/a"} auth=${legacyQueryAuth.authMethod}`,
+      );
+      close(1008, "legacy websocket query auth is unsupported; use connect handshake");
+      return;
+    }
+
+    const connectNonce = randomUUID();
+    send({
+      type: "event",
+      event: "connect.challenge",
+      payload: { nonce: connectNonce, ts: Date.now() },
+    });
 
     socket.once("error", (err) => {
       if (isWsPayloadLimitError(err)) {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -362,8 +362,13 @@ describe("handleChatEvent", () => {
     expect(state.chatRunId).toBe(null);
     expect(state.chatStream).toBe(null);
     expect(state.lastError).toBe("LLM request timed out.");
-    expect(state.chatMessages).toHaveLength(1);
+    // Partial stream is preserved before the error message
+    expect(state.chatMessages).toHaveLength(2);
     expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Working..." }],
+    });
+    expect(state.chatMessages[1]).toMatchObject({
       role: "assistant",
       content: [{ type: "text", text: "⚠️ LLM request timed out." }],
     });

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -344,6 +344,50 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toEqual([existingMessage, partialMessage]);
   });
 
+  it("appends an inline chat error message for failed runs", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Working...",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "LLM request timed out.",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.lastError).toBe("LLM request timed out.");
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "⚠️ LLM request timed out." }],
+    });
+  });
+
+  it("does not double-prefix warning markers for failed runs", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "⚠️ API rate limit reached. Please try again later.",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatMessages[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "⚠️ API rate limit reached. Please try again later." }],
+    });
+  });
+
   it("falls back to streamed partial when aborted payload message is invalid", () => {
     const existingMessage = {
       role: "user",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -137,6 +137,14 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
   return { text, hasNonTextContent };
 }
 
+function formatChatErrorMessage(errorMessage: string | undefined): string {
+  const trimmed = errorMessage?.trim() ?? "";
+  if (!trimmed) {
+    return "⚠️ chat error";
+  }
+  return /^⚠️\s*/.test(trimmed) ? trimmed : `⚠️ ${trimmed}`;
+}
+
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {
   if (!message || typeof message !== "object") {
@@ -775,6 +783,15 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
+    const formattedError = formatChatErrorMessage(payload.errorMessage);
+    state.chatMessages = [
+      ...state.chatMessages,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: formattedError }],
+        timestamp: Date.now(),
+      },
+    ];
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -784,6 +784,20 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
     const formattedError = formatChatErrorMessage(payload.errorMessage);
+    // Preserve any partial streamed content before appending the error,
+    // consistent with the done/aborted paths that commit chatStream as a
+    // fallback. Without this, mid-stream errors silently discard content.
+    const streamedText = state.chatStream ?? "";
+    if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
+      state.chatMessages = [
+        ...state.chatMessages,
+        {
+          role: "assistant",
+          content: [{ type: "text", text: streamedText }],
+          timestamp: Date.now(),
+        },
+      ];
+    }
     state.chatMessages = [
       ...state.chatMessages,
       {


### PR DESCRIPTION
## Summary

Focused extraction of the core fix pieces from #40150 (which has merge conflicts and significant scope creep), targeting the remaining open symptoms of #40082 that were not addressed by #40008 (kimi tool schema, merged Mar 9) or #50930 (mid-turn 429 silent no-reply, merged Mar 25).

Three narrowly scoped changes:

- **Downgraded text-form tool call detection** (`payloads.ts`, `pi-embedded-utils.ts`): when the model emits `[Tool Call: read (ID: toolu_1)]` as plain text instead of a structured `tool_use` block, the payload builder now detects this and surfaces an explicit error instead of silently passing through non-executing text. Excludes normal assistant prose that quotes these markers inline.

- **Placeholder/filler reply detection** (`payloads.ts`): short replies matching "One sec" / "let me check" / "hold on" patterns (≤220 chars, ≤4 lines) with zero structured tool activity are surfaced as explicit errors instead of being treated as meaningful task progress. This directly addresses the user-visible symptom from #40082 where agents say they will work but nothing happens.

- **Webchat inline error rendering** (`chat.ts`): `state: "error"` chat events now append a visible error message to the chat history instead of only updating hidden `lastError` state. Errors are prefixed with ⚠️ without double-prefixing already-marked messages.

- **Legacy WS query-auth fast rejection** (`ws-connection.ts`): clients using the old `/ws?agent=...&token=...` URL format are rejected immediately with a clear close reason (code 1008) instead of waiting for the handshake timeout. This eliminates the repeated timeout noise reported in #40082.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] UI / DX

## Linked Issue/PR

- Addresses #40082
- Addresses #40069
- Supersedes #40150 (cherry-picked core fixes only, clean rebase on current main)
- Builds on #40008 (kimi tool schema fix, merged) and #50930 (mid-turn 429 fix, merged)

## User-visible / Behavior Changes

- Agents that emit text-form tool calls or placeholder "One sec" replies now surface explicit error messages instead of appearing to succeed silently.
- Webchat shows inline error messages when a run fails, rather than only updating hidden error state.
- Legacy websocket clients are rejected immediately with a descriptive close reason.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Use a model/provider that occasionally emits tool calls as text instead of structured blocks
2. Or trigger a short non-executing filler reply
3. Observe the previous behavior: silent pass-through, no error surfaced
4. On this branch: explicit error message surfaced to user

### Evidence

- `pnpm test -- src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-utils.test.ts ui/src/ui/controllers/chat.test.ts` — 81 tests pass
- `pnpm check` — clean
- `pnpm build` — clean

## Human Verification

- Verified scenarios:
  - Downgraded tool call text → error surfaced
  - Placeholder reply → error surfaced
  - Normal substantive replies → pass through unchanged
  - Inline-quoted tool markers → not falsely flagged
  - Webchat error events → inline message appended
  - Already-prefixed warnings → no double-prefix
- Edge cases checked:
  - Replies with structured tool activity → not flagged even if text matches patterns
  - Long replies (>220 chars) → not flagged
  - Multi-line replies (>4 lines) → not flagged

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: short legitimate assistant acknowledgments could be flagged as non-executing placeholders.
  - Mitigation: heuristic is intentionally narrow — short-only (≤220 chars, ≤4 lines), keyed to explicit future-action phrases, and skipped when any structured tool activity occurred.
- Risk: legacy websocket clients that still depend on query-auth will now fail fast.
  - Mitigation: failure is now explicit and points callers to the supported connect handshake instead of timing out silently.

## Acknowledgments

Core detection logic extracted from #40150 by @cgdusek. Rebased cleanly onto current main with no unrelated changes.