### PR TITLE
fix: skip Homebrew dependency for skill install on Linux (#14593)

### DIFF
--- a/src/agents/skills-install-fallback.test.ts
+++ b/src/agents/skills-install-fallback.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import {
   hasBinaryMock,
@@ -187,6 +187,215 @@ describe("skills-install fallback edge cases", () => {
 
     expect(result.ok).toBe(false);
     expect(result.message).toContain("sudo is not usable");
+  });
+
+  describe("brew formula apt fallback on Linux", () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+
+    function setPlatform(platform: string) {
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    }
+
+    afterEach(() => {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    });
+
+    it("falls back to apt-get when brew is missing on Linux (root user)", async () => {
+      setPlatform("linux");
+      mockAvailableBinaries(["apt-get"]);
+
+      // Mock process.getuid to simulate root
+      const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(0);
+
+      // apt-get update (best effort) -> success
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: "",
+        stderr: "",
+      });
+      // apt-get install -> success
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: "installed openai-whisper",
+        stderr: "",
+      });
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tool-root", "brew", {
+        formula: "openai-whisper",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-root",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["apt-get", "update", "-qq"],
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      );
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["apt-get", "install", "-y", "openai-whisper"],
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      );
+
+      getuidSpy.mockRestore();
+    });
+
+    it("falls back to sudo apt-get when brew is missing on Linux (non-root)", async () => {
+      setPlatform("linux");
+      mockAvailableBinaries(["apt-get", "sudo"]);
+
+      // Mock process.getuid to simulate non-root
+      const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1000);
+
+      // sudo -n true check -> success
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: "",
+        stderr: "",
+      });
+      // sudo apt-get update -> success
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: "",
+        stderr: "",
+      });
+      // sudo apt-get install -> success
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: "installed openai-whisper",
+        stderr: "",
+      });
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tool-sudo", "brew", {
+        formula: "openai-whisper",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-sudo",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["sudo", "-n", "true"],
+        expect.objectContaining({ timeoutMs: 5_000 }),
+      );
+      expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+        ["sudo", "apt-get", "install", "-y", "openai-whisper"],
+        expect.objectContaining({ timeoutMs: expect.any(Number) }),
+      );
+
+      getuidSpy.mockRestore();
+    });
+
+    it("returns failure when apt fallback fails on Linux", async () => {
+      setPlatform("linux");
+      mockAvailableBinaries(["apt-get"]);
+
+      const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(0);
+
+      // apt-get update -> success
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 0,
+        stdout: "",
+        stderr: "",
+      });
+      // apt-get install -> failure
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 100,
+        stdout: "",
+        stderr: "E: Unable to locate package openai-whisper",
+      });
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tool-apt-fail", "brew", {
+        formula: "openai-whisper",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-apt-fail",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("automatic install");
+      expect(result.message).toContain("apt failed");
+
+      getuidSpy.mockRestore();
+    });
+
+    it("returns brew-not-installed error when apt-get is unavailable on Linux", async () => {
+      setPlatform("linux");
+      // No apt-get, no brew
+      mockAvailableBinaries([]);
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tool-no-apt", "brew", {
+        formula: "openai-whisper",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-no-apt",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("brew not installed");
+    });
+
+    it("returns sudo-required error when sudo needs password on Linux", async () => {
+      setPlatform("linux");
+      mockAvailableBinaries(["apt-get", "sudo"]);
+
+      const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(1000);
+
+      // sudo -n true -> fails (password required)
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "sudo: a password is required",
+      });
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tool-sudo-fail", "brew", {
+        formula: "openai-whisper",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-sudo-fail",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("sudo requires a password");
+
+      getuidSpy.mockRestore();
+    });
+
+    it("does not attempt apt fallback on macOS", async () => {
+      setPlatform("darwin");
+      mockAvailableBinaries(["apt-get"]); // hypothetical, but should not be used
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tool-macos", "brew", {
+        formula: "openai-whisper",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-macos",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("brew not installed");
+      expect(result.message).not.toContain("apt");
+      // No commands should have been run
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
   });
 
   it("uv not installed and no brew returns helpful error without curl auto-install", async () => {

--- a/src/agents/skills-install-fallback.test.ts
+++ b/src/agents/skills-install-fallback.test.ts
@@ -376,6 +376,26 @@ describe("skills-install fallback edge cases", () => {
       getuidSpy.mockRestore();
     });
 
+    it("skips apt fallback for tap-qualified brew formulas", async () => {
+      setPlatform("linux");
+      mockAvailableBinaries(["apt-get"]);
+
+      await writeSkillWithInstaller(workspaceDir, "brew-tap-qualified", "brew", {
+        formula: "homebrew/cask/ffmpeg",
+      });
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tap-qualified",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("brew not installed");
+      // No apt-get commands should have been attempted
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+
     it("does not attempt apt fallback on macOS", async () => {
       setPlatform("darwin");
       mockAvailableBinaries(["apt-get"]); // hypothetical, but should not be used

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -269,6 +269,75 @@ function resolveBrewMissingFailure(spec: SkillInstallSpec): SkillInstallResult {
   return createInstallFailure({ message: `brew not installed — ${hint}` });
 }
 
+type AptInstallMessages = {
+  /** Shown when apt-get install itself fails. */
+  failure: string;
+  /** Shown when sudo binary is not available. */
+  noSudo: string;
+  /** Shown when passwordless sudo probe fails. */
+  sudoPassword: string;
+};
+
+/**
+ * Shared helper: attempt to install a package via apt-get on Linux.
+ * Handles root vs non-root (sudo) flows, apt-get update, and apt-get install.
+ *
+ * Returns `undefined` on success (package installed), or a failure result.
+ */
+async function installViaApt(
+  pkg: string,
+  messages: AptInstallMessages,
+  timeoutMs?: number,
+): Promise<SkillInstallResult | undefined> {
+  const effectiveTimeout = timeoutMs ?? 300_000;
+  const aptInstallArgv = ["apt-get", "install", "-y", pkg];
+  const aptUpdateArgv = ["apt-get", "update", "-qq"];
+
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  if (isRoot) {
+    // Best effort: fresh containers often need package indexes populated.
+    await runBestEffortCommand(aptUpdateArgv, { timeoutMs: effectiveTimeout });
+    const aptResult = await runCommandSafely(aptInstallArgv, { timeoutMs: effectiveTimeout });
+    if (aptResult.code === 0) {
+      return undefined;
+    }
+    return createInstallFailure({
+      message: messages.failure,
+      ...aptResult,
+    });
+  }
+
+  if (!hasBinary("sudo")) {
+    return createInstallFailure({
+      message: messages.noSudo,
+    });
+  }
+
+  const sudoCheck = await runCommandSafely(["sudo", "-n", "true"], {
+    timeoutMs: 5_000,
+  });
+  if (sudoCheck.code !== 0) {
+    return createInstallFailure({
+      message: messages.sudoPassword,
+      ...sudoCheck,
+    });
+  }
+
+  // Best effort: fresh containers often need package indexes populated.
+  await runBestEffortCommand(["sudo", ...aptUpdateArgv], { timeoutMs: effectiveTimeout });
+  const aptResult = await runCommandSafely(["sudo", ...aptInstallArgv], {
+    timeoutMs: effectiveTimeout,
+  });
+  if (aptResult.code === 0) {
+    return undefined;
+  }
+
+  return createInstallFailure({
+    message: messages.failure,
+    ...aptResult,
+  });
+}
+
 /**
  * Attempt to install a brew formula via apt-get on Linux when Homebrew is not
  * available. Many brew formula names match their apt package counterpart, so
@@ -280,51 +349,16 @@ async function installBrewFormulaViaApt(
   formula: string,
   timeoutMs: number,
 ): Promise<SkillInstallResult | undefined> {
-  const aptInstallArgv = ["apt-get", "install", "-y", formula];
-  const aptUpdateArgv = ["apt-get", "update", "-qq"];
-  const aptFailureMessage = `brew not installed — automatic install of "${formula}" via apt failed. Install Homebrew from https://brew.sh or install "${formula}" manually using your system package manager.`;
-
-  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
-  if (isRoot) {
-    await runBestEffortCommand(aptUpdateArgv, { timeoutMs });
-    const aptResult = await runCommandSafely(aptInstallArgv, { timeoutMs });
-    if (aptResult.code === 0) {
-      return undefined;
-    }
-    return createInstallFailure({
-      message: aptFailureMessage,
-      ...aptResult,
-    });
-  }
-
-  if (!hasBinary("sudo")) {
-    return createInstallFailure({
-      message: `brew not installed — apt-get is available but sudo is not installed. Install Homebrew from https://brew.sh or install "${formula}" manually.`,
-    });
-  }
-
-  const sudoCheck = await runCommandSafely(["sudo", "-n", "true"], {
-    timeoutMs: 5_000,
-  });
-  if (sudoCheck.code !== 0) {
-    return createInstallFailure({
-      message: `brew not installed — apt-get is available but sudo requires a password. Install Homebrew from https://brew.sh or install "${formula}" manually.`,
-      ...sudoCheck,
-    });
-  }
-
-  await runBestEffortCommand(["sudo", ...aptUpdateArgv], { timeoutMs });
-  const aptResult = await runCommandSafely(["sudo", ...aptInstallArgv], {
+  const trimmed = formula.trim();
+  return installViaApt(
+    trimmed,
+    {
+      failure: `brew not installed — automatic install of "${trimmed}" via apt failed. Install Homebrew from https://brew.sh or install "${trimmed}" manually using your system package manager.`,
+      noSudo: `brew not installed — apt-get is available but sudo is not installed. Install Homebrew from https://brew.sh or install "${trimmed}" manually.`,
+      sudoPassword: `brew not installed — apt-get is available but sudo requires a password. Install Homebrew from https://brew.sh or install "${trimmed}" manually.`,
+    },
     timeoutMs,
-  });
-  if (aptResult.code === 0) {
-    return undefined;
-  }
-
-  return createInstallFailure({
-    message: aptFailureMessage,
-    ...aptResult,
-  });
+  );
 }
 
 async function ensureUvInstalled(params: {
@@ -357,56 +391,18 @@ async function ensureUvInstalled(params: {
 }
 
 async function installGoViaApt(timeoutMs: number): Promise<SkillInstallResult | undefined> {
-  const aptInstallArgv = ["apt-get", "install", "-y", "golang-go"];
-  const aptUpdateArgv = ["apt-get", "update", "-qq"];
-  const aptFailureMessage =
-    "go not installed — automatic install via apt failed. Install manually: https://go.dev/doc/install";
-
-  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
-  if (isRoot) {
-    // Best effort: fresh containers often need package indexes populated.
-    await runBestEffortCommand(aptUpdateArgv, { timeoutMs });
-    const aptResult = await runCommandSafely(aptInstallArgv, { timeoutMs });
-    if (aptResult.code === 0) {
-      return undefined;
-    }
-    return createInstallFailure({
-      message: aptFailureMessage,
-      ...aptResult,
-    });
-  }
-
-  if (!hasBinary("sudo")) {
-    return createInstallFailure({
-      message:
+  return installViaApt(
+    "golang-go",
+    {
+      failure:
+        "go not installed — automatic install via apt failed. Install manually: https://go.dev/doc/install",
+      noSudo:
         "go not installed — apt-get is available but sudo is not installed. Install manually: https://go.dev/doc/install",
-    });
-  }
-
-  const sudoCheck = await runCommandSafely(["sudo", "-n", "true"], {
-    timeoutMs: 5_000,
-  });
-  if (sudoCheck.code !== 0) {
-    return createInstallFailure({
-      message:
+      sudoPassword:
         "go not installed — apt-get is available but sudo is not usable (missing or requires a password). Install manually: https://go.dev/doc/install",
-      ...sudoCheck,
-    });
-  }
-
-  // Best effort: fresh containers often need package indexes populated.
-  await runBestEffortCommand(["sudo", ...aptUpdateArgv], { timeoutMs });
-  const aptResult = await runCommandSafely(["sudo", ...aptInstallArgv], {
+    },
     timeoutMs,
-  });
-  if (aptResult.code === 0) {
-    return undefined;
-  }
-
-  return createInstallFailure({
-    message: aptFailureMessage,
-    ...aptResult,
-  });
+  );
 }
 
 async function ensureGoInstalled(params: {
@@ -548,8 +544,9 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
   const brewExe = hasBinary("brew") ? "brew" : resolveBrewExecutable();
   if (spec.kind === "brew" && !brewExe) {
     // On Linux, attempt to install the formula via apt-get before giving up.
-    if (process.platform === "linux" && hasBinary("apt-get") && spec.formula) {
-      const aptResult = await installBrewFormulaViaApt(spec.formula, timeoutMs);
+    if (process.platform === "linux" && hasBinary("apt-get")) {
+      // formula is guaranteed non-empty here: buildInstallCommand already validated it.
+      const aptResult = await installBrewFormulaViaApt(spec.formula!, timeoutMs);
       if (!aptResult) {
         return withWarnings(createInstallSuccess({ code: 0, stdout: "", stderr: "" }), warnings);
       }

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -269,6 +269,64 @@ function resolveBrewMissingFailure(spec: SkillInstallSpec): SkillInstallResult {
   return createInstallFailure({ message: `brew not installed — ${hint}` });
 }
 
+/**
+ * Attempt to install a brew formula via apt-get on Linux when Homebrew is not
+ * available. Many brew formula names match their apt package counterpart, so
+ * this is a best-effort convenience for Docker / headless Linux environments.
+ *
+ * Returns `undefined` on success (package installed), or a failure result.
+ */
+async function installBrewFormulaViaApt(
+  formula: string,
+  timeoutMs: number,
+): Promise<SkillInstallResult | undefined> {
+  const aptInstallArgv = ["apt-get", "install", "-y", formula];
+  const aptUpdateArgv = ["apt-get", "update", "-qq"];
+  const aptFailureMessage = `brew not installed — automatic install of "${formula}" via apt failed. Install Homebrew from https://brew.sh or install "${formula}" manually using your system package manager.`;
+
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  if (isRoot) {
+    await runBestEffortCommand(aptUpdateArgv, { timeoutMs });
+    const aptResult = await runCommandSafely(aptInstallArgv, { timeoutMs });
+    if (aptResult.code === 0) {
+      return undefined;
+    }
+    return createInstallFailure({
+      message: aptFailureMessage,
+      ...aptResult,
+    });
+  }
+
+  if (!hasBinary("sudo")) {
+    return createInstallFailure({
+      message: `brew not installed — apt-get is available but sudo is not installed. Install Homebrew from https://brew.sh or install "${formula}" manually.`,
+    });
+  }
+
+  const sudoCheck = await runCommandSafely(["sudo", "-n", "true"], {
+    timeoutMs: 5_000,
+  });
+  if (sudoCheck.code !== 0) {
+    return createInstallFailure({
+      message: `brew not installed — apt-get is available but sudo requires a password. Install Homebrew from https://brew.sh or install "${formula}" manually.`,
+      ...sudoCheck,
+    });
+  }
+
+  await runBestEffortCommand(["sudo", ...aptUpdateArgv], { timeoutMs });
+  const aptResult = await runCommandSafely(["sudo", ...aptInstallArgv], {
+    timeoutMs,
+  });
+  if (aptResult.code === 0) {
+    return undefined;
+  }
+
+  return createInstallFailure({
+    message: aptFailureMessage,
+    ...aptResult,
+  });
+}
+
 async function ensureUvInstalled(params: {
   spec: SkillInstallSpec;
   brewExe?: string;
@@ -489,6 +547,14 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
 
   const brewExe = hasBinary("brew") ? "brew" : resolveBrewExecutable();
   if (spec.kind === "brew" && !brewExe) {
+    // On Linux, attempt to install the formula via apt-get before giving up.
+    if (process.platform === "linux" && hasBinary("apt-get") && spec.formula) {
+      const aptResult = await installBrewFormulaViaApt(spec.formula, timeoutMs);
+      if (!aptResult) {
+        return withWarnings(createInstallSuccess({ code: 0, stdout: "", stderr: "" }), warnings);
+      }
+      return withWarnings(aptResult, warnings);
+    }
     return withWarnings(resolveBrewMissingFailure(spec), warnings);
   }
 

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -348,8 +348,14 @@ async function installViaApt(
 async function installBrewFormulaViaApt(
   formula: string,
   timeoutMs: number,
-): Promise<SkillInstallResult | undefined> {
+): Promise<SkillInstallResult | null | undefined> {
   const trimmed = formula.trim();
+
+  // Tap-qualified brew formulas (e.g. "homebrew/cask/ffmpeg") have no apt equivalent
+  if (trimmed.includes("/")) {
+    return null;
+  }
+
   return installViaApt(
     trimmed,
     {
@@ -547,10 +553,14 @@ export async function installSkill(params: SkillInstallRequest): Promise<SkillIn
     if (process.platform === "linux" && hasBinary("apt-get")) {
       // formula is guaranteed non-empty here: buildInstallCommand already validated it.
       const aptResult = await installBrewFormulaViaApt(spec.formula!, timeoutMs);
-      if (!aptResult) {
+      // null → tap-qualified formula, skip apt and fall through to brew-missing error
+      if (aptResult === null) {
+        /* fall through */
+      } else if (!aptResult) {
         return withWarnings(createInstallSuccess({ code: 0, stdout: "", stderr: "" }), warnings);
+      } else {
+        return withWarnings(aptResult, warnings);
       }
-      return withWarnings(aptResult, warnings);
     }
     return withWarnings(resolveBrewMissingFailure(spec), warnings);
   }


### PR DESCRIPTION
## Summary
- When `kind: "brew"` skill install runs on Linux without Homebrew, fall back to `apt-get install <formula>` (root or passwordless sudo) before giving up
- Follows the existing `installGoViaApt` pattern already used for `go` kind installs
- On macOS (or Linux without `apt-get`), behavior is unchanged -- the existing "brew not installed" error is returned
- Closes #14593

## Test plan
- [x] Added 6 new tests in `skills-install-fallback.test.ts` covering: root apt install, sudo apt install, apt failure, no apt-get available, sudo password required, macOS no-fallback
- [x] `pnpm check` passes (lint, typecheck, format)
- [x] `pnpm test -- src/agents/skills-install-fallback.test.ts` passes (9/9)
- [x] `pnpm test -- src/agents/skills-install.test.ts` passes (2/2)

AI-Assisted PR Checklist:
- [x] Marked as AI-assisted
- [x] Testing degree: fully tested
- [x] Code reviewed by LLM
- [x] I understand what the code does

🤖 Generated with [Claude Code](https://claude.com/claude-code)