### PR TITLE
feat: SkillFoundry quality gates + weighted recall for memory-core

### DIFF
--- a/.agents/skills/anvil/SKILL.md
+++ b/.agents/skills/anvil/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: anvil
+description: 6-tier quality gate that runs between every agent handoff — syntax, smoke test, self-adversarial review, scope validation, contract enforcement, and shadow risk assessment. Ported from SkillFoundry for use in OpenClaw agentic coding tasks.
+---
+
+# $anvil — The Anvil Quality Gate
+
+> 6-tier validation system that catches issues between every agent phase.
+
+## Usage
+
+```
+$anvil                    Run all tiers on current story/changed files
+$anvil t1                 Tier 1 only (syntax, banned patterns, imports)
+$anvil t1 <file>          Tier 1 on specific file
+$anvil t2                 Tier 2 (canary smoke test)
+$anvil t3                 Tier 3 (self-adversarial review of last implementation)
+$anvil t4                 Tier 4 (scope validation: expected vs actual files)
+$anvil t5                 Tier 5 (contract enforcement: API spec vs implementation)
+$anvil t6                 Tier 6 (shadow tester: risk assessment of changed code)
+$anvil --report           Full Anvil report on last story
+```
+
+## The 6 Tiers
+
+| Tier | Name                    | Type                  | What It Catches                               |
+| ---- | ----------------------- | --------------------- | --------------------------------------------- |
+| T1   | Shell Pre-Flight        | Shell checks (no LLM) | Syntax errors, banned patterns, missing files |
+| T2   | Canary Smoke Test       | Quick execution test  | Module won't import, won't compile            |
+| T3   | Self-Adversarial Review | Coder self-critique   | Untested failure modes, blind spots           |
+| T4   | Scope Validation        | Diff comparison       | Scope creep, incomplete implementation        |
+| T5   | Contract Enforcement    | API contract check    | API drift, wrong signatures                   |
+| T6   | Shadow Tester           | Risk assessment       | Priority risks for tester                     |
+
+## Instructions
+
+You are **The Anvil** — the quality gate that strikes between every agent handoff. When `$anvil` is invoked, run validation checks on the current story or changed files.
+
+### T1 — Shell Pre-Flight
+
+Run manually (no `scripts/anvil.sh` in OpenClaw — use inline commands):
+
+```bash
+# Syntax and banned pattern scan on changed files
+git diff --name-only | xargs -I{} sh -c '
+  echo "=== {} ==="
+  # TypeScript/JS: check for banned patterns
+  grep -nE "TODO|FIXME|PLACEHOLDER|STUB|NOT IMPLEMENTED|throw new Error\(\"Not implemented" {} || true
+  # Check imports resolve (TypeScript)
+  [[ "{}" == *.ts ]] && pnpm tsgo --noEmit --allowImportingTsExtensions {} 2>&1 | head -20 || true
+'
+```
+
+Banned patterns (zero-tolerance in production code):
+
+```
+TODO, FIXME, HACK, XXX, PLACEHOLDER, STUB, MOCK (outside test files),
+NOT IMPLEMENTED, WIP, TEMPORARY, TEMP, COMING SOON, Lorem ipsum
+```
+
+Banned code patterns:
+
+```typescript
+throw new Error("Not implemented");
+return null; // placeholder
+return undefined;
+return []; // empty stub
+return {}; // empty stub
+// @ts-ignore  (without justification comment)
+any; // type evasion — use real types or unknown
+```
+
+**T1 scan command:**
+
+```bash
+grep -rn "TODO\|FIXME\|PLACEHOLDER\|STUB\|NOT IMPLEMENTED\|COMING SOON" \
+  --include="*.ts" --include="*.js" \
+  --exclude-dir=node_modules --exclude-dir=dist \
+  --exclude="*.test.ts" --exclude="*.test.js" \
+  --exclude="*.spec.ts"
+```
+
+### T2 — Canary Smoke Test
+
+```bash
+# TypeScript: build check
+pnpm build 2>&1 | tail -30
+
+# Or scoped type check
+pnpm tsgo 2>&1 | tail -30
+```
+
+### T3 — Self-Adversarial Review
+
+For the recently implemented code:
+
+1. List 3+ failure modes (what could go wrong)
+2. Each must have a mitigation (test/guard/validation)
+3. Verdict: **RESILIENT** or **VULNERABLE**
+
+### T4 — Scope Validation
+
+Compare expected changes from the task description vs `git diff --name-only`. Flag:
+
+- Unexpected files modified (scope creep)
+- Expected files missing (incomplete)
+
+### T5 — Contract Enforcement
+
+If the task has an API contract (OpenAPI spec, TypeScript interfaces, DTOs):
+
+- Verify all endpoint paths exist in implementation
+- Check request/response field names match contract exactly
+- No extra or missing required fields
+
+```bash
+# Find interface definitions
+grep -rn "interface\|type.*=" src/ --include="*.ts" | grep -v test | head -30
+```
+
+### T6 — Shadow Risk Assessment
+
+Read changed files and generate a prioritized risk list:
+
+- HIGH: security boundaries, auth checks, data integrity
+- MEDIUM: error handling, edge cases, concurrent access
+- LOW: logging gaps, documentation drift
+
+## Output Format
+
+```
+The Anvil — Quality Gate Report
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  T1 (Shell Pre-Flight):      PASS / WARN / FAIL
+  T2 (Canary Smoke Test):     PASS / FAIL / SKIP
+  T3 (Self-Adversarial):      RESILIENT / VULNERABLE / SKIP
+  T4 (Scope Validation):      PASS / WARN / FAIL / SKIP
+  T5 (Contract Enforcement):  PASS / WARN / FAIL / SKIP
+  T6 (Shadow Risk):           [N] HIGH, [N] MEDIUM, [N] LOW
+
+  Overall: PASS / WARN / FAIL
+  Action: CONTINUE / FIX_REQUIRED / BLOCK
+```
+
+## Handoff Protocol
+
+### Anvil → Fix (on FAIL)
+
+Route failures with structured context:
+
+```
+ANVIL → FIX HANDOFF
+Tier: T1 / T5
+File: <path>
+Line: <line>
+Issue: <description>
+Fix Type: REMOVE_BANNED_PATTERN / CONTRACT_VIOLATION / TYPE_ERROR
+```
+
+### Anvil → Continue (on PASS)
+
+```
+ANVIL PASS — T6 risk list attached for tester reference
+Ready for: next pipeline stage
+```
+
+## OpenClaw Integration
+
+Run `$anvil` after any of these agent actions:
+
+- After implementing a new extension or channel handler
+- Before merging a PR (`$openclaw-pr-maintainer` calls this)
+- After modifying plugin SDK interfaces (T5 contract check)
+- Before any `pnpm build` gate
+
+```bash
+# Quick local gate (matches CI)
+pnpm check && pnpm test -- <changed-files-pattern>
+```
+
+## Error Handling
+
+| Error                | Resolution                               |
+| -------------------- | ---------------------------------------- |
+| No changed files     | Use `git diff HEAD~1 --name-only`        |
+| T2 import fails      | Run `pnpm install` then retry            |
+| T5 no contract found | Skip T5; note it explicitly              |
+| Tier timeout         | Skip with TIMEOUT, log for investigation |
+
+## Reflection Protocol
+
+**Pre-Execution:** Which files changed? Is there story/task context for T4/T5? Should all 6 tiers run?
+
+**Post-Execution:** Were findings real (not false positives)? Are all findings actionable? Was the handoff structured?
+
+**Self-Score (1-10):**
+
+- Thoroughness: No inappropriate skips? Re-run if <6.
+- Accuracy: No false positives?
+- Actionability: Each finding has clear fix instructions?
+
+---
+
+_The Anvil — Strike early. Strike often. Every handoff is a checkpoint._

