### PR TITLE
fix(daemon): systemd install enables OPENCLAW_SYSTEMD_UNIT (fixes node install)

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -477,7 +477,7 @@ export async function stageSystemdService({
 }
 
 async function activateSystemdService(params: { env: GatewayServiceEnv }) {
-  const serviceName = resolveGatewaySystemdServiceName(params.env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(params.env);
   const unitName = `${serviceName}.service`;
   const reload = await execSystemctlUser(params.env, ["daemon-reload"]);
   if (reload.code !== 0) {


### PR DESCRIPTION
## Problem

`installSystemdService` writes the unit file using `resolveSystemdUnitPath` → `resolveSystemdServiceName` (honors `OPENCLAW_SYSTEMD_UNIT`), but `activateSystemdService` always ran `systemctl enable/restart` for `resolveGatewaySystemdServiceName` only (`openclaw-gateway`).

So `openclaw node install` staged `openclaw-node.service` but tried to enable `openclaw-gateway.service`, producing:

`systemctl enable failed: Unit file openclaw-gateway.service does not exist.`

## Change

Use `resolveSystemdServiceName` in `activateSystemdService` so enable/restart targets the same unit that was written.

## Testing

- `pnpm exec vitest run src/daemon/systemd.test.ts` (43 tests)