### PR TITLE
fix(telegram): clarify inbound document fallback reason

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -51,6 +51,7 @@ import {
   resolveInboundMediaFileId,
 } from "./bot-handlers.media.js";
 import type { TelegramMediaRef } from "./bot-message-context.js";
+import type { TelegramMessageContextOptions } from "./bot-message-context.types.js";
 import { RegisterTelegramHandlerParams } from "./bot-native-commands.js";
 import {
   MEDIA_GROUP_TIMEOUT_MS,
@@ -149,6 +150,7 @@ export const registerTelegramHandlers = ({
     allMedia: TelegramMediaRef[];
     storeAllowFrom: string[];
     receivedAtMs: number;
+    options?: TelegramMessageContextOptions;
     debounceKey: string | null;
     debounceLane: TelegramDebounceLane;
     botUsername?: string;
@@ -234,6 +236,7 @@ export const registerTelegramHandlers = ({
           last.allMedia,
           last.storeAllowFrom,
           {
+            ...(last.options ?? {}),
             receivedAtMs: last.receivedAtMs,
             ingressBuffer: "inbound-debounce",
           },
@@ -400,7 +403,7 @@ export const registerTelegramHandlers = ({
           );
           continue;
         }
-        if (media) {
+        if (media?.path) {
           allMedia.push({
             path: media.path,
             contentType: media.contentType,
@@ -499,7 +502,7 @@ export const registerTelegramHandlers = ({
         telegramTransport,
         telegramCfg.apiRoot,
       );
-      if (!media) {
+      if (!media?.path) {
         return [];
       }
       return [
@@ -1064,7 +1067,7 @@ export const registerTelegramHandlers = ({
       return;
     }
 
-    const allMedia = media
+    const allMedia = media?.path
       ? [
           {
             path: media.path,
@@ -1086,6 +1089,7 @@ export const registerTelegramHandlers = ({
       msg,
       allMedia,
       storeAllowFrom,
+      options: media?.unavailableText ? { mediaUnavailableText: media.unavailableText } : undefined,
       receivedAtMs: Date.now(),
       debounceKey,
       debounceLane,

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -158,8 +158,11 @@ export async function resolveTelegramInboundBody(params: {
   const locationText = locationData ? formatLocationText(locationData) : undefined;
   const rawText = expandTextLinks(messageTextParts.text, messageTextParts.entities).trim();
   const hasUserText = Boolean(rawText || locationText);
+  const mediaUnavailableText = options?.mediaUnavailableText?.trim();
   let rawBody = [rawText, locationText].filter(Boolean).join("\n").trim();
-  if (!rawBody) {
+  if (mediaUnavailableText) {
+    rawBody = [rawBody, placeholder, mediaUnavailableText].filter(Boolean).join("\n").trim();
+  } else if (!rawBody) {
     rawBody = placeholder;
   }
   if (!rawBody && allMedia.length === 0) {

--- a/extensions/telegram/src/bot-message-context.media-fallback.test.ts
+++ b/extensions/telegram/src/bot-message-context.media-fallback.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext document fallback messaging", () => {
+  it("renders the placeholder with the Telegram document fallback reason", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat: { id: 1234, type: "private" },
+        date: 1700000000,
+        text: undefined,
+        from: { id: 42, first_name: "Alice" },
+        document: { file_id: "doc-1", file_unique_id: "doc-u1" },
+      },
+      options: {
+        mediaUnavailableText: "Telegram attachment unavailable: file too large for Bot API download",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.BodyForAgent).toBe(
+      "<media:document>\nTelegram attachment unavailable: file too large for Bot API download",
+    );
+    expect(ctx?.ctxPayload?.Body).toContain("<media:document>");
+    expect(ctx?.ctxPayload?.Body).toContain(
+      "Telegram attachment unavailable: file too large for Bot API download",
+    );
+  });
+
+  it("keeps user text, document placeholder, and fallback reason in order", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 2,
+        chat: { id: 1234, type: "private" },
+        date: 1700000001,
+        text: "please review this",
+        from: { id: 42, first_name: "Alice" },
+        document: { file_id: "doc-2", file_unique_id: "doc-u2" },
+      },
+      options: {
+        mediaUnavailableText: "Telegram attachment unavailable: download failed",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.BodyForAgent).toBe(
+      [
+        "please review this",
+        "<media:document>",
+        "Telegram attachment unavailable: download failed",
+      ].join("\n"),
+    );
+  });
+});

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -18,6 +18,7 @@ export type TelegramMediaRef = {
 export type TelegramMessageContextOptions = {
   forceWasMentioned?: boolean;
   messageIdOverride?: string;
+  mediaUnavailableText?: string;
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
 };

--- a/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts
@@ -190,6 +190,21 @@ describe("resolveMedia getFile retry", () => {
     );
   });
 
+  it("keeps the document success path unchanged when download succeeds", async () => {
+    const getFile = vi.fn().mockResolvedValue({ file_path: "documents/file_42.pdf" });
+    mockPdfFetchAndSave("file_42.pdf");
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        path: "/tmp/file_42---uuid.pdf",
+        placeholder: "<media:document>",
+      }),
+    );
+    expect(result?.unavailableText).toBeUndefined();
+  });
+
   it.each(["voice", "photo", "video"] as const)(
     "returns null for %s when getFile exhausts retries so message is not dropped",
     async (mediaField) => {
@@ -203,6 +218,22 @@ describe("resolveMedia getFile retry", () => {
       expect(result).toBeNull();
     },
   );
+
+  it("returns a document fallback reason when getFile exhausts retries", async () => {
+    const getFile = vi.fn().mockRejectedValue(new Error("Network request for 'getFile' failed!"));
+
+    const promise = resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+    await flushRetryTimers();
+    const result = await promise;
+
+    expect(getFile).toHaveBeenCalledTimes(3);
+    expect(result).toEqual(
+      expect.objectContaining({
+        placeholder: "<media:document>",
+        unavailableText: "Telegram attachment unavailable: download failed",
+      }),
+    );
+  });
 
   it("does not catch errors from fetchRemoteMedia (only getFile is retried)", async () => {
     const getFile = vi.fn().mockResolvedValue({ file_path: "voice/file_0.oga" });
@@ -250,6 +281,20 @@ describe("resolveMedia getFile retry", () => {
       expect(result).toBeNull();
     },
   );
+
+  it("returns a document fallback reason when file is too big", async () => {
+    const getFile = vi.fn().mockRejectedValue(createFileTooBigError());
+
+    const result = await resolveMedia(makeCtx("document", getFile), MAX_MEDIA_BYTES, BOT_TOKEN);
+
+    expect(getFile).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({
+        placeholder: "<media:document>",
+        unavailableText: "Telegram attachment unavailable: file too large for Bot API download",
+      }),
+    );
+  });
 
   it("throws when getFile returns no file_path", async () => {
     const getFile = vi.fn().mockResolvedValue({});

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -15,6 +15,7 @@ import { resolveTelegramMediaPlaceholder } from "./helpers.js";
 import type { StickerMetadata, TelegramContext } from "./types.js";
 
 const FILE_TOO_BIG_RE = /file is too big/i;
+type TelegramMediaUnavailableReason = "download-failed" | "file-too-large";
 const GrammyErrorCtor: typeof GrammyError | undefined =
   typeof GrammyError === "function" ? GrammyError : undefined;
 
@@ -83,11 +84,21 @@ function resolveTelegramFileName(msg: TelegramContext["message"]): string | unde
   );
 }
 
+function buildTelegramDocumentUnavailableText(reason: TelegramMediaUnavailableReason): string {
+  if (reason === "file-too-large") {
+    return "Telegram attachment unavailable: file too large for Bot API download";
+  }
+  return "Telegram attachment unavailable: download failed";
+}
+
 async function resolveTelegramFileWithRetry(
   ctx: TelegramContext,
-): Promise<{ file_path?: string } | null> {
+): Promise<
+  | { file: { file_path?: string }; unavailableReason?: undefined }
+  | { file?: undefined; unavailableReason: TelegramMediaUnavailableReason }
+> {
   try {
-    return await retryAsync(() => ctx.getFile(), {
+    const file = await retryAsync(() => ctx.getFile(), {
       attempts: 3,
       minDelayMs: 1000,
       maxDelayMs: 4000,
@@ -97,6 +108,11 @@ async function resolveTelegramFileWithRetry(
       onRetry: ({ attempt, maxAttempts }) =>
         logVerbose(`telegram: getFile retry ${attempt}/${maxAttempts}`),
     });
+    return file
+      ? { file }
+      : {
+          unavailableReason: "download-failed",
+        };
   } catch (err) {
     // Handle "file is too big" separately - Telegram Bot API has a 20MB download limit
     if (isFileTooBigError(err)) {
@@ -105,12 +121,16 @@ async function resolveTelegramFileWithRetry(
           "telegram: getFile failed - file exceeds Telegram Bot API 20MB limit; skipping attachment",
         ),
       );
-      return null;
+      return {
+        unavailableReason: "file-too-large",
+      };
     }
     // All retries exhausted — return null so the message still reaches the agent
     // with a type-based placeholder (e.g. <media:audio>) instead of being dropped.
     logVerbose(`telegram: getFile failed after retries: ${String(err)}`);
-    return null;
+    return {
+      unavailableReason: "download-failed",
+    };
   }
 }
 
@@ -204,8 +224,8 @@ async function resolveStickerMedia(params: {
   }
 
   try {
-    const file = await resolveTelegramFileWithRetry(ctx);
-    if (!file?.file_path) {
+    const fileResult = await resolveTelegramFileWithRetry(ctx);
+    if (!fileResult.file?.file_path) {
       logVerbose("telegram: getFile returned no file_path for sticker");
       return null;
     }
@@ -215,7 +235,7 @@ async function resolveStickerMedia(params: {
       return null;
     }
     const saved = await downloadAndSaveTelegramFile({
-      filePath: file.file_path,
+      filePath: fileResult.file.file_path,
       token,
       transport: resolvedTransport,
       maxBytes,
@@ -277,10 +297,11 @@ export async function resolveMedia(
   transport?: TelegramTransport,
   apiRoot?: string,
 ): Promise<{
-  path: string;
+  path?: string;
   contentType?: string;
   placeholder: string;
   stickerMetadata?: StickerMetadata;
+  unavailableText?: string;
 } | null> {
   const msg = ctx.message;
   const stickerResolved = await resolveStickerMedia({
@@ -300,10 +321,17 @@ export async function resolveMedia(
     return null;
   }
 
-  const file = await resolveTelegramFileWithRetry(ctx);
-  if (!file) {
+  const fileResult = await resolveTelegramFileWithRetry(ctx);
+  if (!fileResult.file) {
+    if (msg.document) {
+      return {
+        placeholder: resolveTelegramMediaPlaceholder(msg) ?? "<media:document>",
+        unavailableText: buildTelegramDocumentUnavailableText(fileResult.unavailableReason),
+      };
+    }
     return null;
   }
+  const file = fileResult.file;
   if (!file.file_path) {
     throw new Error("Telegram getFile returned no file_path");
   }


### PR DESCRIPTION
## Summary

* Problem: Inbound Telegram document download failures could degrade into a placeholder-only body like `<media:document>` with no explanation.
* Why it matters: This makes attachment failures ambiguous and harder for the agent to interpret, especially for Bot API size-limit cases.
* What changed: Preserve `<media:document>` for failed inbound document downloads and append an explicit reason line for `file too large` vs `download failed`.
* What did NOT change (scope boundary): This PR does not add support for downloading Telegram files over the Bot API size limit and does not change proxy, timeout, SSRF, or unrelated media behavior.

## Change Type (select all)

* [x] Bug fix
* [ ] Feature
* [ ] Refactor required for the fix
* [ ] Docs
* [ ] Security hardening
* [ ] Chore/infra

## Scope (select all touched areas)

* [ ] Gateway / orchestration
* [ ] Skills / tool execution
* [ ] Auth / tokens
* [ ] Memory / storage
* [x] Integrations
* [ ] API / contracts
* [ ] UI / DX
* [ ] CI/CD / infra

## Linked Issue/PR

* Related #55917
* [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

* Root cause: Failed inbound Telegram document downloads could fall back to placeholder-only output without surfacing why the attachment was unavailable.
* Missing detection / guardrail: Existing coverage did not lock in the final rendered body behavior for failed inbound document downloads.
* Prior context (`git blame`, prior PR, issue, or refactor if known): Scoped to the Telegram inbound document fallback path discussed in #55917.
* Why this regressed now: The fallback path preserved message delivery, but not enough user-visible context to explain attachment unavailability.
* If unknown, what was ruled out: Ruled out broader Telegram transport, proxy, timeout, SSRF, and Bot API size-limit behavior changes as part of this fix.

## Regression Test Plan (if applicable)

* Coverage level that should have caught this:

  * [x] Unit test
  * [x] Seam / integration test
  * [ ] End-to-end test
  * [ ] Existing coverage already sufficient
* Target test or file:

  * `extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts`
  * `extensions/telegram/src/bot-message-context.media-fallback.test.ts`
* Scenario the test should lock in:

  * successful document download path remains unchanged
  * failed document download returns an explicit fallback reason
  * file-too-large and generic download failure are distinguished
  * final rendered body keeps `<media:document>` and includes the unavailable reason
  * text + failed document preserves user text, placeholder, and reason
* Why this is the smallest reliable guardrail: The bug spans both resolver behavior and final body rendering, so focused resolver coverage plus one final body-format test is the smallest reliable guardrail.
* Existing test that already covers this (if any): Existing retry coverage covered related resolver behavior, but not final body rendering for failed inbound document downloads.
* If no new test is added, why not: N/A

## User-visible / Behavior Changes

* Failed inbound Telegram document downloads no longer degrade into a silent placeholder-only body.
* Failed inbound documents still preserve `<media:document>`.
* The final message body now includes one explicit reason line:

  * `Telegram attachment unavailable: file too large for Bot API download`
  * `Telegram attachment unavailable: download failed`
* Successful inbound document downloads remain unchanged.

## Diagram (if applicable)

```text
Before:
[inbound Telegram document download fails] -> [body becomes <media:document>] -> [failure reason is unclear]

After:
[inbound Telegram document download fails]
  -> [keep <media:document>]
  -> [append explicit unavailable reason]
  -> [agent sees both document placeholder and failure reason]
```

## Security Impact (required)

* New permissions/capabilities? (`Yes/No`) No
* Secrets/tokens handling changed? (`Yes/No`) No
* New/changed network calls? (`Yes/No`) No
* Command/tool execution surface changed? (`Yes/No`) No
* Data access scope changed? (`Yes/No`) No
* If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

* OS: Windows 10
* Runtime/container: local dev environment
* Model/provider: N/A
* Integration/channel (if any): Telegram extension logic
* Relevant config (redacted): standard local repo/test setup

### Steps

1. Receive an inbound Telegram document message.
2. Hit a document download failure in the existing fallback path.
3. Build the final message body for agent ingestion.

### Expected

* The final body keeps `<media:document>`.
* The final body includes an explicit unavailable reason.
* Successful document downloads remain unchanged.

### Actual

* Before this fix, failed inbound Telegram document downloads could degrade into a placeholder-only body such as `<media:document>` with no explicit reason.

## Evidence

Attach at least one:

* [x] Failing test/log before + passing after
* [ ] Trace/log snippets
* [ ] Screenshot/recording
* [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

* Verified scenarios:

  * Reviewed the final reduced patch and confirmed it stays scoped to Telegram inbound document fallback messaging.
  * Ran focused local tests for resolver behavior and final body rendering.
* Edge cases checked:

  * successful document download path remains unchanged
  * file-too-large fallback reason
  * generic download-failed fallback reason
  * text + failed document preserves user text, placeholder, and reason
* What you did **not** verify:

  * live end-to-end Telegram bot reproduction

## Review Conversations

* [x] I replied to or resolved every bot review conversation I addressed in this PR.
* [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

* Backward compatible? (`Yes/No`) Yes
* Config/env changes? (`Yes/No`) No
* Migration needed? (`Yes/No`) No
* If yes, exact upgrade steps: N/A

## Risks and Mitigations

* Risk: The unavailable-reason plumbing now flows through Telegram message-context handling.

  * Mitigation: The patch is scoped to failed inbound document handling and covered by focused resolver/body tests.
* Risk: Final body formatting could accidentally drop user text or the placeholder.

  * Mitigation: Focused rendered-body coverage locks in both document-only and text + failed document output.

