### PR TITLE
Telegram: show model display names instead of raw IDs in /models selector

### DIFF
--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -21,5 +21,6 @@ export function createModelsProviderData(
       provider: defaultProvider,
       model: entries[defaultProvider]?.[0] ?? "gpt-4o",
     },
+    modelNames: new Map<string, string>(),
   };
 }

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -23,6 +23,7 @@ const data = {
     provider: "anthropic",
     model: "claude-opus-4-5",
   },
+  modelNames: new Map<string, string>(),
 };
 
 describe("Mattermost model picker", () => {
@@ -154,6 +155,7 @@ describe("Mattermost model picker", () => {
           provider: "openai",
           model: "gpt-5",
         },
+        modelNames: new Map<string, string>(),
       };
 
       expect(

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -16,7 +16,7 @@ const mockState = vi.hoisted(() => ({
     team_id: "team-1",
   })),
   resolveCommandText: vi.fn((_trigger: string, text: string) => text),
-  buildModelsProviderData: vi.fn(async () => ({ providers: [] })),
+  buildModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
   resolveMattermostModelPickerEntry: vi.fn(() => ({ kind: "summary" })),
   authorizeMattermostCommandInvocation: vi.fn(() => ({
     ok: true,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1366,7 +1366,7 @@ export const registerTelegramHandlers = ({
           runtimeCfg,
           sessionState.agentId,
         );
-        const { byProvider, providers } = modelData;
+        const { byProvider, providers, modelNames } = modelData;
 
         const editMessageWithButtons = async (
           text: string,
@@ -1441,6 +1441,7 @@ export const registerTelegramHandlers = ({
             currentPage: safePage,
             totalPages,
             pageSize,
+            modelNames,
           });
           const text = formatModelsAvailableHeader({
             provider,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -32,6 +32,7 @@ const buildModelsProviderData = vi.hoisted(() =>
     byProvider: new Map<string, Set<string>>(),
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-test" },
+    modelNames: new Map<string, string>(),
   })),
 );
 const listSkillCommandsForAgents = vi.hoisted(() => vi.fn(() => []));

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -112,6 +112,7 @@ export function createNativeCommandTestParams(
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+      modelNames: new Map<string, string>(),
     })) as TelegramBotDeps["buildModelsProviderData"],
     listSkillCommandsForAgents,
     wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -209,6 +209,7 @@ function registerAndResolveCommandHandlerBase(params: {
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+      modelNames: new Map<string, string>(),
     })),
     listSkillCommandsForAgents: vi.fn(() => []),
     wasSentByBot: vi.fn(() => false),

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -126,6 +126,7 @@ export function createNativeCommandsHarness(params?: {
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+      modelNames: new Map<string, string>(),
     })),
     listSkillCommandsForAgents: vi.fn(() => []),
     wasSentByBot: vi.fn(() => false),

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -205,6 +205,7 @@ function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
   byProvider: Map<string, Set<string>>;
   providers: string[];
   resolvedDefault: { provider: string; model: string };
+  modelNames: Map<string, string>;
 } {
   const byProvider = new Map<string, Set<string>>();
   const add = (providerRaw: string | undefined, modelRaw: string | undefined) => {
@@ -227,7 +228,7 @@ function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
   }
 
   const providers = [...byProvider.keys()].toSorted();
-  return { byProvider, providers, resolvedDefault };
+  return { byProvider, providers, resolvedDefault, modelNames: new Map() };
 }
 
 vi.doMock("openclaw/plugin-sdk/command-auth", async (importOriginal) => {

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -160,6 +160,7 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
     byProvider: new Map<string, Set<string>>(),
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+    modelNames: new Map<string, string>(),
   })) as TelegramBotDeps["buildModelsProviderData"],
   listSkillCommandsForAgents: vi.fn(() => []) as TelegramBotDeps["listSkillCommandsForAgents"],
   wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -261,6 +261,49 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("displays model name from modelNames map instead of raw ID", () => {
+    const modelNames = new Map([
+      ["e8ccc8aa-1d76-47a3-acf6-0448a72347d8", "Nexos Gpt 5 2"],
+      ["claude-sonnet-4", "Claude Sonnet 4"],
+    ]);
+    const result = buildModelsKeyboard({
+      provider: "nexos",
+      models: ["e8ccc8aa-1d76-47a3-acf6-0448a72347d8"],
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+    // Model button should show the name, not the UUID
+    expect(result[0]?.[0]?.text).toBe("Nexos Gpt 5 2");
+    // Callback data should still use the model ID
+    expect(result[0]?.[0]?.callback_data).toContain("e8ccc8aa-1d76-47a3-acf6-0448a72347d8");
+  });
+
+  it("falls back to model ID when modelNames has no entry", () => {
+    const modelNames = new Map([["other-model", "Other Model"]]);
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["claude-sonnet-4"],
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+    expect(result[0]?.[0]?.text).toBe("claude-sonnet-4");
+  });
+
+  it("marks current model with check when using modelNames", () => {
+    const modelNames = new Map([["claude-sonnet-4", "Claude Sonnet 4"]]);
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["claude-sonnet-4"],
+      currentModel: "anthropic/claude-sonnet-4",
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+    expect(result[0]?.[0]?.text).toBe("Claude Sonnet 4 ✓");
+  });
+
   it("keeps short display IDs untouched and truncates overly long IDs", () => {
     const cases = [
       {

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -33,6 +33,8 @@ export type ModelsKeyboardParams = {
   currentPage: number;
   totalPages: number;
   pageSize?: number;
+  /** Optional map from model ID to human-readable display name. */
+  modelNames?: ReadonlyMap<string, string>;
 };
 
 const MODELS_PAGE_SIZE = 8;
@@ -180,7 +182,7 @@ export function buildProviderKeyboard(providers: ProviderInfo[]): ButtonRow[] {
  * Build model list keyboard with pagination and back button.
  */
 export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
-  const { provider, models, currentModel, currentPage, totalPages } = params;
+  const { provider, models, currentModel, currentPage, totalPages, modelNames } = params;
   const pageSize = params.pageSize ?? MODELS_PAGE_SIZE;
 
   if (models.length === 0) {
@@ -207,7 +209,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     }
 
     const isCurrentModel = model === currentModelId;
-    const displayText = truncateModelId(model, 38);
+    const displayLabel = modelNames?.get(model) ?? model;
+    const displayText = truncateModelId(displayLabel, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 
     rows.push([

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -28,6 +28,8 @@ export type ModelsProviderData = {
   byProvider: Map<string, Set<string>>;
   providers: string[];
   resolvedDefault: { provider: string; model: string };
+  /** Map from model ID to human-readable display name (when different from ID). */
+  modelNames: Map<string, string>;
 };
 
 /**
@@ -58,6 +60,7 @@ export async function buildModelsProviderData(
   });
 
   const byProvider = new Map<string, Set<string>>();
+  const modelNames = new Map<string, string>();
   const add = (p: string, m: string) => {
     const key = normalizeProviderId(p);
     const set = byProvider.get(key) ?? new Set<string>();
@@ -105,6 +108,9 @@ export async function buildModelsProviderData(
 
   for (const entry of allowed.allowedCatalog) {
     add(entry.provider, entry.id);
+    if (entry.name && entry.name !== entry.id) {
+      modelNames.set(entry.id, entry.name);
+    }
   }
 
   // Include config-only allowlist keys that aren't in the curated catalog.
@@ -119,7 +125,7 @@ export async function buildModelsProviderData(
 
   const providers = [...byProvider.keys()].toSorted();
 
-  return { byProvider, providers, resolvedDefault };
+  return { byProvider, providers, resolvedDefault, modelNames };
 }
 
 function formatProviderLine(params: { provider: string; count: number }): string {
@@ -234,7 +240,10 @@ export async function resolveModelsCommandReply(params: {
   const argText = body.replace(/^\/models\b/i, "").trim();
   const { provider, page, pageSize, all } = parseModelsArgs(argText);
 
-  const { byProvider, providers } = await buildModelsProviderData(params.cfg, params.agentId);
+  const { byProvider, providers, modelNames } = await buildModelsProviderData(
+    params.cfg,
+    params.agentId,
+  );
   const isTelegram = params.surface === "telegram";
 
   // Provider list (no provider specified)
@@ -310,6 +319,7 @@ export async function resolveModelsCommandReply(params: {
       currentPage: safePage,
       totalPages,
       pageSize: telegramPageSize,
+      modelNames,
     });
 
     const text = formatModelsAvailableHeader({


### PR DESCRIPTION
## Summary

Fixes #56165

When using `/models` in Telegram, the model selector buttons displayed raw model IDs (e.g. UUIDs like `e8ccc8aa-1d76-47a3-acf6-0448a72347d8` for Nexos provider) instead of the configured human-readable names (e.g. "Nexos Gpt 5 2").

## Root Cause

`buildModelsKeyboard` received only model ID strings and passed them directly to `truncateModelId()` for display text. There was no mechanism to look up a model's configured display name.

## Changes

- **`extensions/telegram/src/model-buttons.ts`**: Added optional `modelNames` map (`ReadonlyMap<string, string>`) to `ModelsKeyboardParams`. When present, the display text uses the mapped name instead of the raw model ID. Callback data still uses the model ID for selection logic.
- **`src/auto-reply/reply/commands-models.ts`**: Added `modelNames` field to `ModelsProviderData`. During `buildModelsProviderData`, catalog entries with a `name` different from their `id` are recorded in the map. The map is passed through to `buildModelsKeyboard` on the Telegram path.
- **`extensions/telegram/src/bot-handlers.runtime.ts`**: Destructures `modelNames` from model data and passes it to `buildModelsKeyboard`.
- **Test updates**: Added 3 new test cases covering name display, fallback to ID, and current-model checkmark with names. Updated all mock `buildModelsProviderData` implementations across Telegram, Discord, and Mattermost test harnesses to include the new `modelNames` field.

## Testing

- `pnpm test -- extensions/telegram/src/model-buttons.test.ts` — 23/23 passed
- `pnpm test -- extensions/discord/src/monitor/native-command.model-picker.test.ts` — 8/8 passed