### PR TITLE
fix(mattermost): fallback to channel post when RootId is stale (invalid)

### DIFF
--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -13,6 +13,7 @@ import {
   fetchMattermostUserTeams,
   normalizeMattermostBaseUrl,
   uploadMattermostFile,
+  type MattermostPost,
   type MattermostUser,
   type CreateDmChannelRetryOptions,
 } from "./client.js";
@@ -452,13 +453,45 @@ export async function sendMessageMattermost(
     throw new Error("Mattermost message is empty");
   }
 
-  const post = await createMattermostPost(client, {
-    channelId,
-    message,
-    rootId: opts.replyToId,
-    fileIds,
-    props,
-  });
+  let post: MattermostPost;
+  if (opts.replyToId) {
+    try {
+      post = await createMattermostPost(client, {
+        channelId,
+        message,
+        rootId: opts.replyToId,
+        fileIds,
+        props,
+      });
+    } catch (firstErr) {
+      // If the API returns "Invalid RootId" (stale thread reference after gateway restart),
+      // retry the post as a regular channel message instead of failing silently.
+      const errMsg = firstErr instanceof Error ? firstErr.message : String(firstErr);
+      if (errMsg.includes("Invalid RootId") || errMsg.includes("400")) {
+        logger.debug?.(
+          `mattermost send: reply to RootId ${opts.replyToId} failed (${errMsg}), ` +
+            "retrying as regular channel message",
+        );
+        post = await createMattermostPost(client, {
+          channelId,
+          message,
+          rootId: undefined,
+          fileIds,
+          props,
+        });
+      } else {
+        throw firstErr;
+      }
+    }
+  } else {
+    post = await createMattermostPost(client, {
+      channelId,
+      message,
+      rootId: undefined,
+      fileIds,
+      props,
+    });
+  }
 
   recordMattermostOutboundActivity(accountId);
 


### PR DESCRIPTION
## Summary

After a gateway restart, Mattermost bot sessions retain stale `RootId` references from previous thread replies. When the bot tries to reply, the Mattermost API returns:

```
400 Bad Request: Invalid RootId parameter.
```

This causes the message to fail silently with no user-visible response.

## Fix

In `sendMessageMattermost()`, when posting with a `replyToId` (RootId) fails with an "Invalid RootId" or 400 error, the code now catches the failure and retries the post **without** `rootId`, posting as a regular channel message instead.

## Changes

- `extensions/mattermost/src/mattermost/send.ts`: Added try/catch around `createMattermostPost` with `replyToId`. On `Invalid RootId` error, retries the same post without `rootId`.
- Also added `type MattermostPost` import since the new code references it explicitly.

## Testing

1. Set up Mattermost channel with gateway
2. Restart the gateway
3. Send a message to the bot — it should respond instead of failing silently
4. Normal thread replies (valid RootId) should continue to work normally

## Related Issue

Fixes #56295