### PR TITLE
fix(matrix): prevent mixed matrix-js-sdk entrypoints from crashing plugin load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: use the original message `create_time` instead of `Date.now()` for inbound timestamps so offline-retried messages carry the correct authoring time, preventing mis-targeted agent actions on stale instructions. (#52809) Thanks @schumilin.
 - Control UI/Skills: open skill detail dialogs with the browser modal lifecycle so clicking a skill row keeps the panel centered instead of rendering it off-screen at the bottom of the page.
 - Matrix/replies: include quoted poll question/options in inbound reply context so the agent sees the original poll content when users reply to Matrix poll messages. (#55056) Thanks @alberthild.
+- Matrix/plugins: keep plugin bootstrap from crashing when built runtime mixes bare and deep `matrix-js-sdk` entrypoints, so unrelated channels do not get taken down during plugin load. (#56273) Thanks @aquaright1.
 - Agents/sandbox: honor `tools.sandbox.tools.alsoAllow`, let explicit sandbox re-allows remove matching built-in default-deny tools, and keep sandbox explain/error guidance aligned with the effective sandbox tool policy. (#54492) Thanks @ngutman.
 - Agents/sandbox: make blocked-tool guidance glob-aware again, redact/sanitize session-specific explain hints for safer copy-paste, and avoid leaking control-character session keys in those hints. (#54684) Thanks @ngutman.
 - Agents/compaction: trigger timeout recovery compaction before retrying high-context LLM timeouts so embedded runs stop repeating oversized requests. (#46417) thanks @joeykrug.

--- a/extensions/matrix/src/matrix/client/file-sync-store.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.ts
@@ -2,13 +2,13 @@ import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import {
   Category,
+  MemoryStore,
+  SyncAccumulator,
   type ISyncData,
   type IRooms,
   type ISyncResponse,
   type IStoredClientOpts,
-} from "matrix-js-sdk";
-import { MemoryStore } from "matrix-js-sdk/lib/store/memory.js";
-import { SyncAccumulator } from "matrix-js-sdk/lib/sync-accumulator.js";
+} from "matrix-js-sdk/lib/matrix.js";
 import { writeJsonFileAtomically } from "../../runtime-api.js";
 import { createAsyncLock } from "../async-lock.js";
 import { LogService } from "../sdk/logger.js";

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -175,8 +175,8 @@ function createMatrixJsClientStub(): MatrixJsClientStub {
 let matrixJsClient = createMatrixJsClientStub();
 let lastCreateClientOpts: Record<string, unknown> | null = null;
 
-vi.mock("matrix-js-sdk", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("matrix-js-sdk")>();
+vi.mock("matrix-js-sdk/lib/matrix.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("matrix-js-sdk/lib/matrix.js")>();
   return {
     ...actual,
     ClientEvent: { Event: "event", Room: "Room" },

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -8,7 +8,7 @@ import {
   createClient as createMatrixJsClient,
   type MatrixClient as MatrixJsClient,
   type MatrixEvent,
-} from "matrix-js-sdk";
+} from "matrix-js-sdk/lib/matrix.js";
 import { VerificationMethod } from "matrix-js-sdk/lib/types.js";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/core";
 import type { SsrFPolicy } from "../runtime-api.js";

--- a/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
+++ b/extensions/matrix/src/matrix/sdk/decrypt-bridge.ts
@@ -1,5 +1,5 @@
-import { MatrixEventEvent, type MatrixEvent } from "matrix-js-sdk";
 import { CryptoEvent } from "matrix-js-sdk/lib/crypto-api/CryptoEvent.js";
+import { MatrixEventEvent, type MatrixEvent } from "matrix-js-sdk/lib/matrix.js";
 import { LogService, noop } from "./logger.js";
 
 type MatrixDecryptIfNeededClient = {

--- a/src/plugin-sdk/index.bundle.test.ts
+++ b/src/plugin-sdk/index.bundle.test.ts
@@ -15,7 +15,7 @@ const bundledCoverageEntrySources = {
   ...buildPluginSdkEntrySources(bundledRepresentativeEntrypoints),
   ...matrixRuntimeCoverageEntries,
 };
-const bareMatrixSdkImportPattern = /from\s+["']matrix-js-sdk["']/;
+const bareMatrixSdkImportPattern = /(?:from|require|import)\s*\(?\s*["']matrix-js-sdk["']/;
 
 async function listBuiltJsFiles(rootDir: string): Promise<string[]> {
   const entries = await fs.readdir(rootDir, { withFileTypes: true });

--- a/src/plugin-sdk/index.bundle.test.ts
+++ b/src/plugin-sdk/index.bundle.test.ts
@@ -8,7 +8,13 @@ import { buildPluginSdkEntrySources, pluginSdkEntrypoints } from "./entrypoints.
 const require = createRequire(import.meta.url);
 const tsdownModuleUrl = pathToFileURL(require.resolve("tsdown")).href;
 const bundledRepresentativeEntrypoints = ["matrix-runtime-heavy"] as const;
-const bundledCoverageEntrySources = buildPluginSdkEntrySources(bundledRepresentativeEntrypoints);
+const matrixRuntimeCoverageEntries = {
+  "matrix-runtime-sdk": "extensions/matrix/src/matrix/sdk.ts",
+} as const;
+const bundledCoverageEntrySources = {
+  ...buildPluginSdkEntrySources(bundledRepresentativeEntrypoints),
+  ...matrixRuntimeCoverageEntries,
+};
 const bareMatrixSdkImportPattern = /from\s+["']matrix-js-sdk["']/;
 
 async function listBuiltJsFiles(rootDir: string): Promise<string[]> {
@@ -49,7 +55,9 @@ describe("plugin-sdk bundled exports", () => {
       },
       // Full plugin-sdk coverage belongs to `pnpm build`, package contract
       // guardrails, and `subpaths.test.ts`. This file only keeps the expensive
-      // bundler path honest across representative entrypoint families.
+      // bundler path honest across representative entrypoint families plus the
+      // Matrix SDK runtime import surface that historically crashed plugin
+      // loading when bare and deep SDK entrypoints mixed.
       entry: bundledCoverageEntrySources,
       env: { NODE_ENV: "production" },
       fixedExtension: false,
@@ -61,6 +69,11 @@ describe("plugin-sdk bundled exports", () => {
     expect(pluginSdkEntrypoints.length).toBeGreaterThan(bundledRepresentativeEntrypoints.length);
     await Promise.all(
       bundledRepresentativeEntrypoints.map(async (entry) => {
+        await expect(fs.stat(path.join(outDir, `${entry}.js`))).resolves.toBeTruthy();
+      }),
+    );
+    await Promise.all(
+      Object.keys(matrixRuntimeCoverageEntries).map(async (entry) => {
         await expect(fs.stat(path.join(outDir, `${entry}.js`))).resolves.toBeTruthy();
       }),
     );

--- a/src/plugin-sdk/index.bundle.test.ts
+++ b/src/plugin-sdk/index.bundle.test.ts
@@ -9,6 +9,21 @@ const require = createRequire(import.meta.url);
 const tsdownModuleUrl = pathToFileURL(require.resolve("tsdown")).href;
 const bundledRepresentativeEntrypoints = ["matrix-runtime-heavy"] as const;
 const bundledCoverageEntrySources = buildPluginSdkEntrySources(bundledRepresentativeEntrypoints);
+const bareMatrixSdkImportPattern = /from\s+["']matrix-js-sdk["']/;
+
+async function listBuiltJsFiles(rootDir: string): Promise<string[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(rootDir, entry.name);
+      if (entry.isDirectory()) {
+        return await listBuiltJsFiles(entryPath);
+      }
+      return entry.isFile() && entry.name.endsWith(".js") ? [entryPath] : [];
+    }),
+  );
+  return nested.flat();
+}
 
 describe("plugin-sdk bundled exports", () => {
   it("emits importable bundled subpath entries", { timeout: 120_000 }, async () => {
@@ -49,6 +64,16 @@ describe("plugin-sdk bundled exports", () => {
         await expect(fs.stat(path.join(outDir, `${entry}.js`))).resolves.toBeTruthy();
       }),
     );
+    const builtJsFiles = await listBuiltJsFiles(outDir);
+    const filesWithBareMatrixSdkImports = (
+      await Promise.all(
+        builtJsFiles.map(async (filePath) => {
+          const contents = await fs.readFile(filePath, "utf8");
+          return bareMatrixSdkImportPattern.test(contents) ? filePath : null;
+        }),
+      )
+    ).filter((filePath): filePath is string => filePath !== null);
+    expect(filesWithBareMatrixSdkImports).toEqual([]);
 
     // Export list and package-specifier coverage already live in
     // package-contract-guardrails.test.ts and subpaths.test.ts. Keep this file


### PR DESCRIPTION
## Summary


- Problem: built Matrix runtime output mixed the bare `matrix-js-sdk` entrypoint with deep `matrix-js-sdk/lib/*` imports, which triggered the SDK's multiple-entrypoint guard during plugin load.
- Why it matters: when that guard throws during startup, it can abort the shared bundled plugin-loading pass, so other providers like Discord or Telegram can appear broken even though Matrix is the thing crashing bootstrap.
- What changed: Matrix runtime imports that used the bare package now import from `matrix-js-sdk/lib/matrix.js`, and a representative bundle test now fails if built output reintroduces a bare `from "matrix-js-sdk"` import.
- What did NOT change (scope boundary): this PR does not add a `pnpm` patch, does not change `tsdown.config.ts`, and does not alter Matrix crypto/logger deep imports that still require dedicated subpaths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Matrix extension used both bare `matrix-js-sdk` imports and deep `matrix-js-sdk/lib/*` imports. Because the host build keeps `matrix-js-sdk` external, those import forms survived into built chunks like `dist/auth-profiles-*.js`, where the bare import evaluated `lib/index.js` and tripped the SDK's multiple-entrypoint guard.
- Missing detection / guardrail: there was no bundle-level regression check asserting that representative built Matrix runtime output avoided the bare `matrix-js-sdk` entrypoint.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the Matrix extension already depended on both root and deep SDK surfaces; this PR keeps the required deep imports but removes the bare runtime entrypoint usage.
- Why this regressed now: plugin loading reached a built artifact shape where the mixed import forms coexisted in the same runtime path.
- If unknown, what was ruled out: this PR does not rely on the local `node_modules` workaround or a `pnpm` patch; built output was inspected before and after the source import change.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/index.bundle.test.ts`
- Scenario the test should lock in: build the representative bundled Matrix runtime and fail if any emitted JS artifact still contains a bare `from "matrix-js-sdk"` import.
- Why this is the smallest reliable guardrail: it exercises the actual tsdown output shape that triggered the crash without needing a full live gateway/plugin-load harness.
- Existing test that already covers this (if any): `pnpm test:build:singleton` complements this by checking built plugin loading, but it did not previously assert the Matrix import shape.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bundled/plugin-loaded OpenClaw builds no longer hit the Matrix SDK multiple-entrypoint crash path caused by mixed bare and deep Matrix SDK imports. In practice, this prevents startup/plugin bootstrap from repeatedly failing and avoids collateral breakage where unrelated providers like Discord stop working because Matrix crashed the shared plugin-loading pass.

## Diagram (if applicable)

```text
Before:
[startup] -> [load bundled plugins] -> [Matrix runtime mixes bare + deep matrix-js-sdk entrypoints]
         -> [matrix-js-sdk guard throws] -> [plugin bootstrap aborts] -> [restart/retry] -> [other providers look broken]

After:
[startup] -> [load bundled plugins] -> [Matrix runtime uses lib/matrix.js + required lib/* imports only]
         -> [no multiple-entrypoint throw] -> [plugin loading continues] -> [Discord/other providers keep working]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace checkout
- Model/provider: N/A
- Integration/channel (if any): Matrix / bundled plugin loading
- Relevant config (redacted): none required for the artifact-level repro

### Steps

1. Build or inspect an OpenClaw checkout where the Matrix extension contributes to bundled runtime output.
2. Load or inspect the generated runtime chunk (for example `dist/auth-profiles-*.js`).
3. Observe mixed `from "matrix-js-sdk"` and `from "matrix-js-sdk/lib/*"` imports in the same built artifact.
4. Start OpenClaw or trigger plugin loading through the built runtime path.

### Expected

- Matrix runtime uses a single SDK entrypoint strategy and plugin loading continues normally.

### Actual

- The Matrix SDK detects multiple entrypoints, throws during plugin bootstrap, and startup may retry/restart while unrelated providers appear broken.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Built artifact inspection after this change showed `dist/auth-profiles-*.js` importing Matrix from `matrix-js-sdk/lib/matrix.js` plus required deep `lib/*` subpaths, with no bare `from "matrix-js-sdk"` import remaining.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run extensions/matrix/src/matrix/sdk.test.ts`, `pnpm exec vitest run extensions/matrix/src/matrix/client/file-sync-store.test.ts`, `pnpm exec vitest run src/plugin-sdk/index.bundle.test.ts`, and `pnpm test:build:singleton`; inspected generated `dist/auth-profiles-*.js` afterward.
- Edge cases checked: representative bundled Matrix runtime shape, Matrix SDK test mock path, and built plugin singleton smoke.
- What you did **not** verify: a live end-to-end gateway/plugin-load repro against a real Matrix configuration, and a clearly completed `pnpm build` shell exit even though the updated dist artifacts were generated and inspected.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `matrix-js-sdk/lib/matrix.js` is still a deep SDK path and could change in a future SDK upgrade.
  - Mitigation: OpenClaw is pinned to `matrix-js-sdk@41.2.0` here, and the new bundle regression test should catch import-shape drift during future updates.
- Risk: the regression test checks representative bundled output rather than every possible chunk.
  - Mitigation: the exact historically affected built artifact (`dist/auth-profiles-*.js`) was also inspected after the change, and the built plugin smoke test still passes.
