### PR TITLE
zalo: gate image downloads before DM auth

### DIFF
--- a/extensions/zalo/src/monitor.image.polling.test.ts
+++ b/extensions/zalo/src/monitor.image.polling.test.ts
@@ -8,6 +8,7 @@ import {
   getUpdatesMock,
   getZaloRuntimeMock,
   resetLifecycleTestState,
+  sendMessageMock,
 } from "../../../test/helpers/extensions/zalo-lifecycle.js";
 
 describe("Zalo polling image handling", () => {
@@ -58,6 +59,40 @@ describe("Zalo polling image handling", () => {
       finalizeInboundContextMock,
       recordInboundSessionMock,
     });
+
+    abort.abort();
+    await run;
+  });
+
+  it("rejects unauthorized DM images before downloading media", async () => {
+    getUpdatesMock
+      .mockResolvedValueOnce({
+        ok: true,
+        result: createImageUpdate(),
+      })
+      .mockImplementation(() => new Promise(() => {}));
+
+    const { monitorZaloProvider } = await import("./monitor.js");
+    const abort = new AbortController();
+    const runtime = createRuntimeEnv();
+    const { account, config } = createLifecycleMonitorSetup({
+      accountId: "default",
+      dmPolicy: "pairing",
+      allowFrom: ["allowed-user"],
+    });
+    const run = monitorZaloProvider({
+      token: "zalo-token", // pragma: allowlist secret
+      account,
+      config,
+      runtime,
+      abortSignal: abort.signal,
+    });
+
+    await vi.waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1));
+    expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
+    expect(saveMediaBufferMock).not.toHaveBeenCalled();
+    expect(finalizeInboundContextMock).not.toHaveBeenCalled();
+    expect(recordInboundSessionMock).not.toHaveBeenCalled();
 
     abort.abort();
     await run;

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -93,10 +93,19 @@ type ZaloMessagePipelineParams = ZaloProcessingContext & {
   text?: string;
   mediaPath?: string;
   mediaType?: string;
+  authorization?: ZaloMessageAuthorizationResult;
 };
 type ZaloImageMessageParams = ZaloProcessingContext & {
   message: ZaloMessage;
   mediaMaxMb: number;
+};
+type ZaloMessageAuthorizationResult = {
+  chatId: string;
+  commandAuthorized: boolean | undefined;
+  isGroup: boolean;
+  rawBody: string;
+  senderId: string;
+  senderName: string | undefined;
 };
 
 function formatZaloError(error: unknown): string {
@@ -285,6 +294,15 @@ async function handleTextMessage(
 async function handleImageMessage(params: ZaloImageMessageParams): Promise<void> {
   const { message, mediaMaxMb, account, core, runtime } = params;
   const { photo_url, caption } = message;
+  const authorization = await authorizeZaloMessage({
+    ...params,
+    text: caption,
+    mediaPath: photo_url ? "__pending_media__" : undefined,
+    mediaType: undefined,
+  });
+  if (!authorization) {
+    return;
+  }
 
   let mediaPath: string | undefined;
   let mediaType: string | undefined;
@@ -308,32 +326,24 @@ async function handleImageMessage(params: ZaloImageMessageParams): Promise<void>
 
   await processMessageWithPipeline({
     ...params,
+    authorization,
     text: caption,
     mediaPath,
     mediaType,
   });
 }
 
-async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Promise<void> {
-  const {
-    message,
-    token,
-    account,
-    config,
-    runtime,
-    core,
-    text,
-    mediaPath,
-    mediaType,
-    statusSink,
-    fetcher,
-  } = params;
+async function authorizeZaloMessage(
+  params: ZaloMessagePipelineParams,
+): Promise<ZaloMessageAuthorizationResult | undefined> {
+  const { message, account, config, runtime, core, text, mediaPath, token, statusSink, fetcher } =
+    params;
   const pairing = createChannelPairingController({
     core,
     channel: "zalo",
     accountId: account.accountId,
   });
-  const { from, chat, message_id, date } = message;
+  const { from, chat } = message;
 
   const isGroup = chat.chat_type === "GROUP";
   const chatId = chat.id;
@@ -435,6 +445,44 @@ async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Pr
     }
     return;
   }
+
+  return {
+    chatId,
+    commandAuthorized,
+    isGroup,
+    rawBody,
+    senderId,
+    senderName,
+  };
+}
+
+async function processMessageWithPipeline(params: ZaloMessagePipelineParams): Promise<void> {
+  const {
+    message,
+    token,
+    account,
+    config,
+    runtime,
+    core,
+    text,
+    mediaPath,
+    mediaType,
+    statusSink,
+    fetcher,
+    authorization: authorizationOverride,
+  } = params;
+  const { message_id, date } = message;
+  const authorization =
+    authorizationOverride ??
+    (await authorizeZaloMessage({
+      ...params,
+      mediaPath,
+      mediaType,
+    }));
+  if (!authorization) {
+    return;
+  }
+  const { isGroup, chatId, senderId, senderName, rawBody, commandAuthorized } = authorization;
 
   const { route, buildEnvelope } = resolveInboundRouteEnvelopeBuilderWithRuntime({
     cfg: config,

--- a/extensions/zalo/src/monitor.ts
+++ b/extensions/zalo/src/monitor.ts
@@ -297,6 +297,7 @@ async function handleImageMessage(params: ZaloImageMessageParams): Promise<void>
   const authorization = await authorizeZaloMessage({
     ...params,
     text: caption,
+    // Use a sentinel so auth sees this as an inbound image before the download happens.
     mediaPath: photo_url ? "__pending_media__" : undefined,
     mediaType: undefined,
   });


### PR DESCRIPTION
## Summary
- gates Zalo image handling through the existing DM/group authorization path before any media download starts
- reuses the same authorization result inside the inbound pipeline so authorized behavior stays aligned

## Changes
- extracts the Zalo authorization logic in `extensions/zalo/src/monitor.ts` into a reusable helper
- checks image-message authorization before calling `fetchRemoteMedia()` or `saveMediaBuffer()`
- adds a regression test covering an unauthorized DM image that now gets a pairing reply without downloading media

## Validation
- Ran `pnpm test -- extensions/zalo/src/monitor.image.polling.test.ts`
- Verified unauthorized DM image handling does not call `fetchRemoteMedia()` or `saveMediaBuffer()` before rejection
- Ran local agentic review via `claude -p "/review"`; it did not return actionable code feedback in this checkout and instead asked for a PR number

## Notes
- `pnpm build` currently fails on the current `origin/main` baseline in unrelated files: `src/agents/compaction.ts` and `src/agents/pi-extensions/compaction-safeguard.ts`
