### PR TITLE
telegram: cache botInfo across polling cycles to eliminate getMe() init stall

### DIFF
--- a/extensions/telegram/src/bot.runtime.ts
+++ b/extensions/telegram/src/bot.runtime.ts
@@ -2,3 +2,4 @@ export { sequentialize } from "@grammyjs/runner";
 export { apiThrottler } from "@grammyjs/transformer-throttler";
 export { Bot } from "grammy";
 export type { ApiClientOptions } from "grammy";
+export type { UserFromGetMe } from "@grammyjs/types";

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -33,7 +33,13 @@ import {
   resolveTelegramUpdateId,
   type TelegramUpdateKeyContext,
 } from "./bot-updates.js";
-import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.runtime.js";
+import {
+  apiThrottler,
+  Bot,
+  sequentialize,
+  type ApiClientOptions,
+  type UserFromGetMe,
+} from "./bot.runtime.js";
 import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
 import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
@@ -65,6 +71,10 @@ export type TelegramBotOptions = {
   /** Pre-resolved Telegram transport to reuse across bot instances. If not provided, creates a new one. */
   telegramTransport?: TelegramTransport;
   telegramDeps?: TelegramBotDeps;
+  /** Cached bot info from a previous `bot.init()` / `getMe()` call.
+   *  When provided, grammy skips the `getMe()` network call on startup,
+   *  eliminating the init-retry stall after network recovery. */
+  botInfo?: UserFromGetMe;
 };
 
 export { getTelegramSequentialKey };
@@ -254,7 +264,10 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         }
       : undefined;
 
