### PR TITLE
fix(telegram): download animation (GIF/video) files to media/inbound directory

### DIFF
--- a/extensions/telegram/src/bot-handlers.media.ts
+++ b/extensions/telegram/src/bot-handlers.media.ts
@@ -17,7 +17,15 @@ export function hasInboundMedia(msg: Message): boolean {
   return (
     Boolean(msg.media_group_id) ||
     (Array.isArray(msg.photo) && msg.photo.length > 0) ||
-    Boolean(msg.video ?? msg.video_note ?? msg.document ?? msg.audio ?? msg.voice ?? msg.sticker)
+    Boolean(
+      msg.video ??
+      msg.video_note ??
+      msg.animation ??
+      msg.document ??
+      msg.audio ??
+      msg.voice ??
+      msg.sticker,
+    )
   );
 }
 
@@ -33,6 +41,7 @@ export function resolveInboundMediaFileId(msg: Message): string | undefined {
     msg.photo?.[msg.photo.length - 1]?.file_id ??
     msg.video?.file_id ??
     msg.video_note?.file_id ??
+    msg.animation?.file_id ??
     msg.document?.file_id ??
     msg.audio?.file_id ??
     msg.voice?.file_id

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -391,3 +391,102 @@ describe("telegram forwarded bursts", () => {
     FORWARD_BURST_TEST_TIMEOUT_MS,
   );
 });
+
+describe("telegram video/animation media downloads (regression #56312)", () => {
+  const VIDEO_MEDIA_TEST_TIMEOUT_MS = process.platform === "win32" ? 120_000 : 90_000;
+
+  it(
+    "downloads video files to media/inbound and emits <media:video> placeholder",
+    async () => {
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const fetchSpy = mockTelegramFileDownload({
+        contentType: "video/mp4",
+        bytes: new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+      });
+
+      try {
+        await handler({
+          message: {
+            message_id: 100,
+            chat: { id: 1234, type: "private" },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            date: 1736380800,
+            video: {
+              file_id: "video_file_id_1",
+              file_unique_id: "video_unique_1",
+              width: 1280,
+              height: 720,
+              duration: 10,
+              file_size: 1024,
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({ file_path: "videos/video1.mp4" }),
+        });
+
+        expect(runtimeError).not.toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "https://api.telegram.org/file/bottok/videos/video1.mp4",
+          }),
+        );
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        const payload = replySpy.mock.calls[0][0] as { Body?: string; MediaPaths?: string[] };
+        expect(payload.Body).toContain("<media:video>");
+        expect(Array.isArray(payload.MediaPaths) && payload.MediaPaths.length > 0).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    VIDEO_MEDIA_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "downloads animation (GIF) files to media/inbound and emits <media:video> placeholder",
+    async () => {
+      const runtimeError = vi.fn();
+      const { handler, replySpy } = await createBotHandlerWithOptions({ runtimeError });
+      const fetchSpy = mockTelegramFileDownload({
+        contentType: "video/mp4",
+        bytes: new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]),
+      });
+
+      try {
+        await handler({
+          message: {
+            message_id: 101,
+            chat: { id: 1234, type: "private" },
+            from: { id: 777, is_bot: false, first_name: "Ada" },
+            date: 1736380800,
+            animation: {
+              file_id: "animation_file_id_1",
+              file_unique_id: "animation_unique_1",
+              width: 480,
+              height: 270,
+              duration: 3,
+              file_size: 512,
+              file_name: "funny.mp4",
+            },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({ file_path: "animations/anim1.mp4" }),
+        });
+
+        expect(runtimeError).not.toHaveBeenCalled();
+        expect(fetchSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: "https://api.telegram.org/file/bottok/animations/anim1.mp4",
+          }),
+        );
+        expect(replySpy).toHaveBeenCalledTimes(1);
+        const payload = replySpy.mock.calls[0][0] as { Body?: string; MediaPaths?: string[] };
+        expect(payload.Body).toContain("<media:video>");
+        expect(Array.isArray(payload.MediaPaths) && payload.MediaPaths.length > 0).toBe(true);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+    VIDEO_MEDIA_TEST_TIMEOUT_MS,
+  );
+});

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -75,6 +75,7 @@ function resolveMediaFileRef(msg: TelegramContext["message"]) {
     msg.photo?.[msg.photo.length - 1] ??
     msg.video ??
     msg.video_note ??
+    msg.animation ??
     msg.document ??
     msg.audio ??
     msg.voice

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -273,7 +273,10 @@ export function buildSenderName(msg: Message) {
 
 export function resolveTelegramMediaPlaceholder(
   msg:
-    | Pick<Message, "photo" | "video" | "video_note" | "audio" | "voice" | "document" | "sticker">
+    | Pick<
+        Message,
+        "photo" | "video" | "video_note" | "animation" | "audio" | "voice" | "document" | "sticker"
+      >
     | undefined
     | null,
 ): string | undefined {
@@ -283,7 +286,7 @@ export function resolveTelegramMediaPlaceholder(
   if (msg.photo) {
     return "<media:image>";
   }
-  if (msg.video || msg.video_note) {
+  if (msg.video || msg.video_note || msg.animation) {
     return "<media:video>";
   }
   if (msg.audio || msg.voice) {


### PR DESCRIPTION
## What

Add `animation` to all four spots in the Telegram media download pipeline so GIF-style video messages are downloaded to `media/inbound/` like regular videos.

Fixes #56312

## Root Cause

`video` and `video_note` were handled correctly, but `animation` (Telegram's type for GIFs and looping videos without sound) was missing from:

1. `hasInboundMedia` — animation messages were not detected as having media
2. `resolveInboundMediaFileId` — animation file IDs were not resolved for reply handling
3. `resolveMediaFileRef` — animation was not included in the download path
4. `resolveTelegramMediaPlaceholder` — animation produced no `<media:video>` placeholder

The user's 60MB video was likely sent as a Telegram `animation` (looping, no audio) rather than a `video` — explaining why images worked but videos didn't.

## Fix

Added `msg.animation` in all four functions above, consistent with how `video` and `video_note` are handled.

## Tests

2 new regression tests in `bot.media.downloads-media-file-path-no-file-download.e2e.test.ts`:
- `video` messages → downloaded + `<media:video>` placeholder ✅
- `animation` messages → downloaded + `<media:video>` placeholder ✅

All 1100 tests pass.