### PR TITLE
Exec approvals: reject wrapper carrier allow-always targets

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -652,4 +652,50 @@ $0 \\"$1\\"" touch {marker}`,
       persistedPattern: benign,
     });
   });
+
+  it("rejects positional carrier when carried executable is a dispatch wrapper", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    makeExecutable(dir, "env");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const { persisted } = resolvePersistedPatterns({
+      command: `sh -lc '$0 "$@"' env echo SAFE`,
+      dir,
+      env,
+      safeBins,
+    });
+    expect(persisted).toEqual([]);
+
+    const second = evaluateShellAllowlist({
+      command: `sh -lc '$0 "$@"' env BASH_ENV=/tmp/payload.sh bash -lc 'id > /tmp/pwned'`,
+      allowlist: persisted.map((pattern) => ({ pattern })),
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
+  });
+
+  it("rejects positional carrier when carried executable is a shell wrapper", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    makeExecutable(dir, "bash");
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const { persisted } = resolvePersistedPatterns({
+      command: `sh -lc '$0 "$@"' bash -lc 'echo safe'`,
+      dir,
+      env,
+      safeBins,
+    });
+    expect(persisted).toEqual([]);
+  });
 });

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -697,5 +697,15 @@ $0 \\"$1\\"" touch {marker}`,
       safeBins,
     });
     expect(persisted).toEqual([]);
+
+    const second = evaluateShellAllowlist({
+      command: `sh -lc '$0 "$@"' bash -lc 'id > /tmp/pwned'`,
+      allowlist: persisted.map((pattern) => ({ pattern })),
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
   });
 });

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isDispatchWrapperExecutable } from "./dispatch-wrapper-resolution.js";
 import {
   analyzeShellCommand,
   isWindowsPlatform,
@@ -460,6 +461,13 @@ function resolveShellWrapperPositionalArgvCandidatePath(params: {
     .map((token) => token.trim())
     .find((token) => token.length > 0);
   if (!carriedExecutable) {
+    return undefined;
+  }
+
+  // Reject wrapper targets carried through `$0 "$@"` because their trailing argv can
+  // widen execution semantics beyond the original approved command.
+  const carriedName = normalizeExecutableToken(carriedExecutable);
+  if (isDispatchWrapperExecutable(carriedName) || isShellWrapperExecutable(carriedName)) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- Tightens positional-carrier allowlist resolution for shell wrapper commands
- Stops carried wrapper targets from being persisted through `allow-always`

## Changes
- Rejects positional-carrier targets that normalize to dispatch wrappers or shell wrappers before resolving an allowlist candidate path
- Adds regression coverage for carried `env` and `bash` targets so stronger follow-up payloads remain allowlist misses

## Validation
- Ran `pnpm test -- src/infra/exec-approvals-allow-always.test.ts`
- Ran `pnpm build`
- Verified the carrier repro now returns `persisted: []`, `allowlistSatisfied: false`, and `requiresAsk: true`
- Ran local agentic review with `claude -p "/review"`; it produced no actionable code feedback

## Notes
- Residual risk or follow-up: existing allowlist entries created before this change are outside the scope of this patch
