### PR TITLE
feat: include model in response usage footer

### DIFF
--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -1,4 +1,5 @@
 import { estimateUsageCost, formatTokenCount, formatUsd } from "../../utils/usage-format.js";
+import { formatProviderModelRef } from "../model-runtime.js";
 import type { ReplyPayload } from "../types.js";
 
 export const formatResponseUsageLine = (params: {
@@ -9,6 +10,8 @@ export const formatResponseUsageLine = (params: {
     cacheWrite?: number;
   };
   showCost: boolean;
+  providerUsed?: string;
+  modelUsed?: string;
   costConfig?: {
     input: number;
     output: number;
@@ -40,7 +43,8 @@ export const formatResponseUsageLine = (params: {
         })
       : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  const suffix = costLabel ? ` · est ${costLabel}` : "";
+  const modelLabel = formatProviderModelRef(params.providerUsed ?? "", params.modelUsed ?? "");
+  const suffix = `${costLabel ? ` · est ${costLabel}` : ""}${modelLabel ? ` · model ${modelLabel}` : ""}`;
   return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
 };
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -656,6 +656,8 @@ export async function runReplyAgent(params: {
       let formatted = formatResponseUsageLine({
         usage,
         showCost,
+        providerUsed,
+        modelUsed,
         costConfig,
       });
       if (formatted && responseUsageMode === "full" && sessionKey) {


### PR DESCRIPTION
## Summary
- include the actual answering provider/model in the response usage footer
- pass `providerUsed` and `modelUsed` into `formatResponseUsageLine`
- keep existing cost/session behavior unchanged

## Example
Before:

```text
Usage: 12k in / 970 out
```

After:

```text
Usage: 12k in / 970 out · model openai-codex/gpt-5.4-mini
```

With cost enabled:

```text
Usage: 12k in / 970 out · est $0.01 · model openai-codex/gpt-5.4-mini
```

## Why
The runner already knows the actual model/provider that produced the reply at the point where the usage footer is assembled, so surfacing it there is low-risk and more informative than showing tokens alone.

This also avoids relying on router/planner intent: the footer reports the model that actually answered.

## Validation
- local focused smoke test for `formatResponseUsageLine`
- repo checks triggered during commit/push completed successfully
