### PR TITLE
[codex] Fix symlinked local media root validation

### DIFF
--- a/src/media/local-media-access.test.ts
+++ b/src/media/local-media-access.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertLocalMediaAllowed } from "./local-media-access.js";
+
+describe("assertLocalMediaAllowed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts unresolved tmp paths when the allowed root resolves through a symlink", async () => {
+    const mediaPath = "/tmp/openclaw/video.mp4";
+    const rootPath = "/tmp/openclaw";
+
+    vi.spyOn(fs, "realpath").mockImplementation(async (targetPath: string) => {
+      if (targetPath === mediaPath) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      if (targetPath === rootPath) {
+        return "/private/tmp/openclaw";
+      }
+      return targetPath;
+    });
+
+    await expect(assertLocalMediaAllowed(mediaPath, [rootPath])).resolves.toBeUndefined();
+  });
+
+  it("accepts realpath-normalized tmp paths when the configured root keeps the original form", async () => {
+    const mediaPath = "/tmp/openclaw/video.mp4";
+    const rootPath = "/tmp/openclaw";
+
+    vi.spyOn(fs, "realpath").mockImplementation(async (targetPath: string) => {
+      if (targetPath === mediaPath) {
+        return "/private/tmp/openclaw/video.mp4";
+      }
+      if (targetPath === rootPath) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return targetPath;
+    });
+
+    await expect(assertLocalMediaAllowed(mediaPath, [rootPath])).resolves.toBeUndefined();
+  });
+
+  it("still rejects sibling paths outside the allowed symlinked root", async () => {
+    const mediaPath = "/tmp/openclaw-other/video.mp4";
+    const rootPath = "/tmp/openclaw";
+
+    vi.spyOn(fs, "realpath").mockImplementation(async (targetPath: string) => {
+      if (targetPath === mediaPath) {
+        return "/private/tmp/openclaw-other/video.mp4";
+      }
+      if (targetPath === rootPath) {
+        return "/private/tmp/openclaw";
+      }
+      return targetPath;
+    });
+
+    await expect(assertLocalMediaAllowed(mediaPath, [rootPath])).rejects.toMatchObject({
+      code: "path-not-allowed",
+    });
+  });
+});

--- a/src/media/local-media-access.ts
+++ b/src/media/local-media-access.ts
@@ -27,6 +27,22 @@ export function getDefaultLocalRoots(): readonly string[] {
   return getDefaultMediaLocalRoots();
 }
 
+async function resolvePathVariants(targetPath: string): Promise<string[]> {
+  const variants = new Set<string>();
+  variants.add(path.resolve(targetPath));
+  try {
+    variants.add(await fs.realpath(targetPath));
+  } catch {
+    // Keep the unresolved absolute path so callers can still validate paths
+    // that live under symlinked roots such as /tmp on macOS.
+  }
+  return Array.from(variants);
+}
+
+function isPathWithinRoot(targetPath: string, rootPath: string): boolean {
+  return targetPath === rootPath || targetPath.startsWith(rootPath + path.sep);
+}
+
 export async function assertLocalMediaAllowed(
   mediaPath: string,
   localRoots: readonly string[] | "any" | undefined,
@@ -42,12 +58,8 @@ export async function assertLocalMediaAllowed(
     });
   }
   const roots = localRoots ?? getDefaultLocalRoots();
-  let resolved: string;
-  try {
-    resolved = await fs.realpath(mediaPath);
-  } catch {
-    resolved = path.resolve(mediaPath);
-  }
+  const resolvedVariants = await resolvePathVariants(mediaPath);
+  const resolved = resolvedVariants[0] ?? path.resolve(mediaPath);
 
   if (localRoots === undefined) {
     const workspaceRoot = roots.find((root) => path.basename(root) === "workspace");
@@ -67,19 +79,20 @@ export async function assertLocalMediaAllowed(
   }
 
   for (const root of roots) {
-    let resolvedRoot: string;
-    try {
-      resolvedRoot = await fs.realpath(root);
-    } catch {
-      resolvedRoot = path.resolve(root);
-    }
-    if (resolvedRoot === path.parse(resolvedRoot).root) {
+    const resolvedRootVariants = await resolvePathVariants(root);
+    if (resolvedRootVariants.some((resolvedRoot) => resolvedRoot === path.parse(resolvedRoot).root)) {
       throw new LocalMediaAccessError(
         "invalid-root",
         `Invalid localRoots entry (refuses filesystem root): ${root}. Pass a narrower directory.`,
       );
     }
-    if (resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)) {
+    if (
+      resolvedVariants.some((resolvedVariant) =>
+        resolvedRootVariants.some((resolvedRoot) =>
+          isPathWithinRoot(resolvedVariant, resolvedRoot),
+        ),
+      )
+    ) {
       return;
     }
   }


### PR DESCRIPTION
## Summary
- accept both resolved and canonical path variants when validating local media roots
- add regression tests for macOS `/tmp` and `/private/tmp` symlinked path combinations

## Why
On macOS, local files written under `/tmp/...` may canonicalize to `/private/tmp/...`. The previous validation compared only one resolved form, which could falsely reject valid local media under an allowed root. That broke Telegram local MP4 sends in our runtime even though `/tmp/openclaw` was already allowed.

## Impact
This keeps the existing local root boundary in place, but avoids false negatives when the media path and the configured root are the same location expressed through different symlink forms.

## Validation
- targeted Vitest run for `src/media/local-media-access.test.ts`
- targeted media tests on the same runtime patch set
- live smoke test sending a local MP4 from `/tmp/openclaw/...` through Telegram after rebuilding the runtime
