### PR TITLE
fix(media): require fs access for dynamic local roots

### DIFF
--- a/src/agents/tool-fs-policy.test.ts
+++ b/src/agents/tool-fs-policy.test.ts
@@ -74,6 +74,16 @@ describe("resolveEffectiveToolFsRootExpansionAllowed", () => {
     expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "main" })).toBe(true);
   });
 
+  it("treats an explicit tools.fs block as a filesystem opt-in", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+        fs: {},
+      },
+    };
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "main" })).toBe(true);
+  });
+
   it("keeps root expansion disabled when tools.fs only restricts access to the workspace", () => {
     const cfg: OpenClawConfig = {
       tools: {
@@ -121,6 +131,27 @@ describe("resolveEffectiveToolFsRootExpansionAllowed", () => {
             id: "messenger",
             tools: {
               alsoAllow: ["message"],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "messenger" })).toBe(false);
+  });
+
+  it("honors agent workspaceOnly overrides over global fs opt-in", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+        fs: { workspaceOnly: false },
+      },
+      agents: {
+        list: [
+          {
+            id: "messenger",
+            tools: {
+              fs: { workspaceOnly: true },
             },
           },
         ],

--- a/src/agents/tool-fs-policy.test.ts
+++ b/src/agents/tool-fs-policy.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveEffectiveToolFsWorkspaceOnly } from "./tool-fs-policy.js";
+import {
+  resolveEffectiveToolFsReadEnabled,
+  resolveEffectiveToolFsWorkspaceOnly,
+} from "./tool-fs-policy.js";
 
 describe("resolveEffectiveToolFsWorkspaceOnly", () => {
   it("returns false by default when tools.fs.workspaceOnly is unset", () => {
@@ -46,5 +49,28 @@ describe("resolveEffectiveToolFsWorkspaceOnly", () => {
       },
     };
     expect(resolveEffectiveToolFsWorkspaceOnly({ cfg, agentId: "main" })).toBe(true);
+  });
+});
+
+describe("resolveEffectiveToolFsReadEnabled", () => {
+  it("allows reads by default when no restrictive profile is configured", () => {
+    expect(resolveEffectiveToolFsReadEnabled({ cfg: {}, agentId: "main" })).toBe(true);
+  });
+
+  it("disables reads for messaging profile agents without filesystem opt-in", () => {
+    const cfg: OpenClawConfig = {
+      tools: { profile: "messaging" },
+    };
+    expect(resolveEffectiveToolFsReadEnabled({ cfg, agentId: "main" })).toBe(false);
+  });
+
+  it("re-enables reads when tools.fs is configured for messaging profile agents", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+        fs: { workspaceOnly: false },
+      },
+    };
+    expect(resolveEffectiveToolFsReadEnabled({ cfg, agentId: "main" })).toBe(true);
   });
 });

--- a/src/agents/tool-fs-policy.test.ts
+++ b/src/agents/tool-fs-policy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  resolveEffectiveToolFsReadEnabled,
+  resolveEffectiveToolFsRootExpansionAllowed,
   resolveEffectiveToolFsWorkspaceOnly,
 } from "./tool-fs-policy.js";
 
@@ -52,25 +52,81 @@ describe("resolveEffectiveToolFsWorkspaceOnly", () => {
   });
 });
 
