### PR TITLE
fix: display model name instead of ID in Telegram model selector (#56165)

### DIFF
--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -21,5 +21,6 @@ export function createModelsProviderData(
       provider: defaultProvider,
       model: entries[defaultProvider]?.[0] ?? "gpt-4o",
     },
+    modelNames: new Map<string, string>(),
   };
 }

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -23,6 +23,7 @@ const data = {
     provider: "anthropic",
     model: "claude-opus-4-5",
   },
+  modelNames: new Map<string, string>(),
 };
 
 describe("Mattermost model picker", () => {
@@ -154,6 +155,7 @@ describe("Mattermost model picker", () => {
           provider: "openai",
           model: "gpt-5",
         },
+        modelNames: new Map<string, string>(),
       };
 
       expect(

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -16,7 +16,7 @@ const mockState = vi.hoisted(() => ({
     team_id: "team-1",
   })),
   resolveCommandText: vi.fn((_trigger: string, text: string) => text),
-  buildModelsProviderData: vi.fn(async () => ({ providers: [] })),
+  buildModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
   resolveMattermostModelPickerEntry: vi.fn(() => ({ kind: "summary" })),
   authorizeMattermostCommandInvocation: vi.fn(() => ({
     ok: true,

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1366,7 +1366,7 @@ export const registerTelegramHandlers = ({
           runtimeCfg,
           sessionState.agentId,
         );
-        const { byProvider, providers } = modelData;
+        const { byProvider, providers, modelNames } = modelData;
 
         const editMessageWithButtons = async (
           text: string,
@@ -1441,6 +1441,7 @@ export const registerTelegramHandlers = ({
             currentPage: safePage,
             totalPages,
             pageSize,
+            modelNames,
           });
           const text = formatModelsAvailableHeader({
             provider,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -32,6 +32,7 @@ const buildModelsProviderData = vi.hoisted(() =>
     byProvider: new Map<string, Set<string>>(),
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-test" },
+    modelNames: new Map<string, string>(),
   })),
 );
 const listSkillCommandsForAgents = vi.hoisted(() => vi.fn(() => []));

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -112,6 +112,7 @@ export function createNativeCommandTestParams(
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+      modelNames: new Map<string, string>(),
     })) as TelegramBotDeps["buildModelsProviderData"],
     listSkillCommandsForAgents,
     wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -209,6 +209,7 @@ function registerAndResolveCommandHandlerBase(params: {
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+      modelNames: new Map<string, string>(),
     })),
     listSkillCommandsForAgents: vi.fn(() => []),
     wasSentByBot: vi.fn(() => false),

--- a/extensions/telegram/src/bot-native-commands.test-helpers.ts
+++ b/extensions/telegram/src/bot-native-commands.test-helpers.ts
@@ -126,6 +126,7 @@ export function createNativeCommandsHarness(params?: {
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+      modelNames: new Map<string, string>(),
     })),
     listSkillCommandsForAgents: vi.fn(() => []),
     wasSentByBot: vi.fn(() => false),

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -205,6 +205,7 @@ function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
   byProvider: Map<string, Set<string>>;
   providers: string[];
   resolvedDefault: { provider: string; model: string };
+  modelNames: Map<string, string>;
 } {
   const byProvider = new Map<string, Set<string>>();
   const add = (providerRaw: string | undefined, modelRaw: string | undefined) => {
@@ -227,7 +228,7 @@ function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
   }
 
   const providers = [...byProvider.keys()].toSorted();
-  return { byProvider, providers, resolvedDefault };
+  return { byProvider, providers, resolvedDefault, modelNames: new Map<string, string>() };
 }
 
 vi.doMock("openclaw/plugin-sdk/command-auth", async (importOriginal) => {

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -160,6 +160,7 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
     byProvider: new Map<string, Set<string>>(),
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-4.1" },
+    modelNames: new Map<string, string>(),
   })) as TelegramBotDeps["buildModelsProviderData"],
   listSkillCommandsForAgents: vi.fn(() => []) as TelegramBotDeps["listSkillCommandsForAgents"],
   wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -225,8 +225,8 @@ describe("buildModelsKeyboard", () => {
 
   it("uses modelNames for display text when provided", () => {
     const modelNames = new Map([
-      ["a1b2c3d4-e5f6-7890-abcd-ef1234567890", "Claude Sonnet 4"],
-      ["claude-opus-4", "Claude Opus 4"],
+      ["nexos/a1b2c3d4-e5f6-7890-abcd-ef1234567890", "Claude Sonnet 4"],
+      ["nexos/claude-opus-4", "Claude Opus 4"],
     ]);
     const result = buildModelsKeyboard({
       provider: "nexos",
@@ -246,7 +246,7 @@ describe("buildModelsKeyboard", () => {
   });
 
   it("falls back to model ID when modelNames does not contain an entry", () => {
-    const modelNames = new Map([["known-id", "Known Model"]]);
+    const modelNames = new Map([["anthropic/known-id", "Known Model"]]);
     const result = buildModelsKeyboard({
       provider: "anthropic",
       models: ["known-id", "unknown-id"],
@@ -256,6 +256,31 @@ describe("buildModelsKeyboard", () => {
     });
     expect(result[0]?.[0]?.text).toBe("Known Model");
     expect(result[1]?.[0]?.text).toBe("unknown-id");
+  });
+
+  it("uses provider-scoped modelNames keys to avoid cross-provider collisions", () => {
+    const modelNames = new Map([
+      ["openai/shared-id", "OpenAI Shared"],
+      ["anthropic/shared-id", "Anthropic Shared"],
+    ]);
+
+    const openaiResult = buildModelsKeyboard({
+      provider: "openai",
+      models: ["shared-id"],
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+    const anthropicResult = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["shared-id"],
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+
+    expect(openaiResult[0]?.[0]?.text).toBe("OpenAI Shared");
+    expect(anthropicResult[0]?.[0]?.text).toBe("Anthropic Shared");
   });
 
   it("renders pagination controls for first, middle, and last pages", () => {

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -223,6 +223,41 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("uses modelNames for display text when provided", () => {
+    const modelNames = new Map([
+      ["a1b2c3d4-e5f6-7890-abcd-ef1234567890", "Claude Sonnet 4"],
+      ["claude-opus-4", "Claude Opus 4"],
+    ]);
+    const result = buildModelsKeyboard({
+      provider: "nexos",
+      models: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890", "claude-opus-4"],
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+    // 2 model rows + back button
+    expect(result).toHaveLength(3);
+    expect(result[0]?.[0]?.text).toBe("Claude Sonnet 4");
+    expect(result[1]?.[0]?.text).toBe("Claude Opus 4");
+    // callback_data still uses the raw model ID, not the display name
+    expect(result[0]?.[0]?.callback_data).toBe(
+      "mdl_sel_nexos/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    );
+  });
+
+  it("falls back to model ID when modelNames does not contain an entry", () => {
+    const modelNames = new Map([["known-id", "Known Model"]]);
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["known-id", "unknown-id"],
+      currentPage: 1,
+      totalPages: 1,
+      modelNames,
+    });
+    expect(result[0]?.[0]?.text).toBe("Known Model");
+    expect(result[1]?.[0]?.text).toBe("unknown-id");
+  });
+
   it("renders pagination controls for first, middle, and last pages", () => {
     const cases = [
       {

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -33,8 +33,8 @@ export type ModelsKeyboardParams = {
   currentPage: number;
   totalPages: number;
   pageSize?: number;
-  /** Optional map from model ID to display name. When provided, the display
-   *  name is shown on the button instead of the raw model ID. */
+  /** Optional map from provider/model to display name. When provided, the
+   *  display name is shown on the button instead of the raw model ID. */
   modelNames?: ReadonlyMap<string, string>;
 };
 
@@ -210,7 +210,7 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     }
 
     const isCurrentModel = model === currentModelId;
-    const displayLabel = modelNames?.get(model) ?? model;
+    const displayLabel = modelNames?.get(`${provider}/${model}`) ?? model;
     const displayText = truncateModelId(displayLabel, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -33,6 +33,9 @@ export type ModelsKeyboardParams = {
   currentPage: number;
   totalPages: number;
   pageSize?: number;
+  /** Optional map from model ID to display name. When provided, the display
+   *  name is shown on the button instead of the raw model ID. */
+  modelNames?: ReadonlyMap<string, string>;
 };
 
 const MODELS_PAGE_SIZE = 8;
@@ -180,7 +183,7 @@ export function buildProviderKeyboard(providers: ProviderInfo[]): ButtonRow[] {
  * Build model list keyboard with pagination and back button.
  */
 export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
-  const { provider, models, currentModel, currentPage, totalPages } = params;
+  const { provider, models, currentModel, currentPage, totalPages, modelNames } = params;
   const pageSize = params.pageSize ?? MODELS_PAGE_SIZE;
 
   if (models.length === 0) {
@@ -207,7 +210,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     }
 
     const isCurrentModel = model === currentModelId;
-    const displayText = truncateModelId(model, 38);
+    const displayLabel = modelNames?.get(model) ?? model;
+    const displayText = truncateModelId(displayLabel, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 
     rows.push([

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -28,6 +28,8 @@ export type ModelsProviderData = {
   byProvider: Map<string, Set<string>>;
   providers: string[];
   resolvedDefault: { provider: string; model: string };
+  /** Map from model ID to human-readable display name (when different from ID). */
+  modelNames: Map<string, string>;
 };
 
 /**
@@ -119,7 +121,16 @@ export async function buildModelsProviderData(
 
   const providers = [...byProvider.keys()].toSorted();
 
-  return { byProvider, providers, resolvedDefault };
+  // Build a model-ID-to-display-name map from the catalog so UI surfaces can
+  // show human-readable names instead of raw IDs (e.g. UUIDs from Nexos).
+  const modelNames = new Map<string, string>();
+  for (const entry of catalog) {
+    if (entry.name && entry.name !== entry.id) {
+      modelNames.set(entry.id, entry.name);
+    }
+  }
+
+  return { byProvider, providers, resolvedDefault, modelNames };
 }
 
 function formatProviderLine(params: { provider: string; count: number }): string {
@@ -234,7 +245,10 @@ export async function resolveModelsCommandReply(params: {
   const argText = body.replace(/^\/models\b/i, "").trim();
   const { provider, page, pageSize, all } = parseModelsArgs(argText);
 
-  const { byProvider, providers } = await buildModelsProviderData(params.cfg, params.agentId);
+  const { byProvider, providers, modelNames } = await buildModelsProviderData(
+    params.cfg,
+    params.agentId,
+  );
   const isTelegram = params.surface === "telegram";
 
   // Provider list (no provider specified)
@@ -310,6 +324,7 @@ export async function resolveModelsCommandReply(params: {
       currentPage: safePage,
       totalPages,
       pageSize: telegramPageSize,
+      modelNames,
     });
 
     const text = formatModelsAvailableHeader({

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -28,7 +28,7 @@ export type ModelsProviderData = {
   byProvider: Map<string, Set<string>>;
   providers: string[];
   resolvedDefault: { provider: string; model: string };
-  /** Map from model ID to human-readable display name (when different from ID). */
+  /** Map from provider/model to human-readable display name (when different from model ID). */
   modelNames: Map<string, string>;
 };
 
@@ -121,12 +121,12 @@ export async function buildModelsProviderData(
 
   const providers = [...byProvider.keys()].toSorted();
 
-  // Build a model-ID-to-display-name map from the catalog so UI surfaces can
-  // show human-readable names instead of raw IDs (e.g. UUIDs from Nexos).
+  // Build a provider-scoped model display-name map so surfaces can show
+  // human-readable names without colliding across providers that share IDs.
   const modelNames = new Map<string, string>();
   for (const entry of catalog) {
     if (entry.name && entry.name !== entry.id) {
-      modelNames.set(entry.id, entry.name);
+      modelNames.set(`${normalizeProviderId(entry.provider)}/${entry.id}`, entry.name);
     }
   }
 


### PR DESCRIPTION
## Summary
- Telegram `/models` keyboard now shows the configured model `name` (e.g. "Nexos Gpt 5 2") instead of raw IDs/UUIDs
- Added `modelNames` map to `ModelsProviderData` populated from the model catalog
- `buildModelsKeyboard` prefers `modelNames.get(id) ?? id` for display text; callback data still uses raw ID
- Includes tests verifying name display and fallback behavior

## Test plan
- [x] Existing 22 model-buttons tests pass
- [x] New tests: verify name is displayed when available, falls back to ID when not
- [ ] Manual: configure a provider with UUID model IDs and readable names, verify `/models` shows names

Closes #56165