### PR TITLE
fix: preserve indentation when stripping reply directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 - Microsoft Teams/proactive DMs: prefer the freshest personal conversation reference for `user:<aadObjectId>` sends when multiple stored references exist, so replies stop targeting stale DM threads. (#54702) Thanks @gumclaw.
 - Gateway/plugins: reuse the session workspace when building HTTP `/tools/invoke` tool lists and harden tool construction to infer the session agent workspace by default, so workspace plugins do not re-register on repeated HTTP tool calls. (#56101) thanks @neeravmakwana
 - Brave/web search: normalize unsupported Brave `country` filters to `ALL` before request and cache-key generation so locale-derived values like `VN` stop failing with upstream 422 validation errors. (#55695) Thanks @chen-zhang-cs-code.
+- Discord/replies: preserve leading indentation when stripping inline reply tags so reply-tagged plain text and fenced code blocks keep their formatting. (#55960) Thanks @Nanako0129.
 
 ## 2026.3.24
 

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  parseInlineDirectives,
   stripInlineDirectiveTagsForDelivery,
   stripInlineDirectiveTagsForDisplay,
   stripInlineDirectiveTagsFromMessageForDisplay,
@@ -48,6 +49,30 @@ describe("stripInlineDirectiveTagsForDelivery", () => {
     const result = stripInlineDirectiveTagsForDelivery(input);
     expect(result.changed).toBe(false);
     expect(result.text).toBe(input);
+  });
+});
+
+describe("parseInlineDirectives", () => {
+  test("preserves leading spaces after stripping a reply tag", () => {
+    const input = "[[reply_to_current]]    keep this indent\n        and this one";
+    const result = parseInlineDirectives(input);
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.text).toBe("    keep this indent\n        and this one");
+  });
+
+  test("preserves fenced code block indentation after stripping a reply tag", () => {
+    const input = [
+      "[[reply_to_current]]",
+      "```python",
+      "    if True:",
+      "        print('ok')",
+      "```",
+    ].join("\n");
+    const result = parseInlineDirectives(input);
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.text).toBe(
+      ["```python", "    if True:", "        print('ok')", "```"].join("\n"),
+    );
   });
 });
 

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -74,6 +74,20 @@ describe("parseInlineDirectives", () => {
       ["```python", "    if True:", "        print('ok')", "```"].join("\n"),
     );
   });
+
+  test("preserves word boundaries when a reply tag is adjacent to text", () => {
+    const input = "see[[reply_to_current]]now";
+    const result = parseInlineDirectives(input);
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.text).toBe("see now");
+  });
+
+  test("drops all leading blank lines introduced by a stripped reply tag", () => {
+    const input = "[[reply_to_current]]\n\ntext";
+    const result = parseInlineDirectives(input);
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.text).toBe("text");
+  });
 });
 
 describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -21,9 +21,12 @@ const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
 
 function normalizeDirectiveWhitespace(text: string): string {
   return text
-    .replace(/[ \t]+/g, " ")
-    .replace(/[ \t]*\n[ \t]*/g, "\n")
-    .trim();
+    .replace(/\r\n/g, "\n")
+    .replace(/([^\s\n])[ \t]{2,}([^\s\n])/g, "$1 $2")
+    .replace(/^\n/, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
 }
 
 type StripInlineDirectiveTagsResult = {
@@ -130,7 +133,7 @@ export function parseInlineDirectives(
   cleaned = cleaned.replace(AUDIO_TAG_RE, (match) => {
     audioAsVoice = true;
     hasAudioTag = true;
-    return stripAudioTag ? " " : match;
+    return stripAudioTag ? "" : match;
   });
 
   cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined) => {
@@ -143,7 +146,7 @@ export function parseInlineDirectives(
         lastExplicitId = id;
       }
     }
-    return stripReplyTags ? " " : match;
+    return stripReplyTags ? "" : match;
   });
 
   cleaned = normalizeDirectiveWhitespace(cleaned);

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -19,11 +19,17 @@ const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
 
