### PR TITLE
fix(pairing): expand default bootstrap profile and use subset matching for verification

### DIFF
--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -164,6 +164,24 @@ describe("device bootstrap tokens", () => {
     await expect(fs.readFile(bootstrapPath, "utf8")).resolves.toBe("{}");
   });
 
+  it("honors operator.admin when validating requested operator subsets", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      profile: {
+        roles: ["operator"],
+        scopes: ["operator.admin"],
+      },
+    });
+
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.read", "operator.write", "operator.pairing"],
+      }),
+    ).resolves.toEqual({ ok: true });
+  });
+
   it("keeps the token when required verification fields are blank", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({ baseDir });

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -64,8 +64,18 @@ describe("device bootstrap tokens", () => {
       ts: Date.now(),
       issuedAtMs: Date.now(),
       profile: {
-        roles: ["node"],
-        scopes: [],
+        roles: ["node", "operator"],
+        scopes: [
+          "node.camera",
+          "node.display",
+          "node.exec",
+          "node.voice",
+          "operator.approvals",
+          "operator.pairing",
+          "operator.read",
+          "operator.talk.secrets",
+          "operator.write",
+        ],
       },
     });
   });
@@ -74,7 +84,9 @@ describe("device bootstrap tokens", () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
-    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, { role: "operator" }),
+    ).resolves.toEqual({ ok: true });
 
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({
       ok: false,
@@ -145,7 +157,9 @@ describe("device bootstrap tokens", () => {
       "utf8",
     );
 
-    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, { role: "node", scopes: [] }),
+    ).resolves.toEqual({ ok: true });
 
     await expect(fs.readFile(bootstrapPath, "utf8")).resolves.toBe("{}");
   });

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {
   normalizeDeviceBootstrapProfile,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
-  sameDeviceBootstrapProfile,
+  satisfiesDeviceBootstrapProfile,
   type DeviceBootstrapProfile,
   type DeviceBootstrapProfileInput,
 } from "../shared/device-bootstrap-profile.js";
@@ -188,10 +188,10 @@ export async function verifyDeviceBootstrapToken(params: {
     });
     const allowedProfile = resolvePersistedBootstrapProfile(record);
     // Fail closed for unbound legacy setup codes and for any attempt to redeem
-    // the token outside the exact role/scope profile it was issued for.
+    // the token outside the roles/scopes profile it was issued for.
     if (
       allowedProfile.roles.length === 0 ||
-      !sameDeviceBootstrapProfile(requestedProfile, allowedProfile)
+      !satisfiesDeviceBootstrapProfile(requestedProfile, allowedProfile)
     ) {
       return { ok: false, reason: "bootstrap_token_invalid" };
     }

--- a/src/plugin-sdk/device-bootstrap.ts
+++ b/src/plugin-sdk/device-bootstrap.ts
@@ -10,6 +10,7 @@ export {
   normalizeDeviceBootstrapProfile,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   sameDeviceBootstrapProfile,
+  satisfiesDeviceBootstrapProfile,
   type DeviceBootstrapProfile,
   type DeviceBootstrapProfileInput,
 } from "../shared/device-bootstrap-profile.js";

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -1,4 +1,5 @@
 import { normalizeDeviceAuthRole, normalizeDeviceAuthScopes } from "./device-auth.js";
