### PR TITLE
telegram: cache botInfo across polling cycles to eliminate getMe() init stall

### DIFF
--- a/extensions/telegram/src/bot.runtime.ts
+++ b/extensions/telegram/src/bot.runtime.ts
@@ -2,3 +2,4 @@ export { sequentialize } from "@grammyjs/runner";
 export { apiThrottler } from "@grammyjs/transformer-throttler";
 export { Bot } from "grammy";
 export type { ApiClientOptions } from "grammy";
+export type { UserFromGetMe } from "@grammyjs/types";

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -33,7 +33,13 @@ import {
   resolveTelegramUpdateId,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
-import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.runtime.js";
+import {
+  apiThrottler,
+  Bot,
+  sequentialize,
+  type ApiClientOptions,
+  type UserFromGetMe,
+} from "./bot.runtime.js";
 import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
 import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
@@ -65,6 +71,10 @@ export type TelegramBotOptions = {
   /** Pre-resolved Telegram transport to reuse across bot instances. If not provided, creates a new one. */
   telegramTransport?: TelegramTransport;
   telegramDeps?: TelegramBotDeps;
+  /** Cached bot info from a previous `bot.init()` / `getMe()` call.
+   *  When provided, grammy skips the `getMe()` network call on startup,
+   *  eliminating the init-retry stall after network recovery. */
+  botInfo?: UserFromGetMe;
 };
 
 export { getTelegramSequentialKey };
@@ -254,7 +264,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         }
       : undefined;
 
