### PR TITLE
fix: prefer local pairing access for devices cli on loopback

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,7 +683,7 @@ importers:
     dependencies:
       '@create-markdown/preview':
         specifier: ^2.0.0
-        version: 2.0.0(@create-markdown/core@2.0.0)(shiki@3.23.0)
+        version: 2.0.0(shiki@3.23.0)
       '@noble/ed25519':
         specifier: 3.0.1
         version: 3.0.1
@@ -1036,10 +1036,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@create-markdown/core@2.0.0':
-    resolution: {integrity: sha512-xOmhoiDSa82EzjXp3aViQdB+xfCP4E2jEKxJiKJ702sup3p/CTCtL8fZBKQ3BvzASQRpq/xKCRXZZwRrg1DmZQ==}
-    engines: {node: '>=20.0.0'}
 
   '@create-markdown/preview@2.0.0':
     resolution: {integrity: sha512-3WTGCrCOVBy9wH2X82Oa2ZHJ+eiEqu8AlucckenWVtFSbzRKzkxgci0BRw7IDvsOsTUEMxS9Ltc9/hSUHkdidA==}
@@ -7478,12 +7474,8 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@create-markdown/core@2.0.0':
-    optional: true
-
-  '@create-markdown/preview@2.0.0(@create-markdown/core@2.0.0)(shiki@3.23.0)':
+  '@create-markdown/preview@2.0.0(shiki@3.23.0)':
     optionalDependencies:
-      '@create-markdown/core': 2.0.0
       shiki: 3.23.0
 
   '@csstools/color-helpers@6.0.2': {}

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -7,7 +7,7 @@ runtime.exit.mockImplementation(() => {});
 const callGateway = vi.fn();
 const buildGatewayConnectionDetails = vi.fn(() => ({
   url: "ws://127.0.0.1:18789",
-  urlSource: "local loopback",
+  urlSource: "config",
   message: "",
 }));
 const listDevicePairing = vi.fn();
@@ -240,10 +240,12 @@ describe("devices cli tokens", () => {
 });
 
 describe("devices cli local fallback", () => {
-  const fallbackNotice = "Direct scope access failed; using local fallback.";
-
-  it("falls back to local pairing list when gateway returns pairing required on loopback", async () => {
-    callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+  it("uses local pairing list directly on implicit loopback", async () => {
+    buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "local loopback",
+      message: "",
+    });
     listDevicePairing.mockResolvedValueOnce({
       pending: [{ requestId: "req-1", deviceId: "device-1", publicKey: "pk", ts: 1 }],
       paired: [],
@@ -252,17 +254,42 @@ describe("devices cli local fallback", () => {
 
     await runDevicesCommand(["list"]);
 
-    expect(callGateway).toHaveBeenCalledWith(
-      expect.objectContaining({ method: "device.pair.list" }),
-    );
+    expect(callGateway).not.toHaveBeenCalled();
     expect(listDevicePairing).toHaveBeenCalledTimes(1);
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
+  });
+
+  it("uses local pairing list directly on implicit loopback in json mode", async () => {
+    buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "local loopback",
+      message: "",
+    });
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [],
+      paired: [
+        {
+          deviceId: "device-1",
+          publicKey: "pk",
+          createdAtMs: 1,
+          approvedAtMs: 1,
+        },
+      ],
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesCommand(["list", "--json"]);
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(listDevicePairing).toHaveBeenCalledTimes(1);
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining('"deviceId": "device-1"'));
   });
 
   it("falls back to local approve when gateway returns pairing required on loopback", async () => {
-    callGateway
-      .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"))
-      .mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "local loopback",
+      message: "",
+    });
     listDevicePairing.mockResolvedValueOnce({
       pending: [{ requestId: "req-latest", deviceId: "device-1", publicKey: "pk", ts: 2 }],
       paired: [],
@@ -281,12 +308,16 @@ describe("devices cli local fallback", () => {
     await runDevicesApprove(["--latest"]);
 
     expect(approveDevicePairing).toHaveBeenCalledWith("req-latest");
-    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining(fallbackNotice));
     expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("Approved"));
   });
 
   it("does not use local fallback when an explicit --url is provided", async () => {
     callGateway.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    buildGatewayConnectionDetails.mockReturnValue({
+      url: "ws://127.0.0.1:18789",
+      urlSource: "local loopback",
+      message: "",
+    });
 
     await expect(
       runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]),
@@ -325,7 +356,7 @@ afterEach(() => {
   buildGatewayConnectionDetails.mockClear();
   buildGatewayConnectionDetails.mockReturnValue({
     url: "ws://127.0.0.1:18789",
-    urlSource: "local loopback",
+    urlSource: "config",
     message: "",
   });
   listDevicePairing.mockClear();

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -99,9 +99,28 @@ function normalizeErrorMessage(error: unknown): string {
   return String(error);
 }
 
+function shouldPreferLocalPairingAccess(opts: DevicesRpcOpts): boolean {
+  if (typeof opts.url === "string" && opts.url.trim().length > 0) {
+    return false;
+  }
+  const connection = buildGatewayConnectionDetails();
+  if (connection.urlSource !== "local loopback") {
+    return false;
+  }
+  try {
+    return isLoopbackHost(new URL(connection.url).hostname);
+  } catch {
+    return false;
+  }
+}
+
 function shouldUseLocalPairingFallback(opts: DevicesRpcOpts, error: unknown): boolean {
   const message = normalizeErrorMessage(error).toLowerCase();
-  if (!message.includes("pairing required")) {
+  const isRecoverableLocalFailure =
+    message.includes("pairing required") ||
+    message.includes("gateway timeout") ||
+    message.includes("gateway client stopped");
+  if (!isRecoverableLocalFailure) {
     return false;
   }
   if (typeof opts.url === "string" && opts.url.trim().length > 0) {
@@ -129,6 +148,13 @@ function redactLocalPairedDevice(device: InfraPairedDevice): PairedDevice {
 }
 
 async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePairingList> {
+  if (shouldPreferLocalPairingAccess(opts)) {
+    const local = await listDevicePairing();
+    return {
+      pending: local.pending as PendingDevice[],
+      paired: local.paired.map((device) => redactLocalPairedDevice(device)),
+    };
+  }
   try {
     return parseDevicePairingList(await callGatewayCli("device.pair.list", opts, {}));
   } catch (error) {
@@ -150,6 +176,16 @@ async function approvePairingWithFallback(
   opts: DevicesRpcOpts,
   requestId: string,
 ): Promise<Record<string, unknown> | null> {
+  if (shouldPreferLocalPairingAccess(opts)) {
+    const approved = await approveDevicePairing(requestId);
+    if (!approved) {
+      return null;
+    }
+    return {
+      requestId,
+      device: redactLocalPairedDevice(approved.device),
+    };
+  }
   try {
     return await callGatewayCli("device.pair.approve", opts, { requestId });
   } catch (error) {


### PR DESCRIPTION
## Summary\n- prefer local pairing file access for devices CLI on local loopback connections\n- avoid unnecessary RPC timeout/client-stopped failures for local device list/approve flows\n- add coverage for local loopback and non-loopback behavior\n\n## Testing\n- pnpm exec vitest run src/cli/devices-cli.test.ts\n- pnpm build\n- node openclaw.mjs devices list --json\n- node openclaw.mjs gateway health