### PR TITLE
fix(sessions): honor spawned tree lineage across agents

### DIFF
--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -100,6 +100,32 @@ describe("sessions tools visibility", () => {
     });
   });
 
+  it("allows spawned ACP child sessions under tree visibility even when the child uses a different agent id", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { agentToAgent: { enabled: false } },
+    };
+    mockGatewayWithHistory((req) => {
+      if (req.method === "sessions.list" && req.params?.spawnedBy === "main") {
+        return { sessions: [{ key: "agent:opencode:acp:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee" }] };
+      }
+      if (req.method === "sessions.resolve") {
+        const key = typeof req.params?.key === "string" ? String(req.params?.key) : "";
+        return { key };
+      }
+      return undefined;
+    });
+
+    const tool = getSessionsHistoryTool();
+    const result = await tool.execute("call-acp-child", {
+      sessionKey: "agent:opencode:acp:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+    });
+
+    expect(result.details).toMatchObject({
+      sessionKey: "agent:opencode:acp:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee",
+    });
+  });
+
   it("allows broader access when tools.sessions.visibility=all", async () => {
     mockConfig = {
       session: { mainKey: "main", scope: "per-sender" },

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -141,6 +141,35 @@ describe("createSessionVisibilityGuard", () => {
     sessionsResolutionTesting.setDepsForTest();
   });
 
+  it("allows spawned tree targets even when the child session belongs to a different agent", async () => {
+    sessionsResolutionTesting.setDepsForTest({
+      callGateway: vi.fn(async (request: { method?: string; params?: { key?: string } }) => {
+        if (request.method === "sessions.resolve") {
+          return { key: request.params?.key };
+        }
+        if (request.method === "sessions.list") {
+          return {
+            sessions: [{ key: "agent:opencode:acp:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee" }],
+          };
+        }
+        return {};
+      }) as never,
+    });
+
+    const guard = await createSessionVisibilityGuard({
+      action: "history",
+      requesterSessionKey: "agent:main:main",
+      visibility: "tree",
+      a2aPolicy: createAgentToAgentPolicy({} as unknown as OpenClawConfig),
+    });
+
+    expect(guard.check("agent:opencode:acp:aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee")).toEqual({
+      allowed: true,
+    });
+
+    sessionsResolutionTesting.setDepsForTest();
+  });
+
   it("blocks cross-agent send when agent-to-agent is disabled", async () => {
     const guard = await createSessionVisibilityGuard({
       action: "send",

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -199,6 +199,15 @@ export async function createSessionVisibilityGuard(params: {
 
   const check = (targetSessionKey: string): SessionAccessResult => {
     const targetAgentId = resolveAgentIdFromSessionKey(targetSessionKey);
+    const isSpawnedTreeTarget =
+      params.visibility === "tree" &&
+      targetSessionKey !== params.requesterSessionKey &&
+      spawnedKeys?.has(targetSessionKey);
+
+    if (isSpawnedTreeTarget) {
+      return { allowed: true };
+    }
+
     const isCrossAgent = targetAgentId !== requesterAgentId;
     if (isCrossAgent) {
       if (params.visibility !== "all") {


### PR DESCRIPTION
## Summary
- allow spawned ACP child sessions when `tools.sessions.visibility` is set to `tree`, even when the child session key belongs to a different `agent:` id
- add a guard-level regression test for spawned cross-agent child visibility
- add a tool-level regression test proving `sessions_history` now returns the spawned child session

## Root Cause
The visibility guard rejected cross-agent session keys before considering whether the target session belonged to the caller's spawned session tree. Spawned ACP child sessions therefore stayed hidden even under tree visibility.

## Scope
- changes only the session visibility guard and the related visibility tests
- does not broaden generic cross-agent access outside the existing spawned-tree lineage rules

## Testing
- `pnpm exec vitest run src/agents/tools/sessions-access.test.ts src/agents/openclaw-tools.sessions-visibility.test.ts`
- `pnpm build`
- `pnpm check`
- `pnpm test`

## Screenshots
- Not applicable

Closes #54878
