### PR TITLE
fix(plugins): clear matrix-js-sdk entrypoint flag before jiti plugin loads

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -851,6 +851,21 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     return loader;
   };
 
+  // matrix-js-sdk sets globalThis.__js_sdk_entrypoint on first import and throws
+  // on any subsequent import. When the dist bundle already loaded it, jiti-loaded
+  // plugins hit the guard even if they don't use matrix themselves. Wrap the jiti
+  // loader to temporarily clear the flag during module resolution.
+  const loadWithJiti = (modulePath: string) => {
+    const g = globalThis as Record<string, unknown>;
+    const saved = g.__js_sdk_entrypoint;
+    g.__js_sdk_entrypoint = undefined;
+    try {
+      return getJiti(modulePath)(modulePath);
+    } finally {
+      g.__js_sdk_entrypoint = saved;
+    }
+  };
+
   let createPluginRuntimeFactory: ((options?: CreatePluginRuntimeOptions) => PluginRuntime) | null =
     null;
   const resolveCreatePluginRuntime = (): ((
@@ -865,7 +880,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (!runtimeModulePath) {
       throw new Error("Unable to resolve plugin runtime module");
     }
-    const runtimeModule = getJiti(runtimeModulePath)(runtimeModulePath) as {
+    const runtimeModule = loadWithJiti(runtimeModulePath) as {
       createPluginRuntime?: (options?: CreatePluginRuntimeOptions) => PluginRuntime;
     };
     if (typeof runtimeModule.createPluginRuntime !== "function") {
@@ -1198,7 +1213,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      mod = loadWithJiti(safeSource) as OpenClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,


### PR DESCRIPTION
## Summary

- Fix `Multiple matrix-js-sdk entrypoints detected!` error that prevents **all** plugins from loading when running from source (dev environment)
- `matrix-js-sdk` sets `globalThis.__js_sdk_entrypoint` on first import and throws on any subsequent import. When the dist bundle already loaded it, jiti-loaded plugins hit the guard even if they don't depend on matrix themselves
- Wraps jiti load calls in `loadOpenClawPlugins` to temporarily clear the flag during module resolution, then restore it

Related: #50868, #50581

## Test plan

- [x] `pnpm build` passes
- [x] `openclaw channels list` loads all plugins without errors (previously all 5 plugins failed)
- [x] `openclaw gateway run` starts successfully with Telegram channel connected
- [x] Verified the fix only affects the jiti (dev/source) loading path; npm-installed users are not impacted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>