### PR TITLE
fix: allow plugin configSchema fields in plugins.entries via passthrough

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -164,7 +164,7 @@ const PluginEntrySchema = z
       .optional(),
     config: z.record(z.string(), z.unknown()).optional(),
   })
-  .strict();
+  .passthrough();
 
 const TalkProviderEntrySchema = z
   .object({


### PR DESCRIPTION
## Problem

plugins.entries rejects plugin configSchema fields as "Unrecognized key" (#55863). When a plugin declares custom config fields (e.g., `qdrantUrl` for memory-qdrant), adding them to `plugins.entries.<plugin>` in openclaw.json triggers a config validation error.

## Root Cause

`PluginEntrySchema` in `src/config/zod-schema.ts` uses `.strict()` which rejects any fields not explicitly defined. Only `enabled`, `hooks`, `subagent`, and `config` are allowed. Plugin-specific fields declared in the plugin's configSchema cannot be placed at the top level of a plugin entry.

While plugins can use the `config` sub-object to pass custom fields, many plugin configs and documentation expect fields directly under the plugin entry name (e.g., `plugins.entries.memory-qdrant.qdrantUrl`).

## Fix

Changed `PluginEntrySchema` from `.strict()` to `.passthrough()`. This allows plugin-specific fields to pass through config validation while still validating the known fields (`enabled`, `hooks`, `subagent`, `config`).

Change: 1 file, 1 line.

## Testing

- Plugin entries with custom fields (e.g., `qdrantUrl`) no longer trigger validation errors
- Known fields (`enabled`, `hooks`, `subagent`, `config`) continue to be validated
- `openclaw doctor --fix` no longer removes valid plugin entries

Fixes #55863
