### PR TITLE
feat(outbound): strip markdown for plain-text channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/plugins: reuse the session workspace when building HTTP `/tools/invoke` tool lists and harden tool construction to infer the session agent workspace by default, so workspace plugins do not re-register on repeated HTTP tool calls. (#56101) thanks @neeravmakwana
 - Brave/web search: normalize unsupported Brave `country` filters to `ALL` before request and cache-key generation so locale-derived values like `VN` stop failing with upstream 422 validation errors. (#55695) Thanks @chen-zhang-cs-code.
 - Discord/replies: preserve leading indentation when stripping inline reply tags so reply-tagged plain text and fenced code blocks keep their formatting. (#55960) Thanks @Nanako0129.
+- Outbound/markdown: strip Markdown formatting from outbound messages on plain-text channels (iMessage, SMS, IRC) so LLM replies read as natural text instead of raw `**asterisks**`. Configurable per-channel via `markdown.strip` (default: auto-detect based on channel capability).
 
 ## 2026.3.24
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -1266,6 +1266,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA = {
                           toolSchemaProfile: {
                             type: "string",
                           },
+                          unsupportedToolSchemaKeywords: {
+                            type: "array",
+                            items: {
+                              type: "string",
+                              minLength: 1,
+                            },
+                          },
                           nativeWebSearchTool: {
                             type: "boolean",
                           },

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -36,6 +36,8 @@ export type MarkdownTableMode = "off" | "bullets" | "code";
 export type MarkdownConfig = {
   /** Table rendering mode (off|bullets|code). */
   tables?: MarkdownTableMode;
+  /** Strip markdown formatting from outbound messages (true|false|"auto"). Default: "auto". */
+  strip?: boolean | "auto";
 };
 
 export type HumanDelayConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -372,6 +372,7 @@ export const MarkdownTableModeSchema = z.enum(["off", "bullets", "code"]);
 export const MarkdownConfigSchema = z
   .object({
     tables: MarkdownTableModeSchema.optional(),
+    strip: z.union([z.boolean(), z.literal("auto")]).optional(),
   })
   .strict()
   .optional();

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -19,6 +19,7 @@ import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
 } from "../../config/sessions.js";
+import type { MarkdownConfig } from "../../config/types.base.js";
 import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import {
@@ -31,6 +32,7 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getAgentScopedMediaLocalRootsForSources } from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { stripMarkdown } from "../../shared/text/strip-markdown.js";
 import { throwIfAborted } from "./abort.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { ackDelivery, enqueueDelivery, failDelivery } from "./delivery-queue.js";
@@ -38,7 +40,7 @@ import type { OutboundIdentity } from "./identity.js";
 import type { DeliveryMirror } from "./mirror.js";
 import type { NormalizedOutboundPayload } from "./payloads.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
-import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
+import { isPlainTextSurface, sanitizeForPlainText, shouldStripMarkdown } from "./sanitize-text.js";
 import { resolveOutboundSendDep, type OutboundSendDeps } from "./send-deps.js";
 import type { OutboundSessionContext } from "./session-context.js";
 import type { OutboundChannel } from "./targets.js";
@@ -320,6 +322,7 @@ function normalizePayloadsForChannelDelivery(
   payloads: ReplyPayload[],
   channel: Exclude<OutboundChannel, "none">,
   handler: ChannelHandler,
+  markdownConfig?: MarkdownConfig,
 ): ReplyPayload[] {
   const normalizedPayloads: ReplyPayload[] = [];
   for (const payload of normalizeReplyPayloadsForDelivery(payloads)) {
@@ -335,6 +338,18 @@ function normalizePayloadsForChannelDelivery(
         };
       }
     }
+    // Strip markdown formatting for channels that cannot render it.
+    // Runs after HTML sanitization because sanitizeForPlainText converts
+    // HTML tags to lightweight markup (e.g. <b> → *text*) that stripMarkdown
+    // then removes.
+    if (shouldStripMarkdown(channel, markdownConfig) && sanitizedPayload.text) {
+      if (!handler.shouldSkipPlainTextSanitization?.(sanitizedPayload)) {
+        sanitizedPayload = {
+          ...sanitizedPayload,
+          text: stripMarkdown(sanitizedPayload.text),
+        };
+      }
+    }
     const normalizedPayload = handler.normalizePayload
       ? handler.normalizePayload(sanitizedPayload)
       : sanitizedPayload;
@@ -346,6 +361,14 @@ function normalizePayloadsForChannelDelivery(
     }
   }
   return normalizedPayloads;
+}
+
+function resolveChannelMarkdownConfig(
+  cfg: OpenClawConfig,
+  channel: string,
+): MarkdownConfig | undefined {
+  const channelsConfig = cfg.channels as Record<string, { markdown?: MarkdownConfig }> | undefined;
+  return channelsConfig?.[channel]?.markdown;
 }
 
 function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPayload {
@@ -633,7 +656,13 @@ async function deliverOutboundPayloadsCore(
       results.push(await handler.sendText(chunk, overrides));
     }
   };
-  const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel, handler);
+  const channelMarkdownConfig = resolveChannelMarkdownConfig(cfg, channel);
+  const normalizedPayloads = normalizePayloadsForChannelDelivery(
+    payloads,
+    channel,
+    handler,
+    channelMarkdownConfig,
+  );
   const hookRunner = getGlobalHookRunner();
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;

