### PR TITLE
sandbox: block sensitive external bind sources

### DIFF
--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -58,6 +58,17 @@ describe("getBlockedBindReason", () => {
     );
   });
 
+  it("still blocks OS-home sensitive paths when OPENCLAW_HOME is overridden", () => {
+    vi.stubEnv("HOME", "/home/tester");
+    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+    expect(getBlockedBindReason("/home/tester/.aws:/mnt/aws:ro")).toEqual(
+      expect.objectContaining({
+        kind: "targets",
+        blockedPath: "/home/tester/.aws",
+      }),
+    );
+  });
+
   it("blocks the resolved OpenClaw state directory override", () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", "/srv/openclaw-state");
     expect(getBlockedBindReason("/srv/openclaw-state/credentials:/mnt/state:ro")).toEqual(
@@ -182,6 +193,13 @@ describe("validateBindMounts", () => {
     expect(() => validateBindMounts([`${join(realHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
       /blocked path/,
     );
+  });
+
+  it("blocks OS-home sensitive paths when OPENCLAW_HOME points elsewhere", () => {
+    vi.stubEnv("HOME", "/home/tester");
+    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+
+    expect(() => validateBindMounts(["/home/tester/.ssh:/mnt/ssh:ro"])).toThrow(/blocked path/);
   });
 
   it("blocks symlink-parent escapes with non-existent leaf outside allowed roots", () => {

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, symlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -191,6 +191,32 @@ describe("validateBindMounts", () => {
     vi.stubEnv("OPENCLAW_HOME", linkedHome);
 
     expect(() => validateBindMounts([`${join(realHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
+      /blocked path/,
+    );
+  });
+
+  it("refreshes canonical blocked aliases when OPENCLAW_HOME symlinks retarget", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-home-"));
+    const firstHome = join(dir, "home-a");
+    const secondHome = join(dir, "home-b");
+    const linkedHome = join(dir, "linked-home");
+    mkdirSync(join(firstHome, ".ssh"), { recursive: true });
+    mkdirSync(join(secondHome, ".ssh"), { recursive: true });
+    symlinkSync(firstHome, linkedHome);
+    vi.stubEnv("OPENCLAW_HOME", linkedHome);
+
+    expect(() => validateBindMounts([`${join(firstHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
+      /blocked path/,
+    );
+
+    unlinkSync(linkedHome);
+    symlinkSync(secondHome, linkedHome);
+
+    expect(() => validateBindMounts([`${join(secondHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
       /blocked path/,
     );
   });

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getBlockedBindReason,
   validateBindMounts,
@@ -16,6 +16,10 @@ function expectBindMountsToThrow(binds: string[], expected: RegExp, label: strin
 }
 
 describe("getBlockedBindReason", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("blocks common Docker socket directories", () => {
     expect(getBlockedBindReason("/run:/run")).toEqual(expect.objectContaining({ kind: "targets" }));
     expect(getBlockedBindReason("/var/run:/var/run:ro")).toEqual(
@@ -25,6 +29,32 @@ describe("getBlockedBindReason", () => {
 
   it("does not block /var by default", () => {
     expect(getBlockedBindReason("/var:/var")).toBeNull();
+  });
+
+  it("blocks sensitive home subdirectories", () => {
+    vi.stubEnv("HOME", "/home/tester");
+    expect(getBlockedBindReason("/home/tester/.openclaw:/mnt/state:ro")).toEqual(
+      expect.objectContaining({
+        kind: "targets",
+        blockedPath: "/home/tester/.openclaw",
+      }),
+    );
+    expect(getBlockedBindReason("/home/tester/.ssh:/mnt/ssh:ro")).toEqual(
+      expect.objectContaining({
+        kind: "targets",
+        blockedPath: "/home/tester/.ssh",
+      }),
+    );
+  });
+
+  it("blocks the resolved OpenClaw state directory override", () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/srv/openclaw-state");
+    expect(getBlockedBindReason("/srv/openclaw-state/credentials:/mnt/state:ro")).toEqual(
+      expect.objectContaining({
+        kind: "targets",
+        blockedPath: "/srv/openclaw-state",
+      }),
+    );
   });
 });
 

--- a/src/agents/sandbox/validate-sandbox-security.test.ts
+++ b/src/agents/sandbox/validate-sandbox-security.test.ts
@@ -47,6 +47,17 @@ describe("getBlockedBindReason", () => {
     );
   });
 
+  it("blocks sensitive home subdirectories under OPENCLAW_HOME", () => {
+    vi.stubEnv("HOME", "/home/tester");
+    vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+    expect(getBlockedBindReason("/srv/openclaw-home/.ssh:/mnt/ssh:ro")).toEqual(
+      expect.objectContaining({
+        kind: "targets",
+        blockedPath: "/srv/openclaw-home/.ssh",
+      }),
+    );
+  });
+
   it("blocks the resolved OpenClaw state directory override", () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", "/srv/openclaw-state");
     expect(getBlockedBindReason("/srv/openclaw-state/credentials:/mnt/state:ro")).toEqual(
@@ -59,6 +70,10 @@ describe("getBlockedBindReason", () => {
 });
 
 describe("validateBindMounts", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("allows legitimate project directory mounts", () => {
     expect(() =>
       validateBindMounts([
@@ -150,6 +165,23 @@ describe("validateBindMounts", () => {
     symlinkSync("/etc", link);
     const run = () => validateBindMounts([`${link}/passwd:/mnt/passwd:ro`]);
     expect(run).toThrow(/blocked path/);
+  });
+
+  it("blocks canonicalized sensitive paths derived from OPENCLAW_HOME", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-home-"));
+    const realHome = join(dir, "real-home");
+    const linkedHome = join(dir, "linked-home");
+    mkdirSync(join(realHome, ".ssh"), { recursive: true });
+    symlinkSync(realHome, linkedHome);
+    vi.stubEnv("OPENCLAW_HOME", linkedHome);
+
+    expect(() => validateBindMounts([`${join(realHome, ".ssh")}:/mnt/ssh:ro`])).toThrow(
+      /blocked path/,
+    );
   });
 
   it("blocks symlink-parent escapes with non-existent leaf outside allowed roots", () => {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -16,8 +16,9 @@ import {
 } from "./host-paths.js";
 import { getBlockedNetworkModeReason } from "./network-mode.js";
 
-// Targeted denylist: host paths that should never be exposed inside sandbox containers.
-// Exported for reuse in security audit collectors.
+// Static portion of the targeted denylist: host paths that should never be exposed
+// inside sandbox containers. The full runtime set also includes sensitive home
+// subdirectories and the resolved OpenClaw state directory.
 export const BLOCKED_HOST_PATHS = [
   "/etc",
   "/private/etc",
@@ -40,6 +41,12 @@ export const BLOCKED_HOST_PATHS = [
 ];
 
 const BLOCKED_HOME_SUBPATHS = [".aws", ".config", ".kube", ".openclaw", ".ssh"] as const;
+let cachedBlockedHostPaths:
+  | {
+      key: string;
+      paths: string[];
+    }
+  | undefined;
 
 const BLOCKED_SECCOMP_PROFILES = new Set(["unconfined"]);
 const BLOCKED_APPARMOR_PROFILES = new Set(["unconfined"]);
@@ -125,16 +132,25 @@ export function getBlockedReasonForSourcePath(sourceNormalized: string): Blocked
   return null;
 }
 
-function getBlockedHostPaths(): string[] {
-  const blocked = new Set(BLOCKED_HOST_PATHS.map(normalizeHostPath));
+export function getBlockedHostPaths(): string[] {
   const homedir = normalizeHostPath(os.homedir());
+  const stateDir = normalizeHostPath(resolveStateDir());
+  const cacheKey = `${homedir}\u0000${stateDir}`;
+  if (cachedBlockedHostPaths?.key === cacheKey) {
+    return cachedBlockedHostPaths.paths;
+  }
+
+  const blocked = new Set(BLOCKED_HOST_PATHS.map(normalizeHostPath));
   if (homedir !== "/") {
     for (const suffix of BLOCKED_HOME_SUBPATHS) {
       blocked.add(normalizeHostPath(path.posix.join(homedir, suffix)));
     }
   }
-  blocked.add(normalizeHostPath(resolveStateDir()));
-  return [...blocked];
+  blocked.add(stateDir);
+
+  const paths = [...blocked];
+  cachedBlockedHostPaths = { key: cacheKey, paths };
+  return paths;
 }
 
 function normalizeAllowedRoots(roots: string[] | undefined): string[] {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -49,6 +49,11 @@ let cachedBlockedHostPaths:
     }
   | undefined;
 
+type BlockedHostPathAlias = {
+  lexical: string;
+  canonical: string;
+};
+
 const BLOCKED_SECCOMP_PROFILES = new Set(["unconfined"]);
 const BLOCKED_APPARMOR_PROFILES = new Set(["unconfined"]);
 const RESERVED_CONTAINER_TARGET_PATHS = ["/workspace", SANDBOX_AGENT_WORKSPACE_MOUNT];
@@ -137,37 +142,48 @@ export function getBlockedHostPaths(): string[] {
   const effectiveHome = normalizeHostPath(resolveRequiredHomeDir(process.env, os.homedir));
   const osHome = normalizeHostPath(resolveRequiredOsHomeDir(process.env, os.homedir));
   const stateDir = normalizeHostPath(resolveStateDir());
-  const cacheKey = `${effectiveHome}\u0000${osHome}\u0000${stateDir}`;
-  if (cachedBlockedHostPaths?.key === cacheKey) {
-    return cachedBlockedHostPaths.paths;
-  }
-
-  const blocked = new Set<string>();
+  const aliases: BlockedHostPathAlias[] = [];
   for (const candidate of BLOCKED_HOST_PATHS) {
-    addBlockedHostPath(blocked, candidate);
+    aliases.push(resolveBlockedHostPathAlias(candidate));
   }
   for (const home of new Set([effectiveHome, osHome])) {
     if (home === "/") {
       continue;
     }
     for (const suffix of BLOCKED_HOME_SUBPATHS) {
-      addBlockedHostPath(blocked, path.posix.join(home, suffix));
+      aliases.push(resolveBlockedHostPathAlias(path.posix.join(home, suffix)));
     }
   }
-  addBlockedHostPath(blocked, stateDir);
+  aliases.push(resolveBlockedHostPathAlias(stateDir));
+
+  const cacheKey = aliases.flatMap(({ lexical, canonical }) => [lexical, canonical]).join("\u0000");
+  if (cachedBlockedHostPaths?.key === cacheKey) {
+    return cachedBlockedHostPaths.paths;
+  }
+
+  const blocked = new Set<string>();
+  for (const alias of aliases) {
+    addBlockedHostPath(blocked, alias);
+  }
 
   const paths = [...blocked];
   cachedBlockedHostPaths = { key: cacheKey, paths };
   return paths;
 }
 
-function addBlockedHostPath(blocked: Set<string>, candidate: string): void {
-  const normalized = normalizeHostPath(candidate);
-  blocked.add(normalized);
+function resolveBlockedHostPathAlias(candidate: string): BlockedHostPathAlias {
+  const lexical = normalizeHostPath(candidate);
+  return {
+    lexical,
+    canonical: resolveSandboxHostPathViaExistingAncestor(lexical),
+  };
+}
 
-  const canonical = resolveSandboxHostPathViaExistingAncestor(normalized);
-  if (canonical !== normalized) {
-    blocked.add(canonical);
+function addBlockedHostPath(blocked: Set<string>, alias: BlockedHostPathAlias): void {
+  blocked.add(alias.lexical);
+
+  if (alias.canonical !== alias.lexical) {
+    blocked.add(alias.canonical);
   }
 }
 

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -5,6 +5,9 @@
  * Enforced at runtime when creating sandbox containers.
  */
 
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import {
@@ -30,7 +33,13 @@ export const BLOCKED_HOST_PATHS = [
   "/var/run/docker.sock",
   "/private/var/run/docker.sock",
   "/run/docker.sock",
+  "/var/lib/docker",
+  "/private/var/lib/docker",
+  "/var/log",
+  "/private/var/log",
 ];
+
+const BLOCKED_HOME_SUBPATHS = [".aws", ".config", ".kube", ".openclaw", ".ssh"] as const;
 
 const BLOCKED_SECCOMP_PROFILES = new Set(["unconfined"]);
 const BLOCKED_APPARMOR_PROFILES = new Set(["unconfined"]);
@@ -107,13 +116,25 @@ export function getBlockedReasonForSourcePath(sourceNormalized: string): Blocked
   if (sourceNormalized === "/") {
     return { kind: "covers", blockedPath: "/" };
   }
-  for (const blocked of BLOCKED_HOST_PATHS) {
+  for (const blocked of getBlockedHostPaths()) {
     if (sourceNormalized === blocked || sourceNormalized.startsWith(blocked + "/")) {
       return { kind: "targets", blockedPath: blocked };
     }
   }
 
   return null;
+}
+
+function getBlockedHostPaths(): string[] {
+  const blocked = new Set(BLOCKED_HOST_PATHS.map(normalizeHostPath));
+  const homedir = normalizeHostPath(os.homedir());
+  if (homedir !== "/") {
+    for (const suffix of BLOCKED_HOME_SUBPATHS) {
+      blocked.add(normalizeHostPath(path.posix.join(homedir, suffix)));
+    }
+  }
+  blocked.add(normalizeHostPath(resolveStateDir()));
+  return [...blocked];
 }
 
 function normalizeAllowedRoots(roots: string[] | undefined): string[] {

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -8,7 +8,7 @@
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
-import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
+import { resolveRequiredHomeDir, resolveRequiredOsHomeDir } from "../../infra/home-dir.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import {
@@ -134,9 +134,10 @@ export function getBlockedReasonForSourcePath(sourceNormalized: string): Blocked
 }
 
 export function getBlockedHostPaths(): string[] {
-  const homedir = normalizeHostPath(resolveRequiredHomeDir(process.env, os.homedir));
+  const effectiveHome = normalizeHostPath(resolveRequiredHomeDir(process.env, os.homedir));
+  const osHome = normalizeHostPath(resolveRequiredOsHomeDir(process.env, os.homedir));
   const stateDir = normalizeHostPath(resolveStateDir());
-  const cacheKey = `${homedir}\u0000${stateDir}`;
+  const cacheKey = `${effectiveHome}\u0000${osHome}\u0000${stateDir}`;
   if (cachedBlockedHostPaths?.key === cacheKey) {
     return cachedBlockedHostPaths.paths;
   }
@@ -145,9 +146,12 @@ export function getBlockedHostPaths(): string[] {
   for (const candidate of BLOCKED_HOST_PATHS) {
     addBlockedHostPath(blocked, candidate);
   }
-  if (homedir !== "/") {
+  for (const home of new Set([effectiveHome, osHome])) {
+    if (home === "/") {
+      continue;
+    }
     for (const suffix of BLOCKED_HOME_SUBPATHS) {
-      addBlockedHostPath(blocked, path.posix.join(homedir, suffix));
+      addBlockedHostPath(blocked, path.posix.join(home, suffix));
     }
   }
   addBlockedHostPath(blocked, stateDir);

--- a/src/agents/sandbox/validate-sandbox-security.ts
+++ b/src/agents/sandbox/validate-sandbox-security.ts
@@ -8,6 +8,7 @@
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../../config/paths.js";
+import { resolveRequiredHomeDir } from "../../infra/home-dir.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import {
@@ -133,24 +134,37 @@ export function getBlockedReasonForSourcePath(sourceNormalized: string): Blocked
 }
 
 export function getBlockedHostPaths(): string[] {
-  const homedir = normalizeHostPath(os.homedir());
+  const homedir = normalizeHostPath(resolveRequiredHomeDir(process.env, os.homedir));
   const stateDir = normalizeHostPath(resolveStateDir());
   const cacheKey = `${homedir}\u0000${stateDir}`;
   if (cachedBlockedHostPaths?.key === cacheKey) {
     return cachedBlockedHostPaths.paths;
   }
 
-  const blocked = new Set(BLOCKED_HOST_PATHS.map(normalizeHostPath));
+  const blocked = new Set<string>();
+  for (const candidate of BLOCKED_HOST_PATHS) {
+    addBlockedHostPath(blocked, candidate);
+  }
   if (homedir !== "/") {
     for (const suffix of BLOCKED_HOME_SUBPATHS) {
-      blocked.add(normalizeHostPath(path.posix.join(homedir, suffix)));
+      addBlockedHostPath(blocked, path.posix.join(homedir, suffix));
     }
   }
-  blocked.add(stateDir);
+  addBlockedHostPath(blocked, stateDir);
 
   const paths = [...blocked];
   cachedBlockedHostPaths = { key: cacheKey, paths };
   return paths;
+}
+
+function addBlockedHostPath(blocked: Set<string>, candidate: string): void {
+  const normalized = normalizeHostPath(candidate);
+  blocked.add(normalized);
+
+  const canonical = resolveSandboxHostPathViaExistingAncestor(normalized);
+  if (canonical !== normalized) {
+    blocked.add(canonical);
+  }
 }
 
 function normalizeAllowedRoots(roots: string[] | undefined): string[] {


### PR DESCRIPTION
## Summary
- block sensitive host paths even when external sandbox bind sources are allowed
- cover user-state and OpenClaw state roots without blocking normal project mounts

## Changes
- extend sandbox bind validation to reject Docker internals, log directories, sensitive home subdirectories, and the resolved OpenClaw state dir
- add regression tests for home-scoped sensitive paths and OPENCLAW_STATE_DIR overrides

## Validation
- Ran `pnpm test -- src/agents/sandbox/validate-sandbox-security.test.ts`
- Ran `pnpm check`
- Ran local agentic review via `claude -p "/review"`; it did not produce code feedback in this environment

## Notes
- Residual risk or follow-up: this keeps user project directories mountable under `$HOME` while blocking common credential and state roots