### PR TITLE
Gateway: disconnect revoked device sessions

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -52,6 +52,7 @@ describe("deviceHandlers", () => {
     const opts = createOptions("device.pair.remove", { deviceId: " device-1 " });
 
     await deviceHandlers["device.pair.remove"](opts);
+    await Promise.resolve();
 
     expect(removePairedDeviceMock).toHaveBeenCalledWith(" device-1 ");
     expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1");
@@ -84,6 +85,7 @@ describe("deviceHandlers", () => {
     });
 
     await deviceHandlers["device.token.revoke"](opts);
+    await Promise.resolve();
 
     expect(revokeDeviceTokenMock).toHaveBeenCalledWith({
       deviceId: " device-1 ",

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { deviceHandlers } from "./devices.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+
+const { removePairedDeviceMock, revokeDeviceTokenMock } = vi.hoisted(() => ({
+  removePairedDeviceMock: vi.fn(),
+  revokeDeviceTokenMock: vi.fn(),
+}));
+
+vi.mock("../../infra/device-pairing.js", async () => {
+  const actual = await vi.importActual<typeof import("../../infra/device-pairing.js")>(
+    "../../infra/device-pairing.js",
+  );
+  return {
+    ...actual,
+    removePairedDevice: removePairedDeviceMock,
+    revokeDeviceToken: revokeDeviceTokenMock,
+  };
+});
+
+function createOptions(
+  method: string,
+  params: Record<string, unknown>,
+  overrides?: Partial<GatewayRequestHandlerOptions>,
+): GatewayRequestHandlerOptions {
+  return {
+    req: { type: "req", id: "req-1", method, params },
+    params,
+    client: null,
+    isWebchatConnect: () => false,
+    respond: vi.fn(),
+    context: {
+      disconnectClientsForDevice: vi.fn(),
+      logGateway: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+    },
+    ...overrides,
+  } as unknown as GatewayRequestHandlerOptions;
+}
+
+describe("deviceHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disconnects active clients after removing a paired device", async () => {
+    removePairedDeviceMock.mockResolvedValue({ deviceId: "device-1", removedAtMs: 123 });
+    const opts = createOptions("device.pair.remove", { deviceId: "device-1" });
+
+    await deviceHandlers["device.pair.remove"](opts);
+
+    expect(removePairedDeviceMock).toHaveBeenCalledWith("device-1");
+    expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1");
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      { deviceId: "device-1", removedAtMs: 123 },
+      undefined,
+    );
+  });
+
+  it("does not disconnect clients when device removal fails", async () => {
+    removePairedDeviceMock.mockResolvedValue(null);
+    const opts = createOptions("device.pair.remove", { deviceId: "device-1" });
+
+    await deviceHandlers["device.pair.remove"](opts);
+
+    expect(opts.context.disconnectClientsForDevice).not.toHaveBeenCalled();
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown deviceId" }),
+    );
+  });
+
+  it("disconnects active clients after revoking a device token", async () => {
+    revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
+    const opts = createOptions("device.token.revoke", {
+      deviceId: "device-1",
+      role: "operator",
+    });
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(revokeDeviceTokenMock).toHaveBeenCalledWith({ deviceId: "device-1", role: "operator" });
+    expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1");
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      { deviceId: "device-1", role: "operator", revokedAtMs: 456 },
+      undefined,
+    );
+  });
+
+  it("does not disconnect clients when token revocation fails", async () => {
+    revokeDeviceTokenMock.mockResolvedValue(null);
+    const opts = createOptions("device.token.revoke", {
+      deviceId: "device-1",
+      role: "operator",
+    });
+
+    await deviceHandlers["device.token.revoke"](opts);
+
+    expect(opts.context.disconnectClientsForDevice).not.toHaveBeenCalled();
+    expect(opts.respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "unknown deviceId/role" }),
+    );
+  });
+});

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -49,11 +49,11 @@ describe("deviceHandlers", () => {
 
   it("disconnects active clients after removing a paired device", async () => {
     removePairedDeviceMock.mockResolvedValue({ deviceId: "device-1", removedAtMs: 123 });
-    const opts = createOptions("device.pair.remove", { deviceId: "device-1" });
+    const opts = createOptions("device.pair.remove", { deviceId: " device-1 " });
 
     await deviceHandlers["device.pair.remove"](opts);
 
-    expect(removePairedDeviceMock).toHaveBeenCalledWith("device-1");
+    expect(removePairedDeviceMock).toHaveBeenCalledWith(" device-1 ");
     expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1");
     expect(opts.respond).toHaveBeenCalledWith(
       true,
@@ -79,13 +79,16 @@ describe("deviceHandlers", () => {
   it("disconnects active clients after revoking a device token", async () => {
     revokeDeviceTokenMock.mockResolvedValue({ role: "operator", revokedAtMs: 456 });
     const opts = createOptions("device.token.revoke", {
-      deviceId: "device-1",
-      role: "operator",
+      deviceId: " device-1 ",
+      role: " operator ",
     });
 
     await deviceHandlers["device.token.revoke"](opts);
 
-    expect(revokeDeviceTokenMock).toHaveBeenCalledWith({ deviceId: "device-1", role: "operator" });
+    expect(revokeDeviceTokenMock).toHaveBeenCalledWith({
+      deviceId: " device-1 ",
+      role: " operator ",
+    });
     expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1");
     expect(opts.respond).toHaveBeenCalledWith(
       true,

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -89,7 +89,9 @@ describe("deviceHandlers", () => {
       deviceId: " device-1 ",
       role: " operator ",
     });
-    expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1");
+    expect(opts.context.disconnectClientsForDevice).toHaveBeenCalledWith("device-1", {
+      role: "operator",
+    });
     expect(opts.respond).toHaveBeenCalledWith(
       true,
       { deviceId: "device-1", role: "operator", revokedAtMs: 456 },

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -171,6 +171,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId"));
       return;
     }
+    context.disconnectClientsForDevice?.(deviceId);
     context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
     respond(true, removed, undefined);
   },
@@ -283,6 +284,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));
       return;
     }
+    context.disconnectClientsForDevice?.(deviceId);
     context.logGateway.info(`device token revoked device=${deviceId} role=${entry.role}`);
     respond(
       true,

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -171,9 +171,11 @@ export const deviceHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId"));
       return;
     }
-    context.disconnectClientsForDevice?.(removed.deviceId);
     context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
     respond(true, removed, undefined);
+    queueMicrotask(() => {
+      context.disconnectClientsForDevice?.(removed.deviceId);
+    });
   },
   "device.token.rotate": async ({ params, respond, context, client }) => {
     if (!validateDeviceTokenRotateParams(params)) {
@@ -285,7 +287,6 @@ export const deviceHandlers: GatewayRequestHandlers = {
       return;
     }
     const normalizedDeviceId = deviceId.trim();
-    context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
     context.logGateway.info(`device token revoked device=${normalizedDeviceId} role=${entry.role}`);
     respond(
       true,
@@ -296,5 +297,8 @@ export const deviceHandlers: GatewayRequestHandlers = {
       },
       undefined,
     );
+    queueMicrotask(() => {
+      context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
+    });
   },
 };

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -171,7 +171,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId"));
       return;
     }
-    context.disconnectClientsForDevice?.(deviceId);
+    context.disconnectClientsForDevice?.(removed.deviceId);
     context.logGateway.info(`device pairing removed device=${removed.deviceId}`);
     respond(true, removed, undefined);
   },
@@ -284,11 +284,16 @@ export const deviceHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown deviceId/role"));
       return;
     }
-    context.disconnectClientsForDevice?.(deviceId);
-    context.logGateway.info(`device token revoked device=${deviceId} role=${entry.role}`);
+    const normalizedDeviceId = deviceId.trim();
+    context.disconnectClientsForDevice?.(normalizedDeviceId);
+    context.logGateway.info(`device token revoked device=${normalizedDeviceId} role=${entry.role}`);
     respond(
       true,
-      { deviceId, role: entry.role, revokedAtMs: entry.revokedAtMs ?? Date.now() },
+      {
+        deviceId: normalizedDeviceId,
+        role: entry.role,
+        revokedAtMs: entry.revokedAtMs ?? Date.now(),
+      },
       undefined,
     );
   },

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -285,7 +285,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       return;
     }
     const normalizedDeviceId = deviceId.trim();
