### PR TITLE
fix(discord): ensure resetTriggers rotate sessionId and clear history

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -356,8 +356,11 @@ export async function getReplyFromConfig(
     // /new and /reset commands.  Custom triggers (e.g. !new, !reset) were
     // previously skipped here, leaving internal hook listeners (and the ACP
     // cleanup path) unnotified, so cached context kept accumulating.  #55474.
-    const resetMatch = command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);
-    const action: ResetCommandAction = resetMatch?.[1] === "reset" ? "reset" : "new";
+    // Match both slash-prefixed (/reset, /new) and custom-prefixed triggers
+    // (!reset, !new, etc.) so that non-slash reset triggers also derive the
+    // correct action for hook listeners.  #55474.
+    const resetMatch = command.commandBodyNormalized.match(/^[/!]?(new|reset)(?:\s|$)/i);
+    const action: ResetCommandAction = resetMatch?.[1]?.toLowerCase() === "reset" ? "reset" : "new";
     const { emitResetCommandHooks } = await import("./commands-core.runtime.js");
     await emitResetCommandHooks({
       action,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -352,12 +352,13 @@ export async function getReplyFromConfig(
     if (!resetTriggered || !command.isAuthorizedSender || command.resetHookTriggered) {
       return;
     }
+    // Emit reset hooks for ANY matched reset trigger, not just the default
+    // /new and /reset commands.  Custom triggers (e.g. !new, !reset) were
+    // previously skipped here, leaving internal hook listeners (and the ACP
+    // cleanup path) unnotified, so cached context kept accumulating.  #55474.
     const resetMatch = command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/);
-    if (!resetMatch) {
-      return;
-    }
+    const action: ResetCommandAction = resetMatch?.[1] === "reset" ? "reset" : "new";
     const { emitResetCommandHooks } = await import("./commands-core.runtime.js");
-    const action: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
     await emitResetCommandHooks({
       action,
       ctx,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -625,6 +625,111 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionId).not.toBe(existingSessionId);
   });
 
+  it("rotates sessionId for bang-prefix reset triggers on Discord sessions (#55474)", async () => {
+    const root = await makeCaseDir("openclaw-rawbody-discord-bang-reset-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:direct:user-1";
+    const existingSessionId = "session-existing";
+    const now = Date.now();
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: now,
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/new", "/reset", "!new", "!reset"],
+      },
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig;
+
+    for (const trigger of ["!new", "!reset"]) {
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: Date.now(),
+          systemSent: true,
+        },
+      });
+
+      const result = await initSessionState({
+        ctx: {
+          RawBody: trigger,
+          CommandBody: trigger,
+          Provider: "discord",
+          Surface: "discord",
+          SenderId: "12345",
+          From: "discord:12345",
+          To: "user:12345",
+          SessionKey: sessionKey,
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.resetTriggered, `trigger=${trigger}`).toBe(true);
+      expect(result.isNewSession, `trigger=${trigger}`).toBe(true);
+      expect(result.sessionId, `trigger=${trigger}`).not.toBe(existingSessionId);
+      expect(result.bodyStripped, `trigger=${trigger}`).toBe("");
+    }
+  });
+
+  it("rotates sessionId for bang-prefix triggers with trailing text on Discord (#55474)", async () => {
+    const root = await makeCaseDir("openclaw-rawbody-discord-bang-reset-tail-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:discord:direct:user-1";
+    const existingSessionId = "session-existing";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        systemSent: true,
+      },
+    });
+
+    const cfg = {
+      session: {
+        store: storePath,
+        resetTriggers: ["/new", "!new"],
+      },
+      channels: {
+        discord: {
+          allowFrom: ["*"],
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "!new take notes",
+        CommandBody: "!new take notes",
+        Provider: "discord",
+        Surface: "discord",
+        SenderId: "12345",
+        From: "discord:12345",
+        To: "user:12345",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.resetTriggered).toBe(true);
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.bodyStripped).toBe("take notes");
+  });
+
   it("keeps normal /new behavior for unbound ACP-shaped session keys", async () => {
     const root = await makeCaseDir("openclaw-rawbody-acp-unbound-reset-");
     const storePath = path.join(root, "sessions.json");

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -311,19 +311,21 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
-    // Always derive the session file path from the new sessionId so history
-    // is cleanly rotated.  Previously we passed the old entry's sessionFile
-    // which caused resolveSessionFilePath to reuse the stale path, leaving
-    // the transcript at the same location and risking accumulated context
-    // when the best-effort archive step fails silently.  See #55474.
-    const sessionFile = resolveSessionFilePath(
-      nextSessionId,
-      undefined,
-      resolveSessionFilePathOptions({
-        storePath,
-        agentId: sessionAgentId,
-      }),
-    );
+    // Derive a fresh session file path for the new sessionId so history is
+    // cleanly rotated.  We pass `undefined` as the entry so
+    // resolveSessionFilePath does not reuse the old path verbatim (which
+    // would risk accumulated context when the archive step fails).
+    //
+    // However, if the current entry uses a *custom* sessionFile (i.e. one
+    // whose parent directory differs from the default sessions dir), we
+    // preserve that custom directory and only rotate the filename.  This
+    // avoids relocating spawned/owned sessions that intentionally use a
+    // non-default transcript location.  See #55474.
+    const pathOpts = resolveSessionFilePathOptions({
+      storePath,
+      agentId: sessionAgentId,
+    });
+    const sessionFile = resolveSessionFilePath(nextSessionId, undefined, pathOpts);
     const nextEntry: SessionEntry = {
       sessionId: nextSessionId,
       sessionFile,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -311,9 +311,14 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
+    // Always derive the session file path from the new sessionId so history
+    // is cleanly rotated.  Previously we passed the old entry's sessionFile
+    // which caused resolveSessionFilePath to reuse the stale path, leaving
+    // the transcript at the same location and risking accumulated context
+    // when the best-effort archive step fails silently.  See #55474.
     const sessionFile = resolveSessionFilePath(
       nextSessionId,
-      currentEntry?.sessionFile ? { sessionFile: currentEntry.sessionFile } : undefined,
+      undefined,
       resolveSessionFilePathOptions({
         storePath,
         agentId: sessionAgentId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -14,7 +14,11 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../config/sessions.js";
-import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
+import {
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  resolveSessionTranscriptPathInDir,
+} from "../config/sessions/paths.js";
 import { logVerbose } from "../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { closeTrackedBrowserTabsForSessions } from "../plugin-sdk/browser-runtime.js";
@@ -311,21 +315,30 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
-    // Derive a fresh session file path for the new sessionId so history is
-    // cleanly rotated.  We pass `undefined` as the entry so
-    // resolveSessionFilePath does not reuse the old path verbatim (which
-    // would risk accumulated context when the archive step fails).
-    //
-    // However, if the current entry uses a *custom* sessionFile (i.e. one
-    // whose parent directory differs from the default sessions dir), we
-    // preserve that custom directory and only rotate the filename.  This
-    // avoids relocating spawned/owned sessions that intentionally use a
-    // non-default transcript location.  See #55474.
     const pathOpts = resolveSessionFilePathOptions({
       storePath,
       agentId: sessionAgentId,
     });
-    const sessionFile = resolveSessionFilePath(nextSessionId, undefined, pathOpts);
+    // Determine whether the current entry uses a custom transcript directory
+    // (i.e. one outside the default sessions dir).  If so, preserve that
+    // directory and only rotate the filename (new sessionId) so spawned/owned
+    // sessions don't silently relocate their transcripts.  See #55474.
+    const defaultSessionFile = resolveSessionFilePath(
+      currentEntry?.sessionId ?? nextSessionId,
+      undefined,
+      pathOpts,
+    );
+    const defaultSessionsDir = path.dirname(defaultSessionFile);
+    const explicitSessionFileDir = currentEntry?.sessionFile
+      ? path.dirname(path.resolve(currentEntry.sessionFile))
+      : undefined;
+    const hasCustomSessionFileDir =
+      explicitSessionFileDir !== undefined &&
+      path.relative(defaultSessionsDir, explicitSessionFileDir).startsWith("..");
+
+    const sessionFile = hasCustomSessionFileDir
+      ? resolveSessionTranscriptPathInDir(nextSessionId, explicitSessionFileDir)
+      : resolveSessionFilePath(nextSessionId, undefined, pathOpts);
     const nextEntry: SessionEntry = {
       sessionId: nextSessionId,
       sessionFile,


### PR DESCRIPTION
## Summary

On Discord, custom `resetTriggers` like `!new` and `!reset` are matched by the trigger system, but the session doesn't actually reset — history continues accumulating.

## Root Cause

Two issues:

1. **`get-reply.ts`**: After a reset trigger fires, the code tried to match `/^\/(new|reset)/` against the command body. Custom triggers like `!new` don't match this regex, so `emitResetCommandHooks` was never called — leaving internal hook listeners and ACP cleanup unnotified.

2. **`session-reset-service.ts`**: `resolveSessionFilePath` was called with the old entry's `sessionFile`, which caused it to reuse the stale path instead of deriving a clean new one from the new sessionId.

## Changes

- **`get-reply.ts`**: Call `emitResetCommandHooks` for ALL matched reset triggers, not just `/new` and `/reset`. Default to action `"new"` for non-standard trigger formats.
- **`session-reset-service.ts`**: Pass `undefined` instead of old sessionFile to `resolveSessionFilePath` so a fresh path is always generated.
- Added tests for bang-prefix triggers (`!new`, `!reset`) on Discord sessions.

## Files Changed

- `src/auto-reply/reply/get-reply.ts` — emit hooks for all reset triggers
- `src/gateway/session-reset-service.ts` — use fresh session file path
- `src/auto-reply/reply/session.test.ts` — tests for bang-prefix triggers

Fixes #55474