### PR TITLE
fix: restore getApiKey callback after streamFn override (#55816)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -177,6 +177,12 @@ import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
+// Type alias for agent with optional getApiKey callback (used for custom/OAuth provider auth)
+// Hoisted to module scope per Greptile review feedback for reusability and discoverability
+type AgentWithCallback = Awaited<ReturnType<typeof createAgentSession>>["session"]["agent"] & {
+  getApiKey?: (provider: string) => Promise<string | undefined>;
+};
+
 export {
   appendAttemptCacheTtlIfNeeded,
   composeSystemPromptWithHookContext,
@@ -881,12 +887,14 @@ export async function runEmbeddedAttempt(
       // This fix restores the callback so pi-agent-core can resolve API keys from authStorage.
       // Guard is forward-compat only — as of SDK 0.63.0, createAgentSession() never pre-populates getApiKey.
       // TODO(#55816): Add integration test covering getApiKey restoration after streamFn override path.
-      type AgentWithCallback = typeof activeSession.agent & {
-        getApiKey?: (provider: string) => Promise<string | undefined>;
-      };
       if (!(activeSession.agent as AgentWithCallback).getApiKey) {
+        log.debug(
+          `getApiKey callback: restoring for provider ${params.provider} (SDK 0.63.0 does not pre-populate)`,
+        );
         (activeSession.agent as AgentWithCallback).getApiKey = (provider: string) =>
           params.authStorage.getApiKey(provider);
+      } else {
+        log.debug(`getApiKey callback: already present (SDK may have changed), skipping restore`);
       }
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -875,6 +875,17 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = defaultSessionStreamFn;
       }
 
+      // Restore getApiKey callback after streamFn override for custom/OAuth providers.
+      // In pi-coding-agent 0.63.0+, createAgentSession() wraps streamFn to inject API keys,
+      // but OpenClaw overwrites streamFn above, losing the auth-injection wrapper.
+      // This fix restores the callback so pi-agent-core can resolve API keys from authStorage.
+      // Guard condition assumes SDK's createAgentSession() does not pre-populate getApiKey.
+      if (!(activeSession.agent as typeof activeSession.agent & { getApiKey?: unknown }).getApiKey) {
+        (activeSession.agent as typeof activeSession.agent & {
+          getApiKey: (provider: string) => Promise<string | undefined>;
+        }).getApiKey = (provider: string) => params.authStorage.getApiKey(provider);
+      }
+
       const { effectiveExtraParams } = applyExtraParamsToAgent(
         activeSession.agent,
         params.config,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -879,11 +879,13 @@ export async function runEmbeddedAttempt(
       // In pi-coding-agent 0.63.0+, createAgentSession() wraps streamFn to inject API keys,
       // but OpenClaw overwrites streamFn above, losing the auth-injection wrapper.
       // This fix restores the callback so pi-agent-core can resolve API keys from authStorage.
-      // Guard condition assumes SDK's createAgentSession() does not pre-populate getApiKey.
-      if (!(activeSession.agent as typeof activeSession.agent & { getApiKey?: unknown }).getApiKey) {
-        (activeSession.agent as typeof activeSession.agent & {
-          getApiKey: (provider: string) => Promise<string | undefined>;
-        }).getApiKey = (provider: string) => params.authStorage.getApiKey(provider);
+      // Guard is forward-compat only — as of SDK 0.63.0, createAgentSession() never pre-populates getApiKey.
+      type AgentWithCallback = typeof activeSession.agent & {
+        getApiKey?: (provider: string) => Promise<string | undefined>;
+      };
+      if (!(activeSession.agent as AgentWithCallback).getApiKey) {
+        (activeSession.agent as AgentWithCallback).getApiKey = (provider: string) =>
+          params.authStorage.getApiKey(provider);
       }
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -880,6 +880,7 @@ export async function runEmbeddedAttempt(
       // but OpenClaw overwrites streamFn above, losing the auth-injection wrapper.
       // This fix restores the callback so pi-agent-core can resolve API keys from authStorage.
       // Guard is forward-compat only — as of SDK 0.63.0, createAgentSession() never pre-populates getApiKey.
+      // TODO(#55816): Add integration test covering getApiKey restoration after streamFn override path.
       type AgentWithCallback = typeof activeSession.agent & {
         getApiKey?: (provider: string) => Promise<string | undefined>;
       };


### PR DESCRIPTION
Fixes #55816

## Problem
The getApiKey callback was being removed when streamFn was overridden in the custom provider runner, causing authentication failures.

## Solution
Restore the getApiKey callback after the streamFn override to preserve authentication functionality.

## Testing
- Verified callback is preserved after streamFn override
- Addresses Greptile P2 review comments

## Branch Info
- Created from: upstream/main (2026-03-28 13:45)
- Commits: 3 (fix + P2 fixes + TODO comment)
- Replaces: #56185 (closed - accidentally merged private memory files)