### PR TITLE
fix(feishu): suppress NO_REPLY in outbound sends

### DIFF
--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -256,6 +256,36 @@ describe("feishuOutbound.sendText replyToId forwarding", () => {
     );
     expect(sendMessageFeishuMock.mock.calls[0][0].replyToMessageId).toBeUndefined();
   });
+
+  it("strips trailing NO_REPLY from visible text", async () => {
+    await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "📊 report\n\nNO_REPLY",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        text: "📊 report",
+        accountId: "main",
+      }),
+    );
+  });
+
+  it("suppresses pure NO_REPLY text sends", async () => {
+    const result = await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "NO_REPLY",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ channel: "feishu", messageId: "suppressed" }));
+  });
 });
 
 describe("feishuOutbound.sendMedia replyToId forwarding", () => {
@@ -353,6 +383,25 @@ describe("feishuOutbound.sendMedia renderMode", () => {
         to: "chat_1",
         text: "caption",
         replyToMessageId: "om_thread_1",
+        accountId: "main",
+      }),
+    );
+  });
+
+  it("drops NO_REPLY captions before media sends", async () => {
+    await feishuOutbound.sendMedia?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text: "NO_REPLY",
+      mediaUrl: "https://example.com/image.png",
+      accountId: "main",
+    });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat_1",
+        mediaUrl: "https://example.com/image.png",
         accountId: "main",
       }),
     );

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import { isSilentReplyText, stripSilentToken } from "../../../src/auto-reply/tokens.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { sendMediaFeishu } from "./media.js";
@@ -42,6 +43,17 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
 
 function shouldUseCard(text: string): boolean {
   return /```[\s\S]*?```/.test(text) || /\|.+\|[\r\n]+\|[-:| ]+\|/.test(text);
+}
+
+function normalizeFeishuOutboundText(text: string | undefined): string {
+  if (!text) return "";
+  if (isSilentReplyText(text)) {
+    return "";
+  }
+  if (text.includes("NO_REPLY")) {
+    return stripSilentToken(text);
+  }
+  return text;
 }
 
 function resolveReplyToMessageId(params: {
@@ -95,10 +107,11 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       identity,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const normalizedText = normalizeFeishuOutboundText(text);
       // Scheme A compatibility shim:
       // when upstream accidentally returns a local image path as plain text,
       // auto-upload and send as Feishu image message instead of leaking path text.
-      const localImagePath = normalizePossibleLocalImagePath(text);
+      const localImagePath = normalizePossibleLocalImagePath(normalizedText);
       if (localImagePath) {
         try {
           return await sendMediaFeishu({
@@ -115,9 +128,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         }
       }
 
+      if (!normalizedText.trim()) {
+        return { channel: "feishu", messageId: "suppressed" };
+      }
+
       const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
       const renderMode = account.config?.renderMode ?? "auto";
-      const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+      const useCard =
+        renderMode === "card" || (renderMode === "auto" && shouldUseCard(normalizedText));
       if (useCard) {
         const header = identity
           ? {
@@ -130,7 +148,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         return await sendStructuredCardFeishu({
           cfg,
           to,
-          text,
+          text: normalizedText,
           replyToMessageId,
           replyInThread: threadId != null && !replyToId,
           accountId: accountId ?? undefined,
@@ -140,7 +158,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       return await sendOutboundText({
         cfg,
         to,
-        text,
+        text: normalizedText,
         accountId: accountId ?? undefined,
         replyToMessageId,
       });
@@ -156,12 +174,13 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       threadId,
     }) => {
       const replyToMessageId = resolveReplyToMessageId({ replyToId, threadId });
+      const normalizedText = normalizeFeishuOutboundText(text);
       // Send text first if provided
-      if (text?.trim()) {
+      if (normalizedText.trim()) {
         await sendOutboundText({
           cfg,
           to,
-          text,
+          text: normalizedText,
           accountId: accountId ?? undefined,
           replyToMessageId,
         });
@@ -193,10 +212,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       }
 
       // No media URL, just return text result
+      if (!mediaUrl && !normalizedText.trim()) {
+        return { channel: "feishu", messageId: "suppressed" };
+      }
+
       return await sendOutboundText({
         cfg,
         to,
-        text: text ?? "",
+        text: normalizedText,
         accountId: accountId ?? undefined,
         replyToMessageId,
       });


### PR DESCRIPTION
## Summary
- suppress pure `NO_REPLY` Feishu outbound text sends before they hit the transport
- strip trailing/mixed `NO_REPLY` control tokens from visible Feishu text
- keep media sends working while dropping silent-only captions

## Testing
- pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/outbound.test.ts
- pnpm exec oxfmt --check extensions/feishu/src/outbound.ts extensions/feishu/src/outbound.test.ts

Closes #56117