### PR TITLE
fix(hooks): always load bundled hooks regardless of hooks.internal.enabled

### DIFF
--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -65,10 +65,10 @@ export async function loadInternalHooks(
     bundledHooksDir?: string;
   },
 ): Promise<number> {
-  // Check if hooks are enabled
-  if (!cfg.hooks?.internal?.enabled) {
-    return 0;
-  }
+  // Bundled hooks (openclaw-bundled) are always loaded by default.
+  // Workspace/managed hooks require explicit opt-in via hooks.internal.enabled.
+  const hooksEnabled = cfg.hooks?.internal?.enabled === true;
+  const loadBundledOnly = cfg.hooks?.internal?.enabled === undefined;
 
   let loadedCount = 0;
 
@@ -80,8 +80,13 @@ export async function loadInternalHooks(
       bundledHooksDir: opts?.bundledHooksDir,
     });
 
-    // Filter by eligibility
-    const eligible = hookEntries.filter((entry) => shouldIncludeHook({ entry, config: cfg }));
+    // Filter by eligibility: bundled hooks always eligible, others require explicit enable
+    const eligible = hookEntries.filter((entry) => {
+      if (entry.hook.source === "openclaw-bundled") {
+        return true; // Bundled hooks always load
+      }
+      return hooksEnabled && shouldIncludeHook({ entry, config: cfg });
+    });
 
     for (const entry of eligible) {
       try {


### PR DESCRIPTION
## 🐛 Problem

Bundled hooks (including session-memory) are not loading for fresh installs, causing /new and /reset commands to not save session context to memory.

**Fixes #55929**

## ✅ Root Cause

loadInternalHooks() returns 0 when hooks.internal.enabled is undefined (default), preventing ALL hooks from loading — including bundled hooks that should be enabled by default.

## 🔧 Solution

- Bundled hooks (openclaw-bundled): always load (respects default-on policy)
- Workspace/managed hooks: still require explicit hooks.internal.enabled: true

## 📝 Changes

- src/hooks/loader.ts: Modify loadInternalHooks() to always load bundled hooks

## 🧪 Testing

- Fresh install: bundled hooks (including session-memory) now load automatically
- Existing config with hooks.internal.enabled: true: no change
- Existing config with hooks.internal.enabled: false: bundled hooks still load, workspace hooks disabled