### PR TITLE
fix: enable internal hooks by default

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -14725,7 +14725,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
     },
     "hooks.internal.enabled": {
       label: "Internal Hooks Enabled",
-      help: "Enables processing for internal hook handlers and configured entries in the internal hook runtime. Keep disabled unless internal hook handlers are intentionally configured.",
+      help: "Enables processing for internal hook handlers and configured entries in the internal hook runtime. Enabled by default when not explicitly set.",
       tags: ["advanced"],
     },
     "hooks.internal.handlers": {

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -65,8 +65,8 @@ export async function loadInternalHooks(
     bundledHooksDir?: string;
   },
 ): Promise<number> {
-  // Check if hooks are enabled
-  if (!cfg.hooks?.internal?.enabled) {
+  // Internal hooks are enabled by default; only skip when explicitly disabled
+  if (cfg.hooks?.internal?.enabled === false) {
     return 0;
   }
 
@@ -153,7 +153,7 @@ export async function loadInternalHooks(
   }
 
   // 2. Load legacy config handlers (backwards compatibility)
-  const handlers = cfg.hooks.internal.handlers ?? [];
+  const handlers = cfg.hooks?.internal?.handlers ?? [];
   for (const handlerConfig of handlers) {
     try {
       // Legacy handler paths: keep them workspace-relative.

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -375,7 +375,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       source: record.source,
     });
 
-    const hookSystemEnabled = config?.hooks?.internal?.enabled === true;
+    const hookSystemEnabled = config?.hooks?.internal?.enabled !== false;
     if (!hookSystemEnabled || opts?.register === false) {
       return;
     }

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -528,7 +528,7 @@ export function collectAttackSurfaceSummaryFindings(cfg: OpenClawConfig): Securi
   const group = summarizeGroupPolicy(cfg);
   const elevated = cfg.tools?.elevated?.enabled !== false;
   const webhooksEnabled = cfg.hooks?.enabled === true;
-  const internalHooksEnabled = cfg.hooks?.internal?.enabled === true;
+  const internalHooksEnabled = cfg.hooks?.internal?.enabled !== false;
   const browserEnabled = cfg.browser?.enabled ?? true;
 
   const detail =


### PR DESCRIPTION
## Summary

Fixes #55929

Internal hooks (including `session-memory`) are not loaded on fresh installs because `hooks.internal.enabled` defaults to `undefined`, and the loader checks `!cfg.hooks?.internal?.enabled` which is `true` for `undefined`.

This breaks `/new` and `/reset` session-memory saving.

## Changes

- **src/hooks/loader.ts**: Changed `if (!cfg.hooks?.internal?.enabled)` to `if (cfg.hooks?.internal?.enabled === false)` — internal hooks are now enabled by default (opt-out)
- **src/plugins/registry.ts**: Changed `=== true` to `!== false` for consistency
- **src/security/audit-extra.sync.ts**: Same change for audit reporting
- **src/config/schema.base.generated.ts**: Updated help text to reflect default-enabled behavior

## Testing

Fresh install users no longer need to explicitly run `openclaw config set hooks.internal.enabled true` to get session-memory hooks working.