-  const bot = new botRuntime.Bot(opts.token, client ? { client } : undefined);
+  const bot = new botRuntime.Bot(opts.token, {
+    ...(client ? { client } : {}),
+    ...(opts.botInfo ? { botInfo: opts.botInfo } : {}),
+  });
   bot.api.config.use(botRuntime.apiThrottler());
   // Catch all errors from bot middleware to prevent unhandled rejections
   bot.catch((err) => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -34,14 +34,17 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
 
 function makeBot() {
-  return {
+  const bot = {
     api: {
       deleteWebhook: vi.fn(async () => true),
       getUpdates: vi.fn(async () => []),
       config: { use: vi.fn() },
     },
     stop: vi.fn(async () => undefined),
+    init: vi.fn(async () => undefined),
+    botInfo: { id: 123, is_bot: true, first_name: "Test", username: "testbot" },
   };
+  return bot;
 }
 
 function installPollingStallWatchdogHarness() {
@@ -156,6 +159,8 @@ describe("TelegramPollingSession", () => {
         config: { use: vi.fn() },
       },
       stop: botStop,
+      init: vi.fn(async () => undefined),
+      botInfo: { id: 123, is_bot: true, first_name: "Test", username: "testbot" },
     };
     createTelegramBotMock.mockReturnValue(bot);
 
@@ -213,6 +218,8 @@ describe("TelegramPollingSession", () => {
         config: { use: vi.fn() },
       },
       stop: botStop,
+      init: vi.fn(async () => undefined),
+      botInfo: { id: 123, is_bot: true, first_name: "Test", username: "testbot" },
     };
     createTelegramBotMock.mockReturnValue(bot);
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/infra-runtime";
 import { formatDurationPrecise } from "openclaw/plugin-sdk/infra-runtime";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import type { UserFromGetMe } from "./bot.runtime.js";
 import { type TelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
@@ -62,6 +63,10 @@ export class TelegramPollingSession {
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
   #transportState: TelegramPollingTransportState;
+  /** Cached botInfo from the first successful `getMe()` call.
+   *  Passed to subsequent Bot instances so grammy skips `bot.init()` → `getMe()`,
+   *  eliminating the init-retry stall after network recovery. */
+  #cachedBotInfo: UserFromGetMe | undefined;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -142,7 +147,7 @@ export class TelegramPollingSession {
     this.#activeFetchAbort = fetchAbortController;
     const telegramTransport = this.#transportState.acquireForNextCycle();
     try {
-      return createTelegramBot({
+      const bot = createTelegramBot({
         token: this.opts.token,
         runtime: this.opts.runtime,
         proxyFetch: this.opts.proxyFetch,
@@ -154,7 +159,59 @@ export class TelegramPollingSession {
           onUpdateId: this.opts.persistUpdateId,
         },
         telegramTransport,
+        botInfo: this.#cachedBotInfo,
       });
+      // On the first cycle, eagerly init the bot so we can cache botInfo.
+      // Subsequent cycles already have botInfo injected into the Bot constructor,
+      // so bot.init() inside the runner will be a no-op (isInited() === true).
+      if (!this.#cachedBotInfo) {
+        // Use a dedicated abort controller for the eager init so that a timeout
+        // does not poison the bot's fetch pipeline (fetchAbortController stays
+        // intact for the polling cycle that follows).
+        const EAGER_INIT_TIMEOUT_MS = 15_000;
+        const initAbort = new AbortController();
+
+        // Forward session-level abort → init controller.
+        // Guard against the race where abort fires between the while-loop
+        // check and this point — an already-aborted signal won't fire the
+        // listener, so we must check eagerly.
+        const onSessionAbort = () => initAbort.abort();
+        if (this.opts.abortSignal?.aborted) {
+          initAbort.abort();
+        } else {
+          this.opts.abortSignal?.addEventListener("abort", onSessionAbort, { once: true });
+        }
+
+        // Time-box the init so a stalled network cannot block the session
+        // outside the watchdog's protection.
+        const initTimeout = setTimeout(() => initAbort.abort(), EAGER_INIT_TIMEOUT_MS);
+        try {
+          // grammy's init() accepts AbortSignal from the `abort-controller` polyfill package,
+          // which is structurally incompatible with the native Node.js AbortSignal at the type
+          // level. At runtime they are interchangeable, so we suppress the type error.
+          // @ts-ignore — grammy AbortSignal (abort-controller polyfill) vs native Node.js AbortSignal
+          await bot.init(initAbort.signal);
+          this.#cachedBotInfo = bot.botInfo;
+          this.opts.log(
+            "[telegram] Cached botInfo from initial getMe(); subsequent cycles will skip init.",
+          );
+        } catch {
+          // If the session itself was aborted, short-circuit immediately so
+          // runUntilAbort() does not continue into webhook cleanup / polling
+          // setup over the still-live fetchAbortController.
+          if (this.opts.abortSignal?.aborted) {
+            return undefined;
+          }
+          // Otherwise non-fatal: network unavailable or timeout fired.
+          // The runner will call bot.init() itself with its own retry logic
+          // under the watchdog. We skip caching and let the existing code
+          // path handle it.
+        } finally {
+          clearTimeout(initTimeout);
+          this.opts.abortSignal?.removeEventListener("abort", onSessionAbort);
+        }
+      }
+      return bot;
     } catch (err) {
       await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");
       if (this.#activeFetchAbort === fetchAbortController) {


### PR DESCRIPTION
## Problem

Every polling cycle restart triggers `bot.init()` → `getMe()`, and grammY's internal exponential-backoff retry (up to ~20 minutes) cannot be cancelled. After a transient network issue, this causes severe recovery stalls.

## Solution

- Cache `botInfo` from the first successful `getMe()` and inject it into subsequent `Bot` constructors so `bot.init()` becomes a no-op (`isInited() === true`).
- On the first cycle, eagerly call `bot.init()` with a **dedicated 15s timeout** (separate `AbortController`) so a stalled network cannot block the session outside the watchdog's protection.
- If the session abort signal fires during eager init, **short-circuit immediately** instead of continuing into webhook cleanup / polling setup.
- Non-fatal fallback: if eager init fails (timeout or network), the runner handles it under the watchdog as before.

## Changes

- `extensions/telegram/src/bot.runtime.ts` — export `UserFromGetMe` type
- `extensions/telegram/src/bot.ts` — accept optional `botInfo` in factory
- `extensions/telegram/src/polling-session.ts` — cache botInfo, init timeout, abort short-circuit
- `extensions/telegram/src/polling-session.test.ts` — test coverage