### PR TITLE
fix(discord): recover components v2 text in reply context

### DIFF
--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -652,6 +652,42 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toBe("hello from content");
   });
 
+  it("uses components v2 text when content is empty", () => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "",
+        components: [
+          {
+            components: [
+              { content: "## Approval needed" },
+              { content: "Run this command" },
+            ],
+          },
+        ],
+      }) as Message,
+    );
+
+    expect(text).toBe("## Approval needed\nRun this command");
+  });
+
+  it("uses forwarded snapshot components v2 text when snapshot content is empty", () => {
+    const text = resolveDiscordMessageText(
+      asForwardedSnapshotMessage({
+        content: "",
+        embeds: [],
+        components: [
+          {
+            components: [{ content: "Forwarded approval details" }],
+          },
+        ],
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toContain("[Forwarded message from @Bob]");
+    expect(text).toContain("Forwarded approval details");
+  });
+
   it("joins forwarded snapshot embed title and description when content is empty", () => {
     const text = resolveDiscordMessageText(
       asForwardedSnapshotMessage({

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -86,6 +86,7 @@ type DiscordSnapshotMessage = {
   attachments?: APIAttachment[] | null;
   stickers?: APIStickerItem[] | null;
   sticker_items?: APIStickerItem[] | null;
+  components?: unknown;
   author?: DiscordSnapshotAuthor | null;
 };
 
@@ -509,8 +510,10 @@ export function resolveDiscordMessageText(
     (message.embeds?.[0] as { title?: string | null; description?: string | null } | undefined) ??
       null,
   );
+  const componentText = resolveDiscordMessageComponentText(message);
   const rawText =
     message.content?.trim() ||
+    componentText ||
     buildDiscordMediaPlaceholder({
       attachments: message.attachments ?? undefined,
       stickers: resolveDiscordMessageStickers(message),
@@ -592,12 +595,65 @@ function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapsho
 
 function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): string {
   const content = snapshot.content?.trim() ?? "";
+  const componentText = resolveDiscordComponentText(snapshot.components);
   const attachmentText = buildDiscordMediaPlaceholder({
     attachments: snapshot.attachments ?? undefined,
     stickers: resolveDiscordSnapshotStickers(snapshot),
   });
   const embedText = resolveDiscordEmbedText(snapshot.embeds?.[0]);
-  return content || attachmentText || embedText || "";
+  return content || componentText || attachmentText || embedText || "";
+}
+
+function resolveDiscordMessageComponentText(message: Message): string {
+  const rawData = (message as { rawData?: { components?: unknown } }).rawData;
+  const directComponents = (message as { components?: unknown }).components;
+  return resolveDiscordComponentText(rawData?.components ?? directComponents);
+}
+
+function resolveDiscordComponentText(value: unknown): string {
+  const fragments: string[] = [];
+  const visit = (node: unknown) => {
+    if (!node) {
+      return;
+    }
+    if (typeof node === "string") {
+      const trimmed = node.trim();
+      if (trimmed) {
+        fragments.push(trimmed);
+      }
+      return;
+    }
+    if (Array.isArray(node)) {
+      for (const entry of node) {
+        visit(entry);
+      }
+      return;
+    }
+    if (typeof node !== "object") {
+      return;
+    }
+    const record = node as Record<string, unknown>;
+    if (typeof record.content === "string") {
+      visit(record.content);
+    }
+    if (typeof record.text === "string") {
+      visit(record.text);
+    }
+    if (Array.isArray(record.texts)) {
+      visit(record.texts);
+    }
+    if (Array.isArray(record.components)) {
+      visit(record.components);
+    }
+    if (Array.isArray(record.items)) {
+      visit(record.items);
+    }
+    if (record.accessory && typeof record.accessory === "object") {
+      visit(record.accessory);
+    }
+  };
+  visit(value);
+  return fragments.join("\n").trim();
 }
 
 function formatDiscordSnapshotAuthor(


### PR DESCRIPTION
## Summary
- recover text from Discord Components v2 payloads when `message.content` is empty
- apply the same fallback for forwarded snapshot messages used by reply-context/history resolution
- add regression tests for normal messages and forwarded snapshots

## Why
Issue #56228 reports that replies to Components v2-only Discord messages lose the referenced body text. That breaks reply context for approval cards / native UI messages that store their visible text in component `TextDisplay` blocks instead of `content`.

## Testing
- Added targeted regression tests in `extensions/discord/src/monitor/message-utils.test.ts`
- Tried running `pnpm test -- extensions/discord/src/monitor/message-utils.test.ts`, but local test execution hit an existing environment/bootstrap failure (`bundledChannelPlugins is not iterable`) before tests executed