### PR TITLE
ui: fix cron workspace form sticky offset using CSS variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/Cron: keep the workspace form sticky offset aligned with the shell layout variable so the scheduled-job form no longer leaves a stale top gap after the topbar size changes. (#55978) Thanks @yzhong52.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1016,8 +1016,8 @@
 
 .cron-workspace-form {
   position: sticky;
-  top: 74px;
-  max-height: calc(100vh - 74px - 32px);
+  top: 0;
+  max-height: calc(100vh - var(--shell-topbar-height) - 32px);
   overflow-y: auto;
 }
 

--- a/ui/src/styles/components.test.ts
+++ b/ui/src/styles/components.test.ts
@@ -15,3 +15,14 @@ describe("agent fallback chip styles", () => {
     expect(css).toContain(".agent-chip-input .chip-remove:disabled");
   });
 });
+
+describe("cron workspace form styles", () => {
+  it("keeps the sticky form offset tied to the shell layout", () => {
+    const css = readFileSync(path.join(process.cwd(), "ui/src/styles/components.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.cron-workspace-form\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;[^}]*max-height:\s*calc\(100vh - var\(--shell-topbar-height\) - 32px\);/s,
+    );
+    expect(css).not.toContain("max-height: calc(100vh - 74px - 32px);");
+  });
+});

--- a/ui/src/styles/components.test.ts
+++ b/ui/src/styles/components.test.ts
@@ -1,10 +1,22 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+function readComponentsCss() {
+  const candidates = [
+    path.join(process.cwd(), "ui/src/styles/components.css"),
+    path.join(process.cwd(), "src/styles/components.css"),
+  ];
+  const cssPath = candidates.find((candidate) => existsSync(candidate));
+  if (!cssPath) {
+    throw new Error("Unable to find ui/src/styles/components.css");
+  }
+  return readFileSync(cssPath, "utf8");
+}
+
 describe("agent fallback chip styles", () => {
   it("styles the chip remove control inside the agent model input", () => {
-    const css = readFileSync(path.join(process.cwd(), "ui/src/styles/components.css"), "utf8");
+    const css = readComponentsCss();
 
     expect(css).toContain(".agent-chip-input .chip {");
     expect(css).toContain(".agent-chip-input .chip-remove {");
@@ -18,11 +30,14 @@ describe("agent fallback chip styles", () => {
 
 describe("cron workspace form styles", () => {
   it("keeps the sticky form offset tied to the shell layout", () => {
-    const css = readFileSync(path.join(process.cwd(), "ui/src/styles/components.css"), "utf8");
+    const css = readComponentsCss();
+    const rule = css.match(/\.cron-workspace-form\s*\{(?<body>[^}]*)\}/)?.groups?.body;
 
-    expect(css).toMatch(
-      /\.cron-workspace-form\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;[^}]*max-height:\s*calc\(100vh - var\(--shell-topbar-height\) - 32px\);/s,
-    );
+    expect(rule).toBeDefined();
+    expect(rule).toContain("position: sticky;");
+    expect(rule).toContain("top: 0;");
+    expect(rule).toContain("max-height: calc(100vh - var(--shell-topbar-height) - 32px);");
+    expect(rule).not.toContain("top: 74px;");
     expect(css).not.toContain("max-height: calc(100vh - 74px - 32px);");
   });
 });


### PR DESCRIPTION
## Summary

- Problem: On the `/cron` page, scrolling up while the cursor is over the left "Jobs" panel causes the left panel to scroll correctly, but the right "New Job" panel stops scrolling prematurely and leaves a gap at the top. The root cause is a hardcoded `top: 74px` sticky offset that doesn't match the actual topbar height (52px via `--shell-topbar-height`).
- Why it matters: The right panel appears broken during normal use — users see an unexpected gap and cannot scroll the form to the top.
- What changed: Replaced the hardcoded `74px` with `top: 0` and `var(--shell-topbar-height)` in the `max-height` calculation so the sticky positioning tracks the CSS variable used by the shell layout.
- What did NOT change (scope boundary): No logic, behavior, or non-CSS code was touched; only the sticky offset values in `components.css`.

This is how it looks before:

https://github.com/user-attachments/assets/73788d37-9dcd-4e66-a209-a57e1825896e

This is how it looks after:

https://github.com/user-attachments/assets/0ae6d194-ccfd-4e68-97a4-0a16d17f0abd




## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: The sticky offset was hardcoded to `74px` instead of referencing `--shell-topbar-height` (52px), creating a mismatch with the actual shell layout.
- Missing detection / guardrail: No visual regression test covering sticky positioning of the cron workspace form.
- Prior context: The `--shell-topbar-height` CSS variable was already defined in `layout.css` and used throughout the shell grid; this one component was not updated to use it.
- Why this regressed now: Likely the topbar height was changed at some point and `components.css` was not updated in sync.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

N/A — CSS-only layout fix with no logic change; no automated test can reliably cover sticky scroll positioning without a visual regression framework.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): None
- If no new test is added, why not: CSS sticky positioning cannot be reliably asserted with the current test setup (no visual regression / headless scroll tests).

## User-visible / Behavior Changes

The cron workspace form now sticks correctly below the topbar instead of being offset by ~22px too far down.

## Diagram (if applicable)

```text
Before:
[topbar: 52px] -> [~22px gap] -> [sticky form starts at 74px]

After:
[topbar: 52px] -> [sticky form starts at 0px relative to scroll container, max-height uses --shell-topbar-height]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Browser (dev server)
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Open `/cron` in the UI.
2. Position the cursor over the left "Jobs" panel and scroll up.
3. Observe the right "New Job" panel.

### Expected

- The form sticks flush below the topbar.

### Actual (before fix)

- The form was offset ~22px too low due to the hardcoded `74px` value not matching the actual topbar height of 52px.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Opened cron workspace in dev UI; confirmed sticky form aligns correctly below the topbar after the fix.
- Edge cases checked: Scrolled with different content lengths; topbar remains correctly offset.
- What you did **not** verify: Mobile layout (separate `layout.mobile.css` may have a different topbar height).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Mobile layout uses a separate `layout.mobile.css` which may define `--shell-topbar-height` differently — the fix may not fully apply on mobile.
  - Mitigation: The CSS variable is already defined per-breakpoint in `layout.mobile.css`; the fix will automatically use the correct value on mobile as well.