--- a/.agents/skills/gate-keeper/SKILL.md
+++ b/.agents/skills/gate-keeper/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: gate-keeper
+description: Cold-blooded quality guardian that blocks phase advancement without evidence. Enforces banned patterns, three-layer validation, and auto-routes violations to the right specialist. Ported from SkillFoundry for OpenClaw agentic coding tasks.
+---
+
+# $gate-keeper — Reptilian Gate Keeper
+
+**Role:** Cold-blooded guardian who stands between stages of development and permits passage only when capability is demonstrated through irrefutable evidence.
+
+**Purpose:** Enforce production-ready standards, detect violations, and either auto-remediate or escalate to specialists.
+
+## Hard Rules
+
+- ALWAYS demand evidence of capability before permitting phase advancement
+- NEVER allow passage based on time elapsed, lines written, or promises
+- REJECT submissions that lack test results, security checks, or documentation
+- DO verify every claim against concrete artifacts (test reports, coverage data)
+- CHECK that all quality gates have objective, measurable pass criteria
+- ENSURE failed gates produce actionable feedback with specific remediation steps
+- IMPLEMENT escalation for repeated gate failures — three consecutive fails triggers review
+
+## Core Philosophy
+
+**No phase advances based on:** time elapsed · lines of code written · optimistic assertions · "almost done" · "works on my machine"
+
+**Phases advance based on:** demonstrated capability · passing tests · code that executes correctly · evidence of survival in target environment · reproducible success
+
+## Operating Modes
+
+```
+$gate-keeper --mode=block       # Traditional blocking mode (default)
+$gate-keeper --mode=auto-fix    # Route violations to appropriate agent
+$gate-keeper --mode=report      # Report violations without blocking
+```
+
+## ZERO TOLERANCE: BANNED PATTERNS
+
+Before ANY gate evaluation, scan for banned patterns:
+
+```bash
+grep -rn "TODO\|FIXME\|HACK\|XXX\|PLACEHOLDER\|STUB\|NOT IMPLEMENTED\|COMING SOON\|WIP\|TEMPORARY\|Lorem ipsum" \
+  --include="*.ts" --include="*.js" --include="*.tsx" --include="*.jsx" \
+  --exclude-dir=node_modules --exclude-dir=dist \
+  --exclude="*.test.ts" --exclude="*.test.js" --exclude="*.spec.*"
+```
+
+**ANY MATCH IN PRODUCTION CODE:**
+
+- Block Mode: GATE LOCKED
+- Auto-Fix Mode: Route to fix
+
+Banned code patterns (TypeScript/JavaScript):
+
+```typescript
+throw new Error("Not implemented");
+return null; // placeholder
+return undefined;
+return []; // empty stub
+return {}; // empty stub
+// @ts-ignore  (without justification)
+```
+
+## Evidence-Based Capability Gates
+
+Track accumulated **evidence** across 5 levels. Gates unlock when sufficient proof is demonstrated.
+
+| Level | Capability             | Evidence Threshold | What Proves It                             |
+| ----- | ---------------------- | ------------------ | ------------------------------------------ |
+| 1     | Syntax Validation      | 10 evidences       | Code compiles/parses without errors        |
+| 2     | Code Execution         | 20 evidences       | Tests pass, endpoints respond              |
+| 3     | Domain Problem-Solving | 30 evidences       | Business logic correct, edge cases handled |
+| 4     | Ambiguity Handling     | 50 evidences       | Unclear requirements resolved correctly    |
+| 5     | Integration Validation | 25 evidences       | Works end-to-end with real data            |
+
+| Evidence Type    | Weight |
+| ---------------- | ------ |
+| TestPassed       | 1      |
+| ExecutionSuccess | 2      |
+| UserConfirmation | 3      |
+| ReviewApproved   | 2      |
+
+Report progress: `"Gate 2 (Code Execution): 15/20 evidences"`
+
+## THREE-LAYER ENFORCEMENT
+
+Every full-stack change must pass validation on ALL affected layers:
+
+| Layer                | Required Evidence                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------- |
+| **Backend/Core**     | All endpoints/handlers work, tests pass, auth enforced, input validation complete     |
+| **Extension/Plugin** | Plugin manifest valid, lifecycle hooks complete, no cross-boundary imports            |
+| **CLI/Channel**      | Commands respond correctly, channel setup wizard complete, no mock data in production |
+
+```bash
+# Validate OpenClaw-specific layers
+$layer-check              # Full three-layer validation (see $layer-check skill)
+pnpm check                # Lint + type check
+pnpm test                 # Full test suite
+pnpm build                # Build output valid (required for plugin SDK changes)
+```
+
+## Violation Type → Agent Routing
+
+| Violation Type          | Auto-Fixable? | Route To                         |
+| ----------------------- | ------------- | -------------------------------- |
+| Missing tests           | ✅ Yes        | Add tests                        |
+| Test coverage < 70%     | ✅ Yes        | Add tests                        |
+| Security patterns       | ✅ Yes        | $security-triage or fix manually |
+| Dead/unused code        | ✅ Yes        | Remove it                        |
+| Banned patterns         | ✅ Yes        | Remove or implement              |
+| Missing types (`any`)   | ✅ Yes        | Add real types                   |
+| Plugin manifest issue   | ✅ Yes        | Fix `openclaw.plugin.json`       |
+| API contract violation  | ⚠️ Depends    | Verify against spec              |
+| Architectural ambiguity | ❌ No         | **ESCALATE to user**             |
+| Security policy choice  | ❌ No         | **ESCALATE to user**             |
+
+## Gate Decision Formats
+
+### GATE OPENED
+
+```
+✅ GATE OPENED: [Stage] → [Next Stage]
+
+Capability Demonstrated:
+- All tests pass (coverage: X%)
+- pnpm check: clean
+- pnpm build: clean
+- No banned patterns
+
+Next Gate: [what must be proven next]
+```
+
+### GATE LOCKED (Block Mode)
+
+```
+🚫 GATE LOCKED: [Stage] BLOCKED
+
+Failed Requirements:
+- [specific violation with file:line]
+- [specific violation with file:line]
+
+Required Actions:
+1. [actionable fix]
+2. [actionable fix]
+```
+
+### AUTO-FIX ROUTED
+
+```
+🔧 AUTO-FIX INITIATED
+
+Violations Found:
+1. [violation] → Fix: [action]
+2. [violation] → Fix: [action]
+
+Re-validation after fix...
+```
+
+### ESCALATION REQUIRED
+
+```
+⚠️ GATE LOCKED: ESCALATION REQUIRED
+
+Reason: [architectural decision / security policy choice]
+Attempts: [N]
+User input required to proceed.
+```
+
+## Time Pressure Response
+
+> The crocodile doesn't rush because the gazelle is impatient.
+>
+> Options: reduce scope to what's proven · accept the delay · ship with documented known issues
+>
+> Never: lower quality standards · ship with placeholders · skip security validation
+
+## OpenClaw Gate Sequence
+
+For changes to OpenClaw:
+
+1. `pnpm check` — lint + types
+2. `pnpm test -- <touched-files>` — scoped tests
+3. `$anvil` — 6-tier quality check
+4. `pnpm build` — required if touching plugin SDK, lazy-loading boundaries, or published surfaces
+5. `$gate-keeper` — final verdict before push
+
+## Regression Detection
+
+If advancing breaks previous capabilities:
+
+1. Immediate gate lock
+2. Regression tests must be added
+3. Must prove non-regression before re-attempting
+
+---
+
+_The Gate Keeper: No passage without proof. Standards never negotiable._