-describe("resolveEffectiveToolFsReadEnabled", () => {
-  it("allows reads by default when no restrictive profile is configured", () => {
-    expect(resolveEffectiveToolFsReadEnabled({ cfg: {}, agentId: "main" })).toBe(true);
+describe("resolveEffectiveToolFsRootExpansionAllowed", () => {
+  it("allows root expansion by default when no restrictive profile is configured", () => {
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg: {}, agentId: "main" })).toBe(true);
   });
 
-  it("disables reads for messaging profile agents without filesystem opt-in", () => {
+  it("disables root expansion for messaging profile agents without filesystem opt-in", () => {
     const cfg: OpenClawConfig = {
       tools: { profile: "messaging" },
     };
-    expect(resolveEffectiveToolFsReadEnabled({ cfg, agentId: "main" })).toBe(false);
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "main" })).toBe(false);
   });
 
-  it("re-enables reads when tools.fs is configured for messaging profile agents", () => {
+  it("re-enables root expansion when tools.fs explicitly allows non-workspace reads", () => {
     const cfg: OpenClawConfig = {
       tools: {
         profile: "messaging",
         fs: { workspaceOnly: false },
       },
     };
-    expect(resolveEffectiveToolFsReadEnabled({ cfg, agentId: "main" })).toBe(true);
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "main" })).toBe(true);
+  });
+
+  it("keeps root expansion disabled when tools.fs only restricts access to the workspace", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+        fs: { workspaceOnly: true },
+      },
+    };
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "main" })).toBe(false);
+  });
+
+  it("prefers agent profile overrides over the global profile in both directions", () => {
+    const cfg: OpenClawConfig = {
+      tools: { profile: "messaging" },
+      agents: {
+        list: [
+          { id: "coder", tools: { profile: "coding" } },
+          { id: "messenger", tools: { profile: "messaging" } },
+        ],
+      },
+    };
+
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "coder" })).toBe(true);
+
+    const invertedCfg: OpenClawConfig = {
+      tools: { profile: "coding" },
+      agents: {
+        list: [{ id: "messenger", tools: { profile: "messaging" } }],
+      },
+    };
+
+    expect(
+      resolveEffectiveToolFsRootExpansionAllowed({ cfg: invertedCfg, agentId: "messenger" }),
+    ).toBe(false);
+  });
+
+  it("uses agent alsoAllow in place of global alsoAllow when resolving expansion", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        profile: "messaging",
+        alsoAllow: ["read"],
+      },
+      agents: {
+        list: [
+          {
+            id: "messenger",
+            tools: {
+              alsoAllow: ["message"],
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveEffectiveToolFsRootExpansionAllowed({ cfg, agentId: "messenger" })).toBe(false);
   });
 });

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -33,7 +33,7 @@ export function resolveEffectiveToolFsWorkspaceOnly(params: {
   return resolveToolFsConfig(params).workspaceOnly === true;
 }
 
-export function resolveEffectiveToolFsReadEnabled(params: {
+export function resolveEffectiveToolFsRootExpansionAllowed(params: {
   cfg?: OpenClawConfig;
   agentId?: string;
 }): boolean {
@@ -44,11 +44,10 @@ export function resolveEffectiveToolFsReadEnabled(params: {
   const agentTools = params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools : undefined;
   const globalTools = cfg.tools;
   const profile = agentTools?.profile ?? globalTools?.profile;
-  const profileAlsoAllow = new Set([
-    ...(agentTools?.alsoAllow ?? []),
-    ...(globalTools?.alsoAllow ?? []),
-  ]);
-  if (agentTools?.fs || globalTools?.fs) {
+  const profileAlsoAllow = new Set(agentTools?.alsoAllow ?? globalTools?.alsoAllow ?? []);
+  const fsAllowsExpansion =
+    agentTools?.fs?.workspaceOnly === false || globalTools?.fs?.workspaceOnly === false;
+  if (fsAllowsExpansion) {
     profileAlsoAllow.add("read");
     profileAlsoAllow.add("write");
     profileAlsoAllow.add("edit");

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -45,9 +45,12 @@ export function resolveEffectiveToolFsRootExpansionAllowed(params: {
   const globalTools = cfg.tools;
   const profile = agentTools?.profile ?? globalTools?.profile;
   const profileAlsoAllow = new Set(agentTools?.alsoAllow ?? globalTools?.alsoAllow ?? []);
-  const fsAllowsExpansion =
-    agentTools?.fs?.workspaceOnly === false || globalTools?.fs?.workspaceOnly === false;
-  if (fsAllowsExpansion) {
+  const fsConfig = resolveToolFsConfig(params);
+  const hasExplicitFsConfig = agentTools?.fs !== undefined || globalTools?.fs !== undefined;
+  if (fsConfig.workspaceOnly === true) {
+    return false;
+  }
+  if (hasExplicitFsConfig) {
     profileAlsoAllow.add("read");
     profileAlsoAllow.add("write");
     profileAlsoAllow.add("edit");

--- a/src/agents/tool-fs-policy.ts
+++ b/src/agents/tool-fs-policy.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentConfig } from "./agent-scope.js";
+import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
+import { isToolAllowedByPolicies } from "./tool-policy-match.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 
 export type ToolFsPolicy = {
   workspaceOnly: boolean;
@@ -28,4 +31,33 @@ export function resolveEffectiveToolFsWorkspaceOnly(params: {
   agentId?: string;
 }): boolean {
   return resolveToolFsConfig(params).workspaceOnly === true;
+}
+
+export function resolveEffectiveToolFsReadEnabled(params: {
+  cfg?: OpenClawConfig;
+  agentId?: string;
+}): boolean {
+  const cfg = params.cfg;
+  if (!cfg) {
+    return true;
+  }
+  const agentTools = params.agentId ? resolveAgentConfig(cfg, params.agentId)?.tools : undefined;
+  const globalTools = cfg.tools;
+  const profile = agentTools?.profile ?? globalTools?.profile;
+  const profileAlsoAllow = new Set([
+    ...(agentTools?.alsoAllow ?? []),
+    ...(globalTools?.alsoAllow ?? []),
+  ]);
+  if (agentTools?.fs || globalTools?.fs) {
+    profileAlsoAllow.add("read");
+    profileAlsoAllow.add("write");
+    profileAlsoAllow.add("edit");
+  }
+  const profilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(profile),
+    profileAlsoAllow.size > 0 ? Array.from(profileAlsoAllow) : undefined,
+  );
+  const globalPolicy = pickSandboxToolPolicy(globalTools);
+  const agentPolicy = pickSandboxToolPolicy(agentTools);
+  return isToolAllowedByPolicies("read", [profilePolicy, globalPolicy, agentPolicy]);
 }

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -91,4 +91,35 @@ describe("local media roots", () => {
       normalizeHostPath("/Users/peter/Pictures"),
     );
   });
+
+  it("does not widen media roots for messaging-profile agents without filesystem tools", () => {
+    const stateDir = path.join("/tmp", "openclaw-messaging-media-roots-state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const roots = getAgentScopedMediaLocalRootsForSources({
+      cfg: { tools: { profile: "messaging" } },
+      agentId: "ops",
+      mediaSources: ["/Users/peter/Pictures/photo.png"],
+    });
+
+    expect(roots.map(normalizeHostPath)).not.toContain(normalizeHostPath("/Users/peter/Pictures"));
+  });
+
+  it("widens media roots again when messaging-profile agents explicitly enable filesystem tools", () => {
+    const stateDir = path.join("/tmp", "openclaw-messaging-fs-media-roots-state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const roots = getAgentScopedMediaLocalRootsForSources({
+      cfg: {
+        tools: {
+          profile: "messaging",
+          fs: { workspaceOnly: false },
+        },
+      },
+      agentId: "ops",
+      mediaSources: ["/Users/peter/Pictures/photo.png"],
+    });
+
+    expect(roots.map(normalizeHostPath)).toContain(normalizeHostPath("/Users/peter/Pictures"));
+  });
 });

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
-import { resolveEffectiveToolFsWorkspaceOnly } from "../agents/tool-fs-policy.js";
+import {
+  resolveEffectiveToolFsReadEnabled,
+  resolveEffectiveToolFsWorkspaceOnly,
+} from "../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { safeFileURLToPath } from "../infra/local-file-access.js";
@@ -110,6 +113,9 @@ export function getAgentScopedMediaLocalRootsForSources(params: {
 }): readonly string[] {
   const roots = getAgentScopedMediaLocalRoots(params.cfg, params.agentId);
   if (resolveEffectiveToolFsWorkspaceOnly({ cfg: params.cfg, agentId: params.agentId })) {
+    return roots;
+  }
+  if (!resolveEffectiveToolFsReadEnabled({ cfg: params.cfg, agentId: params.agentId })) {
     return roots;
   }
   return appendLocalMediaParentRoots(roots, params.mediaSources);

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import {
-  resolveEffectiveToolFsReadEnabled,
+  resolveEffectiveToolFsRootExpansionAllowed,
   resolveEffectiveToolFsWorkspaceOnly,
 } from "../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -115,7 +115,7 @@ export function getAgentScopedMediaLocalRootsForSources(params: {
   if (resolveEffectiveToolFsWorkspaceOnly({ cfg: params.cfg, agentId: params.agentId })) {
     return roots;
   }
-  if (!resolveEffectiveToolFsReadEnabled({ cfg: params.cfg, agentId: params.agentId })) {
+  if (!resolveEffectiveToolFsRootExpansionAllowed({ cfg: params.cfg, agentId: params.agentId })) {
     return roots;
   }
   return appendLocalMediaParentRoots(roots, params.mediaSources);


### PR DESCRIPTION
## Summary

- Problem: `getAgentScopedMediaLocalRootsForSources()` widened local media roots from any absolute attachment path, even when the active tool profile did not expose filesystem reads.
- Why it matters: messaging-only agents could end up with broader local attachment access than their tool policy intended.
- What changed: local media root expansion now checks the effective filesystem-read policy before appending source parent directories, while preserving existing behavior for profiles that explicitly allow filesystem tools.
- What did NOT change (scope boundary): workspace-only handling, configured base media roots, and attachment normalization behavior outside this policy gate.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: media root synthesis trusted outbound attachment source paths without checking whether the current tool policy actually allowed local file reads.
- Missing detection / guardrail: tests covered workspace-only gating, but not restrictive profiles that still route through outbound media helpers.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the helper synthesized extra parent roots to support local attachments, but did not align that behavior with restrictive profile resolution.
- If unknown, what was ruled out: this was not caused by channel-specific adapters; the widening happened in the shared media root helper.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/media/local-roots.test.ts`, `src/agents/tool-fs-policy.test.ts`
- Scenario the test should lock in: messaging-profile agents keep their configured roots unless filesystem tools are explicitly enabled, while explicit `tools.fs` opt-in still allows parent-root expansion.
- Why this is the smallest reliable guardrail: the behavior is decided in shared policy/root helpers before channel dispatch, so unit coverage on those helpers is the narrowest direct lock.
- Existing test that already covers this (if any): the existing local-roots tests already covered workspace-only gating.
- If no new test is added, why not:

## User-visible / Behavior Changes

- Messaging-profile agents no longer widen attachment roots from arbitrary local paths unless filesystem tools are explicitly enabled.

## Diagram (if applicable)

```text
Before:
[messaging-profile send with local media path] -> [append parent dir to allowed roots] -> [attachment path accepted]

After:
[messaging-profile send with local media path] -> [check effective fs-read access] -> [keep configured roots only]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: local attachment access is narrowed for restrictive profiles by requiring effective filesystem-read access before widening parent roots.

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: Node 24 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `tools.profile: messaging`; optional `tools.fs.workspaceOnly: false`

### Steps

1. Run `pnpm test -- src/media/local-roots.test.ts src/agents/tool-fs-policy.test.ts`.
2. Run `pnpm check`.
3. Confirm messaging-profile coverage does not append `/Users/peter/Pictures` without filesystem opt-in, and does append it once `tools.fs` is configured.

### Expected

- Restrictive profiles keep configured roots only.
- Explicit filesystem opt-in preserves dynamic parent-root expansion.

### Actual

- Matches expected behavior with tests and local checks passing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted helper tests for messaging-profile gating and explicit filesystem opt-in, plus full `pnpm check`.
- Edge cases checked: existing workspace-only behavior still short-circuits parent-root expansion.
- What you did **not** verify: end-to-end delivery against a live channel.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: profiles that relied on implicit local attachment reads without explicit filesystem tool access will now reject those paths.
  - Mitigation: the prior behavior is preserved when filesystem tools are intentionally enabled, and the change is covered by direct helper tests.
