### PR TITLE
Improve Feishu streaming visibility and filter scratchpad text

### DIFF
--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -218,6 +218,17 @@ describe("FeishuConfigSchema optimization flags", () => {
     expect(result.accounts?.main?.typingIndicator).toBe(false);
     expect(result.accounts?.main?.resolveSenderNames).toBe(false);
   });
+
+  it("accepts account-level statusLanguage", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: {
+          statusLanguage: "en",
+        },
+      },
+    });
+    expect(result.accounts?.main?.statusLanguage).toBe("en");
+  });
 });
 
 describe("FeishuConfigSchema actions", () => {

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -137,6 +137,7 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  * causing the reply to appear as a topic (话题) under the original message.
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
+const StatusLanguageSchema = z.enum(["zh-CN", "en"]).optional();
 
 export const FeishuGroupSchema = z
   .object({
@@ -182,6 +183,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  statusLanguage: StatusLanguageSchema,
 };
 
 /**

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -4,6 +4,7 @@ type StreamingSessionStub = {
   active: boolean;
   start: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
+  updateNoteContent: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   isActive: ReturnType<typeof vi.fn>;
 };
@@ -48,6 +49,7 @@ vi.mock("./streaming-card.js", async () => {
         this.active = true;
       });
       update = vi.fn(async () => {});
+      updateNoteContent = vi.fn(async () => {});
       close = vi.fn(async () => {
         this.active = false;
       });
@@ -277,7 +279,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyInThread: undefined,
         rootId: "om_root_topic",
         header: { title: "agent", template: "blue" },
-        note: "Agent: agent",
+        note: expect.stringContaining("Agent: agent | 状态: 处理中"),
       }),
     );
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
@@ -296,7 +298,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```", {
-      note: "Agent: agent",
+      note: expect.stringContaining("Agent: agent | 状态: 已完成"),
     });
   });
 
@@ -310,13 +312,13 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances).toHaveLength(2);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```", {
-      note: "Agent: agent",
+      note: expect.stringContaining("Agent: agent | 状态: 已完成"),
     });
     expect(streamingInstances[1].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[1].close).toHaveBeenCalledWith(
       "```md\n完整回复第一段 + 第二段\n```",
       {
-        note: "Agent: agent",
+        note: expect.stringContaining("Agent: agent | 状态: 已完成"),
       },
     );
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
@@ -333,7 +335,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n同一条回复\n```", {
-      note: "Agent: agent",
+      note: expect.stringContaining("Agent: agent | 状态: 已完成"),
     });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
@@ -399,7 +401,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledWith("hellolo world", {
-      note: "Agent: agent",
+      note: expect.stringContaining("Agent: agent | 状态: 已完成"),
     });
   });
 
@@ -631,9 +633,38 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyToMessageId: "om_msg",
         replyInThread: true,
         header: { title: "agent", template: "blue" },
-        note: "Agent: agent",
+        note: expect.stringContaining("Agent: agent | 状态: 处理中"),
       }),
     );
+  });
+
+  it("filters codex scratchpad-like english text from feishu replies", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "auto",
+        streaming: false,
+      },
+    });
+
+    const { result, options } = createDispatcherHarness();
+    result.replyOptions.onModelSelected?.({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      thinkLevel: "off",
+    });
+    await options.deliver(
+      {
+        text: "Need maybe use direct curl. Need inspect page meta and create draft.",
+      },
+      { kind: "final" },
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("disables streaming for thread replies and keeps reply metadata", async () => {

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -638,6 +638,40 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("supports optional english streaming status note", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+        statusLanguage: "en",
+      },
+    });
+
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledWith(
+      "oc_chat",
+      "chat_id",
+      expect.objectContaining({
+        note: expect.stringContaining("Agent: agent | Status: In progress"),
+      }),
+    );
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "```ts\nconst x = 1\n```",
+      expect.objectContaining({
+        note: expect.stringContaining("Agent: agent | Status: Completed"),
+      }),
+    );
+  });
+
   it("filters codex scratchpad-like english text from feishu replies", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -22,6 +22,7 @@ import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } fr
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
+import type { FeishuStatusLanguage } from "./types.js";
 
 /** Detect if text contains markdown elements that benefit from card rendering */
 function shouldUseCard(text: string): boolean {
@@ -122,6 +123,29 @@ function isLikelyCodexScratchpadText(text: string, provider?: string): boolean {
       cleaned,
     )
   );
+}
+
+function resolveStatusCopy(language: FeishuStatusLanguage) {
+  if (language === "en") {
+    return {
+      locale: "en-GB",
+      statusLabel: "Status",
+      activityLabel: "Last activity",
+      processing: "In progress",
+      finalizing: "Finalizing",
+      completed: "Completed",
+      completionPingPrefix: "Completed:",
+    } as const;
+  }
+  return {
+    locale: "zh-CN",
+    statusLabel: "状态",
+    activityLabel: "最后活动",
+    processing: "处理中",
+    finalizing: "整理结果",
+    completed: "已完成",
+    completionPingPrefix: "已完成：",
+  } as const;
 }
 
 export type CreateFeishuReplyDispatcherParams = {
@@ -251,13 +275,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   let streamingStartedAt = 0;
   let lastActivityAt = 0;
-  let lastKnownStatus = "处理中";
+  const statusLanguage = account.config?.statusLanguage ?? "zh-CN";
+  const statusCopy = resolveStatusCopy(statusLanguage);
+  let lastKnownStatus = statusCopy.processing;
   const STREAMING_NOTE_HEARTBEAT_MS = 15_000;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
   const formatActivityTime = (timestamp: number): string =>
     timestamp > 0
-      ? new Date(timestamp).toLocaleTimeString("zh-CN", {
+      ? new Date(timestamp).toLocaleTimeString(statusCopy.locale, {
           hour12: false,
           hour: "2-digit",
           minute: "2-digit",
@@ -267,9 +293,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
 
   const buildStreamingNote = (status = lastKnownStatus): string => {
     const base = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-    const parts = [base, `状态: ${status}`];
+    const parts = [base, `${statusCopy.statusLabel}: ${status}`];
     if (lastActivityAt > 0) {
-      parts.push(`最后活动: ${formatActivityTime(lastActivityAt)}`);
+      parts.push(`${statusCopy.activityLabel}: ${formatActivityTime(lastActivityAt)}`);
     }
     return parts.join(" | ");
   };
@@ -286,7 +312,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     });
   };
 
-  const markStreamingActivity = (status = "处理中") => {
+  const markStreamingActivity = (status = statusCopy.processing) => {
     lastActivityAt = Date.now();
     refreshStreamingNote(status);
   };
@@ -356,7 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (options?.dedupeWithLastPartial) {
       lastPartial = nextText;
     }
-    markStreamingActivity("处理中");
+    markStreamingActivity(statusCopy.processing);
     const mode = options?.mode ?? "snapshot";
     streamText =
       mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
@@ -366,7 +392,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const queueReasoningUpdate = (nextThinking: string) => {
     if (!nextThinking) return;
     reasoningText = nextThinking;
-    markStreamingActivity("处理中");
+    markStreamingActivity(statusCopy.processing);
     flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
   };
 
@@ -376,7 +402,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     }
     streamingStartedAt = Date.now();
     lastActivityAt = streamingStartedAt;
-    lastKnownStatus = "处理中";
+    lastKnownStatus = statusCopy.processing;
     streamingStartPromise = (async () => {
       const creds =
         account.appId && account.appSecret
@@ -397,7 +423,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,
-          note: buildStreamingNote("处理中"),
+          note: buildStreamingNote(statusCopy.processing),
         });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
@@ -419,9 +445,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      lastKnownStatus = "已完成";
+      lastKnownStatus = statusCopy.completed;
       lastActivityAt = Date.now();
-      const finalNote = buildStreamingNote("已完成");
+      const finalNote = buildStreamingNote(statusCopy.completed);
       await streaming.close(text, { note: finalNote });
     }
     streaming = null;
@@ -431,7 +457,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     reasoningText = "";
     streamingStartedAt = 0;
     lastActivityAt = 0;
-    lastKnownStatus = "处理中";
+    lastKnownStatus = statusCopy.processing;
   };
 
   const sendChunkedTextReply = async (params: {
@@ -530,7 +556,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta" });
             }
             if (info?.kind === "final") {
-              markStreamingActivity("整理结果");
+              markStreamingActivity(statusCopy.finalizing);
               streamText = mergeStreamingText(streamText, text);
               await closeStreaming();
               deliveredFinalTexts.add(text);
@@ -538,7 +564,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 await sendMessageFeishu({
                   cfg,
                   to: chatId,
-                  text: `已完成：${text.replace(/\n/g, " ").trim().slice(0, 100)}`,
+                  text: `${statusCopy.completionPingPrefix} ${text.replace(/\n/g, " ").trim().slice(0, 100)}`,
                   replyToMessageId: sendReplyToMessageId,
                   replyInThread: effectiveReplyInThread,
                   accountId,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -72,6 +72,58 @@ function resolveCardNote(
   return parts.join(" | ");
 }
 
+function sanitizeReplyText(text: string | undefined): string {
+  if (!text) {
+    return "";
+  }
+  return text
+    .replace(/🧹\s*Compacting context\.\.\.\s*/g, "")
+    .replace(/<\/?final>\s*/gi, "")
+    .trim();
+}
+
+function isLikelyCodexScratchpadText(text: string, provider?: string): boolean {
+  if ((provider ?? "").toLowerCase() !== "openai-codex") {
+    return false;
+  }
+  const cleaned = sanitizeReplyText(text);
+  if (!cleaned || /[\u4e00-\u9fff]/.test(cleaned)) {
+    return false;
+  }
+  if (cleaned.length > 2000 || !/[A-Za-z]/.test(cleaned)) {
+    return false;
+  }
+  if (/^\[\[reply_to_current\]\]/.test(cleaned)) {
+    return false;
+  }
+  if (
+    /^(Need|Need to|Let's|We can|Use |Only |Translation failed|Found |Now |Maybe |Better |Looks translated|Great|Good\b)/i.test(
+      cleaned,
+    )
+  ) {
+    return true;
+  }
+  if (
+    /\b(?:tool|script|page|workflow|upload|translate|header|footer|meta|rest|curl|draft|create|update|inspect|verify|extract|body|html|template|slug|publish|wordpress|elementor)\b/i.test(
+      cleaned,
+    ) &&
+    /\b(?:need|maybe|likely|could|should|let's|let us|try|test|inspect|verify|create|update|copy|fetch|extract|build|retry|respond)\b/i.test(
+      cleaned,
+    )
+  ) {
+    return true;
+  }
+  return (
+    cleaned.split(/\s+/).length >= 8 &&
+    /[.?!]/.test(cleaned) &&
+    !/[`[{(<]/.test(cleaned) &&
+    /^[A-Za-z0-9 ,.:;'"\/_-]+$/.test(cleaned) &&
+    /\b(?:need|maybe|likely|could|should|let's|try|inspect|verify|create|update|copy|fetch|extract|build|retry|respond)\b/i.test(
+      cleaned,
+    )
+  );
+}
+
 export type CreateFeishuReplyDispatcherParams = {
   cfg: ClawdbotConfig;
   agentId: string;
@@ -196,7 +248,70 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  let streamingStartedAt = 0;
+  let lastActivityAt = 0;
+  let lastKnownStatus = "处理中";
+  const STREAMING_NOTE_HEARTBEAT_MS = 15_000;
   type StreamTextUpdateMode = "snapshot" | "delta";
+
+  const formatActivityTime = (timestamp: number): string =>
+    timestamp > 0
+      ? new Date(timestamp).toLocaleTimeString("zh-CN", {
+          hour12: false,
+          hour: "2-digit",
+          minute: "2-digit",
+          second: "2-digit",
+        })
+      : "";
+
+  const buildStreamingNote = (status = lastKnownStatus): string => {
+    const base = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+    const parts = [base, `状态: ${status}`];
+    if (lastActivityAt > 0) {
+      parts.push(`最后活动: ${formatActivityTime(lastActivityAt)}`);
+    }
+    return parts.join(" | ");
+  };
+
+  const refreshStreamingNote = (status = lastKnownStatus) => {
+    lastKnownStatus = status;
+    partialUpdateQueue = partialUpdateQueue.then(async () => {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      if (streaming?.isActive()) {
+        await streaming.updateNoteContent(buildStreamingNote(status));
+      }
+    });
+  };
+
+  const markStreamingActivity = (status = "处理中") => {
+    lastActivityAt = Date.now();
+    refreshStreamingNote(status);
+  };
+
+  const stopHeartbeat = () => {
+    if (!heartbeatTimer) {
+      return;
+    }
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  };
+
+  const startHeartbeat = () => {
+    stopHeartbeat();
+    heartbeatTimer = setInterval(() => {
+      if (!streaming?.isActive()) {
+        return;
+      }
+      lastActivityAt = Date.now();
+      refreshStreamingNote(lastKnownStatus);
+    }, STREAMING_NOTE_HEARTBEAT_MS);
+  };
+
+  const shouldSendCompletionPing = () =>
+    streamingStartedAt > 0 && Date.now() - streamingStartedAt >= 15_000;
 
   const formatReasoningPrefix = (thinking: string): string => {
     if (!thinking) return "";
@@ -241,6 +356,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (options?.dedupeWithLastPartial) {
       lastPartial = nextText;
     }
+    markStreamingActivity("处理中");
     const mode = options?.mode ?? "snapshot";
     streamText =
       mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
@@ -250,6 +366,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const queueReasoningUpdate = (nextThinking: string) => {
     if (!nextThinking) return;
     reasoningText = nextThinking;
+    markStreamingActivity("处理中");
     flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
   };
 
@@ -257,6 +374,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (!streamingEnabled || streamingStartPromise || streaming) {
       return;
     }
+    streamingStartedAt = Date.now();
+    lastActivityAt = streamingStartedAt;
+    lastKnownStatus = "处理中";
     streamingStartPromise = (async () => {
       const creds =
         account.appId && account.appSecret
@@ -277,7 +397,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           replyInThread: effectiveReplyInThread,
           rootId,
           header: cardHeader,
-          note: cardNote,
+          note: buildStreamingNote("处理中"),
         });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);
@@ -285,9 +405,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         streamingStartPromise = null; // allow retry on next deliver
       }
     })();
+    startHeartbeat();
   };
 
   const closeStreaming = async () => {
+    stopHeartbeat();
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
@@ -297,7 +419,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+      lastKnownStatus = "已完成";
+      lastActivityAt = Date.now();
+      const finalNote = buildStreamingNote("已完成");
       await streaming.close(text, { note: finalNote });
     }
     streaming = null;
@@ -305,6 +429,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamText = "";
     lastPartial = "";
     reasoningText = "";
+    streamingStartedAt = 0;
+    lastActivityAt = 0;
+    lastKnownStatus = "处理中";
   };
 
   const sendChunkedTextReply = async (params: {
@@ -362,8 +489,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       },
       deliver: async (payload: ReplyPayload, info) => {
         const reply = resolveSendableOutboundReplyParts(payload);
-        const text = reply.text;
-        const hasText = reply.hasText;
+        const text = sanitizeReplyText(reply.text);
+        const hasText =
+          Boolean(text) && !isLikelyCodexScratchpadText(text, prefixContext.prefixContext.provider);
         const hasMedia = reply.hasMedia;
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
@@ -402,9 +530,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               queueStreamingUpdate(text, { mode: "delta" });
             }
             if (info?.kind === "final") {
+              markStreamingActivity("整理结果");
               streamText = mergeStreamingText(streamText, text);
               await closeStreaming();
               deliveredFinalTexts.add(text);
+              if (shouldSendCompletionPing()) {
+                await sendMessageFeishu({
+                  cfg,
+                  to: chatId,
+                  text: `已完成：${text.replace(/\n/g, " ").trim().slice(0, 100)}`,
+                  replyToMessageId: sendReplyToMessageId,
+                  replyInThread: effectiveReplyInThread,
+                  accountId,
+                });
+              }
             }
             // Send media even when streaming handled the text
             if (hasMedia) {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -357,7 +357,7 @@ export class FeishuStreamingSession {
     await this.queue;
   }
 
-  private async updateNoteContent(note: string): Promise<void> {
+  async updateNoteContent(note: string): Promise<void> {
     if (!this.state || !this.state.hasNote) {
       return;
     }

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -13,6 +13,7 @@ export type FeishuAccountConfig = z.infer<typeof FeishuAccountConfigSchema>;
 
 export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
+export type FeishuStatusLanguage = "zh-CN" | "en";
 
 export type FeishuDefaultAccountSelectionSource =
   | "explicit-default"


### PR DESCRIPTION
# Upstream Draft: Feishu IM Long-Task Visibility

## Issue Draft

### Title

Feishu IM long-task visibility: status footer, last activity, completion confirmation, and scratchpad suppression

### Summary

When OpenClaw is used through Feishu IM, long-running agent tasks can feel like a black box:

- users cannot tell whether the agent is still alive or stuck
- streaming text updates can pollute the message body
- panel completion and IM delivery can get out of sync
- internal Codex/OpenAI scratchpad text may leak into the chat

I prototyped a Feishu-specific improvement locally and the result feels much better for real long-running agent work.

The key idea is:

- keep the chat body for real output
- move task state into a card footer / note
- show low-noise `last activity`
- separate execution completion from IM delivery completion
- suppress internal scratchpad-style planning text from user-facing IM replies

### Problems Observed

#### 1. Long tasks feel like a black box

In Feishu, users often cannot tell whether the agent is:

- still working
- stuck
- disconnected
- already finished but failed to notify clearly

#### 2. Progress updates in the body are noisy

If heartbeat/progress is appended into the body, the result becomes chat pollution very quickly.

This is especially bad in IM interfaces where users expect concise, conversational updates.

#### 3. Completion and delivery are different states

Sometimes the panel/runtime shows the task as finished, but the Feishu side still looks stuck or never gives a clear completion signal.

#### 4. Internal scratchpad text can leak into Feishu

With Codex/OpenAI-style execution, partial English planning text may appear in the IM thread, for example:

- `Need maybe use direct curl...`
- `Let's inspect...`
- `Could create draft page...`

These are internal planning notes, not user-facing output.

## Proposed Design

### A. Add a status footer / note to Feishu streaming cards

Instead of appending progress text into the body, show a footer like:

- `Agent: ... | Model: ... | Provider: ... | 状态: 处理中 | 最后活动: 09:13:20`

This keeps the body clean while still giving users confidence that the task is alive.

### B. Expose low-noise last activity

Show `最后活动` in the footer and update it on meaningful activity.

This is much less noisy than writing heartbeat text into the main body.

### C. Separate execution completion from delivery completion

The UI/runtime should distinguish:

- the agent run is done
- the Feishu streaming card/final message was delivered successfully

This makes it much easier to reason about "finished but not visibly delivered" situations.

### D. Send a lightweight completion confirmation for long tasks

For long streaming tasks, optionally send a short text confirmation after completion, such as:

- `已完成：...`

This gives users an explicit completion signal even if the card closure itself is subtle.

### E. Suppress internal scratchpad text from Feishu

Internal English planning text should not be forwarded to IM users.

Only user-facing final text and meaningful tool outcomes should be shown.

## Why This Helps

- reduces black-box feeling
- improves trust during long-running work
- avoids body pollution
- handles panel-vs-IM mismatch more honestly
- makes Codex/OpenAI execution usable in a chat interface

## Suggested Scope

Good candidates for upstreaming now:

- Feishu streaming card footer / note
- last activity display
- completion confirmation ping
- graceful cleanup on interrupt/restart
- scratchpad suppression in IM

Better left out of the first PR:

- local supervisor / auto-followup policy
- model-specific prompt tuning
- user-specific workflow rules

---

## PR Draft

### Title

Improve Feishu long-task visibility with status footer and scratchpad filtering

### Summary

This PR improves the Feishu IM experience for long-running agent tasks.

It introduces a status-footer-first approach for streaming replies:

- keep the message body focused on real output
- show task state in a card footer / note
- expose `last activity`
- improve completion visibility
- suppress internal scratchpad-style planning text from user-facing IM messages

### What Changed

#### 1. Status footer for Feishu streaming cards

Streaming cards now support a footer/note that can show:

- agent identity
- model/provider
- current status
- last activity
- lightweight progress summary

#### 2. Completion confirmation for long tasks

Long-running streaming tasks can emit a short completion confirmation after the card is finalized.

#### 3. Better interrupt/restart handling

Active Feishu streaming cards are cleaned up more gracefully when the monitor/gateway is interrupted or restarted.

#### 4. Scratchpad filtering

Internal Codex/OpenAI scratchpad-style English planning text is filtered out before it reaches Feishu.

### Why

Before this change:

- long tasks often felt stuck or opaque
- progress updates in the body were noisy
- completion visibility was weak
- internal planning text could leak into IM

After this change:

- long tasks are easier to monitor
- IM remains cleaner
- completion is more obvious
- internal planning text stays internal

### Notes

This PR intentionally focuses on generic Feishu IM UX improvements.

It does **not** include:

- local supervisor automation
- agent-specific continuation policy
- model-specific prompt tuning

Those are better handled separately from the core Feishu channel behavior.

