### PR TITLE
fix(gateway): block internal session keys in tools invoke

### DIFF
--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -630,6 +630,26 @@ describe("POST /tools/invoke", () => {
     expect(resMain.status).toBe(200);
   });
 
+  it.each([
+    "agent:main:subagent:worker",
+    "agent:main:cron:daily",
+    "agent:main:acp:session-1",
+  ])("rejects internal session key override %s", async (sessionKey) => {
+    allowAgentsListForMain();
+
+    const res = await invokeAgentsListAuthed({ sessionKey });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: {
+        type: "invalid_request_error",
+        message: "tools.invoke does not allow internal session keys",
+      },
+    });
+    expect(lastCreateOpenClawToolsContext).toBeUndefined();
+    expect(hookMocks.runBeforeToolCallHook).not.toHaveBeenCalled();
+  });
+
   it("maps tool input/auth errors to 400/403 and unexpected execution errors to 500", async () => {
     cfg = {
       ...cfg,

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -22,7 +22,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import { isSubagentSessionKey } from "../routing/session-key.js";
+import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "../security/dangerous-tools.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
@@ -38,6 +38,12 @@ import { getHeader } from "./http-utils.js";
 
 const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
 const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
+
+function isInternalGatewayToolSessionKey(sessionKey: string): boolean {
+  return (
+    isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey) || isAcpSessionKey(sessionKey)
+  );
+}
 
 type ToolsInvokeBody = {
   tool?: unknown;
@@ -207,6 +213,10 @@ export async function handleToolsInvokeHttpRequest(
   const rawSessionKey = resolveSessionKeyFromBody(body);
   const sessionKey =
     !rawSessionKey || rawSessionKey === "main" ? resolveMainSessionKey(cfg) : rawSessionKey;
+  if (isInternalGatewayToolSessionKey(sessionKey)) {
+    sendInvalidRequest(res, "tools.invoke does not allow internal session keys");
+    return true;
+  }
 
   // Resolve message channel/account hints (optional headers) for policy inheritance.
   const messageChannel = normalizeMessageChannel(


### PR DESCRIPTION
## Summary
- reject /tools/invoke requests that try to bind tool execution to internal subagent, cron, or ACP session keys
- keep ordinary main-session and user-session invokes unchanged
- add regression coverage for subagent, cron, and ACP session-key overrides

## Testing
- pnpm exec vitest run src/gateway/tools-invoke-http.test.ts src/gateway/tools-invoke-http.cron-regression.test.ts