### PR TITLE
fix: inject context.agentId into toToolDefinitions hook dispatch

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -704,6 +704,12 @@ export async function compactEmbeddedPiSessionDirect(
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookContext: {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          runId: params.runId,
+        },
       });
 
       const { session } = await createAgentSession({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -762,6 +762,12 @@ export async function runEmbeddedAttempt(
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
+        hookContext: {
+          agentId: sessionAgentId,
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          runId: params.runId,
+        },
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools

--- a/src/agents/pi-embedded-runner/tool-split.ts
+++ b/src/agents/pi-embedded-runner/tool-split.ts
@@ -1,17 +1,22 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { HookContext } from "../pi-tools.before-tool-call.js";
 import { toToolDefinitions } from "../pi-tool-definition-adapter.js";
 
 // We always pass tools via `customTools` so our policy filtering, sandbox integration,
 // and extended toolset remain consistent across providers.
 type AnyAgentTool = AgentTool;
 
-export function splitSdkTools(options: { tools: AnyAgentTool[]; sandboxEnabled: boolean }): {
+export function splitSdkTools(options: {
+  tools: AnyAgentTool[];
+  sandboxEnabled: boolean;
+  hookContext?: HookContext;
+}): {
   builtInTools: AnyAgentTool[];
   customTools: ReturnType<typeof toToolDefinitions>;
 } {
-  const { tools } = options;
+  const { tools, hookContext } = options;
   return {
     builtInTools: [],
-    customTools: toToolDefinitions(tools),
+    customTools: toToolDefinitions(tools, hookContext),
   };
 }

--- a/src/agents/pi-tool-definition-adapter.hookcontext.test.ts
+++ b/src/agents/pi-tool-definition-adapter.hookcontext.test.ts
@@ -1,0 +1,97 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { splitSdkTools } from "./pi-embedded-runner.js";
+import { toToolDefinitions } from "./pi-tool-definition-adapter.js";
+import * as beforeToolCallMod from "./pi-tools.before-tool-call.js";
+
+function createReadTool() {
+  return {
+    name: "read",
+    label: "Read",
+    description: "reads",
+    parameters: Type.Object({}),
+    execute: vi.fn(async () => ({ content: [], details: { ok: true } })),
+  } satisfies AgentTool;
+}
+
+type ToolExecute = ReturnType<typeof toToolDefinitions>[number]["execute"];
+const extensionContext = {} as Parameters<ToolExecute>[4];
+
+describe("hookContext threading", () => {
+  const runBeforeSpy = vi.spyOn(beforeToolCallMod, "runBeforeToolCallHook");
+  const isWrappedSpy = vi.spyOn(beforeToolCallMod, "isToolWrappedWithBeforeToolCallHook");
+
+  beforeEach(() => {
+    runBeforeSpy.mockClear();
+    runBeforeSpy.mockImplementation(async ({ params }) => ({
+      blocked: false,
+      params,
+    }));
+    isWrappedSpy.mockClear();
+    isWrappedSpy.mockReturnValue(false);
+  });
+
+  const hookContext = {
+    agentId: "test-agent",
+    sessionKey: "test-session",
+    sessionId: "test-session-id",
+    runId: "test-run-id",
+  };
+
+  describe("toToolDefinitions", () => {
+    it("passes hookContext as ctx to runBeforeToolCallHook", async () => {
+      const defs = toToolDefinitions([createReadTool()], hookContext);
+      const def = defs[0];
+      if (!def) {
+        throw new Error("missing tool definition");
+      }
+      await def.execute("call-ctx", { path: "/tmp/file" }, undefined, undefined, extensionContext);
+
+      expect(runBeforeSpy).toHaveBeenCalledOnce();
+      expect(runBeforeSpy).toHaveBeenCalledWith(expect.objectContaining({ ctx: hookContext }));
+    });
+
+    it("passes ctx as undefined when hookContext is omitted", async () => {
+      const defs = toToolDefinitions([createReadTool()]);
+      const def = defs[0];
+      if (!def) {
+        throw new Error("missing tool definition");
+      }
+      await def.execute(
+        "call-no-ctx",
+        { path: "/tmp/file" },
+        undefined,
+        undefined,
+        extensionContext,
+      );
+
+      expect(runBeforeSpy).toHaveBeenCalledOnce();
+      expect(runBeforeSpy).toHaveBeenCalledWith(expect.objectContaining({ ctx: undefined }));
+    });
+  });
+
+  describe("splitSdkTools", () => {
+    it("threads hookContext through to runBeforeToolCallHook", async () => {
+      const { customTools } = splitSdkTools({
+        tools: [createReadTool()],
+        sandboxEnabled: false,
+        hookContext,
+      });
+      const def = customTools[0];
+      if (!def) {
+        throw new Error("missing tool definition");
+      }
+      await def.execute(
+        "call-split",
+        { path: "/tmp/file" },
+        undefined,
+        undefined,
+        extensionContext,
+      );
+
+      expect(runBeforeSpy).toHaveBeenCalledOnce();
+      expect(runBeforeSpy).toHaveBeenCalledWith(expect.objectContaining({ ctx: hookContext }));
+    });
+  });
+});

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -114,7 +114,10 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   };
 }
 
-export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
+export function toToolDefinitions(
+  tools: AnyAgentTool[],
+  hookContext?: HookContext,
+): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
@@ -133,6 +136,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
               toolName: name,
               params,
               toolCallId,
+              ctx: hookContext,
             });
             if (hookOutcome.blocked) {
               throw new Error(hookOutcome.reason);


### PR DESCRIPTION
## Problem

`toToolDefinitions()` in `pi-tool-definition-adapter.ts` calls `runBeforeToolCallHook()` without the `ctx` field, so plugins receiving the `before_tool_call` hook have no `agentId` in their `PluginHookToolContext`.

This only affects the fallback path for tools not already wrapped by `wrapToolWithBeforeToolCallHook()` — the HTTP invoke path (`tools-invoke-http.ts:324`) and `toClientToolDefinitions()` already pass `ctx` correctly.

## Fix

Add an optional `hookContext?: HookContext` parameter to `toToolDefinitions()` (matching the existing pattern in `toClientToolDefinitions()`), thread it through `splitSdkTools()`, and populate it from the already-available `sessionAgentId` in both `attempt.ts` and `compact.ts`.

## Changes

| File | Change |
|------|--------|
| `pi-tool-definition-adapter.ts` | Add `hookContext?` param, pass `ctx: hookContext` to `runBeforeToolCallHook` |
| `tool-split.ts` | Thread `hookContext` through `splitSdkTools()` |
| `run/attempt.ts` | Pass `{ agentId, sessionKey, sessionId, runId }` to `splitSdkTools` |
| `compact.ts` | Same as attempt.ts for the compaction path |

4 files, +25 -4 lines. Fully backward compatible — `hookContext` is optional.