### PR TITLE
fix(tools): strip ACP-only fields silently when runtime=subagent in sessions_spawn

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -200,7 +200,7 @@ describe("sessions_spawn tool", () => {
     );
   });
 
-  it("rejects resumeSessionId without runtime=acp", async () => {
+  it("silently strips resumeSessionId when runtime is not acp (proceeds as subagent)", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -210,8 +210,9 @@ describe("sessions_spawn tool", () => {
       resumeSessionId: "7f4a78e0-f6be-43fe-855c-c1c4fd229bc4",
     });
 
-    expect(JSON.stringify(result)).toContain("resumeSessionId is only supported for runtime=acp");
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    // Should succeed and route to subagent (resumeSessionId silently dropped)
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalled();
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
@@ -239,7 +240,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('silently strips streamTo when runtime is not "acp" and proceeds as subagent', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -250,13 +251,10 @@ describe("sessions_spawn tool", () => {
       streamTo: "parent",
     });
 
-    expect(result.details).toMatchObject({
-      status: "error",
-    });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
+    // Should succeed — streamTo is silently stripped for non-acp runtimes
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalled();
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -127,18 +127,13 @@ export function createSessionsSpawnTool(
           }>)
         : undefined;
 
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
-
-      if (resumeSessionId && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `resumeSessionId is only supported for runtime=acp; got runtime=${runtime}`,
-        });
+      // ACP-only fields: silently strip when runtime is not "acp" so that
+      // schema-following models can include them without breaking subagent spawns.
+      let effectiveStreamTo: "parent" | undefined = streamTo;
+      let effectiveResumeSessionId: string | undefined = resumeSessionId;
+      if (runtime !== "acp") {
+        effectiveStreamTo = undefined;
+        effectiveResumeSessionId = undefined;
       }
 
       if (runtime === "acp") {
@@ -154,12 +149,12 @@ export function createSessionsSpawnTool(
             task,
             label: label || undefined,
             agentId: requestedAgentId,
-            resumeSessionId,
+            resumeSessionId: effectiveResumeSessionId,
             cwd,
             mode: mode && ACP_SPAWN_MODES.includes(mode) ? mode : undefined,
             thread,
             sandbox,
-            streamTo,
+            streamTo: effectiveStreamTo,
           },
           {
             agentSessionKey: opts?.agentSessionKey,


### PR DESCRIPTION
## What

When `runtime="subagent"`, silently strip `streamTo` and `resumeSessionId` instead of returning an error, so schema-following models that include ACP-only fields in subagent calls don't break multi-agent workflows.

Fixes #56326

## Root Cause

The two validation guards in `sessions-spawn-tool.ts` threw errors if `streamTo` or `resumeSessionId` were present with `runtime !== "acp"`. Schema-following models see both fields in the shared tool schema and may include them in subagent calls, causing immediate failure before dispatch.

## Fix

Replaced the hard errors with a silent-strip block:

```ts
// Strip ACP-only fields silently when not using ACP runtime
if (runtime !== "acp") {
  effectiveStreamTo = undefined;
  effectiveResumeSessionId = undefined;
}
```

Subagent dispatch then proceeds normally with those fields absent.

## Tests

Updated 2 existing tests (previously asserting old error behavior) to assert the new behavior: calls with ACP-only fields + `runtime="subagent"` succeed and route to the subagent dispatcher. All 9 tests pass.