### PR TITLE
feat(commands): support /steer shorthand for main-session queue steering

### DIFF
--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -206,6 +206,25 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("please now");
   });
 
+  it("treats /steer text as queue steer shorthand", () => {
+    const res = extractQueueDirective("/steer check progress");
+    expect(res.hasDirective).toBe(true);
+    expect(res.queueMode).toBe("steer");
+    expect(res.cleaned).toBe("check progress");
+  });
+
+  it("does not treat /steer with a numeric target as queue shorthand", () => {
+    const res = extractQueueDirective("/steer 2 check progress");
+    expect(res.hasDirective).toBe(false);
+    expect(res.cleaned).toBe("/steer 2 check progress");
+  });
+
+  it("does not treat bare /steer as queue shorthand", () => {
+    const res = extractQueueDirective("/steer");
+    expect(res.hasDirective).toBe(false);
+    expect(res.cleaned).toBe("/steer");
+  });
+
   it("extracts reply_to_current tag", () => {
     const res = extractReplyToTag("ok [[reply_to_current]]", "msg-1");
     expect(res.replyToId).toBe("msg-1");

--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -1,5 +1,6 @@
 import { listControlledSubagentRuns } from "../../agents/subagent-control.js";
 import { logVerbose } from "../../globals.js";
+import { isSubagentSessionKey } from "../../routing/session-key.js";
 import { handleSubagentsAgentsAction } from "./commands-subagents/action-agents.js";
 import { handleSubagentsFocusAction } from "./commands-subagents/action-focus.js";
 import { handleSubagentsHelpAction } from "./commands-subagents/action-help.js";
@@ -19,6 +20,7 @@ import {
   stopWithText,
 } from "./commands-subagents/shared.js";
 import type { CommandHandler } from "./commands-types.js";
+import { isSubagentIndexToken } from "./subagents-utils.js";
 
 export { extractMessageText };
 
@@ -55,6 +57,15 @@ export const handleSubagentsCommand: CommandHandler = async (params, allowTextCo
       : resolveRequesterSessionKey(params);
   if (!requesterKey) {
     return stopWithText("⚠️ Missing session key.");
+  }
+
+  if (
+    handledPrefix === "/steer" &&
+    !isSubagentSessionKey(requesterKey) &&
+    restTokens.length > 0 &&
+    !isSubagentIndexToken(restTokens[0])
+  ) {
+    return null;
   }
 
   const ctx: SubagentsCommandContext = {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -2978,6 +2978,30 @@ describe("handleCommands subagents", () => {
     expect(trackedRuns[0].endedAt).toBeUndefined();
   });
 
+  it("lets main-session /steer messages fall through to queue steering", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/steer check progress", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(true);
+    expect(result.reply).toBeUndefined();
+  });
+
+  it("keeps bare /steer usage guidance", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/steer", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Usage: /steer <id|#> <message>");
+  });
+
   it("steers ended orchestrators that are still waiting on active descendants", async () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };

--- a/src/auto-reply/reply/queue/directive.ts
+++ b/src/auto-reply/reply/queue/directive.ts
@@ -1,5 +1,6 @@
 import { parseDurationMs } from "../../../cli/parse-duration.js";
 import { skipDirectiveArgPrefix, takeDirectiveToken } from "../directive-parsing.js";
+import { isSubagentIndexToken } from "../subagents-utils.js";
 import { normalizeQueueDropPolicy, normalizeQueueMode } from "./normalize.js";
 import type { QueueDropPolicy, QueueMode } from "./types.js";
 
@@ -146,6 +147,24 @@ export function extractQueueDirective(body?: string): {
   const re = /(?:^|\s)\/queue(?=$|\s|:)/i;
   const match = re.exec(body);
   if (!match) {
+    const steerMatch = /(?:^|\s)\/steer(?=$|\s|:)/i.exec(body);
+    if (steerMatch) {
+      const start = steerMatch.index + steerMatch[0].indexOf("/steer");
+      const argsStart = start + "/steer".length;
+      const trimmedArgs = body.slice(argsStart).trim();
+      const [firstToken] = trimmedArgs.split(/\s+/, 1);
+      if (trimmedArgs && !isSubagentIndexToken(firstToken)) {
+        const cleanedRaw = `${body.slice(0, start)} ${body.slice(argsStart)}`;
+        return {
+          cleaned: cleanedRaw.replace(/\s+/g, " ").trim(),
+          queueMode: "steer",
+          queueReset: false,
+          rawMode: "steer",
+          hasDirective: true,
+          hasOptions: false,
+        };
+      }
+    }
     return {
       cleaned: body.trim(),
       hasDirective: false,

--- a/src/auto-reply/reply/subagents-utils.test.ts
+++ b/src/auto-reply/reply/subagents-utils.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SubagentRunRecord } from "../../agents/subagent-registry.js";
 import {
   resolveSubagentLabel,
+  isSubagentIndexToken,
   resolveSubagentTargetFromRuns,
   sortSubagentRuns,
 } from "./subagents-utils.js";
@@ -58,6 +59,13 @@ describe("subagents utils", () => {
       makeRun({ runId: "c", startedAt: 12, createdAt: 20 }),
     ]);
     expect(sorted.map((entry) => entry.runId)).toEqual(["b", "c", "a"]);
+  });
+
+  it("recognizes numeric and #numeric subagent index tokens", () => {
+    expect(isSubagentIndexToken("2")).toBe(true);
+    expect(isSubagentIndexToken("#2")).toBe(true);
+    expect(isSubagentIndexToken("worker")).toBe(false);
+    expect(isSubagentIndexToken(undefined)).toBe(false);
   });
 
   it("selects last from sorted runs", () => {

--- a/src/auto-reply/reply/subagents-utils.ts
+++ b/src/auto-reply/reply/subagents-utils.ts
@@ -36,6 +36,11 @@ export type SubagentTargetResolution = {
   error?: string;
 };
 
+export function isSubagentIndexToken(token: string | undefined): boolean {
+  const trimmed = token?.trim();
+  return Boolean(trimmed && (/^\d+$/.test(trimmed) || /^#\d+$/.test(trimmed)));
+}
+
 export function resolveSubagentTargetFromRuns(params: {
   runs: SubagentRunRecord[];
   token: string | undefined;


### PR DESCRIPTION
## Summary
- let main-session `/steer <message>` fall through to inline queue steering instead of being consumed by the subagent command handler
- keep numeric and `#N` targets on the existing subagent steer path by sharing one small target-shape helper
- add focused tests for the shorthand parser, the main-session fallthrough behavior, and the legacy subagent path
- AI-assisted

## Test plan
- [x] `pnpm exec vitest run src/auto-reply/reply/subagents-utils.test.ts src/auto-reply/reply.directive.parse.test.ts src/auto-reply/reply/commands.test.ts -t "steer|subagent index|queue shorthand"`
- [x] `pnpm exec oxlint --type-aware src/auto-reply/reply/commands-subagents.ts src/auto-reply/reply/queue/directive.ts src/auto-reply/reply/subagents-utils.ts src/auto-reply/reply/commands.test.ts src/auto-reply/reply.directive.parse.test.ts src/auto-reply/reply/subagents-utils.test.ts`
- [x] pre-commit hook ran `pnpm check`

References #34881

Made with [Cursor](https://cursor.com)