-    context.disconnectClientsForDevice?.(normalizedDeviceId);
+    context.disconnectClientsForDevice?.(normalizedDeviceId, { role: entry.role });
     context.logGateway.info(`device token revoked device=${normalizedDeviceId} role=${entry.role}`);
     respond(
       true,

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -57,6 +57,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
   hasExecApprovalClients?: (excludeConnId?: string) => boolean;
+  disconnectClientsForDevice?: (deviceId: string) => void;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -57,7 +57,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
   hasExecApprovalClients?: (excludeConnId?: string) => boolean;
-  disconnectClientsForDevice?: (deviceId: string) => void;
+  disconnectClientsForDevice?: (deviceId: string, opts?: { role?: string }) => void;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1196,6 +1196,18 @@ export async function startGatewayServer(
         }
         return false;
       },
+      disconnectClientsForDevice: (deviceId: string) => {
+        for (const gatewayClient of clients) {
+          if (gatewayClient.connect.device?.id !== deviceId) {
+            continue;
+          }
+          try {
+            gatewayClient.socket.close(4001, "device removed");
+          } catch {
+            /* ignore */
+          }
+        }
+      },
       nodeRegistry,
       agentRunSeq,
       chatAbortControllers,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1196,9 +1196,12 @@ export async function startGatewayServer(
         }
         return false;
       },
-      disconnectClientsForDevice: (deviceId: string) => {
+      disconnectClientsForDevice: (deviceId: string, opts?: { role?: string }) => {
         for (const gatewayClient of clients) {
           if (gatewayClient.connect.device?.id !== deviceId) {
+            continue;
+          }
+          if (opts?.role && gatewayClient.connect.role !== opts.role) {
             continue;
           }
           try {


### PR DESCRIPTION
## Summary
- disconnect active gateway clients when a paired device is removed
- disconnect active gateway clients when a device token is revoked

## Changes
- added a `disconnectClientsForDevice` hook to the gateway request context
- wired the gateway runtime to close live sockets for a removed or revoked device
- added handler-level regression tests covering both successful and failed disconnect paths

## Validation
- ran `pnpm test -- src/gateway/server-methods/devices.test.ts`
- ran `pnpm test -- src/gateway/server-methods/server-methods.test.ts -t "exec approval handlers"`
- ran `pnpm check`
- ran `pnpm build`
- ran local agentic review via `claude -p "/review"`; it requested a PR number or open-PR context, so there was no actionable feedback to apply locally

## Notes
- existing coverage for rejected fresh reconnects remains in the auth suite; this patch adds coverage for the live-session disconnect hook in the device handlers
