### PR TITLE
fix(gateway): use agent workspace dir in session transcript cwd

### DIFF
--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { loadConfig } from "../config.js";
 import { parseSessionThreadInfo } from "./delivery-info.js";
 import {
   resolveDefaultSessionStorePath,
@@ -67,17 +69,21 @@ export function resolveMirroredTranscriptText(params: {
 async function ensureSessionHeader(params: {
   sessionFile: string;
   sessionId: string;
+  agentId?: string;
 }): Promise<void> {
   if (fs.existsSync(params.sessionFile)) {
     return;
   }
   await fs.promises.mkdir(path.dirname(params.sessionFile), { recursive: true });
+  const cwd = params.agentId
+    ? resolveAgentWorkspaceDir(loadConfig(), params.agentId)
+    : process.cwd();
   const header = {
     type: "session",
     version: CURRENT_SESSION_VERSION,
     id: params.sessionId,
     timestamp: new Date().toISOString(),
-    cwd: process.cwd(),
+    cwd,
   };
   await fs.promises.writeFile(params.sessionFile, `${JSON.stringify(header)}\n`, {
     encoding: "utf-8",
@@ -179,7 +185,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     };
   }
 
-  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
+  await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId, agentId: params.agentId });
 
   const existingMessageId = params.idempotencyKey
     ? await transcriptHasIdempotencyKey(sessionFile, params.idempotencyKey)

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
@@ -10,6 +10,7 @@ import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.j
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
+import { loadConfig } from "../../config/config.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { type SavedMedia, saveMediaBuffer } from "../../media/store.js";
@@ -743,7 +744,11 @@ function resolveTranscriptPath(params: {
   }
 }
 
-function ensureTranscriptFile(params: { transcriptPath: string; sessionId: string }): {
+function ensureTranscriptFile(params: {
+  transcriptPath: string;
+  sessionId: string;
+  agentId?: string;
+}): {
   ok: boolean;
   error?: string;
 } {
@@ -752,12 +757,15 @@ function ensureTranscriptFile(params: { transcriptPath: string; sessionId: strin
   }
   try {
     fs.mkdirSync(path.dirname(params.transcriptPath), { recursive: true });
+    const cwd = params.agentId
+      ? resolveAgentWorkspaceDir(loadConfig(), params.agentId)
+      : process.cwd();
     const header = {
       type: "session",
       version: CURRENT_SESSION_VERSION,
       id: params.sessionId,
       timestamp: new Date().toISOString(),
-      cwd: process.cwd(),
+      cwd,
     };
     fs.writeFileSync(params.transcriptPath, `${JSON.stringify(header)}\n`, {
       encoding: "utf-8",
@@ -819,6 +827,7 @@ function appendAssistantTranscriptMessage(params: {
     const ensured = ensureTranscriptFile({
       transcriptPath,
       sessionId: params.sessionId,
+      agentId: params.agentId,
     });
     if (!ensured.ok) {
       return { ok: false, error: ensured.error ?? "failed to create transcript file" };

--- a/src/gateway/server-methods/sessions.ensure-transcript.test.ts
+++ b/src/gateway/server-methods/sessions.ensure-transcript.test.ts
@@ -17,9 +17,11 @@ vi.mock("../../config/config.js", () => ({
 
 describe("ensureSessionTranscriptFile", () => {
   let tmpDir: string;
+  let storePath: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-test-"));
+    storePath = path.join(tmpDir, "sessions.json");
   });
 
   afterEach(() => {
@@ -31,7 +33,7 @@ describe("ensureSessionTranscriptFile", () => {
     const result = ensureSessionTranscriptFile({
       cfg: {} as never,
       sessionId,
-      storePath: tmpDir,
+      storePath,
       agentId: "chief",
     });
     expect(result.ok).toBe(true);
@@ -52,7 +54,7 @@ describe("ensureSessionTranscriptFile", () => {
     const first = ensureSessionTranscriptFile({
       cfg: {} as never,
       sessionId,
-      storePath: tmpDir,
+      storePath,
       agentId: "chief",
     });
     expect(first.ok).toBe(true);
@@ -65,7 +67,7 @@ describe("ensureSessionTranscriptFile", () => {
     const second = ensureSessionTranscriptFile({
       cfg: {} as never,
       sessionId,
-      storePath: tmpDir,
+      storePath,
       agentId: "chief",
     });
     expect(second.ok).toBe(true);

--- a/src/gateway/server-methods/sessions.ensure-transcript.test.ts
+++ b/src/gateway/server-methods/sessions.ensure-transcript.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureSessionTranscriptFile } from "./sessions.js";
+
+const FAKE_WORKSPACE = "/home/node/.openclaw/workspaces/chief";
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: vi.fn(() => "chief"),
+  resolveAgentWorkspaceDir: vi.fn(() => FAKE_WORKSPACE),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+describe("ensureSessionTranscriptFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes agent workspace dir as cwd, not process.cwd()", () => {
+    const sessionId = "test-session-001";
+    const result = ensureSessionTranscriptFile({
+      cfg: {} as never,
+      sessionId,
+      storePath: tmpDir,
+      agentId: "chief",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const content = fs.readFileSync(result.transcriptPath, "utf-8").trim();
+    const header = JSON.parse(content);
+    expect(header.cwd).toBe(FAKE_WORKSPACE);
+    expect(header.cwd).not.toBe(process.cwd());
+    expect(header.type).toBe("session");
+    expect(header.id).toBe(sessionId);
+  });
+
+  it("does not overwrite an existing transcript file", () => {
+    const sessionId = "test-session-002";
+    const first = ensureSessionTranscriptFile({
+      cfg: {} as never,
+      sessionId,
+      storePath: tmpDir,
+      agentId: "chief",
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+
+    const originalContent = fs.readFileSync(first.transcriptPath, "utf-8");
+
+    const second = ensureSessionTranscriptFile({
+      cfg: {} as never,
+      sessionId,
+      storePath: tmpDir,
+      agentId: "chief",
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      return;
+    }
+
+    expect(fs.readFileSync(second.transcriptPath, "utf-8")).toBe(originalContent);
+  });
+});

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
-import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   abortEmbeddedPiRun,
   isEmbeddedPiRunActive,
@@ -10,6 +10,7 @@ import {
 } from "../../agents/pi-embedded-runner/runs.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import { loadConfig } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadSessionStore,
   resolveMainSessionKey,
@@ -220,6 +221,7 @@ function buildDashboardSessionKey(agentId: string): string {
 }
 
 function ensureSessionTranscriptFile(params: {
+  cfg: OpenClawConfig;
   sessionId: string;
   storePath: string;
   sessionFile?: string;
@@ -241,7 +243,7 @@ function ensureSessionTranscriptFile(params: {
         version: CURRENT_SESSION_VERSION,
         id: params.sessionId,
         timestamp: new Date().toISOString(),
-        cwd: process.cwd(),
+        cwd: resolveAgentWorkspaceDir(params.cfg, params.agentId),
       };
       fs.writeFileSync(transcriptPath, `${JSON.stringify(header)}\n`, {
         encoding: "utf-8",
@@ -722,6 +724,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const ensured = ensureSessionTranscriptFile({
+      cfg,
       sessionId: created.entry.sessionId,
       storePath: target.storePath,
       sessionFile: created.entry.sessionFile,

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -220,7 +220,8 @@ function buildDashboardSessionKey(agentId: string): string {
   return `agent:${agentId}:dashboard:${randomUUID()}`;
 }
 
-function ensureSessionTranscriptFile(params: {
+/** @internal Exported for testing only. */
+export function ensureSessionTranscriptFile(params: {
   cfg: OpenClawConfig;
   sessionId: string;
   storePath: string;


### PR DESCRIPTION
## Summary
- Fix regression from `7b61ca1b06` where `ensureSessionTranscriptFile` hardcodes `cwd: process.cwd()` (resolves to `/app` in Docker) instead of the agent's workspace directory
- DM-bound sessions (WhatsApp, etc.) were getting `cwd: "/app"` in their transcript headers, breaking bootstrap file injection (zero tool calls)
- Replace with `resolveAgentWorkspaceDir(cfg, agentId)` to resolve the correct workspace path (e.g., `/home/node/.openclaw/workspaces/chief`)

## Evidence
- Pre-regression transcripts: `"cwd": "/home/node/.openclaw/workspaces/chief"` (working, tools available)
- Post-regression transcripts: `"cwd": "/app"` (broken, zero tool calls)

## Test plan
- [x] Scoped tests pass: `npx vitest run src/gateway/server-methods/server-methods.test.ts` (52/52 passing)
- [x] Verified `tsgo` errors are pre-existing on clean tree (unrelated `compaction.ts`, `skills/source.ts`)
- [x] Lint/format clean on touched file
- [x] Deploy to Docker gateway and verify new DM-bound sessions get correct `cwd` in transcript header