### PR TITLE
feat(podman): add macOS support with optional --runas service user

### DIFF
--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -27,7 +27,35 @@ The intended model is:
 
 <Steps>
   <Step title="One-time setup">
-    From the repo root, run `./scripts/podman/setup.sh`.
+    From the repo root, run the setup script. By default it uses your current user, builds the container image, and writes config under `~/.openclaw`:
+
+    ```bash
+    ./scripts/podman/setup.sh
+    ```
+
+    This also creates a minimal config at `~/.openclaw/openclaw.json` (sets `gateway.mode` to `"local"`) so the Gateway can start without running the wizard.
+
+    By default the container is **not** installed as a systemd service -- you start it manually in the next step. For a production-style setup with auto-start and restarts, pass `--quadlet` instead:
+
+    ```bash
+    ./scripts/podman/setup.sh --quadlet
+    ```
+
+    (Or set `OPENCLAW_PODMAN_QUADLET=1`. Use `--container` to install only the container and launch script.)
+
+    To create and use a dedicated service user instead of your current user, pass `--runas`:
+
+    ```bash
+    ./scripts/podman/setup.sh --runas              # creates an "openclaw" user
+    ./scripts/podman/setup.sh --runas myuser        # creates a "myuser" user
+    ./scripts/podman/setup.sh --runas --quadlet     # service user + auto-start
+    ```
+
+    **Optional build-time env vars** (set before running `scripts/podman/setup.sh`):
+
+    - `OPENCLAW_DOCKER_APT_PACKAGES` -- install extra apt packages during image build.
+    - `OPENCLAW_EXTENSIONS` -- pre-install extension dependencies (space-separated names, e.g. `diagnostics-otel matrix`).
+
   </Step>
 
   <Step title="Start the Gateway container">
@@ -203,6 +231,14 @@ systemctl --user restart openclaw.service
 ```
 
 For boot persistence on SSH/headless hosts, enable lingering for your current user:
+
+### Dedicated service user (`--runas`)
+
+When you pass `--runas`, the setup script creates a dedicated non-login user:
+
+- **Shell:** `nologin` -- no interactive login; reduces attack surface.
+- **Home:** `/home/openclaw` (Linux) or `/Users/openclaw` (macOS) -- holds `~/.openclaw` (config, workspace) and the launch script `run-openclaw-podman.sh`.
+- **Rootless Podman:** On Linux, the user must have a **subuid** and **subgid** range. Many distros assign these automatically when the user is created. If setup prints a warning, add lines to `/etc/subuid` and `/etc/subgid`:
 
 ```bash
 sudo loginctl enable-linger "$(whoami)"

--- a/scripts/podman/setup.sh
+++ b/scripts/podman/setup.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
-# One-time host setup for rootless OpenClaw in Podman. Uses the current
-# non-root user throughout, builds or pulls the image into that user's Podman
-# store, writes config under ~/.openclaw by default, and uses the repo-local
+# One-time host setup for rootless OpenClaw in Podman. By default, uses the
+# current non-root user throughout, builds or pulls the image into that user's
+# Podman store, writes config under ~/.openclaw, and uses the repo-local
 # launch script at ./scripts/run-openclaw-podman.sh.
 #
-# Usage: ./scripts/podman/setup.sh [--quadlet|--container]
-#   --quadlet   Install a Podman Quadlet as the current user's systemd service
+# With --runas, creates a dedicated service user (default: openclaw), builds
+# the image, exports/loads it into that user's Podman store, and installs the
+# launch script into their home directory.
+#
+# Usage: ./scripts/podman/setup.sh [--quadlet|--container] [--runas [username]]
+#   --quadlet   Install as an auto-start service (systemd Quadlet on Linux, launchd on macOS)
 #   --container Only install image + config; you start the container manually (default)
+#   --runas [u] Create/use a dedicated service user (default: openclaw) instead of $USER
 #   Or set OPENCLAW_PODMAN_QUADLET=1 (or 0) to choose without a flag.
 #
 # After this, start the gateway manually:
 #   ./scripts/run-openclaw-podman.sh launch
-#   ./scripts/run-openclaw-podman.sh launch setup
+#   ./scripts/run-openclaw-podman.sh launch setup   # onboarding wizard
 # Or, if you used --quadlet:
 #   systemctl --user start openclaw.service
+# With --runas:
+#   Linux: sudo -u openclaw /home/openclaw/run-openclaw-podman.sh
+#   macOS: sudo -u openclaw /Users/openclaw/run-openclaw-podman.sh
+#   Quadlet (Linux): sudo systemctl --machine openclaw@ --user start openclaw.service
+#   Quadlet (macOS): sudo launchctl kickstart system/ai.openclaw.podman
 set -euo pipefail
 
 REPO_PATH="${OPENCLAW_REPO_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
@@ -25,9 +35,11 @@ OPENCLAW_CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-}"
 OPENCLAW_WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-}"
 OPENCLAW_IMAGE="${OPENCLAW_PODMAN_IMAGE:-${OPENCLAW_IMAGE:-openclaw:local}}"
 OPENCLAW_CONTAINER_NAME="${OPENCLAW_PODMAN_CONTAINER:-openclaw}"
