### PR TITLE
fix(channels): pin outbound adapter registry resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ Docs: https://docs.openclaw.ai
 - Message tool/buttons: keep the shared `buttons` schema optional in merged tool definitions so plain `action=send` calls stop failing validation when no buttons are provided. (#54418) Thanks @adzendo.
 - Agents/openai-compatible tool calls: deduplicate repeated tool call ids across live assistant messages and replayed history so OpenAI-compatible backends no longer reject duplicate `tool_call_id` values with HTTP 400. (#40996) Thanks @xaeon2026.
 - Models/openai-completions: default non-native OpenAI-compatible providers to omit tool-definition `strict` fields unless users explicitly opt back in, so tool calling keeps working on providers that reject that option. (#45497) Thanks @sahancava.
+- Plugins/channels: make outbound adapter loading follow the pinned channel registry snapshot so registry rewrites no longer drop configured outbound adapters mid-process. (#55382) Thanks @bill492.
+- Maintainer follow-up: harden channel-registry cache invalidation and test isolation for pinned outbound adapters. Thanks @vincentkoc.
 - Plugins/context engines: retry strict legacy `assemble()` calls without the new `prompt` field when older engines reject it, preserving prompt-aware retrieval compatibility for pre-prompt plugins. (#50848) thanks @danhdoan.
 - CLI/update status: explicitly say `up to date` when the local version already matches npm latest, while keeping the availability logic unchanged. (#51409) Thanks @dongzhenye.
 - Daemon/Linux: stop flagging non-gateway systemd services as duplicate gateways just because their unit files mention OpenClaw, reducing false-positive doctor/log noise. (#45328) Thanks @gregretkowski.

--- a/src/channels/plugins/contracts/plugins-core.contract.test.ts
+++ b/src/channels/plugins/contracts/plugins-core.contract.test.ts
@@ -29,7 +29,12 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import type { LineProbeResult } from "../../../plugin-sdk/line.js";
 import { clearPluginDiscoveryCache } from "../../../plugins/discovery.js";
 import { clearPluginManifestRegistryCache } from "../../../plugins/manifest-registry.js";
-import { setActivePluginRegistry } from "../../../plugins/runtime.js";
+import {
+  releasePinnedPluginChannelRegistry,
+  pinActivePluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
   createMSTeamsTestPluginBase,
@@ -73,10 +78,14 @@ describe("channel plugin registry", () => {
   });
 
   beforeEach(() => {
+    resetPluginRuntimeStateForTest();
+    releasePinnedPluginChannelRegistry();
     setActivePluginRegistry(emptyRegistry);
   });
 
   afterEach(() => {
+    releasePinnedPluginChannelRegistry();
+    resetPluginRuntimeStateForTest();
     setActivePluginRegistry(emptyRegistry);
     clearPluginDiscoveryCache();
     clearPluginManifestRegistryCache();
@@ -615,10 +624,14 @@ async function expectDirectoryIds(
 
 describe("channel plugin loader", () => {
   beforeEach(() => {
+    resetPluginRuntimeStateForTest();
+    releasePinnedPluginChannelRegistry();
     setActivePluginRegistry(emptyRegistry);
   });
 
   afterEach(() => {
+    releasePinnedPluginChannelRegistry();
+    resetPluginRuntimeStateForTest();
     setActivePluginRegistry(emptyRegistry);
     clearPluginDiscoveryCache();
     clearPluginManifestRegistryCache();
@@ -648,6 +661,17 @@ describe("channel plugin loader", () => {
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
     setActivePluginRegistry(registryWithMSTeamsV2);
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutboundV2);
+  });
+
+  it("keeps outbound adapters on the pinned channel registry across active registry swaps", async () => {
+    setActivePluginRegistry(registryWithMSTeams);
+    pinActivePluginChannelRegistry(registryWithMSTeams);
+
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
+
+    setActivePluginRegistry(emptyRegistry);
+
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
   });
 
   it("returns undefined when plugin has no outbound adapter", async () => {

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,8 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  getActivePluginChannelRegistry,
+  getActivePluginChannelRegistryVersion,
+} from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -11,25 +14,31 @@ export function createChannelRegistryLoader<TValue>(
 ): (id: ChannelId) => Promise<TValue | undefined> {
   const cache = new Map<ChannelId, TValue>();
   let lastRegistry: PluginRegistry | null = null;
+  let lastRegistryVersion = -1;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
-    if (registry !== lastRegistry) {
+    const registry = getActivePluginChannelRegistry();
+    const registryVersion = getActivePluginChannelRegistryVersion();
+    if (registry !== lastRegistry || registryVersion !== lastRegistryVersion) {
       cache.clear();
       lastRegistry = registry;
-    }
-    const cached = cache.get(id);
-    if (cached) {
-      return cached;
+      lastRegistryVersion = registryVersion;
     }
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cache.delete(id);
       return undefined;
     }
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
+    if (!resolved) {
+      cache.delete(id);
+      return undefined;
     }
+    const cached = cache.get(id);
+    if (cached === resolved) {
+      return cached;
+    }
+    cache.set(id, resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- resolve outbound adapters from the pinned channel registry snapshot instead of the mutable active registry
- clear channel-registry loader cache when the pinned snapshot or version changes
- update the contract tests to cover pinned outbound behavior and reset pinned registry state between cases
- add unreleased changelog credit for the original reporter and maintainer follow-up

## Validation
- pnpm test -- src/channels/plugins/contracts/plugins-core.contract.test.ts src/plugins/runtime.channel-pin.test.ts
- pnpm build

Fixes #55382
