### PR TITLE
fix: accept plugin channel ids in hook mappings

### DIFF
--- a/src/config/config.hook-mapping-channels.test.ts
+++ b/src/config/config.hook-mapping-channels.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectWithPlugins } from "./config.js";
+
+describe("hook mapping channel validation", () => {
+  it("accepts configured runtime channel ids such as feishu", () => {
+    const res = validateConfigObjectWithPlugins({
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "app-id",
+          appSecret: "app-secret",
+        },
+      },
+      hooks: {
+        mappings: [
+          {
+            deliver: true,
+            channel: "feishu",
+            to: "test",
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects unknown hook mapping channel ids", () => {
+    const res = validateConfigObjectWithPlugins({
+      hooks: {
+        mappings: [
+          {
+            deliver: true,
+            channel: "definitely-not-a-channel",
+            to: "test",
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.issues).toContainEqual(
+      expect.objectContaining({
+        path: "hooks.mappings.0.channel",
+        message: expect.stringContaining("unknown hook mapping channel"),
+      }),
+    );
+  });
+});

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -746,6 +746,41 @@ function validateConfigObjectWithPluginsBase(
     issues.push({ path, message: `unknown heartbeat target: ${target}` });
   };
 
+  const hookMappingChannelIds = new Set<string>(["last", ...CHANNEL_IDS]);
+
+  const validateHookMappingChannel = (channel: string | undefined, path: string) => {
+    if (typeof channel !== "string") {
+      return;
+    }
+    const trimmed = channel.trim();
+    if (!trimmed) {
+      issues.push({ path, message: "hook mapping channel must not be empty" });
+      return;
+    }
+    const normalized = trimmed.toLowerCase();
+    if (!hookMappingChannelIds.has(normalized)) {
+      const { registry } = ensureRegistry();
+      for (const record of registry.plugins) {
+        for (const channelId of record.channels) {
+          const pluginChannel = channelId.trim();
+          if (pluginChannel) {
+            hookMappingChannelIds.add(pluginChannel.toLowerCase());
+          }
+        }
+      }
+    }
+    if (hookMappingChannelIds.has(normalized)) {
+      return;
+    }
+    issues.push({ path, message: `unknown hook mapping channel: ${channel}` });
+  };
+
+  if (Array.isArray(config.hooks?.mappings)) {
+    for (const [index, mapping] of config.hooks.mappings.entries()) {
+      validateHookMappingChannel(mapping?.channel, `hooks.mappings.${index}.channel`);
+    }
+  }
+
   validateHeartbeatTarget(
     config.agents?.defaults?.heartbeat?.target,
     "agents.defaults.heartbeat.target",

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -49,19 +49,7 @@ export const HookMappingSchema = z
     textTemplate: z.string().optional(),
     deliver: z.boolean().optional(),
     allowUnsafeExternalContent: z.boolean().optional(),
-    channel: z
-      .union([
-        z.literal("last"),
-        z.literal("whatsapp"),
-        z.literal("telegram"),
-        z.literal("discord"),
-        z.literal("irc"),
-        z.literal("slack"),
-        z.literal("signal"),
-        z.literal("imessage"),
-        z.literal("msteams"),
-      ])
-      .optional(),
+    channel: z.string().trim().min(1).optional(),
     to: z.string().optional(),
     model: z.string().optional(),
     thinking: z.string().optional(),


### PR DESCRIPTION
## Summary
- allow non-empty string channel ids in hook mapping schema so plugin-owned channels can parse
- validate hook mapping channels against bundled and runtime-discovered plugin channels
- add regression coverage for `feishu` and unknown channel ids

Fixes #56226