-PLATFORM_NAME="$(uname -s 2>/dev/null || echo unknown)"
 HOST_GATEWAY_PORT="${OPENCLAW_PODMAN_GATEWAY_HOST_PORT:-${OPENCLAW_GATEWAY_PORT:-18789}}"
 QUADLET_GATEWAY_PORT="18789"
+
+OS_NAME="$(uname -s 2>/dev/null || echo unknown)"
+is_macos() { [[ "$OS_NAME" == "Darwin" ]]; }
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -36,7 +48,65 @@ require_cmd() {
   fi
 }
 
+is_writable_dir() {
+  local dir="$1"
+  [[ -n "$dir" && -d "$dir" && ! -L "$dir" && -w "$dir" && -x "$dir" ]]
+}
+
+stat_octal_mode() {
+  if is_macos; then
+    stat -f '%Lp' "$1" 2>/dev/null || true
+  else
+    stat -Lc '%a' "$1" 2>/dev/null || true
+  fi
+}
+
+stat_owner_uid() {
+  if is_macos; then
+    stat -f '%u' "$1" 2>/dev/null || true
+  else
+    stat -Lc '%u' "$1" 2>/dev/null || true
+  fi
+}
+
 is_root() { [[ "$(id -u)" -eq 0 ]]; }
+
+is_safe_tmp_base() {
+  local dir="$1"
+  local mode=""
+  local owner=""
+  is_writable_dir "$dir" || return 1
+  mode="$(stat_octal_mode "$dir")"
+  if [[ -n "$mode" ]]; then
+    local perm=$((8#$mode))
+    if (( (perm & 0022) != 0 && (perm & 01000) == 0 )); then
+      return 1
+    fi
+  fi
+  if is_root; then
+    owner="$(stat_owner_uid "$dir")"
+    if [[ -n "$owner" && "$owner" != "0" ]]; then
+      return 1
+    fi
+  fi
+  return 0
+}
+
+resolve_image_tmp_dir() {
+  if ! is_root && is_safe_tmp_base "${TMPDIR:-}"; then
+    printf '%s' "$TMPDIR"
+    return 0
+  fi
+  if is_safe_tmp_base "/var/tmp"; then
+    printf '%s' "/var/tmp"
+    return 0
+  fi
+  if is_safe_tmp_base "/tmp"; then
+    printf '%s' "/tmp"
+    return 0
+  fi
+  printf '%s' "/tmp"
+}
 
 fail() {
   echo "$*" >&2
@@ -167,14 +237,20 @@ escape_sed_replacement_pipe_delim() {
 resolve_user_home() {
   local user="$1"
   local home=""
-  if command -v getent >/dev/null 2>&1; then
+  if is_macos; then
+    home="$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || true)"
+  elif command -v getent >/dev/null 2>&1; then
     home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
   fi
   if [[ -z "$home" && -f /etc/passwd ]]; then
     home="$(awk -F: -v u="$user" '$1==u {print $6}' /etc/passwd 2>/dev/null || true)"
   fi
   if [[ -z "$home" ]]; then
-    home="/home/$user"
+    if is_macos; then
+      home="/Users/$user"
+    else
+      home="/home/$user"
+    fi
   fi
   printf '%s' "$home"
 }
@@ -297,12 +373,80 @@ upsert_env_var() {
   chmod 600 "$file" 2>/dev/null || true
 }
 
+# --- --runas helpers (only used when a dedicated service user is requested) ---
+
+run_root() {
+  if is_root; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+run_as_user() {
+  local user="$1"
+  shift
+  if command -v sudo >/dev/null 2>&1; then
+    ( cd /tmp 2>/dev/null || cd /; sudo -u "$user" "$@" )
+  elif is_root && command -v runuser >/dev/null 2>&1; then
+    ( cd /tmp 2>/dev/null || cd /; runuser -u "$user" -- "$@" )
+  else
+    echo "Need sudo (or root+runuser) to run commands as $user." >&2
+    exit 1
+  fi
+}
+
+run_as_service_user() {
+  run_as_user "$OPENCLAW_USER" env HOME="$OPENCLAW_HOME" "$@"
+}
+
+user_exists() {
+  local user="$1"
+  if command -v getent >/dev/null 2>&1; then
+    getent passwd "$user" >/dev/null 2>&1 && return 0
+  fi
+  id -u "$user" >/dev/null 2>&1
+}
+
+resolve_nologin_shell() {
+  for cand in /usr/bin/false /usr/sbin/nologin /sbin/nologin /usr/bin/nologin /bin/false; do
+    if [[ -x "$cand" ]]; then
+      printf '%s' "$cand"
+      return 0
+    fi
+  done
+  printf '%s' "/usr/sbin/nologin"
+}
+
+ensure_subid_entry() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    return 1
+  fi
+  grep -q "^${OPENCLAW_USER}:" "$file" 2>/dev/null
+}
+
+# --- Parse arguments ---
+
 INSTALL_QUADLET=false
-for arg in "$@"; do
-  case "$arg" in
-    --quadlet) INSTALL_QUADLET=true ;;
+RUNAS_MODE=false
+RUNAS_USER="openclaw"
+args=("$@")
+i=0
+while (( i < ${#args[@]} )); do
+  case "${args[$i]}" in
+    --quadlet)   INSTALL_QUADLET=true ;;
     --container) INSTALL_QUADLET=false ;;
+    --runas)
+      RUNAS_MODE=true
+      # If next arg exists and doesn't start with --, treat it as username
+      if (( i+1 < ${#args[@]} )) && [[ "${args[$((i+1))]}" != --* ]]; then
+        RUNAS_USER="${args[$((i+1))]}"
+        ((i++))
+      fi
+      ;;
   esac
+  ((i++))
 done
 if [[ -n "${OPENCLAW_PODMAN_QUADLET:-}" ]]; then
   case "${OPENCLAW_PODMAN_QUADLET,,}" in
@@ -310,8 +454,18 @@ if [[ -n "${OPENCLAW_PODMAN_QUADLET:-}" ]]; then
     0|no|false) INSTALL_QUADLET=false ;;
   esac
 fi
-if [[ "$INSTALL_QUADLET" == true && "$PLATFORM_NAME" != "Linux" ]]; then
-  fail "--quadlet is only supported on Linux with systemd user services."
+
+# Override user when --runas is active
+if [[ "$RUNAS_MODE" == true ]]; then
+  OPENCLAW_USER="$RUNAS_USER"
+fi
+
+# Quadlet guard: without --runas, only Linux systemd is supported.
+# With --runas, macOS uses launchd and Linux uses systemd.
+if [[ "$INSTALL_QUADLET" == true && "$RUNAS_MODE" == false ]]; then
+  if ! [[ "$OS_NAME" == "Linux" ]]; then
+    fail "--quadlet without --runas is only supported on Linux with systemd user services."
+  fi
 fi
 
 SEED_GATEWAY_PORT="$HOST_GATEWAY_PORT"
@@ -319,11 +473,21 @@ if [[ "$INSTALL_QUADLET" == true ]]; then
   SEED_GATEWAY_PORT="$QUADLET_GATEWAY_PORT"
 fi
 
+# --- Pre-flight checks ---
+
 require_cmd podman
-if is_root; then
-  echo "Run scripts/podman/setup.sh as your normal user so Podman stays rootless." >&2
-  exit 1
+
+if [[ "$RUNAS_MODE" == false ]]; then
+  if is_root; then
+    echo "Run scripts/podman/setup.sh as your normal user so Podman stays rootless." >&2
+    exit 1
+  fi
+else
+  if ! is_root; then
+    require_cmd sudo
+  fi
 fi
+
 if [[ "$OPENCLAW_IMAGE" == "openclaw:local" ]] && [[ ! -f "$REPO_PATH/Dockerfile" ]]; then
   echo "Dockerfile not found at $REPO_PATH. Set OPENCLAW_REPO_PATH to the repo root." >&2
   exit 1
@@ -333,7 +497,60 @@ if [[ ! -f "$RUN_SCRIPT_SRC" ]]; then
   exit 1
 fi
 
-if [[ -z "$OPENCLAW_HOME" ]]; then
+# --- --runas: create dedicated service user if needed ---
+
+if [[ "$RUNAS_MODE" == true ]]; then
+  if ! user_exists "$OPENCLAW_USER"; then
+    NOLOGIN_SHELL="$(resolve_nologin_shell)"
+    echo "Creating user $OPENCLAW_USER ($NOLOGIN_SHELL, with home)..."
+    if is_macos; then
+      MACOS_UID=""
+      EXISTING_UIDS="$(dscl . -list /Users UniqueID 2>/dev/null | awk '{print $2}')"
+      for candidate_uid in $(seq 400 499); do
+        if ! printf '%s\n' "$EXISTING_UIDS" | grep -qx "$candidate_uid"; then
+          MACOS_UID="$candidate_uid"
+          break
+        fi
+      done
+      if [[ -z "$MACOS_UID" ]]; then
+        echo "Could not find a free system UID (400-499) on macOS." >&2
+        exit 1
+      fi
+      MACOS_HOME="/Users/$OPENCLAW_USER"
+      run_root dscl . -create "/Users/$OPENCLAW_USER"
+      run_root dscl . -create "/Users/$OPENCLAW_USER" UserShell "$NOLOGIN_SHELL"
+      run_root dscl . -create "/Users/$OPENCLAW_USER" UniqueID "$MACOS_UID"
+      run_root dscl . -create "/Users/$OPENCLAW_USER" PrimaryGroupID "$MACOS_UID"
+      run_root dscl . -create "/Users/$OPENCLAW_USER" NFSHomeDirectory "$MACOS_HOME"
+      run_root dscl . -create "/Users/$OPENCLAW_USER" RealName "OpenClaw Service"
+      if ! dscl . -read "/Groups/$OPENCLAW_USER" PrimaryGroupID &>/dev/null; then
+        run_root dscl . -create "/Groups/$OPENCLAW_USER"
+        run_root dscl . -create "/Groups/$OPENCLAW_USER" PrimaryGroupID "$MACOS_UID"
+        run_root dscl . -append "/Groups/$OPENCLAW_USER" GroupMembership "$OPENCLAW_USER"
+      fi
+      run_root mkdir -p "$MACOS_HOME"
+      run_root chown "$MACOS_UID:$MACOS_UID" "$MACOS_HOME"
+      run_root chmod 700 "$MACOS_HOME"
+      run_root dscl . -create "/Users/$OPENCLAW_USER" IsHidden 1
+    elif command -v useradd >/dev/null 2>&1; then
+      run_root useradd -m -s "$NOLOGIN_SHELL" "$OPENCLAW_USER"
+    elif command -v adduser >/dev/null 2>&1; then
+      run_root adduser --disabled-password --gecos "" --shell "$NOLOGIN_SHELL" "$OPENCLAW_USER"
+    else
+      echo "Neither useradd nor adduser found, cannot create user $OPENCLAW_USER." >&2
+      exit 1
+    fi
+  else
+    echo "User $OPENCLAW_USER already exists."
+  fi
+fi
+
+# --- Resolve home/config paths ---
+
+# In --runas mode, always resolve home from the service user, not the invoker.
+if [[ "$RUNAS_MODE" == true ]]; then
+  OPENCLAW_HOME="$(resolve_user_home "$OPENCLAW_USER")"
+elif [[ -z "$OPENCLAW_HOME" ]]; then
   OPENCLAW_HOME="$(resolve_user_home "$OPENCLAW_USER")"
 fi
 if [[ -z "$OPENCLAW_HOME" ]]; then
@@ -354,9 +571,44 @@ validate_image_name "$OPENCLAW_IMAGE"
 validate_port "gateway host port" "$HOST_GATEWAY_PORT"
 validate_port "seed gateway port" "$SEED_GATEWAY_PORT"
 
-install -d -m 700 "$OPENCLAW_CONFIG_DIR" "$OPENCLAW_WORKSPACE_DIR"
-ensure_private_existing_dir_owned_by_user "config directory" "$OPENCLAW_CONFIG_DIR"
-ensure_private_existing_dir_owned_by_user "workspace directory" "$OPENCLAW_WORKSPACE_DIR"
+# --- --runas: Linux lingering, subuid/subgid, create dirs as service user ---
+
+if [[ "$RUNAS_MODE" == true ]]; then
+  OPENCLAW_UID="$(id -u "$OPENCLAW_USER" 2>/dev/null || true)"
+
+  # Linux: enable systemd lingering and prepare /run/user runtime dirs
+  if ! is_macos; then
+    if command -v loginctl &>/dev/null; then
+      run_root loginctl enable-linger "$OPENCLAW_USER" 2>/dev/null || true
+    fi
+    if [[ -n "${OPENCLAW_UID:-}" && -d /run/user ]] && command -v systemctl &>/dev/null; then
+      if [[ ! -d "/run/user/$OPENCLAW_UID" ]]; then
+        run_root install -d -m 700 -o "$OPENCLAW_UID" -g "$OPENCLAW_UID" "/run/user/$OPENCLAW_UID" || true
+      fi
+      run_root mkdir -p "/run/user/$OPENCLAW_UID/containers" || true
+      run_root chown "$OPENCLAW_UID:$OPENCLAW_UID" "/run/user/$OPENCLAW_UID/containers" || true
+      run_root chmod 700 "/run/user/$OPENCLAW_UID/containers" || true
+    fi
+  fi
+
+  # Linux: check subuid/subgid (macOS Podman uses a VM)
+  if ! is_macos; then
+    if ! ensure_subid_entry /etc/subuid || ! ensure_subid_entry /etc/subgid; then
+      echo "WARNING: ${OPENCLAW_USER} may not have subuid/subgid ranges configured." >&2
+      echo "If rootless Podman fails, add '${OPENCLAW_USER}:100000:65536' to both /etc/subuid and /etc/subgid." >&2
+    fi
+  fi
+
+  # Create dirs owned by service user
+  run_root install -d -m 700 -o "$OPENCLAW_UID" -g "$OPENCLAW_UID" "$OPENCLAW_HOME" "$OPENCLAW_CONFIG_DIR"
+  run_root install -d -m 700 -o "$OPENCLAW_UID" -g "$OPENCLAW_UID" "$OPENCLAW_WORKSPACE_DIR"
+else
+  install -d -m 700 "$OPENCLAW_CONFIG_DIR" "$OPENCLAW_WORKSPACE_DIR"
+  ensure_private_existing_dir_owned_by_user "config directory" "$OPENCLAW_CONFIG_DIR"
+  ensure_private_existing_dir_owned_by_user "workspace directory" "$OPENCLAW_WORKSPACE_DIR"
+fi
+
+# --- Build / pull image ---
 
 BUILD_ARGS=()
 if [[ -n "${OPENCLAW_DOCKER_APT_PACKAGES:-}" ]]; then
@@ -366,37 +618,97 @@ if [[ -n "${OPENCLAW_EXTENSIONS:-}" ]]; then
   BUILD_ARGS+=(--build-arg "OPENCLAW_EXTENSIONS=${OPENCLAW_EXTENSIONS}")
 fi
 
-if [[ "$OPENCLAW_IMAGE" == "openclaw:local" ]]; then
-  echo "Building image $OPENCLAW_IMAGE ..."
-  podman build -t "$OPENCLAW_IMAGE" -f "$REPO_PATH/Dockerfile" "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}" "$REPO_PATH"
-else
-  if podman image exists "$OPENCLAW_IMAGE" >/dev/null 2>&1; then
-    echo "Using existing image $OPENCLAW_IMAGE"
+if [[ "$RUNAS_MODE" == true ]]; then
+  # Build or pull as current user, export to tar, load into service user's store
+  IMAGE_TMP_BASE="$(resolve_image_tmp_dir)"
+  echo "Using temp base for image export: $IMAGE_TMP_BASE"
+  IMAGE_TAR_DIR="$(mktemp -d "${IMAGE_TMP_BASE%/}/openclaw-podman-image.XXXXXX")"
+  chmod 711 "$IMAGE_TAR_DIR"
+  IMAGE_TAR="$IMAGE_TAR_DIR/openclaw-image.tar"
+  cleanup_image_tar() {
+    rm -rf "$IMAGE_TAR_DIR"
+  }
+  trap cleanup_image_tar EXIT
+
+  if [[ "$OPENCLAW_IMAGE" == "openclaw:local" ]]; then
+    echo "Building image $OPENCLAW_IMAGE ..."
+    podman build -t "$OPENCLAW_IMAGE" -f "$REPO_PATH/Dockerfile" "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}" "$REPO_PATH"
   else
-    echo "Pulling image $OPENCLAW_IMAGE ..."
-    podman pull "$OPENCLAW_IMAGE"
+    if podman image exists "$OPENCLAW_IMAGE" >/dev/null 2>&1; then
+      echo "Using existing image $OPENCLAW_IMAGE"
+    else
+      echo "Pulling image $OPENCLAW_IMAGE ..."
+      podman pull "$OPENCLAW_IMAGE"
+    fi
+  fi
+  echo "Saving image to $IMAGE_TAR ..."
+  podman save -o "$IMAGE_TAR" "$OPENCLAW_IMAGE"
+  chmod 644 "$IMAGE_TAR"
+
+  echo "Loading image into $OPENCLAW_USER Podman store..."
+  run_as_service_user podman load -i "$IMAGE_TAR"
+
+  # Install launch script into service user's home
+  LAUNCH_SCRIPT_DST="$OPENCLAW_HOME/run-openclaw-podman.sh"
+  echo "Installing launch script to $LAUNCH_SCRIPT_DST ..."
+  run_root install -m 0755 -o "$OPENCLAW_UID" -g "$OPENCLAW_UID" "$RUN_SCRIPT_SRC" "$LAUNCH_SCRIPT_DST"
+else
+  if [[ "$OPENCLAW_IMAGE" == "openclaw:local" ]]; then
+    echo "Building image $OPENCLAW_IMAGE ..."
+    podman build -t "$OPENCLAW_IMAGE" -f "$REPO_PATH/Dockerfile" "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}" "$REPO_PATH"
+  else
+    if podman image exists "$OPENCLAW_IMAGE" >/dev/null 2>&1; then
+      echo "Using existing image $OPENCLAW_IMAGE"
+    else
+      echo "Pulling image $OPENCLAW_IMAGE ..."
+      podman pull "$OPENCLAW_IMAGE"
+    fi
   fi
 fi
 
+# --- Env file + config ---
+
 ENV_FILE="$OPENCLAW_CONFIG_DIR/.env"
-if [[ ! -f "$ENV_FILE" ]]; then
-  TOKEN="$(generate_token_hex_32)"
-  (
-    umask 077
-    write_file_atomically "$ENV_FILE" 600 <<EOF
+if [[ "$RUNAS_MODE" == true ]]; then
+  if [[ ! -f "$ENV_FILE" ]]; then
+    TOKEN="$(generate_token_hex_32)"
+    run_as_service_user sh -lc "umask 077 && printf '%s\n' 'OPENCLAW_GATEWAY_TOKEN=$TOKEN' > '$ENV_FILE'"
+    echo "Generated OPENCLAW_GATEWAY_TOKEN and wrote it to $ENV_FILE"
+  fi
+  # Persist image/container names so the launch script uses the same values.
+  # Use the host-side upsert_env_var via run_root since the env file is owned
+  # by the service user and we already have elevated privileges in --runas mode.
+  run_root sh -c "chmod 600 '$ENV_FILE' 2>/dev/null || true"
+  upsert_env_var "$ENV_FILE" "OPENCLAW_PODMAN_CONTAINER" "$OPENCLAW_CONTAINER_NAME"
+  upsert_env_var "$ENV_FILE" "OPENCLAW_PODMAN_IMAGE" "$OPENCLAW_IMAGE"
+  run_root chown "$OPENCLAW_UID:$OPENCLAW_UID" "$ENV_FILE"
+
+  CONFIG_JSON="$OPENCLAW_CONFIG_DIR/openclaw.json"
+  if [[ ! -f "$CONFIG_JSON" ]]; then
+    run_as_service_user sh -lc "umask 077 && cat > '$CONFIG_JSON' <<'JSON'
+{ \"gateway\": { \"mode\": \"local\" } }
+JSON"
+    echo "Wrote minimal config to $CONFIG_JSON"
+  fi
+else
+  if [[ ! -f "$ENV_FILE" ]]; then
+    TOKEN="$(generate_token_hex_32)"
+    (
+      umask 077
+      write_file_atomically "$ENV_FILE" 600 <<EOF
 OPENCLAW_GATEWAY_TOKEN=$TOKEN
 EOF
-  )
-  echo "Generated OPENCLAW_GATEWAY_TOKEN and wrote it to $ENV_FILE"
-fi
-upsert_env_var "$ENV_FILE" "OPENCLAW_PODMAN_CONTAINER" "$OPENCLAW_CONTAINER_NAME"
-upsert_env_var "$ENV_FILE" "OPENCLAW_PODMAN_IMAGE" "$OPENCLAW_IMAGE"
+    )
+    echo "Generated OPENCLAW_GATEWAY_TOKEN and wrote it to $ENV_FILE"
+  fi
+  upsert_env_var "$ENV_FILE" "OPENCLAW_PODMAN_CONTAINER" "$OPENCLAW_CONTAINER_NAME"
+  upsert_env_var "$ENV_FILE" "OPENCLAW_PODMAN_IMAGE" "$OPENCLAW_IMAGE"
 
-CONFIG_JSON="$OPENCLAW_CONFIG_DIR/openclaw.json"
-if [[ ! -f "$CONFIG_JSON" ]]; then
-  (
-    umask 077
-    write_file_atomically "$CONFIG_JSON" 600 <<JSON
+  CONFIG_JSON="$OPENCLAW_CONFIG_DIR/openclaw.json"
+  if [[ ! -f "$CONFIG_JSON" ]]; then
+    (
+      umask 077
+      write_file_atomically "$CONFIG_JSON" 600 <<JSON
 {
   "gateway": {
     "mode": "local",
@@ -409,46 +721,127 @@ if [[ ! -f "$CONFIG_JSON" ]]; then
   }
 }
 JSON
-  )
-  echo "Wrote minimal config to $CONFIG_JSON"
+    )
+    echo "Wrote minimal config to $CONFIG_JSON"
+  fi
+  seed_local_control_ui_origins "$CONFIG_JSON" "$SEED_GATEWAY_PORT"
 fi
-seed_local_control_ui_origins "$CONFIG_JSON" "$SEED_GATEWAY_PORT"
+
+# --- Quadlet / service installation ---
 
 if [[ "$INSTALL_QUADLET" == true ]]; then
-  QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
-  QUADLET_DST="$QUADLET_DIR/openclaw.container"
-  echo "Installing Quadlet to $QUADLET_DST ..."
-  mkdir -p "$QUADLET_DIR"
-  ensure_safe_existing_dir "quadlet directory" "$QUADLET_DIR"
-  OPENCLAW_HOME_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_HOME")"
-  OPENCLAW_CONFIG_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_CONFIG_DIR")"
-  OPENCLAW_WORKSPACE_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_WORKSPACE_DIR")"
-  OPENCLAW_IMAGE_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_IMAGE")"
-  OPENCLAW_CONTAINER_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_CONTAINER_NAME")"
-  sed \
-    -e "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_ESCAPED|g" \
-    -e "s|{{OPENCLAW_CONFIG_DIR}}|$OPENCLAW_CONFIG_ESCAPED|g" \
-    -e "s|{{OPENCLAW_WORKSPACE_DIR}}|$OPENCLAW_WORKSPACE_ESCAPED|g" \
-    -e "s|{{IMAGE_NAME}}|$OPENCLAW_IMAGE_ESCAPED|g" \
-    -e "s|{{CONTAINER_NAME}}|$OPENCLAW_CONTAINER_ESCAPED|g" \
-    "$QUADLET_TEMPLATE" | write_file_atomically "$QUADLET_DST" 644
-
-  if command -v systemctl >/dev/null 2>&1; then
-    echo "Reloading and starting user service..."
-    if systemctl --user daemon-reload && systemctl --user start openclaw.service; then
-      echo "Quadlet installed and service started."
+  if [[ "$RUNAS_MODE" == true ]]; then
+    if is_macos; then
+      # macOS: install a LaunchDaemon so it starts at boot without requiring
+      # the service user to have a GUI session. UserName drops privileges.
+      LAUNCHD_PLIST_DIR="/Library/LaunchDaemons"
+      LAUNCHD_PLIST_DST="$LAUNCHD_PLIST_DIR/ai.openclaw.podman.plist"
+      LAUNCH_SCRIPT_DST="$OPENCLAW_HOME/run-openclaw-podman.sh"
+      PLIST_TMP="$(mktemp "/tmp/ai.openclaw.podman.plist.XXXXXX")"
+      echo "Installing launchd plist to $LAUNCHD_PLIST_DST ..."
+      cat > "$PLIST_TMP" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.openclaw.podman</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${LAUNCH_SCRIPT_DST}</string>
+    <string>launch</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>UserName</key>
+  <string>${OPENCLAW_USER}</string>
+  <key>StandardOutPath</key>
+  <string>${OPENCLAW_HOME}/.openclaw/openclaw-podman.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>${OPENCLAW_HOME}/.openclaw/openclaw-podman.stderr.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>${OPENCLAW_HOME}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>
+PLIST
+      run_root install -m 0644 -o root -g wheel "$PLIST_TMP" "$LAUNCHD_PLIST_DST"
+      rm -f "$PLIST_TMP"
+      echo "Loading launchd service..."
+      run_root launchctl bootstrap system/ "$LAUNCHD_PLIST_DST" 2>/dev/null || \
+        run_root launchctl load "$LAUNCHD_PLIST_DST" 2>/dev/null || true
+      echo "launchd daemon installed and service loaded."
     else
-      echo "Quadlet installed, but automatic start failed." >&2
-      echo "Try: systemctl --user daemon-reload && systemctl --user start openclaw.service" >&2
-      if command -v loginctl >/dev/null 2>&1; then
-        echo "For boot persistence on headless hosts, you may also need: sudo loginctl enable-linger $(whoami)" >&2
-      fi
+      # Linux --runas: install quadlet for the service user
+      QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
+      QUADLET_DST="$QUADLET_DIR/openclaw.container"
+      echo "Installing Quadlet to $QUADLET_DST ..."
+      run_as_service_user mkdir -p "$QUADLET_DIR"
+      OPENCLAW_HOME_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_HOME")"
+      OPENCLAW_CONFIG_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_CONFIG_DIR")"
+      OPENCLAW_WORKSPACE_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_WORKSPACE_DIR")"
+      OPENCLAW_IMAGE_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_IMAGE")"
+      OPENCLAW_CONTAINER_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_CONTAINER_NAME")"
+      sed \
+        -e "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_ESCAPED|g" \
+        -e "s|{{OPENCLAW_CONFIG_DIR}}|$OPENCLAW_CONFIG_ESCAPED|g" \
+        -e "s|{{OPENCLAW_WORKSPACE_DIR}}|$OPENCLAW_WORKSPACE_ESCAPED|g" \
+        -e "s|{{IMAGE_NAME}}|$OPENCLAW_IMAGE_ESCAPED|g" \
+        -e "s|{{CONTAINER_NAME}}|$OPENCLAW_CONTAINER_ESCAPED|g" \
+        "$QUADLET_TEMPLATE" | \
+        run_as_service_user sh -lc "cat > '$QUADLET_DST'"
+      run_as_service_user chmod 0644 "$QUADLET_DST"
+
+      echo "Reloading and enabling user service..."
+      run_root systemctl --machine "${OPENCLAW_USER}@" --user daemon-reload
+      run_root systemctl --machine "${OPENCLAW_USER}@" --user enable --now openclaw.service
+      echo "Quadlet installed and service started."
     fi
   else
-    echo "systemctl not found; Quadlet installed but not started." >&2
+    # Default path: install quadlet as current user's systemd service
+    QUADLET_DIR="$OPENCLAW_HOME/.config/containers/systemd"
+    QUADLET_DST="$QUADLET_DIR/openclaw.container"
+    echo "Installing Quadlet to $QUADLET_DST ..."
+    mkdir -p "$QUADLET_DIR"
+    ensure_safe_existing_dir "quadlet directory" "$QUADLET_DIR"
+    OPENCLAW_HOME_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_HOME")"
+    OPENCLAW_CONFIG_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_CONFIG_DIR")"
+    OPENCLAW_WORKSPACE_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_WORKSPACE_DIR")"
+    OPENCLAW_IMAGE_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_IMAGE")"
+    OPENCLAW_CONTAINER_ESCAPED="$(escape_sed_replacement_pipe_delim "$OPENCLAW_CONTAINER_NAME")"
+    sed \
+      -e "s|{{OPENCLAW_HOME}}|$OPENCLAW_HOME_ESCAPED|g" \
+      -e "s|{{OPENCLAW_CONFIG_DIR}}|$OPENCLAW_CONFIG_ESCAPED|g" \
+      -e "s|{{OPENCLAW_WORKSPACE_DIR}}|$OPENCLAW_WORKSPACE_ESCAPED|g" \
+      -e "s|{{IMAGE_NAME}}|$OPENCLAW_IMAGE_ESCAPED|g" \
+      -e "s|{{CONTAINER_NAME}}|$OPENCLAW_CONTAINER_ESCAPED|g" \
+      "$QUADLET_TEMPLATE" | write_file_atomically "$QUADLET_DST" 644
+
+    if command -v systemctl >/dev/null 2>&1; then
+      echo "Reloading and starting user service..."
+      if systemctl --user daemon-reload && systemctl --user start openclaw.service; then
+        echo "Quadlet installed and service started."
+      else
+        echo "Quadlet installed, but automatic start failed." >&2
+        echo "Try: systemctl --user daemon-reload && systemctl --user start openclaw.service" >&2
+        if command -v loginctl >/dev/null 2>&1; then
+          echo "For boot persistence on headless hosts, you may also need: sudo loginctl enable-linger $(whoami)" >&2
+        fi
+      fi
+    else
+      echo "systemctl not found; Quadlet installed but not started." >&2
+    fi
   fi
 else
-  echo "Container setup complete."
+  if [[ "$RUNAS_MODE" == true ]]; then
+    echo "Container + launch script installed."
+  else
+    echo "Container setup complete."
+  fi
 fi
 
 echo
@@ -456,3 +849,6 @@ echo "Next:"
 echo "  ./scripts/run-openclaw-podman.sh launch"
 echo "  ./scripts/run-openclaw-podman.sh launch setup"
 echo "  openclaw --container $OPENCLAW_CONTAINER_NAME dashboard --no-open"
+if is_macos; then
+  echo "  For auto-start: ./scripts/podman/setup.sh --quadlet --runas (installs a launchd plist)."
+fi

--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -10,23 +10,34 @@
 #   openclaw --container openclaw dashboard --no-open
 #   openclaw --container openclaw channels login
 #
+# If running as a dedicated service user (see setup.sh --runas):
+#   Linux: sudo -u openclaw /home/openclaw/run-openclaw-podman.sh [setup]
+#   macOS: sudo -u openclaw /Users/openclaw/run-openclaw-podman.sh [setup]
+#
 # Legacy: "setup-host" delegates to the Podman setup script
 
 set -euo pipefail
 
 PLATFORM_NAME="$(uname -s 2>/dev/null || echo unknown)"
+OS_NAME="$PLATFORM_NAME"
 
 resolve_user_home() {
   local user="$1"
   local home=""
-  if command -v getent >/dev/null 2>&1; then
+  if [[ "$OS_NAME" == "Darwin" ]]; then
+    home="$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '{print $2}' || true)"
+  elif command -v getent >/dev/null 2>&1; then
     home="$(getent passwd "$user" 2>/dev/null | cut -d: -f6 || true)"
   fi
   if [[ -z "$home" && -f /etc/passwd ]]; then
     home="$(awk -F: -v u="$user" '$1==u {print $6}' /etc/passwd 2>/dev/null || true)"
   fi
   if [[ -z "$home" ]]; then
-    home="/home/$user"
+    if [[ "$OS_NAME" == "Darwin" ]]; then
+      home="/Users/$user"
+    else
+      home="/home/$user"
+    fi
   fi
   printf '%s' "$home"
 }
@@ -569,6 +580,4 @@ if [[ "$PLATFORM_NAME" == "Darwin" ]]; then
   echo "  Then open http://127.0.0.1:28889/"
   echo "  Note: find <podman-vm-ssh-port> with: podman system connection list"
 fi
-if [[ "$PLATFORM_NAME" == "Linux" ]]; then
-  echo "For auto-start/restarts, use: ./scripts/podman/setup.sh --quadlet (Quadlet + systemd user service)."
-fi
+echo "For auto-start/restarts, use: ./scripts/podman/setup.sh --quadlet (systemd Quadlet on Linux, launchd on macOS)."


### PR DESCRIPTION
## Summary

- Adds macOS support to the Podman setup and launch scripts (dscl user creation, launchd plist for auto-start, Darwin-aware helpers throughout)
- Introduces `--runas [username]` flag (defaults to `openclaw`) as an opt-in dedicated service user mode, while keeping the default path running as `$USER` (upstream's simpler approach)
- Updates `docs/install/podman.md` with `--runas` documentation and examples
- Syncs runtime-api guardrail baselines for `chunkTextForOutbound` export (pre-existing drift)

## Design

**Default (no flags):** Runs as `$USER`, builds/pulls image directly into current user's Podman store, systemd `--user` quadlet on Linux.

**`--runas [username]`:** Creates a dedicated non-login service user (dscl on macOS, useradd/adduser on Linux), exports image to tar and loads into service user's store, installs launch script in service user's home, supports launchd plist on macOS and systemd `--machine` quadlet on Linux.

## Test plan

- [ ] Verify `./scripts/podman/setup.sh` works on Linux without `--runas` (default path)
- [ ] Verify `./scripts/podman/setup.sh --runas` creates dedicated user on Linux
- [ ] Verify `./scripts/podman/setup.sh --runas` creates dedicated user on macOS via dscl
- [ ] Verify `./scripts/podman/setup.sh --quadlet` installs systemd user service on Linux
- [ ] Verify `./scripts/podman/setup.sh --runas --quadlet` installs launchd plist on macOS
- [ ] Verify `pnpm test -- src/plugin-sdk/runtime-api-guardrails.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)