### PR TITLE
docker: allow configurable runtime uid/gid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    user: "${OPENCLAW_UID:-1000}:${OPENCLAW_GID:-1000}"
     environment:
       HOME: /home/node
       TERM: xterm-256color
@@ -51,6 +52,7 @@ services:
 
   openclaw-cli:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
+    user: "${OPENCLAW_UID:-1000}:${OPENCLAW_GID:-1000}"
     network_mode: "service:openclaw-gateway"
     cap_drop:
       - NET_RAW

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -270,11 +270,23 @@ See the [`ClawDock` Helper README](https://github.com/openclaw/openclaw/blob/mai
   </Accordion>
 
   <Accordion title="Permissions and EACCES">
-    The image runs as `node` (uid 1000). If you see permission errors on
-    `/home/node/.openclaw`, make sure your host bind mounts are owned by uid 1000:
+    The runtime container user defaults to `1000:1000`, but Docker installs can
+    override that with `OPENCLAW_UID` / `OPENCLAW_GID` (for example Unraid's
+    `99:100`). If you see permission errors on `/home/node/.openclaw`, make sure
+    your host bind mounts are writable by the configured runtime UID/GID.
+
+    For the default runtime user:
 
     ```bash
     sudo chown -R 1000:1000 /path/to/openclaw-config /path/to/openclaw-workspace
+    ```
+
+    For common Unraid ownership:
+
+    ```bash
+    export OPENCLAW_UID=99
+    export OPENCLAW_GID=100
+    ./scripts/docker/setup.sh
     ```
 
   </Accordion>

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -134,6 +134,8 @@ The setup script accepts these optional environment variables:
 | `OPENCLAW_EXTENSIONS`          | Pre-install extension deps at build time (space-separated names) |
 | `OPENCLAW_EXTRA_MOUNTS`        | Extra host bind mounts (comma-separated `source:target[:opts]`)  |
 | `OPENCLAW_HOME_VOLUME`         | Persist `/home/node` in a named Docker volume                    |
+| `OPENCLAW_UID`                 | Runtime container user UID (default: `1000`)                     |
+| `OPENCLAW_GID`                 | Runtime container group GID (default: `1000`)                   |
 | `OPENCLAW_SANDBOX`             | Opt in to sandbox bootstrap (`1`, `true`, `yes`, `on`)           |
 | `OPENCLAW_DOCKER_SOCKET`       | Override Docker socket path                                      |
 
@@ -175,6 +177,40 @@ Use bind mode values in `gateway.bind` (`lan` / `loopback` / `custom` /
 Docker Compose bind-mounts `OPENCLAW_CONFIG_DIR` to `/home/node/.openclaw` and
 `OPENCLAW_WORKSPACE_DIR` to `/home/node/.openclaw/workspace`, so those paths
 survive container replacement.
+
+The runtime image defaults to the non-root `node` user (UID/GID `1000:1000`).
+Docker installs can override that runtime user with `OPENCLAW_UID` and
+`OPENCLAW_GID` (for example Unraid's `99:100`). `scripts/docker/setup.sh`
+repairs ownership for the config dir and OpenClaw-managed metadata under
+`workspace/.openclaw`, but it intentionally does **not** recursively `chown`
+your whole workspace mount.
+
+Practical implication:
+
+- OpenClaw config/state under `/home/node/.openclaw` should be auto-fixed by the setup script for the selected runtime UID/GID.
+- Your actual workspace files under `/home/node/.openclaw/workspace` still need host-side permissions that allow the chosen runtime UID/GID to write.
+- Sandbox sessions are different: when `agents.defaults.sandbox.docker.user` is unset, OpenClaw auto-detects the mounted workspace owner and runs the sandbox container as that `UID:GID`.
+
+**Unraid note:** if your appdata/share is owned by `nobody:users` (`99:100`),
+set:
+
+```bash
+export OPENCLAW_UID=99
+export OPENCLAW_GID=100
+./scripts/docker/setup.sh
+```
+
+This keeps the gateway/CLI containers aligned with typical Unraid ownership
+without weakening OpenClaw's internal sensitive-file hardening (`0600`/`0700`
+for config, credentials, sessions, and similar state files).
+
+If you change runtime UID/GID on an existing install, make sure existing state
+files are writable by the new user before restarting. Old files owned by root or
+`1000:1000` can still trigger `EACCES` even after the compose services switch
+users.
+
+Avoid SMB/NFS export modes that map writes to a different anonymous UID/GID than
+the one Docker sees locally.
 
 For full persistence details on VM deployments, see
 [Docker VM Runtime - What persists where](/install/docker-vm-runtime#what-persists-where).

--- a/scripts/docker/setup.sh
+++ b/scripts/docker/setup.sh
@@ -11,6 +11,8 @@ RAW_SANDBOX_SETTING="${OPENCLAW_SANDBOX:-}"
 SANDBOX_ENABLED=""
 DOCKER_SOCKET_PATH="${OPENCLAW_DOCKER_SOCKET:-}"
 TIMEZONE="${OPENCLAW_TZ:-}"
+RUNTIME_UID_RAW="${OPENCLAW_UID:-1000}"
+RUNTIME_GID_RAW="${OPENCLAW_GID:-1000}"
 
 fail() {
   echo "ERROR: $*" >&2
@@ -174,6 +176,14 @@ is_valid_timezone() {
   [[ -e "/usr/share/zoneinfo/$value" && ! -d "/usr/share/zoneinfo/$value" ]]
 }
 
+validate_numeric_id() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    fail "$label must be a numeric UID/GID value."
+  fi
+}
+
 validate_mount_path_value() {
   local label="$1"
   local value="$2"
@@ -228,6 +238,8 @@ OPENCLAW_WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
 
 validate_mount_path_value "OPENCLAW_CONFIG_DIR" "$OPENCLAW_CONFIG_DIR"
 validate_mount_path_value "OPENCLAW_WORKSPACE_DIR" "$OPENCLAW_WORKSPACE_DIR"
+validate_numeric_id "OPENCLAW_UID" "$RUNTIME_UID_RAW"
+validate_numeric_id "OPENCLAW_GID" "$RUNTIME_GID_RAW"
 if [[ -n "$HOME_VOLUME_NAME" ]]; then
   if [[ "$HOME_VOLUME_NAME" == *"/"* ]]; then
     validate_mount_path_value "OPENCLAW_HOME_VOLUME" "$HOME_VOLUME_NAME"
@@ -275,6 +287,8 @@ export OPENCLAW_ALLOW_INSECURE_PRIVATE_WS="${OPENCLAW_ALLOW_INSECURE_PRIVATE_WS:
 export OPENCLAW_SANDBOX="$SANDBOX_ENABLED"
 export OPENCLAW_DOCKER_SOCKET="$DOCKER_SOCKET_PATH"
 export OPENCLAW_TZ="$TIMEZONE"
+export OPENCLAW_UID="$RUNTIME_UID_RAW"
+export OPENCLAW_GID="$RUNTIME_GID_RAW"
 
 # Detect Docker socket GID for sandbox group_add.
 DOCKER_GID=""
@@ -460,7 +474,9 @@ upsert_env "$ENV_FILE" \
   DOCKER_GID \
   OPENCLAW_INSTALL_DOCKER_CLI \
   OPENCLAW_ALLOW_INSECURE_PRIVATE_WS \
-  OPENCLAW_TZ
+  OPENCLAW_TZ \
+  OPENCLAW_UID \
+  OPENCLAW_GID
 
 if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
   echo "==> Building Docker image: $IMAGE_NAME"
@@ -479,11 +495,11 @@ else
   fi
 fi
 
-# Ensure bind-mounted data directories are writable by the container's `node`
-# user (uid 1000). Host-created dirs inherit the host user's uid which may
-# differ, causing EACCES when the container tries to mkdir/write.
-# Running a brief root container to chown is the portable Docker idiom --
-# it works regardless of the host uid and doesn't require host-side root.
+# Ensure bind-mounted data directories are writable by the runtime UID/GID.
+# Host-created dirs inherit the host user's ownership which may differ, causing
+# EACCES when the container tries to mkdir/write sensitive state.
+# Running a brief root container to chown is the portable Docker idiom -- it
+# works regardless of the host uid and doesn't require host-side root.
 echo ""
 echo "==> Fixing data-directory permissions"
 # Use -xdev to restrict chown to the config-dir mount only — without it,
@@ -492,14 +508,15 @@ echo "==> Fixing data-directory permissions"
 # After fixing the config dir, only the OpenClaw metadata subdirectory
 # (.openclaw/) inside the workspace gets chowned, not the user's project files.
 run_prestart_gateway --user root --entrypoint sh openclaw-gateway -c \
-  'find /home/node/.openclaw -xdev -exec chown node:node {} +; \
-   [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R node:node /home/node/.openclaw/workspace/.openclaw || true'
+  'find /home/node/.openclaw -xdev -exec chown '"$OPENCLAW_UID:$OPENCLAW_GID"' {} +; \
+   [ -d /home/node/.openclaw/workspace/.openclaw ] && chown -R '"$OPENCLAW_UID:$OPENCLAW_GID"' /home/node/.openclaw/workspace/.openclaw || true'
 
 echo ""
 echo "==> Onboarding (interactive)"
 echo "Docker setup pins Gateway mode to local."
 echo "Gateway runtime bind comes from OPENCLAW_GATEWAY_BIND (default: lan)."
 echo "Current runtime bind: $OPENCLAW_GATEWAY_BIND"
+echo "Runtime UID:GID: $OPENCLAW_UID:$OPENCLAW_GID"
 echo "Gateway token: $OPENCLAW_GATEWAY_TOKEN"
 echo "Tailscale exposure: Off (use host-level tailnet/Tailscale setup separately)."
 echo "Install Gateway daemon: No (managed by Docker Compose)"


### PR DESCRIPTION
## Summary
- allow Docker installs to override the runtime container UID/GID via `OPENCLAW_UID` / `OPENCLAW_GID`
- propagate the configured UID/GID through `docker-compose.yml` and `scripts/docker/setup.sh`
- document Unraid/NAS ownership guidance without weakening sensitive file permissions

## Why
OpenClaw's Docker setup currently assumes a runtime user of `node` (`1000:1000`). That works on many Linux hosts, but it creates friction on Unraid/NAS-style deployments where bind-mounted appdata is commonly owned by `nobody:users` (`99:100`).

This patch keeps the default behavior unchanged for existing installs while allowing operators to align the container runtime user with host mount ownership.

## What changed
- `docker-compose.yml`
  - run both `openclaw-gateway` and `openclaw-cli` as `${OPENCLAW_UID:-1000}:${OPENCLAW_GID:-1000}`
- `scripts/docker/setup.sh`
  - validate numeric `OPENCLAW_UID` / `OPENCLAW_GID`
  - export/persist them into `.env`
  - use the configured UID/GID when repairing ownership for config state and `workspace/.openclaw`
- `docs/install/docker.md`
  - document the new env vars
  - add Unraid (`99:100`) examples
  - clarify permissions/EACCES troubleshooting and migration notes

## Security notes
- this does **not** loosen OpenClaw's sensitive-file hardening
- config, credentials, sessions, and similar state files still rely on the app's existing `0600` / `0700` behavior
- the setup script still avoids recursively chowning the user's whole workspace

## Migration notes
If an existing install switches from `1000:1000` to another UID/GID, old state files may still be owned by the previous runtime user. The docs now call this out explicitly because those stale owners can still trigger `EACCES` until corrected.