+import { roleScopesAllow } from "./operator-scope-compat.js";
 
 export type DeviceBootstrapProfile = {
   roles: string[];
@@ -69,9 +70,28 @@ export function satisfiesDeviceBootstrapProfile(
   requested: DeviceBootstrapProfile,
   allowed: DeviceBootstrapProfile,
 ): boolean {
-  return (
-    requested.roles.length > 0 &&
-    requested.roles.every((role) => allowed.roles.includes(role)) &&
-    requested.scopes.every((scope) => allowed.scopes.includes(scope))
+  if (requested.roles.length === 0) {
+    return false;
+  }
+  const rolesMatch = requested.roles.every((role) => allowed.roles.includes(role));
+  if (!rolesMatch) {
+    return false;
+  }
+
+  // Scopes must be permitted under at least one of the requested roles
+  // (usually there is only one role requested during verification).
+  const scopesMatch = requested.roles.some((role) =>
+    roleScopesAllow({
+      role,
+      requestedScopes: requested.scopes,
+      allowedScopes: allowed.scopes,
+    }),
   );
+
+  // If no scopes are requested, scopesMatch will be true.
+  // If multiple roles are requested, and some scopes are 'operator' scopes and some are 'node' scopes,
+  // roleScopesAllow requires that ALL requested scopes be valid for the GIVEN role.
+  // To support multi-role requests requesting a mix of scopes, we must fall back to basic inclusion
+  // if `roleScopesAllow` fails, because `roleScopesAllow` enforces prefix checking (e.g. `operator.` for operator).
+  return scopesMatch || requested.scopes.every((scope) => allowed.scopes.includes(scope));
 }

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -70,6 +70,7 @@ export function satisfiesDeviceBootstrapProfile(
   allowed: DeviceBootstrapProfile,
 ): boolean {
   return (
+    requested.roles.length > 0 &&
     requested.roles.every((role) => allowed.roles.includes(role)) &&
     requested.scopes.every((scope) => allowed.scopes.includes(scope))
   );

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -10,21 +10,6 @@ export type DeviceBootstrapProfileInput = {
   scopes?: readonly string[];
 };
 
-export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
-  roles: ["node", "operator"],
-  scopes: [
-    "node.camera",
-    "node.display",
-    "node.exec",
-    "node.voice",
-    "operator.approvals",
-    "operator.pairing",
-    "operator.read",
-    "operator.talk.secrets",
-    "operator.write",
-  ],
-};
-
 function normalizeBootstrapRoles(roles: readonly string[] | undefined): string[] {
   if (!Array.isArray(roles)) {
     return [];
@@ -47,6 +32,22 @@ export function normalizeDeviceBootstrapProfile(
     scopes: normalizeDeviceAuthScopes(input?.scopes ? [...input.scopes] : []),
   };
 }
+
+export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile =
+  normalizeDeviceBootstrapProfile({
+    roles: ["operator", "node"],
+    scopes: [
+      "operator.read",
+      "operator.write",
+      "operator.talk.secrets",
+      "operator.approvals",
+      "operator.pairing",
+      "node.exec",
+      "node.display",
+      "node.camera",
+      "node.voice",
+    ],
+  });
 
 export function sameDeviceBootstrapProfile(
   left: DeviceBootstrapProfile,

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -11,8 +11,18 @@ export type DeviceBootstrapProfileInput = {
 };
 
 export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
-  roles: ["node"],
-  scopes: [],
+  roles: ["operator", "node"],
+  scopes: [
+    "operator.read",
+    "operator.write",
+    "operator.talk.secrets",
+    "operator.approvals",
+    "operator.pairing",
+    "node.exec",
+    "node.display",
+    "node.camera",
+    "node.voice",
+  ],
 };
 
 function normalizeBootstrapRoles(roles: readonly string[] | undefined): string[] {

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -11,17 +11,17 @@ export type DeviceBootstrapProfileInput = {
 };
 
 export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
-  roles: ["operator", "node"],
+  roles: ["node", "operator"],
   scopes: [
-    "operator.read",
-    "operator.write",
-    "operator.talk.secrets",
+    "node.camera",
+    "node.display",
+    "node.exec",
+    "node.voice",
     "operator.approvals",
     "operator.pairing",
-    "node.exec",
-    "node.display",
-    "node.camera",
-    "node.voice",
+    "operator.read",
+    "operator.talk.secrets",
+    "operator.write",
   ],
 };
 
@@ -57,5 +57,19 @@ export function sameDeviceBootstrapProfile(
     left.scopes.length === right.scopes.length &&
     left.roles.every((value, index) => value === right.roles[index]) &&
     left.scopes.every((value, index) => value === right.scopes[index])
+  );
+}
+
+/**
+ * Checks if the requested profile is satisfied by the allowed profile.
+ * A requested profile is satisfied if all its roles and scopes are present in the allowed profile.
+ */
+export function satisfiesDeviceBootstrapProfile(
+  requested: DeviceBootstrapProfile,
+  allowed: DeviceBootstrapProfile,
+): boolean {
+  return (
+    requested.roles.every((role) => allowed.roles.includes(role)) &&
+    requested.scopes.every((scope) => allowed.scopes.includes(scope))
   );
 }


### PR DESCRIPTION
This PR fixes the Android app pairing issue by expanding the default bootstrap profile to include the 'operator' role and necessary 'operator.*' and 'node.*' scopes.

Key changes:
1. **Subset matching for bootstrap verification**: Updated `verifyDeviceBootstrapToken` to use a new `satisfiesDeviceBootstrapProfile` helper. This allows a device to pair with a subset of the roles/scopes issued in the bootstrap token (e.g., requesting just the 'operator' role when the token allows both 'operator' and 'node'). This resolves the mismatch where the default profile now has two roles but devices only request one.
2. **Expanded default profile**: Included standard operator permissions in `PAIRING_SETUP_BOOTSTRAP_PROFILE` so new devices have functional permissions immediately after pairing.
3. **Sorted constant**: Ensured `PAIRING_SETUP_BOOTSTRAP_PROFILE` is alphabetically sorted to match normalization results and maintain test consistency.