### PR TITLE
fix: repair CI regressions on main

### DIFF
--- a/extensions/browser/src/browser/control-service.plugin-disabled.test.ts
+++ b/extensions/browser/src/browser/control-service.plugin-disabled.test.ts
@@ -3,34 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   ensureBrowserControlAuth: vi.fn(async () => ({ generatedToken: false })),
   createBrowserRuntimeState: vi.fn(async () => ({ ok: true })),
-  loadConfig: vi.fn(() => ({
-    browser: {
-      enabled: true,
-    },
-    plugins: {
-      entries: {
-        browser: {
-          enabled: false,
-        },
-      },
-    },
-  })),
-}));
-
-vi.mock("openclaw/plugin-sdk/browser-support", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/browser-support")>();
-  return {
-    ...actual,
-    loadConfig: mocks.loadConfig,
-  };
-});
-
-vi.mock("./config.js", () => ({
-  resolveBrowserConfig: vi.fn(() => ({
-    enabled: true,
-    controlPort: 18791,
-    profiles: { openclaw: { cdpPort: 18800 } },
-  })),
+  isDefaultBrowserPluginEnabled: vi.fn(() => false),
 }));
 
 vi.mock("./control-auth.js", () => ({
@@ -44,11 +17,15 @@ vi.mock("./runtime-lifecycle.js", () => ({
 
 let startBrowserControlServiceFromConfig: typeof import("../control-service.js").startBrowserControlServiceFromConfig;
 
+vi.mock("../plugin-enabled.js", () => ({
+  isDefaultBrowserPluginEnabled: mocks.isDefaultBrowserPluginEnabled,
+}));
+
 describe("startBrowserControlServiceFromConfig", () => {
   beforeEach(async () => {
     mocks.ensureBrowserControlAuth.mockClear();
     mocks.createBrowserRuntimeState.mockClear();
-    mocks.loadConfig.mockClear();
+    mocks.isDefaultBrowserPluginEnabled.mockClear();
     vi.resetModules();
     ({ startBrowserControlServiceFromConfig } = await import("../control-service.js"));
   });

--- a/extensions/browser/src/browser/resolved-config-refresh.ts
+++ b/extensions/browser/src/browser/resolved-config-refresh.ts
@@ -1,4 +1,4 @@
-import { createConfigIO, getRuntimeConfigSnapshot } from "../config/config.js";
+import * as browserConfigRuntime from "../config/config.js";
 import { resolveBrowserConfig, resolveProfile, type ResolvedBrowserProfile } from "./config.js";
 import type { BrowserServerState } from "./server-context.types.js";
 
@@ -73,10 +73,14 @@ export function refreshResolvedBrowserConfigFromDisk(params: {
     return;
   }
 
-  // Route-level browser config hot reload should observe on-disk changes immediately.
-  // The shared loadConfig() helper may return a cached snapshot for the configured TTL,
-  // which can leave request-time browser guards stale (for example evaluateEnabled).
-  const cfg = getRuntimeConfigSnapshot() ?? createConfigIO().loadConfig();
+  const cfg =
+    params.mode === "fresh"
+      ? // Fresh mode bypasses the shared cached snapshot so request-time profile
+        // lookups can observe new on-disk profiles without mutating global cache state.
+        browserConfigRuntime.createConfigIO().loadConfig()
+      : // Cached mode preserves the normal runtime snapshot semantics and only falls back
+        // to the shared config loader when no snapshot has been primed yet.
+        (browserConfigRuntime.getRuntimeConfigSnapshot() ?? browserConfigRuntime.loadConfig());
   const freshResolved = resolveBrowserConfig(cfg.browser, cfg);
   applyResolvedConfig(params.current, freshResolved);
 }

--- a/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
@@ -18,8 +18,8 @@ function buildConfig() {
   };
 }
 
-vi.mock("../config/config.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../config/config.js")>();
+vi.mock("openclaw/plugin-sdk/config-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/config-runtime")>();
   return {
     ...actual,
     createConfigIO: () => ({

--- a/extensions/browser/src/config/config.ts
+++ b/extensions/browser/src/config/config.ts
@@ -1,1 +1,18 @@
-export * from "openclaw/plugin-sdk/browser-support";
+import {
+  createConfigIO as createConfigIORuntime,
+  getRuntimeConfigSnapshot as getRuntimeConfigSnapshotRuntime,
+  loadConfig as loadConfigRuntime,
+  readConfigFileSnapshotForWrite as readConfigFileSnapshotForWriteRuntime,
+  writeConfigFile as writeConfigFileRuntime,
+} from "openclaw/plugin-sdk/config-runtime";
+
+export const createConfigIO = createConfigIORuntime;
+export const getRuntimeConfigSnapshot = getRuntimeConfigSnapshotRuntime;
+export const loadConfig = loadConfigRuntime;
+export const readConfigFileSnapshotForWrite = readConfigFileSnapshotForWriteRuntime;
+export const writeConfigFile = writeConfigFileRuntime;
+export type {
+  BrowserConfig,
+  BrowserProfileConfig,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";

--- a/extensions/browser/src/control-service.ts
+++ b/extensions/browser/src/control-service.ts
@@ -1,8 +1,9 @@
-import { createSubsystemLogger, loadConfig } from "openclaw/plugin-sdk/browser-support";
 import { resolveBrowserConfig } from "./browser/config.js";
 import { ensureBrowserControlAuth } from "./browser/control-auth.js";
 import { createBrowserRuntimeState, stopBrowserRuntime } from "./browser/runtime-lifecycle.js";
 import { type BrowserServerState, createBrowserRouteContext } from "./browser/server-context.js";
+import { loadConfig } from "./config/config.js";
+import { createSubsystemLogger } from "./logging/subsystem.js";
 import { isDefaultBrowserPluginEnabled } from "./plugin-enabled.js";
 
 let state: BrowserServerState | null = null;

--- a/extensions/browser/src/infra/tmp-openclaw-dir.ts
+++ b/extensions/browser/src/infra/tmp-openclaw-dir.ts
@@ -1,1 +1,1 @@
-export * from "openclaw/plugin-sdk/browser-support";
+export * from "openclaw/plugin-sdk/temp-path";

--- a/extensions/browser/src/logging/subsystem.ts
+++ b/extensions/browser/src/logging/subsystem.ts
@@ -1,1 +1,1 @@
-export * from "openclaw/plugin-sdk/browser-support";
+export * from "openclaw/plugin-sdk/runtime-env";

--- a/extensions/browser/src/server.ts
+++ b/extensions/browser/src/server.ts
@@ -1,6 +1,5 @@
 import type { Server } from "node:http";
 import express from "express";
-import { createSubsystemLogger, loadConfig } from "openclaw/plugin-sdk/browser-support";
 import { resolveBrowserConfig } from "./browser/config.js";
 import { ensureBrowserControlAuth, resolveBrowserControlAuth } from "./browser/control-auth.js";
 import { registerBrowserRoutes } from "./browser/routes/index.js";
@@ -11,6 +10,8 @@ import {
   installBrowserAuthMiddleware,
   installBrowserCommonMiddleware,
 } from "./browser/server-middleware.js";
+import { loadConfig } from "./config/config.js";
+import { createSubsystemLogger } from "./logging/subsystem.js";
 import { isDefaultBrowserPluginEnabled } from "./plugin-enabled.js";
 
 let state: BrowserServerState | null = null;

--- a/extensions/feishu/runtime-api.ts
+++ b/extensions/feishu/runtime-api.ts
@@ -1,25 +1,60 @@
 // Private runtime barrel for the bundled Feishu extension.
-// Keep this barrel thin and aligned with the local extension surface.
+// Keep named exports explicit so Jiti can preserve this surface when tests
+// partially load bundled channel config/runtime modules.
 
 export type {
+  AllowlistMatch,
+  AnyAgentTool,
+  BaseProbeResult,
+  ChannelGroupContext,
   ChannelMessageActionName,
   ChannelMeta,
   ChannelOutboundAdapter,
-  OpenClawConfig as ClawdbotConfig,
+  ChannelPlugin,
+  ClawdbotConfig,
+  GroupToolPolicyConfig,
+  HistoryEntry,
   OpenClawConfig,
   OpenClawPluginApi,
+  OutboundIdentity,
   PluginRuntime,
+  ReplyPayload,
   RuntimeEnv,
 } from "openclaw/plugin-sdk/feishu";
 export {
   DEFAULT_ACCOUNT_ID,
+  DEFAULT_GROUP_HISTORY_LIMIT,
   PAIRING_APPROVED_MESSAGE,
+  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+  applyBasicWebhookRequestGuards,
+  buildAgentMediaPayload,
   buildChannelConfigSchema,
+  buildPendingHistoryContextFromMap,
   buildProbeChannelStatusSummary,
+  clearHistoryEntriesIfEnabled,
   createActionGate,
+  createChannelPairingController,
+  createChannelReplyPipeline,
+  createDedupeCache,
   createDefaultChannelRuntimeState,
+  createFixedWindowRateLimiter,
+  createPersistentDedupe,
+  createReplyPrefixContext,
+  createWebhookAnomalyTracker,
+  evaluateSenderGroupAccessForPolicy,
+  fetchWithSsrFGuard,
+  installRequestBodyLimitGuard,
+  logTypingFailure,
+  normalizeAgentId,
+  readJsonFileWithFallback,
+  recordPendingHistoryEntryIfEnabled,
+  resolveAgentOutboundIdentity,
+  resolveDefaultGroupPolicy,
+  resolveOpenProviderRuntimeGroupPolicy,
+  warnMissingProviderGroupPolicyFallbackOnce,
+  withTempDownloadPath,
 } from "openclaw/plugin-sdk/feishu";
-export * from "openclaw/plugin-sdk/feishu";
 export {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,

--- a/extensions/feishu/src/directory.test.ts
+++ b/extensions/feishu/src/directory.test.ts
@@ -1,12 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
 
-const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
-
-vi.mock("./accounts.js", () => ({
-  resolveFeishuAccount: resolveFeishuAccountMock,
-}));
 
 vi.mock("./client.js", () => ({
   createFeishuClient: createFeishuClientMock,
@@ -20,27 +15,50 @@ import {
 } from "./directory.js";
 
 describe("feishu directory (config-backed)", () => {
-  const cfg = {} as ClawdbotConfig;
-
-  function makeStaticAccount() {
+  function createStaticConfig(): ClawdbotConfig {
     return {
-      configured: false,
-      config: {
-        allowFrom: ["user:alice", "user:bob"],
-        dms: {
-          "user:carla": {},
+      channels: {
+        feishu: {
+          enabled: true,
+          allowFrom: ["user:alice", "user:bob"],
+          dms: {
+            "user:carla": {},
+          },
+          groups: {
+            "chat-1": {},
+          },
+          groupAllowFrom: ["chat-2"],
         },
-        groups: {
-          "chat-1": {},
-        },
-        groupAllowFrom: ["chat-2"],
       },
-    };
+    } as ClawdbotConfig;
   }
 
-  resolveFeishuAccountMock.mockImplementation(() => makeStaticAccount());
+  function createLiveConfig(): ClawdbotConfig {
+    return {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "app-id",
+          appSecret: "app-secret",
+          allowFrom: ["user:alice", "user:bob"],
+          dms: {
+            "user:carla": {},
+          },
+          groups: {
+            "chat-1": {},
+          },
+          groupAllowFrom: ["chat-2"],
+        },
+      },
+    } as ClawdbotConfig;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("merges allowFrom + dms into peer entries", async () => {
+    const cfg = createStaticConfig();
     const peers = await listFeishuDirectoryPeers({ cfg, query: "a" });
     expect(peers).toEqual([
       { kind: "user", id: "alice" },
@@ -49,17 +67,19 @@ describe("feishu directory (config-backed)", () => {
   });
 
   it("normalizes spaced provider-prefixed peer entries", async () => {
-    resolveFeishuAccountMock.mockReturnValueOnce({
-      configured: false,
-      config: {
-        allowFrom: [" feishu:user:ou_alice "],
-        dms: {
-          " lark:dm:ou_carla ": {},
+    const cfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          allowFrom: [" feishu:user:ou_alice "],
+          dms: {
+            " lark:dm:ou_carla ": {},
+          },
+          groups: {},
+          groupAllowFrom: [],
         },
-        groups: {},
-        groupAllowFrom: [],
       },
-    });
+    } as ClawdbotConfig;
 
     const peers = await listFeishuDirectoryPeers({ cfg });
     expect(peers).toEqual([
@@ -69,6 +89,7 @@ describe("feishu directory (config-backed)", () => {
   });
 
   it("merges groups map + groupAllowFrom into group entries", async () => {
+    const cfg = createStaticConfig();
     const groups = await listFeishuDirectoryGroups({ cfg });
     expect(groups).toEqual([
       { kind: "group", id: "chat-1" },
@@ -77,10 +98,7 @@ describe("feishu directory (config-backed)", () => {
   });
 
   it("falls back to static peers on live lookup failure by default", async () => {
-    resolveFeishuAccountMock.mockReturnValueOnce({
-      ...makeStaticAccount(),
-      configured: true,
-    });
+    const cfg = createLiveConfig();
     createFeishuClientMock.mockReturnValueOnce({
       contact: {
         user: {
@@ -99,10 +117,7 @@ describe("feishu directory (config-backed)", () => {
   });
 
   it("surfaces live peer lookup failures when fallback is disabled", async () => {
-    resolveFeishuAccountMock.mockReturnValueOnce({
-      ...makeStaticAccount(),
-      configured: true,
-    });
+    const cfg = createLiveConfig();
     createFeishuClientMock.mockReturnValueOnce({
       contact: {
         user: {
@@ -119,10 +134,7 @@ describe("feishu directory (config-backed)", () => {
   });
 
   it("surfaces live group lookup failures when fallback is disabled", async () => {
-    resolveFeishuAccountMock.mockReturnValueOnce({
-      ...makeStaticAccount(),
-      configured: true,
-    });
+    const cfg = createLiveConfig();
     createFeishuClientMock.mockReturnValueOnce({
       im: {
         chat: {

--- a/extensions/feishu/src/docx.account-selection.test.ts
+++ b/extensions/feishu/src/docx.account-selection.test.ts
@@ -1,17 +1,17 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { registerFeishuDocTools } from "./docx.js";
+import { __testing as feishuDocTesting, registerFeishuDocTools } from "./docx.js";
+import { resolveFeishuToolAccount } from "./tool-account.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
-const createFeishuClientMock = vi.fn((creds: { appId?: string } | undefined) => ({
+const createFeishuToolClientMock = vi.fn((creds: { appId?: string } | undefined) => ({
   __appId: creds?.appId,
+  docx: {
+    documentBlock: {
+      list: vi.fn(async () => ({ code: 0, data: { items: [] } })),
+    },
+  },
 }));
-
-vi.mock("./client.js", () => {
-  return {
-    createFeishuClient: (creds: { appId?: string } | undefined) => createFeishuClientMock(creds),
-  };
-});
 
 // Patch SDK import so tool execution can run without network concerns.
 vi.mock("@larksuiteoapi/node-sdk", () => {
@@ -21,6 +21,20 @@ vi.mock("@larksuiteoapi/node-sdk", () => {
 });
 
 describe("feishu_doc account selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    feishuDocTesting.setDepsForTest({
+      createFeishuToolClient: ({ api, executeParams, defaultAccountId }) =>
+        createFeishuToolClientMock(
+          resolveFeishuToolAccount({ api, executeParams, defaultAccountId }),
+        ) as never,
+    });
+  });
+
+  afterEach(() => {
+    feishuDocTesting.setDepsForTest(null);
+  });
+
   function createDocEnabledConfig(): OpenClawPluginApi["config"] {
     return {
       channels: {
@@ -47,9 +61,9 @@ describe("feishu_doc account selection", () => {
     await docToolA.execute("call-a", { action: "list_blocks", doc_token: "d" });
     await docToolB.execute("call-b", { action: "list_blocks", doc_token: "d" });
 
-    expect(createFeishuClientMock).toHaveBeenCalledTimes(2);
-    expect(createFeishuClientMock.mock.calls[0]?.[0]?.appId).toBe("app-a");
-    expect(createFeishuClientMock.mock.calls[1]?.[0]?.appId).toBe("app-b");
+    expect(createFeishuToolClientMock).toHaveBeenCalledTimes(2);
+    expect(createFeishuToolClientMock.mock.calls[0]?.[0]?.appId).toBe("app-a");
+    expect(createFeishuToolClientMock.mock.calls[1]?.[0]?.appId).toBe("app-b");
   });
 
   test("explicit accountId param overrides agentAccountId context", async () => {
@@ -65,6 +79,6 @@ describe("feishu_doc account selection", () => {
       accountId: "a",
     });
 
-    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
+    expect(createFeishuToolClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
   });
 });

--- a/extensions/feishu/src/docx.account-selection.test.ts
+++ b/extensions/feishu/src/docx.account-selection.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { __testing as feishuDocTesting, registerFeishuDocTools } from "./docx.js";
+import { registerFeishuDocTools } from "./docx.js";
+import { setFeishuDocDepsForTest } from "./docx.test-helpers.js";
 import { resolveFeishuToolAccount } from "./tool-account.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
@@ -23,7 +24,7 @@ vi.mock("@larksuiteoapi/node-sdk", () => {
 describe("feishu_doc account selection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    feishuDocTesting.setDepsForTest({
+    setFeishuDocDepsForTest({
       createFeishuToolClient: ({ api, executeParams, defaultAccountId }) =>
         createFeishuToolClientMock(
           resolveFeishuToolAccount({ api, executeParams, defaultAccountId }),
@@ -32,7 +33,7 @@ describe("feishu_doc account selection", () => {
   });
 
   afterEach(() => {
-    feishuDocTesting.setDepsForTest(null);
+    setFeishuDocDepsForTest(null);
   });
 
   function createDocEnabledConfig(): OpenClawPluginApi["config"] {

--- a/extensions/feishu/src/docx.deps.ts
+++ b/extensions/feishu/src/docx.deps.ts
@@ -1,0 +1,30 @@
+import { getFeishuRuntime } from "./runtime.js";
+import {
+  createFeishuToolClient,
+  resolveAnyEnabledFeishuToolsConfig,
+  resolveFeishuToolAccount,
+} from "./tool-account.js";
+
+export type FeishuDocDeps = {
+  getFeishuRuntime: typeof getFeishuRuntime;
+  createFeishuToolClient: typeof createFeishuToolClient;
+  resolveAnyEnabledFeishuToolsConfig: typeof resolveAnyEnabledFeishuToolsConfig;
+  resolveFeishuToolAccount: typeof resolveFeishuToolAccount;
+};
+
+export const feishuDocDeps: FeishuDocDeps = {
+  getFeishuRuntime,
+  createFeishuToolClient,
+  resolveAnyEnabledFeishuToolsConfig,
+  resolveFeishuToolAccount,
+};
+
+export function setFeishuDocDepsForTest(overrides: Partial<FeishuDocDeps> | null): void {
+  feishuDocDeps.getFeishuRuntime = overrides?.getFeishuRuntime ?? getFeishuRuntime;
+  feishuDocDeps.createFeishuToolClient =
+    overrides?.createFeishuToolClient ?? createFeishuToolClient;
+  feishuDocDeps.resolveAnyEnabledFeishuToolsConfig =
+    overrides?.resolveAnyEnabledFeishuToolsConfig ?? resolveAnyEnabledFeishuToolsConfig;
+  feishuDocDeps.resolveFeishuToolAccount =
+    overrides?.resolveFeishuToolAccount ?? resolveFeishuToolAccount;
+}

--- a/extensions/feishu/src/docx.test-helpers.ts
+++ b/extensions/feishu/src/docx.test-helpers.ts
@@ -1,0 +1,1 @@
+export { setFeishuDocDepsForTest } from "./docx.deps.js";

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -1,7 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "../../../test/helpers/extensions/plugin-runtime-mock.js";
 import { createToolFactoryHarness, type ToolLike } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const createFeishuToolClientMock = vi.hoisted(() => vi.fn());
+const resolveAnyEnabledFeishuToolsConfigMock = vi.hoisted(() => vi.fn());
+const resolveFeishuToolAccountMock = vi.hoisted(() => vi.fn());
 const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
 const loadWebMediaMock = vi.hoisted(() => vi.fn());
 const convertMock = vi.hoisted(() => vi.fn());
@@ -16,24 +20,7 @@ const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
 const blockPatchMock = vi.hoisted(() => vi.fn());
 const scopeListMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./client.js", () => ({
-  createFeishuClient: createFeishuClientMock,
-}));
-
-vi.mock("./runtime.js", () => ({
-  getFeishuRuntime: () => ({
-    channel: {
-      media: {
-        fetchRemoteMedia: fetchRemoteMediaMock,
-      },
-    },
-    media: {
-      loadWebMedia: loadWebMediaMock,
-    },
-  }),
-}));
-
-import { registerFeishuDocTools } from "./docx.js";
+import { __testing as feishuDocTesting, registerFeishuDocTools } from "./docx.js";
 
 type ToolResultWithDetails = {
   details: Record<string, unknown>;
@@ -76,6 +63,36 @@ describe("feishu_doc image fetch hardening", () => {
         },
       },
     });
+    createFeishuToolClientMock.mockImplementation(() => createFeishuClientMock());
+    resolveAnyEnabledFeishuToolsConfigMock.mockReturnValue({
+      doc: true,
+      chat: false,
+      wiki: false,
+      drive: false,
+      perm: false,
+      scopes: false,
+    });
+    resolveFeishuToolAccountMock.mockReturnValue({
+      config: {
+        mediaMaxMb: 30,
+      },
+    });
+    feishuDocTesting.setDepsForTest({
+      getFeishuRuntime: () =>
+        createPluginRuntimeMock({
+          channel: {
+            media: {
+              fetchRemoteMedia: fetchRemoteMediaMock,
+            },
+          },
+          media: {
+            loadWebMedia: loadWebMediaMock,
+          },
+        }),
+      createFeishuToolClient: createFeishuToolClientMock,
+      resolveAnyEnabledFeishuToolsConfig: resolveAnyEnabledFeishuToolsConfigMock,
+      resolveFeishuToolAccount: resolveFeishuToolAccountMock,
+    });
 
     convertMock.mockResolvedValue({
       code: 0,
@@ -117,6 +134,10 @@ describe("feishu_doc image fetch hardening", () => {
     permissionMemberCreateMock.mockResolvedValue({ code: 0 });
     blockPatchMock.mockResolvedValue({ code: 0 });
     scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+  });
+
+  afterEach(() => {
+    feishuDocTesting.setDepsForTest(null);
   });
 
   function resolveFeishuDocTool(context: Record<string, unknown> = {}) {

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -20,7 +20,8 @@ const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
 const blockPatchMock = vi.hoisted(() => vi.fn());
 const scopeListMock = vi.hoisted(() => vi.fn());
 
-import { __testing as feishuDocTesting, registerFeishuDocTools } from "./docx.js";
+import { registerFeishuDocTools } from "./docx.js";
+import { setFeishuDocDepsForTest } from "./docx.test-helpers.js";
 
 type ToolResultWithDetails = {
   details: Record<string, unknown>;
@@ -77,7 +78,7 @@ describe("feishu_doc image fetch hardening", () => {
         mediaMaxMb: 30,
       },
     });
-    feishuDocTesting.setDepsForTest({
+    setFeishuDocDepsForTest({
       getFeishuRuntime: () =>
         createPluginRuntimeMock({
           channel: {
@@ -137,7 +138,7 @@ describe("feishu_doc image fetch hardening", () => {
   });
 
   afterEach(() => {
-    feishuDocTesting.setDepsForTest(null);
+    setFeishuDocDepsForTest(null);
   });
 
   function resolveFeishuDocTool(context: Record<string, unknown> = {}) {

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -18,38 +18,7 @@ import {
   mergeTableCells,
 } from "./docx-table-ops.js";
 import type { FeishuDocxBlock, FeishuDocxBlockChild } from "./docx-types.js";
-import { getFeishuRuntime } from "./runtime.js";
-import {
-  createFeishuToolClient,
-  resolveAnyEnabledFeishuToolsConfig,
-  resolveFeishuToolAccount,
-} from "./tool-account.js";
-
-const feishuDocDeps = {
-  getFeishuRuntime,
-  createFeishuToolClient,
-  resolveAnyEnabledFeishuToolsConfig,
-  resolveFeishuToolAccount,
-};
-
-export const __testing = {
-  setDepsForTest(
-    overrides: Partial<{
-      getFeishuRuntime: typeof getFeishuRuntime;
-      createFeishuToolClient: typeof createFeishuToolClient;
-      resolveAnyEnabledFeishuToolsConfig: typeof resolveAnyEnabledFeishuToolsConfig;
-      resolveFeishuToolAccount: typeof resolveFeishuToolAccount;
-    }> | null,
-  ) {
-    feishuDocDeps.getFeishuRuntime = overrides?.getFeishuRuntime ?? getFeishuRuntime;
-    feishuDocDeps.createFeishuToolClient =
-      overrides?.createFeishuToolClient ?? createFeishuToolClient;
-    feishuDocDeps.resolveAnyEnabledFeishuToolsConfig =
-      overrides?.resolveAnyEnabledFeishuToolsConfig ?? resolveAnyEnabledFeishuToolsConfig;
-    feishuDocDeps.resolveFeishuToolAccount =
-      overrides?.resolveFeishuToolAccount ?? resolveFeishuToolAccount;
-  },
-};
+import { feishuDocDeps } from "./docx.deps.js";
 
 // ============ Helpers ============
 

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -25,6 +25,32 @@ import {
   resolveFeishuToolAccount,
 } from "./tool-account.js";
 
+const feishuDocDeps = {
+  getFeishuRuntime,
+  createFeishuToolClient,
+  resolveAnyEnabledFeishuToolsConfig,
+  resolveFeishuToolAccount,
+};
+
+export const __testing = {
+  setDepsForTest(
+    overrides: Partial<{
+      getFeishuRuntime: typeof getFeishuRuntime;
+      createFeishuToolClient: typeof createFeishuToolClient;
+      resolveAnyEnabledFeishuToolsConfig: typeof resolveAnyEnabledFeishuToolsConfig;
+      resolveFeishuToolAccount: typeof resolveFeishuToolAccount;
+    }> | null,
+  ) {
+    feishuDocDeps.getFeishuRuntime = overrides?.getFeishuRuntime ?? getFeishuRuntime;
+    feishuDocDeps.createFeishuToolClient =
+      overrides?.createFeishuToolClient ?? createFeishuToolClient;
+    feishuDocDeps.resolveAnyEnabledFeishuToolsConfig =
+      overrides?.resolveAnyEnabledFeishuToolsConfig ?? resolveAnyEnabledFeishuToolsConfig;
+    feishuDocDeps.resolveFeishuToolAccount =
+      overrides?.resolveFeishuToolAccount ?? resolveFeishuToolAccount;
+  },
+};
+
 // ============ Helpers ============
 
 function json(data: unknown) {
@@ -510,7 +536,10 @@ async function uploadImageToDocx(
 }
 
 async function downloadImage(url: string, maxBytes: number): Promise<Buffer> {
-  const fetched = await getFeishuRuntime().channel.media.fetchRemoteMedia({ url, maxBytes });
+  const fetched = await feishuDocDeps.getFeishuRuntime().channel.media.fetchRemoteMedia({
+    url,
+    maxBytes,
+  });
   return fetched.buffer;
 }
 
@@ -586,7 +615,7 @@ async function resolveUploadInput(
       // localRoots left undefined so loadWebMedia uses default roots (tmp, media,
       // workspace, sandboxes) plus workspace-profile auto-discovery.
       const resolvedPath = resolve(candidate);
-      const loaded = await getFeishuRuntime().media.loadWebMedia(resolvedPath, {
+      const loaded = await feishuDocDeps.getFeishuRuntime().media.loadWebMedia(resolvedPath, {
         maxBytes,
         optimizeImages: false,
       });
@@ -635,7 +664,10 @@ async function resolveUploadInput(
   }
 
   if (url) {
-    const fetched = await getFeishuRuntime().channel.media.fetchRemoteMedia({ url, maxBytes });
+    const fetched = await feishuDocDeps.getFeishuRuntime().channel.media.fetchRemoteMedia({
+      url,
+      maxBytes,
+    });
     const urlPath = new URL(url).pathname;
     const guessed = urlPath.split("/").pop() || "upload.bin";
     return {
@@ -647,7 +679,7 @@ async function resolveUploadInput(
   // Use loadWebMedia to enforce localRoots sandbox (same as sendMediaFeishu).
   // localRoots left undefined — see comment above.
   const resolvedFilePath = resolve(filePath!);
-  const loaded = await getFeishuRuntime().media.loadWebMedia(resolvedFilePath, {
+  const loaded = await feishuDocDeps.getFeishuRuntime().media.loadWebMedia(resolvedFilePath, {
     maxBytes,
     optimizeImages: false,
   });
@@ -1361,19 +1393,19 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
   }
 
   // Register if enabled on any account; account routing is resolved per execution.
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = feishuDocDeps.resolveAnyEnabledFeishuToolsConfig(accounts);
 
   const registered: string[] = [];
   type FeishuDocExecuteParams = FeishuDocParams & { accountId?: string };
 
   const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
-    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+    feishuDocDeps.createFeishuToolClient({ api, executeParams: params, defaultAccountId });
 
   const getMediaMaxBytes = (
     params: { accountId?: string } | undefined,
     defaultAccountId?: string,
   ) =>
-    (resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId }).config
+    (feishuDocDeps.resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId }).config
       ?.mediaMaxMb ?? 30) *
     1024 *
     1024;

--- a/extensions/irc/src/channel.ts
+++ b/extensions/irc/src/channel.ts
@@ -51,6 +51,19 @@ import { ircSetupWizard } from "./setup-surface.js";
 import type { CoreConfig, IrcProbe } from "./types.js";
 
 const meta = getChatChannelMeta("irc");
+const ircChannelDeps = {
+  monitorIrcProvider,
+};
+
+export const __testing = {
+  setDepsForTest(
+    overrides: Partial<{
+      monitorIrcProvider: typeof monitorIrcProvider;
+    }> | null,
+  ) {
+    ircChannelDeps.monitorIrcProvider = overrides?.monitorIrcProvider ?? monitorIrcProvider;
+  },
+};
 
 function normalizePairingTarget(raw: string): string {
   const normalized = normalizeIrcAllowEntry(raw);
@@ -301,7 +314,7 @@ export const ircPlugin: ChannelPlugin<ResolvedIrcAccount, IrcProbe> = createChat
         await runStoppablePassiveMonitor({
           abortSignal: ctx.abortSignal,
           start: async () =>
-            await monitorIrcProvider({
+            await ircChannelDeps.monitorIrcProvider({
               accountId: account.accountId,
               config: ctx.cfg as CoreConfig,
               runtime: ctx.runtime,

--- a/extensions/irc/src/setup.test.ts
+++ b/extensions/irc/src/setup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createPluginSetupWizardAdapter,
   createTestWizardPrompter,
@@ -12,8 +12,7 @@ import {
   waitForStartedMocks,
 } from "../../../test/helpers/extensions/start-account-lifecycle.js";
 import type { ResolvedIrcAccount } from "./accounts.js";
-import { ircPlugin } from "./channel.js";
-import { setIrcRuntime } from "./runtime.js";
+import { __testing as ircChannelTesting, ircPlugin } from "./channel.js";
 import {
   ircSetupAdapter,
   parsePort,
@@ -49,28 +48,9 @@ function buildAccount(): ResolvedIrcAccount {
   };
 }
 
-function installIrcRuntime() {
-  setIrcRuntime({
-    logging: {
-      shouldLogVerbose: vi.fn(() => false),
-      getChildLogger: vi.fn(() => ({
-        debug: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      })),
-    },
-    channel: {
-      activity: {
-        record: vi.fn(),
-        get: vi.fn(),
-      },
-    },
-  } as never);
-}
-
 describe("irc setup", () => {
   afterEach(() => {
+    ircChannelTesting.setDepsForTest(null);
     vi.clearAllMocks();
   });
 
@@ -342,16 +322,14 @@ describe("irc setup", () => {
 
   it("keeps startAccount pending until abort, then stops the monitor", async () => {
     const stop = vi.fn();
-    vi.resetModules();
-    vi.doMock("../../../src/generated/bundled-channel-entries.generated.ts", () => ({
-      GENERATED_BUNDLED_CHANNEL_ENTRIES: [],
-    }));
     hoisted.monitorIrcProvider.mockResolvedValue({ stop });
-    installIrcRuntime();
-    const { ircPlugin: runtimeMockedPlugin } = await import("./channel.js");
+    ircChannelTesting.setDepsForTest({
+      monitorIrcProvider:
+        hoisted.monitorIrcProvider as typeof import("./monitor.js").monitorIrcProvider,
+    });
 
     const { abort, task, isSettled } = startAccountAndTrackLifecycle({
-      startAccount: runtimeMockedPlugin.gateway!.startAccount!,
+      startAccount: ircPlugin.gateway!.startAccount!,
       account: buildAccount(),
     });
 

--- a/extensions/irc/src/setup.test.ts
+++ b/extensions/irc/src/setup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createPluginSetupWizardAdapter,
   createTestWizardPrompter,
@@ -28,14 +28,6 @@ import type { CoreConfig } from "./types.js";
 const hoisted = vi.hoisted(() => ({
   monitorIrcProvider: vi.fn(),
 }));
-
-vi.mock("./monitor.js", async () => {
-  const actual = await vi.importActual<typeof import("./monitor.js")>("./monitor.js");
-  return {
-    ...actual,
-    monitorIrcProvider: hoisted.monitorIrcProvider,
-  };
-});
 
 const ircConfigureAdapter = createPluginSetupWizardAdapter(ircPlugin);
 

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -1,24 +1,34 @@
 import { EventEmitter } from "node:events";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  __testing as synologyClientTesting,
+  fetchChatUsers,
+  resolveLegacyWebhookNameToChatUserId,
+  sendFileUrl,
+  sendMessage,
+} from "./client.js";
 
-// Mock http and https modules before importing the client
-vi.mock("node:https", () => {
-  const mockRequest = vi.fn();
-  const mockGet = vi.fn();
-  return { default: { request: mockRequest, get: mockGet }, request: mockRequest, get: mockGet };
-});
-
-vi.mock("node:http", () => {
-  const mockRequest = vi.fn();
-  const mockGet = vi.fn();
-  return { default: { request: mockRequest, get: mockGet }, request: mockRequest, get: mockGet };
-});
-
-// Import after mocks are set up
-const { sendMessage, sendFileUrl, fetchChatUsers, resolveLegacyWebhookNameToChatUserId } =
-  await import("./client.js");
-const https = await import("node:https");
 let fakeNowMs = 1_700_000_000_000;
+const requestMock = vi.fn();
+const getMock = vi.fn();
+
+beforeEach(() => {
+  requestMock.mockReset();
+  getMock.mockReset();
+  synologyClientTesting.setDepsForTest({
+    httpRequest: requestMock as typeof import("node:http").request,
+    httpsRequest: requestMock as typeof import("node:https").request,
+    httpGet: getMock as typeof import("node:http").get,
+    httpsGet: getMock as typeof import("node:https").get,
+  });
+  synologyClientTesting.resetStateForTest();
+});
+
+afterEach(() => {
+  synologyClientTesting.setDepsForTest(null);
+  synologyClientTesting.resetStateForTest();
+  vi.useRealTimers();
+});
 
 async function settleTimers<T>(promise: Promise<T>): Promise<T> {
   await Promise.resolve();
@@ -27,8 +37,7 @@ async function settleTimers<T>(promise: Promise<T>): Promise<T> {
 }
 
 function mockResponse(statusCode: number, body: string) {
-  const httpsRequest = vi.mocked(https.request);
-  httpsRequest.mockImplementation((_url: any, _opts: any, callback: any) => {
+  requestMock.mockImplementation((_url: any, _opts: any, callback: any) => {
     const res = new EventEmitter() as any;
     res.statusCode = statusCode;
     process.nextTick(() => {
@@ -54,14 +63,9 @@ function mockFailureResponse(statusCode = 500) {
 
 function installFakeTimerHarness() {
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers();
     fakeNowMs += 10_000;
     vi.setSystemTime(fakeNowMs);
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 }
 
@@ -83,9 +87,8 @@ describe("sendMessage", () => {
   it("includes user_ids when userId is numeric", async () => {
     mockSuccessResponse();
     await settleTimers(sendMessage("https://nas.example.com/incoming", "Hello", 42));
-    const httpsRequest = vi.mocked(https.request);
-    expect(httpsRequest).toHaveBeenCalled();
-    const callArgs = httpsRequest.mock.calls[0];
+    expect(requestMock).toHaveBeenCalled();
+    const callArgs = requestMock.mock.calls[0];
     expect(callArgs[0]).toBe("https://nas.example.com/incoming");
   });
 });
@@ -127,7 +130,6 @@ function mockUserListResponseImpl(
   users: Array<{ user_id: number; username: string; nickname: string }>,
   once: boolean,
 ) {
-  const httpsGet = vi.mocked((https as any).get);
   const impl = (_url: any, _opts: any, callback: any) => {
     const res = new EventEmitter() as any;
     res.statusCode = 200;
@@ -141,10 +143,10 @@ function mockUserListResponseImpl(
     return req;
   };
   if (once) {
-    httpsGet.mockImplementationOnce(impl);
+    getMock.mockImplementationOnce(impl);
     return;
   }
-  httpsGet.mockImplementation(impl);
+  getMock.mockImplementation(impl);
 }
 
 describe("resolveLegacyWebhookNameToChatUserId", () => {
@@ -154,15 +156,10 @@ describe("resolveLegacyWebhookNameToChatUserId", () => {
     "https://nas2.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=chatbot&version=2&token=%22test-2%22";
 
   beforeEach(() => {
-    vi.clearAllMocks();
     vi.useFakeTimers();
     // Advance time to invalidate any cached user list from previous tests
     fakeNowMs += 10 * 60 * 1000;
     vi.setSystemTime(fakeNowMs);
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
   });
 
   it("resolves user by nickname (webhook username = Chat nickname)", async () => {
@@ -222,8 +219,7 @@ describe("resolveLegacyWebhookNameToChatUserId", () => {
       incomingUrl: baseUrl,
       mutableWebhookUsername: "anyone",
     });
-    const httpsGet = vi.mocked((https as any).get);
-    expect(httpsGet).toHaveBeenCalledWith(
+    expect(getMock).toHaveBeenCalledWith(
       expect.stringContaining("method=user_list"),
       expect.any(Object),
       expect.any(Function),
@@ -245,8 +241,7 @@ describe("resolveLegacyWebhookNameToChatUserId", () => {
 
     expect(result1).toBe(4);
     expect(result2).toBe(9);
-    const httpsGet = vi.mocked((https as any).get);
-    expect(httpsGet).toHaveBeenCalledTimes(2);
+    expect(getMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -254,8 +249,7 @@ describe("fetchChatUsers", () => {
   installFakeTimerHarness();
 
   it("filters malformed user entries while keeping valid ones", async () => {
-    const httpsGet = vi.mocked((https as any).get);
-    httpsGet.mockImplementation((_url: any, _opts: any, callback: any) => {
+    getMock.mockImplementation((_url: any, _opts: any, callback: any) => {
       const res = new EventEmitter() as any;
       res.statusCode = 200;
       process.nextTick(() => {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -11,6 +11,13 @@ import { z } from "zod";
 const MIN_SEND_INTERVAL_MS = 500;
 let lastSendTime = 0;
 
+type SynologyClientDeps = {
+  httpRequest: typeof http.request;
+  httpsRequest: typeof https.request;
+  httpGet: typeof http.get;
+  httpsGet: typeof https.get;
+};
+
 // --- Chat user_id resolution ---
 // Synology Chat uses two different user_id spaces:
 //   - Outgoing webhook user_id: per-integration sequential ID (e.g. 1)
@@ -69,6 +76,25 @@ const ChatUserListResponseSchema = z.object({
 // Cache user lists per bot endpoint to avoid cross-account bleed.
 const chatUserCache = new Map<string, ChatUserCacheEntry>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const synologyClientDeps: SynologyClientDeps = {
+  httpRequest: http.request,
+  httpsRequest: https.request,
+  httpGet: http.get,
+  httpsGet: https.get,
+};
+
+export const __testing = {
+  setDepsForTest(overrides?: Partial<SynologyClientDeps> | null) {
+    synologyClientDeps.httpRequest = overrides?.httpRequest ?? http.request;
+    synologyClientDeps.httpsRequest = overrides?.httpsRequest ?? https.request;
+    synologyClientDeps.httpGet = overrides?.httpGet ?? http.get;
+    synologyClientDeps.httpsGet = overrides?.httpsGet ?? https.get;
+  },
+  resetStateForTest() {
+    lastSendTime = 0;
+    chatUserCache.clear();
+  },
+};
 
 /**
  * Send a text message to Synology Chat via the incoming webhook.
@@ -164,40 +190,39 @@ export async function fetchChatUsers(
       resolve(cached?.users ?? []);
       return;
     }
-    const transport = parsedUrl.protocol === "https:" ? https : http;
+    const get =
+      parsedUrl.protocol === "https:" ? synologyClientDeps.httpsGet : synologyClientDeps.httpGet;
 
-    transport
-      .get(listUrl, { rejectUnauthorized: !allowInsecureSsl } as any, (res) => {
-        let data = "";
-        res.on("data", (c: Buffer) => {
-          data += c.toString();
-        });
-        res.on("end", () => {
-          const result = safeParseJsonWithSchema(ChatUserListResponseSchema, data);
-          if (!result) {
-            log?.warn("fetchChatUsers: failed to parse user_list response");
-            resolve(cached?.users ?? []);
-            return;
-          }
-
-          if (result.success) {
-            const users = result.data?.users ?? [];
-            chatUserCache.set(listUrl, {
-              users,
-              cachedAt: now,
-            });
-            resolve(users);
-            return;
-          }
-
-          log?.warn(`fetchChatUsers: API returned success=${result.success}, using cached data`);
+    get(listUrl, { rejectUnauthorized: !allowInsecureSsl } as any, (res) => {
+      let data = "";
+      res.on("data", (c: Buffer) => {
+        data += c.toString();
+      });
+      res.on("end", () => {
+        const result = safeParseJsonWithSchema(ChatUserListResponseSchema, data);
+        if (!result) {
+          log?.warn("fetchChatUsers: failed to parse user_list response");
           resolve(cached?.users ?? []);
-        });
-      })
-      .on("error", (err) => {
-        log?.warn(`fetchChatUsers: HTTP error — ${err instanceof Error ? err.message : err}`);
+          return;
+        }
+
+        if (result.success) {
+          const users = result.data?.users ?? [];
+          chatUserCache.set(listUrl, {
+            users,
+            cachedAt: now,
+          });
+          resolve(users);
+          return;
+        }
+
+        log?.warn(`fetchChatUsers: API returned success=${result.success}, using cached data`);
         resolve(cached?.users ?? []);
       });
+    }).on("error", (err) => {
+      log?.warn(`fetchChatUsers: HTTP error — ${err instanceof Error ? err.message : err}`);
+      resolve(cached?.users ?? []);
+    });
   });
 }
 
@@ -255,9 +280,12 @@ function doPost(url: string, body: string, allowInsecureSsl = true): Promise<boo
       reject(new Error(`Invalid URL: ${url}`));
       return;
     }
-    const transport = parsedUrl.protocol === "https:" ? https : http;
+    const request =
+      parsedUrl.protocol === "https:"
+        ? synologyClientDeps.httpsRequest
+        : synologyClientDeps.httpRequest;
 
-    const req = transport.request(
+    const req = request(
       url,
       {
         method: "POST",

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -1,18 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { resolveLegacyWebhookNameToChatUserId, sendMessage } from "./client.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeFormBody, makeReq, makeRes, makeStalledReq } from "./test-http-utils.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 import type { WebhookHandlerDeps } from "./webhook-handler.js";
 import {
+  __testing as synologyWebhookHandlerTesting,
   clearSynologyWebhookRateLimiterStateForTest,
   createWebhookHandler,
 } from "./webhook-handler.js";
 
-// Mock sendMessage and resolveLegacyWebhookNameToChatUserId to prevent real HTTP calls
-vi.mock("./client.js", () => ({
-  sendMessage: vi.fn().mockResolvedValue(true),
-  resolveLegacyWebhookNameToChatUserId: vi.fn().mockResolvedValue(undefined),
-}));
+const sendMessageMock = vi.fn();
+const resolveLegacyWebhookNameToChatUserIdMock = vi.fn();
 
 function makeAccount(
   overrides: Partial<ResolvedSynologyChatAccount> = {},
@@ -50,7 +47,7 @@ async function runDangerousNameMatchReply(
     accountIdSuffix: string;
   },
 ) {
-  vi.mocked(resolveLegacyWebhookNameToChatUserId).mockResolvedValueOnce(options.resolvedChatUserId);
+  resolveLegacyWebhookNameToChatUserIdMock.mockResolvedValueOnce(options.resolvedChatUserId);
   const deliver = vi.fn().mockResolvedValue("Bot reply");
   const handler = createWebhookHandler({
     account: makeAccount({
@@ -66,7 +63,7 @@ async function runDangerousNameMatchReply(
   await handler(req, res);
 
   expect(res._status).toBe(204);
-  expect(resolveLegacyWebhookNameToChatUserId).toHaveBeenCalledWith({
+  expect(resolveLegacyWebhookNameToChatUserIdMock).toHaveBeenCalledWith({
     incomingUrl: "https://nas.example.com/incoming",
     mutableWebhookUsername: "testuser",
     allowInsecureSsl: true,
@@ -81,11 +78,24 @@ describe("createWebhookHandler", () => {
 
   beforeEach(() => {
     clearSynologyWebhookRateLimiterStateForTest();
+    sendMessageMock.mockReset();
+    sendMessageMock.mockResolvedValue(true);
+    resolveLegacyWebhookNameToChatUserIdMock.mockReset();
+    resolveLegacyWebhookNameToChatUserIdMock.mockResolvedValue(undefined);
+    synologyWebhookHandlerTesting.setDepsForTest({
+      sendMessage: sendMessageMock as typeof import("./client.js").sendMessage,
+      resolveLegacyWebhookNameToChatUserId:
+        resolveLegacyWebhookNameToChatUserIdMock as typeof import("./client.js").resolveLegacyWebhookNameToChatUserId,
+    });
     log = {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
     };
+  });
+
+  afterEach(() => {
+    synologyWebhookHandlerTesting.setDepsForTest(null);
   });
 
   async function expectForbiddenByPolicy(params: {
@@ -496,14 +506,14 @@ describe("createWebhookHandler", () => {
     await handler(req, res);
 
     expect(res._status).toBe(204);
-    expect(resolveLegacyWebhookNameToChatUserId).not.toHaveBeenCalled();
+    expect(resolveLegacyWebhookNameToChatUserIdMock).not.toHaveBeenCalled();
     expect(deliver).toHaveBeenCalledWith(
       expect.objectContaining({
         from: "123",
         chatUserId: "123",
       }),
     );
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessageMock).toHaveBeenCalledWith(
       "https://nas.example.com/incoming",
       "Bot reply",
       "123",
@@ -522,7 +532,7 @@ describe("createWebhookHandler", () => {
         chatUserId: "456",
       }),
     );
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessageMock).toHaveBeenCalledWith(
       "https://nas.example.com/incoming",
       "Bot reply",
       "456",
@@ -543,7 +553,7 @@ describe("createWebhookHandler", () => {
         chatUserId: "123",
       }),
     );
-    expect(sendMessage).toHaveBeenCalledWith(
+    expect(sendMessageMock).toHaveBeenCalledWith(
       "https://nas.example.com/incoming",
       "Bot reply",
       "123",

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -22,10 +22,27 @@ const PREAUTH_BODY_TIMEOUT_MS = 5_000;
 const PREAUTH_MAX_REQUESTS_PER_MINUTE = 10;
 const INVALID_TOKEN_WINDOW_MS = 60_000;
 const INVALID_TOKEN_MAX_TRACKED_KEYS = 5_000;
+const synologyWebhookClientDeps = {
+  sendMessage,
+  resolveLegacyWebhookNameToChatUserId,
+};
 
 type InvalidTokenRateLimitState = {
   count: number;
   windowStartMs: number;
+};
+
+export const __testing = {
+  setDepsForTest(
+    overrides: Partial<{
+      sendMessage: typeof sendMessage;
+      resolveLegacyWebhookNameToChatUserId: typeof resolveLegacyWebhookNameToChatUserId;
+    }> | null,
+  ) {
+    synologyWebhookClientDeps.sendMessage = overrides?.sendMessage ?? sendMessage;
+    synologyWebhookClientDeps.resolveLegacyWebhookNameToChatUserId =
+      overrides?.resolveLegacyWebhookNameToChatUserId ?? resolveLegacyWebhookNameToChatUserId;
+  },
 };
 
 class InvalidTokenRateLimiter {
@@ -481,12 +498,13 @@ async function resolveSynologyReplyDeliveryUserId(params: {
     return params.payload.user_id;
   }
 
-  const resolvedChatApiUserId = await resolveLegacyWebhookNameToChatUserId({
-    incomingUrl: params.account.incomingUrl,
-    mutableWebhookUsername: params.payload.username,
-    allowInsecureSsl: params.account.allowInsecureSsl,
-    log: params.log,
-  });
+  const resolvedChatApiUserId =
+    await synologyWebhookClientDeps.resolveLegacyWebhookNameToChatUserId({
+      incomingUrl: params.account.incomingUrl,
+      mutableWebhookUsername: params.payload.username,
+      allowInsecureSsl: params.account.allowInsecureSsl,
+      log: params.log,
+    });
   if (resolvedChatApiUserId !== undefined) {
     return String(resolvedChatApiUserId);
   }
@@ -529,7 +547,7 @@ async function processAuthorizedSynologyWebhook(params: {
       return;
     }
 
-    await sendMessage(
+    await synologyWebhookClientDeps.sendMessage(
       params.account.incomingUrl,
       reply,
       deliveryUserId,
@@ -544,7 +562,7 @@ async function processAuthorizedSynologyWebhook(params: {
     params.log?.error?.(
       `Failed to process message from ${params.message.payload.username}: ${errMsg}`,
     );
-    await sendMessage(
+    await synologyWebhookClientDeps.sendMessage(
       params.account.incomingUrl,
       "Sorry, an error occurred while processing your message.",
       deliveryUserId,

--- a/src/agents/compaction.retry.test.ts
+++ b/src/agents/compaction.retry.test.ts
@@ -56,7 +56,7 @@ describe("compaction retry integration", () => {
   } as unknown as NonNullable<ExtensionContext["model"]>;
 
   const invokeGenerateSummary = (signal = new AbortController().signal) =>
-    mockGenerateSummary(testMessages, testModel, 1000, "test-api-key", signal);
+    mockGenerateSummary(testMessages, testModel, 1000, "test-api-key", undefined, signal);
 
   const runSummaryRetry = (options: Parameters<typeof retryAsync>[1]) =>
     retryAsync(() => invokeGenerateSummary(), options);

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -257,6 +257,7 @@ async function summarizeChunks(params: {
           model,
           params.reserveTokens,
           params.apiKey,
+          params.headers,
           params.signal,
           effectiveInstructions,
           summary,

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { installDownloadSpec } from "./skills-install-download.js";
 import { setTempStateDir } from "./skills-install.download-test-utils.js";
@@ -60,7 +61,10 @@ function buildEntry(name: string): SkillEntry {
       description: `${name} test skill`,
       filePath: path.join(skillDir, "SKILL.md"),
       baseDir: skillDir,
-      source: "openclaw-workspace",
+      sourceInfo: createSyntheticSourceInfo(path.join(skillDir, "SKILL.md"), {
+        source: "openclaw-workspace",
+        baseDir: skillDir,
+      }),
       disableModelInvocation: false,
     },
     frontmatter: {},

--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -1,3 +1,4 @@
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
 import type { SkillEntry } from "./skills/types.js";
@@ -17,7 +18,10 @@ describe("buildWorkspaceSkillStatus", () => {
         description: "test",
         filePath: "/tmp/os-scoped",
         baseDir: "/tmp",
-        source: "test",
+        sourceInfo: createSyntheticSourceInfo("/tmp/os-scoped", {
+          source: "test",
+          baseDir: "/tmp",
+        }),
         disableModelInvocation: false,
       },
       frontmatter: {},

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -1,3 +1,4 @@
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
@@ -24,7 +25,10 @@ function makeEntry(params: {
       description: `desc:${params.name}`,
       filePath: `/tmp/${params.name}/SKILL.md`,
       baseDir: `/tmp/${params.name}`,
-      source: params.source ?? "openclaw-workspace",
+      sourceInfo: createSyntheticSourceInfo(`/tmp/${params.name}/SKILL.md`, {
+        source: params.source ?? "openclaw-workspace",
+        baseDir: `/tmp/${params.name}`,
+      }),
       disableModelInvocation: false,
     },
     frontmatter: {},

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -1,3 +1,4 @@
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { resolveSkillsPromptForRun } from "./skills.js";
 import type { SkillEntry } from "./skills/types.js";
@@ -17,7 +18,10 @@ describe("resolveSkillsPromptForRun", () => {
         description: "Demo",
         filePath: "/app/skills/demo-skill/SKILL.md",
         baseDir: "/app/skills/demo-skill",
-        source: "openclaw-bundled",
+        sourceInfo: createSyntheticSourceInfo("/app/skills/demo-skill/SKILL.md", {
+          source: "openclaw-bundled",
+          baseDir: "/app/skills/demo-skill",
+        }),
         disableModelInvocation: false,
       },
       frontmatter: {},

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -1,5 +1,9 @@
 import os from "node:os";
-import { formatSkillsForPrompt, type Skill } from "@mariozechner/pi-coding-agent";
+import {
+  createSyntheticSourceInfo,
+  formatSkillsForPrompt,
+  type Skill,
+} from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SkillEntry } from "./types.js";
@@ -15,7 +19,10 @@ function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/S
     description: desc,
     filePath,
     baseDir: `/skills/${name}`,
-    source: "workspace",
+    sourceInfo: createSyntheticSourceInfo(filePath, {
+      source: "workspace",
+      baseDir: `/skills/${name}`,
+    }),
     disableModelInvocation: false,
   };
 }

--- a/src/agents/skills/source.ts
+++ b/src/agents/skills/source.ts
@@ -1,5 +1,5 @@
 import type { Skill } from "@mariozechner/pi-coding-agent";
 
 export function resolveSkillSource(skill: Skill): string {
-  return skill.source ?? "unknown";
+  return skill.sourceInfo.source ?? "unknown";
 }

--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -1,4 +1,6 @@
-import { loadConfig, resolveGatewayPort } from "../../config/config.js";
+import { loadConfig } from "../../config/io.js";
+import { resolveGatewayPort } from "../../config/paths.js";
+import type { OpenClawConfig } from "../../config/types.js";
 import { callGateway } from "../../gateway/call.js";
 import { resolveGatewayCredentialsFromConfig, trimToUndefined } from "../../gateway/credentials.js";
 import {
@@ -57,7 +59,7 @@ function canonicalizeToolGatewayWsUrl(raw: string): { origin: string; key: strin
 }
 
 function validateGatewayUrlOverrideForAgentTools(params: {
-  cfg: ReturnType<typeof loadConfig>;
+  cfg: OpenClawConfig;
   urlOverride: string;
 }): { url: string; target: GatewayOverrideTarget } {
   const { cfg } = params;
@@ -100,7 +102,7 @@ function validateGatewayUrlOverrideForAgentTools(params: {
 }
 
 function resolveGatewayOverrideToken(params: {
-  cfg: ReturnType<typeof loadConfig>;
+  cfg: OpenClawConfig;
   target: GatewayOverrideTarget;
   explicitToken?: string;
 }): string | undefined {

--- a/src/cli/skills-cli.formatting.test.ts
+++ b/src/cli/skills-cli.formatting.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import type { SkillEntry } from "../agents/skills.js";
@@ -38,7 +39,10 @@ describe("skills-cli (e2e)", () => {
           description: "Capture UI screenshots",
           filePath: path.join(baseDir, "SKILL.md"),
           baseDir,
-          source: "openclaw-bundled",
+          sourceInfo: createSyntheticSourceInfo(path.join(baseDir, "SKILL.md"), {
+            source: "openclaw-bundled",
+            baseDir,
+          }),
           disableModelInvocation: false,
         },
         frontmatter: {},

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1,16 +1,11 @@
 import { randomUUID } from "node:crypto";
-import type { OpenClawConfig } from "../config/config.js";
-import {
-  loadConfig,
-  resolveConfigPath,
-  resolveGatewayPort,
-  resolveStateDir,
-} from "../config/config.js";
+import { loadConfig } from "../config/io.js";
 import {
   resolveConfigPath as resolveConfigPathFromPaths,
   resolveGatewayPort as resolveGatewayPortFromPaths,
   resolveStateDir as resolveStateDirFromPaths,
 } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
@@ -91,9 +86,9 @@ const defaultGatewayCallDeps = {
   createGatewayClient: defaultCreateGatewayClient,
   loadConfig,
   loadOrCreateDeviceIdentity,
-  resolveGatewayPort,
-  resolveConfigPath,
-  resolveStateDir,
+  resolveGatewayPort: resolveGatewayPortFromPaths,
+  resolveConfigPath: resolveConfigPathFromPaths,
+  resolveStateDir: resolveStateDirFromPaths,
   loadGatewayTlsRuntime,
 };
 const gatewayCallDeps = {

--- a/src/plugin-sdk/browser-support.ts
+++ b/src/plugin-sdk/browser-support.ts
@@ -1,12 +1,11 @@
-export { loadConfig } from "../config/config.js";
-export {
-  createConfigIO,
-  getRuntimeConfigSnapshot,
-  writeConfigFile,
-  type BrowserConfig,
-  type BrowserProfileConfig,
-} from "../config/config.js";
+type CallGatewayToolArgs = Parameters<
+  (typeof import("../agents/tools/gateway.js"))["callGatewayTool"]
+>;
+
+export { loadConfig } from "../config/io.js";
+export { createConfigIO, getRuntimeConfigSnapshot, writeConfigFile } from "../config/io.js";
 export { resolveGatewayPort } from "../config/paths.js";
+export type { BrowserConfig, BrowserProfileConfig } from "../config/types.browser.js";
 export {
   DEFAULT_BROWSER_CONTROL_PORT,
   deriveDefaultBrowserCdpPortRange,
@@ -33,7 +32,6 @@ export { isLoopbackHost } from "../gateway/net.js";
 export { ensureGatewayStartupAuth } from "../gateway/startup-auth.js";
 export type { AnyAgentTool } from "../agents/tools/common.js";
 export { imageResultFromFile, jsonResult, readStringParam } from "../agents/tools/common.js";
-export { callGatewayTool } from "../agents/tools/gateway.js";
 export type { NodeListNode } from "../agents/tools/nodes-utils.js";
 export {
   listNodes,
@@ -67,7 +65,7 @@ export {
   safeParseJson,
 } from "../gateway/server-methods/nodes.helpers.js";
 export type { GatewayRequestHandlers } from "../gateway/server-methods/types.js";
-export type { OpenClawConfig } from "../config/config.js";
+export type { OpenClawConfig } from "../config/types.js";
 export { extractErrorCode, formatErrorMessage } from "../infra/errors.js";
 export {
   SafeOpenError,
@@ -90,3 +88,10 @@ export { rawDataToString } from "../infra/ws.js";
 export { runExec } from "../process/exec.js";
 export { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 export type { MockFn } from "../test-utils/vitest-mock-fn.js";
+
+export async function callGatewayTool<T = Record<string, unknown>>(
+  ...args: CallGatewayToolArgs
+): Promise<T> {
+  const mod = await import("../agents/tools/gateway.js");
+  return (await mod.callGatewayTool<T>(...args)) as T;
+}

--- a/src/plugin-sdk/config-runtime.ts
+++ b/src/plugin-sdk/config-runtime.ts
@@ -2,6 +2,7 @@
 // config writes, or session-store helpers without importing src internals.
 
 export {
+  createConfigIO,
   getRuntimeConfigSnapshot,
   loadConfig,
   readConfigFileSnapshotForWrite,
@@ -80,6 +81,7 @@ export type {
   TtsModelOverrideConfig,
   TtsProvider,
 } from "../config/types.js";
+export type { BrowserConfig, BrowserProfileConfig } from "../config/types.browser.js";
 export {
   loadSessionStore,
   readSessionUpdatedAt,

--- a/src/plugin-sdk/speech-core.ts
+++ b/src/plugin-sdk/speech-core.ts
@@ -1,5 +1,25 @@
 // Shared speech-provider implementation helpers for bundled and third-party plugins.
 
+import { parseTtsDirectives as parseTtsDirectivesImpl } from "../tts/directives.js";
+import {
+  canonicalizeSpeechProviderId as canonicalizeSpeechProviderIdImpl,
+  getSpeechProvider as getSpeechProviderImpl,
+  listSpeechProviders as listSpeechProvidersImpl,
+  normalizeSpeechProviderId as normalizeSpeechProviderIdImpl,
+} from "../tts/provider-registry.js";
+import {
+  normalizeTtsAutoMode as normalizeTtsAutoModeImpl,
+  TTS_AUTO_MODES as TTS_AUTO_MODES_IMPL,
+} from "../tts/tts-auto-mode.js";
+import {
+  normalizeApplyTextNormalization as normalizeApplyTextNormalizationImpl,
+  normalizeLanguageCode as normalizeLanguageCodeImpl,
+  normalizeSeed as normalizeSeedImpl,
+  requireInRange as requireInRangeImpl,
+  scheduleCleanup as scheduleCleanupImpl,
+  summarizeText as summarizeTextImpl,
+} from "../tts/tts-core.js";
+
 export type { SpeechProviderPlugin } from "../plugins/types.js";
 export type {
   SpeechDirectiveTokenParseContext,
@@ -19,19 +39,16 @@ export type {
   TtsDirectiveParseResult,
 } from "../tts/provider-types.js";
 
-export {
-  scheduleCleanup,
-  summarizeText,
-  normalizeApplyTextNormalization,
-  normalizeLanguageCode,
-  normalizeSeed,
-  requireInRange,
-} from "../tts/tts-core.js";
-export { parseTtsDirectives } from "../tts/directives.js";
-export {
-  canonicalizeSpeechProviderId,
-  getSpeechProvider,
-  listSpeechProviders,
-  normalizeSpeechProviderId,
-} from "../tts/provider-registry.js";
-export { normalizeTtsAutoMode, TTS_AUTO_MODES } from "../tts/tts-auto-mode.js";
+export const scheduleCleanup = scheduleCleanupImpl;
+export const summarizeText = summarizeTextImpl;
+export const normalizeApplyTextNormalization = normalizeApplyTextNormalizationImpl;
+export const normalizeLanguageCode = normalizeLanguageCodeImpl;
+export const normalizeSeed = normalizeSeedImpl;
+export const requireInRange = requireInRangeImpl;
+export const parseTtsDirectives = parseTtsDirectivesImpl;
+export const canonicalizeSpeechProviderId = canonicalizeSpeechProviderIdImpl;
+export const getSpeechProvider = getSpeechProviderImpl;
+export const listSpeechProviders = listSpeechProvidersImpl;
+export const normalizeSpeechProviderId = normalizeSpeechProviderIdImpl;
+export const normalizeTtsAutoMode = normalizeTtsAutoModeImpl;
+export const TTS_AUTO_MODES = TTS_AUTO_MODES_IMPL;

--- a/src/plugin-sdk/speech.ts
+++ b/src/plugin-sdk/speech.ts
@@ -1,9 +1,12 @@
 // Public speech helpers for bundled or third-party plugins.
 
-export { parseTtsDirectives } from "../tts/directives.js";
+import { parseTtsDirectives as parseTtsDirectivesImpl } from "../tts/directives.js";
+
 export type {
   SpeechModelOverridePolicy,
   SpeechVoiceOption,
   TtsDirectiveOverrides,
   TtsDirectiveParseResult,
 } from "../tts/provider-types.js";
+
+export const parseTtsDirectives = parseTtsDirectivesImpl;

--- a/src/plugin-sdk/temp-path.ts
+++ b/src/plugin-sdk/temp-path.ts
@@ -3,6 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 
+export { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+
 function sanitizePrefix(prefix: string): string {
   const normalized = prefix.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
   return normalized || "tmp";

--- a/src/plugins/contracts/loader.contract.test.ts
+++ b/src/plugins/contracts/loader.contract.test.ts
@@ -1,8 +1,10 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withBundledPluginAllowlistCompat } from "../bundled-compat.js";
 import { resolveBundledWebSearchPluginIds } from "../bundled-web-search.js";
+import { clearPluginLoaderCache } from "../loader.js";
 import { loadPluginManifestRegistry } from "../manifest-registry.js";
 import { __testing as providerTesting } from "../providers.js";
+import { resetPluginRuntimeStateForTest } from "../runtime.js";
 import { resolveBundledPluginWebSearchProviders } from "../web-search-providers.js";
 import { providerContractCompatPluginIds } from "./registry.js";
 import { uniqueSortedStrings } from "./testkit.js";
@@ -28,6 +30,8 @@ describe("plugin loader contract", () => {
   let webSearchAllowlistCompatConfig: ReturnType<typeof withBundledPluginAllowlistCompat>;
 
   beforeAll(() => {
+    clearPluginLoaderCache();
+    resetPluginRuntimeStateForTest();
     providerPluginIds = uniqueSortedStrings(providerContractCompatPluginIds);
     manifestProviderPluginIds = resolveBundledManifestProviderPluginIds();
     compatPluginIds = providerTesting.resolveBundledProviderCompatPluginIds({
@@ -62,6 +66,11 @@ describe("plugin loader contract", () => {
       },
       pluginIds: webSearchPluginIds,
     });
+  });
+
+  afterAll(() => {
+    clearPluginLoaderCache();
+    resetPluginRuntimeStateForTest();
   });
 
   beforeEach(() => {

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { resolveBundledWebSearchPluginIds } from "../bundled-web-search.js";
+import { clearPluginLoaderCache } from "../loader.js";
 import { loadPluginManifestRegistry } from "../manifest-registry.js";
+import { resetPluginRuntimeStateForTest } from "../runtime.js";
 import {
   imageGenerationProviderContractRegistry,
   mediaUnderstandingProviderContractRegistry,
@@ -13,6 +15,16 @@ import {
 const REGISTRY_CONTRACT_TIMEOUT_MS = 300_000;
 
 describe("plugin contract registry", () => {
+  beforeAll(() => {
+    clearPluginLoaderCache();
+    resetPluginRuntimeStateForTest();
+  });
+
+  afterAll(() => {
+    clearPluginLoaderCache();
+    resetPluginRuntimeStateForTest();
+  });
+
   it("loads bundled non-provider capability registries without import-time failure", () => {
     expect(providerContractLoadError).toBeUndefined();
     expect(pluginRegistrationContractRegistry.length).toBeGreaterThan(0);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -65,6 +65,7 @@ import { withIsolatedTestHome } from "./test-env.js";
 
 // Set HOME/state isolation before importing any runtime OpenClaw modules.
 const testEnv = withIsolatedTestHome();
+const skipDefaultPluginRegistry = process.env.OPENCLAW_SKIP_DEFAULT_TEST_PLUGIN_REGISTRY === "1";
 
 installProcessWarningFilter();
 
@@ -319,7 +320,9 @@ function installDefaultPluginRegistry(): void {
 }
 
 beforeAll(() => {
-  installDefaultPluginRegistry();
+  if (!skipDefaultPluginRegistry) {
+    installDefaultPluginRegistry();
+  }
 });
 
 afterEach(async () => {
@@ -327,7 +330,7 @@ afterEach(async () => {
   resetContextWindowCacheForTest();
   resetModelsJsonReadyCacheForTest();
   resetSessionWriteLockStateForTest();
-  if (globalRegistryState.registry !== DEFAULT_PLUGIN_REGISTRY) {
+  if (!skipDefaultPluginRegistry && globalRegistryState.registry !== DEFAULT_PLUGIN_REGISTRY) {
     installDefaultPluginRegistry();
     globalRegistryState.key = null;
     globalRegistryState.version += 1;

--- a/vitest.contracts.config.ts
+++ b/vitest.contracts.config.ts
@@ -1,10 +1,14 @@
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 
 export function createContractsVitestConfig(env?: Record<string, string | undefined>) {
+  const contractsEnv = {
+    OPENCLAW_SKIP_DEFAULT_TEST_PLUGIN_REGISTRY: "1",
+    ...env,
+  };
   return createScopedVitestConfig(
     ["src/channels/plugins/contracts/**/*.test.ts", "src/plugins/contracts/**/*.test.ts"],
     {
-      env,
+      env: contractsEnv,
       passWithNoTests: true,
     },
   );


### PR DESCRIPTION
## Summary

- Problem: latest `main` had CI regressions from upstream API drift and brittle test seams across compaction/skills, Discord rate-limit handling, browser config wrappers, and Telegram/Feishu test wiring.
- Why it matters: `pnpm tsgo`, `pnpm build`, and targeted CI lanes on `main` were red, which blocks maintainers from landing unrelated work safely.
- What changed: rebased onto current `origin/main`, kept upstream compaction/skills fixes, then patched the remaining browser, Telegram, Feishu, Discord, and plugin-sdk wrapper breakage so the failing lanes pass again.
- What did NOT change (scope boundary): no dependency version changes, no product behavior changes beyond bug fixes needed to restore existing test/build expectations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: multiple upstream interface changes landed independently, including pi-coding-agent auth/source metadata changes and Carbon's `RateLimitError` constructor change, while several tests still relied on broad ESM mocks that no longer matched the effective runtime import seams.
- Missing detection / guardrail: the targeted suites existed, but the broken branch state on `main` showed these regressions were not reconciled together before landing.
- Prior context (`git blame`, prior PR, issue, or refactor if known): upstream `main` already picked up compaction/skills fixes (`25210317b8`, `c774db9a1f`, `b7b3c806b4`), while the remaining browser/Telegram/Feishu/Discord failures still needed follow-up.
- Why this regressed now: upstream APIs and module boundaries changed, but all dependent tests and wrapper seams were not updated in the same landing sequence.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `extensions/browser/**`, `extensions/telegram/src/channel.test.ts`, `extensions/feishu/src/docx.test.ts`, `extensions/discord/src/monitor/provider.test.ts`, `extensions/discord/src/send.creates-thread.test.ts`, `src/agents/pi-extensions/compaction-safeguard.test.ts`
- Scenario the test should lock in: wrapper exports stay aligned with the plugin SDK, Discord rate-limit callers match Carbon's current API, and Telegram/Feishu helper seams stay deterministic under module reloads.
- Why this is the smallest reliable guardrail: these failures only reproduced reliably at the boundary where runtime helpers, SDK exports, and integration-specific tests meet.
- Existing test that already covers this (if any): the files above; this PR fixes them rather than adding broader new coverage.
- If no new test is added, why not: existing targeted suites directly exercised the regressions and now pass again.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.17.0, pnpm
- Model/provider: N/A
- Integration/channel (if any): Browser, Discord, Feishu, Telegram
- Relevant config (redacted): default local maintainer checkout on latest `origin/main`

### Steps

1. Reproduce on latest `origin/main` with `pnpm tsgo`, `pnpm build`, and targeted test files from the failing CI lanes.
2. Patch the remaining API/test seam drift on a branch rebased onto `origin/main`.
3. Rerun `pnpm tsgo`, `pnpm build`, `pnpm test -- extensions/browser`, `pnpm test -- extensions/telegram/src/channel.test.ts extensions/feishu/src/docx.test.ts`, `pnpm test -- extensions/discord/src/monitor/provider.test.ts extensions/discord/src/send.creates-thread.test.ts`, and `pnpm test -- src/agents/pi-extensions/compaction-safeguard.test.ts`.

### Expected

- Build/typecheck and the previously failing targeted suites pass on top of current `origin/main`.

### Actual

- They pass with this branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the failing `main` CI surfaces locally, rebased onto latest `origin/main`, then reran the exact targeted build/type/test commands after the fixes.
- Edge cases checked: Discord rate-limit constructor shape; browser wrapper exports; Telegram and Feishu deterministic helper injection after module reload/reset; compaction-safeguard test helper compatibility with current upstream auth lookup.
- What you did **not** verify: full `pnpm test` across the entire repository.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: browser test seams could diverge again if wrapper exports change without updating the narrowed local barrels.
  - Mitigation: keep wrapper imports narrow and covered by the targeted browser tests rerun in this PR.
- Risk: integration tests that depend on third-party constructor/helper contracts can drift again on upstream package changes.
  - Mitigation: the updated targeted Discord and compaction-safeguard tests now reflect the current upstream interfaces.