--- a/.agents/skills/layer-check/SKILL.md
+++ b/.agents/skills/layer-check/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: layer-check
+description: Three-layer enforcement validator for OpenClaw changes — Core/Backend, Extension/Plugin, and CLI/Channel layers. Catches incomplete implementations, banned patterns, missing tests, and cross-layer consistency gaps. Ported from SkillFoundry.
+---
+
+# $layer-check — Three-Layer Enforcement
+
+> "A mock is a lie you tell yourself. This system does not tolerate lies."
+> "Three layers. Three gates. Zero exceptions."
+
+## Invocation
+
+```
+$layer-check              Full three-layer validation
+$layer-check core         Core/backend layer only
+$layer-check extension    Extension/plugin layer only
+$layer-check channel      Channel/CLI layer only
+$layer-check scan         Banned pattern scan only
+$layer-check audit        Generate audit log entry
+```
+
+## ZERO TOLERANCE: BANNED PATTERNS
+
+Any code containing these patterns is **IMMEDIATELY REJECTED**:
+
+```bash
+# Run before any layer check
+grep -rn "TODO\|FIXME\|HACK\|PLACEHOLDER\|STUB\|NOT IMPLEMENTED\|WIP\|TEMPORARY\|Lorem ipsum" \
+  --include="*.ts" --include="*.js" \
+  --exclude-dir=node_modules --exclude-dir=dist \
+  --exclude="*.test.ts" --exclude="*.spec.*"
+```
+
+Banned behaviors (beyond keywords):
+
+- Mock data in production code (not test files)
+- Hardcoded credentials or tokens
+- `any` type without justification comment
+- `// @ts-ignore` without justification comment
+- `eslint-disable` without justification
+- Empty catch blocks (`catch {}`)
+- `console.log` in production paths (use OpenClaw's `createSubsystemLogger`)
+
+## LAYER 1: CORE / BACKEND
+
+```
+CORE LAYER CHECKLIST:
+□ All changed functions have correct TypeScript types (no `any`)
+□ Error handling uses OpenClaw patterns (createSubsystemLogger, not console.log)
+□ Input validation at all entry points
+□ No hardcoded credentials or tokens
+□ Auth/permissions enforced server-side (not only gated in UI)
+□ SSRF policy honored for any outbound HTTP calls
+□ Parameterized queries / safe interpolation for any DB access
+□ Timeouts on external service calls
+
+EVIDENCE REQUIRED:
+□ pnpm tsgo — no type errors in touched files
+□ pnpm test -- <touched-files> — scoped tests pass
+□ No new warnings in pnpm build output
+```
+
+## LAYER 2: EXTENSION / PLUGIN
+
+```
+EXTENSION LAYER CHECKLIST:
+□ openclaw.plugin.json manifest is valid and complete
+□ Plugin id matches directory name and package name
+□ No workspace:* in dependencies (use devDependencies/peerDependencies)
+□ No direct imports from core src/** (use openclaw/plugin-sdk/* only)
+□ No cross-extension relative imports (../../other-extension)
+□ Runtime deps in dependencies, build-only deps in devDependencies
+□ Plugin lifecycle hooks (setup, teardown) handled cleanly
+□ Channel capability matrix complete (if channel plugin)
+□ DM policy and group policy defined (if channel plugin)
+
+EVIDENCE REQUIRED:
+□ pnpm check — passes in extension package
+□ Extension builds cleanly: cd extensions/<id> && pnpm build
+□ pnpm test -- extensions/<id> — extension tests pass
+□ No [INEFFECTIVE_DYNAMIC_IMPORT] warnings after pnpm build
+```
+
+## LAYER 3: CLI / CHANNEL
+
+```
+CLI / CHANNEL LAYER CHECKLIST:
+□ All new commands registered correctly (no stubs)
+□ Command help text is accurate and complete
+□ Channel setup wizard reaches completion (no placeholder steps)
+□ No mock/static data returned to channel messages
+□ Status output uses src/terminal/table.ts patterns
+□ Progress uses src/cli/progress.ts (osc-progress / @clack/prompts)
+□ No hardcoded colors (use src/terminal/palette.ts)
+□ Messages to external channels are final (no streaming partial replies)
+
+EVIDENCE REQUIRED:
+□ openclaw <command> --help — output is correct
+□ Manual or automated test of command flow
+□ No console.log in channel message handlers
+```
+
+## ITERATION ENFORCEMENT
+
+Every story/task completion MUST include:
+
+### Documentation Gate
+
+```
+□ Public functions/exports have JSDoc comments explaining WHY
+□ New config fields documented in config schema
+□ If touching docs/: internal links use root-relative paths (no .md extension)
+□ CHANGELOG updated (user-facing changes only, appended to end of section)
+```
+
+### Security Gate
+
+```
+□ No new secrets committed (run: git diff | grep -i "password\|secret\|token\|api_key")
+□ Input sanitization on all user-controlled data
+□ Auth tokens not logged
+□ No dangerouslySetInnerHTML / eval() without sanitization
+□ SSRF prevention for any URL-accepting code
+```
+
+### Audit Entry
+
+```
+| Date | Task | Layers | Security | Docs | Tests | Verdict |
+|------|------|--------|----------|------|-------|---------|
+| [date] | [task] | Core:✓ Ext:✓ CLI:✓ | ✓ | ✓ | ✓ | PASS |
+```
+
+## POST-IMPLEMENTATION VERDICT
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ LAYER ENFORCEMENT VERDICT                                   │
+├─────────────────────────────────────────────────────────────┤
+│ Task: [description]                                         │
+│ Date: [timestamp]                                           │
+│                                                             │
+│ CORE LAYER:                                                 │
+│ ├─ Types: [✓/✗]                                             │
+│ ├─ Tests: [✓/✗]                                             │
+│ ├─ Security: [✓/✗]                                          │
+│ └─ Status: [PASS/FAIL]                                      │
+│                                                             │
+│ EXTENSION LAYER:                                            │
+│ ├─ Manifest Valid: [✓/✗]                                    │
+│ ├─ Import Boundaries: [✓/✗]                                 │
+│ ├─ Build Clean: [✓/✗]                                       │
+│ └─ Status: [PASS/FAIL]                                      │
+│                                                             │
+│ CLI/CHANNEL LAYER:                                          │
+│ ├─ Commands Complete: [✓/✗]                                 │
+│ ├─ No Mock Data: [✓/✗]                                      │
+│ ├─ Patterns Followed: [✓/✗]                                 │
+│ └─ Status: [PASS/FAIL]                                      │
+│                                                             │
+│ ITERATION GATES:                                            │
+│ ├─ Documentation: [✓/✗]                                     │
+│ ├─ Security Scan: [✓/✗]                                     │
+│ └─ Audit Log: [✓/✗]                                         │
+│                                                             │
+│ BANNED PATTERN SCAN: [CLEAN/VIOLATIONS]                     │
+│                                                             │
+│ ══════════════════════════════════════════════════════════ │
+│ VERDICT: [APPROVED / REJECTED]                              │
+│                                                             │
+│ If REJECTED:                                                │
+│ - [Specific failure reason with file:line]                  │
+│ - [Required fix]                                            │
+│ - [Re-validation instructions]                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Integration with OpenClaw Pipeline
+
+`$layer-check` runs automatically in:
+
+- `$gate-keeper` validation (calls `$layer-check` before gate decision)
+- `$anvil T4/T5` (scope + contract checks overlap with layer enforcement)
+- `$openclaw-pr-maintainer` (bug-fix evidence bar requires layer validation)
+
+For changes spanning all three layers (e.g., new channel + config + CLI):
+
+```bash
+# Full validation sequence
+pnpm check                      # lint + types (all packages)
+pnpm test                       # full suite
+pnpm build                      # required for SDK/boundary changes
+$layer-check                    # three-layer verdict
+$anvil                          # 6-tier quality gate
+```
+
+## Reflection Protocol
+
+**Pre-Execution:**
+
+1. Which layers does this change affect?
+2. Are banned pattern exclusions correct (not excluding production files)?
+3. Are there recent migrations or SDK changes that affect layer integrity?
+
+**Post-Execution:**
+
+1. Did all affected layers pass independently?
+2. Were banned patterns resolved (not just documented)?
+3. Is the audit entry complete with evidence for each gate?
+4. Are there cross-layer consistency gaps (e.g., CLI expects config fields extension doesn't expose)?
+
+**Self-Score (0-10):**
+
+- Layer Coverage: All affected layers validated with evidence?
+- Banned Pattern Detection: Scan thorough, violations resolved?
+- Cross-Layer Consistency: CLI/Extension/Core alignment verified?
+- Gate Rigor: No shortcuts on documentation, security, or audit?
+
+**If overall < 7.0:** Re-run failed layer checks before closing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Docs: https://docs.openclaw.ai
 - Docs: add `pnpm docs:check-links:anchors` for Mintlify anchor validation while keeping `scripts/docs-link-audit.mjs` as the stable link-audit entrypoint. (#55912) Thanks @velvet-shark.
 - Plugins/hooks: add async `requireApproval` to `before_tool_call` hooks, letting plugins pause tool execution and prompt the user for approval via the exec approval overlay, Telegram buttons, Discord interactions, or the `/approve` command on any channel. The `/approve` command now handles both exec and plugin approvals with automatic fallback. (#55339) Thanks @vaclavbelak and @joshavant.
 - ACP/channels: add current-conversation ACP binds for Discord, BlueBubbles, and iMessage so `/acp spawn codex --bind here` can turn the current chat into a Codex-backed workspace without creating a child thread, and document the distinction between chat surface, ACP session, and runtime workspace.
+- Memory/CLI: add weighted recall scoring to `memory-core` — each chunk carries a relevance weight (default 1.0) multiplied into hybrid search scores after vector + BM25 + temporal-decay. Use `openclaw memory feedback recall <id>` to boost a useful result (+0.1, max 3.0) or `openclaw memory feedback correct <id>` to demote a stale one (weight → 0.3). Weights persist per-agent in `memory-weights.json`.
+- Skills: add `$anvil`, `$gate-keeper`, and `$layer-check` agent skills — a 6-tier quality gate, evidence-based phase guardian, and three-layer enforcement validator for use in OpenClaw agentic coding tasks.
 
 ### Fixes
 

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -2,6 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { resolveAgentDir } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
   colorize,
   defaultRuntime,
@@ -29,6 +30,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import type { MemoryCommandOptions, MemorySearchCommandOptions } from "./cli.types.js";
 import { getMemorySearchManager } from "./memory/index.js";
+import { WeightedRecallStore } from "./memory/weighted-recall.js";
 
 type MemoryManager = NonNullable<Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]>;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
@@ -762,4 +764,68 @@ export async function runMemorySearch(
       defaultRuntime.log(lines.join("\n").trim());
     },
   });
+}
+
+/**
+ * `openclaw memory feedback recall <chunk-id>`
+ *
+ * Marks a search result chunk as useful, boosting its relevance weight by
+ * WEIGHT_RECALL_INCREMENT (0.1) up to a maximum of 3.0. Mirrors SkillFoundry's
+ * `$memory` recall feedback that promotes entries the agent found valuable.
+ */
+export async function runMemoryFeedbackRecall(
+  chunkId: string,
+  opts: MemoryCommandOptions,
+): Promise<void> {
+  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory feedback recall");
+  emitMemorySecretResolveDiagnostics(diagnostics);
+  const agentId = resolveAgent(cfg, opts.agent);
+  const stateDir = resolveAgentDir(cfg, agentId);
+  const store = new WeightedRecallStore(stateDir);
+  const prevWeight = await store.getWeight(chunkId);
+  await store.recordRecall(chunkId);
+  await store.flush();
+  const nextWeight = await store.getWeight(chunkId);
+  const rich = isRich();
+  defaultRuntime.log(
+    `${colorize(rich, theme.success, "✓")} Recall recorded for ${colorize(rich, theme.accent, chunkId)}: ` +
+      `weight ${colorize(rich, theme.muted, prevWeight.toFixed(2))} → ${colorize(rich, theme.success, nextWeight.toFixed(2))}`,
+  );
+}
+
+/**
+ * `openclaw memory feedback correct <chunk-id>`
+ *
+ * Demotes a stale or incorrect chunk by setting its weight to
+ * WEIGHT_CORRECTION_ORIGINAL (0.3). The chunk remains in the index and can
+ * still be found, but it will rank significantly lower in hybrid scoring.
+ * Mirrors SkillFoundry's correction chain that deprioritizes superseded entries.
+ *
+ * Create a corrected replacement entry in your memory files; the replacement
+ * starts at the default weight (1.0) and accumulates recall boosts over time.
+ */
+export async function runMemoryFeedbackCorrect(
+  chunkId: string,
+  opts: MemoryCommandOptions,
+): Promise<void> {
+  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory feedback correct");
+  emitMemorySecretResolveDiagnostics(diagnostics);
+  const agentId = resolveAgent(cfg, opts.agent);
+  const stateDir = resolveAgentDir(cfg, agentId);
+  const store = new WeightedRecallStore(stateDir);
+  const prevWeight = await store.getWeight(chunkId);
+  const correctionWeight = await store.recordCorrection(chunkId);
+  await store.flush();
+  const rich = isRich();
+  defaultRuntime.log(
+    `${colorize(rich, theme.warn, "⚠")} Correction recorded for ${colorize(rich, theme.accent, chunkId)}: ` +
+      `weight ${colorize(rich, theme.muted, prevWeight.toFixed(2))} → ${colorize(rich, theme.warn, "0.30")} (demoted)`,
+  );
+  defaultRuntime.log(
+    colorize(
+      rich,
+      theme.muted,
+      `Add the corrected content to a memory file. New entries start at weight ${correctionWeight.toFixed(2)}.`,
+    ),
+  );
 }

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -30,7 +30,7 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import type { MemoryCommandOptions, MemorySearchCommandOptions } from "./cli.types.js";
 import { getMemorySearchManager } from "./memory/index.js";
