### PR TITLE
fix(sessions): sanitize stale provider/model references (#56206)

### DIFF
--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -9,6 +9,17 @@
     "@grammyjs/transformer-throttler": "^1.2.1",
     "grammy": "^1.41.1"
   },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.27"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -19,6 +19,7 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { validateSessionStore } from "../../config/sessions/store-validation.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import { listAgentIds } from "../agent-scope.js";
@@ -133,6 +134,16 @@ export function resolveSession(opts: {
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
   });
+
+  // Validate and sanitize session entries against current configuration.
+  // This prevents stale provider/model references from removed providers
+  // (e.g., openrouter) from causing runtime errors.
+  const modifiedCount = validateSessionStore(sessionStore, opts.cfg);
+  if (modifiedCount > 0) {
+    // Note: We don't persist the changes here to avoid write amplification.
+    // The session will be naturally updated on next run with correct values.
+  }
+
   const now = Date.now();
 
   const sessionEntry = sessionKey ? sessionStore[sessionKey] : undefined;

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -20,6 +20,7 @@ import {
   type SessionEntry,
 } from "../../config/sessions.js";
 import { validateSessionStore } from "../../config/sessions/store-validation.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import { listAgentIds } from "../agent-scope.js";
@@ -140,8 +141,8 @@ export function resolveSession(opts: {
   // (e.g., openrouter) from causing runtime errors.
   const modifiedCount = validateSessionStore(sessionStore, opts.cfg);
   if (modifiedCount > 0) {
-    // Note: We don't persist the changes here to avoid write amplification.
-    // The session will be naturally updated on next run with correct values.
+    const log = createSubsystemLogger("session");
+    log.info(`Sanitized ${modifiedCount} session entries with stale provider/model references`);
   }
 
   const now = Date.now();

--- a/src/config/sessions/store-validation.test.ts
+++ b/src/config/sessions/store-validation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config.js";
+import { validateAndSanitizeSessionEntry, validateSessionStore } from "./store-validation.js";
+import type { SessionEntry } from "./types.js";
+
+function createMockConfig(providers: string[]): OpenClawConfig {
+  const models: Record<string, { baseUrl?: string }> = {};
+  for (const provider of providers) {
+    models[provider] = { baseUrl: `https://${provider}.example.com` };
+  }
+  return {
+    models: {
+      providers: models,
+    },
+  } as OpenClawConfig;
+}
+
+function createMockSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: "test-session",
+    updatedAt: Date.now(),
+    ...overrides,
+  } as SessionEntry;
+}
+
+describe("store-validation", () => {
+  describe("validateAndSanitizeSessionEntry", () => {
+    it("does not modify entry when provider is configured", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const entry = createMockSessionEntry({
+        providerOverride: "anthropic",
+        modelOverride: "claude-sonnet-4-6",
+      });
+
+      const modified = validateAndSanitizeSessionEntry(entry, cfg);
+
+      expect(modified).toBe(false);
+      expect(entry.providerOverride).toBe("anthropic");
+      expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    });
+
+    it("clears providerOverride and modelOverride when provider is not configured", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const entry = createMockSessionEntry({
+        providerOverride: "openrouter",
+        modelOverride: "claude-sonnet-4-6",
+      });
+
+      const modified = validateAndSanitizeSessionEntry(entry, cfg);
+
+      expect(modified).toBe(true);
+      expect(entry.providerOverride).toBeUndefined();
+      expect(entry.modelOverride).toBeUndefined();
+    });
+
+    it("clears modelProvider and model when provider is not configured", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const entry = createMockSessionEntry({
+        modelProvider: "openrouter",
+        model: "claude-sonnet-4-6",
+      });
+
+      const modified = validateAndSanitizeSessionEntry(entry, cfg);
+
+      expect(modified).toBe(true);
+      expect(entry.modelProvider).toBeUndefined();
+      expect(entry.model).toBeUndefined();
+    });
+
+    it("handles empty provider config gracefully", () => {
+      const cfg = createMockConfig([]);
+      const entry = createMockSessionEntry({
+        providerOverride: "openrouter",
+        modelOverride: "claude-sonnet-4-6",
+      });
+
+      const modified = validateAndSanitizeSessionEntry(entry, cfg);
+
+      expect(modified).toBe(true);
+      expect(entry.providerOverride).toBeUndefined();
+      expect(entry.modelOverride).toBeUndefined();
+    });
+
+    it("does not modify entry when only modelOverride is set without providerOverride", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const entry = createMockSessionEntry({
+        modelOverride: "claude-sonnet-4-6",
+      });
+
+      const modified = validateAndSanitizeSessionEntry(entry, cfg);
+
+      // Should not modify because we can't determine which provider to check
+      expect(modified).toBe(false);
+      expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    });
+  });
+
+  describe("validateSessionStore", () => {
+    it("validates all entries in the store", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const store: Record<string, SessionEntry> = {
+        "session-1": createMockSessionEntry({
+          providerOverride: "anthropic",
+          modelOverride: "claude-sonnet-4-6",
+        }),
+        "session-2": createMockSessionEntry({
+          providerOverride: "openrouter",
+          modelOverride: "claude-sonnet-4-6",
+        }),
+        "session-3": createMockSessionEntry({
+          modelProvider: "openrouter",
+          model: "gpt-4",
+        }),
+      };
+
+      const modifiedCount = validateSessionStore(store, cfg);
+
+      expect(modifiedCount).toBe(2);
+      expect(store["session-1"].providerOverride).toBe("anthropic"); // unchanged
+      expect(store["session-2"].providerOverride).toBeUndefined(); // cleared
+      expect(store["session-3"].modelProvider).toBeUndefined(); // cleared
+    });
+
+    it("returns 0 when no entries need modification", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const store: Record<string, SessionEntry> = {
+        "session-1": createMockSessionEntry({
+          providerOverride: "anthropic",
+          modelOverride: "claude-sonnet-4-6",
+        }),
+        "session-2": createMockSessionEntry({
+          modelProvider: "openai",
+          model: "gpt-4",
+        }),
+      };
+
+      const modifiedCount = validateSessionStore(store, cfg);
+
+      expect(modifiedCount).toBe(0);
+    });
+
+    it("handles empty store gracefully", () => {
+      const cfg = createMockConfig(["anthropic", "openai"]);
+      const store: Record<string, SessionEntry> = {};
+
+      const modifiedCount = validateSessionStore(store, cfg);
+
+      expect(modifiedCount).toBe(0);
+    });
+  });
+});

