### PR TITLE
fix(cli): respect current agent workspace for skills install (#56161)

### DIFF
--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentIdByWorkspacePath,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import {
   installSkillFromClawHub,
   readTrackedClawHubSkillSlugs,
@@ -42,6 +46,14 @@ async function runSkillsAction(render: (report: SkillStatusReport) => string): P
 
 function resolveActiveWorkspaceDir(): string {
   const config = loadConfig();
+  const cwd = process.cwd();
+  // Check if current working directory is within a configured agent workspace.
+  // This allows `openclaw skills install` to work from sub-agent workspaces.
+  const agentId = resolveAgentIdByWorkspacePath(config, cwd);
+  if (agentId) {
+    return resolveAgentWorkspaceDir(config, agentId);
+  }
+  // Fall back to default agent workspace.
   return resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
 }
 


### PR DESCRIPTION
Fixes #56161

## Problem
`openclaw skills install` always installs to the default agent workspace (`~/.openclaw/workspace/skills/`), ignoring the current working directory. This prevents users from installing skills to sub-agent workspaces.

## Steps to Reproduce
1. Configure multiple agents (e.g., main and writer)
2. Navigate to writer agent's workspace: `cd ~/.openclaw/workspace-writer`
3. Run: `openclaw skills install content-writer`
4. Observe skill is installed to `~/.openclaw/workspace/skills/` instead of `~/.openclaw/workspace-writer/skills/`

## Root Cause
`resolveActiveWorkspaceDir()` in `src/cli/skills-cli.ts` always uses `resolveDefaultAgentId(config)`, ignoring the current working directory.

## Solution
Check if current working directory is within a configured agent workspace using `resolveAgentIdByWorkspacePath()`. If yes, use that agent's workspace. Otherwise, fall back to default agent workspace.

## Changes
- `src/cli/skills-cli.ts`: Updated `resolveActiveWorkspaceDir()` to detect current agent workspace from cwd
- Added import of `resolveAgentIdByWorkspacePath` from `../agents/agent-scope.js`

## Testing
- Type check: ✅ Passed
- Lint: ✅ Passed
- Manual test: Run `openclaw skills install` from a sub-agent workspace directory

## Branch Info
- Created from: upstream/main (2026-03-28)
- Files changed: 1 (src/cli/skills-cli.ts)
- Lines: +13, -1