### PR TITLE
fix(telegram ): prevent polling watchdog from aborting in-flight message delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/slash commands: make `/steer` and `/redirect` work from the chat command palette with visible pending state for active-run `/steer`, correct redirected-run tracking, and a single canonical `/steer` entry in the command menu. (#54625) Thanks @fuller-stack-dev.
 - Exec: fail closed when the implicit sandbox host has no sandbox runtime, and stop denied async approval followups from reusing prior command output from the same session. (#56800) Thanks @scoootscooob.
 - Plugins/ClawHub: sanitize temporary archive filenames for scoped package names and slash-containing skill slugs so `openclaw plugins install @scope/name` no longer fails with `ENOENT` during archive download. (#56452) Thanks @soimy.
+- Telegram/polling: keep the watchdog from aborting long-running reply delivery by treating recent non-polling API activity as bounded liveness instead of a hard stall. (#56343) Thanks @openperf.
 
 ## 2026.3.28
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -58,7 +58,8 @@ function installPollingStallWatchdogHarness() {
   const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
   const dateNowSpy = vi
     .spyOn(Date, "now")
-    .mockImplementationOnce(() => 0)
+    .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
+    .mockImplementationOnce(() => 0) // lastApiActivityAt init
     .mockImplementation(() => 120_001);
 
   return {
@@ -361,6 +362,120 @@ describe("TelegramPollingSession", () => {
 
     expectTelegramBotTransportSequence(transport1, transport2);
     expect(createTelegramTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger stall restart when non-getUpdates API calls are active", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+
+    // Capture the API middleware so we can simulate sendMessage calls
+    let apiMiddleware:
+      | ((
+          prev: (...args: unknown[]) => Promise<unknown>,
+          method: string,
+          payload: unknown,
+        ) => Promise<unknown>)
+      | undefined;
+
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: vi.fn((fn: typeof apiMiddleware) => {
+            apiMiddleware = fn;
+          }),
+        },
+      },
+      stop: botStop,
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+
+    let firstTaskResolve: (() => void) | undefined;
+    const firstTask = new Promise<void>((resolve) => {
+      firstTaskResolve = resolve;
+    });
+    runMock.mockImplementation(() => ({
+      task: () => firstTask,
+      stop: async () => {
+        await runnerStop();
+        firstTaskResolve?.();
+      },
+      isRunning: () => true,
+    }));
+
+    // t=0: lastGetUpdatesAt and lastApiActivityAt initialized
+    // t=120_001: watchdog fires (getUpdates stale for 120s)
+    // But right before watchdog, a sendMessage succeeded at t=120_000
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn) => {
+      watchdog = fn as () => void;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
+      void Promise.resolve().then(() => (fn as () => void)());
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
+      .mockImplementationOnce(() => 0) // lastApiActivityAt init
+      // Call 3+: watchdog check time and sendMessage activity time
+      .mockImplementation(() => 120_001);
+
+    let watchdog: (() => void) | undefined;
+    const log = vi.fn();
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log,
+      telegramTransport: undefined,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+
+      // Wait for watchdog to be captured
+      for (let attempt = 0; attempt < 20 && !watchdog; attempt += 1) {
+        await Promise.resolve();
+      }
+      expect(watchdog).toBeTypeOf("function");
+
+      // Simulate a sendMessage call through the middleware before watchdog fires.
+      // This updates lastApiActivityAt, proving the network is alive.
+      if (apiMiddleware) {
+        const fakePrev = vi.fn(async () => ({ ok: true }));
+        await apiMiddleware(fakePrev, "sendMessage", { chat_id: 123, text: "hello" });
+      }
+
+      // Now fire the watchdog — getUpdates is stale (120s) but API was just active
+      watchdog?.();
+
+      // The watchdog should NOT have triggered a restart
+      expect(runnerStop).not.toHaveBeenCalled();
+      expect(botStop).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+
+      // Clean up: abort to end the session
+      abort.abort();
+      firstTaskResolve?.();
+      await runPromise;
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+      dateNowSpy.mockRestore();
+    }
   });
 
   it("reuses the transport after a getUpdates conflict", async () => {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -422,7 +422,8 @@ describe("TelegramPollingSession", () => {
       .spyOn(Date, "now")
       .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
       .mockImplementationOnce(() => 0) // lastApiActivityAt init
-      // Call 3+: watchdog check time and sendMessage activity time
+      // All subsequent calls (sendMessage completion + watchdog check) return
+      // the same value, giving apiIdle = 0 — well below the stall threshold.
       .mockImplementation(() => 120_001);
 
     let watchdog: (() => void) | undefined;
@@ -466,6 +467,125 @@ describe("TelegramPollingSession", () => {
       expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
 
       // Clean up: abort to end the session
+      abort.abort();
+      firstTaskResolve?.();
+      await runPromise;
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+      dateNowSpy.mockRestore();
+    }
+  });
+
+  it("does not trigger stall restart while a non-getUpdates API call is in-flight", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+
+    let apiMiddleware:
+      | ((
+          prev: (...args: unknown[]) => Promise<unknown>,
+          method: string,
+          payload: unknown,
+        ) => Promise<unknown>)
+      | undefined;
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: vi.fn((fn: typeof apiMiddleware) => {
+            apiMiddleware = fn;
+          }),
+        },
+      },
+      stop: botStop,
+    });
+
+    let firstTaskResolve: (() => void) | undefined;
+    runMock.mockReturnValue({
+      task: () =>
+        new Promise<void>((resolve) => {
+          firstTaskResolve = resolve;
+        }),
+      stop: async () => {
+        await runnerStop();
+        firstTaskResolve?.();
+      },
+      isRunning: () => true,
+    });
+
+    // t=0: lastGetUpdatesAt and lastApiActivityAt initialized
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn) => {
+      watchdog = fn as () => void;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
+      void Promise.resolve().then(() => (fn as () => void)());
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
+      .mockImplementationOnce(() => 0) // lastApiActivityAt init
+      // All subsequent calls return 120_001, simulating 120s elapsed.
+      .mockImplementation(() => 120_001);
+
+    let watchdog: (() => void) | undefined;
+    const log = vi.fn();
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log,
+      telegramTransport: undefined,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+
+      for (let attempt = 0; attempt < 20 && !watchdog; attempt += 1) {
+        await Promise.resolve();
+      }
+      expect(watchdog).toBeTypeOf("function");
+
+      // Start an in-flight sendMessage that has NOT yet resolved.
+      // This simulates a slow delivery where the API call is still pending.
+      let resolveSendMessage: ((v: unknown) => void) | undefined;
+      if (apiMiddleware) {
+        const slowPrev = vi.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveSendMessage = resolve;
+            }),
+        );
+        // Fire-and-forget: the call is in-flight but not awaited yet
+        const sendPromise = apiMiddleware(slowPrev, "sendMessage", { chat_id: 123, text: "hello" });
+
+        // Fire the watchdog while sendMessage is still in-flight.
+        // Even though apiIdle > threshold, inFlightApiCalls > 0 should suppress.
+        watchdog?.();
+
+        // The watchdog should NOT have triggered a restart
+        expect(runnerStop).not.toHaveBeenCalled();
+        expect(botStop).not.toHaveBeenCalled();
+        expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+
+        // Resolve the in-flight call to clean up
+        resolveSendMessage?.({ ok: true });
+        await sendPromise;
+      }
+
       abort.abort();
       firstTaskResolve?.();
       await runPromise;

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -711,6 +711,136 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("does not trigger stall restart when a newer non-getUpdates API call starts while an older one is still in-flight", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+
+    let apiMiddleware:
+      | ((
+          prev: (...args: unknown[]) => Promise<unknown>,
+          method: string,
+          payload: unknown,
+        ) => Promise<unknown>)
+      | undefined;
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: vi.fn((fn: typeof apiMiddleware) => {
+            apiMiddleware = fn;
+          }),
+        },
+      },
+      stop: botStop,
+    });
+
+    let firstTaskResolve: (() => void) | undefined;
+    runMock.mockReturnValue({
+      task: () =>
+        new Promise<void>((resolve) => {
+          firstTaskResolve = resolve;
+        }),
+      stop: async () => {
+        await runnerStop();
+        firstTaskResolve?.();
+      },
+      isRunning: () => true,
+    });
+
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn) => {
+      watchdog = fn as () => void;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
+      void Promise.resolve().then(() => (fn as () => void)());
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
+      .mockImplementationOnce(() => 0) // lastApiActivityAt init
+      .mockImplementationOnce(() => 1) // first sendMessage start
+      .mockImplementationOnce(() => 120_000) // second sendMessage start
+      .mockImplementation(() => 120_001);
+
+    let watchdog: (() => void) | undefined;
+    const log = vi.fn();
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log,
+      telegramTransport: undefined,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+
+      for (let attempt = 0; attempt < 20 && !watchdog; attempt += 1) {
+        await Promise.resolve();
+      }
+      expect(watchdog).toBeTypeOf("function");
+
+      let resolveFirstSend: ((v: unknown) => void) | undefined;
+      let resolveSecondSend: ((v: unknown) => void) | undefined;
+      if (apiMiddleware) {
+        const firstSendPromise = apiMiddleware(
+          vi.fn(
+            () =>
+              new Promise((resolve) => {
+                resolveFirstSend = resolve;
+              }),
+          ),
+          "sendMessage",
+          { chat_id: 123, text: "older" },
+        );
+        const secondSendPromise = apiMiddleware(
+          vi.fn(
+            () =>
+              new Promise((resolve) => {
+                resolveSecondSend = resolve;
+              }),
+          ),
+          "sendMessage",
+          { chat_id: 123, text: "newer" },
+        );
+
+        // The older send is stale, but the newer send started just now.
+        // Watchdog liveness must follow the newest active non-getUpdates call.
+        watchdog?.();
+
+        expect(runnerStop).not.toHaveBeenCalled();
+        expect(botStop).not.toHaveBeenCalled();
+        expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+
+        resolveFirstSend?.({ ok: true });
+        resolveSecondSend?.({ ok: true });
+        await firstSendPromise;
+        await secondSendPromise;
+      }
+
+      abort.abort();
+      firstTaskResolve?.();
+      await runPromise;
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+      dateNowSpy.mockRestore();
+    }
+  });
+
   it("reuses the transport after a getUpdates conflict", async () => {
     const abort = new AbortController();
     const conflictError = Object.assign(

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -479,7 +479,7 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("does not trigger stall restart while a non-getUpdates API call is in-flight", async () => {
+  it("does not trigger stall restart while a recent non-getUpdates API call is in-flight", async () => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);
     const runnerStop = vi.fn(async () => undefined);
@@ -532,7 +532,7 @@ describe("TelegramPollingSession", () => {
       .spyOn(Date, "now")
       .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
       .mockImplementationOnce(() => 0) // lastApiActivityAt init
-      // All subsequent calls return 120_001, simulating 120s elapsed.
+      .mockImplementationOnce(() => 60_000) // sendMessage start
       .mockImplementation(() => 120_001);
 
     let watchdog: (() => void) | undefined;
@@ -573,7 +573,7 @@ describe("TelegramPollingSession", () => {
         const sendPromise = apiMiddleware(slowPrev, "sendMessage", { chat_id: 123, text: "hello" });
 
         // Fire the watchdog while sendMessage is still in-flight.
-        // Even though apiIdle > threshold, inFlightApiCalls > 0 should suppress.
+        // The in-flight call started 60s ago, so API liveness is still recent.
         watchdog?.();
 
         // The watchdog should NOT have triggered a restart
@@ -582,6 +582,119 @@ describe("TelegramPollingSession", () => {
         expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
 
         // Resolve the in-flight call to clean up
+        resolveSendMessage?.({ ok: true });
+        await sendPromise;
+      }
+
+      abort.abort();
+      firstTaskResolve?.();
+      await runPromise;
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+      dateNowSpy.mockRestore();
+    }
+  });
+
+  it("triggers stall restart when a non-getUpdates API call has been in-flight past the threshold", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+
+    let apiMiddleware:
+      | ((
+          prev: (...args: unknown[]) => Promise<unknown>,
+          method: string,
+          payload: unknown,
+        ) => Promise<unknown>)
+      | undefined;
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        getUpdates: vi.fn(async () => []),
+        config: {
+          use: vi.fn((fn: typeof apiMiddleware) => {
+            apiMiddleware = fn;
+          }),
+        },
+      },
+      stop: botStop,
+    });
+
+    let firstTaskResolve: (() => void) | undefined;
+    runMock.mockReturnValue({
+      task: () =>
+        new Promise<void>((resolve) => {
+          firstTaskResolve = resolve;
+        }),
+      stop: async () => {
+        await runnerStop();
+        firstTaskResolve?.();
+      },
+      isRunning: () => true,
+    });
+
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn) => {
+      watchdog = fn as () => void;
+      return 1 as unknown as ReturnType<typeof setInterval>;
+    });
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => {});
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation((fn) => {
+      void Promise.resolve().then(() => (fn as () => void)());
+      return 1 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => {});
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementationOnce(() => 0) // lastGetUpdatesAt init
+      .mockImplementationOnce(() => 0) // lastApiActivityAt init
+      .mockImplementationOnce(() => 1) // sendMessage start
+      .mockImplementation(() => 120_001);
+
+    let watchdog: (() => void) | undefined;
+    const log = vi.fn();
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log,
+      telegramTransport: undefined,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+
+      for (let attempt = 0; attempt < 20 && !watchdog; attempt += 1) {
+        await Promise.resolve();
+      }
+      expect(watchdog).toBeTypeOf("function");
+
+      let resolveSendMessage: ((v: unknown) => void) | undefined;
+      if (apiMiddleware) {
+        const slowPrev = vi.fn(
+          () =>
+            new Promise((resolve) => {
+              resolveSendMessage = resolve;
+            }),
+        );
+        const sendPromise = apiMiddleware(slowPrev, "sendMessage", { chat_id: 123, text: "hello" });
+
+        // The in-flight send started at t=1 and is still stuck at t=120_001.
+        // That is older than the watchdog threshold, so restart should proceed.
+        watchdog?.();
+
+        expect(runnerStop).toHaveBeenCalledTimes(1);
+        expect(botStop).toHaveBeenCalledTimes(1);
+        expect(log).toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+
         resolveSendMessage?.({ ok: true });
         await sendPromise;
       }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -205,6 +205,7 @@ export class TelegramPollingSession {
 
     let lastGetUpdatesAt = Date.now();
     let lastApiActivityAt = Date.now();
+    let oldestInFlightApiStartedAt: number | null = null;
     let inFlightApiCalls = 0;
     let lastGetUpdatesStartedAt: number | null = null;
     let lastGetUpdatesFinishedAt: number | null = null;
@@ -218,19 +219,20 @@ export class TelegramPollingSession {
 
     bot.api.config.use(async (prev, method, payload, signal) => {
       if (method !== "getUpdates") {
-        // Track in-flight non-getUpdates API calls so the watchdog can
-        // distinguish "network dead" from "delivery in progress".
+        const startedAt = Date.now();
+        if (inFlightApiCalls === 0) {
+          oldestInFlightApiStartedAt = startedAt;
+        }
         inFlightApiCalls += 1;
         try {
           const result = await prev(method, payload, signal);
-          // Any successful non-getUpdates API call (sendMessage, sendChatAction, …)
-          // proves the network is alive. Update the activity timestamp so the
-          // polling-stall watchdog does not misinterpret slow message processing
-          // as a network stall.
           lastApiActivityAt = Date.now();
           return result;
         } finally {
           inFlightApiCalls = Math.max(0, inFlightApiCalls - 1);
+          if (inFlightApiCalls === 0) {
+            oldestInFlightApiStartedAt = null;
+          }
         }
       }
 
@@ -316,17 +318,18 @@ export class TelegramPollingSession {
       const idleElapsed =
         inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
       const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
-      const apiIdle = now - lastApiActivityAt;
+      const apiLivenessAt =
+        oldestInFlightApiStartedAt == null
+          ? lastApiActivityAt
+          : Math.max(lastApiActivityAt, oldestInFlightApiStartedAt);
+      const apiElapsed = now - apiLivenessAt;
 
-      // Only treat as a stall if BOTH getUpdates and all other API activity
-      // (sendMessage, sendChatAction, …) have been silent beyond the threshold,
-      // AND no non-getUpdates API call is currently in-flight.
-      // This prevents the watchdog from aborting in-flight sendMessage calls
-      // when the agent is simply taking a long time to process a message.
+      // Treat recent non-getUpdates success and recent non-getUpdates start as
+      // the same liveness signal. Slow delivery should suppress the watchdog,
+      // but only for the same bounded window as recent successful API traffic.
       if (
         elapsed > POLL_STALL_THRESHOLD_MS &&
-        apiIdle > POLL_STALL_THRESHOLD_MS &&
-        inFlightApiCalls === 0 &&
+        apiElapsed > POLL_STALL_THRESHOLD_MS &&
         runner.isRunning()
       ) {
         if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -204,6 +204,7 @@ export class TelegramPollingSession {
     await this.#confirmPersistedOffset(bot);
 
     let lastGetUpdatesAt = Date.now();
+    let lastApiActivityAt = Date.now();
     let lastGetUpdatesStartedAt: number | null = null;
     let lastGetUpdatesFinishedAt: number | null = null;
     let lastGetUpdatesDurationMs: number | null = null;
@@ -216,7 +217,13 @@ export class TelegramPollingSession {
 
     bot.api.config.use(async (prev, method, payload, signal) => {
       if (method !== "getUpdates") {
-        return prev(method, payload, signal);
+        const result = await prev(method, payload, signal);
+        // Any successful non-getUpdates API call (sendMessage, sendChatAction, …)
+        // proves the network is alive. Update the activity timestamp so the
+        // polling-stall watchdog does not misinterpret slow message processing
+        // as a network stall.
+        lastApiActivityAt = Date.now();
+        return result;
       }
 
       const startedAt = Date.now();
@@ -301,8 +308,17 @@ export class TelegramPollingSession {
       const idleElapsed =
         inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
       const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
+      const apiIdle = now - lastApiActivityAt;
 
-      if (elapsed > POLL_STALL_THRESHOLD_MS && runner.isRunning()) {
+      // Only treat as a stall if BOTH getUpdates and all other API activity
+      // (sendMessage, sendChatAction, …) have been silent beyond the threshold.
+      // This prevents the watchdog from aborting in-flight sendMessage calls
+      // when the agent is simply taking a long time to process a message.
+      if (
+        elapsed > POLL_STALL_THRESHOLD_MS &&
+        apiIdle > POLL_STALL_THRESHOLD_MS &&
+        runner.isRunning()
+      ) {
         if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {
           return;
         }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -205,8 +205,9 @@ export class TelegramPollingSession {
 
     let lastGetUpdatesAt = Date.now();
     let lastApiActivityAt = Date.now();
-    let oldestInFlightApiStartedAt: number | null = null;
-    let inFlightApiCalls = 0;
+    let nextInFlightApiCallId = 0;
+    let latestInFlightApiStartedAt: number | null = null;
+    const inFlightApiStartedAt = new Map<number, number>();
     let lastGetUpdatesStartedAt: number | null = null;
     let lastGetUpdatesFinishedAt: number | null = null;
     let lastGetUpdatesDurationMs: number | null = null;
@@ -220,18 +221,28 @@ export class TelegramPollingSession {
     bot.api.config.use(async (prev, method, payload, signal) => {
       if (method !== "getUpdates") {
         const startedAt = Date.now();
-        if (inFlightApiCalls === 0) {
-          oldestInFlightApiStartedAt = startedAt;
-        }
-        inFlightApiCalls += 1;
+        const callId = nextInFlightApiCallId;
+        nextInFlightApiCallId += 1;
+        inFlightApiStartedAt.set(callId, startedAt);
+        latestInFlightApiStartedAt =
+          latestInFlightApiStartedAt == null
+            ? startedAt
+            : Math.max(latestInFlightApiStartedAt, startedAt);
         try {
           const result = await prev(method, payload, signal);
           lastApiActivityAt = Date.now();
           return result;
         } finally {
-          inFlightApiCalls = Math.max(0, inFlightApiCalls - 1);
-          if (inFlightApiCalls === 0) {
-            oldestInFlightApiStartedAt = null;
+          inFlightApiStartedAt.delete(callId);
+          if (latestInFlightApiStartedAt === startedAt) {
+            let newestStartedAt: number | null = null;
+            for (const activeStartedAt of inFlightApiStartedAt.values()) {
+              newestStartedAt =
+                newestStartedAt == null
+                  ? activeStartedAt
+                  : Math.max(newestStartedAt, activeStartedAt);
+            }
+            latestInFlightApiStartedAt = newestStartedAt;
           }
         }
       }
@@ -319,9 +330,9 @@ export class TelegramPollingSession {
         inFlightGetUpdates > 0 ? 0 : now - (lastGetUpdatesFinishedAt ?? lastGetUpdatesAt);
       const elapsed = inFlightGetUpdates > 0 ? activeElapsed : idleElapsed;
       const apiLivenessAt =
-        oldestInFlightApiStartedAt == null
+        latestInFlightApiStartedAt == null
           ? lastApiActivityAt
-          : Math.max(lastApiActivityAt, oldestInFlightApiStartedAt);
+          : Math.max(lastApiActivityAt, latestInFlightApiStartedAt);
       const apiElapsed = now - apiLivenessAt;
 
       // Treat recent non-getUpdates success and recent non-getUpdates start as

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -205,6 +205,7 @@ export class TelegramPollingSession {
 
     let lastGetUpdatesAt = Date.now();
     let lastApiActivityAt = Date.now();
+    let inFlightApiCalls = 0;
     let lastGetUpdatesStartedAt: number | null = null;
     let lastGetUpdatesFinishedAt: number | null = null;
     let lastGetUpdatesDurationMs: number | null = null;
@@ -217,13 +218,20 @@ export class TelegramPollingSession {
 
     bot.api.config.use(async (prev, method, payload, signal) => {
       if (method !== "getUpdates") {
-        const result = await prev(method, payload, signal);
-        // Any successful non-getUpdates API call (sendMessage, sendChatAction, …)
-        // proves the network is alive. Update the activity timestamp so the
-        // polling-stall watchdog does not misinterpret slow message processing
-        // as a network stall.
-        lastApiActivityAt = Date.now();
-        return result;
+        // Track in-flight non-getUpdates API calls so the watchdog can
+        // distinguish "network dead" from "delivery in progress".
+        inFlightApiCalls += 1;
+        try {
+          const result = await prev(method, payload, signal);
+          // Any successful non-getUpdates API call (sendMessage, sendChatAction, …)
+          // proves the network is alive. Update the activity timestamp so the
+          // polling-stall watchdog does not misinterpret slow message processing
+          // as a network stall.
+          lastApiActivityAt = Date.now();
+          return result;
+        } finally {
+          inFlightApiCalls = Math.max(0, inFlightApiCalls - 1);
+        }
       }
 
       const startedAt = Date.now();
@@ -311,12 +319,14 @@ export class TelegramPollingSession {
       const apiIdle = now - lastApiActivityAt;
 
       // Only treat as a stall if BOTH getUpdates and all other API activity
-      // (sendMessage, sendChatAction, …) have been silent beyond the threshold.
+      // (sendMessage, sendChatAction, …) have been silent beyond the threshold,
+      // AND no non-getUpdates API call is currently in-flight.
       // This prevents the watchdog from aborting in-flight sendMessage calls
       // when the agent is simply taking a long time to process a message.
       if (
         elapsed > POLL_STALL_THRESHOLD_MS &&
         apiIdle > POLL_STALL_THRESHOLD_MS &&
+        inFlightApiCalls === 0 &&
         runner.isRunning()
       ) {
         if (stallDiagLoggedAt && now - stallDiagLoggedAt < POLL_STALL_THRESHOLD_MS / 2) {


### PR DESCRIPTION
## Summary

The polling-stall watchdog in `TelegramPollingSession` silently drops agent replies when message processing takes longer than 90 seconds. This is a data-loss bug — the agent completes its work, but the user never receives the response.

## Root Cause

The watchdog checks every 30s whether `getUpdates` has been called within the last 90s. If not, it assumes the network is stalled and calls `fetchAbortController.abort()`, which cancels **all** in-flight Telegram API requests — including `sendMessage`.

The problem: grammY's `run()` processes updates sequentially. While the agent is thinking (running LLM inference, tool calls, etc.), `getUpdates` naturally pauses. With local models (Ollama, llama.cpp) or long context windows, processing easily exceeds 90s. The watchdog cannot distinguish "network is dead" from "agent is busy", so it kills the reply mid-delivery.

The abort flows through the shared `fetchAbortController` → bot.ts fetch wrapper → undici → `AbortError: This operation was aborted`, and `sendMessage` is not retried on abort errors (confirmed in `delivery.send.ts`).

## Fix

Track a `lastApiActivityAt` timestamp that updates on **any** successful Telegram API call (not just `getUpdates`). The watchdog now requires **both** conditions to trigger:

1. No `getUpdates` for >90s (existing check)
2. No API activity at all for >90s (new check)

If `sendMessage` or `sendChatAction` succeeds during message processing, it proves the network is alive, and the watchdog stays quiet. Only when the connection is genuinely dead (no API calls succeed) does the watchdog intervene.

This is a minimal, backward-compatible change — 2 files, +141/−5 lines (including tests).

## Changes

| File | What changed |
|------|-------------|
| `extensions/telegram/src/polling-session.ts` | Added `lastApiActivityAt` tracking in API middleware; watchdog now checks both `elapsed` and `apiIdle` before triggering |
| `extensions/telegram/src/polling-session.test.ts` | Fixed existing stall test to account for new timestamp initialization; added regression test verifying that recent `sendMessage` activity suppresses the watchdog |

## Reproduction

1. Configure a local Ollama model (or any model with >90s response time)
2. Send a message via Telegram channel
3. Observe: agent processes the message, but the reply is silently dropped
4. Logs show: `[telegram] Polling stall detected (no getUpdates for 102.25s); forcing restart.`
5. Stacktrace points to `stopRunner` at `polling-session.ts:214` aborting the fetch

## Related Issues

This single root cause has been reported independently by multiple users:

| Issue | Title | Version |
|-------|-------|---------|
| #56065 | Telegram lost messages with 'Network request failed' | v2026.3.24 |
| #53374 | Gateway hangs with Ollama model in main Telegram session | v2026.3.23-2 |
| #54708 | Message Loss on Telegram Network Failure | v2026.3.23-2 |

Fixes #56065