### PR TITLE
fix(outbound): fall back to pinned channel-surface registry in registry loader

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+
+describe("createChannelRegistryLoader", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("resolves value from the active registry", async () => {
+    const registry = createEmptyPluginRegistry();
+    const outbound = { sendText: async () => ({}) };
+    registry.channels = [
+      { plugin: { id: "discord", outbound } } as never,
+    ];
+    setActivePluginRegistry(registry);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBe(outbound);
+  });
+
+  it("returns undefined when channel is not in any registry", async () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBeUndefined();
+  });
+
+  it("falls back to pinned channel-surface registry when active registry lacks the channel", async () => {
+    // Simulate gateway startup: plugins loaded with Discord, channel surface pinned.
+    const startup = createEmptyPluginRegistry();
+    const outbound = { sendText: async () => ({}) };
+    startup.channels = [
+      { plugin: { id: "discord", outbound } } as never,
+    ];
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    // Simulate a non-primary plugin reload (config-schema read, provider
+    // snapshot) that replaces the active registry with a minimal one that
+    // does NOT include channel plugins.
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(replacement);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBe(outbound);
+  });
+
+  it("does not fall back when channel surface is the same as active registry", async () => {
+    // Both registries are the same object — no channel in it.
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBeUndefined();
+  });
+
+  it("invalidates cache when pinned channel registry is released", async () => {
+    // 1. Pinned startup has discord; active replacement does not.
+    const startup = createEmptyPluginRegistry();
+    const outbound = { sendText: async () => ({}) };
+    startup.channels = [{ plugin: { id: "discord", outbound } } as never];
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(replacement);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    // Resolved from pinned surface and cached.
+    expect(await loader("discord")).toBe(outbound);
+
+    // 2. Release pin — channel surface falls back to active (no discord).
+    releasePinnedPluginChannelRegistry(startup);
+
+    // Cache should be invalidated by the channel-version bump even though
+    // the active registry pointer did not change.
+    expect(await loader("discord")).toBeUndefined();
+  });
+
+  it("clears cache when active registry changes", async () => {
+    const first = createEmptyPluginRegistry();
+    const outbound1 = { sendText: async () => ({ v: 1 }) };
+    first.channels = [{ plugin: { id: "discord", outbound: outbound1 } } as never];
+    setActivePluginRegistry(first);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    expect(await loader("discord")).toBe(outbound1);
+
+    // Swap registry — cache should invalidate.
+    const second = createEmptyPluginRegistry();
+    const outbound2 = { sendText: async () => ({ v: 2 }) };
+    second.channels = [{ plugin: { id: "discord", outbound: outbound2 } } as never];
+    setActivePluginRegistry(second);
+
+    expect(await loader("discord")).toBe(outbound2);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,9 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  getActivePluginChannelRegistry,
+  getActivePluginChannelRegistryVersion,
+  getActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -11,25 +15,49 @@ export function createChannelRegistryLoader<TValue>(
 ): (id: ChannelId) => Promise<TValue | undefined> {
   const cache = new Map<ChannelId, TValue>();
   let lastRegistry: PluginRegistry | null = null;
+  let lastChannelVersion = -1;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
     const registry = getActivePluginRegistry();
-    if (registry !== lastRegistry) {
+    const channelVersion = getActivePluginChannelRegistryVersion();
+    if (registry !== lastRegistry || channelVersion !== lastChannelVersion) {
       cache.clear();
       lastRegistry = registry;
+      lastChannelVersion = channelVersion;
     }
     const cached = cache.get(id);
     if (cached) {
       return cached;
     }
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-    if (!pluginEntry) {
+    // Fall back to the channel-surface registry when the active registry does
+    // not contain the requested channel.  The channel surface is pinned at
+    // gateway startup and is immune to later non-primary plugin reloads (e.g.
+    // config-schema reads, provider snapshots) that can replace the active
+    // registry with a minimal set that omits channel plugins.  This mirrors
+    // what `getChannelPlugin` already does via `requireActivePluginChannelRegistry`.
+    // See: https://github.com/openclaw/openclaw/issues/12769
+    const effectiveEntry =
+      pluginEntry ?? resolveFromChannelSurface(id, registry);
+    if (!effectiveEntry) {
       return undefined;
     }
-    const resolved = resolveValue(pluginEntry);
+    const resolved = resolveValue(effectiveEntry);
     if (resolved) {
       cache.set(id, resolved);
     }
     return resolved;
   };
+}
+
+function resolveFromChannelSurface(
+  id: ChannelId,
+  activeRegistry: PluginRegistry | null,
+): PluginChannelRegistration | undefined {
+  const channelRegistry = getActivePluginChannelRegistry();
+  // Only fall back when the channel surface is a different (pinned) registry.
+  if (!channelRegistry || channelRegistry === activeRegistry) {
+    return undefined;
+  }
+  return channelRegistry.channels.find((entry) => entry.plugin.id === id);
 }


### PR DESCRIPTION
## Problem

Isolated cron job delivery and subagent announce-back intermittently fail with:

- `Outbound not configured for channel: discord`
- `Unsupported channel: discord`

This happens when a non-primary plugin reload (config-schema read, provider snapshot, etc.) replaces the active plugin registry with a minimal set that omits channel plugins. The outbound registry loader (`createChannelRegistryLoader`) only checks the active registry, missing the channel that was fully loaded at gateway startup.

## Root Cause

The channel-surface registry is pinned at gateway startup via `pinActivePluginChannelRegistry()` and is immune to subsequent registry swaps. However, `createChannelRegistryLoader` (used by `loadChannelOutboundAdapter`) only reads from `getActivePluginRegistry()` — not the pinned channel surface.

This means `getChannelPlugin("discord")` (which uses `requireActivePluginChannelRegistry()`) succeeds, but `loadChannelOutboundAdapter("discord")` fails — they see different registries.

Two prior fixes attempted to address this:
- `fa6ff39` — added `resolveDirectFromActiveRegistry` fallback
- `0c2ae71` — added `resolveOutboundChannelPlugin` call before `loadChannelOutboundAdapter`

Both fixes resolve the plugin from the active registry — which is exactly the registry that gets swapped out. Neither falls back to the pinned channel surface.

## Fix

Add a fallback in `createChannelRegistryLoader` to check the channel-surface registry when the active registry does not contain the requested channel. This mirrors what `getChannelPlugin` already does via `requireActivePluginChannelRegistry`.

The fallback only activates when the channel-surface registry is a different (pinned) object from the active registry, avoiding unnecessary lookups in the common case.

## Testing

- 5 new unit tests covering: normal resolution, missing channel, pinned fallback, same-registry no-fallback, and cache invalidation
- All existing `runtime.channel-pin`, `channel-resolution`, and `outbound` tests pass

Fixes #12769
Refs #14266, #55551, #54745