-import { WeightedRecallStore } from "./memory/weighted-recall.js";
+import { WeightedRecallStore, WEIGHT_CORRECTION_ORIGINAL } from "./memory/weighted-recall.js";
 
 type MemoryManager = NonNullable<Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]>;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
@@ -819,7 +819,7 @@ export async function runMemoryFeedbackCorrect(
   const rich = isRich();
   defaultRuntime.log(
     `${colorize(rich, theme.warn, "⚠")} Correction recorded for ${colorize(rich, theme.accent, chunkId)}: ` +
-      `weight ${colorize(rich, theme.muted, prevWeight.toFixed(2))} → ${colorize(rich, theme.warn, "0.30")} (demoted)`,
+      `weight ${colorize(rich, theme.muted, prevWeight.toFixed(2))} → ${colorize(rich, theme.warn, WEIGHT_CORRECTION_ORIGINAL.toFixed(2))} (demoted)`,
   );
   defaultRuntime.log(
     colorize(

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -30,6 +30,19 @@ async function runMemorySearch(queryArg: string | undefined, opts: MemorySearchC
   await runtime.runMemorySearch(queryArg, opts);
 }
 
+async function runMemoryFeedbackRecall(chunkId: string, opts: MemoryCommandOptions): Promise<void> {
+  const runtime = await loadMemoryCliRuntime();
+  await runtime.runMemoryFeedbackRecall(chunkId, opts);
+}
+
+async function runMemoryFeedbackCorrect(
+  chunkId: string,
+  opts: MemoryCommandOptions,
+): Promise<void> {
+  const runtime = await loadMemoryCliRuntime();
+  await runtime.runMemoryFeedbackCorrect(chunkId, opts);
+}
+
 export function registerMemoryCli(program: Command) {
   const memory = program
     .command("memory")
@@ -70,6 +83,40 @@ export function registerMemoryCli(program: Command) {
     .option("--verbose", "Verbose logging", false)
     .action(async (opts: MemoryCommandOptions) => {
       await runMemoryIndex(opts);
+    });
+
+  const feedback = memory
+    .command("feedback")
+    .description("Adjust memory relevance weights (ported from SkillFoundry weighted recall)")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw memory feedback recall <chunk-id>",
+            "Mark a result as useful (+0.1 weight boost).",
+          ],
+          [
+            "openclaw memory feedback correct <chunk-id>",
+            "Demote a stale/wrong chunk (weight → 0.3).",
+          ],
+        ])}\n`,
+    );
+
+  feedback
+    .command("recall <chunk-id>")
+    .description("Boost a chunk's relevance weight by 0.1 (max 3.0)")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .action(async (chunkId: string, opts: MemoryCommandOptions) => {
+      await runMemoryFeedbackRecall(chunkId, opts);
+    });
+
+  feedback
+    .command("correct <chunk-id>")
+    .description("Demote a stale or incorrect chunk (weight → 0.3)")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .action(async (chunkId: string, opts: MemoryCommandOptions) => {
+      await runMemoryFeedbackCorrect(chunkId, opts);
     });
 
   memory

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -30,6 +30,7 @@ import {
 import { bm25RankToScore, buildFtsQuery, mergeHybridResults } from "./hybrid.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import { searchKeyword, searchVector } from "./manager-search.js";
+import { applyWeightsToResults, WeightedRecallStore } from "./weighted-recall.js";
 const SNIPPET_MAX_CHARS = 700;
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
@@ -80,6 +81,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected readonly agentId: string;
   protected readonly workspaceDir: string;
   protected readonly settings: ResolvedMemorySearchConfig;
+  readonly weightStore: WeightedRecallStore;
   protected provider: EmbeddingProvider | null;
   private readonly requestedProvider: EmbeddingProviderRequest;
   private providerInitPromise: Promise<void> | null = null;
@@ -229,6 +231,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.agentId = params.agentId;
     this.workspaceDir = params.workspaceDir;
     this.settings = params.settings;
+    this.weightStore = new WeightedRecallStore(resolveAgentDir(params.cfg, params.agentId));
     this.provider = null;
     this.requestedProvider = params.settings.provider;
     if (params.providerResult) {
@@ -529,7 +532,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       mmr: params.mmr,
       temporalDecay: params.temporalDecay,
       workspaceDir: this.workspaceDir,
-    }).then((entries) => entries.map((entry) => entry as MemorySearchResult));
+    }).then(async (entries) => {
+      const weighted = await applyWeightsToResults(
+        entries.map((e) => ({ ...(e as MemorySearchResult & { id: string }) })),
+        this.weightStore,
+      );
+      return weighted.map((entry) => entry as MemorySearchResult);
+    });
   }
 
   async sync(params?: {

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -337,6 +337,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     if (!hasIndexedContent) {
       return [];
     }
+    // Invalidate the weight cache so CLI feedback writes from other processes
+    // are visible without requiring a gateway restart.
+    this.weightStore.invalidate();
     await this.ensureProviderInitialized();
     const minScore = opts?.minScore ?? this.settings.query.minScore;
     const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
@@ -374,12 +377,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         }
       }
 
-      const merged = [...seenIds.values()]
+      const weighted = await applyWeightsToResults([...seenIds.values()], this.weightStore);
+      return weighted
         .toSorted((a, b) => b.score - a.score)
         .filter((entry) => entry.score >= minScore)
         .slice(0, maxResults);
-
-      return merged;
     }
 
     // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
@@ -395,7 +397,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       : [];
 
     if (!hybrid.enabled || !this.fts.enabled || !this.fts.available) {
-      return vectorResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+      const weighted = await applyWeightsToResults(vectorResults, this.weightStore);
+      return weighted
+        .toSorted((a, b) => b.score - a.score)
+        .filter((entry) => entry.score >= minScore)
+        .slice(0, maxResults);
     }
 
     const merged = await this.mergeHybridResults({
@@ -508,6 +514,13 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     mmr?: { enabled: boolean; lambda: number };
     temporalDecay?: { enabled: boolean; halfLifeDays: number };
   }): Promise<MemorySearchResult[]> {
+    // Build a composite-key → id lookup from the input results (which carry ids)
+    // so we can re-attach ids after mergeHybridResults strips them from its output.
+    const idByKey = new Map<string, string>();
+    for (const r of [...params.vector, ...params.keyword]) {
+      idByKey.set(`${r.source}:${r.path}:${r.startLine}:${r.endLine}`, r.id);
+    }
+
     return mergeHybridResults({
       vector: params.vector.map((r) => ({
         id: r.id,
@@ -533,11 +546,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       temporalDecay: params.temporalDecay,
       workspaceDir: this.workspaceDir,
     }).then(async (entries) => {
-      const weighted = await applyWeightsToResults(
-        entries.map((e) => ({ ...(e as MemorySearchResult & { id: string }) })),
-        this.weightStore,
-      );
-      return weighted.map((entry) => entry as MemorySearchResult);
+      const entriesWithId = entries.map((e) => ({
+        ...e,
+        id: idByKey.get(`${e.source}:${e.path}:${e.startLine}:${e.endLine}`) ?? "",
+      }));
+      const weighted = await applyWeightsToResults(entriesWithId, this.weightStore);
+      return weighted
+        .toSorted((a, b) => b.score - a.score)
+        .map(({ id: _id, ...rest }) => rest as MemorySearchResult);
     });
   }
 

--- a/extensions/memory-core/src/memory/weighted-recall.test.ts
+++ b/extensions/memory-core/src/memory/weighted-recall.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyWeightsToResults,
+  WEIGHT_CORRECTION_NEW,
+  WEIGHT_CORRECTION_ORIGINAL,
+  WEIGHT_DEFAULT,
+  WEIGHT_RECALL_INCREMENT,
+  WeightedRecallStore,
+} from "./weighted-recall.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-weighted-recall-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("WeightedRecallStore", () => {
+  it("returns default weight for unknown chunk", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    expect(await store.getWeight("unknown-id")).toBe(WEIGHT_DEFAULT);
+  });
+
+  it("increments weight on recall", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    await store.recordRecall("chunk-1");
+    expect(await store.getWeight("chunk-1")).toBeCloseTo(WEIGHT_DEFAULT + WEIGHT_RECALL_INCREMENT);
+  });
+
+  it("accumulates multiple recalls", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    await store.recordRecall("chunk-1");
+    await store.recordRecall("chunk-1");
+    await store.recordRecall("chunk-1");
+    expect(await store.getWeight("chunk-1")).toBeCloseTo(
+      WEIGHT_DEFAULT + WEIGHT_RECALL_INCREMENT * 3,
+    );
+  });
+
+  it("clamps recall weight at MAX", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    // Recall 25 times — should not exceed 3.0
+    for (let i = 0; i < 25; i++) {
+      await store.recordRecall("chunk-1");
+    }
+    expect(await store.getWeight("chunk-1")).toBeLessThanOrEqual(3.0);
+  });
+
+  it("demotes original on correction", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    const newWeight = await store.recordCorrection("original-id");
+    expect(await store.getWeight("original-id")).toBe(WEIGHT_CORRECTION_ORIGINAL);
+    expect(newWeight).toBe(WEIGHT_CORRECTION_NEW);
+  });
+
+  it("persists weights across instances after flush", async () => {
+    const store1 = new WeightedRecallStore(tmpDir);
+    await store1.recordRecall("chunk-a");
+    await store1.recordRecall("chunk-a");
+    await store1.flush();
+
+    const store2 = new WeightedRecallStore(tmpDir);
+    expect(await store2.getWeight("chunk-a")).toBeCloseTo(
+      WEIGHT_DEFAULT + WEIGHT_RECALL_INCREMENT * 2,
+    );
+  });
+
+  it("does not write file when not dirty", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    await store.flush(); // nothing dirty yet
+    const weightsPath = path.join(tmpDir, "memory-weights.json");
+    await expect(fs.stat(weightsPath)).rejects.toThrow(); // file should not exist
+  });
+
+  it("handles missing weights file gracefully", async () => {
+    const store = new WeightedRecallStore(path.join(tmpDir, "does-not-exist"));
+    expect(await store.getWeight("any")).toBe(WEIGHT_DEFAULT);
+  });
+});
+
+describe("applyWeightsToResults", () => {
+  it("returns results unchanged when all weights are default", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    const results = [
+      { id: "a", score: 0.9, path: "p", source: "memory", snippet: "" },
+      { id: "b", score: 0.7, path: "p", source: "memory", snippet: "" },
+    ];
+    const weighted = await applyWeightsToResults(results, store);
+    expect(weighted[0].score).toBe(0.9);
+    expect(weighted[1].score).toBe(0.7);
+  });
+
+  it("boosts score of recalled chunk", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    await store.recordRecall("a");
+    const results = [
+      { id: "a", score: 0.5, path: "p", source: "memory", snippet: "" },
+      { id: "b", score: 0.9, path: "p", source: "memory", snippet: "" },
+    ];
+    const weighted = await applyWeightsToResults(results, store);
+    // chunk-a score should increase
+    expect(weighted[0].score).toBeGreaterThan(0.5);
+    // chunk-b score unchanged
+    expect(weighted[1].score).toBe(0.9);
+  });
+
+  it("demotes score of corrected chunk", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    await store.recordCorrection("stale-id");
+    const results = [{ id: "stale-id", score: 0.8, path: "p", source: "memory", snippet: "" }];
+    const weighted = await applyWeightsToResults(results, store);
+    expect(weighted[0].score).toBeLessThan(0.8);
+    expect(weighted[0].score).toBeCloseTo(0.8 * WEIGHT_CORRECTION_ORIGINAL);
+  });
+
+  it("returns empty array unchanged", async () => {
+    const store = new WeightedRecallStore(tmpDir);
+    expect(await applyWeightsToResults([], store)).toEqual([]);
+  });
+});

--- a/extensions/memory-core/src/memory/weighted-recall.ts
+++ b/extensions/memory-core/src/memory/weighted-recall.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Weighted recall store, ported from SkillFoundry's memory_bank/ weight system.
+ *
+ * Each chunk accumulates an explicit relevance weight (default 1.0) that is
+ * multiplied into the hybrid search score after vector + BM25 + temporal-decay
+ * scoring.  The update rules mirror SkillFoundry's memory_bank conventions:
+ *
+ *   - Recall  : weight += 0.1  (agent confirmed this memory was useful)
+ *   - Correct : original → 0.3, correction entry starts at 0.7
+ *
+ * Weights are clamped to [MIN_WEIGHT, MAX_WEIGHT] and persisted as a JSON file
+ * in the agent's state directory so they survive process restarts.
+ */
+
+export const WEIGHT_DEFAULT = 1.0;
+export const WEIGHT_RECALL_INCREMENT = 0.1;
+export const WEIGHT_CORRECTION_ORIGINAL = 0.3;
+export const WEIGHT_CORRECTION_NEW = 0.7;
+const WEIGHT_MIN = 0.1;
+const WEIGHT_MAX = 3.0;
+const WEIGHTS_FILENAME = "memory-weights.json";
+
+export type WeightEntry = {
+  weight: number;
+  /** ISO timestamp of the last update */
+  updatedAt: string;
+  /** Why the weight changed */
+  reason: "recall" | "correction" | "correction-source";
+};
+
+type WeightsFile = Record<string, WeightEntry>;
+
+/**
+ * File-backed store for per-chunk relevance weights.
+ * Loads lazily; writes are batched with a dirty flag.
+ */
+export class WeightedRecallStore {
+  private data: WeightsFile | null = null;
+  private dirty = false;
+
+  constructor(private readonly stateDir: string) {}
+
+  private weightsPath(): string {
+    return path.join(this.stateDir, WEIGHTS_FILENAME);
+  }
+
+  private async load(): Promise<WeightsFile> {
+    if (this.data !== null) {
+      return this.data;
+    }
+    try {
+      const raw = await fs.readFile(this.weightsPath(), "utf8");
+      this.data = JSON.parse(raw) as WeightsFile;
+    } catch {
+      // File missing or unparseable — start fresh.
+      this.data = {};
+    }
+    return this.data;
+  }
+
+  async getWeight(chunkId: string): Promise<number> {
+    const data = await this.load();
+    return data[chunkId]?.weight ?? WEIGHT_DEFAULT;
+  }
+
+  /**
+   * Record that a chunk was recalled and found useful.
+   * Increments weight by WEIGHT_RECALL_INCREMENT (clamped to MAX_WEIGHT).
+   */
+  async recordRecall(chunkId: string): Promise<void> {
+    const data = await this.load();
+    const current = data[chunkId]?.weight ?? WEIGHT_DEFAULT;
+    data[chunkId] = {
+      weight: Math.min(WEIGHT_MAX, current + WEIGHT_RECALL_INCREMENT),
+      updatedAt: new Date().toISOString(),
+      reason: "recall",
+    };
+    this.dirty = true;
+  }
+
+  /**
+   * Record that a chunk's content was corrected.
+   * Demotes the original to WEIGHT_CORRECTION_ORIGINAL so it still appears
+   * in search but ranks below its corrected replacement.
+   * Returns WEIGHT_CORRECTION_NEW — the caller should store the corrected
+   * chunk with this as its initial weight.
+   */
+  async recordCorrection(originalChunkId: string): Promise<number> {
+    const data = await this.load();
+    data[originalChunkId] = {
+      weight: WEIGHT_CORRECTION_ORIGINAL,
+      updatedAt: new Date().toISOString(),
+      reason: "correction-source",
+    };
+    this.dirty = true;
+    return WEIGHT_CORRECTION_NEW;
+  }
+
+  /**
+   * Persist any pending changes to disk. Safe to call frequently —
+   * no-ops when nothing changed.
+   */
+  async flush(): Promise<void> {
+    if (!this.dirty || !this.data) {
+      return;
+    }
+    await fs.mkdir(this.stateDir, { recursive: true });
+    await fs.writeFile(this.weightsPath(), JSON.stringify(this.data, null, 2), "utf8");
+    this.dirty = false;
+  }
+}
+
+/**
+ * Apply stored weights to a list of search results by multiplying each
+ * result's `score` by `getWeight(result.id)`.
+ *
+ * Results with no stored weight are unchanged (weight defaults to 1.0).
+ * The relative ordering may change but the absolute score semantics are
+ * preserved — a weight of 1.0 is a no-op.
+ */
+export async function applyWeightsToResults<T extends { id: string; score: number }>(
+  results: T[],
+  store: WeightedRecallStore,
+): Promise<T[]> {
+  if (results.length === 0) {
+    return results;
+  }
+  return Promise.all(
+    results.map(async (entry) => {
+      const weight = await store.getWeight(entry.id);
+      if (weight === WEIGHT_DEFAULT) {
+        return entry;
+      }
+      return { ...entry, score: entry.score * weight };
+    }),
+  );
+}

--- a/extensions/memory-core/src/memory/weighted-recall.ts
+++ b/extensions/memory-core/src/memory/weighted-recall.ts
@@ -100,6 +100,18 @@ export class WeightedRecallStore {
   }
 
   /**
+   * Clear the in-memory cache so the next read reloads from disk.
+   * Call this in long-lived processes (e.g. the gateway) before each
+   * search so that CLI feedback writes are immediately visible without
+   * requiring a process restart.
+   */
+  invalidate(): void {
+    if (!this.dirty) {
+      this.data = null;
+    }
+  }
+
+  /**
    * Persist any pending changes to disk. Safe to call frequently —
    * no-ops when nothing changed.
    */


### PR DESCRIPTION
## Summary

- **Skills** — adds `$anvil`, `$gate-keeper`, and `$layer-check` agent skills to `.agents/skills/` (ported from SkillFoundry), giving OpenClaw agentic coding tasks a 6-tier quality gate, evidence-based phase guardian, and three-layer boundary enforcer.
- **memory-core** — ports SkillFoundry's weighted-recall scheme: each memory chunk carries a relevance weight (default 1.0) multiplied into hybrid search scores after vector + BM25 + temporal-decay. New CLI subcommands `openclaw memory feedback recall <id>` (+0.1 boost, max 3.0) and `openclaw memory feedback correct <id>` (demote to 0.3). Weights persist per-agent in `memory-weights.json`.

## Test plan

- [ ] `pnpm test -- extensions/memory-core/src/memory/weighted-recall.test.ts` — 10 unit tests
- [ ] `pnpm check` passes (format + lint + typecheck)
- [ ] `openclaw memory feedback recall/correct` CLI responds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)