--- a/src/config/sessions/store-validation.ts
+++ b/src/config/sessions/store-validation.ts
@@ -1,0 +1,81 @@
+/**
+ * Session store validation utilities.
+ *
+ * Validates session entries against current configuration to prevent
+ * stale provider/model references from causing runtime errors.
+ */
+
+import type { OpenClawConfig } from "../config.js";
+import type { SessionEntry } from "./types.js";
+
+/**
+ * Get list of configured provider IDs from the current configuration.
+ */
+function listConfiguredProviderIds(cfg: OpenClawConfig): string[] {
+  const providers = cfg.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return [];
+  }
+  return Object.keys(providers);
+}
+
+/**
+ * Validate and sanitize a session entry's model/provider overrides.
+ *
+ * If the session references a provider that is no longer configured,
+ * clear the override fields to prevent runtime errors.
+ *
+ * @param entry - The session entry to validate (mutated in place)
+ * @param cfg - Current OpenClaw configuration
+ * @returns true if the entry was modified, false otherwise
+ */
+export function validateAndSanitizeSessionEntry(entry: SessionEntry, cfg: OpenClawConfig): boolean {
+  const configuredProviders = new Set(listConfiguredProviderIds(cfg));
+  let modified = false;
+
+  // Validate modelOverride/providerOverride
+  if (entry.providerOverride || entry.modelOverride) {
+    const provider = entry.providerOverride?.trim();
+    if (provider && !configuredProviders.has(provider)) {
+      // Provider override references a removed provider — clear both fields
+      delete entry.providerOverride;
+      delete entry.modelOverride;
+      modified = true;
+    }
+  }
+
+  // Validate runtime model/modelProvider fields
+  if (entry.modelProvider || entry.model) {
+    const provider = entry.modelProvider?.trim();
+    if (provider && !configuredProviders.has(provider)) {
+      // Runtime model references a removed provider — clear both fields
+      delete entry.modelProvider;
+      delete entry.model;
+      modified = true;
+    }
+  }
+
+  return modified;
+}
+
+/**
+ * Validate all entries in a session store.
+ *
+ * @param store - The session store object (mutated in place)
+ * @param cfg - Current OpenClaw configuration
+ * @returns Number of entries that were modified
+ */
+export function validateSessionStore(
+  store: Record<string, SessionEntry>,
+  cfg: OpenClawConfig,
+): number {
+  let modifiedCount = 0;
+
+  for (const entry of Object.values(store)) {
+    if (validateAndSanitizeSessionEntry(entry, cfg)) {
+      modifiedCount++;
+    }
+  }
+
+  return modifiedCount;
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -218,6 +218,11 @@ export function loadSessionStore(
       sizeBytes: currentFileStat?.sizeBytes,
     });
     if (cached) {
+      // Apply validation when cfg is provided, even on cache hits.
+      // This ensures stale provider references are always sanitized.
+      if (opts.cfg) {
+        validateSessionStore(cached, opts.cfg);
+      }
       return cached;
     }
   }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -15,6 +15,7 @@ import {
   type DeliveryContext,
 } from "../../utils/delivery-context.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
