### PR TITLE
fal: guard image fetches

### DIFF
--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -1,33 +1,46 @@
 import * as providerAuth from "openclaw/plugin-sdk/provider-auth";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchWithSsrFGuardMock, ssrfPolicyFromAllowPrivateNetworkMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+  ssrfPolicyFromAllowPrivateNetworkMock: vi.fn((allowPrivateNetwork: boolean | null | undefined) =>
+    allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  ssrfPolicyFromAllowPrivateNetwork: ssrfPolicyFromAllowPrivateNetworkMock,
+}));
+
 import { buildFalImageGenerationProvider } from "./image-generation-provider.js";
 
-function expectFalJsonPost(
-  fetchMock: ReturnType<typeof vi.fn>,
-  params: {
-    call: number;
-    url: string;
-    body: Record<string, unknown>;
-  },
-) {
-  expect(fetchMock).toHaveBeenNthCalledWith(
+function expectFalJsonPost(params: { call: number; url: string; body: Record<string, unknown> }) {
+  expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
     params.call,
-    params.url,
     expect.objectContaining({
-      method: "POST",
-      headers: expect.objectContaining({
-        Authorization: "Key fal-test-key",
-        "Content-Type": "application/json",
+      url: params.url,
+      init: expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Key fal-test-key",
+          "Content-Type": "application/json",
+        }),
       }),
+      auditContext: "fal-image-generate",
     }),
   );
 
-  const request = fetchMock.mock.calls[params.call - 1]?.[1];
+  const request = fetchWithSsrFGuardMock.mock.calls[params.call - 1]?.[0];
   expect(request).toBeTruthy();
