### PR TITLE
feat: show Created and Last Used timestamps in devices list

### DIFF
--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -7,7 +7,7 @@ import {
   summarizeDeviceTokens,
   type PairedDevice as InfraPairedDevice,
 } from "../infra/device-pairing.js";
-import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
+import { formatRelativeTimestamp, formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { defaultRuntime } from "../runtime.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
@@ -32,6 +32,7 @@ type DeviceTokenSummary = {
   role: string;
   scopes?: string[];
   revokedAtMs?: number;
+  lastUsedAtMs?: number;
 };
 
 type PendingDevice = {
@@ -189,6 +190,19 @@ function selectLatestPendingRequest(pending: PendingDevice[] | undefined) {
   });
 }
 
+function latestTokenUsedAtMs(tokens: DeviceTokenSummary[] | undefined): number | undefined {
+  if (!tokens?.length) {
+    return undefined;
+  }
+  let latest: number | undefined;
+  for (const t of tokens) {
+    if (typeof t.lastUsedAtMs === "number" && (latest == null || t.lastUsedAtMs > latest)) {
+      latest = t.lastUsedAtMs;
+    }
+  }
+  return latest;
+}
+
 function formatTokenSummary(tokens: DeviceTokenSummary[] | undefined) {
   if (!tokens || tokens.length === 0) {
     return "none";
@@ -292,6 +306,8 @@ export function registerDevicesCli(program: Command) {
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },
                 { key: "IP", header: "IP", minWidth: 12 },
+                { key: "Created", header: "Created", minWidth: 10 },
+                { key: "Last Used", header: "Last Used", minWidth: 10 },
               ],
               rows: list.paired.map((device) => ({
                 Device: device.displayName || device.deviceId,
@@ -299,6 +315,11 @@ export function registerDevicesCli(program: Command) {
                 Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
                 Tokens: formatTokenSummary(device.tokens),
                 IP: device.remoteIp ?? "",
+                Created: formatRelativeTimestamp(device.createdAtMs, { dateFallback: true }),
+                "Last Used": formatRelativeTimestamp(latestTokenUsedAtMs(device.tokens), {
+                  dateFallback: true,
+                  fallback: "",
+                }),
               })),
             }).trimEnd(),
           );

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -196,6 +196,9 @@ function latestTokenUsedAtMs(tokens: DeviceTokenSummary[] | undefined): number |
   }
   let latest: number | undefined;
   for (const t of tokens) {
+    if (t.revokedAtMs != null) {
+      continue;
+    }
     if (typeof t.lastUsedAtMs === "number" && (latest == null || t.lastUsedAtMs > latest)) {
       latest = t.lastUsedAtMs;
     }
@@ -315,7 +318,10 @@ export function registerDevicesCli(program: Command) {
                 Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
                 Tokens: formatTokenSummary(device.tokens),
                 IP: device.remoteIp ?? "",
-                Created: formatRelativeTimestamp(device.createdAtMs, { dateFallback: true }),
+                Created: formatRelativeTimestamp(device.createdAtMs, {
+                  dateFallback: true,
+                  fallback: "",
+                }),
                 "Last Used": formatRelativeTimestamp(latestTokenUsedAtMs(device.tokens), {
                   dateFallback: true,
                   fallback: "",


### PR DESCRIPTION
## Summary
- Adds **Created** and **Last Used** columns to the `openclaw devices list` paired table
- Uses `formatRelativeTimestamp` with `dateFallback: true` — recent timestamps show as "5m ago" / "3d ago", older ones as "Mar 5"
- "Last Used" derives the most recent `lastUsedAtMs` across a device's tokens; blank if never used

Makes it easy to spot stale browser sessions without piping through `--json`.

## Test plan
- [ ] Run `openclaw devices list` and verify new columns appear
- [ ] Confirm timestamps display as friendly relative times
- [ ] Verify `--json` output is unchanged
- [ ] Run existing `devices-cli.test.ts` tests