### PR TITLE
fix(telegram): add devDependencies and peerDependencies for openclaw (#56219)

### DIFF
--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -9,6 +9,17 @@
     "@grammyjs/transformer-throttler": "^1.2.1",
     "grammy": "^1.41.1"
   },
+  "devDependencies": {
+    "openclaw": "workspace:*"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.3.27"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"


### PR DESCRIPTION
Fixes #56219

## Problem

After upgrading to OpenClaw 2026.3.27, Telegram plugin fails to load with error:
```
TypeError: (0 , _directoryRuntime.createInspectedDirectoryEntriesLister) is not a function
Plugin source: /home/justin/openclaw/extensions/telegram/index.ts
```

## Root Cause

The telegram plugin was missing `devDependencies` and `peerDependencies` declarations for `openclaw`.

According to repo guidelines:
> Plugins: put `openclaw` in `devDependencies` or `peerDependencies` instead (runtime resolves `openclaw/plugin-sdk` via jiti alias).

Without these declarations, the plugin cannot properly resolve `openclaw/plugin-sdk/*` imports at runtime when installed via npm.

**Comparison:**
- ✅ discord plugin has both `devDependencies` and `peerDependencies`
- ❌ telegram plugin was missing both (removed in v2026.2.24)

## Solution

Add `devDependencies` and `peerDependencies` to telegram plugin's package.json, matching the discord plugin configuration:

```json
{
  "devDependencies": {
    "openclaw": "workspace:*"
  },
  "peerDependencies": {
    "openclaw": ">=2026.3.27"
  },
  "peerDependenciesMeta": {
    "openclaw": {
      "optional": true
    }
  }
}
```

## Impact

- ✅ Fixes #56219 - Telegram plugin load failure
- ✅ Ensures proper runtime resolution of `openclaw/plugin-sdk/*` imports
- ✅ Aligns telegram plugin with repo guidelines and other plugins (discord)
- ✅ No breaking changes

## Testing

- Type check: ✅ Passed
- Lint: ✅ Passed

## Files Changed

- `extensions/telegram/package.json` (+11 lines)
