### PR TITLE
Discord: apply component interaction policy gates

### DIFF
--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -286,6 +286,15 @@ export async function ensureGuildComponentMemberAllowed(params: {
     return true;
   }
 
+  async function replyUnauthorized() {
+    try {
+      await interaction.reply({
+        content: unauthorizedReply,
+        ...replyOpts,
+      });
+    } catch {}
+  }
+
   const channelConfig = resolveDiscordChannelConfigWithFallback({
     guildInfo,
     channelId,
@@ -298,6 +307,7 @@ export async function ensureGuildComponentMemberAllowed(params: {
   });
 
   if (channelConfig?.enabled === false) {
+    await replyUnauthorized();
     return false;
   }
   const channelAllowlistConfigured =
@@ -311,9 +321,11 @@ export async function ensureGuildComponentMemberAllowed(params: {
       channelAllowed,
     })
   ) {
+    await replyUnauthorized();
     return false;
   }
   if (channelConfig?.allowed === false) {
+    await replyUnauthorized();
     return false;
   }
 
@@ -333,12 +345,7 @@ export async function ensureGuildComponentMemberAllowed(params: {
   }
 
   logVerbose(`agent ${componentLabel}: blocked user ${user.id} (not in users/roles allowlist)`);
-  try {
-    await interaction.reply({
-      content: unauthorizedReply,
-      ...replyOpts,
-    });
-  } catch {}
+  await replyUnauthorized();
   return false;
 }
 

--- a/extensions/discord/src/monitor/agent-components-helpers.ts
+++ b/extensions/discord/src/monitor/agent-components-helpers.ts
@@ -15,6 +15,7 @@ import { resolveCommandAuthorizedFromAuthorizers } from "openclaw/plugin-sdk/com
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/config-runtime";
+import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import * as conversationRuntime from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -29,6 +30,7 @@ import {
 } from "../components.js";
 import {
   type DiscordGuildEntryResolved,
+  isDiscordGroupAllowedByPolicy,
   normalizeDiscordAllowList,
   normalizeDiscordSlug,
   resolveDiscordAllowListMatch,
@@ -265,6 +267,7 @@ export async function ensureGuildComponentMemberAllowed(params: {
   componentLabel: string;
   unauthorizedReply: string;
   allowNameMatching: boolean;
+  groupPolicy: "open" | "disabled" | "allowlist";
 }) {
   const {
     interaction,
@@ -293,6 +296,26 @@ export async function ensureGuildComponentMemberAllowed(params: {
     parentSlug: channelCtx.parentSlug,
     scope: channelCtx.isThread ? "thread" : "channel",
   });
+
+  if (channelConfig?.enabled === false) {
+    return false;
+  }
+  const channelAllowlistConfigured =
+    Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
+  const channelAllowed = channelConfig?.allowed !== false;
+  if (
+    !isDiscordGroupAllowedByPolicy({
+      groupPolicy: params.groupPolicy,
+      guildAllowlisted: Boolean(guildInfo),
+      channelAllowlistConfigured,
+      channelAllowed,
+    })
+  ) {
+    return false;
+  }
+  if (channelConfig?.allowed === false) {
+    return false;
+  }
 
   const { memberAllowed } = resolveDiscordMemberAccessState({
     channelConfig,
@@ -390,6 +413,11 @@ export async function ensureAgentComponentInteractionAllowed(params: {
     componentLabel: params.componentLabel,
     unauthorizedReply: params.unauthorizedReply,
     allowNameMatching: isDangerousNameMatchingEnabled(params.ctx.discordConfig),
+    groupPolicy: resolveOpenProviderRuntimeGroupPolicy({
+      providerConfigPresent: params.ctx.cfg.channels?.discord !== undefined,
+      groupPolicy: params.ctx.discordConfig?.groupPolicy,
+      defaultGroupPolicy: params.ctx.cfg.channels?.defaults?.groupPolicy,
+    }).groupPolicy,
   });
   if (!memberAllowed) {
     return null;

--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -27,6 +27,7 @@ import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pi
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/config-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/config-runtime";
+import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import {
@@ -103,6 +104,16 @@ import {
 import { buildDirectLabel, buildGuildLabel } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
 import { sendTyping } from "./typing.js";
+
+function resolveComponentGroupPolicy(
+  ctx: AgentComponentContext,
+): "open" | "disabled" | "allowlist" {
+  return resolveOpenProviderRuntimeGroupPolicy({
+    providerConfigPresent: ctx.cfg.channels?.discord !== undefined,
+    groupPolicy: ctx.discordConfig?.groupPolicy,
+    defaultGroupPolicy: ctx.cfg.channels?.defaults?.groupPolicy,
+  }).groupPolicy;
+}
 
 async function dispatchPluginDiscordInteractiveEvent(params: {
   ctx: AgentComponentContext;
@@ -574,6 +585,7 @@ async function handleDiscordComponentEvent(params: {
     componentLabel: params.componentLabel,
     unauthorizedReply,
     allowNameMatching,
+    groupPolicy: resolveComponentGroupPolicy(params.ctx),
   });
   if (!memberAllowed) {
     return;
@@ -755,6 +767,7 @@ async function handleDiscordModalTrigger(params: {
     componentLabel: "form",
     unauthorizedReply,
     allowNameMatching: isDangerousNameMatchingEnabled(params.ctx.discordConfig),
+    groupPolicy: resolveComponentGroupPolicy(params.ctx),
   });
   if (!memberAllowed) {
     return;
@@ -1218,6 +1231,7 @@ class DiscordComponentModal extends Modal {
       componentLabel: "form",
       unauthorizedReply: "You are not authorized to use this form.",
       allowNameMatching,
+      groupPolicy: resolveComponentGroupPolicy(this.ctx),
     });
     if (!memberAllowed) {
       return;

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -452,6 +452,99 @@ describe("discord component interactions", () => {
     expect(resolveDiscordComponentEntry({ id: "btn_1", consume: false })).not.toBeNull();
   });
 
+  it("blocks buttons from guilds removed from the allowlist", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry()],
+      modals: [],
+    });
+
+    const button = createDiscordComponentButton(
+      createComponentContext({
+        cfg: {
+          channels: { discord: { replyToMode: "first", groupPolicy: "allowlist" } },
+        } as OpenClawConfig,
+        discordConfig: createDiscordConfig({ groupPolicy: "allowlist" }),
+        guildEntries: {},
+      }),
+    );
+    const { interaction, reply } = createComponentButtonInteraction({
+      rawData: {
+        channel_id: "guild-channel",
+        guild_id: "gone",
+        id: "interaction-guild-removed",
+        member: { roles: [] },
+      } as unknown as ButtonInteraction["rawData"],
+      guild: { id: "gone", name: "Test Guild" } as unknown as ButtonInteraction["guild"],
+    });
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    expect(reply).not.toHaveBeenCalled();
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks buttons on disabled guild channels", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry()],
+      modals: [],
+    });
+
+    const button = createDiscordComponentButton(
+      createComponentContext({
+        cfg: {
+          channels: { discord: { replyToMode: "first", groupPolicy: "allowlist" } },
+        } as OpenClawConfig,
+        discordConfig: createDiscordConfig({ groupPolicy: "allowlist" }),
+        guildEntries: { g1: { channels: { "guild-channel": { allow: true, enabled: false } } } },
+      }),
+    );
+    const { interaction, reply } = createComponentButtonInteraction({
+      rawData: {
+        channel_id: "guild-channel",
+        guild_id: "g1",
+        id: "interaction-guild-disabled",
+        member: { roles: [] },
+      } as unknown as ButtonInteraction["rawData"],
+      guild: { id: "g1", name: "Test Guild" } as unknown as ButtonInteraction["guild"],
+    });
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    expect(reply).not.toHaveBeenCalled();
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks buttons on denied guild channels", async () => {
+    registerDiscordComponentEntries({
+      entries: [createButtonEntry()],
+      modals: [],
+    });
+
+    const button = createDiscordComponentButton(
+      createComponentContext({
+        cfg: {
+          channels: { discord: { replyToMode: "first", groupPolicy: "allowlist" } },
+        } as OpenClawConfig,
+        discordConfig: createDiscordConfig({ groupPolicy: "allowlist" }),
+        guildEntries: { g1: { channels: { "guild-channel": { allow: false } } } },
+      }),
+    );
+    const { interaction, reply } = createComponentButtonInteraction({
+      rawData: {
+        channel_id: "guild-channel",
+        guild_id: "g1",
+        id: "interaction-guild-denied",
+        member: { roles: [] },
+      } as unknown as ButtonInteraction["rawData"],
+      guild: { id: "g1", name: "Test Guild" } as unknown as ButtonInteraction["guild"],
+    });
+
+    await button.run(interaction, { cid: "btn_1" } as ComponentData);
+
+    expect(reply).not.toHaveBeenCalled();
+    expect(dispatchReplyMock).not.toHaveBeenCalled();
+  });
+
   async function runModalSubmission(params?: { reusable?: boolean }) {
     registerDiscordComponentEntries({
       entries: [],

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -479,7 +479,10 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(reply).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({
+      content: "You are not authorized to use this button.",
+      ephemeral: true,
+    });
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 
@@ -510,7 +513,10 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(reply).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({
+      content: "You are not authorized to use this button.",
+      ephemeral: true,
+    });
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 
@@ -541,7 +547,10 @@ describe("discord component interactions", () => {
 
     await button.run(interaction, { cid: "btn_1" } as ComponentData);
 
-    expect(reply).not.toHaveBeenCalled();
+    expect(reply).toHaveBeenCalledWith({
+      content: "You are not authorized to use this button.",
+      ephemeral: true,
+    });
     expect(dispatchReplyMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -639,6 +639,7 @@ describe("monitorDiscordProvider", () => {
         retry_after: 193.632,
         global: false,
       },
+      request,
     );
     rateLimitError.discordCode = 30034;
     clientHandleDeployRequestMock.mockRejectedValueOnce(rateLimitError);

--- a/extensions/discord/src/send.creates-thread.test.ts
+++ b/extensions/discord/src/send.creates-thread.test.ts
@@ -423,11 +423,15 @@ function createMockRateLimitError(retryAfter = 0.001): RateLimitError {
       "X-RateLimit-Bucket": "test-bucket",
     },
   });
-  return new RateLimitError(response, {
-    message: "You are being rate limited.",
-    retry_after: retryAfter,
-    global: false,
-  });
+  return new RateLimitError(
+    response,
+    {
+      message: "You are being rate limited.",
+      retry_after: retryAfter,
+      global: false,
+    },
+    request,
+  );
 }
 
 describe("retry rate limits", () => {

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -283,11 +283,15 @@ export async function sendDiscordVoiceMessage(
           retry_after?: number;
           global?: boolean;
         };
-        throw new RateLimitError(res, {
-          message: retryData.message ?? "You are being rate limited.",
-          retry_after: retryData.retry_after ?? 1,
-          global: retryData.global ?? false,
-        });
+        throw new RateLimitError(
+          res,
+          {
+            message: retryData.message ?? "You are being rate limited.",
+            retry_after: retryData.retry_after ?? 1,
+            global: retryData.global ?? false,
+          },
+          uploadUrlRequest,
+        );
       }
       const errorBody = (await res.json().catch(() => null)) as {
         code?: number;


### PR DESCRIPTION
## Summary
- Applies the existing Discord guild/channel policy checks to component interactions
- Keeps component ingress aligned with message and reaction handling

## Changes
- Added `groupPolicy`, `channelConfig.enabled`, and `channelConfig.allowed` enforcement to component interaction authorization
- Resolved runtime Discord group policy for direct component and modal entry points
- Added regression coverage for removed guilds plus disabled and denied guild channels

## Validation
- Ran `pnpm test -- extensions/discord/src/monitor/monitor.test.ts`
- Ran `pnpm build`
- Ran local agentic review and did not receive actionable findings

## Notes
- Residual risk or follow-up: live Discord end-to-end behavior was not exercised locally; coverage is through targeted unit/integration tests
- Incorporated earlier implementation direction from the existing private branch and preserved co-author credit in the commit history
