### PR TITLE
fix(gateway): broadcast sessions.changed even when message is undefined

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -926,11 +926,15 @@ export async function startGatewayServer(
       : onSessionTranscriptUpdate((update) => {
           const sessionKey =
             update.sessionKey ?? resolveSessionKeyForTranscriptFile(update.sessionFile);
-          if (!sessionKey || update.message === undefined) {
+          if (!sessionKey) {
+            return;
+          }
+          const sessionEventConnIds = sessionEventSubscribers.getAll();
+          if (update.message === undefined && sessionEventConnIds.size === 0) {
             return;
           }
           const connIds = new Set<string>();
-          for (const connId of sessionEventSubscribers.getAll()) {
+          for (const connId of sessionEventConnIds) {
             connIds.add(connId);
           }
           for (const connId of sessionMessageSubscribers.get(sessionKey)) {
@@ -994,24 +998,25 @@ export async function startGatewayServer(
                 runtimeMs: sessionRow.runtimeMs,
               }
             : {};
-          const message = attachOpenClawTranscriptMeta(update.message, {
-            ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
-            ...(typeof messageSeq === "number" ? { seq: messageSeq } : {}),
-          });
-          broadcastToConnIds(
-            "session.message",
-            {
-              sessionKey,
-              message,
-              ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
-              ...(typeof messageSeq === "number" ? { messageSeq } : {}),
-              ...sessionSnapshot,
-            },
-            connIds,
-            { dropIfSlow: true },
-          );
+          if (update.message !== undefined) {
+            const message = attachOpenClawTranscriptMeta(update.message, {
+              ...(typeof update.messageId === "string" ? { id: update.messageId } : {}),
+              ...(typeof messageSeq === "number" ? { seq: messageSeq } : {}),
+            });
+            broadcastToConnIds(
+              "session.message",
+              {
+                sessionKey,
+                message,
+                ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
+                ...(typeof messageSeq === "number" ? { messageSeq } : {}),
+                ...sessionSnapshot,
+              },
+              connIds,
+              { dropIfSlow: true },
+            );
+          }
 
-          const sessionEventConnIds = sessionEventSubscribers.getAll();
           if (sessionEventConnIds.size > 0) {
             broadcastToConnIds(
               "sessions.changed",


### PR DESCRIPTION
## Summary

- **Problem**: When `emitSessionTranscriptUpdate()` is called without a message payload (only `sessionFile`), the gateway skips broadcasting `sessions.changed` because of the condition `update.message === undefined`.
- **Why it matters**: Control UI session list doesn't refresh when new messages arrive from external channels (Feishu, etc.), requiring manual page refresh.
- **What changed**: Removed `|| update.message === undefined` from the condition; wrapped `session.message` broadcast inside `if (update.message !== undefined)`.
- **What did NOT change**: No API changes, no Control UI changes.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

- Closes #40960
- Closes #44707

## Root Cause

The condition `if (!sessionKey || update.message === undefined)` was too strict. Many callers only pass `sessionFile` without `message`, causing all broadcasts to be skipped.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## User-visible / Behavior Changes

Control UI session list now refreshes automatically when new messages arrive from external channels.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

None. The change is minimal and only affects broadcast conditions.