### PR TITLE
fix(byteplus): strip unsupported JSON schema keywords for BytePlus/ark provider

### DIFF
--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -98,6 +98,12 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const hasXaiSchemaProfile = usesXaiToolSchemaProfile(options?.modelCompat);
+  // BytePlus/ark rejects tool schemas that contain keywords not supported by its decoding
+  // guidance engine (e.g. `patternProperties`). It shares the same restricted subset as
+  // Gemini, so we reuse cleanSchemaForGemini to strip those unsupported keywords.
+  const isByteplusProvider =
+    options?.modelProvider?.toLowerCase().includes("byteplus") ||
+    options?.modelId?.toLowerCase().includes("ark");
 
   function applyProviderCleaning(s: unknown): unknown {
     if (isGeminiProvider && !isAnthropicProvider) {
@@ -105,6 +111,9 @@ export function normalizeToolParameters(
     }
     if (hasXaiSchemaProfile) {
       return stripXaiUnsupportedKeywords(s);
+    }
+    if (isByteplusProvider) {
+      return cleanSchemaForGemini(s);
     }
     return s;
   }


### PR DESCRIPTION
## Summary

BytePlus/ark models return HTTP 400 with the error:

```
Invalid decoding guidance syntax: Keyword 'patternProperties' is not supported for type 'object'
```

This happens because `normalizeToolParameters` in `src/agents/pi-tools.schema.ts` already strips unsupported JSON Schema keywords for Gemini and xAI providers, but has no handling for the BytePlus/ark provider. Any tool schema that contains `patternProperties` (or similar keywords outside ark's restricted subset) will cause the request to fail.

## Fix

Detect BytePlus providers by checking whether `modelProvider` contains `"byteplus"` or `modelId` contains `"ark"` inside `normalizeToolParameters`, and run the existing `cleanSchemaForGemini` pass on their schemas. BytePlus/ark enforces the same restricted JSON Schema subset as Gemini, so `cleanSchemaForGemini` is the right scrubber to reuse here.

```ts
const isByteplusProvider =
  options?.modelProvider?.toLowerCase().includes("byteplus") ||
  options?.modelId?.toLowerCase().includes("ark");

function applyProviderCleaning(s: unknown): unknown {
  if (isGeminiProvider && !isAnthropicProvider) return cleanSchemaForGemini(s);
  if (hasXaiSchemaProfile) return stripXaiUnsupportedKeywords(s);
  if (isByteplusProvider) return cleanSchemaForGemini(s);
  return s;
}
```

## Related

This is the same class of provider-specific schema restriction that was already addressed for Gemini and xAI. Related to #54491 which covers a similar schema-cleaning need for another provider.

## Test plan

- [ ] Confirm `normalizeToolParameters` called with `modelProvider: "byteplus"` or `modelId: "ep-xxx-ark"` strips `patternProperties` from the tool schema
- [ ] Confirm Gemini, xAI, and Anthropic paths are unaffected
- [ ] Manually test with a BytePlus/ark model endpoint and a tool that has `patternProperties` in its schema