### PR TITLE
fix(plugins): reuse active registry for sub-agent tool resolution

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3645,6 +3645,75 @@ describe("resolveRuntimePluginRegistry", () => {
 
     expect(resolveRuntimePluginRegistry()).toBe(registry);
   });
+
+  it("falls back to the active registry when the caller is not gateway-scoped and cache keys differ", () => {
+    const registry = createEmptyPluginRegistry();
+    // Simulate gateway startup: load with onlyPluginIds + coreGatewayHandlers
+    const gatewayOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      onlyPluginIds: ["telegram", "demo"],
+      coreGatewayHandlers: {
+        "sessions.get": () => undefined,
+      },
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    const { cacheKey: gatewayKey } = __testing.resolvePluginLoadCacheContext(gatewayOptions);
+    setActivePluginRegistry(registry, gatewayKey);
+
+    // Sub-agent tool resolution: same config/workspace but no gateway-specific fields.
+    // Cache key will differ, but the active registry should still be returned.
+    const toolOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    expect(resolveRuntimePluginRegistry(toolOptions)).toBe(registry);
+  });
+
+  it("does not fall back to the active registry when the caller uses gateway-scoped options", () => {
+    const registry = createEmptyPluginRegistry();
+    const gatewayOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      onlyPluginIds: ["telegram"],
+      coreGatewayHandlers: {
+        "sessions.get": () => undefined,
+      },
+    };
+    const { cacheKey: gatewayKey } = __testing.resolvePluginLoadCacheContext(gatewayOptions);
+    setActivePluginRegistry(registry, gatewayKey);
+
+    // A different gateway-scoped load should NOT fall back to the active registry.
+    const differentGatewayOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      onlyPluginIds: ["discord"],
+    };
+    // This will attempt loadOpenClawPlugins which will fail since plugins
+    // are disabled in test env, but we verify it does NOT return the gateway registry.
+    expect(resolveRuntimePluginRegistry(differentGatewayOptions)).not.toBe(registry);
+  });
 });
 
 describe("clearPluginLoaderCache", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -157,6 +157,7 @@ export const __testing = {
   resolvePluginRuntimeModulePath,
   shouldPreferNativeJiti,
   getCompatibleActivePluginRegistry,
+  isGatewayScopedLoad,
   resolvePluginLoadCacheContext,
   get maxPluginRegistryCacheEntries() {
     return pluginRegistryCacheEntryCap;
@@ -305,6 +306,22 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   };
 }
 
+/**
+ * Returns true when the load options include gateway-specific fields that
+ * restrict or reshape the plugin set (onlyPluginIds, coreGatewayHandlers,
+ * includeSetupOnlyChannelPlugins, preferSetupRuntimeForChannelPlugins).
+ * When these are absent the caller wants the full plugin set and the active
+ * gateway registry is a safe superset.
+ */
+function isGatewayScopedLoad(options: PluginLoadOptions): boolean {
+  return Boolean(
+    options.onlyPluginIds?.length ||
+    options.coreGatewayHandlers ||
+    options.includeSetupOnlyChannelPlugins ||
+    options.preferSetupRuntimeForChannelPlugins,
+  );
+}
+
 function getCompatibleActivePluginRegistry(
   options: PluginLoadOptions = {},
 ): PluginRegistry | undefined {
@@ -330,7 +347,22 @@ export function resolveRuntimePluginRegistry(
   if (!options || !hasExplicitCompatibilityInputs(options)) {
     return getCompatibleActivePluginRegistry();
   }
-  return getCompatibleActivePluginRegistry(options) ?? loadOpenClawPlugins(options);
+  const compatible = getCompatibleActivePluginRegistry(options);
+  if (compatible) {
+    return compatible;
+  }
+  // When the caller does not restrict the plugin set with gateway-specific
+  // fields (onlyPluginIds, coreGatewayHandlers, etc.), the active registry
+  // set during gateway startup is a safe superset of what the caller needs.
+  // Reuse it to avoid a redundant load that may miss already-activated
+  // plugin state (tool registrations, hooks, memory providers).
+  if (!isGatewayScopedLoad(options)) {
+    const active = getActivePluginRegistry();
+    if (active) {
+      return active;
+    }
+  }
+  return loadOpenClawPlugins(options);
 }
 
 function validatePluginConfig(params: {


### PR DESCRIPTION
## Summary

When a sub-agent session starts, `createOpenClawTools()` resolves the tool list before `loadOpenClawPlugins()` has run for that session context. Plugin-registered tools (e.g. honcho memory tools) miss the resolution window entirely and appear as "unknown entries" in the allowlist.

The gateway start flow works correctly because plugins load during `gateway_start` before any session resolves tools — the active registry already has everything.

## Root Cause

`resolveRuntimePluginRegistry()` compares cache keys to decide whether to reuse the active registry. Sub-agent callers pass different options (no `onlyPluginIds`, no `coreGatewayHandlers`) which produces a different cache key — so the active registry is bypassed and a fresh `loadOpenClawPlugins()` is triggered too late.

## Fix

Add an `isGatewayScopedLoad()` check: when the caller does **not** restrict the plugin set with gateway-specific fields (`onlyPluginIds`, `coreGatewayHandlers`, `includeSetupOnlyChannelPlugins`, `preferSetupRuntimeForChannelPlugins`), the active registry set during gateway startup is a safe superset. Reuse it directly instead of falling through to a redundant load.

This is the minimal change — one new predicate function and a fallback path in `resolveRuntimePluginRegistry()`.

## Changes

- `src/plugins/loader.ts` — add `isGatewayScopedLoad()` helper; update `resolveRuntimePluginRegistry()` to fall back to active registry for non-gateway-scoped callers
- `src/plugins/loader.test.ts` — two new test cases covering the fallback and the non-fallback paths

## Test Plan

- [x] `pnpm tsgo` — 0 type errors
- [x] `pnpm lint` — 0 warnings/errors
- [x] `pnpm build` — clean

Fixes #56208