-  expect(JSON.parse(String(request?.body))).toEqual(params.body);
+  expect(JSON.parse(String(request?.init?.body))).toEqual(params.body);
 }
 
 describe("fal image-generation provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -38,26 +51,34 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
-    const fetchMock = vi
-      .fn()
+    const releaseRequest = vi.fn(async () => {});
+    const releaseDownload = vi.fn(async () => {});
+    fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          images: [
-            {
-              url: "https://v3.fal.media/files/example/generated.png",
-              content_type: "image/png",
-            },
-          ],
-          prompt: "draw a cat",
-        }),
+        response: new Response(
+          JSON.stringify({
+            images: [
+              {
+                url: "https://v3.fal.media/files/example/generated.png",
+                content_type: "image/png",
+              },
+            ],
+            prompt: "draw a cat",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: releaseRequest,
       })
       .mockResolvedValueOnce({
-        ok: true,
-        headers: new Headers({ "content-type": "image/png" }),
-        arrayBuffer: async () => Buffer.from("png-data"),
+        response: new Response(Buffer.from("png-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: releaseDownload,
       });
-    vi.stubGlobal("fetch", fetchMock);
 
     const provider = buildFalImageGenerationProvider();
     const result = await provider.generateImage({
@@ -69,7 +90,7 @@ describe("fal image-generation provider", () => {
       size: "1536x1024",
     });
 
-    expectFalJsonPost(fetchMock, {
+    expectFalJsonPost({
       call: 1,
       url: "https://fal.run/fal-ai/flux/dev",
       body: {
@@ -79,10 +100,15 @@ describe("fal image-generation provider", () => {
         output_format: "png",
       },
     });
-    expect(fetchMock).toHaveBeenNthCalledWith(
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
       2,
-      "https://v3.fal.media/files/example/generated.png",
+      expect.objectContaining({
+        url: "https://v3.fal.media/files/example/generated.png",
+        auditContext: "fal-image-download",
+      }),
     );
+    expect(releaseRequest).toHaveBeenCalledTimes(1);
+    expect(releaseDownload).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       images: [
         {
@@ -102,20 +128,26 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
-    const fetchMock = vi
-      .fn()
+    fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          images: [{ url: "https://v3.fal.media/files/example/edited.png" }],
-        }),
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/edited.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
       })
       .mockResolvedValueOnce({
-        ok: true,
-        headers: new Headers({ "content-type": "image/png" }),
-        arrayBuffer: async () => Buffer.from("edited-data"),
+        response: new Response(Buffer.from("edited-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
       });
-    vi.stubGlobal("fetch", fetchMock);
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -133,7 +165,7 @@ describe("fal image-generation provider", () => {
       ],
     });
 
-    expectFalJsonPost(fetchMock, {
+    expectFalJsonPost({
       call: 1,
       url: "https://fal.run/fal-ai/flux/dev/image-to-image",
       body: {
@@ -152,20 +184,26 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
-    const fetchMock = vi
-      .fn()
+    fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          images: [{ url: "https://v3.fal.media/files/example/wide.png" }],
-        }),
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/wide.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
       })
       .mockResolvedValueOnce({
-        ok: true,
-        headers: new Headers({ "content-type": "image/png" }),
-        arrayBuffer: async () => Buffer.from("wide-data"),
+        response: new Response(Buffer.from("wide-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
       });
-    vi.stubGlobal("fetch", fetchMock);
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -176,7 +214,7 @@ describe("fal image-generation provider", () => {
       aspectRatio: "16:9",
     });
 
-    expectFalJsonPost(fetchMock, {
+    expectFalJsonPost({
       call: 1,
       url: "https://fal.run/fal-ai/flux/dev",
       body: {
@@ -194,20 +232,26 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
-    const fetchMock = vi
-      .fn()
+    fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          images: [{ url: "https://v3.fal.media/files/example/portrait.png" }],
-        }),
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "https://v3.fal.media/files/example/portrait.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
       })
       .mockResolvedValueOnce({
-        ok: true,
-        headers: new Headers({ "content-type": "image/png" }),
-        arrayBuffer: async () => Buffer.from("portrait-data"),
+        response: new Response(Buffer.from("portrait-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
       });
-    vi.stubGlobal("fetch", fetchMock);
 
     const provider = buildFalImageGenerationProvider();
     await provider.generateImage({
@@ -219,7 +263,7 @@ describe("fal image-generation provider", () => {
       aspectRatio: "9:16",
     });
 
-    expectFalJsonPost(fetchMock, {
+    expectFalJsonPost({
       call: 1,
       url: "https://fal.run/fal-ai/flux/dev",
       body: {
@@ -271,5 +315,47 @@ describe("fal image-generation provider", () => {
         inputImages: [{ buffer: Buffer.from("one"), mimeType: "image/png" }],
       }),
     ).rejects.toThrow("does not support aspectRatio overrides");
+  });
+
+  it("blocks private-network image download URLs through the SSRF guard", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    const blocked = new Error("Blocked: resolves to private/internal/special-use IP address");
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockRejectedValueOnce(blocked);
+
+    const provider = buildFalImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "fal",
+        model: "fal-ai/flux/dev",
+        prompt: "draw a cat",
+        cfg: {},
+      }),
+    ).rejects.toThrow(blocked.message);
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        auditContext: "fal-image-download",
+      }),
+    );
+    expect(ssrfPolicyFromAllowPrivateNetworkMock).toHaveBeenCalledWith(false);
   });
 });

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -102,6 +102,7 @@ describe("fal image-generation provider", () => {
       expect.objectContaining({
         url: "https://v3.fal.media/files/example/generated.png",
         auditContext: "fal-image-download",
+        policy: undefined,
       }),
     );
     expect(releaseRequest).toHaveBeenCalledTimes(1);
@@ -355,6 +356,74 @@ describe("fal image-generation provider", () => {
       expect.objectContaining({
         url: "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
         auditContext: "fal-image-download",
+        policy: undefined,
+      }),
+    );
+  });
+
+  it("allows trusted private relay hosts derived from configured baseUrl", async () => {
+    vi.spyOn(providerAuth, "resolveApiKeyForProvider").mockResolvedValue({
+      apiKey: "fal-test-key",
+      source: "env",
+      mode: "api-key",
+    });
+    _setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
+    const relayPolicy = {
+      allowPrivateNetwork: true,
+      hostnameAllowlist: ["relay.internal", "*.relay.internal"],
+    };
+    fetchWithSsrFGuardMock
+      .mockResolvedValueOnce({
+        response: new Response(
+          JSON.stringify({
+            images: [{ url: "http://media.relay.internal/files/generated.png" }],
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+        release: vi.fn(async () => {}),
+      })
+      .mockResolvedValueOnce({
+        response: new Response(Buffer.from("png-data"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+        release: vi.fn(async () => {}),
+      });
+
+    const provider = buildFalImageGenerationProvider();
+    await provider.generateImage({
+      provider: "fal",
+      model: "fal-ai/flux/dev",
+      prompt: "draw a cat",
+      cfg: {
+        models: {
+          providers: {
+            fal: {
+              baseUrl: "http://relay.internal:8080",
+              models: [],
+            },
+          },
+        },
+      },
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        url: "http://relay.internal:8080/fal-ai/flux/dev",
+        auditContext: "fal-image-generate",
+        policy: relayPolicy,
+      }),
+    );
+    expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        url: "http://media.relay.internal/files/generated.png",
+        auditContext: "fal-image-download",
+        policy: relayPolicy,
       }),
     );
   });

--- a/extensions/fal/image-generation-provider.test.ts
+++ b/extensions/fal/image-generation-provider.test.ts
@@ -1,19 +1,14 @@
 import * as providerAuth from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fetchWithSsrFGuardMock, ssrfPolicyFromAllowPrivateNetworkMock } = vi.hoisted(() => ({
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
-  ssrfPolicyFromAllowPrivateNetworkMock: vi.fn((allowPrivateNetwork: boolean | null | undefined) =>
-    allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
-  ),
 }));
 
-vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
-  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
-  ssrfPolicyFromAllowPrivateNetwork: ssrfPolicyFromAllowPrivateNetworkMock,
-}));
-
-import { buildFalImageGenerationProvider } from "./image-generation-provider.js";
+import {
+  _setFalFetchGuardForTesting,
+  buildFalImageGenerationProvider,
+} from "./image-generation-provider.js";
 
 function expectFalJsonPost(params: { call: number; url: string; body: Record<string, unknown> }) {
   expect(fetchWithSsrFGuardMock).toHaveBeenNthCalledWith(
@@ -42,6 +37,7 @@ describe("fal image-generation provider", () => {
   });
 
   afterEach(() => {
+    _setFalFetchGuardForTesting(null);
     vi.restoreAllMocks();
   });
 
@@ -51,6 +47,7 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
+    _setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     const releaseRequest = vi.fn(async () => {});
     const releaseDownload = vi.fn(async () => {});
     fetchWithSsrFGuardMock
@@ -128,6 +125,7 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
+    _setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(
@@ -184,6 +182,7 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
+    _setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(
@@ -232,6 +231,7 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
+    _setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
         response: new Response(
@@ -323,6 +323,7 @@ describe("fal image-generation provider", () => {
       source: "env",
       mode: "api-key",
     });
+    _setFalFetchGuardForTesting(fetchWithSsrFGuardMock);
     const blocked = new Error("Blocked: resolves to private/internal/special-use IP address");
     fetchWithSsrFGuardMock
       .mockResolvedValueOnce({
@@ -356,6 +357,5 @@ describe("fal image-generation provider", () => {
         auditContext: "fal-image-download",
       }),
     );
-    expect(ssrfPolicyFromAllowPrivateNetworkMock).toHaveBeenCalledWith(false);
   });
 });

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -33,6 +33,12 @@ type FalImageGenerationResponse = {
 
 type FalImageSize = string | { width: number; height: number };
 
+let falFetchGuard = fetchWithSsrFGuard;
+
+export function _setFalFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
+  falFetchGuard = impl ?? fetchWithSsrFGuard;
+}
+
 function resolveFalBaseUrl(cfg: Parameters<typeof resolveApiKeyForProvider>[0]["cfg"]): string {
   const direct = cfg?.models?.providers?.fal?.baseUrl?.trim();
   return (direct || DEFAULT_FAL_BASE_URL).replace(/\/+$/u, "");
@@ -179,7 +185,7 @@ function fileExtensionForMimeType(mimeType: string | undefined): string {
 }
 
 async function fetchImageBuffer(url: string): Promise<{ buffer: Buffer; mimeType: string }> {
-  const { response, release } = await fetchWithSsrFGuard({
+  const { response, release } = await falFetchGuard({
     url,
     policy: ssrfPolicyFromAllowPrivateNetwork(false),
     auditContext: "fal-image-download",
@@ -265,7 +271,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         requestBody.image_url = toDataUri(input.buffer, input.mimeType);
       }
 
-      const { response, release } = await fetchWithSsrFGuard({
+      const { response, release } = await falFetchGuard({
         url: `${resolveFalBaseUrl(req.cfg)}/${model}`,
         init: {
           method: "POST",

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -2,6 +2,10 @@ import type {
   GeneratedImageAsset,
   ImageGenerationProvider,
 } from "openclaw/plugin-sdk/image-generation";
+import {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromAllowPrivateNetwork,
+} from "openclaw/plugin-sdk/infra-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth";
 
 const DEFAULT_FAL_BASE_URL = "https://fal.run";
@@ -175,16 +179,24 @@ function fileExtensionForMimeType(mimeType: string | undefined): string {
 }
 
 async function fetchImageBuffer(url: string): Promise<{ buffer: Buffer; mimeType: string }> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(
-      `fal image download failed (${response.status}): ${text || response.statusText}`,
-    );
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    policy: ssrfPolicyFromAllowPrivateNetwork(false),
+    auditContext: "fal-image-download",
+  });
+  try {
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(
+        `fal image download failed (${response.status}): ${text || response.statusText}`,
+      );
+    }
+    const mimeType = response.headers.get("content-type")?.trim() || "image/png";
+    const arrayBuffer = await response.arrayBuffer();
+    return { buffer: Buffer.from(arrayBuffer), mimeType };
+  } finally {
+    await release();
   }
-  const mimeType = response.headers.get("content-type")?.trim() || "image/png";
-  const arrayBuffer = await response.arrayBuffer();
-  return { buffer: Buffer.from(arrayBuffer), mimeType };
 }
 
 export function buildFalImageGenerationProvider(): ImageGenerationProvider {
@@ -253,50 +265,58 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         requestBody.image_url = toDataUri(input.buffer, input.mimeType);
       }
 
-      const response = await fetch(`${resolveFalBaseUrl(req.cfg)}/${model}`, {
-        method: "POST",
-        headers: {
-          Authorization: `Key ${auth.apiKey}`,
-          "Content-Type": "application/json",
+      const { response, release } = await fetchWithSsrFGuard({
+        url: `${resolveFalBaseUrl(req.cfg)}/${model}`,
+        init: {
+          method: "POST",
+          headers: {
+            Authorization: `Key ${auth.apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(requestBody),
         },
-        body: JSON.stringify(requestBody),
+        policy: ssrfPolicyFromAllowPrivateNetwork(false),
+        auditContext: "fal-image-generate",
       });
-
-      if (!response.ok) {
-        const text = await response.text().catch(() => "");
-        throw new Error(
-          `fal image generation failed (${response.status}): ${text || response.statusText}`,
-        );
-      }
-
-      const payload = (await response.json()) as FalImageGenerationResponse;
-      const images: GeneratedImageAsset[] = [];
-      let imageIndex = 0;
-      for (const entry of payload.images ?? []) {
-        const url = entry.url?.trim();
-        if (!url) {
-          continue;
+      try {
+        if (!response.ok) {
+          const text = await response.text().catch(() => "");
+          throw new Error(
+            `fal image generation failed (${response.status}): ${text || response.statusText}`,
+          );
         }
-        const downloaded = await fetchImageBuffer(url);
-        imageIndex += 1;
-        images.push({
-          buffer: downloaded.buffer,
-          mimeType: downloaded.mimeType,
-          fileName: `image-${imageIndex}.${fileExtensionForMimeType(
-            downloaded.mimeType || entry.content_type,
-          )}`,
-        });
-      }
 
-      if (images.length === 0) {
-        throw new Error("fal image generation response missing image data");
-      }
+        const payload = (await response.json()) as FalImageGenerationResponse;
+        const images: GeneratedImageAsset[] = [];
+        let imageIndex = 0;
+        for (const entry of payload.images ?? []) {
+          const url = entry.url?.trim();
+          if (!url) {
+            continue;
+          }
+          const downloaded = await fetchImageBuffer(url);
+          imageIndex += 1;
+          images.push({
+            buffer: downloaded.buffer,
+            mimeType: downloaded.mimeType,
+            fileName: `image-${imageIndex}.${fileExtensionForMimeType(
+              downloaded.mimeType || entry.content_type,
+            )}`,
+          });
+        }
 
-      return {
-        images,
-        model,
-        metadata: payload.prompt ? { prompt: payload.prompt } : undefined,
-      };
+        if (images.length === 0) {
+          throw new Error("fal image generation response missing image data");
+        }
+
+        return {
+          images,
+          model,
+          metadata: payload.prompt ? { prompt: payload.prompt } : undefined,
+        };
+      } finally {
+        await release();
+      }
     },
   };
 }

--- a/extensions/fal/image-generation-provider.ts
+++ b/extensions/fal/image-generation-provider.ts
@@ -3,7 +3,9 @@ import type {
   ImageGenerationProvider,
 } from "openclaw/plugin-sdk/image-generation";
 import {
+  buildHostnameAllowlistPolicyFromSuffixAllowlist,
   fetchWithSsrFGuard,
+  type SsrFPolicy,
   ssrfPolicyFromAllowPrivateNetwork,
 } from "openclaw/plugin-sdk/infra-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth";
@@ -32,11 +34,80 @@ type FalImageGenerationResponse = {
 };
 
 type FalImageSize = string | { width: number; height: number };
+type FalNetworkPolicy = {
+  apiPolicy?: SsrFPolicy;
+  trustedDownloadHostSuffix?: string;
+  trustedDownloadPolicy?: SsrFPolicy;
+};
 
 let falFetchGuard = fetchWithSsrFGuard;
 
 export function _setFalFetchGuardForTesting(impl: typeof fetchWithSsrFGuard | null): void {
   falFetchGuard = impl ?? fetchWithSsrFGuard;
+}
+
+function mergeSsrFPolicies(...policies: Array<SsrFPolicy | undefined>): SsrFPolicy | undefined {
+  const merged: SsrFPolicy = {};
+  for (const policy of policies) {
+    if (!policy) {
+      continue;
+    }
+    if (policy.allowPrivateNetwork) {
+      merged.allowPrivateNetwork = true;
+    }
+    if (policy.dangerouslyAllowPrivateNetwork) {
+      merged.dangerouslyAllowPrivateNetwork = true;
+    }
+    if (policy.allowRfc2544BenchmarkRange) {
+      merged.allowRfc2544BenchmarkRange = true;
+    }
+    if (policy.allowedHostnames?.length) {
+      merged.allowedHostnames = Array.from(
+        new Set([...(merged.allowedHostnames ?? []), ...policy.allowedHostnames]),
+      );
+    }
+    if (policy.hostnameAllowlist?.length) {
+      merged.hostnameAllowlist = Array.from(
+        new Set([...(merged.hostnameAllowlist ?? []), ...policy.hostnameAllowlist]),
+      );
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function matchesTrustedHostSuffix(hostname: string, trustedSuffix: string): boolean {
+  const normalizedHost = hostname.trim().toLowerCase();
+  const normalizedSuffix = trustedSuffix.trim().toLowerCase();
+  return normalizedHost === normalizedSuffix || normalizedHost.endsWith(`.${normalizedSuffix}`);
+}
+
+function resolveFalNetworkPolicy(
+  cfg: Parameters<typeof resolveApiKeyForProvider>[0]["cfg"],
+): FalNetworkPolicy {
+  const baseUrl = resolveFalBaseUrl(cfg);
+  const explicitBaseUrl = cfg?.models?.providers?.fal?.baseUrl?.trim();
+  let parsedBaseUrl: URL;
+  try {
+    parsedBaseUrl = new URL(baseUrl);
+  } catch {
+    return {};
+  }
+
+  const hostSuffix = parsedBaseUrl.hostname.trim().toLowerCase();
+  if (!hostSuffix) {
+    return {};
+  }
+
+  const hostPolicy = buildHostnameAllowlistPolicyFromSuffixAllowlist([hostSuffix]);
+  const privateNetworkPolicy = explicitBaseUrl
+    ? ssrfPolicyFromAllowPrivateNetwork(true)
+    : undefined;
+  const trustedHostPolicy = mergeSsrFPolicies(hostPolicy, privateNetworkPolicy);
+  return {
+    apiPolicy: trustedHostPolicy,
+    trustedDownloadHostSuffix: explicitBaseUrl ? hostSuffix : undefined,
+    trustedDownloadPolicy: explicitBaseUrl ? trustedHostPolicy : undefined,
+  };
 }
 
 function resolveFalBaseUrl(cfg: Parameters<typeof resolveApiKeyForProvider>[0]["cfg"]): string {
@@ -184,10 +255,26 @@ function fileExtensionForMimeType(mimeType: string | undefined): string {
   return slashIndex >= 0 ? normalized.slice(slashIndex + 1) || "png" : "png";
 }
 
-async function fetchImageBuffer(url: string): Promise<{ buffer: Buffer; mimeType: string }> {
+async function fetchImageBuffer(
+  url: string,
+  networkPolicy?: FalNetworkPolicy,
+): Promise<{ buffer: Buffer; mimeType: string }> {
+  const downloadPolicy = (() => {
+    const trustedSuffix = networkPolicy?.trustedDownloadHostSuffix;
+    const trustedPolicy = networkPolicy?.trustedDownloadPolicy;
+    if (!trustedSuffix || !trustedPolicy) {
+      return undefined;
+    }
+    try {
+      const parsed = new URL(url);
+      return matchesTrustedHostSuffix(parsed.hostname, trustedSuffix) ? trustedPolicy : undefined;
+    } catch {
+      return undefined;
+    }
+  })();
   const { response, release } = await falFetchGuard({
     url,
-    policy: ssrfPolicyFromAllowPrivateNetwork(false),
+    policy: downloadPolicy,
     auditContext: "fal-image-download",
   });
   try {
@@ -254,6 +341,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
         hasInputImages,
       });
       const model = ensureFalModelPath(req.model, hasInputImages);
+      const networkPolicy = resolveFalNetworkPolicy(req.cfg);
       const requestBody: Record<string, unknown> = {
         prompt: req.prompt,
         num_images: req.count ?? 1,
@@ -281,7 +369,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           },
           body: JSON.stringify(requestBody),
         },
-        policy: ssrfPolicyFromAllowPrivateNetwork(false),
+        policy: networkPolicy.apiPolicy,
         auditContext: "fal-image-generate",
       });
       try {
@@ -300,7 +388,7 @@ export function buildFalImageGenerationProvider(): ImageGenerationProvider {
           if (!url) {
             continue;
           }
-          const downloaded = await fetchImageBuffer(url);
+          const downloaded = await fetchImageBuffer(url, networkPolicy);
           imageIndex += 1;
           images.push({
             buffer: downloaded.buffer,


### PR DESCRIPTION
## Summary
- route fal image generation requests through the shared guarded fetch helper
- guard image download URLs returned by fal before fetching the bytes
- add regression coverage for guarded relay responses and blocked private-network targets

## Changes
- replaced raw fetch calls in `extensions/fal/image-generation-provider.ts` with `fetchWithSsrFGuard`
- released guarded fetch handles after both the API request and image download flows
- updated `extensions/fal/image-generation-provider.test.ts` to assert the guarded fetch usage directly

## Validation
- Ran `pnpm test -- extensions/fal/image-generation-provider.test.ts`
- Ran `pnpm check`
- Ran `pnpm build`
- Ran local agentic review via `claude -p "/review"`; it exited early requesting `gh pr list` approval, so there was no actionable review output to address

## Notes
- Residual risk or follow-up: none beyond normal CI confirmation on the PR head commit