-  const bot = new botRuntime.Bot(opts.token, client ? { client } : undefined);
+  const bot = new botRuntime.Bot(opts.token, {
+    ...(client ? { client } : {}),
+    ...(opts.botInfo ? { botInfo: opts.botInfo } : {}),
+  });
   bot.api.config.use(botRuntime.apiThrottler());
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -34,14 +34,17 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
 
 function makeBot() {
-  return {
+  const bot = {
     api: {
       deleteWebhook: vi.fn(async () => true),
       getUpdates: vi.fn(async () => []),
       config: { use: vi.fn() },
     },
     stop: vi.fn(async () => undefined),
+    init: vi.fn(async () => undefined),
+    botInfo: { id: 123, is_bot: true, first_name: "Test", username: "testbot" },
   };
+  return bot;
 }
 
 function installPollingStallWatchdogHarness() {
@@ -156,6 +159,8 @@ describe("TelegramPollingSession", () => {
         config: { use: vi.fn() },
       },
       stop: botStop,
+      init: vi.fn(async () => undefined),
+      botInfo: { id: 123, is_bot: true, first_name: "Test", username: "testbot" },
     };
     createTelegramBotMock.mockReturnValue(bot);
 
@@ -213,6 +218,8 @@ describe("TelegramPollingSession", () => {
         config: { use: vi.fn() },
       },
       stop: botStop,
+      init: vi.fn(async () => undefined),
+      botInfo: { id: 123, is_bot: true, first_name: "Test", username: "testbot" },
     };
     createTelegramBotMock.mockReturnValue(bot);
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { formatDurationPrecise } from "openclaw/plugin-sdk/infra-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import type { UserFromGetMe } from "./bot.runtime.js";
 import { type TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
@@ -62,6 +63,10 @@ export class TelegramPollingSession {
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
   #transportState: TelegramPollingTransportState;
+  /** Cached botInfo from the first successful `getMe()` call.
+   *  Passed to subsequent Bot instances so grammy skips `bot.init()` → `getMe()`,
+   *  eliminating the init-retry stall after network recovery. */
+  #cachedBotInfo: UserFromGetMe | undefined;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -142,7 +147,7 @@ export class TelegramPollingSession {
     this.#activeFetchAbort = fetchAbortController;
     const telegramTransport = this.#transportState.acquireForNextCycle();
     try {
-      return createTelegramBot({
+      const bot = createTelegramBot({
         token: this.opts.token,
         runtime: this.opts.runtime,
         proxyFetch: this.opts.proxyFetch,
@@ -154,7 +159,54 @@ export class TelegramPollingSession {
           onUpdateId: this.opts.persistUpdateId,
         },
         telegramTransport,
+        botInfo: this.#cachedBotInfo,
       });
+      // On the first cycle, eagerly init the bot so we can cache botInfo.
+      // Subsequent cycles already have botInfo injected into the Bot constructor,
+      // so bot.init() inside the runner will be a no-op (isInited() === true).
+      if (!this.#cachedBotInfo) {
+        // Use a dedicated abort controller for the eager init so that a timeout
+        // does not poison the bot's fetch pipeline (fetchAbortController stays
+        // intact for the polling cycle that follows).
+        const EAGER_INIT_TIMEOUT_MS = 15_000;
+        const initAbort = new AbortController();
+
+        // Forward session-level abort → init controller.
+        const onSessionAbort = () => initAbort.abort();
+        this.opts.abortSignal?.addEventListener("abort", onSessionAbort, { once: true });
+
+        // Time-box the init so a stalled network cannot block the session
+        // outside the watchdog's protection.
+        const initTimeout = setTimeout(() => initAbort.abort(), EAGER_INIT_TIMEOUT_MS);
+        try {
+          // grammy's init() accepts AbortSignal from the `abort-controller` polyfill package,
+          // which is structurally incompatible with the native Node.js AbortSignal at the type
+          // level. At runtime they are interchangeable, so we suppress the type error.
+          // @ts-ignore — grammy AbortSignal (abort-controller polyfill) vs native Node.js AbortSignal
+          await bot.init(initAbort.signal);
+          this.#cachedBotInfo = bot.botInfo;
+          this.opts.log(
+            "[telegram] Cached botInfo from initial getMe(); subsequent cycles will skip init.",
+          );
+        } catch {
+          // If the session itself was aborted, short-circuit immediately so
+          // runUntilAbort() does not continue into webhook cleanup / polling
+          // setup over the still-live fetchAbortController.
+          if (this.opts.abortSignal?.aborted) {
+            clearTimeout(initTimeout);
+            this.opts.abortSignal.removeEventListener("abort", onSessionAbort);
+            return undefined;
+          }
+          // Otherwise non-fatal: network unavailable or timeout fired.
+          // The runner will call bot.init() itself with its own retry logic
+          // under the watchdog. We skip caching and let the existing code
+          // path handle it.
+        } finally {
+          clearTimeout(initTimeout);
+          this.opts.abortSignal?.removeEventListener("abort", onSessionAbort);
+        }
+      }
+      return bot;
     } catch (err) {
       await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");
       if (this.#activeFetchAbort === fetchAbortController) {


### PR DESCRIPTION
## Problem

After a network interruption, Telegram polling recovery is very slow (30s–minutes). The root cause is that every polling cycle creates a new `Bot` instance without `botInfo`, forcing the grammY runner to call `bot.init()` → `getMe()` on each restart.

Inside grammy, `getMe()` uses `withRetries()` with exponential backoff up to **20 minutes**, and the runner calls `bot.init()` **without passing an AbortSignal**, so this retry loop cannot be externally cancelled.

### Call chain

```
polling-session.ts: runUntilAbort() loop
  → #createPollingBot()
    → createTelegramBot({ token, ... })  // no botInfo passed
      → new Bot(token, { client })       // this.me = undefined
  → run(bot, runnerOptions)              // @grammyjs/runner
    → source.supply()
      → await bot.init()                 // no abort signal!
        → withRetries(() => api.getMe()) // exponential backoff up to 20min
        → ...hangs here...
      → fetchUpdates(...)                // never reached
```

## Fix

1. **Cache `botInfo`**: Store the `UserFromGetMe` result from the first successful `getMe()` call and inject it as `botInfo` into subsequent `Bot` constructor calls. When `botInfo` is provided, grammy's `isInited()` returns `true` immediately, making `bot.init()` a no-op.

2. **Forward `abortSignal` during init**: Wire the session's `abortSignal` to the fetch abort controller during the initial `bot.init()` call, so a shutdown request during first cold start with no network is not blocked by grammy's internal retry loop.

### Changes (3 files, ~50 lines)

- **`bot.runtime.ts`**: Export `UserFromGetMe` type
- **`bot.ts`**: Accept optional `botInfo` in `TelegramBotOptions`, pass to `Bot` constructor
- **`polling-session.ts`**: Cache `botInfo` after first init; forward `abortSignal` during init

### Result

- First cold start: normal `getMe()` call, result cached
- All subsequent cycles: `isInited() === true` → `bot.init()` is no-op → `getUpdates` starts immediately
- Network recovery: new cycle skips `getMe()` entirely → **near-instant polling resume**
- Shutdown during first init: properly cancelled via forwarded abort signal

## Relationship to #55406 / #55407

The startup watchdog (PR #55407) remains valuable as defense-in-depth for edge cases where `botInfo` is not yet cached. This PR addresses the root cause.