### PR TITLE
fix: propagate stop to active subagents

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -54,7 +54,7 @@ vi.mock("../../agents/subagent-registry.js", () => ({
 
 const acpManagerMocks = vi.hoisted(() => ({
   resolveSession: vi.fn<
-    () =>
+    (params?: { sessionKey?: string }) =>
       | { kind: "none" }
       | {
           kind: "ready";
@@ -585,6 +585,50 @@ describe("abort detection", () => {
     expectSessionLaneCleared(childKey);
   });
 
+  it("fast-abort cascades ACP cancel to active child sessions", async () => {
+    const sessionKey = "telegram:parent";
+    const childKey = "agent:main:subagent:child-1";
+    const sessionId = "session-parent";
+    const childSessionId = "session-child";
+    const { cfg } = await createAbortConfig({
+      sessionIdsByKey: {
+        [sessionKey]: sessionId,
+        [childKey]: childSessionId,
+      },
+    });
+
+    subagentRegistryMocks.listSubagentRunsForRequester.mockReturnValueOnce([
+      {
+        runId: "run-1",
+        childSessionKey: childKey,
+        requesterSessionKey: sessionKey,
+        requesterDisplayKey: "telegram:parent",
+        task: "do work",
+        cleanup: "keep",
+        createdAt: Date.now(),
+      },
+    ]);
+    acpManagerMocks.resolveSession.mockImplementation(({ sessionKey }) =>
+      sessionKey === childKey ? { kind: "ready", sessionKey: childKey, meta: {} } : { kind: "none" },
+    );
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey,
+      from: "telegram:parent",
+      to: "telegram:parent",
+    });
+
+    expect(result.stoppedSubagents).toBe(1);
+    expect(acpManagerMocks.cancelSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        sessionKey: childKey,
+        reason: "subagent-stop",
+      }),
+    );
+  });
+
   it("cascade stop kills depth-2 children when stopping depth-1 agent", async () => {
     const sessionKey = "telegram:parent";
     const depth1Key = "agent:main:subagent:child-1";
@@ -864,7 +908,7 @@ describe("abort detection", () => {
       return null;
     });
 
-    const result = stopSubagentsForRequester({
+    const result = await stopSubagentsForRequester({
       cfg: {} as OpenClawConfig,
       requesterSessionKey: oldParentKey,
     });

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -136,10 +136,10 @@ function normalizeRequesterSessionKey(
   return resolveInternalSessionKey({ key: cleaned, alias, mainKey });
 }
 
-export function stopSubagentsForRequester(params: {
+export async function stopSubagentsForRequester(params: {
   cfg: OpenClawConfig;
   requesterSessionKey?: string;
-}): { stopped: number } {
+}): Promise<{ stopped: number }> {
   const requesterKey = normalizeRequesterSessionKey(params.cfg, params.requesterSessionKey);
   if (!requesterKey) {
     return { stopped: 0 };
@@ -169,6 +169,7 @@ export function stopSubagentsForRequester(params: {
   const storeCache = new Map<string, Record<string, SessionEntry>>();
   const seenChildKeys = new Set<string>();
   let stopped = 0;
+  const acpManager = abortDeps.getAcpSessionManager();
 
   for (const run of runs) {
     const childKey = run.childSessionKey?.trim();
@@ -186,8 +187,27 @@ export function stopSubagentsForRequester(params: {
         store = loadSessionStore(storePath);
         storeCache.set(storePath, store);
       }
-      const entry = store[childKey];
+      const { entry, key, legacyKeys } = resolveSessionEntryForKey(store, childKey);
       const sessionId = entry?.sessionId;
+      let acpCancelled = false;
+      const acpResolution = acpManager.resolveSession({
+        cfg: params.cfg,
+        sessionKey: childKey,
+      });
+      if (acpResolution.kind !== "none") {
+        try {
+          await acpManager.cancelSession({
+            cfg: params.cfg,
+            sessionKey: childKey,
+            reason: "subagent-stop",
+          });
+          acpCancelled = true;
+        } catch (error) {
+          logVerbose(
+            `abort: ACP cancel failed for child ${childKey}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
       const aborted = sessionId ? abortDeps.abortEmbeddedPiRun(sessionId) : false;
       const markedTerminated =
         abortDeps.markSubagentRunTerminated({
@@ -196,13 +216,44 @@ export function stopSubagentsForRequester(params: {
           reason: "killed",
         }) > 0;
 
-      if (markedTerminated || aborted || cleared.followupCleared > 0 || cleared.laneCleared > 0) {
+      if (entry && key) {
+        entry.abortedLastRun = true;
+        entry.updatedAt = Date.now();
+        store[key] = entry;
+        for (const legacyKey of legacyKeys ?? []) {
+          if (legacyKey !== key) {
+            delete store[legacyKey];
+          }
+        }
+        await updateSessionStore(storePath, (nextStore) => {
+          const nextEntry = nextStore[key] ?? entry;
+          if (!nextEntry) {
+            return;
+          }
+          nextEntry.abortedLastRun = true;
+          nextEntry.updatedAt = Date.now();
+          nextStore[key] = nextEntry;
+          for (const legacyKey of legacyKeys ?? []) {
+            if (legacyKey !== key) {
+              delete nextStore[legacyKey];
+            }
+          }
+        });
+      }
+
+      if (
+        markedTerminated ||
+        aborted ||
+        acpCancelled ||
+        cleared.followupCleared > 0 ||
+        cleared.laneCleared > 0
+      ) {
         stopped += 1;
       }
     }
 
     // Cascade: also stop any sub-sub-agents spawned by this child.
-    const cascadeResult = stopSubagentsForRequester({
+    const cascadeResult = await stopSubagentsForRequester({
       cfg: params.cfg,
       requesterSessionKey: childKey,
     });
@@ -312,13 +363,13 @@ export async function tryFastAbortFromMessage(params: {
     } else if (abortKey) {
       setAbortMemory(abortKey, true);
     }
-    const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
+    const { stopped } = await stopSubagentsForRequester({ cfg, requesterSessionKey });
     return { handled: true, aborted, stoppedSubagents: stopped };
   }
 
   if (abortKey) {
     setAbortMemory(abortKey, true);
   }
-  const { stopped } = stopSubagentsForRequester({ cfg, requesterSessionKey });
+  const { stopped } = await stopSubagentsForRequester({ cfg, requesterSessionKey });
   return { handled: true, aborted: false, stoppedSubagents: stopped };
 }

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -142,10 +142,20 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
   );
   await triggerInternalHook(hookEvent);
 
-  const { stopped } = stopSubagentsForRequester({
-    cfg: params.cfg,
-    requesterSessionKey: abortTarget.key ?? params.sessionKey,
-  });
+  const primaryRequesterKey = abortTarget.key ?? params.sessionKey;
+  let stopped = 0;
+  if (primaryRequesterKey) {
+    ({ stopped } = await stopSubagentsForRequester({
+      cfg: params.cfg,
+      requesterSessionKey: primaryRequesterKey,
+    }));
+  }
+  if (stopped === 0 && params.sessionKey && params.sessionKey !== primaryRequesterKey) {
+    ({ stopped } = await stopSubagentsForRequester({
+      cfg: params.cfg,
+      requesterSessionKey: params.sessionKey,
+    }));
+  }
 
   return { shouldContinue: false, reply: { text: formatAbortReplyText(stopped) } };
 };

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -135,7 +135,10 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
+  await stopSubagentsForRequester({
+    cfg: params.cfg,
+    requesterSessionKey: params.target.canonicalKey,
+  });
   if (!params.sessionId) {
     clearBootstrapSnapshot(params.target.canonicalKey);
     await closeTrackedBrowserTabs();


### PR DESCRIPTION
## Summary
- make subagent stop propagation awaitable so stop/reset can cascade cleanly
- cancel active ACP-backed child sessions and persist child aborted state
- cover fast-abort child cancellation with a regression test

## Testing
- pnpm exec vitest run src/auto-reply/reply/abort.test.ts (run in /Users/kobe2026/openclaw)
