### PR TITLE
Feishu: guard against duplicate tool registration on config hot-reload

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -61,6 +61,8 @@ export async function monitorFeishuProvider(
   return await monitorFeishuProvider(...args);
 }
 
+let toolsRegistered = false;
+
 export default defineChannelPluginEntry({
   id: "feishu",
   name: "Feishu",
@@ -68,6 +70,10 @@ export default defineChannelPluginEntry({
   plugin: feishuPlugin,
   setRuntime: setFeishuRuntime,
   registerFull(api) {
+    if (toolsRegistered) {
+      return;
+    }
+    toolsRegistered = true;
     registerFeishuSubagentHooks(api);
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);


### PR DESCRIPTION
## Summary

When Feishu plugin config is hot-reloaded, `registerFull()` is called again, causing all tools (doc, chat, wiki, drive, perm, bitable) and subagent hooks to be registered a second time.

Add a module-level `toolsRegistered` flag that short-circuits `registerFull()` after the first successful call.

## Changes

- `extensions/feishu/index.ts`: Add `toolsRegistered` guard to prevent duplicate tool registration on config hot-reload.

## CI Note

The failing CI checks (`docx.account-selection.test.ts` and `voice-call/outbound.test.ts`) are **pre-existing failures on `main`** — they reproduce on a clean checkout of `main` with no changes applied. They are unrelated to this PR.

Closes #56114