### PR TITLE
Gateway: require admin for chat.send reset

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -64,9 +64,8 @@ import {
   waitForTerminalGatewayDedupe,
 } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
+import { RESET_COMMAND_RE } from "./session-reset-command.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
-
-const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
 
 function resolveSenderIsOwnerFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -6,6 +6,7 @@ import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { stripStructuralPrefixes } from "../../auto-reply/reply/mentions.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
@@ -1328,7 +1329,11 @@ export const chatHandlers: GatewayRequestHandlers = {
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const gatewayClientScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
-    if (RESET_COMMAND_RE.test(parsedMessage) && !gatewayClientScopes.includes(ADMIN_SCOPE)) {
+    const normalizedResetCandidate = stripStructuralPrefixes(parsedMessage).trim();
+    if (
+      (RESET_COMMAND_RE.test(parsedMessage) || RESET_COMMAND_RE.test(normalizedResetCandidate)) &&
+      !gatewayClientScopes.includes(ADMIN_SCOPE)
+    ) {
       respond(
         false,
         undefined,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -95,6 +95,7 @@ type ChatAbortRequester = {
   isAdmin: boolean;
 };
 
+const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
 const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
@@ -1326,6 +1327,15 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+    const gatewayClientScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
+    if (RESET_COMMAND_RE.test(parsedMessage) && !gatewayClientScopes.includes(ADMIN_SCOPE)) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${ADMIN_SCOPE}`),
+      );
+      return;
+    }
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -67,6 +67,7 @@ import { injectTimestamp, timestampOptsFromConfig } from "./agent-timestamp.js";
 import { setGatewayDedupeEntry } from "./agent-wait-dedupe.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./attachment-normalize.js";
 import { appendInjectedAssistantMessageToTranscript } from "./chat-transcript-inject.js";
+import { RESET_COMMAND_RE } from "./session-reset-command.js";
 import type {
   GatewayRequestContext,
   GatewayRequestHandlerOptions,
@@ -95,7 +96,6 @@ type ChatAbortRequester = {
   isAdmin: boolean;
 };
 
-const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;
 const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";

--- a/src/gateway/server-methods/session-reset-command.ts
+++ b/src/gateway/server-methods/session-reset-command.ts
@@ -1,0 +1,1 @@
+export const RESET_COMMAND_RE = /^\/(new|reset)(?:\s+([\s\S]*))?$/i;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -746,13 +746,19 @@ describe("gateway server chat", () => {
           expect(directReset.ok).toBe(false);
           expect(directReset.error?.message).toBe("missing scope: operator.admin");
 
-          const sendRes = await rpcReq(scopedWs, "chat.send", {
-            sessionKey: "main",
-            message: "/reset hello after rotate",
-            idempotencyKey: "idem-write-scope-reset-rejected",
-          });
-          expect(sendRes.ok).toBe(false);
-          expect(sendRes.error?.message).toBe("missing scope: operator.admin");
+          for (const [message, idempotencyKey] of [
+            ["/reset hello after rotate", "idem-write-scope-reset-rejected"],
+            [" /reset hello after rotate", "idem-write-scope-reset-leading-space"],
+            ["[12:00] /reset hello after rotate", "idem-write-scope-reset-structured-prefix"],
+          ] as const) {
+            const sendRes = await rpcReq(scopedWs, "chat.send", {
+              sessionKey: "main",
+              message,
+              idempotencyKey,
+            });
+            expect(sendRes.ok).toBe(false);
+            expect(sendRes.error?.message).toBe("missing scope: operator.admin");
+          }
 
           const raw = await fs.readFile(testState.sessionStorePath!, "utf-8");
           const stored = JSON.parse(raw) as {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -726,6 +726,48 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.send rejects /reset for write-scoped gateway callers", async () => {
+    await withGatewayServer(async ({ port }) => {
+      await withMainSessionStore(async () => {
+        let scopedWs: WebSocket | undefined;
+
+        try {
+          scopedWs = new WebSocket(`ws://127.0.0.1:${port}`);
+          trackConnectChallengeNonce(scopedWs);
+          await new Promise<void>((resolve) => scopedWs?.once("open", resolve));
+          await connectOk(scopedWs, {
+            scopes: ["operator.write"],
+          });
+
+          const directReset = await rpcReq(scopedWs, "sessions.reset", {
+            key: "agent:main:main",
+            reason: "reset",
+          });
+          expect(directReset.ok).toBe(false);
+          expect(directReset.error?.message).toBe("missing scope: operator.admin");
+
+          const sendRes = await rpcReq(scopedWs, "chat.send", {
+            sessionKey: "main",
+            message: "/reset hello after rotate",
+            idempotencyKey: "idem-write-scope-reset-rejected",
+          });
+          expect(sendRes.ok).toBe(false);
+          expect(sendRes.error?.message).toBe("missing scope: operator.admin");
+
+          const raw = await fs.readFile(testState.sessionStorePath!, "utf-8");
+          const stored = JSON.parse(raw) as {
+            "agent:main:main"?: {
+              sessionId?: string;
+            };
+          };
+          expect(stored["agent:main:main"]?.sessionId).toBe("sess-main");
+        } finally {
+          scopedWs?.close();
+        }
+      });
+    });
+  });
+
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     await withMainSessionStore(async () => {
       const runId = "idem-wait-chat-1";


### PR DESCRIPTION
## Summary
- align `chat.send` reset handling with the existing admin-only session reset boundary
- add a gateway regression covering write-scoped `/reset` requests through `chat.send`

## Changes
- reject internal `chat.send` `/new` and `/reset` requests unless the caller has `operator.admin`
- keep the direct `sessions.reset` and indirect `chat.send` reset behavior aligned for write-scoped callers
- add a regression test proving the session id does not rotate when `operator.write` attempts `/reset` through `chat.send`

## Validation
- Ran `pnpm test -- src/gateway/server.chat.gateway-server-chat.test.ts`
- Ran `pnpm test -- src/gateway/server-methods/agent.test.ts -t "rejects /reset for write-scoped gateway callers"`
- Ran `claude -p "/review"` (the command returned immediately asking for approval to run `gh pr list`, so no actionable review feedback was produced)

## Notes
- `pnpm build` currently fails in unrelated Discord files already present in this branch: `extensions/discord/src/voice-message.ts:286`, `extensions/discord/src/send.creates-thread.test.ts:423`, and `extensions/discord/src/monitor/provider.test.ts:626`