+function replacementPreservesWordBoundary(source: string, offset: number, length: number): string {
+  const before = source[offset - 1];
+  const after = source[offset + length];
+  return before && after && !/\s/u.test(before) && !/\s/u.test(after) ? " " : "";
+}
+
 function normalizeDirectiveWhitespace(text: string): string {
   return text
     .replace(/\r\n/g, "\n")
-    .replace(/([^\s\n])[ \t]{2,}([^\s\n])/g, "$1 $2")
-    .replace(/^\n/, "")
+    .replace(/([^\s])[ \t]{2,}([^\s])/g, "$1 $2")
+    .replace(/^\n+/, "")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trimEnd();
@@ -130,13 +136,13 @@ export function parseInlineDirectives(
   let sawCurrent = false;
   let lastExplicitId: string | undefined;
 
-  cleaned = cleaned.replace(AUDIO_TAG_RE, (match) => {
+  cleaned = cleaned.replace(AUDIO_TAG_RE, (match, offset, source) => {
     audioAsVoice = true;
     hasAudioTag = true;
-    return stripAudioTag ? "" : match;
+    return stripAudioTag ? replacementPreservesWordBoundary(source, offset, match.length) : match;
   });
 
-  cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined) => {
+  cleaned = cleaned.replace(REPLY_TAG_RE, (match, idRaw: string | undefined, offset, source) => {
     hasReplyTag = true;
     if (idRaw === undefined) {
       sawCurrent = true;
@@ -146,7 +152,7 @@ export function parseInlineDirectives(
         lastExplicitId = id;
       }
     }
-    return stripReplyTags ? "" : match;
+    return stripReplyTags ? replacementPreservesWordBoundary(source, offset, match.length) : match;
   });
 
   cleaned = normalizeDirectiveWhitespace(cleaned);

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -30,6 +30,7 @@ function normalizeDirectiveWhitespace(text: string): string {
     .replace(/\r\n/g, "\n")
     .replace(/([^\s])[ \t]{2,}([^\s])/g, "$1 $2")
     .replace(/^\n+/, "")
+    .replace(/^[ \t](?=\S)/, "")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n")
     .trimEnd();


### PR DESCRIPTION
## Summary

- preserve leading indentation when stripping inline reply directives from assistant replies
- add regression coverage for reply-tagged plain text and fenced code blocks so indentation-sensitive content stays intact

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [ ] Test-only

## Scope

This PR is intentionally narrow.

It only changes inline reply directive whitespace normalization in the shared reply-tag parser.

It does not change:
- Discord message send behavior
- outbound chunking or provider delivery logic
- code block formatting outside the reply-directive path
- Discord's own first-line plain-text leading-space behavior

## Linked Issue/PR

- Related #45580
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

Assistant replies that included inline reply directives such as `[[reply_to_current]]` were parsed through `parseInlineDirectives()`.

That path replaced stripped directive tags with a space and then ran a broad whitespace normalization pass that collapsed repeated spaces and trimmed both ends of the message. As a result, leading indentation was flattened before the reply payload reached the Discord outbound layer.

In local verification, the stored assistant reply content still preserved indentation, and direct Discord sends also preserved indentation. The loss happened while stripping reply directives from assistant-visible reply text.

## Behavior Changes

Before:
- reply-tagged plain text lines could lose intended leading spaces
- fenced code blocks routed through the reply-directive parser lost indentation
- Python/YAML-style examples became visually flattened before delivery

After:
- stripping reply directives preserves leading indentation in downstream lines
- fenced code block indentation remains intact after reply-tag removal
- only minimal whitespace cleanup remains around removed directive tags

## Regression Test Plan

Updated:
- `src/utils/directive-tags.test.ts`

Coverage:
- preserves leading spaces after stripping `[[reply_to_current]]`
- preserves fenced code block indentation after stripping a reply tag
- keeps existing directive stripping behavior for non-indentation cases

## Repro + Verification

Observed locally before the patch:
- assistant replies in Discord threads lost indentation after reply-tag parsing
- direct deterministic sends to Discord preserved indentation, which ruled out the provider send path
- transcript/session inspection showed raw assistant content still contained the expected indentation

With this patch:
- `pnpm vitest run src/utils/directive-tags.test.ts` passes locally
- isolated smoke testing against a repo-local gateway preserved indentation for reply-tagged plain text and fenced code blocks
- the remaining first-line plain-text leading-space trim matches Discord's native behavior and reproduces with manual messages as well

## Tests

Passed locally:
- `pnpm vitest run src/utils/directive-tags.test.ts`
- isolated Discord smoke test with a repo-local gateway against a copied `OPENCLAW_HOME`

## Risks and Mitigations

Risk:
- reply-directive parsing is shared, so whitespace handling changes could affect other directive-tag surfaces

Mitigation:
- the patch stays inside `parseInlineDirectives()` and keeps the change focused on preserving indentation instead of broad whitespace flattening
- regression tests cover both plain text and fenced code block cases
- isolated end-to-end smoke testing verified the real Discord reply path

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and tested by me.
