### PR TITLE
fix(diffs): stage bundled runtime deps after updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Matrix: preserve sender filenames for inbound media by forwarding `originalFilename` to `saveMediaBuffer`. (#55692) thanks @esrehmki.
 - Matrix/mentions: recognize `matrix.to` mentions whose visible label uses the bot's room display name, so `requireMention: true` rooms respond correctly in modern Matrix clients. (#55393) thanks @nickludlam.
 - Ollama/thinking off: route `thinkingLevel=off` through the live Ollama extension request path so thinking-capable Ollama models now receive top-level `think: false` instead of silently generating hidden reasoning tokens. (#53200) Thanks @BruceMacD.
+- Plugins/diffs: stage bundled `@pierre/diffs` runtime dependencies during packaged updates so the bundled diff viewer keeps loading after global installs and updates. (#56077) Thanks @gumadeiras.
 
 ## 2026.3.24
 

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -13,6 +13,9 @@
     "playwright-core": "1.58.2"
   },
   "openclaw": {
+    "bundle": {
+      "stageRuntimeDependencies": true
+    },
     "extensions": [
       "./index.ts"
     ]

--- a/extensions/diffs/src/manifest.test.ts
+++ b/extensions/diffs/src/manifest.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type DiffsPackageManifest = {
+  dependencies?: Record<string, string>;
+  openclaw?: {
+    bundle?: {
+      stageRuntimeDependencies?: boolean;
+    };
+  };
+};
+
+describe("diffs package manifest", () => {
+  it("opts into staging bundled runtime dependencies", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as DiffsPackageManifest;
+
+    expect(packageJson.dependencies?.["@pierre/diffs"]).toBeDefined();
+    expect(packageJson.openclaw?.bundle?.stageRuntimeDependencies).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: the bundled `diffs` plugin loses `@pierre/diffs` after global updates because its runtime deps are not staged into `dist/extensions/diffs/node_modules`
- Why it matters: `openclaw update` can leave the `diffs` plugin unloadable with `Cannot find module '@pierre/diffs'`
- What changed: added `openclaw.bundle.stageRuntimeDependencies: true` to `extensions/diffs/package.json` and added a manifest regression test
- What did NOT change (scope boundary): no updater flow changes, no plugin loader changes, and no broader runtime-deps policy changes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #43963
- Related #43963
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `scripts/stage-bundled-plugin-runtime-deps.mjs` only stages plugin-local runtime deps when the plugin manifest sets `openclaw.bundle.stageRuntimeDependencies: true`, and `extensions/diffs/package.json` did not opt in
- Missing detection / guardrail: there was no plugin-specific regression test asserting that `diffs` keeps its staging opt-in while depending on `@pierre/diffs`
- Prior context (`git blame`, prior PR, issue, or refactor if known): the staged-runtime-deps flow already existed for other bundled plugins such as `discord`, `feishu`, `slack`, and `telegram`; `diffs` was omitted when plugin-local runtime deps were moved into extension manifests
- Why this regressed now: `@pierre/diffs` is unique to the `diffs` plugin, so once global updates replaced the extension directory, there was no staged bundled copy to load at runtime
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/diffs/src/manifest.test.ts`
- Scenario the test should lock in: the `diffs` plugin manifest keeps `stageRuntimeDependencies` enabled while declaring `@pierre/diffs` as a runtime dependency
- Why this is the smallest reliable guardrail: the breakage is caused by missing package metadata, so a direct manifest assertion fails as soon as that opt-in is removed
- Existing test that already covers this (if any): `test/scripts/stage-bundled-plugin-runtime-deps.test.ts` covers the generic staging script behavior, but not the `diffs` manifest configuration
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`diffs` keeps its bundled runtime dependency staging metadata, so packaged/global-update installs will continue to ship `@pierre/diffs` with the plugin instead of requiring a manual reinstall after each update.

## Diagram (if applicable)

```text
Before:
[openclaw update] -> [dist/extensions/diffs replaced] -> [no staged node_modules] -> [plugin load fails]

After:
[openclaw update] -> [runtime deps staging sees diffs opt-in] -> [dist/extensions/diffs/node_modules populated] -> [plugin loads]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): bundled `diffs` plugin packaging
- Relevant config (redacted): N/A

### Steps

1. Inspect `scripts/stage-bundled-plugin-runtime-deps.mjs` and confirm staging only runs when `openclaw.bundle.stageRuntimeDependencies === true`
2. Inspect `extensions/diffs/package.json` and confirm `diffs` had runtime deps but lacked that opt-in
3. Add the missing manifest flag and a regression test, then run targeted verification

### Expected

- `diffs` opts into bundled runtime dependency staging
- targeted regression tests pass

### Actual

- confirmed the missing opt-in in the current tree
- after the fix, targeted tests pass
- full `pnpm build` is currently blocked by unrelated existing TypeScript errors in `src/agents/compaction.ts` and `src/agents/skills/source.ts`

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced the packaging code path, confirmed the missing `diffs` manifest opt-in, ran `pnpm test -- extensions/diffs/src/manifest.test.ts`, and ran `pnpm test -- test/scripts/stage-bundled-plugin-runtime-deps.test.ts`
- Edge cases checked: ensured the generic staging script coverage still passes after the manifest change
- What you did **not** verify: a full end-to-end global `npm i -g openclaw@latest` update cycle, because the current branch has unrelated TypeScript build failures outside this change

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: this relies on the existing staged-runtime-deps packaging path remaining part of the build/release flow
  - Mitigation: the new manifest regression test catches accidental removal of the `diffs` opt-in, and the existing staging-script tests still pass
