### PR TITLE
fix: add feishu to hooks.mappings[].channel allowed values

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -1266,6 +1266,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                           toolSchemaProfile: {
                             type: "string",
                           },
+                          unsupportedToolSchemaKeywords: {
+                            type: "array",
+                            items: {
+                              type: "string",
+                              minLength: 1,
+                            },
+                          },
                           nativeWebSearchTool: {
                             type: "boolean",
                           },
@@ -9250,6 +9257,10 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                     {
                       type: "string",
                       const: "msteams",
+                    },
+                    {
+                      type: "string",
+                      const: "feishu",
                     },
                   ],
                 },

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -60,6 +60,7 @@ export const HookMappingSchema = z
         z.literal("signal"),
         z.literal("imessage"),
         z.literal("msteams"),
+        z.literal("feishu"),
       ])
       .optional(),
     to: z.string().optional(),


### PR DESCRIPTION
## Problem

`hooks.mappings[].channel` rejects valid runtime channel plugins like `feishu` during config parsing (#56226). Even when the feishu channel plugin is properly configured under `channels`, adding `"channel": "feishu"` to a hook mapping causes a config validation error.

## Root Cause

The channel field in `HookMappingSchema` (`src/config/zod-schema.hooks.ts`) uses a zod union of string literals to define valid channels. The list includes whatsapp, telegram, discord, irc, slack, signal, imessage, msteams, but omits `feishu` (and likely other newer channel plugins like googlechat, matrix, etc.).

## Fix

Added `z.literal("feishu")` to the channel union in `HookMappingSchema`. Regenerated `schema.base.generated.ts` via the project's schema generator script.

Changes: 2 files, 12 lines added.

## Testing

- Config with `"hooks.mappings[].channel": "feishu"` no longer triggers validation error
- Other channel values continue to work as before

Fixes #56226
