### PR TITLE
feat(nodes): add visionOS node app (Apple Vision Pro spatial peripheral)

### DIFF
--- a/apps/visionos/Info.plist
+++ b/apps/visionos/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Required for HandTrackingProvider -->
+	<key>NSHandsTrackingUsageDescription</key>
+	<string>OpenClaw Node uses hand tracking to relay spatial gestures to the AI agent.</string>
+
+	<!-- Required for PlaneDetectionProvider, SceneReconstructionProvider, ImageTrackingProvider -->
+	<key>NSWorldSensingUsageDescription</key>
+	<string>OpenClaw Node uses world sensing to give the AI agent awareness of your environment.</string>
+
+	<!-- Required for CameraFrameProvider (Enterprise entitlement also required) -->
+	<key>NSMainCameraUsageDescription</key>
+	<string>OpenClaw Node uses the main camera to provide visual context to the AI agent.</string>
+
+	<!-- Required for LocationManager -->
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>OpenClaw Node can report your location to the AI agent when requested.</string>
+
+	<!-- Required for microphone (camera.clip with audio) -->
+	<key>NSMicrophoneUsageDescription</key>
+	<string>OpenClaw Node uses the microphone when capturing video clips for the AI agent.</string>
+
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationPreferredDefaultSceneSessionRole</key>
+		<string>UIWindowSceneSessionRoleApplication</string>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/apps/visionos/README.md
+++ b/apps/visionos/README.md
@@ -1,0 +1,27 @@
+# visionOS Node
+
+OpenClaw visionOS node — LOAM STUDIO open source contribution.
+
+A native visionOS companion app that pairs with the OpenClaw Gateway as a peripheral node, giving the AI agent spatial awareness, hand tracking, world sensing, and camera input from the Apple Vision Pro.
+
+---
+
+## Documentation
+
+- [**visionOS Node**](docs/nodes/visionos.md) — Setup guide, command reference, architecture, and known limitations
+
+---
+
+## Quick Start
+
+1. Clone and open `visionOS-node/visionOS-node.xcodeproj` in Xcode
+2. Build and run on a physical Apple Vision Pro
+3. Enter your Gateway URL and auth token in Settings
+4. Approve the node: `openclaw devices approve <node-id>`
+5. Tap **Enter Immersive Space** to enable spatial commands
+
+See the [full documentation](docs/nodes/visionos.md) for detailed setup, Gateway configuration, and the complete command reference.
+
+---
+
+Built by [LOAM STUDIO](https://loamstudio.com).

--- a/apps/visionos/Sources/APNsManager.swift
+++ b/apps/visionos/Sources/APNsManager.swift
@@ -1,0 +1,68 @@
+//
+//  APNsManager.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Registers for APNs silent push notifications and forwards
+//  the device token to the gateway via node.apns.
+//
+//  REQUIRES: Push Notifications capability in Xcode + provisioning profile update
+//
+
+import SwiftUI
+import UserNotifications
+
+@MainActor
+final class APNsManager {
+
+    weak var nodeManager: NodeManager?
+
+    init() {
+        requestAuthorization()
+    }
+
+    // MARK: - Authorization + Registration
+
+    private func requestAuthorization() {
+        Task {
+            do {
+                let granted = try await UNUserNotificationCenter.current()
+                    .requestAuthorization(options: [.alert, .sound])
+                print("[APNsManager] Authorization \(granted ? "granted" : "denied")")
+                if granted {
+                    // visionOS uses UIApplication for remote notification registration
+                    // just like iOS/iPadOS (visionOS is built on UIKit foundations).
+                    #if canImport(UIKit)
+                    UIApplication.shared.registerForRemoteNotifications()
+                    #else
+                    print("[APNsManager] UIApplication unavailable — cannot register for remote notifications")
+                    #endif
+                }
+            } catch {
+                print("[APNsManager] Authorization error: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Token callbacks
+
+    func didRegister(token: Data) {
+        let hex = token.map { String(format: "%02x", $0) }.joined()
+        print("[APNsManager] APNs registered: \(hex.prefix(8))...")
+
+        guard let nodeManager else {
+            print("[APNsManager] No nodeManager attached — token not forwarded")
+            return
+        }
+
+        // Send token to gateway: { type:"req", method:"node.apns", params:{ token:"<hex>" } }
+        Task {
+            nodeManager.sendRequest(method: "node.apns", params: ["token": hex])
+        }
+    }
+
+    func didFailToRegister(error: Error) {
+        print("[APNsManager] Registration failed: \(error.localizedDescription)")
+    }
+}

--- a/apps/visionos/Sources/APNsManager.swift
+++ b/apps/visionos/Sources/APNsManager.swift
@@ -28,7 +28,7 @@ final class APNsManager {
         Task {
             do {
                 let granted = try await UNUserNotificationCenter.current()
-                    .requestAuthorization(options: [.alert, .sound])
+                    .requestAuthorization(options: [])
                 print("[APNsManager] Authorization \(granted ? "granted" : "denied")")
                 if granted {
                     // visionOS uses UIApplication for remote notification registration

--- a/apps/visionos/Sources/ConnectionStatusView.swift
+++ b/apps/visionos/Sources/ConnectionStatusView.swift
@@ -1,0 +1,99 @@
+//
+//  ConnectionStatusView.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+
+import SwiftUI
+
+struct ConnectionStatusView: View {
+
+    @EnvironmentObject var nodeManager: NodeManager
+
+    var body: some View {
+        VStack(spacing: 16) {
+
+            // State indicator
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(stateColor)
+                    .frame(width: 12, height: 12)
+                    .shadow(color: stateColor.opacity(0.6), radius: 4)
+
+                Text(nodeManager.connectionState.rawValue)
+                    .font(.headline)
+
+                Spacer()
+
+                if nodeManager.connectionState == .connected {
+                    Text("ID: \(HandshakeManager.deviceID().prefix(12))…")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .monospaced()
+                }
+            }
+
+            // Error message
+            if let error = nodeManager.lastError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Pending approval hint
+            if nodeManager.connectionState == .pending {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Run on your Mac mini to approve:")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("openclaw devices list")
+                        .font(.caption)
+                        .monospaced()
+                        .padding(6)
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(6)
+                    Text("openclaw devices approve <id>")
+                        .font(.caption)
+                        .monospaced()
+                        .padding(6)
+                        .background(.ultraThinMaterial)
+                        .cornerRadius(6)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            // Log (last 8 entries)
+            if !nodeManager.commandLog.isEmpty {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(nodeManager.commandLog.suffix(8), id: \.self) { entry in
+                            Text(entry)
+                                .font(.caption2)
+                                .monospaced()
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(height: 100)
+                .padding(8)
+                .background(.ultraThinMaterial)
+                .cornerRadius(8)
+            }
+        }
+    }
+
+    private var stateColor: Color {
+        switch nodeManager.connectionState {
+        case .connected:    return .green
+        case .connecting,
+             .challenging:  return .yellow
+        case .pending:      return .orange
+        case .error:        return .red
+        case .disconnected: return .gray
+        }
+    }
+}

--- a/apps/visionos/Sources/ContentView.swift
+++ b/apps/visionos/Sources/ContentView.swift
@@ -1,0 +1,84 @@
+//
+//  ContentView.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+
+import SwiftUI
+
+struct ContentView: View {
+
+    @EnvironmentObject var nodeManager: NodeManager
+    @Environment(\.openImmersiveSpace) var openImmersiveSpace
+    @Environment(\.dismissImmersiveSpace) var dismissImmersiveSpace
+
+    var body: some View {
+        VStack(spacing: 24) {
+
+            // Header
+            VStack(spacing: 8) {
+                Text("OpenClaw Node")
+                    .font(.largeTitle.bold())
+                Text("visionOS Peripheral")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            // Connection status
+            ConnectionStatusView()
+                .environmentObject(nodeManager)
+
+            Divider()
+
+            // Gateway config
+            GatewayConfigView()
+                .environmentObject(nodeManager)
+
+            Divider()
+
+            // ImmersiveSpace toggle — keeping this active keeps the node alive
+            VStack(spacing: 12) {
+                Label("Node Active Space", systemImage: "circle.hexagongrid.fill")
+                    .font(.headline)
+
+                Text("The immersive space must stay open to maintain the Gateway connection. Closing it will disconnect the node.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Toggle(nodeManager.immersiveSpaceActive ? "Space Active ✓" : "Open Node Space",
+                       isOn: Binding(
+                        get: { nodeManager.immersiveSpaceActive },
+                        set: { shouldOpen in
+                            Task {
+                                if shouldOpen {
+                                    await openImmersiveSpace(id: "NodeSpace")
+                                } else {
+                                    await dismissImmersiveSpace()
+                                }
+                            }
+                        }
+                       ))
+                .toggleStyle(.button)
+                .tint(nodeManager.immersiveSpaceActive ? .green : .blue)
+            }
+        }
+        .padding(32)
+        .frame(minWidth: 500, minHeight: 600)
+        .onAppear {
+            // Connection is owned by the app window lifecycle, not the ImmersiveSpace.
+            // Auto-connect on first appear if config is set.
+            if !nodeManager.gatewayURL.isEmpty && !nodeManager.isSocketConnected {
+                Task { await nodeManager.connect() }
+            }
+        }
+    }
+}
+
+#Preview(windowStyle: .automatic) {
+    ContentView()
+        .environmentObject(NodeManager())
+}

--- a/apps/visionos/Sources/GatewayConfigView.swift
+++ b/apps/visionos/Sources/GatewayConfigView.swift
@@ -1,0 +1,82 @@
+//
+//  GatewayConfigView.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+
+import SwiftUI
+
+struct GatewayConfigView: View {
+
+    @EnvironmentObject var nodeManager: NodeManager
+    @State private var showToken = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+
+            Text("Gateway Config")
+                .font(.headline)
+
+            // Gateway URL
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Gateway URL")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("your-gateway-host.ts.net", text: $nodeManager.gatewayURL)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+            }
+
+            // Auth token
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Auth Token")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                HStack {
+                    if showToken {
+                        TextField("Token", text: $nodeManager.gatewayToken)
+                            .textFieldStyle(.roundedBorder)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                    } else {
+                        SecureField("Token", text: $nodeManager.gatewayToken)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                    Button {
+                        showToken.toggle()
+                    } label: {
+                        Image(systemName: showToken ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            // Save + Connect buttons
+            HStack(spacing: 12) {
+                Button("Save") {
+                    nodeManager.saveConfig()
+                }
+                .buttonStyle(.bordered)
+
+                Spacer()
+
+                if nodeManager.connectionState == .connected {
+                    Button("Disconnect") {
+                        nodeManager.disconnect()
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                } else {
+                    Button("Connect") {
+                        nodeManager.saveConfig()
+                        Task { await nodeManager.connect() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(nodeManager.gatewayURL.isEmpty || nodeManager.connectionState == .connecting)
+                }
+            }
+        }
+    }
+}

--- a/apps/visionos/Sources/GatewaySocket.swift
+++ b/apps/visionos/Sources/GatewaySocket.swift
@@ -1,0 +1,251 @@
+//
+//  GatewaySocket.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Manages the persistent WebSocket connection to the OpenClaw Gateway.
+//  Uses URLSessionWebSocketTask wrapped in Swift Concurrency so frame
+//  ingestion never blocks the main/rendering thread.
+//
+
+import Foundation
+
+// MARK: - Frame types
+
+enum GatewayFrame {
+    case event(type: String, payload: [String: Any])
+    case request(id: String, method: String, params: [String: Any])
+    case response(id: String, ok: Bool, payload: [String: Any]?, error: [String: Any]?)
+    case unknown([String: Any])
+}
+
+// MARK: - Socket delegate
+
+protocol GatewaySocketDelegate: AnyObject {
+    func socketDidConnect(_ socket: GatewaySocket)
+    func socketDidDisconnect(_ socket: GatewaySocket, error: Error?)
+    func socketDidReceiveChallenge(_ socket: GatewaySocket, nonce: String, ts: String)
+    func socketDidReceiveHelloOk(_ socket: GatewaySocket)
+    func socketDidReceiveHandshakeError(_ socket: GatewaySocket, code: String, message: String)
+    func socketDidReceiveFrame(_ socket: GatewaySocket, frame: GatewayFrame)
+}
+
+// MARK: - GatewaySocket
+
+final class GatewaySocket: NSObject {
+
+    weak var delegate: GatewaySocketDelegate?
+
+    private var task: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private var receiveTask: Task<Void, Never>?
+
+    var isConnected = false
+
+    // MARK: Connect
+
+    func connect(to url: URL) {
+        disconnect()
+
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        urlSession = URLSession(configuration: config, delegate: self, delegateQueue: nil)
+        task = urlSession?.webSocketTask(with: url)
+        task?.resume()
+        startReceiving()
+    }
+
+    // MARK: Exit frame (graceful disconnect)
+
+    /// Sends a `node.event` exit notification before closing, so the gateway
+    /// distinguishes a clean disconnect from an unexpected drop.
+    func sendExitFrame() async {
+        guard isConnected, task != nil else { return }
+        let frame: [String: Any] = [
+            "type": "req",
+            "id": UUID().uuidString.lowercased(),
+            "method": "node.event",
+            "params": [
+                "event": "disconnect",
+                "payloadJSON": "{\"reason\":\"clean-shutdown\"}"
+            ]
+        ]
+        do {
+            try await send(frame)
+            // Brief wait to let the gateway process the exit frame before we close the socket.
+            try await Task.sleep(nanoseconds: 300_000_000)
+        } catch {
+            // Best-effort — socket may already be gone, proceed to close regardless.
+        }
+    }
+
+    // MARK: Disconnect
+
+    func disconnect() {
+        receiveTask?.cancel()
+        receiveTask = nil
+        task?.cancel(with: .normalClosure, reason: nil)
+        task = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+        isConnected = false
+    }
+
+    // MARK: Send
+
+    func send(_ dict: [String: Any]) async throws {
+        guard let task else { throw GatewayError.notConnected }
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        guard let text = String(data: data, encoding: .utf8) else { throw GatewayError.encodingError }
+        try await task.send(.string(text))
+    }
+
+    // MARK: Receive loop
+
+    private func startReceiving() {
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                do {
+                    guard let task = self.task else { break }
+                    let message = try await task.receive()
+                    switch message {
+                    case .string(let text):
+                        self.handleText(text)
+                    case .data(let data):
+                        if let text = String(data: data, encoding: .utf8) {
+                            self.handleText(text)
+                        }
+                    @unknown default:
+                        break
+                    }
+                } catch {
+                    if !Task.isCancelled {
+                        self.isConnected = false
+                        self.delegate?.socketDidDisconnect(self, error: error)
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: Frame parsing
+
+    private func handleText(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return
+        }
+
+        // Log raw frame type for debugging
+        print("[GatewaySocket] RX: \(text.prefix(200))")
+
+        let type = json["type"] as? String ?? ""
+
+        switch type {
+        case "connect.challenge":
+            // Legacy bare frame (kept for compatibility)
+            let nonce = json["nonce"] as? String ?? ""
+            let ts = (json["ts"] as? Int).map(String.init) ?? (json["ts"] as? String ?? "")
+            delegate?.socketDidReceiveChallenge(self, nonce: nonce, ts: ts)
+
+        case "hello-ok":
+            // Legacy bare frame (kept for compatibility)
+            delegate?.socketDidReceiveHelloOk(self)
+
+        case "res":
+            // Protocol v3: connect response → { type:"res", ok:true, payload:{ type:"hello-ok" } }
+            let ok = json["ok"] as? Bool ?? false
+            let payload = json["payload"] as? [String: Any] ?? [:]
+            let payloadType = payload["type"] as? String ?? ""
+            if ok && (payloadType == "hello-ok" || payloadType == "connect.ok") {
+                delegate?.socketDidReceiveHelloOk(self)
+            } else if !ok {
+                // Surface error details so NodeManager can show them in the UI log
+                let error = json["error"] as? [String: Any] ?? payload
+                let code = error["code"] as? String ?? "UNKNOWN"
+                // Check nested error.details for richer diagnostic codes
+                let details = error["details"] as? [String: Any] ?? [:]
+                let detailCode = details["code"] as? String ?? ""
+                let reason = details["reason"] as? String ?? ""
+                let message = error["message"] as? String
+                    ?? error["detail"] as? String
+                    ?? (detailCode.isEmpty ? code : "\(code) · \(detailCode): \(reason)")
+                delegate?.socketDidReceiveHandshakeError(self, code: code, message: message)
+            }
+            // Other res frames (RPC replies) are not currently handled
+
+        case "event":
+            let eventType = json["event"] as? String ?? ""
+            let payload = json["payload"] as? [String: Any] ?? [:]
+
+            // Gateway sends: { type:"event", event:"connect.challenge", payload:{ nonce:"…", ts:1234 } }
+            if eventType == "connect.challenge" {
+                // nonce/ts may be in payload or at top level (both covered)
+                let nonce = (payload["nonce"] as? String)
+                    ?? (json["nonce"] as? String)
+                    ?? ""
+                let ts = (payload["ts"] as? Int).map(String.init)
+                    ?? (payload["ts"] as? String)
+                    ?? (json["ts"] as? Int).map(String.init)
+                    ?? (json["ts"] as? String)
+                    ?? ""
+                delegate?.socketDidReceiveChallenge(self, nonce: nonce, ts: ts)
+            } else if eventType == "hello-ok" || eventType == "connect.ok" {
+                delegate?.socketDidReceiveHelloOk(self)
+            } else {
+                delegate?.socketDidReceiveFrame(self, frame: .event(type: eventType, payload: payload))
+            }
+
+        case "req":
+            let id = json["id"] as? String ?? ""
+            let method = json["method"] as? String ?? ""
+            let params = json["params"] as? [String: Any] ?? [:]
+            delegate?.socketDidReceiveFrame(self, frame: .request(id: id, method: method, params: params))
+
+        default:
+            delegate?.socketDidReceiveFrame(self, frame: .unknown(json))
+        }
+    }
+}
+
+// MARK: - URLSessionWebSocketDelegate
+
+extension GatewaySocket: URLSessionWebSocketDelegate {
+    func urlSession(_ session: URLSession,
+                    webSocketTask: URLSessionWebSocketTask,
+                    didOpenWithProtocol protocol: String?) {
+        isConnected = true
+        delegate?.socketDidConnect(self)
+    }
+
+    func urlSession(_ session: URLSession,
+                    webSocketTask: URLSessionWebSocketTask,
+                    didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+                    reason: Data?) {
+        // Only mark disconnected if we haven't already (e.g. from an explicit disconnect() call).
+        // Do not set isConnected = false here — let disconnect() own that flag so sendExitFrame()
+        // doesn't race against the delegate callback and attempt writes on a dead socket.
+        guard isConnected else { return }
+        isConnected = false
+        delegate?.socketDidDisconnect(self, error: nil)
+    }
+}
+
+// MARK: - Errors
+
+enum GatewayError: LocalizedError {
+    case notConnected
+    case encodingError
+    case handshakeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected: return "Not connected to Gateway"
+        case .encodingError: return "Failed to encode frame"
+        case .handshakeFailed(let reason): return "Handshake failed: \(reason)"
+        }
+    }
+}

--- a/apps/visionos/Sources/HandshakeManager.swift
+++ b/apps/visionos/Sources/HandshakeManager.swift
@@ -1,0 +1,237 @@
+//
+//  HandshakeManager.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Handles the OpenClaw Gateway connect handshake:
+//    1. Receive connect.challenge (nonce + ts)
+//    2. Build v3 signature payload and sign with Ed25519 keypair
+//    3. Send connect req frame with role:"node", caps, commands, permissions
+//    4. Await hello-ok
+//
+//  Signature payload format (v3):
+//    "v3|{deviceId}|{clientId}|{clientMode}|{role}|{scopesCsv}|{signedAtMs}|{token}|{nonce}|{platform}|{deviceFamily}"
+//  Signature and public key are base64url-encoded (no padding).
+//  device.id is derived: SHA-256 hex of raw Ed25519 public key bytes.
+//
+//  Protocol reference: https://docs.openclaw.ai/gateway/protocol
+//
+
+import Foundation
+import CryptoKit
+import Security
+import CommonCrypto
+
+final class HandshakeManager {
+
+    // MARK: - Constants
+
+    private static let clientId    = "node-host"
+    private static let clientMode  = "node"
+    private static let role        = "node"
+    private static let platform    = "visionos"
+    private static let deviceFamily = "headset"
+
+    // MARK: - Signing key
+
+    /// Returns a stable Ed25519 signing keypair from Keychain.
+    /// On first run, generates and stores the keypair.
+    static func signingKey() -> Curve25519.Signing.PrivateKey {
+        let keyTag = "com.openclaw.node.signing-key"
+        if let data = KeychainHelper.readData(key: keyTag),
+           let key = try? Curve25519.Signing.PrivateKey(rawRepresentation: data) {
+            return key
+        }
+        let key = Curve25519.Signing.PrivateKey()
+        KeychainHelper.writeData(key: keyTag, value: key.rawRepresentation)
+        return key
+    }
+
+    // MARK: - Device ID (derived from public key, matches gateway expectation)
+
+    /// Stable device ID = SHA-256 hex of raw Ed25519 public key bytes.
+    /// Matches: crypto.createHash("sha256").update(rawPublicKeyBytes).digest("hex")
+    static func deviceID() -> String {
+        let pubKeyRaw = signingKey().publicKey.rawRepresentation
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        pubKeyRaw.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(pubKeyRaw.count), &hash)
+        }
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Build connect frame
+
+    /// Builds the full connect req frame after receiving the challenge.
+    /// Protocol: { type:"req", id, method:"connect", params:{ ... } }
+    static func buildConnectFrame(
+        nonce: String,
+        ts: String,
+        gatewayToken: String
+    ) -> [String: Any] {
+        let key = signingKey()
+        let id = deviceID()
+        let scopes: [String] = []
+        let scopesCsv = scopes.joined(separator: ",")
+        let token = gatewayToken
+
+        // signedAtMs: current time in milliseconds (device.signedAt in the frame).
+        // Gateway uses device.signedAt directly as signedAtMs in payload verification —
+        // NOT the challenge ts. Must be within DEVICE_SIGNATURE_SKEW_MS of server time.
+        let signedAtMs = Int64(Date().timeIntervalSince1970 * 1000)
+
+        // Build v3 signature payload string
+        // "v3|deviceId|clientId|clientMode|role|scopesCsv|signedAtMs|token|nonce|platform|deviceFamily"
+        let payloadString = [
+            "v3",
+            id,
+            clientId,
+            clientMode,
+            role,
+            scopesCsv,
+            String(signedAtMs),
+            token,
+            nonce,
+            platform,
+            deviceFamily
+        ].joined(separator: "|")
+
+        // Sign payload string bytes (not just nonce)
+        let payloadData = Data(payloadString.utf8)
+        let signatureB64Url: String
+        if let sig = try? key.signature(for: payloadData) {
+            signatureB64Url = base64UrlEncode(sig)
+        } else {
+            signatureB64Url = ""
+        }
+
+        // Public key: base64url-encoded raw bytes
+        let publicKeyB64Url = base64UrlEncode(key.publicKey.rawRepresentation)
+
+        let params: [String: Any] = [
+            "minProtocol": 3,
+            "maxProtocol": 3,
+            "client": [
+                "id": clientId,
+                "version": "0.1.0",
+                "platform": platform,
+                "deviceFamily": deviceFamily,
+                "mode": clientMode
+            ],
+            "role": role,
+            "scopes": scopes,
+            "caps": [
+                "spatial",
+                "camera",
+                "canvas",
+                "location"
+            ],
+            "commands": [
+                "camera.list",
+                "camera.snap",
+                "camera.clip",
+                "canvas.present",
+                "canvas.navigate",
+                "canvas.eval",
+                "canvas.snapshot",
+                "canvas.hide",
+                "location.get",
+                "spatial.hands",
+                "spatial.planes",
+                "spatial.mesh",
+                "device.position",
+                "device.info"
+            ],
+            "permissions": buildPermissionsMap(),
+            "auth": [
+                "token": token
+            ],
+            "userAgent": "visionOS-node/0.1.0",
+            "locale": "en-US",
+            "device": [
+                "id": id,
+                "publicKey": publicKeyB64Url,
+                "signature": signatureB64Url,
+                "signedAt": signedAtMs,
+                "nonce": nonce
+            ]
+        ]
+
+        return [
+            "type": "req",
+            "id": UUID().uuidString.lowercased(),
+            "method": "connect",
+            "params": params
+        ]
+    }
+
+    // MARK: - Permissions map
+
+    private static func buildPermissionsMap() -> [String: Bool] {
+        return [
+            "camera": false,
+            "handTracking": false,
+            "worldSensing": false,
+            "location": false,
+            "microphone": false
+        ]
+    }
+
+    // MARK: - Base64URL helpers
+
+    /// Encode Data as base64url (no padding, - and _ instead of + and /)
+    static func base64UrlEncode(_ data: Data) -> String {
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+// MARK: - KeychainHelper
+
+private enum KeychainHelper {
+
+    static func read(key: String) -> String? {
+        guard let data = readData(key: key) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func write(key: String, value: String) {
+        writeData(key: key, value: Data(value.utf8))
+    }
+
+    static func readData(key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String:       kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: "com.openclaw.node",
+            kSecReturnData as String:  true,
+            kSecMatchLimit as String:  kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    static func writeData(key: String, value: Data) {
+        let query: [String: Any] = [
+            kSecClass as String:       kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: "com.openclaw.node"
+        ]
+        let attrs: [String: Any] = [
+            kSecValueData as String:      value,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attrs as CFDictionary)
+        if updateStatus == errSecItemNotFound {
+            var add = query
+            add[kSecValueData as String]      = value
+            add[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            SecItemAdd(add as CFDictionary, nil)
+        }
+    }
+}

--- a/apps/visionos/Sources/HandshakeManager.swift
+++ b/apps/visionos/Sources/HandshakeManager.swift
@@ -191,7 +191,7 @@ final class HandshakeManager {
 
 // MARK: - KeychainHelper
 
-private enum KeychainHelper {
+enum KeychainHelper {
 
     static func read(key: String) -> String? {
         guard let data = readData(key: key) else { return nil }

--- a/apps/visionos/Sources/LocationManager.swift
+++ b/apps/visionos/Sources/LocationManager.swift
@@ -1,0 +1,83 @@
+//
+//  LocationManager.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Provides one-shot location lookups via CoreLocation.
+//  Authorization is requested on first use.
+//
+
+import CoreLocation
+import Foundation
+
+@MainActor
+final class LocationManager: NSObject, CLLocationManagerDelegate {
+
+    private let clManager = CLLocationManager()
+    private var continuation: CheckedContinuation<CLLocation, Error>?
+
+    override init() {
+        super.init()
+        clManager.delegate = self
+        clManager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    /// Request a one-shot location fix.
+    /// Returns a CLLocation or throws if authorization denied or location unavailable.
+    func requestLocation() async throws -> CLLocation {
+        return try await withCheckedThrowingContinuation { cont in
+            self.continuation = cont
+            let status = self.clManager.authorizationStatus
+            switch status {
+            case .notDetermined:
+                self.clManager.requestWhenInUseAuthorization()
+            case .authorizedWhenInUse, .authorizedAlways:
+                self.clManager.requestLocation()
+            case .denied, .restricted:
+                cont.resume(throwing: LocationError.denied)
+                self.continuation = nil
+            @unknown default:
+                cont.resume(throwing: LocationError.denied)
+                self.continuation = nil
+            }
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.first else { return }
+        Task { @MainActor in
+            self.continuation?.resume(returning: location)
+            self.continuation = nil
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.continuation?.resume(throwing: error)
+            self.continuation = nil
+        }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor in
+            let status = manager.authorizationStatus
+            switch status {
+            case .authorizedWhenInUse, .authorizedAlways:
+                manager.requestLocation()
+            case .denied, .restricted:
+                self.continuation?.resume(throwing: LocationError.denied)
+                self.continuation = nil
+            default:
+                break
+            }
+        }
+    }
+}
+
+enum LocationError: Error {
+    case denied
+    case unavailable
+}

--- a/apps/visionos/Sources/LocationManager.swift
+++ b/apps/visionos/Sources/LocationManager.swift
@@ -25,7 +25,11 @@ final class LocationManager: NSObject, CLLocationManagerDelegate {
 
     /// Request a one-shot location fix.
     /// Returns a CLLocation or throws if authorization denied or location unavailable.
+    /// Concurrent calls are rejected — only one in-flight request allowed at a time.
     func requestLocation() async throws -> CLLocation {
+        guard continuation == nil else {
+            throw LocationError.unavailable
+        }
         return try await withCheckedThrowingContinuation { cont in
             self.continuation = cont
             let status = self.clManager.authorizationStatus

--- a/apps/visionos/Sources/NodeImmersiveView.swift
+++ b/apps/visionos/Sources/NodeImmersiveView.swift
@@ -1,0 +1,50 @@
+//
+//  NodeImmersiveView.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  The ImmersiveSpace that keeps the node process alive.
+//
+//  ARCHITECTURAL NOTE:
+//  visionOS suspends app processes and drops WebSocket connections
+//  as soon as a standard window loses foreground priority. An active
+//  ImmersiveSpace prevents process suspension — as long as this space
+//  is presented, the URLSessionWebSocketTask in GatewaySocket stays alive.
+//
+//  This view is intentionally minimal. It renders nothing visible by default.
+//  Its only job is to exist and be active.
+//
+
+import SwiftUI
+import RealityKit
+import ARKit
+
+struct NodeImmersiveView: View {
+
+    @EnvironmentObject var nodeManager: NodeManager
+
+    var body: some View {
+        RealityView { content in
+            // Empty scene — no visible content required.
+            // ARKit session is managed by SpatialManager, started in .task below.
+        }
+        .task {
+            // Start ARKit data providers when the immersive space opens.
+            await nodeManager.spatialManager.start()
+            await nodeManager.log("ImmersiveSpace active — ARKit session started")
+        }
+        .onAppear {
+            nodeManager.immersiveSpaceActive = true
+            nodeManager.log("ImmersiveSpace opened — ARKit active")
+            // Do NOT connect here — connection is managed by ContentView lifecycle.
+        }
+        .onDisappear {
+            // ImmersiveSpace dismissed — stop ARKit, but keep the socket alive.
+            // The connection is owned by the app process, not the ImmersiveSpace.
+            nodeManager.immersiveSpaceActive = false
+            nodeManager.spatialManager.stop()
+            nodeManager.log("ImmersiveSpace dismissed — ARKit stopped, socket stays alive")
+        }
+    }
+}

--- a/apps/visionos/Sources/NodeManager.swift
+++ b/apps/visionos/Sources/NodeManager.swift
@@ -72,14 +72,16 @@ final class NodeManager: ObservableObject {
         if let saved = UserDefaults.standard.string(forKey: "gatewayURL"), !saved.isEmpty {
             gatewayURL = saved
         }
-        if let saved = UserDefaults.standard.string(forKey: "gatewayToken"), !saved.isEmpty {
+        // Token is a secret — stored in Keychain, not UserDefaults
+        if let saved = KeychainHelper.read(key: "com.openclaw.node.gateway-token"), !saved.isEmpty {
             gatewayToken = saved
         }
     }
 
     func saveConfig() {
         UserDefaults.standard.set(gatewayURL, forKey: "gatewayURL")
-        UserDefaults.standard.set(gatewayToken, forKey: "gatewayToken")
+        // Token is a secret — store in Keychain, not UserDefaults
+        KeychainHelper.write(key: "com.openclaw.node.gateway-token", value: gatewayToken)
     }
 
     // MARK: - Connect / Disconnect

--- a/apps/visionos/Sources/NodeManager.swift
+++ b/apps/visionos/Sources/NodeManager.swift
@@ -1,0 +1,393 @@
+//
+//  NodeManager.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Central state manager and RPC dispatcher.
+//  Drives the connection lifecycle and routes node.invoke commands
+//  to the appropriate handler.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+import CoreLocation
+
+// MARK: - Connection state
+
+enum NodeConnectionState: String {
+    case disconnected   = "Disconnected"
+    case connecting     = "Connecting…"
+    case challenging    = "Handshaking…"
+    case pending        = "Awaiting Gateway Approval"
+    case connected      = "Connected"
+    case error          = "Error"
+}
+
+// MARK: - NodeManager
+
+@MainActor
+final class NodeManager: ObservableObject {
+
+    // Published state (drives UI)
+    @Published var connectionState: NodeConnectionState = .disconnected
+    @Published var gatewayURL: String = ""
+    @Published var gatewayToken: String = ""
+    @Published var lastError: String?
+    @Published var immersiveSpaceActive: Bool = false
+    @Published var isBackgrounded: Bool = false
+    @Published var commandLog: [String] = []
+
+    // Sub-managers
+    let spatialManager = SpatialManager()
+    let locationManager = LocationManager()
+
+    var isSocketConnected: Bool { socket.isConnected }
+
+    // Private
+    private let socket = GatewaySocket()
+    private var reconnectTask: Task<Void, Never>?
+    private var reconnectDelay: TimeInterval = 2.0
+    private let maxReconnectDelay: TimeInterval = 60.0
+
+    init() {
+        socket.delegate = self
+        loadConfig()
+    }
+
+    // MARK: - Scene phase callbacks
+
+    func onBackground() {
+        log("App backgrounded — camera/canvas unavailable")
+    }
+
+    func onForeground() {
+        log("App foregrounded — resuming")
+    }
+
+    // MARK: - Config persistence
+
+    private func loadConfig() {
+        if let saved = UserDefaults.standard.string(forKey: "gatewayURL"), !saved.isEmpty {
+            gatewayURL = saved
+        }
+        if let saved = UserDefaults.standard.string(forKey: "gatewayToken"), !saved.isEmpty {
+            gatewayToken = saved
+        }
+    }
+
+    func saveConfig() {
+        UserDefaults.standard.set(gatewayURL, forKey: "gatewayURL")
+        UserDefaults.standard.set(gatewayToken, forKey: "gatewayToken")
+    }
+
+    // MARK: - Connect / Disconnect
+
+    func connect() {
+        guard !gatewayURL.isEmpty else {
+            lastError = "Gateway URL is required"
+            connectionState = .error
+            return
+        }
+
+        // Normalise: wss:// or ws://
+        var urlString = gatewayURL
+        if !urlString.hasPrefix("ws://") && !urlString.hasPrefix("wss://") {
+            urlString = "wss://\(urlString)"
+        }
+
+        guard let url = URL(string: urlString) else {
+            lastError = "Invalid gateway URL"
+            connectionState = .error
+            return
+        }
+
+        connectionState = .connecting
+        lastError = nil
+        log("Connecting to \(url.absoluteString)…")
+        socket.connect(to: url)
+    }
+
+    func disconnect() {
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        Task {
+            await socket.sendExitFrame()
+            socket.disconnect()
+        }
+        connectionState = .disconnected
+        log("Disconnected")
+    }
+
+    // MARK: - Reconnect (exponential backoff)
+
+    private func scheduleReconnect() {
+        reconnectTask?.cancel()
+        let delay = reconnectDelay
+        reconnectDelay = min(reconnectDelay * 2, maxReconnectDelay)
+
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            await self?.connect()
+        }
+        log("Reconnecting in \(Int(delay))s…")
+    }
+
+    // MARK: - RPC response helpers
+
+    func sendOK(id: String, payload: [String: Any]) {
+        Task {
+            try? await socket.send([
+                "type": "req",
+                "id": UUID().uuidString.lowercased(),
+                "method": "node.invoke.result",
+                "params": [
+                    "id": id,
+                    "nodeId": HandshakeManager.deviceID(),
+                    "ok": true,
+                    "payload": payload
+                ] as [String: Any]
+            ])
+        }
+    }
+
+    func sendError(id: String, code: String, detail: String? = nil) {
+        Task {
+            var err: [String: Any] = ["code": code]
+            if let detail { err["detail"] = detail }
+            try? await socket.send([
+                "type": "req",
+                "id": UUID().uuidString.lowercased(),
+                "method": "node.invoke.result",
+                "params": [
+                    "id": id,
+                    "nodeId": HandshakeManager.deviceID(),
+                    "ok": false,
+                    "error": err
+                ] as [String: Any]
+            ])
+        }
+    }
+
+    // MARK: - Outbound RPC requests
+
+    func sendRequest(method: String, params: [String: Any]) {
+        Task {
+            try? await socket.send([
+                "type": "req",
+                "id": UUID().uuidString.lowercased(),
+                "method": method,
+                "params": params
+            ])
+        }
+    }
+
+    // MARK: - Logging
+
+    func log(_ message: String) {
+        let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .medium)
+        commandLog.append("[\(timestamp)] \(message)")
+        if commandLog.count > 200 { commandLog.removeFirst() }
+    }
+}
+
+// MARK: - GatewaySocketDelegate
+
+extension NodeManager: GatewaySocketDelegate {
+
+    nonisolated func socketDidConnect(_ socket: GatewaySocket) {
+        Task { @MainActor in
+            self.log("Socket connected — awaiting challenge")
+            self.connectionState = .challenging
+        }
+    }
+
+    nonisolated func socketDidDisconnect(_ socket: GatewaySocket, error: Error?) {
+        Task { @MainActor in
+            let msg = error?.localizedDescription ?? "Connection closed"
+            self.log("Disconnected: \(msg)")
+            self.connectionState = .disconnected
+            // Always attempt reconnect — connection is app-level, not ImmersiveSpace-level.
+            self.scheduleReconnect()
+        }
+    }
+
+    nonisolated func socketDidReceiveChallenge(_ socket: GatewaySocket, nonce: String, ts: String) {
+        Task { @MainActor in
+            self.log("Challenge received — responding")
+            let frame = HandshakeManager.buildConnectFrame(
+                nonce: nonce,
+                ts: ts,
+                gatewayToken: self.gatewayToken
+            )
+            try? await socket.send(frame)
+        }
+    }
+
+    nonisolated func socketDidReceiveHelloOk(_ socket: GatewaySocket) {
+        Task { @MainActor in
+            self.reconnectDelay = 2.0  // reset backoff on successful handshake
+            self.connectionState = .connected
+            self.log("✅ Node paired and connected")
+        }
+    }
+
+    nonisolated func socketDidReceiveHandshakeError(_ socket: GatewaySocket, code: String, message: String) {
+        Task { @MainActor in
+            self.lastError = message
+            self.connectionState = .error
+            self.log("❌ Handshake rejected: \(message)")
+        }
+    }
+
+    nonisolated func socketDidReceiveFrame(_ socket: GatewaySocket, frame: GatewayFrame) {
+        Task { @MainActor in
+            switch frame {
+            case .request(let id, let method, let params):
+                await self.dispatchCommand(id: id, method: method, params: params)
+            case .event(let type, let payload):
+                self.log("Event: \(type)")
+                if type == "connect.pending" {
+                    self.connectionState = .pending
+                    self.log("⏳ Waiting for Gateway admin approval — run: openclaw devices approve <id>")
+                } else if type == "node.invoke.request" {
+                    // Gateway delivers node commands as events to nodes
+                    let id = payload["id"] as? String ?? ""
+                    let command = payload["command"] as? String ?? ""
+                    let params = payload["params"] as? [String: Any] ?? [:]
+                    self.log("→ invoke: \(command) (id: \(id))")
+                    await self.dispatchCommand(id: id, method: command, params: params)
+                }
+            case .unknown(let raw):
+                self.log("Unknown frame: \(raw["type"] as? String ?? "?")")
+            case .response:
+                break
+            }
+        }
+    }
+
+    // MARK: - RPC Dispatch
+
+    private func dispatchCommand(id: String, method: String, params: [String: Any]) async {
+        log("→ \(method)")
+
+        // Zero-trust: never trust approval flags in params
+        // Reference: CVE-2026-28466 mitigation
+        guard !containsSmuggledApproval(params) else {
+            log("⚠️ Rejected: smuggled approval field detected in \(method)")
+            sendError(id: id, code: "FORBIDDEN", detail: "Parameter injection rejected")
+            return
+        }
+
+        switch method {
+
+        case "camera.list", "camera.snap", "camera.clip":
+            if isBackgrounded {
+                sendError(id: id, code: "NODE_BACKGROUND_UNAVAILABLE", detail: "camera-unavailable-in-background")
+            } else {
+                sendError(id: id, code: "UNAVAILABLE", detail: "enterprise-entitlement-required")
+            }
+
+        case "spatial.hands":
+            await handleSpatialHands(id: id, params: params)
+
+        case "spatial.planes":
+            await handleSpatialPlanes(id: id, params: params)
+
+        case "spatial.mesh":
+            await handleSpatialMesh(id: id, params: params)
+
+        case "device.position":
+            await handleDevicePosition(id: id, params: params)
+
+        case "device.info":
+            sendOK(id: id, payload: [
+                "platform": "visionos",
+                "modelIdentifier": "RealityDevice14,1",
+                "nodeVersion": "0.1.0",
+                "deviceID": HandshakeManager.deviceID()
+            ])
+
+        case "canvas.present", "canvas.navigate", "canvas.eval", "canvas.snapshot", "canvas.hide":
+            if isBackgrounded {
+                sendError(id: id, code: "NODE_BACKGROUND_UNAVAILABLE", detail: "canvas-unavailable-in-background")
+            } else {
+                // Canvas via WKWebView — Phase 5
+                sendError(id: id, code: "UNAVAILABLE", detail: "canvas-not-implemented")
+            }
+
+        case "location.get":
+            await handleLocationGet(id: id, params: params)
+
+        default:
+            log("Unknown command: \(method)")
+            sendError(id: id, code: "UNKNOWN_COMMAND")
+        }
+    }
+
+    // MARK: - CVE-2026-28466 mitigation
+
+    /// Reject any payload that attempts to smuggle approval overrides.
+    private func containsSmuggledApproval(_ params: [String: Any]) -> Bool {
+        let blockedKeys = ["approved", "approvalDecision", "bypass", "override", "authorized"]
+        return blockedKeys.contains { params[$0] != nil }
+    }
+
+    // MARK: - Spatial handlers
+
+    private func handleSpatialHands(id: String, params: [String: Any]) async {
+        guard spatialManager.isRunning else {
+            sendError(id: id, code: "UNAVAILABLE", detail: "arkit-not-running — open the immersive space first")
+            return
+        }
+        let snapshot = await spatialManager.handsSnapshot()
+        sendOK(id: id, payload: snapshot)
+    }
+
+    private func handleSpatialPlanes(id: String, params: [String: Any]) async {
+        guard spatialManager.isRunning else {
+            sendError(id: id, code: "UNAVAILABLE", detail: "arkit-not-running — open the immersive space first")
+            return
+        }
+        let planes = await spatialManager.planesSnapshot()
+        sendOK(id: id, payload: ["planes": planes, "count": planes.count])
+    }
+
+    private func handleSpatialMesh(id: String, params: [String: Any]) async {
+        guard spatialManager.isRunning else {
+            sendError(id: id, code: "UNAVAILABLE", detail: "arkit-not-running — open the immersive space first")
+            return
+        }
+        let chunks = await spatialManager.meshSnapshot()
+        sendOK(id: id, payload: ["chunks": chunks, "count": chunks.count])
+    }
+
+    private func handleLocationGet(id: String, params: [String: Any]) async {
+        do {
+            let location = try await locationManager.requestLocation()
+            sendOK(id: id, payload: [
+                "latitude": location.coordinate.latitude,
+                "longitude": location.coordinate.longitude,
+                "altitude": location.altitude,
+                "horizontalAccuracy": location.horizontalAccuracy,
+                "verticalAccuracy": location.verticalAccuracy,
+                "timestamp": location.timestamp.timeIntervalSince1970
+            ])
+        } catch LocationError.denied {
+            sendError(id: id, code: "PERMISSION_DENIED", detail: "location-permission-denied")
+        } catch {
+            sendError(id: id, code: "UNAVAILABLE", detail: "location-unavailable: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleDevicePosition(id: String, params: [String: Any]) async {
+        guard spatialManager.isRunning else {
+            sendError(id: id, code: "UNAVAILABLE", detail: "arkit-not-running")
+            return
+        }
+        let pos = await spatialManager.devicePositionSnapshot()
+        sendOK(id: id, payload: pos)
+    }
+}

--- a/apps/visionos/Sources/ScenePhaseMonitor.swift
+++ b/apps/visionos/Sources/ScenePhaseMonitor.swift
@@ -1,0 +1,43 @@
+//
+//  ScenePhaseMonitor.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Observes scenePhase changes and forwards them to NodeManager.
+//  Does NOT disconnect on background — the ImmersiveSpace keeps the
+//  WebSocket alive. Only updates isBackgrounded so RPC dispatch can
+//  return NODE_BACKGROUND_UNAVAILABLE for camera/canvas commands.
+//
+
+import SwiftUI
+
+struct ScenePhaseMonitor: ViewModifier {
+
+    let nodeManager: NodeManager
+    @Environment(\.scenePhase) private var scenePhase
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: scenePhase) { _, newPhase in
+                switch newPhase {
+                case .background:
+                    nodeManager.isBackgrounded = true
+                    nodeManager.onBackground()
+                case .active:
+                    nodeManager.isBackgrounded = false
+                    nodeManager.onForeground()
+                case .inactive:
+                    break // Transitional state — no action
+                @unknown default:
+                    break
+                }
+            }
+    }
+}
+
+extension View {
+    func scenePhaseMonitor(nodeManager: NodeManager) -> some View {
+        modifier(ScenePhaseMonitor(nodeManager: nodeManager))
+    }
+}

--- a/apps/visionos/Sources/SpatialManager.swift
+++ b/apps/visionos/Sources/SpatialManager.swift
@@ -1,0 +1,327 @@
+//
+//  SpatialManager.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+//  Manages ARKit data providers for spatial sensing.
+//  Must be started from within an active ImmersiveSpace.
+//
+//  Providers implemented (Phase 3):
+//    - HandTrackingProvider  → spatial.hands
+//    - WorldTrackingProvider → device.position
+//
+//  Providers implemented (Phase 4):
+//    - PlaneDetectionProvider  → spatial.planes
+//
+//  Providers implemented (Phase 5):
+//    - SceneReconstructionProvider → spatial.mesh
+//
+
+import ARKit
+import RealityKit
+import QuartzCore
+import simd
+
+final class SpatialManager {
+
+    private var session = ARKitSession()
+    private var handTracking = HandTrackingProvider()
+    private var worldTracking = WorldTrackingProvider()
+    private var planeDetection = PlaneDetectionProvider(alignments: [.horizontal, .vertical])
+    private var sceneReconstruction = SceneReconstructionProvider()
+
+    private(set) var isRunning = false
+
+    // Latest anchors — updated by the provider streams
+    private var leftHand: HandAnchor?
+    private var rightHand: HandAnchor?
+    private var deviceAnchor: DeviceAnchor?
+    private var detectedPlanes: [UUID: PlaneAnchor] = [:]
+    private var meshAnchors: [UUID: MeshAnchor] = [:]
+
+    // MARK: - Start (call from ImmersiveSpace .task)
+
+    func start() async {
+        guard HandTrackingProvider.isSupported else {
+            print("[SpatialManager] HandTracking not supported on this device")
+            return
+        }
+
+        // Explicitly request authorization before running — surfaces permission
+        // dialogs and gives a clear error log if denied.
+        print("[SpatialManager] Requesting ARKit authorization...")
+        let authResult = await session.requestAuthorization(for: [.handTracking, .worldSensing])
+        print("[SpatialManager] Auth result — handTracking: \(authResult[.handTracking] ?? .notDetermined), worldSensing: \(authResult[.worldSensing] ?? .notDetermined)")
+
+        guard authResult[.handTracking] == .allowed, authResult[.worldSensing] == .allowed else {
+            print("[SpatialManager] ⚠️ Authorization denied — handTracking: \(authResult[.handTracking] ?? .notDetermined), worldSensing: \(authResult[.worldSensing] ?? .notDetermined)")
+            return
+        }
+
+        do {
+            print("[SpatialManager] Starting ARKit session with hand + world + plane + mesh providers...")
+            try await session.run([handTracking, worldTracking, planeDetection, sceneReconstruction])
+            isRunning = true
+            print("[SpatialManager] ✅ ARKit session running")
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { await self.processHandUpdates() }
+                group.addTask { await self.processWorldUpdates() }
+                group.addTask { await self.processPlaneUpdates() }
+                group.addTask { await self.processMeshUpdates() }
+            }
+        } catch {
+            print("[SpatialManager] ❌ ARKit session error: \(error)")
+        }
+    }
+
+    func stop() {
+        session.stop()
+        isRunning = false
+        // Reset session and providers so they can be reused on next start().
+        // ARKit does not allow restarting a stopped session or re-running
+        // a provider that has already been submitted — new instances are required.
+        session = ARKitSession()
+        handTracking = HandTrackingProvider()
+        worldTracking = WorldTrackingProvider()
+        planeDetection = PlaneDetectionProvider(alignments: [.horizontal, .vertical])
+        sceneReconstruction = SceneReconstructionProvider()
+    }
+
+    // MARK: - Hand tracking stream
+
+    private func processHandUpdates() async {
+        for await update in handTracking.anchorUpdates {
+            switch update.anchor.chirality {
+            case .left:  leftHand  = update.anchor
+            case .right: rightHand = update.anchor
+            }
+        }
+    }
+
+    // MARK: - World tracking stream
+
+    private func processWorldUpdates() async {
+        // WorldTrackingProvider does not have an anchorUpdates stream;
+        // we query device position on demand via queryDeviceAnchor.
+    }
+
+    // MARK: - Plane detection stream
+
+    private func processPlaneUpdates() async {
+        for await update in planeDetection.anchorUpdates {
+            let anchor = update.anchor
+            switch update.event {
+            case .added, .updated:
+                detectedPlanes[anchor.id] = anchor
+            case .removed:
+                detectedPlanes.removeValue(forKey: anchor.id)
+            }
+        }
+    }
+
+    // MARK: - Scene reconstruction stream
+
+    private func processMeshUpdates() async {
+        for await update in sceneReconstruction.anchorUpdates {
+            let anchor = update.anchor
+            switch update.event {
+            case .added, .updated:
+                meshAnchors[anchor.id] = anchor
+            case .removed:
+                meshAnchors.removeValue(forKey: anchor.id)
+            }
+        }
+    }
+
+    // MARK: - Snapshots (called by NodeManager on node.invoke)
+
+    /// Returns a JSON-serializable snapshot of both hands.
+    func handsSnapshot() async -> [String: Any] {
+        var result: [String: Any] = [:]
+
+        if let left = leftHand {
+            result["left"] = encodeHand(left)
+        }
+        if let right = rightHand {
+            result["right"] = encodeHand(right)
+        }
+        result["timestamp"] = Date().timeIntervalSince1970
+
+        return result
+    }
+
+    /// Returns the current head position/orientation.
+    func devicePositionSnapshot() async -> [String: Any] {
+        guard let anchor = worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else {
+            return ["error": "device anchor unavailable"]
+        }
+        let transform = anchor.originFromAnchorTransform
+        return [
+            "transform": encodeMatrix(transform),
+            "timestamp": Date().timeIntervalSince1970
+        ]
+    }
+
+    /// Returns a JSON-serializable snapshot of all detected planes.
+    func planesSnapshot() async -> [[String: Any]] {
+        return detectedPlanes.values.map { anchor in
+            [
+                "id": anchor.id.uuidString,
+                "alignment": encodePlaneAlignment(anchor.alignment),
+                "classification": encodePlaneClassification(anchor.classification),
+                "center": [anchor.originFromAnchorTransform.columns.3.x, anchor.originFromAnchorTransform.columns.3.y, anchor.originFromAnchorTransform.columns.3.z],
+                "extent": [anchor.geometry.extent.width, anchor.geometry.extent.height],
+                "transform": encodeMatrix(anchor.originFromAnchorTransform),
+                "timestamp": Date().timeIntervalSince1970
+            ]
+        }
+    }
+
+    /// Returns a JSON-serializable snapshot of all scene reconstruction mesh chunks.
+    func meshSnapshot() async -> [[String: Any]] {
+        return meshAnchors.values.map { anchor in
+            // Vertices: extract Float3 positions from GeometrySource
+            var vertices: [[Float]] = []
+            let vertexSource = anchor.geometry.vertices
+            let vertexData = Data(buffer: UnsafeBufferPointer(
+                start: vertexSource.buffer.contents().assumingMemoryBound(to: Float.self),
+                count: vertexSource.count * vertexSource.componentsPerVector
+            ))
+            for i in 0..<vertexSource.count {
+                let offset = i * vertexSource.stride / MemoryLayout<Float>.stride
+                let floatBuffer = vertexData.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: Float.self) }
+                let x = floatBuffer[offset]
+                let y = floatBuffer[offset + 1]
+                let z = floatBuffer[offset + 2]
+                vertices.append([x, y, z])
+            }
+
+            // Faces: extract UInt32 indices from GeometryElement
+            var faces: [[Int]] = []
+            let faceElement = anchor.geometry.faces
+            let faceData = Data(buffer: UnsafeBufferPointer(
+                start: faceElement.buffer.contents().assumingMemoryBound(to: UInt32.self),
+                count: faceElement.count * 3
+            ))
+            for i in 0..<faceElement.count {
+                let base = i * 3
+                let idxBuffer = faceData.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: UInt32.self) }
+                faces.append([Int(idxBuffer[base]), Int(idxBuffer[base + 1]), Int(idxBuffer[base + 2])])
+            }
+
+            return [
+                "id": anchor.id.uuidString,
+                "transform": encodeMatrix(anchor.originFromAnchorTransform),
+                "vertexCount": vertexSource.count,
+                "faceCount": faceElement.count,
+                "vertices": vertices,
+                "faces": faces,
+                "timestamp": Date().timeIntervalSince1970
+            ]
+        }
+    }
+
+    // MARK: - Serialization helpers
+
+    private func encodeHand(_ anchor: HandAnchor) -> [String: Any] {
+        var joints: [String: [String: Any]] = [:]
+
+        for joint in HandSkeleton.JointName.allCases {
+            if let j = anchor.handSkeleton?.joint(joint) {
+                joints[joint.description] = [
+                    "transform": encodeMatrix(j.anchorFromJointTransform),
+                    "isTracked": j.isTracked
+                ]
+            }
+        }
+
+        return [
+            "chirality": anchor.chirality == .left ? "left" : "right",
+            "isTracked": anchor.isTracked,
+            "originTransform": encodeMatrix(anchor.originFromAnchorTransform),
+            "joints": joints
+        ]
+    }
+
+    private func encodePlaneAlignment(_ alignment: PlaneAnchor.Alignment) -> String {
+        switch alignment {
+        case .horizontal: return "horizontal"
+        case .vertical:   return "vertical"
+        default:          return "arbitrary"
+        }
+    }
+
+    private func encodePlaneClassification(_ classification: PlaneAnchor.Classification) -> String {
+        switch classification {
+        case .wall:    return "wall"
+        case .floor:   return "floor"
+        case .ceiling: return "ceiling"
+        case .table:   return "table"
+        case .seat:    return "seat"
+        case .door:    return "door"
+        case .window:  return "window"
+        default:       return String(describing: classification)
+        }
+    }
+
+    /// Flattens a simd_float4x4 to a 16-element array for JSON transport.
+    private func encodeMatrix(_ m: simd_float4x4) -> [Float] {
+        return [
+            m.columns.0.x, m.columns.0.y, m.columns.0.z, m.columns.0.w,
+            m.columns.1.x, m.columns.1.y, m.columns.1.z, m.columns.1.w,
+            m.columns.2.x, m.columns.2.y, m.columns.2.z, m.columns.2.w,
+            m.columns.3.x, m.columns.3.y, m.columns.3.z, m.columns.3.w
+        ]
+    }
+}
+
+// MARK: - HandSkeleton.JointName + description
+
+extension HandSkeleton.JointName: CaseIterable {
+    public static var allCases: [HandSkeleton.JointName] = [
+        .wrist,
+        .thumbKnuckle, .thumbIntermediateBase, .thumbIntermediateTip, .thumbTip,
+        .indexFingerMetacarpal, .indexFingerKnuckle, .indexFingerIntermediateBase,
+        .indexFingerIntermediateTip, .indexFingerTip,
+        .middleFingerMetacarpal, .middleFingerKnuckle, .middleFingerIntermediateBase,
+        .middleFingerIntermediateTip, .middleFingerTip,
+        .ringFingerMetacarpal, .ringFingerKnuckle, .ringFingerIntermediateBase,
+        .ringFingerIntermediateTip, .ringFingerTip,
+        .littleFingerMetacarpal, .littleFingerKnuckle, .littleFingerIntermediateBase,
+        .littleFingerIntermediateTip, .littleFingerTip,
+        .forearmWrist
+    ]
+
+    var description: String {
+        switch self {
+        case .wrist: return "wrist"
+        case .thumbKnuckle: return "thumbKnuckle"
+        case .thumbIntermediateBase: return "thumbIntermediateBase"
+        case .thumbIntermediateTip: return "thumbIntermediateTip"
+        case .thumbTip: return "thumbTip"
+        case .indexFingerMetacarpal: return "indexFingerMetacarpal"
+        case .indexFingerKnuckle: return "indexFingerKnuckle"
+        case .indexFingerIntermediateBase: return "indexFingerIntermediateBase"
+        case .indexFingerIntermediateTip: return "indexFingerIntermediateTip"
+        case .indexFingerTip: return "indexFingerTip"
+        case .middleFingerMetacarpal: return "middleFingerMetacarpal"
+        case .middleFingerKnuckle: return "middleFingerKnuckle"
+        case .middleFingerIntermediateBase: return "middleFingerIntermediateBase"
+        case .middleFingerIntermediateTip: return "middleFingerIntermediateTip"
+        case .middleFingerTip: return "middleFingerTip"
+        case .ringFingerMetacarpal: return "ringFingerMetacarpal"
+        case .ringFingerKnuckle: return "ringFingerKnuckle"
+        case .ringFingerIntermediateBase: return "ringFingerIntermediateBase"
+        case .ringFingerIntermediateTip: return "ringFingerIntermediateTip"
+        case .ringFingerTip: return "ringFingerTip"
+        case .littleFingerMetacarpal: return "littleFingerMetacarpal"
+        case .littleFingerKnuckle: return "littleFingerKnuckle"
+        case .littleFingerIntermediateBase: return "littleFingerIntermediateBase"
+        case .littleFingerIntermediateTip: return "littleFingerIntermediateTip"
+        case .littleFingerTip: return "littleFingerTip"
+        case .forearmWrist: return "forearmWrist"
+        default: return "unknown"
+        }
+    }
+}

--- a/apps/visionos/Sources/SpatialManager.swift
+++ b/apps/visionos/Sources/SpatialManager.swift
@@ -23,6 +23,7 @@ import RealityKit
 import QuartzCore
 import simd
 
+@MainActor
 final class SpatialManager {
 
     private var session = ARKitSession()
@@ -188,13 +189,12 @@ final class SpatialManager {
                 start: vertexSource.buffer.contents().assumingMemoryBound(to: Float.self),
                 count: vertexSource.count * vertexSource.componentsPerVector
             ))
-            for i in 0..<vertexSource.count {
-                let offset = i * vertexSource.stride / MemoryLayout<Float>.stride
-                let floatBuffer = vertexData.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: Float.self) }
-                let x = floatBuffer[offset]
-                let y = floatBuffer[offset + 1]
-                let z = floatBuffer[offset + 2]
-                vertices.append([x, y, z])
+            vertexData.withUnsafeBytes { raw in
+                let floatBuffer = raw.baseAddress!.assumingMemoryBound(to: Float.self)
+                for i in 0..<vertexSource.count {
+                    let offset = i * vertexSource.stride / MemoryLayout<Float>.stride
+                    vertices.append([floatBuffer[offset], floatBuffer[offset + 1], floatBuffer[offset + 2]])
+                }
             }
 
             // Faces: extract UInt32 indices from GeometryElement
@@ -204,10 +204,12 @@ final class SpatialManager {
                 start: faceElement.buffer.contents().assumingMemoryBound(to: UInt32.self),
                 count: faceElement.count * 3
             ))
-            for i in 0..<faceElement.count {
-                let base = i * 3
-                let idxBuffer = faceData.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: UInt32.self) }
-                faces.append([Int(idxBuffer[base]), Int(idxBuffer[base + 1]), Int(idxBuffer[base + 2])])
+            faceData.withUnsafeBytes { raw in
+                let idxBuffer = raw.baseAddress!.assumingMemoryBound(to: UInt32.self)
+                for i in 0..<faceElement.count {
+                    let base = i * 3
+                    faces.append([Int(idxBuffer[base]), Int(idxBuffer[base + 1]), Int(idxBuffer[base + 2])])
+                }
             }
 
             return [

--- a/apps/visionos/Sources/visionOS_nodeApp.swift
+++ b/apps/visionos/Sources/visionOS_nodeApp.swift
@@ -1,0 +1,63 @@
+//
+//  visionOS_nodeApp.swift
+//  visionOS-node
+//
+//  OpenClaw visionOS Node — LOAM STUDIO
+//
+
+import SwiftUI
+
+// MARK: - AppDelegate (APNs token callbacks)
+
+// REQUIRES: Push Notifications capability in Xcode + provisioning profile update
+class AppDelegate: NSObject, UIApplicationDelegate {
+
+    var apnsManager: APNsManager?
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        apnsManager?.didRegister(token: deviceToken)
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        apnsManager?.didFailToRegister(error: error)
+    }
+}
+
+// MARK: - App
+
+@main
+struct visionOS_nodeApp: App {
+
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @StateObject private var nodeManager = NodeManager()
+    @State private var apnsManager = APNsManager()
+
+    var body: some Scene {
+
+        // Main window — connection status + settings
+        WindowGroup {
+            ContentView()
+                .environmentObject(nodeManager)
+                .scenePhaseMonitor(nodeManager: nodeManager)
+                .onAppear {
+                    apnsManager.nodeManager = nodeManager
+                    appDelegate.apnsManager = apnsManager
+                }
+        }
+
+        // ImmersiveSpace — REQUIRED for node lifecycle.
+        // As long as this space is active, visionOS will NOT suspend
+        // the process and the WebSocket stays alive.
+        ImmersiveSpace(id: "NodeSpace") {
+            NodeImmersiveView()
+                .environmentObject(nodeManager)
+        }
+        .immersionStyle(selection: .constant(.mixed), in: .mixed)
+    }
+}

--- a/docs/nodes/visionos.md
+++ b/docs/nodes/visionos.md
@@ -1,0 +1,441 @@
+# visionOS Node
+
+A native visionOS companion app that pairs with the OpenClaw Gateway as a peripheral node,
+giving the AI agent spatial awareness, hand tracking, world sensing, and GPS from an
+Apple Vision Pro.
+
+Built by [LOAM STUDIO](https://loamstudio.com).
+
+---
+
+## Overview
+
+The visionOS node connects to your OpenClaw Gateway over WebSocket and exposes the Vision
+Pro's sensor suite as invokable commands. Once paired, your agent can ask "where are the
+user's hands?" or "what flat surfaces are in the room?" and receive live spatial data back
+in structured JSON.
+
+**What it gives your agent:**
+
+| Command | Capability |
+|---|---|
+| `spatial.hands` | Full 26-joint skeletal hand tracking (both hands) |
+| `spatial.planes` | Detected flat surfaces — floors, walls, tables, seats, doors, windows |
+| `spatial.mesh` | Full scene reconstruction as triangulated 3D geometry |
+| `device.position` | Head position and orientation as a 4×4 world-space transform |
+| `device.info` | Device identifiers and node version |
+| `location.get` | GPS coordinates via CoreLocation |
+| `camera.snap` | Still frame from main camera _(requires Apple Enterprise entitlement)_ |
+| `camera.clip` | Short video clip from main camera _(requires Apple Enterprise entitlement)_ |
+
+---
+
+## Requirements
+
+- Apple Vision Pro (visionOS 2.0+)
+- OpenClaw Gateway running on a reachable host (local network or Tailscale)
+- Xcode 16+ for building
+- For `camera.*` commands: Apple Developer Enterprise Program enrollment +
+  `com.apple.developer.arkit.main-camera-access.allow` entitlement
+
+---
+
+## Setup
+
+### 1. Clone and open in Xcode
+
+```bash
+git clone https://github.com/LOAM-STUDIO/visionOS-node.git
+cd visionOS-node
+open visionOS-node/visionOS-node.xcodeproj
+```
+
+### 2. Configure signing
+
+In Xcode → **Signing & Capabilities**, set your team and bundle identifier.
+The app requires a physical Vision Pro — the simulator does not support ARKit providers.
+
+### 3. Build and run on device
+
+Select your Vision Pro in the device list, then **Product → Run** (⌘R).
+
+### 4. Enter your Gateway URL and auth token
+
+On first launch, tap the **Settings** (gear) icon and enter:
+
+- **Gateway URL** — your gateway's address, e.g. `your-gateway-host.ts.net` or a local
+  IP like `192.168.1.100` (the `wss://` prefix is added automatically)
+- **Auth token** — the token from your `openclaw.json` config
+
+### 5. Approve the node on your Gateway
+
+When the node first connects, it enters `Awaiting Gateway Approval` state. On your
+Gateway host, run:
+
+```bash
+openclaw devices list
+openclaw devices approve <node-id>
+```
+
+Once approved, the node status shows **Connected** and your agent can invoke commands.
+
+### 6. Allow the ImmersiveSpace
+
+To enable spatial commands (`spatial.hands`, `spatial.planes`, `spatial.mesh`,
+`device.position`), tap **Enter Immersive Space** from the main screen. This opens a
+minimal mixed-reality space required for ARKit to run. You will be prompted to allow
+**Hand Tracking** and **World Sensing** permissions — both must be granted.
+
+> **Note:** ARKit providers require an active ImmersiveSpace. If you close the immersive
+> space, spatial commands return `arkit-not-running`. `device.position`, `location.get`,
+> and `device.info` continue to work without the space open.
+
+---
+
+## Gateway Configuration
+
+Add the visionOS commands to your gateway's `allowCommands` list in `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "allowCommands": [
+    "camera.snap",
+    "camera.clip",
+    "spatial.planes",
+    "spatial.hands",
+    "spatial.mesh",
+    "device.position",
+    "location.get"
+  ]
+}
+```
+
+---
+
+## Commands Reference
+
+All commands follow the standard OpenClaw `node.invoke` pattern. The gateway sends a
+`node.invoke.request` event to the node; the node replies with a `node.invoke.result`
+request.
+
+---
+
+### `spatial.hands`
+
+Returns a snapshot of both hands' current pose with full 26-joint skeletal data.
+
+**Requires:** Active ImmersiveSpace · Hand Tracking permission
+
+**Response payload:**
+
+```json
+{
+  "left": {
+    "chirality": "left",
+    "isTracked": true,
+    "originTransform": [/* 16-element column-major float array */],
+    "joints": {
+      "wrist": { "transform": [/* 16 floats */], "isTracked": true },
+      "thumbTip": { "transform": [/* 16 floats */], "isTracked": true },
+      "indexFingerTip": { "transform": [/* 16 floats */], "isTracked": true }
+      // … all 26 joints
+    }
+  },
+  "right": { /* same structure */ },
+  "timestamp": 1743120000.0
+}
+```
+
+**All 26 joints per hand:**
+`wrist`, `thumbKnuckle`, `thumbIntermediateBase`, `thumbIntermediateTip`, `thumbTip`,
+`indexFingerMetacarpal`, `indexFingerKnuckle`, `indexFingerIntermediateBase`,
+`indexFingerIntermediateTip`, `indexFingerTip`, `middleFingerMetacarpal`,
+`middleFingerKnuckle`, `middleFingerIntermediateBase`, `middleFingerIntermediateTip`,
+`middleFingerTip`, `ringFingerMetacarpal`, `ringFingerKnuckle`,
+`ringFingerIntermediateBase`, `ringFingerIntermediateTip`, `ringFingerTip`,
+`littleFingerMetacarpal`, `littleFingerKnuckle`, `littleFingerIntermediateBase`,
+`littleFingerIntermediateTip`, `littleFingerTip`, `forearmWrist`
+
+**Transforms** are column-major 4×4 matrices encoded as 16-element float arrays.
+
+---
+
+### `spatial.planes`
+
+Returns all currently detected flat surfaces in the scene.
+
+**Requires:** Active ImmersiveSpace · World Sensing permission
+
+**Response payload:**
+
+```json
+{
+  "planes": [
+    {
+      "id": "A1B2C3D4-…",
+      "alignment": "horizontal",
+      "classification": "floor",
+      "center": [0.0, 0.0, -1.5],
+      "extent": [2.4, 1.8],
+      "transform": [/* 16 floats */],
+      "timestamp": 1743120000.0
+    }
+  ],
+  "count": 12
+}
+```
+
+**`alignment`:** `horizontal` | `vertical` | `arbitrary`
+
+**`classification`:** `floor` | `wall` | `ceiling` | `table` | `seat` | `door` | `window`
+
+---
+
+### `spatial.mesh`
+
+Returns the full scene reconstruction as a set of mesh chunks (triangulated geometry).
+
+**Requires:** Active ImmersiveSpace · World Sensing permission
+
+> **Note:** This command returns large payloads. A typical room scan produces 10–20 chunks
+> with thousands of faces each. Plan for response sizes in the hundreds of KB.
+
+**Response payload:**
+
+```json
+{
+  "chunks": [
+    {
+      "id": "A1B2C3D4-…",
+      "transform": [/* 16 floats */],
+      "vertexCount": 1240,
+      "faceCount": 890,
+      "vertices": [[x, y, z], …],
+      "faces": [[v0, v1, v2], …],
+      "timestamp": 1743120000.0
+    }
+  ],
+  "count": 14
+}
+```
+
+---
+
+### `device.position`
+
+Returns the current head position and orientation in world space.
+
+**Requires:** Active ImmersiveSpace (WorldTrackingProvider)
+
+**Response payload:**
+
+```json
+{
+  "transform": [/* 16-element column-major float array */],
+  "timestamp": 1743120000.0
+}
+```
+
+The transform encodes the full 6DoF head pose. Extract position from `columns[3]` (x, y, z).
+
+---
+
+### `device.info`
+
+Returns device and node metadata. Does not require an ImmersiveSpace.
+
+**Response payload:**
+
+```json
+{
+  "platform": "visionos",
+  "modelIdentifier": "RealityDevice14,1",
+  "nodeVersion": "0.1.0",
+  "deviceID": "be1289e6…"
+}
+```
+
+---
+
+### `location.get`
+
+Returns the device's GPS location via CoreLocation.
+
+**Requires:** Location permission (`NSLocationWhenInUseUsageDescription`)
+
+Does **not** require an active ImmersiveSpace.
+
+**Response payload:**
+
+```json
+{
+  "latitude": 37.7749,
+  "longitude": -122.4194,
+  "altitude": 15.2,
+  "horizontalAccuracy": 19.0,
+  "verticalAccuracy": 5.0,
+  "timestamp": 1743120000.0
+}
+```
+
+---
+
+### `camera.snap` / `camera.clip`
+
+Capture a still image or short video clip from the Vision Pro's main forward-facing camera.
+
+**⚠️ Enterprise entitlement required**
+
+These commands require the `com.apple.developer.arkit.main-camera-access.allow`
+entitlement, which is only available through the Apple Developer Enterprise Program.
+
+Without the entitlement, these commands return:
+
+```json
+{ "code": "UNAVAILABLE", "detail": "enterprise-entitlement-required" }
+```
+
+When the app is backgrounded (ImmersiveSpace closed), they return:
+
+```json
+{ "code": "NODE_BACKGROUND_UNAVAILABLE", "detail": "camera-unavailable-in-background" }
+```
+
+---
+
+## Error Codes
+
+| Code | Meaning |
+|---|---|
+| `UNAVAILABLE` | Command is implemented but a prerequisite is not met (see `detail`) |
+| `NODE_BACKGROUND_UNAVAILABLE` | The ImmersiveSpace is closed; camera/canvas commands cannot run |
+| `PERMISSION_DENIED` | User denied the required system permission |
+| `UNKNOWN_COMMAND` | Command not recognized by this node |
+| `FORBIDDEN` | Request rejected due to security policy (parameter injection attempt) |
+
+---
+
+## Architecture
+
+```
+Vision Pro
+├── visionOS-nodeApp.swift      — App entry point, ImmersiveSpace declaration
+├── ContentView.swift           — Main UI; hosts GatewayConfigView + ConnectionStatusView
+├── Gateway/
+│   ├── GatewaySocket.swift     — URLSessionWebSocketTask, receive loop, frame parsing
+│   ├── HandshakeManager.swift  — v3 protocol: Secure Enclave keypair, nonce signing
+│   ├── NodeManager.swift       — State machine, RPC dispatcher, command handlers
+│   └── LocationManager.swift   — CoreLocation one-shot async wrapper
+├── Spatial/
+│   └── SpatialManager.swift    — ARKit session: hands, world, planes, mesh
+├── Lifecycle/
+│   └── ScenePhaseMonitor.swift — Detects background/foreground, sends exit frame
+├── Notifications/
+│   └── APNsManager.swift       — APNs token registration (future: background wake)
+└── Views/
+    ├── NodeImmersiveView.swift  — Minimal .mixed ImmersiveSpace (ARKit lifecycle anchor)
+    ├── GatewayConfigView.swift  — URL + token settings
+    └── ConnectionStatusView.swift — Live connection status display
+```
+
+### Connection lifecycle
+
+```
+App launch
+  └─ ContentView.onAppear → NodeManager.connect()
+       └─ GatewaySocket connects (WSS)
+            └─ challenge event → HandshakeManager signs nonce → send connect frame
+                 └─ hello-ok → NodeManager: state = .connected
+                      └─ node.invoke.request events → dispatchCommand() → sendOK/sendError
+```
+
+The WebSocket is **app-level**, not ImmersiveSpace-level — the socket stays alive when
+the immersive space is closed. ARKit providers are **ImmersiveSpace-level** — they start
+when the user opens the space and stop when it closes.
+
+### ImmersiveSpace as lifecycle anchor
+
+visionOS suspends apps and kills WebSockets when the app loses foreground focus without
+an active ImmersiveSpace. The `NodeImmersiveView` opens a minimal `.mixed` space solely
+to prevent process suspension — it renders nothing visible. This is architecturally
+required, not optional UI decoration.
+
+### Protocol
+
+The node uses OpenClaw Gateway Protocol v3:
+
+- **Handshake:** The gateway sends `connect.challenge` as a `type:"event"` frame.
+  The node signs the nonce with its Secure Enclave keypair and replies with a
+  `type:"req"` connect frame.
+- **Commands:** The gateway delivers `node.invoke.request` as a `type:"event"` frame
+  with the command and params in the payload.
+- **Responses:** The node replies with `type:"req"`, `method:"node.invoke.result"`,
+  and params `{ id, nodeId, ok, payload | error }`.
+
+### Security
+
+The node implements CVE-2026-28466 mitigations: any incoming RPC params containing
+`approved`, `bypass`, `override`, `authorized`, or `approvalDecision` keys are rejected
+outright with `FORBIDDEN`. Approval decisions are gateway-side only and cannot be
+smuggled through command parameters.
+
+---
+
+## Info.plist Privacy Keys
+
+The following keys must be present in `Info.plist`:
+
+| Key | Used by |
+|---|---|
+| `NSHandsTrackingUsageDescription` | `spatial.hands` |
+| `NSWorldSensingUsageDescription` | `spatial.planes`, `spatial.mesh`, `device.position` |
+| `NSLocationWhenInUseUsageDescription` | `location.get` |
+
+---
+
+## Device Identity & Keychain
+
+The node derives a stable device ID from an Ed25519 keypair stored in Keychain with
+`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. This means:
+
+- The keypair — and therefore the device ID — **persists across app reinstalls and Xcode
+  clean builds**. You will not need to re-approve the node after rebuilding.
+- The identity is **device-bound** and cannot be transferred or backed up.
+- To force a fresh device ID (e.g. to test re-pairing), delete the Keychain item manually:
+
+```swift
+// In a debug build, or via a Settings "Reset Node Identity" button:
+let query: [CFString: Any] = [
+    kSecClass: kSecClassGenericPassword,
+    kSecAttrService: "com.openclaw.node"
+]
+SecItemDelete(query as CFDictionary)
+```
+
+After deleting, the next app launch generates a new keypair and a new device ID, which
+will require re-approval on the Gateway.
+
+---
+
+## Known Limitations
+
+- **Camera requires Enterprise entitlement** — `camera.snap` and `camera.clip` are
+  implemented but blocked on `com.apple.developer.arkit.main-camera-access.allow`.
+  Contact Apple Developer Enterprise support to request this entitlement.
+- **Spatial commands require ImmersiveSpace** — ARKit providers cannot run outside an
+  active ImmersiveSpace. Design your agent workflows to account for the space being open.
+- **`spatial.mesh` payload size** — Full scene reconstructions can be 500KB+. Consider
+  requesting mesh only when needed and caching the result client-side.
+- **No APNs background wake yet** — The app must be in the foreground (ImmersiveSpace
+  open) to receive commands. Background wake via APNs silent push is planned.
+- **Canvas (WKWebView) commands not yet implemented** — `canvas.*` commands are stubbed
+  and return `UNAVAILABLE`.
+
+---
+
+## Contributing
+
+This node is part of LOAM STUDIO's open source contribution to OpenClaw.
+The source lives at [github.com/LOAM-STUDIO/visionOS-node](https://github.com/LOAM-STUDIO/visionOS-node).
+
+Issues, PRs, and feedback welcome.


### PR DESCRIPTION
## Summary

Adds a native visionOS companion app that pairs with the OpenClaw Gateway as a peripheral node, giving the AI agent spatial awareness, hand tracking, world sensing, and GPS from an Apple Vision Pro.

Related: #55944 (platform policy — adds `visionos` to `PLATFORM_DEFAULTS` and command policy rules)

<img width="1920" height="1080" alt="visionOS-node-1" src="https://github.com/user-attachments/assets/3a599189-259f-49ef-bc5f-edf6bbbbf140" />

## What's included

### `apps/visionos/`
A complete SwiftUI visionOS app (visionOS 2.0+, Xcode 24.6):

| File | Purpose |
|---|---|
| `GatewaySocket.swift` | URLSessionWebSocketTask + protocol v3 frame parsing |
| `HandshakeManager.swift` | Ed25519 Secure Enclave keypair, nonce signing |
| `NodeManager.swift` | RPC dispatcher, state machine, exponential backoff reconnect |
| `SpatialManager.swift` | ARKit: HandTracking, WorldTracking, PlaneDetection, SceneReconstruction |
| `LocationManager.swift` | CoreLocation one-shot async wrapper |
| `ScenePhaseMonitor.swift` | Background/foreground detection, exit frame on dismiss |
| `NodeImmersiveView.swift` | Minimal .mixed ImmersiveSpace (ARKit lifecycle anchor) |
| `ContentView.swift` / `GatewayConfigView.swift` / `ConnectionStatusView.swift` | UI |

### `docs/nodes/visionos.md`
Full documentation covering setup, Gateway config, all commands with JSON response schemas, architecture, protocol notes, security, and known limitations.

## Commands implemented

| Command | Capability | Status |
|---|---|---|
| `spatial.hands` | 26-joint skeletal hand tracking (both hands) | ✅ Verified on-device |
| `spatial.planes` | Flat surface detection with classification | ✅ Verified on-device |
| `spatial.mesh` | Full scene reconstruction (triangulated geometry) | ✅ Verified on-device |
| `device.position` | Head position/orientation (6DoF world transform) | ✅ Verified on-device |
| `device.info` | Device metadata | ✅ |
| `location.get` | GPS via CoreLocation | ✅ Verified on-device |
| `camera.snap` | Still frame from main camera | ⚠️ Requires Enterprise entitlement |
| `camera.clip` | Short video clip from main camera | ⚠️ Requires Enterprise entitlement |
| `canvas.*` | WKWebView canvas | 🔜 Planned |

## Key architectural decisions

**ImmersiveSpace as lifecycle anchor** — visionOS suspends apps and kills WebSockets when the app loses foreground without an active ImmersiveSpace. The `NodeImmersiveView` opens a minimal `.mixed` space to prevent process suspension. This is architecturally required.

**WebSocket is app-level** — the socket connects on `ContentView.onAppear` and stays alive when the immersive space is closed. ARKit providers are ImmersiveSpace-level and start/stop with the space.

**Stable device identity** — Ed25519 keypair stored in Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. The device ID persists across app reinstalls and clean builds. Docs include instructions for forcing a reset.

**CVE-2026-28466 mitigation** — Incoming RPC params are validated; requests containing smuggled approval/bypass fields are rejected with `FORBIDDEN` before dispatch.

## Setup

See [docs/nodes/visionos.md](docs/nodes/visionos.md) for full setup instructions including Gateway `allowCommands` config, ARKit permission requirements, and the approval flow.