### PR TITLE
feat: add visionOS platform to node command policy

### DIFF
--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -51,6 +51,14 @@ const SMS_DANGEROUS_COMMANDS = ["sms.send"];
 // iOS nodes don't implement system.run/which, but they do support notifications.
 const IOS_SYSTEM_COMMANDS = [NODE_SYSTEM_NOTIFY_COMMAND];
 
+// visionOS spatial sensing commands (ARKit-backed, available in ImmersiveSpace).
+const VISIONOS_SPATIAL_COMMANDS = [
+  "spatial.hands",
+  "spatial.planes",
+  "spatial.mesh",
+  "device.position",
+];
+
 const SYSTEM_COMMANDS = [
   ...NODE_SYSTEM_RUN_COMMANDS,
   NODE_SYSTEM_NOTIFY_COMMAND,
@@ -114,13 +122,24 @@ const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...MOTION_COMMANDS,
     ...SYSTEM_COMMANDS,
   ],
+  // visionOS (Apple Vision Pro): spatial sensing, camera, canvas, location, device info.
+  // No system.run — Vision Pro is a locked-down headset OS.
+  // camera.snap/clip are gated as dangerous commands (require allowCommands config).
+  visionos: [
+    ...CANVAS_COMMANDS,
+    ...CAMERA_COMMANDS,
+    ...LOCATION_COMMANDS,
+    ...DEVICE_COMMANDS,
+    ...VISIONOS_SPATIAL_COMMANDS,
+    NODE_SYSTEM_NOTIFY_COMMAND,
+  ],
   linux: [...SYSTEM_COMMANDS],
   windows: [...SYSTEM_COMMANDS],
   // Fail-safe: unknown metadata should not receive host exec defaults.
   unknown: [...UNKNOWN_PLATFORM_COMMANDS],
 };
 
-type PlatformId = "ios" | "android" | "macos" | "windows" | "linux" | "unknown";
+type PlatformId = "ios" | "android" | "macos" | "visionos" | "windows" | "linux" | "unknown";
 
 const PLATFORM_PREFIX_RULES: ReadonlyArray<{
   id: Exclude<PlatformId, "unknown">;
@@ -129,6 +148,7 @@ const PLATFORM_PREFIX_RULES: ReadonlyArray<{
   { id: "ios", prefixes: ["ios"] },
   { id: "android", prefixes: ["android"] },
   { id: "macos", prefixes: ["mac", "darwin"] },
+  { id: "visionos", prefixes: ["visionos"] },
   { id: "windows", prefixes: ["win"] },
   { id: "linux", prefixes: ["linux"] },
 ] as const;
@@ -140,6 +160,7 @@ const DEVICE_FAMILY_TOKEN_RULES: ReadonlyArray<{
   { id: "ios", tokens: ["iphone", "ipad", "ios"] },
   { id: "android", tokens: ["android"] },
   { id: "macos", tokens: ["mac"] },
+  { id: "visionos", tokens: ["visionos", "headset", "vision pro"] },
   { id: "windows", tokens: ["windows"] },
   { id: "linux", tokens: ["linux"] },
 ] as const;

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -160,7 +160,7 @@ const DEVICE_FAMILY_TOKEN_RULES: ReadonlyArray<{
   { id: "ios", tokens: ["iphone", "ipad", "ios"] },
   { id: "android", tokens: ["android"] },
   { id: "macos", tokens: ["mac"] },
-  { id: "visionos", tokens: ["visionos", "headset", "vision pro"] },
+  { id: "visionos", tokens: ["visionos", "vision pro"] },
   { id: "windows", tokens: ["windows"] },
   { id: "linux", tokens: ["linux"] },
 ] as const;


### PR DESCRIPTION
## Problem

visionOS nodes (Apple Vision Pro) were not recognized as a distinct platform in `node-command-policy.ts`. The platform string `"visionos"` didn't match any entry in `PLATFORM_PREFIX_RULES`, causing nodes to fall through to the `unknown` allowlist — which only permits safe read commands and blocked declared commands like `camera.snap`.

## Changes

**`src/gateway/node-command-policy.ts`:**

- Added `VISIONOS_SPATIAL_COMMANDS` constant: `spatial.hands`, `spatial.planes`, `spatial.mesh`, `device.position` — ARKit-backed spatial sensing commands available within an active `ImmersiveSpace`
- Added `visionos` entry to `PLATFORM_DEFAULTS` with canvas, camera (safe), location, device info, spatial sensing, and `system.notify`
- Added `visionos` to the `PlatformId` union type
- Added `"visionos"` prefix to `PLATFORM_PREFIX_RULES`
- Added `"visionos"` and `"headset"` device family tokens to `DEVICE_FAMILY_TOKEN_RULES` for robust matching

## Notes

- `camera.snap` and `camera.clip` remain in `DEFAULT_DANGEROUS_NODE_COMMANDS` — consistent with iOS. Operators must explicitly add them via `gateway.nodes.allowCommands` to enable.
- The spatial commands are visionOS-specific and not exposed on other platforms.
- Tested against a live visionOS-node (Apple Vision Pro) connecting to a local gateway.