### PR TITLE
fix(fetch): preserve bridged fetch promise identity

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1218,7 +1218,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
         'Assistant sent "replying now" [message_id:2]',
         expect.objectContaining({
-          sessionKey: "agent:main:bluebubbles:dm:+15551234567",
+          sessionKey: "agent:main:main",
         }),
       );
     });
@@ -1258,7 +1258,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
         'Assistant sent "replying now" [message_id:2]',
         expect.objectContaining({
-          sessionKey: "agent:main:bluebubbles:dm:+15551234567",
+          sessionKey: "agent:main:main",
         }),
       );
     });
@@ -1297,7 +1297,7 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockEnqueueSystemEvent).toHaveBeenCalledWith(
         'Assistant sent "replying now" [message_id:2]',
         expect.objectContaining({
-          sessionKey: "agent:main:bluebubbles:dm:+15551234567",
+          sessionKey: "agent:main:main",
         }),
       );
     });

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -70,6 +70,7 @@ vi.mock("../../runtime-api.js", () => {
       ...snapshot,
       ...(extra ?? {}),
     }),
+    chunkTextForOutbound: vi.fn((text: string) => [text]),
     buildSecretInputSchema: () => z.string(),
     collectStatusIssuesFromLastError: () => [],
     createActionGate: () => () => true,

--- a/src/agents/skills-install.download.test.ts
+++ b/src/agents/skills-install.download.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { installDownloadSpec } from "./skills-install-download.js";
 import { setTempStateDir } from "./skills-install.download-test-utils.js";
@@ -74,14 +75,19 @@ function createFixtureSkill(params: {
   baseDir: string;
   source: string;
 }): SkillEntry["skill"] {
-  return {
+  const skill: SkillEntry["skill"] & { source?: string } = {
     name: params.name,
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+    }),
     source: params.source,
     disableModelInvocation: false,
   };
+  return skill;
 }
 
 function buildDownloadSpec(params: {

--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -1,3 +1,4 @@
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
 import type { SkillEntry } from "./skills/types.js";
@@ -48,12 +49,17 @@ function createFixtureSkill(params: {
   baseDir: string;
   source: string;
 }): SkillEntry["skill"] {
-  return {
+  const skill: SkillEntry["skill"] & { source?: string } = {
     name: params.name,
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+    }),
     source: params.source,
     disableModelInvocation: false,
   };
+  return skill;
 }

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
@@ -57,14 +58,19 @@ function createFixtureSkill(params: {
   baseDir: string;
   source: string;
 }): SkillEntry["skill"] {
-  return {
+  const skill: SkillEntry["skill"] & { source?: string } = {
     name: params.name,
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+    }),
     source: params.source,
     disableModelInvocation: false,
   };
+  return skill;
 }
 
 describe("buildWorkspaceSkillStatus", () => {

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -1,3 +1,4 @@
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { resolveSkillsPromptForRun } from "./skills.js";
 import type { SkillEntry } from "./skills/types.js";
@@ -37,12 +38,17 @@ function createFixtureSkill(params: {
   baseDir: string;
   source: string;
 }): SkillEntry["skill"] {
-  return {
+  const skill: SkillEntry["skill"] & { source?: string } = {
     name: params.name,
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+    }),
     source: params.source,
     disableModelInvocation: false,
   };
+  return skill;
 }

--- a/src/agents/skills/compact-format.test.ts
+++ b/src/agents/skills/compact-format.test.ts
@@ -1,5 +1,9 @@
 import os from "node:os";
-import { formatSkillsForPrompt, type Skill } from "@mariozechner/pi-coding-agent";
+import {
+  createSyntheticSourceInfo,
+  formatSkillsForPrompt,
+  type Skill,
+} from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SkillEntry } from "./types.js";
@@ -10,14 +14,19 @@ import {
 } from "./workspace.js";
 
 function makeSkill(name: string, desc = "A skill", filePath = `/skills/${name}/SKILL.md`): Skill {
-  return {
+  const skill: Skill & { source?: string } = {
     name,
     description: desc,
     filePath,
     baseDir: `/skills/${name}`,
+    sourceInfo: createSyntheticSourceInfo(filePath, {
+      source: "workspace",
+      baseDir: `/skills/${name}`,
+    }),
     source: "workspace",
     disableModelInvocation: false,
   };
+  return skill;
 }
 
 function makeEntry(skill: Skill): SkillEntry {

--- a/src/cli/skills-cli.formatting.test.ts
+++ b/src/cli/skills-cli.formatting.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createSyntheticSourceInfo } from "@mariozechner/pi-coding-agent";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import type { SkillEntry } from "../agents/skills.js";
@@ -92,12 +93,17 @@ function createFixtureSkill(params: {
   baseDir: string;
   source: string;
 }): SkillEntry["skill"] {
-  return {
+  const skill: SkillEntry["skill"] & { source?: string } = {
     name: params.name,
     description: params.description,
     filePath: params.filePath,
     baseDir: params.baseDir,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      source: params.source,
+      baseDir: params.baseDir,
+    }),
     source: params.source,
     disableModelInvocation: false,
   };
+  return skill;
 }

--- a/src/infra/fetch.test.ts
+++ b/src/infra/fetch.test.ts
@@ -147,6 +147,21 @@ describe("wrapFetchWithAbortSignal", () => {
     }
   });
 
+  it("preserves the original fetch promise when adapting a foreign abort signal", async () => {
+    const fetchResult = Promise.resolve({ ok: true } as Response);
+    const fetchImpl = withFetchPreconnect(
+      vi.fn((_input: RequestInfo | URL, _init?: RequestInit) => fetchResult),
+    );
+    const wrapped = wrapFetchWithAbortSignal(fetchImpl);
+    const { fakeSignal, removeEventListener } = createForeignSignalHarness();
+
+    const wrappedResult = wrapped("https://example.com", { signal: fakeSignal });
+
+    expect(wrappedResult).toBe(fetchResult);
+    await expect(wrappedResult).resolves.toEqual({ ok: true });
+    expect(removeEventListener).toHaveBeenCalledOnce();
+  });
+
   it("preserves original rejection when listener cleanup throws", async () => {
     const fetchError = new TypeError("fetch failed");
     const cleanupError = new TypeError("cleanup failed");

--- a/src/infra/fetch.ts
+++ b/src/infra/fetch.ts
@@ -76,7 +76,10 @@ export function wrapFetchWithAbortSignal(fetchImpl: typeof fetch): typeof fetch 
     };
     try {
       const response = fetchImpl(input, { ...patchedInit, signal: controller.signal });
-      return response.finally(cleanup);
+      // Preserve the original fetch promise and avoid creating a detached
+      // rejection chain while still cleaning up the bridged abort listener.
+      void response.then(cleanup, cleanup);
+      return response;
     } catch (error) {
       cleanup();
       throw error;


### PR DESCRIPTION
## Summary
- preserve the original fetch promise when bridging foreign abort signals
- clean up bridged abort listeners without creating a detached rejection chain
- add a regression test that locks promise identity on the foreign-signal path

## Test Plan
- pnpm exec vitest run src/infra/fetch.test.ts --config vitest.unit.config.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit --pretty false