### PR TITLE
fix(pi-runner): use post-hook assistant for expect-final payloads

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -76,6 +76,7 @@ import {
   OVERLOAD_FAILOVER_BACKOFF_POLICY,
   resolveActiveErrorContext,
   resolveMaxRunRetryIterations,
+  selectFinalAssistantForPayloads,
   type RuntimeAuthState,
   scrubAnthropicRefusalMagic,
 } from "./run/helpers.js";
@@ -1248,10 +1249,18 @@ export async function runEmbeddedPiAgent(
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
           };
 
+          const payloadUsesPostHookAssistant =
+            hookRunner?.hasHooks("before_message_write") === true;
+          const payloadLastAssistant = payloadUsesPostHookAssistant
+            ? (selectFinalAssistantForPayloads(
+                attempt.messagesSnapshot,
+              ) as typeof attempt.lastAssistant)
+            : attempt.lastAssistant;
+
           const payloads = buildEmbeddedRunPayloads({
-            assistantTexts: attempt.assistantTexts,
+            assistantTexts: payloadUsesPostHookAssistant ? [] : attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
-            lastAssistant: attempt.lastAssistant,
+            lastAssistant: payloadLastAssistant,
             lastToolError: attempt.lastToolError,
             config: params.config,
             sessionKey: params.sessionKey ?? params.sessionId,

--- a/src/agents/pi-embedded-runner/run/helpers.select-final-assistant.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.select-final-assistant.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { selectFinalAssistantForPayloads } from "./helpers.js";
+
+type SnapshotMessage = {
+  role: string;
+  text: string;
+};
+
+describe("selectFinalAssistantForPayloads", () => {
+  it("returns the current-turn assistant when one exists after the latest user", () => {
+    const result = selectFinalAssistantForPayloads<SnapshotMessage>([
+      { role: "user", text: "old request" },
+      { role: "assistant", text: "old reply" },
+      { role: "user", text: "new request" },
+      { role: "assistant", text: "replacement reply" },
+    ]);
+
+    expect(result).toEqual({ role: "assistant", text: "replacement reply" });
+  });
+
+  it("returns undefined when the current-turn assistant was blocked", () => {
+    const result = selectFinalAssistantForPayloads<SnapshotMessage>([
+      { role: "user", text: "old request" },
+      { role: "assistant", text: "old reply" },
+      { role: "user", text: "new request" },
+    ]);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("falls back to the latest assistant when no user message exists", () => {
+    const result = selectFinalAssistantForPayloads<SnapshotMessage>([
+      { role: "assistant", text: "first reply" },
+      { role: "assistant", text: "latest reply" },
+    ]);
+
+    expect(result).toEqual({ role: "assistant", text: "latest reply" });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -76,6 +76,18 @@ export function resolveActiveErrorContext(params: {
   };
 }
 
+export function selectFinalAssistantForPayloads<T extends { role?: string }>(
+  messagesSnapshot: T[],
+): T | undefined {
+  const lastUserIndex = messagesSnapshot.findLastIndex((message) => message.role === "user");
+  const currentTurnMessages =
+    lastUserIndex >= 0 ? messagesSnapshot.slice(lastUserIndex + 1) : messagesSnapshot;
+  return currentTurnMessages
+    .slice()
+    .toReversed()
+    .find((message) => message.role === "assistant");
+}
+
 export function buildUsageAgentMetaFields(params: {
   usageAccumulator: UsageAccumulator;
   lastAssistantUsage?: UsageSnapshot | null;


### PR DESCRIPTION
## Summary
Makes `--expect-final` payloads reflect the post-hook assistant message when `before_message_write` hooks are active, instead of reusing stale raw `assistantTexts`.

## What changes
- `src/agents/pi-embedded-runner/run.ts`: when `before_message_write` hooks exist, skip the raw `assistantTexts` path and derive the final assistant payload from the post-hook message snapshot
- `src/agents/pi-embedded-runner/run/helpers.ts`: add `selectFinalAssistantForPayloads` to pick the current-turn assistant after the latest user message
- add a focused unit test covering replaced, blocked, and no-user snapshots

## Why
Hook rewrites and blocks were being honored in the saved transcript, but `--expect-final` payloads could still surface stale pre-hook text. That makes callers see content the hook already replaced or suppressed.

## Scope
pi-embedded-runner payload construction only. No changes to hook execution, storage, or unrelated runner paths.

## Verification
- `pnpm test -- --run src/agents/pi-embedded-runner/run/helpers.select-final-assistant.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts`

## Notes
`upstream/main` still has unrelated TypeScript failures outside this change, including `src/agents/skills/source.ts`. Those are out of scope here.
