### PR TITLE
fix(gateway): use agent workspace dir in session transcript cwd

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
@@ -10,6 +10,7 @@ import {
 } from "../../agents/pi-embedded-runner/runs.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { loadConfig } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadSessionStore,
   resolveMainSessionKey,
@@ -220,6 +221,7 @@ function buildDashboardSessionKey(agentId: string): string {
 }
 
 function ensureSessionTranscriptFile(params: {
+  cfg: OpenClawConfig;
   sessionId: string;
   storePath: string;
   sessionFile?: string;
@@ -241,7 +243,7 @@ function ensureSessionTranscriptFile(params: {
         version: CURRENT_SESSION_VERSION,
         id: params.sessionId,
         timestamp: new Date().toISOString(),
-        cwd: process.cwd(),
+        cwd: resolveAgentWorkspaceDir(params.cfg, params.agentId),
       };
       fs.writeFileSync(transcriptPath, `${JSON.stringify(header)}\n`, {
         encoding: "utf-8",
@@ -722,6 +724,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const ensured = ensureSessionTranscriptFile({
+      cfg,
       sessionId: created.entry.sessionId,
       storePath: target.storePath,
       sessionFile: created.entry.sessionFile,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -747,6 +747,12 @@ export async function startGatewayServer(
   let skillsChangeUnsub = () => {};
   let channelHealthMonitor: ReturnType<typeof startChannelHealthMonitor> | null = null;
   let stopModelPricingRefresh = () => {};
+  let deliveryRecoveryTimerStopped = false;
+  let deliveryRecoveryTimer: { stop: () => void } | null = {
+    stop() {
+      deliveryRecoveryTimerStopped = true;
+    },
+  };
   let configReloader: { stop: () => Promise<void> } = { stop: async () => {} };
   const closeOnStartupFailure = async () => {
     if (diagnosticsEnabled) {
@@ -760,6 +766,7 @@ export async function startGatewayServer(
     authRateLimiter?.dispose();
     browserAuthRateLimiter.dispose();
     stopModelPricingRefresh();
+    deliveryRecoveryTimer?.stop();
     channelHealthMonitor?.stop();
     clearSecretsRuntimeSnapshot();
     await createGatewayCloseHandler({
@@ -1112,12 +1119,6 @@ export async function startGatewayServer(
     // Periodic delivery queue recovery: retry pending outbound messages when
     // their target channel is connected.  Replaces the previous startup-only
     // recovery which raced with channel connection.
-    let deliveryRecoveryTimerStopped = false;
-    let deliveryRecoveryTimer: { stop: () => void } | null = {
-      stop() {
-        deliveryRecoveryTimerStopped = true;
-      },
-    };
     if (!minimalTestGateway) {
       void (async () => {
         const { startDeliveryRecoveryTimer } = await import("../infra/outbound/delivery-queue.js");

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1109,18 +1109,52 @@ export async function startGatewayServer(
         ? startGatewayModelPricingRefresh({ config: cfgAtStart })
         : () => {};
 
-    // Recover pending outbound deliveries from previous crash/restart.
+    // Periodic delivery queue recovery: retry pending outbound messages when
+    // their target channel is connected.  Replaces the previous startup-only
+    // recovery which raced with channel connection.
+    let deliveryRecoveryTimerStopped = false;
+    let deliveryRecoveryTimer: { stop: () => void } | null = {
+      stop() {
+        deliveryRecoveryTimerStopped = true;
+      },
+    };
     if (!minimalTestGateway) {
       void (async () => {
-        const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
+        const { startDeliveryRecoveryTimer } = await import("../infra/outbound/delivery-queue.js");
         const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+        if (deliveryRecoveryTimerStopped) {
+          return;
+        }
         const logRecovery = log.child("delivery-recovery");
-        await recoverPendingDeliveries({
+        const timer = startDeliveryRecoveryTimer({
           deliver: deliverOutboundPayloads,
           log: logRecovery,
-          cfg: cfgAtStart,
+          cfg: () => loadConfig(),
+          isChannelConnected: (channel, accountId) => {
+            const snapshot = channelManager.getRuntimeSnapshot();
+            const account = accountId
+              ? snapshot.channelAccounts[channel]?.[accountId]
+              : snapshot.channels[channel];
+            if (!account) {
+              // Channel/account not in snapshot (removed or unconfigured).
+              // Return true so the entry is retried — delivery will fail with
+              // a permanent error and moveToFailed() cleans it up.
+              return true;
+            }
+            // Prefer `connected` (persistent-connection channels like WhatsApp/Discord).
+            // Fall back to `running` for webhook/API channels (Google Chat, IRC, etc.)
+            // that never populate `connected`.
+            return account.connected ?? account.running ?? false;
+          },
         });
-      })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
+        // Re-check after assignment: close() may have raced between the flag
+        // check above and this point, leaving the real timer unstopped.
+        if (deliveryRecoveryTimerStopped) {
+          timer.stop();
+          return;
+        }
+        deliveryRecoveryTimer = timer;
+      })().catch((err) => log.error(`Delivery recovery timer setup failed: ${String(err)}`));
     }
 
     const execApprovalManager = new ExecApprovalManager();
@@ -1453,6 +1487,7 @@ export async function startGatewayServer(
       authRateLimiter?.dispose();
       browserAuthRateLimiter.dispose();
       stopModelPricingRefresh();
+      deliveryRecoveryTimer?.stop();
       channelHealthMonitor?.stop();
       clearSecretsRuntimeSnapshot();
       await close(opts);

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  _resetInFlightTracking,
   ackDelivery,
   failDelivery,
   isDeliveryInFlight,
@@ -281,6 +282,12 @@ export function startDeliveryRecoveryTimer(opts: {
 }): { stop: () => void } {
   const intervalMs = opts.checkIntervalMs ?? 30_000;
   const startupGraceMs = opts.startupGraceMs ?? 5_000;
+
+  // Clear stale in-flight IDs from a previous lifecycle.  The gateway run-loop
+  // can restart in-process (SIGUSR1) without a full process exit, so module-level
+  // state survives.  Any IDs still marked in-flight from the old lifecycle would
+  // permanently suppress recovery for those entries.
+  _resetInFlightTracking();
 
   let stopped = false;
   let sweepInFlight = false;

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -325,6 +325,12 @@ export function startDeliveryRecoveryTimer(opts: {
     }
   }
 
+  // Bail out immediately if the signal was already aborted before we start.
+  if (opts.abortSignal?.aborted) {
+    stop();
+    return { stop };
+  }
+
   // Schedule the first sweep after the startup grace period so channels
   // have time to connect, then sweep on a fixed interval thereafter.
   initialTimer = setTimeout(() => {

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -161,6 +161,8 @@ export async function recoverPendingDeliveries(opts: {
   isChannelConnected?: (channel: string, accountId?: string) => boolean;
   /** Abort signal — checked between entries so an in-flight sweep can be cancelled on shutdown. */
   abortSignal?: AbortSignal;
+  /** When true, remaining entries after time budget are left for the next sweep without burning retries. */
+  periodicTimer?: boolean;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
@@ -183,7 +185,13 @@ export async function recoverPendingDeliveries(opts: {
     const now = Date.now();
     if (now >= deadline) {
       opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next sweep`);
-      await deferRemainingEntriesForBudget(pending.slice(i), opts.stateDir);
+      // When called from a periodic timer, remaining entries will be retried on
+      // the next sweep — don't bump retryCount or they'll burn through MAX_RETRIES
+      // in minutes. Only bump for one-shot startup recovery where there's no timer
+      // to pick them up later.
+      if (!opts.periodicTimer) {
+        await deferRemainingEntriesForBudget(pending.slice(i), opts.stateDir);
+      }
       break;
     }
 
@@ -295,6 +303,7 @@ export function startDeliveryRecoveryTimer(opts: {
         stateDir: opts.stateDir,
         isChannelConnected: opts.isChannelConnected,
         abortSignal: sweepAbort.signal,
+        periodicTimer: true,
       });
     } catch (err) {
       opts.log.error(`Delivery recovery sweep failed: ${String(err)}`);

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -2,6 +2,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import {
   ackDelivery,
   failDelivery,
+  isDeliveryInFlight,
   loadPendingDeliveries,
   moveToFailed,
   type QueuedDelivery,
@@ -13,6 +14,7 @@ export type RecoverySummary = {
   failed: number;
   skippedMaxRetries: number;
   deferredBackoff: number;
+  skippedDisconnected: number;
 };
 
 export type DeliverFn = (
@@ -58,6 +60,7 @@ function createEmptyRecoverySummary(): RecoverySummary {
     failed: 0,
     skippedMaxRetries: 0,
     deferredBackoff: 0,
+    skippedDisconnected: 0,
   };
 }
 
@@ -142,16 +145,22 @@ export function isPermanentDeliveryError(error: string): boolean {
 }
 
 /**
- * On gateway startup, scan the delivery queue and retry any pending entries.
+ * Scan the delivery queue and retry any pending entries.
  * Uses exponential backoff and moves entries that exceed MAX_RETRIES to failed/.
+ * When called from the periodic timer, `isChannelConnected` gates retries so
+ * entries for disconnected channels are skipped without burning retries.
  */
 export async function recoverPendingDeliveries(opts: {
   deliver: DeliverFn;
   log: RecoveryLogger;
   cfg: OpenClawConfig;
   stateDir?: string;
-  /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
+  /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next sweep. Default: 60 000. */
   maxRecoveryMs?: number;
+  /** When provided, entries whose channel is not connected are skipped without incrementing retryCount. */
+  isChannelConnected?: (channel: string, accountId?: string) => boolean;
+  /** Abort signal — checked between entries so an in-flight sweep can be cancelled on shutdown. */
+  abortSignal?: AbortSignal;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
@@ -165,19 +174,37 @@ export async function recoverPendingDeliveries(opts: {
   const summary = createEmptyRecoverySummary();
 
   for (let i = 0; i < pending.length; i++) {
+    if (opts.abortSignal?.aborted) {
+      opts.log.info("Recovery aborted by signal");
+      break;
+    }
+
     const entry = pending[i];
     const now = Date.now();
     if (now >= deadline) {
-      opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
+      opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next sweep`);
       await deferRemainingEntriesForBudget(pending.slice(i), opts.stateDir);
       break;
     }
+
+    // Skip entries currently being sent by the original caller.
+    if (isDeliveryInFlight(entry.id)) {
+      continue;
+    }
+
+    // Always clean up exhausted entries regardless of channel state.
     if (entry.retryCount >= MAX_RETRIES) {
       opts.log.warn(
         `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${MAX_RETRIES}) — moving to failed/`,
       );
       await moveEntryToFailedWithLogging(entry.id, opts.log, opts.stateDir);
       summary.skippedMaxRetries += 1;
+      continue;
+    }
+
+    // Skip entries whose target channel is not connected — don't burn retries.
+    if (opts.isChannelConnected && !opts.isChannelConnected(entry.channel, entry.accountId)) {
+      summary.skippedDisconnected += 1;
       continue;
     }
 
@@ -214,9 +241,101 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${summary.recovered} recovered, ${summary.failed} failed, ${summary.skippedMaxRetries} skipped (max retries), ${summary.deferredBackoff} deferred (backoff), ${summary.skippedDisconnected} skipped (disconnected)`,
   );
   return summary;
+}
+
+/**
+ * Start a periodic timer that re-scans the delivery queue and retries pending
+ * entries whose target channel is connected.  Replaces the old startup-only
+ * recovery which raced with channel connection (~3-5 s after boot).
+ *
+ * Follows the same pattern as `channel-health-monitor.ts`:
+ *   • `setInterval` with a concurrency guard
+ *   • `timer.unref()` so the timer doesn't keep the process alive
+ *   • `AbortSignal` for external cancellation
+ *
+ * @returns An object with a `stop()` method to cancel the timer.
+ */
+export function startDeliveryRecoveryTimer(opts: {
+  deliver: DeliverFn;
+  log: RecoveryLogger;
+  cfg: OpenClawConfig | (() => OpenClawConfig);
+  isChannelConnected: (channel: string, accountId?: string) => boolean;
+  stateDir?: string;
+  /** Interval between sweeps in ms. Default: 30 000 (30 s). */
+  checkIntervalMs?: number;
+  /** Grace period before first sweep in ms. Default: 5 000. */
+  startupGraceMs?: number;
+  /** External abort signal — stops the timer when aborted. */
+  abortSignal?: AbortSignal;
+}): { stop: () => void } {
+  const intervalMs = opts.checkIntervalMs ?? 30_000;
+  const startupGraceMs = opts.startupGraceMs ?? 5_000;
+
+  let stopped = false;
+  let sweepInFlight = false;
+  let initialTimer: ReturnType<typeof setTimeout> | null = null;
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  const sweepAbort = new AbortController();
+
+  async function runSweep(): Promise<void> {
+    if (stopped || sweepInFlight) {
+      return;
+    }
+    sweepInFlight = true;
+    try {
+      const resolvedCfg = typeof opts.cfg === "function" ? opts.cfg() : opts.cfg;
+      await recoverPendingDeliveries({
+        deliver: opts.deliver,
+        log: opts.log,
+        cfg: resolvedCfg,
+        stateDir: opts.stateDir,
+        isChannelConnected: opts.isChannelConnected,
+        abortSignal: sweepAbort.signal,
+      });
+    } catch (err) {
+      opts.log.error(`Delivery recovery sweep failed: ${String(err)}`);
+    } finally {
+      sweepInFlight = false;
+    }
+  }
+
+  function stop(): void {
+    stopped = true;
+    sweepAbort.abort();
+    if (initialTimer) {
+      clearTimeout(initialTimer);
+      initialTimer = null;
+    }
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  // Schedule the first sweep after the startup grace period so channels
+  // have time to connect, then sweep on a fixed interval thereafter.
+  initialTimer = setTimeout(() => {
+    void runSweep();
+    if (stopped) {
+      return;
+    }
+    timer = setInterval(() => void runSweep(), intervalMs);
+    timer.unref();
+  }, startupGraceMs + 1);
+  initialTimer.unref();
+
+  if (opts.abortSignal) {
+    opts.abortSignal.addEventListener("abort", stop, { once: true });
+  }
+
+  opts.log.info(
+    `Delivery recovery timer started (grace=${startupGraceMs}ms, interval=${intervalMs}ms)`,
+  );
+  return { stop };
 }
 
 export { MAX_RETRIES };

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -9,6 +9,24 @@ import type { OutboundChannel } from "./targets.js";
 const QUEUE_DIRNAME = "delivery-queue";
 const FAILED_DIRNAME = "failed";
 
+/**
+ * Tracks delivery IDs that are currently in-flight (between enqueue and ack/fail).
+ * The periodic recovery timer skips these to avoid replaying a send that is still
+ * being attempted by the original caller.  After a crash the set is empty, so
+ * crash-leftover entries are correctly recovered.
+ */
+const inFlightDeliveryIds = new Set<string>();
+
+/** Reset in-flight tracking — test-only. Simulates process restart. */
+export function _resetInFlightTracking(): void {
+  inFlightDeliveryIds.clear();
+}
+
+/** Check whether a delivery ID is currently in-flight. */
+export function isDeliveryInFlight(id: string): boolean {
+  return inFlightDeliveryIds.has(id);
+}
+
 export type QueuedDeliveryPayload = {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
@@ -147,6 +165,7 @@ export async function enqueueDelivery(
     gatewayClientScopes: params.gatewayClientScopes,
     retryCount: 0,
   });
+  inFlightDeliveryIds.add(id);
   return id;
 }
 
@@ -160,6 +179,7 @@ export async function enqueueDelivery(
  * by {@link loadPendingDeliveries} on the next startup without re-sending.
  */
 export async function ackDelivery(id: string, stateDir?: string): Promise<void> {
+  inFlightDeliveryIds.delete(id);
   const { jsonPath, deliveredPath } = resolveQueueEntryPaths(id, stateDir);
   try {
     // Phase 1: atomic rename marks the delivery as complete.
@@ -180,6 +200,7 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
 
 /** Update a queue entry after a failed delivery attempt. */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
+  inFlightDeliveryIds.delete(id);
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const entry = await readQueueEntry(filePath);
   entry.retryCount += 1;

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -179,7 +179,6 @@ export async function enqueueDelivery(
  * by {@link loadPendingDeliveries} on the next startup without re-sending.
  */
 export async function ackDelivery(id: string, stateDir?: string): Promise<void> {
-  inFlightDeliveryIds.delete(id);
   const { jsonPath, deliveredPath } = resolveQueueEntryPaths(id, stateDir);
   try {
     // Phase 1: atomic rename marks the delivery as complete.
@@ -190,12 +189,17 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
       // .json already gone — may have been renamed by a previous ack attempt.
       // Try to clean up a leftover .delivered marker if present.
       await unlinkBestEffort(deliveredPath);
+      inFlightDeliveryIds.delete(id);
       return;
     }
     throw err;
   }
   // Phase 2: remove the marker file.
   await unlinkBestEffort(deliveredPath);
+  // Clear in-flight only after the queue entry is successfully removed.
+  // If the rename fails transiently, the entry stays protected from the
+  // recovery timer so it won't be resent while the original send succeeded.
+  inFlightDeliveryIds.delete(id);
 }
 
 /** Update a queue entry after a failed delivery attempt. */

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -2,10 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  _resetInFlightTracking,
   enqueueDelivery,
   loadPendingDeliveries,
   MAX_RETRIES,
   recoverPendingDeliveries,
+  startDeliveryRecoveryTimer,
+  type DeliverFn,
 } from "./delivery-queue.js";
 import {
   asDeliverFn,
@@ -32,6 +35,8 @@ describe("delivery-queue recovery", () => {
     log?: ReturnType<typeof createRecoveryLog>;
     maxRecoveryMs?: number;
   }) => {
+    // Simulate crash recovery: in-flight set is empty after restart.
+    _resetInFlightTracking();
     const result = await recoverPendingDeliveries({
       deliver: asDeliverFn(deliver),
       log,
@@ -53,6 +58,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      skippedDisconnected: 0,
     });
 
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
@@ -169,12 +175,13 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      skippedDisconnected: 0,
     });
 
     const remaining = await loadPendingDeliveries(tmpDir());
     expect(remaining).toHaveLength(3);
     expect(remaining.every((entry) => entry.retryCount === 1)).toBe(true);
-    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next startup"));
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next sweep"));
   });
 
   it("defers entries until backoff becomes eligible", async () => {
@@ -196,6 +203,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 1,
+      skippedDisconnected: 0,
     });
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(1);
     expect(log.info).toHaveBeenCalledWith(expect.stringContaining("not ready for retry yet"));
@@ -227,6 +235,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 1,
+      skippedDisconnected: 0,
     });
     expect(deliver).toHaveBeenCalledTimes(1);
     expect(deliver).toHaveBeenCalledWith(
@@ -256,6 +265,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 1,
+      skippedDisconnected: 0,
     });
     expect(firstDeliver).not.toHaveBeenCalled();
 
@@ -267,6 +277,7 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      skippedDisconnected: 0,
     });
     expect(secondDeliver).toHaveBeenCalledTimes(1);
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
@@ -283,7 +294,270 @@ describe("delivery-queue recovery", () => {
       failed: 0,
       skippedMaxRetries: 0,
       deferredBackoff: 0,
+      skippedDisconnected: 0,
     });
     expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("skips entries for disconnected channels without burning retries", async () => {
+    await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "wa" }] }, tmpDir());
+    await enqueueDelivery({ channel: "telegram", to: "2", payloads: [{ text: "tg" }] }, tmpDir());
+    _resetInFlightTracking(); // Simulate crash recovery.
+
+    const deliver = vi.fn().mockResolvedValue([]);
+    const result = await recoverPendingDeliveries({
+      deliver: asDeliverFn(deliver),
+      log: createRecoveryLog(),
+      cfg: baseCfg,
+      stateDir: tmpDir(),
+      isChannelConnected: (channel) => channel === "telegram",
+    });
+
+    expect(deliver).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ channel: "telegram" }));
+    expect(result.recovered).toBe(1);
+    expect(result.skippedDisconnected).toBe(1);
+
+    const remaining = await loadPendingDeliveries(tmpDir());
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.channel).toBe("whatsapp");
+    // Retry count should not have been incremented for the skipped entry.
+    expect(remaining[0]?.retryCount).toBe(0);
+  });
+
+  it("recovers all entries when isChannelConnected is not provided", async () => {
+    await enqueueCrashRecoveryEntries();
+    _resetInFlightTracking(); // Simulate crash recovery.
+    const deliver = vi.fn().mockResolvedValue([]);
+    const result = await recoverPendingDeliveries({
+      deliver: asDeliverFn(deliver),
+      log: createRecoveryLog(),
+      cfg: baseCfg,
+      stateDir: tmpDir(),
+    });
+
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(result.recovered).toBe(2);
+    expect(result.skippedDisconnected).toBe(0);
+  });
+
+  describe("startDeliveryRecoveryTimer", () => {
+    const createLog = () => createRecoveryLog();
+
+    it("does not start when abort signal is already aborted", () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const log = createLog();
+      const timer = startDeliveryRecoveryTimer({
+        deliver: vi.fn() as unknown as DeliverFn,
+        log,
+        cfg: baseCfg,
+        isChannelConnected: () => true,
+        stateDir: tmpDir(),
+        abortSignal: controller.signal,
+      });
+
+      timer.stop();
+    });
+
+    it("respects startup grace period", async () => {
+      vi.useFakeTimers();
+      const start = new Date("2026-01-01T00:00:00.000Z");
+      vi.setSystemTime(start);
+
+      await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] }, tmpDir());
+      _resetInFlightTracking(); // Simulate crash recovery.
+
+      const deliver = vi.fn().mockResolvedValue([]);
+      const timer = startDeliveryRecoveryTimer({
+        deliver: deliver as unknown as DeliverFn,
+        log: createLog(),
+        cfg: baseCfg,
+        isChannelConnected: () => true,
+        stateDir: tmpDir(),
+        checkIntervalMs: 1_000,
+        startupGraceMs: 5_000,
+      });
+
+      // First tick at 1s — within grace period, should not deliver.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(deliver).not.toHaveBeenCalled();
+
+      // Tick at 6s — past grace period, should deliver.
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+
+      timer.stop();
+      vi.useRealTimers();
+    });
+
+    it("skips entries for disconnected channels on each sweep", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "wa" }] },
+        tmpDir(),
+      );
+      await enqueueDelivery({ channel: "telegram", to: "2", payloads: [{ text: "tg" }] }, tmpDir());
+      _resetInFlightTracking(); // Simulate crash recovery.
+
+      let whatsappConnected = false;
+      const deliver = vi.fn().mockResolvedValue([]);
+      const timer = startDeliveryRecoveryTimer({
+        deliver: deliver as unknown as DeliverFn,
+        log: createLog(),
+        cfg: baseCfg,
+        isChannelConnected: (channel) => {
+          if (channel === "whatsapp") {
+            return whatsappConnected;
+          }
+          return channel === "telegram";
+        },
+        stateDir: tmpDir(),
+        checkIntervalMs: 1_000,
+        startupGraceMs: 0,
+      });
+
+      // First sweep: telegram connected, whatsapp not.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+      expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ channel: "telegram" }));
+
+      // WhatsApp reconnects.
+      whatsappConnected = true;
+      deliver.mockClear();
+
+      // Second sweep: now both connected. Only whatsapp remains in queue.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+      expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ channel: "whatsapp" }));
+
+      // Queue should be fully drained.
+      const remaining = await loadPendingDeliveries(tmpDir());
+      expect(remaining).toHaveLength(0);
+
+      timer.stop();
+      vi.useRealTimers();
+    });
+
+    it("does not run concurrent sweeps", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] }, tmpDir());
+      _resetInFlightTracking(); // Simulate crash recovery.
+
+      let deliverResolve: (() => void) | null = null;
+      const deliver = vi.fn().mockImplementation(
+        () =>
+          new Promise<unknown[]>((resolve) => {
+            deliverResolve = () => resolve([]);
+          }),
+      );
+
+      const timer = startDeliveryRecoveryTimer({
+        deliver: deliver as unknown as DeliverFn,
+        log: createLog(),
+        cfg: baseCfg,
+        isChannelConnected: () => true,
+        stateDir: tmpDir(),
+        checkIntervalMs: 1_000,
+        startupGraceMs: 0,
+      });
+
+      // First sweep starts — wait for deliver to be called (async I/O in sweep).
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+
+      // Second tick fires while first sweep is in flight (deliver hasn't resolved).
+      await vi.advanceTimersByTimeAsync(1_000);
+      // Still only 1 call — second sweep was skipped by sweepInFlight guard.
+      expect(deliver).toHaveBeenCalledTimes(1);
+
+      // Complete the first sweep.
+      deliverResolve!();
+      await vi.advanceTimersByTimeAsync(0);
+
+      timer.stop();
+      vi.useRealTimers();
+    });
+
+    it("stops via abort signal", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] }, tmpDir());
+      _resetInFlightTracking(); // Simulate crash recovery.
+
+      const controller = new AbortController();
+      const deliver = vi.fn().mockResolvedValue([]);
+      const timer = startDeliveryRecoveryTimer({
+        deliver: deliver as unknown as DeliverFn,
+        log: createLog(),
+        cfg: baseCfg,
+        isChannelConnected: () => true,
+        stateDir: tmpDir(),
+        checkIntervalMs: 1_000,
+        startupGraceMs: 0,
+        abortSignal: controller.signal,
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+
+      // Abort — subsequent ticks should not fire.
+      controller.abort();
+      deliver.mockClear();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(deliver).not.toHaveBeenCalled();
+
+      timer.stop();
+      vi.useRealTimers();
+    });
+
+    it("uses fresh config on each sweep when cfg is a getter", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+      await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "a" }] }, tmpDir());
+      _resetInFlightTracking();
+
+      const cfgA = { tag: "a" };
+      const cfgB = { tag: "b" };
+      let currentCfg: Record<string, string> = cfgA;
+
+      const deliver = vi.fn().mockResolvedValue([]);
+      const timer = startDeliveryRecoveryTimer({
+        deliver: deliver as unknown as DeliverFn,
+        log: createLog(),
+        cfg: () => currentCfg as never,
+        isChannelConnected: () => true,
+        stateDir: tmpDir(),
+        checkIntervalMs: 1_000,
+        startupGraceMs: 0,
+      });
+
+      // First sweep uses cfgA.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+      expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ cfg: cfgA }));
+
+      // Re-enqueue and switch config.
+      await enqueueDelivery({ channel: "whatsapp", to: "+1", payloads: [{ text: "b" }] }, tmpDir());
+      _resetInFlightTracking();
+      currentCfg = cfgB;
+      deliver.mockClear();
+
+      // Second sweep uses cfgB.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(1));
+      expect(deliver).toHaveBeenCalledWith(expect.objectContaining({ cfg: cfgB }));
+
+      timer.stop();
+      vi.useRealTimers();
+    });
   });
 });

--- a/src/infra/outbound/delivery-queue.test-helpers.ts
+++ b/src/infra/outbound/delivery-queue.test-helpers.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, vi } from "vitest";
+import { _resetInFlightTracking } from "./delivery-queue.js";
 import type { DeliverFn, RecoveryLogger } from "./delivery-queue.js";
 
 export function installDeliveryQueueTmpDirHooks(): { readonly tmpDir: () => string } {
@@ -16,6 +17,7 @@ export function installDeliveryQueueTmpDirHooks(): { readonly tmpDir: () => stri
   beforeEach(() => {
     tmpDir = path.join(fixtureRoot, `case-${fixtureCount++}`);
     fs.mkdirSync(tmpDir, { recursive: true });
+    _resetInFlightTracking();
   });
 
   afterAll(() => {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -1,8 +1,10 @@
 export {
+  _resetInFlightTracking,
   ackDelivery,
   enqueueDelivery,
   ensureQueueDir,
   failDelivery,
+  isDeliveryInFlight,
   loadPendingDeliveries,
   moveToFailed,
 } from "./delivery-queue-storage.js";
@@ -13,5 +15,6 @@ export {
   isPermanentDeliveryError,
   MAX_RETRIES,
   recoverPendingDeliveries,
+  startDeliveryRecoveryTimer,
 } from "./delivery-queue-recovery.js";
 export type { DeliverFn, RecoveryLogger, RecoverySummary } from "./delivery-queue-recovery.js";


### PR DESCRIPTION
## Summary
- Fix regression from `7b61ca1b06` where `ensureSessionTranscriptFile` hardcodes `cwd: process.cwd()` (resolves to `/app` in Docker) instead of the agent's workspace directory
- DM-bound sessions (WhatsApp, etc.) were getting `cwd: "/app"` in their transcript headers, breaking bootstrap file injection (zero tool calls)
- Replace with `resolveAgentWorkspaceDir(cfg, agentId)` to resolve the correct workspace path (e.g., `/home/node/.openclaw/workspaces/chief`)

## Evidence
- Pre-regression transcripts: `"cwd": "/home/node/.openclaw/workspaces/chief"` (working, tools available)
- Post-regression transcripts: `"cwd": "/app"` (broken, zero tool calls)

## Test plan
- [x] Scoped tests pass: `npx vitest run src/gateway/server-methods/server-methods.test.ts` (52/52 passing)
- [x] Verified `tsgo` errors are pre-existing on clean tree (unrelated `compaction.ts`, `skills/source.ts`)
- [x] Lint/format clean on touched file
- [ ] Deploy to Docker gateway and verify new DM-bound sessions get correct `cwd` in transcript header