--- a/src/infra/outbound/sanitize-text.test.ts
+++ b/src/infra/outbound/sanitize-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isPlainTextSurface, sanitizeForPlainText } from "./sanitize-text.js";
+import { isPlainTextSurface, sanitizeForPlainText, shouldStripMarkdown } from "./sanitize-text.js";
 
 // ---------------------------------------------------------------------------
 // isPlainTextSurface
@@ -112,5 +112,48 @@ describe("sanitizeForPlainText", () => {
 
   it("collapses excessive newlines", () => {
     expect(sanitizeForPlainText("a<br><br><br><br>b")).toBe("a\n\nb");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldStripMarkdown
+// ---------------------------------------------------------------------------
+
+describe("shouldStripMarkdown", () => {
+  it("returns true for iMessage (auto-detect)", () => {
+    expect(shouldStripMarkdown("imessage")).toBe(true);
+  });
+
+  it("returns true for sms (auto-detect)", () => {
+    expect(shouldStripMarkdown("sms")).toBe(true);
+  });
+
+  it("returns false for discord (auto-detect)", () => {
+    expect(shouldStripMarkdown("discord")).toBe(false);
+  });
+
+  it("returns false for slack (auto-detect)", () => {
+    expect(shouldStripMarkdown("slack")).toBe(false);
+  });
+
+  it("returns true when strip is explicitly true on a markdown-capable channel", () => {
+    expect(shouldStripMarkdown("discord", { strip: true })).toBe(true);
+  });
+
+  it("returns false when strip is explicitly false on a non-markdown channel", () => {
+    expect(shouldStripMarkdown("imessage", { strip: false })).toBe(false);
+  });
+
+  it("returns true for auto with non-markdown channel", () => {
+    expect(shouldStripMarkdown("imessage", { strip: "auto" })).toBe(true);
+  });
+
+  it("returns false for auto with markdown-capable channel", () => {
+    expect(shouldStripMarkdown("discord", { strip: "auto" })).toBe(false);
+  });
+
+  it("treats undefined strip as auto", () => {
+    expect(shouldStripMarkdown("imessage", {})).toBe(true);
+    expect(shouldStripMarkdown("discord", {})).toBe(false);
   });
 });

--- a/src/infra/outbound/sanitize-text.ts
+++ b/src/infra/outbound/sanitize-text.ts
@@ -11,6 +11,9 @@
  * @see https://github.com/openclaw/openclaw/issues/18558
  */
 
+import type { MarkdownConfig } from "../../config/types.base.js";
+import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
+
 /** Channels where HTML tags should be converted/stripped. */
 const PLAIN_TEXT_SURFACES = new Set([
   "whatsapp",
@@ -61,4 +64,24 @@ export function sanitizeForPlainText(text: string): string {
       // Collapse 3+ consecutive newlines into 2
       .replace(/\n{3,}/g, "\n\n")
   );
+}
+
+/**
+ * Determine whether markdown should be stripped for a given channel.
+ *
+ * Resolution order:
+ * - `strip: true` → always strip
+ * - `strip: false` → never strip
+ * - `strip: "auto"` or `undefined` → strip if channel is not markdown-capable
+ */
+export function shouldStripMarkdown(channel: string, markdownConfig?: MarkdownConfig): boolean {
+  const strip = markdownConfig?.strip;
+  if (strip === true) {
+    return true;
+  }
+  if (strip === false) {
+    return false;
+  }
+  // "auto" or undefined — strip if channel cannot render markdown
+  return !isMarkdownCapableMessageChannel(channel);
 }

--- a/src/shared/text/strip-markdown.test.ts
+++ b/src/shared/text/strip-markdown.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdown } from "./strip-markdown.js";
+
+describe("stripMarkdown", () => {
+  // --- bold ----------------------------------------------------------------
+
+  it("strips **bold** markers", () => {
+    expect(stripMarkdown("this is **bold** text")).toBe("this is bold text");
+  });
+
+  it("strips __bold__ markers", () => {
+    expect(stripMarkdown("this is __bold__ text")).toBe("this is bold text");
+  });
+
+  // --- italic --------------------------------------------------------------
+
+  it("strips *italic* markers", () => {
+    expect(stripMarkdown("this is *italic* text")).toBe("this is italic text");
+  });
+
+  it("strips _italic_ markers", () => {
+    expect(stripMarkdown("this is _italic_ text")).toBe("this is italic text");
+  });
+
+  // --- strikethrough -------------------------------------------------------
+
+  it("strips ~~strikethrough~~ markers", () => {
+    expect(stripMarkdown("this is ~~deleted~~ text")).toBe("this is deleted text");
+  });
+
+  // --- headings ------------------------------------------------------------
+
+  it("strips heading markers", () => {
+    expect(stripMarkdown("# Title")).toBe("Title");
+    expect(stripMarkdown("## Subtitle")).toBe("Subtitle");
+    expect(stripMarkdown("###### Deep heading")).toBe("Deep heading");
+  });
+
+  it("preserves mid-line hash symbols", () => {
+    expect(stripMarkdown("issue #42 is open")).toBe("issue #42 is open");
+  });
+
+  // --- blockquotes ---------------------------------------------------------
+
+  it("strips blockquote markers", () => {
+    expect(stripMarkdown("> quoted text")).toBe("quoted text");
+    expect(stripMarkdown(">no space")).toBe("no space");
+  });
+
+  // --- inline code ---------------------------------------------------------
+
+  it("strips inline code backticks", () => {
+    expect(stripMarkdown("run `npm install` now")).toBe("run npm install now");
+  });
+
+  // --- horizontal rules ----------------------------------------------------
+
+  it("removes horizontal rules", () => {
+    expect(stripMarkdown("above\n---\nbelow")).toBe("above\n\nbelow");
+    expect(stripMarkdown("above\n***\nbelow")).toBe("above\n\nbelow");
+  });
+
+  // --- code blocks (NEW) ---------------------------------------------------
+
+  it("strips fenced code blocks", () => {
+    expect(stripMarkdown("before\n```\ncode here\n```\nafter")).toBe("before\ncode here\nafter");
+  });
+
+  it("strips fenced code blocks with language tag", () => {
+    expect(stripMarkdown("before\n```typescript\nconst x = 1;\n```\nafter")).toBe(
+      "before\nconst x = 1;\nafter",
+    );
+  });
+
+  // --- bullet points (NEW) ------------------------------------------------
+
+  it("strips dash bullet points", () => {
+    expect(stripMarkdown("- first item\n- second item")).toBe("first item\nsecond item");
+  });
+
+  it("strips asterisk bullet points", () => {
+    expect(stripMarkdown("* first item\n* second item")).toBe("first item\nsecond item");
+  });
+
+  // --- numbered lists (NEW) ------------------------------------------------
+
+  it("strips numbered list markers", () => {
+    expect(stripMarkdown("1. first\n2. second\n3. third")).toBe("first\nsecond\nthird");
+  });
+
+  // --- links (NEW) ---------------------------------------------------------
+
+  it("converts links to plain text", () => {
+    expect(stripMarkdown("see [the docs](https://example.com) here")).toBe("see the docs here");
+  });
+
+  it("preserves bare URLs", () => {
+    expect(stripMarkdown("visit https://example.com today")).toBe(
+      "visit https://example.com today",
+    );
+  });
+
+  // --- edge cases ----------------------------------------------------------
+
+  it("passes through plain text unchanged", () => {
+    expect(stripMarkdown("just normal text")).toBe("just normal text");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMarkdown("")).toBe("");
+  });
+
+  it("preserves asterisks in math expressions", () => {
+    expect(stripMarkdown("2 * 3 = 6")).toBe("2 * 3 = 6");
+  });
+
+  it("collapses excessive newlines", () => {
+    expect(stripMarkdown("a\n\n\n\nb")).toBe("a\n\nb");
+  });
+
+  it("handles realistic LLM output", () => {
+    const input = [
+      "## Summary",
+      "",
+      "Here's what happened:",
+      "",
+      "- **First thing** was done",
+      "- The `second` thing failed",
+      "- See [details](https://example.com)",
+      "",
+      "```bash",
+      "npm install",
+      "```",
+    ].join("\n");
+
+    const expected = [
+      "Summary",
+      "",
+      "Here's what happened:",
+      "",
+      "First thing was done",
+      "The second thing failed",
+      "See details",
+      "",
+      "npm install",
+    ].join("\n");
+
+    expect(stripMarkdown(input)).toBe(expected);
+  });
+});

--- a/src/shared/text/strip-markdown.ts
+++ b/src/shared/text/strip-markdown.ts
@@ -5,17 +5,42 @@
 export function stripMarkdown(text: string): string {
   let result = text;
 
+  // Fenced code blocks: ```lang\ncode\n``` → code
+  result = result.replace(/```[a-z]*\n?([\s\S]*?)```/g, "$1");
+
+  // Bold: **text** and __text__
   result = result.replace(/\*\*(.+?)\*\*/g, "$1");
   result = result.replace(/__(.+?)__/g, "$1");
 
+  // Italic: *text* and _text_ (negative lookahead/behind to avoid ** and __)
   result = result.replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1");
   result = result.replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1");
 
+  // Strikethrough: ~~text~~
   result = result.replace(/~~(.+?)~~/g, "$1");
+
+  // Headings: # text (start of line only)
   result = result.replace(/^#{1,6}\s+(.+)$/gm, "$1");
+
+  // Blockquotes: > text
   result = result.replace(/^>\s?(.*)$/gm, "$1");
+
+  // Horizontal rules: ---, ***, ___
   result = result.replace(/^[-*_]{3,}$/gm, "");
+
+  // Inline code: `text`
   result = result.replace(/`([^`]+)`/g, "$1");
+
+  // Bullet points: - item or * item (start of line)
+  result = result.replace(/^[-*]\s+/gm, "");
+
+  // Numbered lists: 1. item (start of line)
+  result = result.replace(/^\d+\.\s+/gm, "");
+
+  // Links: [text](url) → text
+  result = result.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+
+  // Collapse 3+ consecutive newlines into 2
   result = result.replace(/\n{3,}/g, "\n\n");
 
   return result.trim();


### PR DESCRIPTION
## Summary

LLMs produce Markdown formatting that renders correctly on Discord/Slack but shows as raw `**asterisks**` and `# headings` on iMessage, SMS, and IRC. OpenClaw already strips HTML for plain-text surfaces via `sanitizeForPlainText()` but Markdown passes through untouched.

This adds automatic Markdown stripping for outbound messages on channels that cannot render it.

### Changes

- Extend `MarkdownConfig` with `strip?: boolean | "auto"` — every channel already has `markdown?: MarkdownConfig`, so no per-channel type changes needed
- Auto-detect based on `isMarkdownCapableMessageChannel()`: strips for non-markdown channels (iMessage, SMS, IRC), preserves for markdown channels (Discord, Slack, Telegram)
- User override: `markdown.strip: true` forces stripping on any channel, `false` disables it
- Runs in the delivery pipeline after HTML sanitization — order matters because `sanitizeForPlainText()` converts `<b>` to `*bold*` which `stripMarkdown()` then catches
- Extends existing `stripMarkdown()` utility (previously TTS-only) with fenced code blocks, bullet points, numbered lists, and markdown links
- Respects the existing `shouldSkipPlainTextSanitization` handler opt-out

### Config example (optional — auto works for most users)

```json
{
  "channels": {
    "imessage": {
      "markdown": { "strip": true }
    }
  }
}
```

### Files changed

| File | Change |
|------|--------|
| `src/config/types.base.ts` | Add `strip` to `MarkdownConfig` |
| `src/config/zod-schema.core.ts` | Add `strip` to `MarkdownConfigSchema` |
| `src/config/schema.base.generated.ts` | Regenerated |
| `src/shared/text/strip-markdown.ts` | Extend with code blocks, bullets, lists, links |
| `src/shared/text/strip-markdown.test.ts` | New — full test coverage for `stripMarkdown()` |
| `src/infra/outbound/sanitize-text.ts` | Add `shouldStripMarkdown()` |
| `src/infra/outbound/sanitize-text.test.ts` | Add tests for `shouldStripMarkdown()` |
| `src/infra/outbound/deliver.ts` | Integrate stripping into delivery pipeline |
| `CHANGELOG.md` | Add entry |

## Test plan

- [x] Verified markdown stripped for iMessage/SMS, preserved for Discord/Slack
- [x] Verified `strip: true/false` overrides auto-detection
- [x] Verified HTML sanitization runs before markdown stripping
- [ ] `pnpm build` passes
- [ ] `pnpm check` passes
- [ ] `pnpm test` passes

---

🤖 AI-assisted: This PR was developed with Claude Code. All code reviewed and understood.