### PR TITLE
fix(cron): correct test assertion for legacy delivery:undefined path (#56078)

### DIFF
--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -55,6 +55,22 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.to).toBe("telegram:123");
   });
 
+  it("treats missing delivery field as mode=none for UI-created jobs without explicit delivery (#56078)", () => {
+    // When delivery field is omitted (legacy/edge case), the function takes
+    // the legacy code path which returns channel: "last" as a fallback.
+    // Note: After the UI fix, new jobs created via UI send { mode: "none" }
+    // explicitly, which goes through the delivery branch and returns channel: undefined.
+    const plan = resolveCronDeliveryPlan(
+      makeJob({
+        delivery: undefined,
+        payload: { kind: "agentTurn", message: "generate report" },
+      }),
+    );
+    expect(plan.mode).toBe("none");
+    expect(plan.requested).toBe(false);
+    expect(plan.channel).toBe("last");
+  });
+
   it("resolves webhook mode without channel routing", () => {
     const plan = resolveCronDeliveryPlan(
       makeJob({

--- a/src/cron/delivery.test.ts
+++ b/src/cron/delivery.test.ts
@@ -55,7 +55,7 @@ describe("resolveCronDeliveryPlan", () => {
     expect(plan.to).toBe("telegram:123");
   });
 
-  it("treats missing delivery field as mode=none for UI-created jobs without explicit delivery (#56078)", () => {
+  it("takes legacy code path and returns channel: 'last' when delivery is undefined (#56078)", () => {
     // When delivery field is omitted (legacy/edge case), the function takes
     // the legacy code path which returns channel: "last" as a fallback.
     // Note: After the UI fix, new jobs created via UI send { mode: "none" }


### PR DESCRIPTION
## Problem

PR #56212 had a P1 test assertion error identified by Greptile:

- Test: 'treats missing delivery field as mode=none for UI-created jobs'
- Incorrect assertion: `expect(plan.channel).toBeUndefined()\)
- Actual value: `"last"` (legacy code path fallback)

## Root Cause

When `delivery: undefined`, the function takes the legacy code path (lines 90-101 of delivery.ts) which computes:

```typescript
const channel = deliveryChannel ?? payloadChannel ?? "last";
// → undefined ?? undefined ?? "last" → "last"
```

## Fix

Updated test assertion to match actual behavior:
```typescript
expect(plan.channel).toBe("last");
```

## Testing

- ✅ Test file updated with correct assertion
- ✅ Added clarifying comment explaining legacy vs UI behavior
- ✅ All lint checks pass

Fixes #56078 (test portion)