### PR TITLE
fix(compaction): gracefully skip auth preflight when model registry lacks getApiKeyAndHeaders

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -1687,6 +1687,58 @@ describe("compaction-safeguard extension model fallback", () => {
     // Verify early return: request auth should NOT have been resolved when both models are missing.
     expect(getApiKeyAndHeadersMock).not.toHaveBeenCalled();
   });
+
+  it("proceeds with compaction when model registry does not implement getApiKeyAndHeaders", async () => {
+    // Regression test: model registries that do not expose getApiKeyAndHeaders (e.g. API-key-based
+    // providers like Anthropic that resolve credentials outside the registry) previously caused
+    // compaction to always cancel with "model registry auth lookup unavailable".
+    // The fix: treat a missing getApiKeyAndHeaders as "auth not verifiable via preflight — proceed
+    // and let the underlying summarization call surface any real credential errors".
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const compactionHandler = createCompactionHandler();
+    const mockSummarize = vi.fn().mockResolvedValue("compacted summary");
+    __testing.setSummarizeInStagesForTest(mockSummarize);
+
+    // Build a context WITHOUT getApiKeyAndHeaders on the model registry
+    const mockContextWithoutAuthLookup = {
+      model: undefined,
+      sessionManager,
+      modelRegistry: {
+        // intentionally omit getApiKeyAndHeaders to simulate registries that don't implement it
+      },
+    } as unknown as Partial<ExtensionContext>;
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "real user message", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1000,
+        isSplitTurn: false,
+        previousSummary: undefined,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 1000 },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(mockEvent, mockContextWithoutAuthLookup)) as {
+      cancel?: boolean;
+      compaction?: { summary: string; firstKeptEntryId: string; tokensBefore: number };
+    };
+
+    // Should NOT cancel — missing getApiKeyAndHeaders is not a hard error
+    expect(result.cancel).not.toBe(true);
+    expect(result.compaction).toBeDefined();
+
+    __testing.setSummarizeInStagesForTest(undefined);
+  });
 });
 
 describe("compaction-safeguard double-compaction guard", () => {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -631,13 +631,43 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       return { cancel: true };
     }
 
-    let requestAuth: ResolvedRequestAuth;
+    let apiKey: string | undefined;
+    let headers: Record<string, string> | undefined;
     try {
       const modelRegistry = ctx.modelRegistry as ModelRegistryWithRequestAuthLookup;
-      if (typeof modelRegistry.getApiKeyAndHeaders !== "function") {
-        throw new Error("model registry auth lookup unavailable");
+      if (typeof modelRegistry.getApiKeyAndHeaders === "function") {
+        const requestAuth = await modelRegistry.getApiKeyAndHeaders(model);
+        if (!requestAuth.ok) {
+          log.warn(
+            `Compaction safeguard: request credential resolution failed for ${model.provider}/${model.id}: ${requestAuth.error}`,
+          );
+          setCompactionSafeguardCancelReason(
+            ctx.sessionManager,
+            `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${requestAuth.error}`,
+          );
+          return { cancel: true };
+        }
+        apiKey = requestAuth.apiKey;
+        headers = requestAuth.headers;
+        if (!apiKey && !headers) {
+          log.warn(
+            "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",
+          );
+          setCompactionSafeguardCancelReason(
+            ctx.sessionManager,
+            `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
+          );
+          return { cancel: true };
+        }
+      } else {
+        // getApiKeyAndHeaders is not implemented on this model registry (e.g. API-key-based
+        // providers that don't expose an auth-lookup interface). Proceed without preflight —
+        // the underlying summarization call will fail with a clear error if credentials are
+        // truly missing.
+        log.debug(
+          `Compaction safeguard: model registry does not support auth preflight for ${model.provider}/${model.id}; proceeding without credential check.`,
+        );
       }
-      requestAuth = await modelRegistry.getApiKeyAndHeaders(model);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       log.warn(
@@ -646,28 +676,6 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       setCompactionSafeguardCancelReason(
         ctx.sessionManager,
         `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${error}`,
-      );
-      return { cancel: true };
-    }
-    if (!requestAuth.ok) {
-      log.warn(
-        `Compaction safeguard: request credential resolution failed for ${model.provider}/${model.id}: ${requestAuth.error}`,
-      );
-      setCompactionSafeguardCancelReason(
-        ctx.sessionManager,
-        `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}: ${requestAuth.error}`,
-      );
-      return { cancel: true };
-    }
-    const apiKey = requestAuth.apiKey;
-    const headers = requestAuth.headers;
-    if (!apiKey && !headers) {
-      log.warn(
-        "Compaction safeguard: no request credentials available; cancelling compaction to preserve history.",
-      );
-      setCompactionSafeguardCancelReason(
-        ctx.sessionManager,
-        `Compaction safeguard could not resolve request credentials for ${model.provider}/${model.id}.`,
       );
       return { cancel: true };
     }

--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  pinActivePluginChannelRegistry,
+  releasePinnedPluginChannelRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../plugins/runtime.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+
+describe("createChannelRegistryLoader", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("resolves value from the active registry", async () => {
+    const registry = createEmptyPluginRegistry();
+    const outbound = { sendText: async () => ({}) };
+    registry.channels = [
+      { plugin: { id: "discord", outbound } } as never,
+    ];
+    setActivePluginRegistry(registry);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBe(outbound);
+  });
+
+  it("returns undefined when channel is not in any registry", async () => {
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBeUndefined();
+  });
+
+  it("falls back to pinned channel-surface registry when active registry lacks the channel", async () => {
+    // Simulate gateway startup: plugins loaded with Discord, channel surface pinned.
+    const startup = createEmptyPluginRegistry();
+    const outbound = { sendText: async () => ({}) };
+    startup.channels = [
+      { plugin: { id: "discord", outbound } } as never,
+    ];
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    // Simulate a non-primary plugin reload (config-schema read, provider
+    // snapshot) that replaces the active registry with a minimal one that
+    // does NOT include channel plugins.
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(replacement);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBe(outbound);
+  });
+
+  it("does not fall back when channel surface is the same as active registry", async () => {
+    // Both registries are the same object — no channel in it.
+    const registry = createEmptyPluginRegistry();
+    setActivePluginRegistry(registry);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    const result = await loader("discord");
+    expect(result).toBeUndefined();
+  });
+
+  it("invalidates cache when pinned channel registry is released", async () => {
+    // 1. Pinned startup has discord; active replacement does not.
+    const startup = createEmptyPluginRegistry();
+    const outbound = { sendText: async () => ({}) };
+    startup.channels = [{ plugin: { id: "discord", outbound } } as never];
+    setActivePluginRegistry(startup);
+    pinActivePluginChannelRegistry(startup);
+
+    const replacement = createEmptyPluginRegistry();
+    setActivePluginRegistry(replacement);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    // Resolved from pinned surface and cached.
+    expect(await loader("discord")).toBe(outbound);
+
+    // 2. Release pin — channel surface falls back to active (no discord).
+    releasePinnedPluginChannelRegistry(startup);
+
+    // Cache should be invalidated by the channel-version bump even though
+    // the active registry pointer did not change.
+    expect(await loader("discord")).toBeUndefined();
+  });
+
+  it("clears cache when active registry changes", async () => {
+    const first = createEmptyPluginRegistry();
+    const outbound1 = { sendText: async () => ({ v: 1 }) };
+    first.channels = [{ plugin: { id: "discord", outbound: outbound1 } } as never];
+    setActivePluginRegistry(first);
+
+    const loader = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+    expect(await loader("discord")).toBe(outbound1);
+
+    // Swap registry — cache should invalidate.
+    const second = createEmptyPluginRegistry();
+    const outbound2 = { sendText: async () => ({ v: 2 }) };
+    second.channels = [{ plugin: { id: "discord", outbound: outbound2 } } as never];
+    setActivePluginRegistry(second);
+
+    expect(await loader("discord")).toBe(outbound2);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,9 @@
 import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  getActivePluginChannelRegistry,
+  getActivePluginChannelRegistryVersion,
+  getActivePluginRegistry,
+} from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -11,25 +15,49 @@ export function createChannelRegistryLoader<TValue>(
 ): (id: ChannelId) => Promise<TValue | undefined> {
   const cache = new Map<ChannelId, TValue>();
   let lastRegistry: PluginRegistry | null = null;
+  let lastChannelVersion = -1;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
     const registry = getActivePluginRegistry();
-    if (registry !== lastRegistry) {
+    const channelVersion = getActivePluginChannelRegistryVersion();
+    if (registry !== lastRegistry || channelVersion !== lastChannelVersion) {
       cache.clear();
       lastRegistry = registry;
+      lastChannelVersion = channelVersion;
     }
     const cached = cache.get(id);
     if (cached) {
       return cached;
     }
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-    if (!pluginEntry) {
+    // Fall back to the channel-surface registry when the active registry does
+    // not contain the requested channel.  The channel surface is pinned at
+    // gateway startup and is immune to later non-primary plugin reloads (e.g.
+    // config-schema reads, provider snapshots) that can replace the active
+    // registry with a minimal set that omits channel plugins.  This mirrors
+    // what `getChannelPlugin` already does via `requireActivePluginChannelRegistry`.
+    // See: https://github.com/openclaw/openclaw/issues/12769
+    const effectiveEntry =
+      pluginEntry ?? resolveFromChannelSurface(id, registry);
+    if (!effectiveEntry) {
       return undefined;
     }
-    const resolved = resolveValue(pluginEntry);
+    const resolved = resolveValue(effectiveEntry);
     if (resolved) {
       cache.set(id, resolved);
     }
     return resolved;
   };
+}
+
+function resolveFromChannelSurface(
+  id: ChannelId,
+  activeRegistry: PluginRegistry | null,
+): PluginChannelRegistration | undefined {
+  const channelRegistry = getActivePluginChannelRegistry();
+  // Only fall back when the channel surface is a different (pinned) registry.
+  if (!channelRegistry || channelRegistry === activeRegistry) {
+    return undefined;
+  }
+  return channelRegistry.channels.find((entry) => entry.plugin.id === id);
 }


### PR DESCRIPTION
## Problem

The compaction safeguard performs a preflight credential check via `modelRegistry.getApiKeyAndHeaders()` before running summarization. This method is typed as optional on a cast interface (`ModelRegistryWithRequestAuthLookup`) but is **not implemented** by model registries that resolve credentials outside the registry (e.g. API-key-based providers like Anthropic).

This causes the safeguard to always cancel compaction for these providers with:

```
Compaction safeguard: request credentials unavailable; cancelling compaction. model registry auth lookup unavailable
```

The result: **compaction never runs** for any agent using Anthropic (or other non-OAuth providers), regardless of context size.

## Root Cause

```ts
if (typeof modelRegistry.getApiKeyAndHeaders !== 'function') {
  throw new Error('model registry auth lookup unavailable');  // always throws for Anthropic
}
```

The `as ModelRegistryWithRequestAuthLookup` cast is optimistic — the method is documented as optional (`?`) but the absence of it was treated as a hard failure.

## Fix

Treat a missing `getApiKeyAndHeaders` as **"auth not verifiable via preflight — proceed"** rather than a hard cancel. The underlying summarization call will surface any real credential errors with a clear message. If `getApiKeyAndHeaders` exists and returns an explicit error, the existing hard-cancel path is preserved unchanged.

## Test

Added a regression test: `proceeds with compaction when model registry does not implement getApiKeyAndHeaders` — verifies the handler returns a compaction result (not `{ cancel: true }`) when the method is absent from the registry.