### PR TITLE
fix(discord): update carbon beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Docs: https://docs.openclaw.ai
 - Agents/model switching: apply `/model` changes to active embedded runs at the next safe retry boundary, so overloaded or retrying turns switch to the newly selected model instead of staying pinned to the old provider.
 - Agents/Codex fallback: classify Codex `server_error` payloads as failoverable, sanitize `Codex error:` payloads before they reach chat, preserve context-overflow guidance for prefixed `invalid_request_error` payloads, and omit provider `request_id` values from user-facing UI copy. (#42892) Thanks @xaeon2026.
 - Memory/search: share memory embedding provider registrations across split plugin runtimes so memory search no longer fails with unknown provider errors after memory-core registers built-in adapters. (#55945) Thanks @glitch418x.
+- Discord/Carbon beta: update `@buape/carbon` to the latest beta and pass the new `RateLimitError` request argument so Discord stays compatible with the upstream beta constructor change. (#55980) Thanks @ngutman.
 
 ## 2026.3.24
 

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
   "dependencies": {
-    "@buape/carbon": "0.0.0-beta-20260317045421",
+    "@buape/carbon": "0.0.0-beta-20260327000044",
     "@discordjs/voice": "^0.19.2",
     "discord-api-types": "^0.38.42",
     "https-proxy-agent": "^8.0.0",

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -636,6 +636,9 @@ describe("monitorDiscordProvider", () => {
         retry_after: 193.632,
         global: false,
       },
+      new Request("https://discord.com/api/v10/applications/app-id/commands", {
+        method: "POST",
+      }),
     );
     rateLimitError.discordCode = 30034;
     clientHandleDeployRequestMock.mockRejectedValueOnce(rateLimitError);

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -420,11 +420,17 @@ function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
       "X-RateLimit-Bucket": "test-bucket",
     },
   });
-  return new RateLimitError(response, {
-    message: "You are being rate limited.",
-    retry_after: retryAfter,
-    global: false,
-  });
+  return new RateLimitError(
+    response,
+    {
+      message: "You are being rate limited.",
+      retry_after: retryAfter,
+      global: false,
+    },
+    new Request("https://discord.com/api/v10/channels/channel-id/messages", {
+      method: "POST",
+    }),
+  );
 }
 
 describe("retry rate limits", () => {

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -265,7 +265,7 @@ export async function sendDiscordVoiceMessage(
   }
   const uploadUrlResponse = await request(async () => {
     const url = `${rest.options?.baseUrl ?? "https://discord.com/api"}/channels/${channelId}/attachments`;
-    const res = await fetch(url, {
+    const uploadUrlRequest = new Request(url, {
       method: "POST",
       headers: {
         Authorization: `Bot ${botToken}`,
@@ -275,6 +275,7 @@ export async function sendDiscordVoiceMessage(
         files: [{ filename, file_size: fileSize, id: "0" }],
       }),
     });
+    const res = await fetch(uploadUrlRequest);
     if (!res.ok) {
       if (res.status === 429) {
         const retryData = (await res.json().catch(() => ({}))) as {
@@ -282,11 +283,15 @@ export async function sendDiscordVoiceMessage(
           retry_after?: number;
           global?: boolean;
         };
-        throw new RateLimitError(res, {
-          message: retryData.message ?? "You are being rate limited.",
-          retry_after: retryData.retry_after ?? 1,
-          global: retryData.global ?? false,
-        });
+        throw new RateLimitError(
+          res,
+          {
+            message: retryData.message ?? "You are being rate limited.",
+            retry_after: retryData.retry_after ?? 1,
+            global: retryData.global ?? false,
+          },
+          uploadUrlRequest,
+        );
       }
       const errorBody = (await res.json().catch(() => null)) as {
         code?: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,8 +322,8 @@ importers:
   extensions/discord:
     dependencies:
       '@buape/carbon':
-        specifier: 0.0.0-beta-20260317045421
-        version: 0.0.0-beta-20260317045421(@discordjs/opus@0.10.0)(hono@4.12.9)(opusscript@0.1.1)
+        specifier: 0.0.0-beta-20260327000044
+        version: 0.0.0-beta-20260327000044(@discordjs/opus@0.10.0)(hono@4.12.9)(opusscript@0.1.1)
       '@discordjs/voice':
         specifier: ^0.19.2
         version: 0.19.2(@discordjs/opus@0.10.0)(opusscript@0.1.1)
@@ -1019,8 +1019,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@buape/carbon@0.0.0-beta-20260317045421':
-    resolution: {integrity: sha512-yM+r5iSxA/iG8CZ2VhK+EkcBQV+y45WLgF7kuczt2Ul1yixjXSCCcM80GppsklfUv7pqM4Dui+7w1WB3f5p7Kg==}
+  '@buape/carbon@0.0.0-beta-20260327000044':
+    resolution: {integrity: sha512-jaGrh83aOFuCaRlN6bgYZqiY/srOwP28XBPBcaonW2qjzQl/Or5KWCkqE36AWpzPdy26PDhIeBdmHMAGc7xLzg==}
 
   '@cacheable/memory@2.0.7':
     resolution: {integrity: sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==}
@@ -7433,7 +7433,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@buape/carbon@0.0.0-beta-20260317045421(@discordjs/opus@0.10.0)(hono@4.12.9)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260327000044(@discordjs/opus@0.10.0)(hono@4.12.9)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.5.0
       discord-api-types: 0.38.37


### PR DESCRIPTION
## Summary

- Problem: `@buape/carbon@beta` moved to `0.0.0-beta-20260327000044`, but OpenClaw's Discord plugin still pinned the older beta and its `RateLimitError` call sites no longer matched the updated constructor.
- Why it matters: bumping Discord's Carbon dependency to the latest beta fails `pnpm build` unless the new request argument is supplied.
- What changed: updated `extensions/discord` to the latest Carbon beta, refreshed `pnpm-lock.yaml`, and passed a real `Request` into the voice upload path and the affected rate-limit tests.
- What did NOT change (scope boundary): no Discord feature behavior or config surface changes were intended beyond compatibility with the new Carbon beta.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: Carbon's new beta changed `RateLimitError` to require a third `Request` constructor argument, but OpenClaw still instantiated it with two arguments in the Discord voice upload path and tests.
- Missing detection / guardrail: the incompatibility was caught by the TypeScript build after the dependency bump.
- Prior context (`git blame`, prior PR, issue, or refactor if known): N/A
- Why this regressed now: the repo was pinned to an older Carbon beta, so the constructor signature change was not exercised until this update.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/send.creates-thread.test.ts`, `extensions/discord/src/monitor/provider.test.ts`, and `extensions/discord/src/voice-message.test.ts`
- Scenario the test should lock in: Discord rate-limit handling should continue constructing Carbon `RateLimitError` instances with the updated request metadata, including the manual voice attachment upload path.
- Why this is the smallest reliable guardrail: these tests already cover the affected Discord integration seams and directly exercise the call sites that needed the new constructor argument.
- Existing test that already covers this (if any): the targeted Discord tests above.
- If no new test is added, why not: existing targeted tests were sufficient once updated for the new constructor contract.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin 25.3.0
- Runtime/container: Node v24.14.0, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. Update `extensions/discord` from `@buape/carbon@0.0.0-beta-20260317045421` to `@buape/carbon@beta`.
2. Run `pnpm build`.
3. Run `pnpm test -- extensions/discord/src/voice-message.test.ts extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/monitor/provider.test.ts`.

### Expected

- The Discord plugin builds and the targeted Discord tests pass against the latest Carbon beta.

### Actual

- Before the compatibility fix, `pnpm build` failed with `extensions/discord/src/voice-message.ts(285,15): error TS2554: Expected 3 arguments, but got 2.`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm build`; `pnpm test -- extensions/discord/src/voice-message.test.ts extensions/discord/src/send.creates-thread.test.ts extensions/discord/src/monitor/provider.test.ts`
- Edge cases checked: manual voice upload rate-limit construction and Discord rate-limit test helpers now provide request metadata expected by the latest Carbon beta.
- What you did **not** verify: live Discord traffic against a real bot token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Carbon beta may contain other upstream changes outside the constructor update.
  - Mitigation: kept the code change scoped to the known type break and ran the targeted Discord test coverage plus a full build.
