### PR TITLE
fix(infra): expand ${VAR} env references in user paths

### DIFF
--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  expandEnvVars,
   expandHomePrefix,
   resolveEffectiveHomeDir,
   resolveHomeRelativePath,
@@ -159,6 +160,55 @@ describe("expandHomePrefix", () => {
   });
 });
 
+describe("expandEnvVars", () => {
+  it.each([
+    {
+      name: "expands braced ${VAR} references",
+      input: "${HOME}/workspace",
+      env: { HOME: "/home/alice" } as NodeJS.ProcessEnv,
+      expected: "/home/alice/workspace",
+    },
+    {
+      name: "expands unbraced $VAR references",
+      input: "$HOME/workspace",
+      env: { HOME: "/home/alice" } as NodeJS.ProcessEnv,
+      expected: "/home/alice/workspace",
+    },
+    {
+      name: "expands XDG_CONFIG_HOME",
+      input: "${XDG_CONFIG_HOME}/skills",
+      env: { XDG_CONFIG_HOME: "/home/node/.config" } as NodeJS.ProcessEnv,
+      expected: "/home/node/.config/skills",
+    },
+    {
+      name: "leaves unknown variables as-is",
+      input: "${UNKNOWN_VAR}/path",
+      env: {} as NodeJS.ProcessEnv,
+      expected: "${UNKNOWN_VAR}/path",
+    },
+    {
+      name: "expands multiple variables in one string",
+      input: "${HOME}/${USER}/docs",
+      env: { HOME: "/home/alice", USER: "alice" } as NodeJS.ProcessEnv,
+      expected: "/home/alice/alice/docs",
+    },
+    {
+      name: "returns input unchanged when no variables present",
+      input: "/tmp/plain/path",
+      env: {} as NodeJS.ProcessEnv,
+      expected: "/tmp/plain/path",
+    },
+    {
+      name: "handles empty env value",
+      input: "${HOME}/workspace",
+      env: { HOME: "" } as NodeJS.ProcessEnv,
+      expected: "/workspace",
+    },
+  ])("$name", ({ input, env, expected }) => {
+    expect(expandEnvVars(input, env)).toBe(expected);
+  });
+});
+
 describe("resolveHomeRelativePath", () => {
   it.each([
     {
@@ -194,6 +244,25 @@ describe("resolveHomeRelativePath", () => {
         },
       },
       expected: path.resolve(process.cwd()),
+    },
+    {
+      name: "expands ${XDG_CONFIG_HOME} in paths",
+      input: "${XDG_CONFIG_HOME}/workspace",
+      opts: {
+        env: { XDG_CONFIG_HOME: "/home/node/.openclaw" } as NodeJS.ProcessEnv,
+      },
+      expected: path.resolve("/home/node/.openclaw/workspace"),
+    },
+    {
+      name: "expands env vars before tilde in combined paths",
+      input: "~/${APP_DIR}/skills",
+      opts: {
+        env: {
+          OPENCLAW_HOME: "/home/alice",
+          APP_DIR: "myapp",
+        } as NodeJS.ProcessEnv,
+      },
+      expected: path.resolve("/home/alice/myapp/skills"),
     },
   ])("$name", ({ input, opts, expected }) => {
     expect(resolveHomeRelativePath(input, opts)).toBe(expected);

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -98,6 +98,19 @@ export function expandHomePrefix(
   return input.replace(/^~(?=$|[\\/])/, home);
 }
 
+/**
+ * Expand `${VAR}` and `$VAR` references in a string using the given environment.
+ * Unknown variables are left as-is so the caller can detect misconfiguration.
+ */
+export function expandEnvVars(input: string, env: NodeJS.ProcessEnv = process.env): string {
+  // Match ${VAR_NAME} (braced) and $VAR_NAME (unbraced, word-boundary delimited).
+  return input.replace(/\$\{([A-Za-z_]\w*)\}|\$([A-Za-z_]\w*)/g, (match, braced, unbraced) => {
+    const varName = braced ?? unbraced;
+    const value = env[varName];
+    return value !== undefined ? value : match;
+  });
+}
+
 export function resolveHomeRelativePath(
   input: string,
   opts?: {
@@ -109,15 +122,18 @@ export function resolveHomeRelativePath(
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed.startsWith("~")) {
-    const expanded = expandHomePrefix(trimmed, {
-      home: resolveRequiredHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir),
-      env: opts?.env,
+  const env = opts?.env ?? process.env;
+  // Expand environment variable references before any other resolution.
+  const envExpanded = expandEnvVars(trimmed, env);
+  if (envExpanded.startsWith("~")) {
+    const expanded = expandHomePrefix(envExpanded, {
+      home: resolveRequiredHomeDir(env, opts?.homedir ?? os.homedir),
+      env,
       homedir: opts?.homedir,
     });
     return path.resolve(expanded);
   }
-  return path.resolve(trimmed);
+  return path.resolve(envExpanded);
 }
 
 export function resolveOsHomeRelativePath(
@@ -131,13 +147,15 @@ export function resolveOsHomeRelativePath(
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed.startsWith("~")) {
-    const expanded = expandHomePrefix(trimmed, {
-      home: resolveRequiredOsHomeDir(opts?.env ?? process.env, opts?.homedir ?? os.homedir),
-      env: opts?.env,
+  const env = opts?.env ?? process.env;
+  const envExpanded = expandEnvVars(trimmed, env);
+  if (envExpanded.startsWith("~")) {
+    const expanded = expandHomePrefix(envExpanded, {
+      home: resolveRequiredOsHomeDir(env, opts?.homedir ?? os.homedir),
+      env,
       homedir: opts?.homedir,
     });
     return path.resolve(expanded);
   }
-  return path.resolve(trimmed);
+  return path.resolve(envExpanded);
 }


### PR DESCRIPTION
Summary
Adds environment variable expansion (${VAR} and $VAR) to path resolution, so config values like ${XDG_CONFIG_HOME}/workspace are properly resolved instead of being treated as literal directory names.

Fixes #53628

AI Disclosure
This patch was drafted with AI assistance (OpenClaw/Claude) under human direction and review. The human contributor identified the issue, guided the implementation, reviewed the diff, and ran the relevant tests.

Problem
When XDG_CONFIG_HOME (or any env var) is used in OpenClaw config paths — common in Docker deployments where it's set via .env — the variable reference is passed through literally. Skills get installed into a directory literally named ${XDG_CONFIG_HOME} rather than the expanded path.

Changes
src/infra/home-dir.ts: Added expandEnvVars() helper that resolves ${VAR} and $VAR patterns against process.env. Integrated into both resolveHomeRelativePath() and resolveOsHomeRelativePath() — env vars are expanded before tilde expansion and path.resolve(). Unknown variables are left as-is so misconfiguration is visible rather than silently producing empty segments.

src/infra/home-dir.test.ts: Added new test cases covering braced/unbraced syntax, XDG_CONFIG_HOME specifically, unknown vars, multiple vars, empty values, and integration with resolveHomeRelativePath().

Testing
All tests in home-dir.test.ts pass, including the new env-var expansion coverage.

The fix applies to all code paths that go through resolveUserPath() → resolveHomeRelativePath(), which includes:

resolveAgentWorkspaceDir() (workspace config)
resolveActiveWorkspaceDir() (CLI skills install)
resolveConfigDir() (state dir resolution)
any other path that flows through resolveUserPath()