### PR TITLE
fix(hooks): default hooks.internal.enabled to true so bundled hooks load on fresh installs

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -167,7 +167,7 @@ export async function startGatewaySidecars(params: {
     );
   }
 
-  if (params.cfg.hooks?.internal?.enabled) {
+  if (params.cfg.hooks?.internal?.enabled !== false) {
     setTimeout(() => {
       const hookEvent = createInternalHookEvent("gateway", "startup", "gateway:startup", {
         cfg: params.cfg,

--- a/src/hooks/loader.test.ts
+++ b/src/hooks/loader.test.ts
@@ -121,7 +121,7 @@ describe("loader", () => {
       expect(getRegisteredEventKeys()).not.toContain("command:new");
     };
 
-    it("should return 0 when hooks are disabled or missing", async () => {
+    it("should return 0 when hooks are explicitly disabled", async () => {
       for (const cfg of [
         {
           hooks: {
@@ -130,7 +130,28 @@ describe("loader", () => {
             },
           },
         } satisfies OpenClawConfig,
+        {
+          hooks: {
+            internal: {
+              enabled: false,
+              handlers: [],
+            },
+          },
+        } satisfies OpenClawConfig,
+      ]) {
+        const count = await loadInternalHooks(cfg, tmpDir);
+        expect(count).toBe(0);
+      }
+    });
+
+    it("should treat missing hooks.internal.enabled as enabled (default-on)", async () => {
+      // Empty config should NOT skip loading — it should attempt discovery.
+      // With no discoverable hooks in the temp dir (bundled dir is overridden
+      // to /nonexistent), this returns 0 but does NOT bail at the guard.
+      for (const cfg of [
         {} satisfies OpenClawConfig,
+        { hooks: {} } satisfies OpenClawConfig,
+        { hooks: { internal: {} } } satisfies OpenClawConfig,
       ]) {
         const count = await loadInternalHooks(cfg, tmpDir);
         expect(count).toBe(0);

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -65,8 +65,8 @@ export async function loadInternalHooks(
     bundledHooksDir?: string;
   },
 ): Promise<number> {
-  // Check if hooks are enabled
-  if (!cfg.hooks?.internal?.enabled) {
+  // Hooks are on by default; only skip when explicitly disabled.
+  if (cfg.hooks?.internal?.enabled === false) {
     return 0;
   }
 
@@ -153,7 +153,7 @@ export async function loadInternalHooks(
   }
 
   // 2. Load legacy config handlers (backwards compatibility)
-  const handlers = cfg.hooks.internal.handlers ?? [];
+  const handlers = cfg.hooks?.internal?.handlers ?? [];
   for (const handlerConfig of handlers) {
     try {
       // Legacy handler paths: keep them workspace-relative.

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { clearInternalHooks, getRegisteredEventKeys } from "../hooks/internal-hooks.js";
 import { emitDiagnosticEvent, resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import { withEnv } from "../test-utils/env.js";
 import { clearPluginCommands, getPluginCommandSpecs } from "./command-registry-state.js";
@@ -1263,6 +1264,42 @@ module.exports = { id: "skipped-scoped-only", register() { throw new Error("skip
     ]);
 
     clearPluginCommands();
+  });
+
+  it("does not register internal hooks globally during non-activating loads", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "internal-hook-snapshot",
+      filename: "internal-hook-snapshot.cjs",
+      body: `module.exports = {
+        id: "internal-hook-snapshot",
+        register(api) {
+          api.registerHook("gateway:startup", () => {}, { name: "snapshot-hook" });
+        },
+      };`,
+    });
+
+    clearInternalHooks();
+    const scoped = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["internal-hook-snapshot"],
+        },
+      },
+      onlyPluginIds: ["internal-hook-snapshot"],
+    });
+
+    expect(scoped.plugins.find((entry) => entry.id === "internal-hook-snapshot")?.status).toBe(
+      "loaded",
+    );
+    expect(scoped.hooks.map((entry) => entry.entry.hook.name)).toEqual(["snapshot-hook"]);
+    expect(getRegisteredEventKeys()).toEqual([]);
+
+    clearInternalHooks();
   });
 
   it("can scope bundled provider loads to deepseek without hanging", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -938,7 +938,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     logger,
     runtime,
     coreGatewayHandlers: options.coreGatewayHandlers as Record<string, GatewayRequestHandler>,
-    suppressGlobalCommands: !shouldActivate,
+    activateGlobalSideEffects: shouldActivate,
   });
 
   const discovery = discoverOpenClawPlugins({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -375,7 +375,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       source: record.source,
     });
 
-    const hookSystemEnabled = config?.hooks?.internal?.enabled === true;
+    const hookSystemEnabled = config?.hooks?.internal?.enabled !== false;
     if (!hookSystemEnabled || opts?.register === false) {
       return;
     }

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -243,9 +243,9 @@ export type PluginRegistryParams = {
   logger: PluginLogger;
   coreGatewayHandlers?: GatewayRequestHandlers;
   runtime: PluginRuntime;
-  // When true, skip writing to the global plugin command registry during register().
-  // Used by non-activating snapshot loads to avoid leaking commands into the running gateway.
-  suppressGlobalCommands?: boolean;
+  // When false, keep registration local to the returned registry and avoid mutating
+  // process-global command/hook state during non-activating snapshot loads.
+  activateGlobalSideEffects?: boolean;
 };
 
 type PluginTypedHookPolicy = {
@@ -376,7 +376,11 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
 
     const hookSystemEnabled = config?.hooks?.internal?.enabled !== false;
-    if (!hookSystemEnabled || opts?.register === false) {
+    if (
+      !registryParams.activateGlobalSideEffects ||
+      !hookSystemEnabled ||
+      opts?.register === false
+    ) {
       return;
     }
 
@@ -812,7 +816,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     // NOTE: cross-plugin duplicate command detection is intentionally skipped here because
     // snapshot registries are isolated and never write to the global command table. Conflicts
     // will surface when the plugin is loaded via the normal activation path at gateway startup.
-    if (registryParams.suppressGlobalCommands) {
+    if (!registryParams.activateGlobalSideEffects) {
       const validationError = validatePluginCommandDefinition(command);
       if (validationError) {
         pushDiagnostic({

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -23,9 +23,16 @@ describe("collectAttackSurfaceSummaryFindings", () => {
       expectedDetail: ["hooks.webhooks: enabled", "hooks.internal: enabled"],
     },
     {
-      name: "reports both hook systems as disabled when neither is configured",
+      name: "reports internal hooks as enabled by default and webhooks as disabled when neither is configured",
       cfg: {} satisfies OpenClawConfig,
-      expectedDetail: ["hooks.webhooks: disabled", "hooks.internal: disabled"],
+      expectedDetail: ["hooks.webhooks: disabled", "hooks.internal: enabled"],
+    },
+    {
+      name: "reports internal hooks as disabled when explicitly set to false",
+      cfg: {
+        hooks: { internal: { enabled: false } },
+      } satisfies OpenClawConfig,
+      expectedDetail: ["hooks.internal: disabled"],
     },
   ])("$name", ({ cfg, expectedDetail }) => {
     const [finding] = collectAttackSurfaceSummaryFindings(cfg);

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -526,7 +526,7 @@ export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): Securi
   const group = summarizeGroupPolicy(cfg);
   const elevated = cfg.tools?.elevated?.enabled !== false;
   const webhooksEnabled = cfg.hooks?.enabled === true;
-  const internalHooksEnabled = cfg.hooks?.internal?.enabled === true;
+  const internalHooksEnabled = cfg.hooks?.internal?.enabled !== false;
   const browserEnabled = cfg.browser?.enabled ?? true;
 
   const detail =


### PR DESCRIPTION
## Summary

Fixes #55929.

On a fresh install, `hooks.internal.enabled` is `undefined` (not set in config). The guard in `loadInternalHooks()` treats this as falsy and skips all hook loading — including bundled hooks like `session-memory`. Users see hooks as "ready" in `openclaw hooks check` but they never actually fire at runtime.

### Root cause

```typescript
if (!cfg.hooks?.internal?.enabled) return 0;  // undefined is falsy → skips loading
```

This conflicts with the hook policy system where bundled/managed hooks use `defaultEnableMode: "default-on"`. The per-hook eligibility check (used by `hooks check`) correctly treats bundled hooks as enabled, but the master switch in the loader disagrees.

### Fix

Change all `hooks.internal.enabled` checks from opt-in (`=== true` / truthy) to opt-out (`!== false`), matching the existing default-on policy for bundled hooks:

| File | Before | After |
|------|--------|-------|
| `src/hooks/loader.ts` | `!cfg.hooks?.internal?.enabled` | `cfg.hooks?.internal?.enabled === false` |
| `src/gateway/server-startup.ts` | `cfg.hooks?.internal?.enabled` | `cfg.hooks?.internal?.enabled !== false` |
| `src/plugins/registry.ts` | `=== true` | `!== false` |
| `src/security/audit-extra.sync.ts` | `=== true` | `!== false` |

Also fixed a latent crash: the legacy handler path accessed `cfg.hooks.internal.handlers` without optional chaining, which would throw when `hooks` or `internal` is undefined (now reachable since empty config no longer bails early).

### Tests

- Updated loader test: empty config no longer means "disabled" — it means "enabled with nothing discoverable"
- Added new test: explicit `enabled: false` correctly disables hooks
- Updated audit test: empty config now reports internal hooks as enabled (matches runtime)
- Added audit test: `enabled: false` correctly reports as disabled
- All 180 hooks tests + 8 audit tests pass

## Test plan

- [x] `src/hooks/loader.test.ts` — 15/15 pass
- [x] `src/hooks/**/*.test.ts` + `src/security/audit-extra.sync.test.ts` — 180/180 pass
- [x] `src/commands/onboard-hooks.test.ts` — 6/6 pass

**Note:** Pre-existing TS errors on `main` in `src/agents/skills/` and `src/agents/compaction.ts` (unrelated to this change) cause `pnpm check` to fail. These errors exist on latest `upstream/main` before this branch.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