+import type { OpenClawConfig } from "../config.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
 import {
@@ -36,6 +37,7 @@ import {
   type SessionMaintenanceWarning,
 } from "./store-maintenance.js";
 import { applySessionStoreMigrations } from "./store-migrations.js";
+import { validateSessionStore } from "./store-validation.js";
 import {
   mergeSessionEntry,
   mergeSessionEntryPreserveActivity,
@@ -205,7 +207,7 @@ type LoadSessionStoreOptions = {
 
 export function loadSessionStore(
   storePath: string,
-  opts: LoadSessionStoreOptions = {},
+  opts: LoadSessionStoreOptions & { cfg?: OpenClawConfig } = {},
 ): Record<string, SessionEntry> {
   // Check cache first if enabled
   if (!opts.skipCache && isSessionStoreCacheEnabled()) {
@@ -264,6 +266,18 @@ export function loadSessionStore(
   }
 
   applySessionStoreMigrations(store);
+
+  // Validate and sanitize session entries against current configuration.
+  // This prevents stale provider/model references from removed providers
+  // (e.g., openrouter) from causing runtime errors.
+  if (opts.cfg) {
+    const modifiedCount = validateSessionStore(store, opts.cfg);
+    if (modifiedCount > 0) {
+      log.info(
+        `Sanitized ${modifiedCount} session entries with stale provider/model references in ${storePath}`,
+      );
+    }
+  }
 
   // Cache the result if caching is enabled
   if (!opts.skipCache && isSessionStoreCacheEnabled()) {


### PR DESCRIPTION
Fixes #56206

## Problem

After removing a provider from configuration, the gateway continues to attempt using models from that provider because session entries retain stale provider/model references.

## Solution

Add validation layer that sanitizes session entries when loaded.

## Testing

8 unit tests, all passing.

## Files Changed

- src/config/sessions/store-validation.ts (new)
- src/config/sessions/store-validation.test.ts (new)
- src/config/sessions/store.ts (modified)
- src/agents/command/session.ts (modified)
