### PR TITLE
fix(msteams): reset stream state after tool calls to prevent message loss

### DIFF
--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -75,6 +75,25 @@ describe("createTeamsReplyStreamController", () => {
     expect(streamInstances[0]?.finalize).toHaveBeenCalled();
   });
 
+  it("uses fallback even when onPartialReply fires after stream finalized", () => {
+    const ctrl = createController();
+
+    // First text segment: streaming tokens arrive
+    ctrl.onPartialReply({ text: "First segment" });
+
+    // First segment complete: preparePayload suppresses and finalizes stream
+    const result1 = ctrl.preparePayload({ text: "First segment" });
+    expect(result1).toBeUndefined();
+    expect(streamInstances[0]?.isFinalized).toBe(true);
+
+    // Post-tool partial replies fire again (stream.update is a no-op since finalized)
+    ctrl.onPartialReply({ text: "Second segment" });
+
+    // Must still use fallback because stream is finalized and can't deliver
+    const result2 = ctrl.preparePayload({ text: "Second segment" });
+    expect(result2).toEqual({ text: "Second segment" });
+  });
+
   it("still strips text from media payloads when stream handled text", () => {
     const ctrl = createController();
     ctrl.onPartialReply({ text: "Some text" });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -94,6 +94,42 @@ describe("createTeamsReplyStreamController", () => {
     expect(result2).toEqual({ text: "Second segment" });
   });
 
+  it("delivers all segments across 3+ tool call rounds", () => {
+    const ctrl = createController();
+
+    // Round 1: text → tool
+    ctrl.onPartialReply({ text: "Segment 1" });
+    expect(ctrl.preparePayload({ text: "Segment 1" })).toBeUndefined();
+
+    // Round 2: text → tool
+    ctrl.onPartialReply({ text: "Segment 2" });
+    const r2 = ctrl.preparePayload({ text: "Segment 2" });
+    expect(r2).toEqual({ text: "Segment 2" });
+
+    // Round 3: final text
+    ctrl.onPartialReply({ text: "Segment 3" });
+    const r3 = ctrl.preparePayload({ text: "Segment 3" });
+    expect(r3).toEqual({ text: "Segment 3" });
+  });
+
+  it("passes media+text payload through fully after stream finalized", () => {
+    const ctrl = createController();
+
+    // First segment streamed and finalized
+    ctrl.onPartialReply({ text: "Streamed text" });
+    ctrl.preparePayload({ text: "Streamed text" });
+
+    // Second segment has both text and media — should pass through fully
+    const result = ctrl.preparePayload({
+      text: "Post-tool text with image",
+      mediaUrl: "https://example.com/tool-output.png",
+    });
+    expect(result).toEqual({
+      text: "Post-tool text with image",
+      mediaUrl: "https://example.com/tool-output.png",
+    });
+  });
+
   it("still strips text from media payloads when stream handled text", () => {
     const ctrl = createController();
     ctrl.onPartialReply({ text: "Some text" });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+const streamInstances = vi.hoisted(
+  () =>
+    [] as Array<{
+      hasContent: boolean;
+      isFinalized: boolean;
+      sendInformativeUpdate: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+      finalize: ReturnType<typeof vi.fn>;
+    }>,
+);
+
+vi.mock("./streaming-message.js", () => ({
+  TeamsHttpStream: class {
+    hasContent = false;
+    isFinalized = false;
+    sendInformativeUpdate = vi.fn(async () => {});
+    update = vi.fn(function (this: { hasContent: boolean }) {
+      this.hasContent = true;
+    });
+    finalize = vi.fn(async function (this: { isFinalized: boolean }) {
+      this.isFinalized = true;
+    });
+
+    constructor() {
+      streamInstances.push(this as never);
+    }
+  },
+}));
+
+import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
+
+describe("createTeamsReplyStreamController", () => {
+  function createController() {
+    streamInstances.length = 0;
+    return createTeamsReplyStreamController({
+      conversationType: "personal",
+      context: { sendActivity: vi.fn(async () => ({ id: "a" })) } as never,
+      feedbackLoopEnabled: false,
+      log: { debug: vi.fn() } as never,
+    });
+  }
+
+  it("suppresses fallback for first text segment that was streamed", () => {
+    const ctrl = createController();
+    ctrl.onPartialReply({ text: "Hello world" });
+
+    const result = ctrl.preparePayload({ text: "Hello world" });
+    expect(result).toBeUndefined();
+  });
+
+  it("allows fallback delivery for second text segment after tool calls", () => {
+    const ctrl = createController();
+
+    // First text segment: streaming tokens arrive
+    ctrl.onPartialReply({ text: "First segment" });
+
+    // First segment complete: preparePayload suppresses (stream handled it)
+    const result1 = ctrl.preparePayload({ text: "First segment" });
+    expect(result1).toBeUndefined();
+
+    // Tool calls happen... then second text segment arrives via deliver()
+    // preparePayload should allow fallback delivery for this segment
+    const result2 = ctrl.preparePayload({ text: "Second segment after tools" });
+    expect(result2).toEqual({ text: "Second segment after tools" });
+  });
+
+  it("finalizes the stream when suppressing first segment", () => {
+    const ctrl = createController();
+    ctrl.onPartialReply({ text: "Streamed text" });
+
+    ctrl.preparePayload({ text: "Streamed text" });
+
+    expect(streamInstances[0]?.finalize).toHaveBeenCalled();
+  });
+
+  it("still strips text from media payloads when stream handled text", () => {
+    const ctrl = createController();
+    ctrl.onPartialReply({ text: "Some text" });
+
+    const result = ctrl.preparePayload({
+      text: "Some text",
+      mediaUrl: "https://example.com/image.png",
+    });
+    expect(result).toEqual({
+      text: undefined,
+      mediaUrl: "https://example.com/image.png",
+    });
+  });
+});

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -35,6 +35,7 @@ export function createTeamsReplyStreamController(params: {
 
   let streamReceivedTokens = false;
   let informativeUpdateSent = false;
+  let pendingFinalize: Promise<void> | undefined;
 
   return {
     async onReplyStart(): Promise<void> {
@@ -62,7 +63,7 @@ export function createTeamsReplyStreamController(params: {
       // subsequent text segments (after tool calls) use fallback delivery.
       // finalize() is idempotent; the later call in markDispatchIdle is a no-op.
       streamReceivedTokens = false;
-      void stream.finalize();
+      pendingFinalize = stream.finalize();
 
       const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
       if (!hasMedia) {
@@ -72,6 +73,7 @@ export function createTeamsReplyStreamController(params: {
     },
 
     async finalize(): Promise<void> {
+      await pendingFinalize;
       await stream?.finalize();
     },
 

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -58,6 +58,12 @@ export function createTeamsReplyStreamController(params: {
         return payload;
       }
 
+      // Stream handled this text segment — finalize it and reset so any
+      // subsequent text segments (after tool calls) use fallback delivery.
+      // finalize() is idempotent; the later call in markDispatchIdle is a no-op.
+      streamReceivedTokens = false;
+      void stream.finalize();
+
       const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
       if (!hasMedia) {
         return undefined;

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -54,7 +54,7 @@ export function createTeamsReplyStreamController(params: {
     },
 
     preparePayload(payload: ReplyPayload): ReplyPayload | undefined {
-      if (!stream || !streamReceivedTokens || !stream.hasContent) {
+      if (!stream || !streamReceivedTokens || !stream.hasContent || stream.isFinalized) {
         return payload;
       }
 


### PR DESCRIPTION
## Summary

- Fixes `preparePayload()` in `reply-stream-controller.ts` to reset `streamReceivedTokens` and finalize the stream after suppressing a delivery, so subsequent text segments (after tool calls) use fallback delivery instead of being silently dropped
- Adds `stream.isFinalized` guard so a finalized stream never re-suppresses fallback delivery even if `onPartialReply` fires again
- Adds 5 unit tests covering the multi-segment delivery path (text → tool call → text)

## Root Cause

When an agent uses tools mid-response, the LLM produces discontinuous text segments. `preparePayload()` used a one-shot `streamReceivedTokens` flag that never reset after the first segment was streamed — so every subsequent `deliver()` call was suppressed, even for text the stream never saw.

## Before / After

**Before fix:** When an agent uses tools mid-response (text → tool calls → more text), `preparePayload()` suppresses fallback delivery for ALL text segments because `streamReceivedTokens` stays `true`. The second text segment after tool calls is silently lost or the response gets fragmented into duplicate messages.

**After fix:** `preparePayload()` resets `streamReceivedTokens` and finalizes the stream after suppressing the first segment. Subsequent text segments (after tool calls) are delivered via the fallback proactive messaging path. The `stream.isFinalized` guard ensures this holds even if `onPartialReply` fires again for post-tool tokens.

## Test plan

- [x] Unit tests: 5 new tests in `reply-stream-controller.test.ts` — all pass
- [x] Existing tests: `reply-dispatcher.test.ts` (5) + `streaming-message.test.ts` (10) — all pass
- [x] VM regression: A1 (basic reply), A4 (streaming), A5 (streaming + tool use), E4 (endpoint) — all pass
- [x] [Full test report](https://github.com/SidU/ocmaintenance/blob/main/teams/testing/reports/2026-03-27_fix-streaming-tool-calls_6828e56.md)

Fixes #56040

🤖 Generated with [Claude Code](https://claude.com/claude-code)